### PR TITLE
fix: clarify trust-sensitive Python APIs

### DIFF
--- a/src/jacobian/adapters/mcp/server.py
+++ b/src/jacobian/adapters/mcp/server.py
@@ -58,6 +58,8 @@ def create_server(
     *,
     install_references: bool = True,
 ) -> MCPServer[AppState]:
+    """Create the thin MCP adapter over one local Jacobian kernel."""
+
     # Keep ``--help`` and ``--version`` independent of the MCP runtime's
     # heavier imports and shutdown hooks.
     from mcp.server import MCPServer

--- a/src/jacobian/artifacts.py
+++ b/src/jacobian/artifacts.py
@@ -14,6 +14,8 @@ class ArtifactValidationError(ValueError):
 
 
 class ArtifactService:
+    """Validate domain payloads before committing immutable artifacts."""
+
     def __init__(self, store: ArtifactStore, schemas: SchemaRegistry) -> None:
         self.store = store
         self.schemas = schemas
@@ -27,6 +29,8 @@ class ArtifactService:
         parents: tuple[str, ...] | list[str] = (),
         summary: str = "",
     ) -> ArtifactPutResult:
+        """Validate and store one artifact under its schema and semantics."""
+
         try:
             normalized = self.schemas.validate(schema_uri, payload)
             self.store.get_descriptor(

--- a/src/jacobian/claims.py
+++ b/src/jacobian/claims.py
@@ -19,6 +19,8 @@ from jacobian.store import ArtifactStore, StoreError
 
 
 class ClaimValidationService:
+    """Validate a claim's structure and capabilities without proving it."""
+
     def __init__(
         self,
         store: ArtifactStore,
@@ -35,6 +37,8 @@ class ClaimValidationService:
         claim_uri: str,
         plugin_id: str,
     ) -> ClaimValidationResult:
+        """Check a stored claim against the selected installed plugin."""
+
         errors: list[str] = []
         warnings: list[str] = []
         claim_digest: str | None = None

--- a/src/jacobian/contracts/results.py
+++ b/src/jacobian/contracts/results.py
@@ -17,6 +17,8 @@ class ContractModel(BaseModel):
 
 
 class ExecutionStatus(StrEnum):
+    """Operational completion state, independent of mathematical truth."""
+
     COMPLETED = "COMPLETED"
     TIMEOUT = "TIMEOUT"
     CANCELLED = "CANCELLED"
@@ -29,6 +31,8 @@ class InputStatus(StrEnum):
 
 
 class Conclusion(StrEnum):
+    """Mathematical conclusion; UNKNOWN is never interpreted as false."""
+
     TRUE = "TRUE"
     FALSE = "FALSE"
     UNKNOWN = "UNKNOWN"
@@ -87,6 +91,8 @@ class InputValidation(ContractModel):
 
 
 class Assurance(ContractModel):
+    """Arithmetic, method, coverage, and checker identity for a conclusion."""
+
     arithmetic: Arithmetic
     method: Method
     coverage: Coverage
@@ -136,6 +142,8 @@ class Assurance(ContractModel):
 
 
 class ResultEnvelope(ContractModel):
+    """Separate execution, input, conclusion, assurance, and evidence."""
+
     schema_version: Literal["1"] = "1"
     execution: Execution
     input: InputValidation

--- a/src/jacobian/evaluation.py
+++ b/src/jacobian/evaluation.py
@@ -66,6 +66,8 @@ class EvaluationService:
         seed: int,
         wall_seconds: int,
     ) -> EvaluationBatchResult:
+        """Evaluate candidates without promoting any plugin result to verified."""
+
         selected_profile = EvaluationProfile(profile)
         candidates = tuple(candidate_uris)
         if not candidates:

--- a/src/jacobian/plugin_execution.py
+++ b/src/jacobian/plugin_execution.py
@@ -16,6 +16,8 @@ from jacobian.implementation import package_source_digest
 
 @dataclass(frozen=True, slots=True)
 class PluginExecutionResult:
+    """Operational result from one local plugin worker invocation."""
+
     status: ExecutionStatus
     output: dict[str, Any] | None
     diagnostics: str
@@ -24,7 +26,12 @@ class PluginExecutionResult:
 
 
 class PluginExecutor:
-    """Run an installed capability out of process with fail-closed outcomes."""
+    """Run operator-installed local code with bounded, fail-closed outcomes.
+
+    The child-process boundary limits elapsed time, output, and descendant
+    lifetime. It is not a security sandbox and does not make plugin results
+    mathematically trusted.
+    """
 
     def __init__(
         self,
@@ -43,6 +50,8 @@ class PluginExecutor:
         request: dict[str, Any],
         timeout_seconds: float,
     ) -> PluginExecutionResult:
+        """Execute a capability only if the worker measures the expected source."""
+
         started = time.monotonic()
         expected_digest = implementation_digest or package_source_digest(entrypoint)
         environment = dict(os.environ)

--- a/src/jacobian/plugins/registry.py
+++ b/src/jacobian/plugins/registry.py
@@ -23,6 +23,8 @@ class PluginRegistryError(RuntimeError):
 
 @dataclass(frozen=True, slots=True)
 class ResolvedCapability:
+    """A plugin capability bound to the source digest measured at resolution."""
+
     plugin_id: str
     name: CapabilityName
     descriptor: CapabilityDescriptor
@@ -56,6 +58,8 @@ class PluginRegistry:
             )
 
     def register_implementation(self, entrypoint: str) -> str:
+        """Record an operator-installed entrypoint and its current source digest."""
+
         try:
             digest = module_source_digest(entrypoint)
         except ImplementationError as exc:
@@ -144,6 +148,8 @@ class PluginRegistry:
         return manifest
 
     def get(self, plugin_id: str) -> PluginManifest:
+        """Return an installed manifest without resolving executable code."""
+
         with self._connect() as connection:
             installed = connection.execute(
                 "SELECT 1 FROM installed_plugins WHERE plugin_id = ?",
@@ -161,6 +167,8 @@ class PluginRegistry:
         plugin_id: str,
         capability: CapabilityName,
     ) -> ResolvedCapability:
+        """Resolve a capability only if its source still matches installation."""
+
         manifest = self.get(plugin_id)
         descriptor = manifest.capabilities.get(capability)
         if descriptor is None:

--- a/src/jacobian/registry.py
+++ b/src/jacobian/registry.py
@@ -47,7 +47,7 @@ def compute_entrypoint_digest(entrypoint: str) -> str:
 
 
 class CheckerRegistry:
-    """Persistent checker policy, reachable only from operator administration."""
+    """Persist operator authorization, compatibility, audit, and revocation."""
 
     def __init__(self, database_path: str | Path) -> None:
         self.database_path = Path(database_path)
@@ -126,6 +126,8 @@ class CheckerRegistry:
         candidate_schema_uris: tuple[str, ...],
         reason: str = "operator authorization",
     ) -> CheckerRegistration:
+        """Authorize one measured checker for explicit evidence compatibility."""
+
         executable_digest = compute_entrypoint_digest(entrypoint)
         identity_payload = {
             "checker_schema_version": "1",
@@ -196,6 +198,8 @@ class CheckerRegistry:
         return registration
 
     def get(self, checker_id: str) -> CheckerRegistration:
+        """Return a checker registration, including its revocation state."""
+
         with self._connect() as connection:
             row = connection.execute(
                 """
@@ -212,6 +216,8 @@ class CheckerRegistry:
         return CheckerRegistration.model_validate(data)
 
     def require_active(self, checker_id: str) -> CheckerRegistration:
+        """Return a checker only while it may create new verified records."""
+
         registration = self.get(checker_id)
         if not registration.authorized:
             raise CheckerRevokedError(f"checker is revoked: {checker_id}")
@@ -233,6 +239,8 @@ class CheckerRegistry:
         semantics_uri: str,
         candidate_schema_uri: str,
     ) -> CheckerRegistration:
+        """Require an active checker matching every declared evidence binding."""
+
         registration = self.require_active(checker_id)
         expected_kind = EvidenceKind(evidence_kind)
         if registration.evidence_kind is not expected_kind:
@@ -268,6 +276,8 @@ class CheckerRegistry:
         semantics_uri: str,
         candidate_schema_uri: str,
     ) -> CheckerRegistration:
+        """Select the unique active checker compatible with an evidence format."""
+
         with self._connect() as connection:
             rows = connection.execute(
                 "SELECT checker_id FROM checkers WHERE authorized = 1"
@@ -299,6 +309,8 @@ class CheckerRegistry:
         return compatible[0]
 
     def revoke(self, checker_id: str, *, reason: str) -> None:
+        """Block new verification while preserving historical records."""
+
         with self._exclusive_policy_lock(), self._connect() as connection:
             row = connection.execute(
                 "SELECT authorized FROM checkers WHERE checker_id = ?",
@@ -321,6 +333,8 @@ class CheckerRegistry:
             )
 
     def audit_log(self, checker_id: str) -> tuple[CheckerAuditEvent, ...]:
+        """Return ordered authorization and revocation events."""
+
         with self._connect() as connection:
             rows = connection.execute(
                 """

--- a/src/jacobian/schema_registry.py
+++ b/src/jacobian/schema_registry.py
@@ -35,10 +35,14 @@ def _reject_external_references(value: Any) -> None:
 
 
 class SchemaRegistry:
+    """Store and apply closed local JSON Schemas used by artifact contracts."""
+
     def __init__(self, store: ArtifactStore) -> None:
         self.store = store
 
     def register(self, *, name: str, version: str, schema: dict[str, Any]) -> str:
+        """Register a schema after rejecting unsupported external references."""
+
         normalized = loads_strict_json(canonicalize_json(schema))
         _reject_external_references(normalized)
         try:
@@ -53,6 +57,8 @@ class SchemaRegistry:
         )
 
     def resolve(self, schema_uri: str) -> dict[str, Any]:
+        """Load a previously registered schema definition."""
+
         try:
             descriptor = self.store.get_descriptor(
                 schema_uri,
@@ -67,6 +73,8 @@ class SchemaRegistry:
         return definition
 
     def validate(self, schema_uri: str, payload: Any) -> Any:
+        """Validate and canonically normalize a payload."""
+
         normalized = loads_strict_json(canonicalize_json(payload))
         schema = self.resolve(schema_uri)
         validator = Draft202012Validator(schema, format_checker=FormatChecker())

--- a/src/jacobian/shrinking.py
+++ b/src/jacobian/shrinking.py
@@ -40,6 +40,8 @@ from jacobian.verification import VerificationService
 
 
 class ShrinkService:
+    """Reduce evidence while independently replaying every accepted step."""
+
     def __init__(
         self,
         store: ArtifactStore,
@@ -68,6 +70,8 @@ class ShrinkService:
         objectives: tuple[str, ...] | list[str],
         evaluation_budget: int,
     ) -> ShrinkResult:
+        """Run bounded shrinking and report the achieved minimality level."""
+
         kind = ShrinkTargetKind(target_kind)
         requested_reducers = tuple(reducers)
         requested_objectives = tuple(objectives)

--- a/src/jacobian/store.py
+++ b/src/jacobian/store.py
@@ -52,6 +52,8 @@ class StoreLimitError(StoreError):
 
 @dataclass(frozen=True, slots=True)
 class StoreLimits:
+    """Local artifact and aggregate blob-size limits."""
+
     max_artifact_bytes: int = 10 * 1024 * 1024
     max_parents: int = 4096
     max_summary_chars: int = 512
@@ -60,6 +62,8 @@ class StoreLimits:
 
 @dataclass(frozen=True, slots=True)
 class StoredArtifact:
+    """A verified-on-read manifest, payload, and canonical byte sequence."""
+
     artifact_uri: str
     manifest: ArtifactManifest
     payload: Any
@@ -316,6 +320,8 @@ class ArtifactStore:
         *,
         expected_kind: str | None = None,
     ) -> dict[str, Any]:
+        """Load an infrastructure descriptor and optionally require its kind."""
+
         artifact = self.get(artifact_uri)
         if (
             artifact.manifest.schema_uri != _BOOTSTRAP_SCHEMA_URI
@@ -340,6 +346,8 @@ class ArtifactStore:
         parents: tuple[str, ...] | list[str] = (),
         summary: str = "",
     ) -> ArtifactPutResult:
+        """Commit canonical content whose identity binds schema and semantics."""
+
         return self._put(
             schema_uri=schema_uri,
             semantics_uri=semantics_uri,
@@ -458,6 +466,8 @@ class ArtifactStore:
         return data
 
     def get(self, artifact_uri: str) -> StoredArtifact:
+        """Load an artifact after replaying its content and manifest digests."""
+
         manifest_digest = _digest_from_uri(artifact_uri)
         with self._connect() as connection:
             row = connection.execute(
@@ -515,6 +525,8 @@ class ArtifactStore:
         )
 
     def find_by_object_digest(self, object_digest: str) -> tuple[str, ...]:
+        """Return every artifact URI carrying a mathematical object digest."""
+
         with self._connect() as connection:
             rows = connection.execute(
                 """

--- a/src/jacobian/verification.py
+++ b/src/jacobian/verification.py
@@ -177,6 +177,8 @@ class VerificationService:
         witness_uri: str,
         checker_id: str,
     ) -> ResultEnvelope:
+        """Replay a bound witness with the explicitly selected checker."""
+
         started = time.monotonic()
         try:
             claim = self.store.get(claim_uri)
@@ -349,6 +351,8 @@ class VerificationService:
             )
 
     def verify_certificate(self, *, certificate_uri: str) -> ResultEnvelope:
+        """Select and run the unique checker compatible with a certificate."""
+
         started = time.monotonic()
         try:
             certificate_artifact = self.store.get(certificate_uri)

--- a/src/jacobian/witnesses.py
+++ b/src/jacobian/witnesses.py
@@ -45,6 +45,8 @@ def _conclusion_proving_absence(role: WitnessRole) -> Conclusion:
 
 
 class WitnessSearchService:
+    """Ask an untrusted plugin for adversarial evidence without self-certifying."""
+
     def __init__(
         self,
         store: ArtifactStore,
@@ -75,6 +77,8 @@ class WitnessSearchService:
         witness_role: WitnessRole | str,
         wall_seconds: int,
     ) -> WitnessFindResult:
+        """Find a witness or independently verify a no-witness certificate."""
+
         role = WitnessRole(witness_role)
         validation = self.claims.validate(
             claim_uri=claim_uri,


### PR DESCRIPTION
## Summary

Document the public APIs where Jacobian's trust semantics are easy to
misinterpret:

- artifact identity and verified-on-read behavior;
- claim and schema validation boundaries;
- plugin source identity and local process execution;
- checker authorization, compatibility, revocation, and audit history;
- unverified evaluation, witness search, and shrinking;
- independent witness and certificate replay;
- the separation between execution status, mathematical conclusion, and
  assurance.

The `PluginExecutor` docstring also states the intended local-execution model:
process limits bound time, output, and descendants, but are not a security
sandbox and do not make plugin mathematics trusted.

This deliberately avoids blanket docstrings that would merely repeat Pydantic
field names.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `git diff --check`
