### PR TITLE
feat(runtime): harden provisional M3 and M4 workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -22,7 +22,7 @@ assignees: []
 <!-- What workarounds or alternative approaches have you considered? -->
 
 **Impact on trust boundaries**
-<!-- Does this change affect the verification kernel, checker registry, or trust model? Reference docs/threat-model.md if relevant. -->
+<!-- Does this change affect the verification kernel, checker registry, or trust model? Reference docs/explanation/threat-model.md if relevant. -->
 
 **Additional context**
 <!-- Reference relevant specifications, benchmarks, or mathematical scenarios. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,7 @@ uv build
 ```
 
 ## Trust & Compatibility Impact
-<!-- Does this change affect the verification kernel, checker registry, artifact format, or public API? Reference docs/threat-model.md if relevant. -->
+<!-- Does this change affect the verification kernel, checker registry, artifact format, or public API? Reference docs/explanation/threat-model.md if relevant. -->
 
 ## Checklist
 - [ ] Tests pass locally (`uv run pytest`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,15 +44,16 @@ Jacobian v0.2 alpha is the current cumulative implementation under
 current release contract; earlier development milestones survive only as
 ordinary regression coverage. The public API and artifact formats remain
 pre-stable.
-`README.md` provides the project overview and document index. Design material
-lives in `docs/`:
+`README.md` provides the project overview, while `docs/index.md` is the
+documentation home. Design material lives in `docs/`:
 
-- `docs/specifications/` contains the current v0.2 specification and
-  provisional specifications for later releases.
-- `docs/adr/` records architectural decisions using numbered filenames such as
-  `0001-python-first-control-plane.md`.
-- Top-level documents cover architecture, tools, conformance, threats,
-  benchmarks, testing strategy, and the roadmap.
+- `docs/tutorials/` contains guided learning paths.
+- `docs/how-to/` contains task-oriented operating guides.
+- `docs/reference/` contains tools, conformance requirements, specifications,
+  milestone contracts, benchmarks, and testing protocols.
+- `docs/explanation/` contains architecture, threats, the roadmap, runtime
+  design, and numbered ADRs.
+- `docs/contributing/` contains maintainer-facing planning material.
 
 Keep `deep_review.md` local; it is intentionally ignored as design source
 material.
@@ -93,10 +94,10 @@ Update `README.md` when adding a public-facing document.
 ## Testing Guidelines
 
 Check changes against the applicable release specification,
-`docs/conformance-v0.2.md`, and
-`docs/testing-strategy.md`. Verify relative links and ensure provisional
-roadmap material is not presented as a stable contract. Report only checks
-that actually ran.
+`docs/reference/conformance-v0.2.md`, and
+`docs/reference/testing-strategy.md`. Verify relative links and ensure
+provisional roadmap material is not presented as a stable contract. Report
+only checks that actually ran.
 
 ## Commit & Pull Request Guidelines
 
@@ -114,4 +115,4 @@ or diagrams materially change, and list the exact validation performed.
 Do not weaken the central invariant: evidence becomes verified only after an
 authorized checker accepts data bound to the exact claim, semantics, candidate,
 and checker version. Discuss changes affecting trust boundaries alongside
-`docs/threat-model.md`.
+`docs/explanation/threat-model.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,73 @@
+# Contributing to Jacobian
+
+Jacobian is pre-stable and verifier-centric. Contributions should preserve the
+boundary between heuristic search or evaluation and independently verified
+evidence.
+
+## Before changing code
+
+Read the [documentation home](docs/index.md), the
+[v0.2 specification](docs/reference/specifications/v0.2.md), and the
+[v0.2 conformance specification](docs/reference/conformance-v0.2.md).
+Changes to checker authorization, plugin isolation, durable state, or evidence
+promotion also require reviewing the
+[threat model](docs/explanation/threat-model.md).
+
+## Development environment
+
+Jacobian uses Python 3.12 and `uv`:
+
+```sh
+uv sync --dev
+uv run pytest
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy
+uv build
+```
+
+Use focused tests while implementing. Run the complete applicable validation
+before handing off the final tree, and report only checks that actually ran.
+
+## Verification rules
+
+- Do not turn a timeout, cancellation, error, incomplete enumeration, or
+  missing witness into a mathematical conclusion.
+- Do not promote an evaluator score, solver status, model answer, or search
+  result directly to `VERIFIED`.
+- Keep execution status, input validity, mathematical conclusion, assurance,
+  and evidence type separate.
+- Bind verified evidence to the exact claim, semantics, candidate, scope,
+  certificate format, and checker identity.
+- Keep checker authorization and trust policy outside untrusted plugins and
+  search workers.
+
+For trust-sensitive changes, write the failing invariant or attack test first
+and verify replay through an independent checker process.
+
+## Documentation
+
+Place documentation according to the reader's task:
+
+- `docs/tutorials/` teaches through a complete guided experience;
+- `docs/how-to/` explains how to complete one specific task;
+- `docs/reference/` defines exact contracts and lookup information;
+- `docs/explanation/` records architecture, rationale, and tradeoffs.
+
+Update `docs/index.md` and the root `README.md` when adding a public entry
+point. Keep v0.2 requirements separate from provisional milestone behavior.
+For documentation-only changes, run:
+
+```sh
+git diff --check
+git diff -- README.md CONTRIBUTING.md docs/
+```
+
+Verify every relative Markdown link before submitting the change.
+
+## Pull requests
+
+Keep each change focused on one outcome. Explain the problem, the resulting
+behavior or contract, any compatibility impact, and the validation performed.
+Link a relevant issue when one exists. Include screenshots only when rendered
+layout or diagrams materially change.

--- a/README.md
+++ b/README.md
@@ -22,13 +22,28 @@ The central invariant is:
 > operator-authorized checker accepts evidence bound to the exact claim,
 > semantics, candidate, and checker version.
 
+## Get started
+
+Jacobian uses Python 3.12 and `uv`. Initialize the locked development
+environment and a local state directory:
+
+```sh
+uv sync --dev
+uv run jacobian --state-dir .jacobian init
+```
+
+Then follow
+[Find and verify a counterexample](docs/tutorials/first-verified-result.md)
+for a complete first experiment. Run `uv run jacobian --help` to inspect the
+CLI or `uv run jacobian-mcp` to start the MCP adapter.
+
 ## Roadmap
 
 | Milestone | Theme | Primary outcome |
 | --- | --- | --- |
 | Current release | Verification and bounded discovery | v0.2 alpha stores, evaluates, attacks, shrinks, independently verifies, enumerates structures, verifies representation changes, and computes exact separators |
-| M3 | Scalable search | Run typed search strategies through one resumable experiment loop |
-| M4 | Conjecture workflows | Repair, generate, falsify, and parametrically generalize conjectures |
+| M3 | Scalable search | Provisional implementation runs typed search strategies through one resumable experiment loop |
+| M4 | Conjecture workflows | Provisional implementation repairs, generates, falsifies, and parametrically generalizes conjectures |
 | M5 | Research corpus integration | Retrieve prior solutions, failures, witnesses, and certificates through an optional provider |
 | Stability target | Stable research platform | Publish a v1.0 API with formal-checking and collaboration support |
 
@@ -37,65 +52,68 @@ without a shared corpus service. Jacobian records its own experiments for
 replay and lineage; corpus-scale retrieval is an optional integration that
 cannot promote evidence or authorize checkers.
 
-The only current implementation and public release contract is v0.2 alpha
-(`0.2.0a0`). It includes both the verification kernel and bounded discovery.
-Earlier development milestones are covered by the current regression suite,
-not presented as separately supported releases. Future milestone plans remain
-provisional and do not determine package version numbers.
+The only public release contract is v0.2 alpha (`0.2.0a0`). It includes the
+verification kernel and bounded discovery. The repository also contains
+provisional M3 and M4 implementations so their contracts can be exercised
+before a later release is declared. Those APIs and artifacts are not part of
+v0.2 conformance and remain free to change.
 
-## Documents
+## Design and documentation
 
-- [Architecture](docs/architecture.md)
-- [Tool surface](docs/tools.md)
-- [Roadmap and milestone gates](docs/roadmap.md)
-- [Reference benchmarks](docs/benchmarks.md)
-- [Mathematical scenario catalog](docs/math-scenarios.md)
-- [Testing strategy and critical areas](docs/testing-strategy.md)
-- [Performance benchmarks](docs/performance-benchmarks.md)
-- [Model-in-the-loop evaluations](docs/agent-evaluations.md)
-- [Threat model](docs/threat-model.md)
-- [v0.2 conformance specification](docs/conformance-v0.2.md)
-- [v0.2 specification](docs/specifications/v0.2.md)
-- [M3 scalable-search milestone](docs/milestones/m3-scalable-search.md)
-- [M4 conjecture-workflows milestone](docs/milestones/m4-conjecture-workflows.md)
-- [M5 research-corpus milestone](docs/milestones/m5-research-corpus.md)
-- [v1.0 specification](docs/specifications/v1.0.md)
-- [Why the control plane is Python-first](docs/adr/0001-python-first-control-plane.md)
-- [Proposed implementation issues](docs/issues.md)
+Jacobian is pre-stable, so the architecture, trust boundaries, and milestone
+gates are part of the working project record. Start with:
+
+- [Architecture](docs/explanation/architecture.md) for the system shape and
+  verification boundary.
+- [Roadmap](docs/explanation/roadmap.md) for active milestone scope and exit
+  gates.
+- [Architecture decision log](docs/explanation/adr/index.md) for accepted
+  cross-cutting decisions and their release scope.
+- [Threat model](docs/explanation/threat-model.md) for protected properties,
+  trust assumptions, and explicit exclusions.
+- [Durable search runtime](docs/explanation/search-runtime.md) for the
+  provisional M3 ownership, persistence, and recovery model.
+
+Release contracts and engineering evidence are:
+
+- [Tool surface](docs/reference/tools.md)
+- [v0.2 specification](docs/reference/specifications/v0.2.md) and
+  [conformance gate](docs/reference/conformance-v0.2.md)
+- [M3](docs/reference/milestones/m3-scalable-search.md) and
+  [M4](docs/reference/milestones/m4-conjecture-workflows.md) provisional
+  contracts
+- [Testing strategy](docs/reference/testing-strategy.md),
+  [scenario catalog](docs/reference/math-scenarios.md), and
+  [performance benchmark protocol](docs/reference/performance-benchmarks.md)
+- [Plugin conformance contract](docs/reference/plugin-conformance.md)
+
+The [documentation home](docs/index.md) provides the complete catalog,
+organized into tutorials, how-to guides, reference, and explanation. Read
+[CONTRIBUTING.md](CONTRIBUTING.md) for development setup, verification rules,
+documentation placement, and pull-request expectations.
 
 ## Current status
 
-v0.2 alpha is implemented as a local Python package, CLI, and MCP adapter.
-It offers seven verification tools alongside bounded enumeration,
+v0.2 alpha is implemented as a local Python package, CLI, and MCP adapter. It
+offers seven verification tools alongside bounded enumeration,
 implementation-bound canonicalization, independently verified representation
 changes, persistent experiment resources, and exact finite-polytope evidence.
-All public contracts and artifact formats remain pre-stable.
 
-The alpha experiment runner is local and single-process. A state directory
-must not be opened by another Jacobian process while an experiment is running;
-multi-process leases and resumable ownership belong to M3.
+The provisional M3/M4 code adds sealed plugin snapshots, a strategy-neutral
+`search.run` service, pause and resume from immutable checkpoints, append-only
+lifecycle events, conjecture transformations, and verified parameter-region
+promotion. The scheduler accepts one strategy worker. Plugin calls run in
+bounded child processes, but the search coordinator and durable state owner
+remain local to one Jacobian process.
 
-```sh
-uv sync --dev
-uv run pytest
-uv run pytest --lf
-uv run pytest --sw
-uv run pytest -m "not integration and not end_to_end"
-uv run ruff check .
-uv run ruff format --check .
-uv run mypy
-uv run deptry .
-uv run pre-commit install
-uv run jacobian --help
-uv run jacobian-mcp
-```
+Use one active Jacobian process per state directory. Restarting that process
+reconstructs interrupted searches as paused or cancelled from durable state;
+it does not provide a multi-process lease or distributed queue. All public
+contracts and artifact formats remain pre-stable.
 
-The full suite uses up to four `pytest-xdist` workers with work stealing. Use
-the marker-filtered command for the fast development loop, or add `-n 0` when
-debugging one test in a single process. After a failure, `--lf` reruns only
-the last failures; `--sw` stops at the first failure and resumes from it on the
-next invocation. Pre-commit keeps commit-time checks fast; the full type,
-dependency, test, and build gates remain explicit.
+Development commands and test-selection guidance live in
+[CONTRIBUTING.md](CONTRIBUTING.md) and the
+[testing strategy](docs/reference/testing-strategy.md).
 
 The MCP adapter is pinned to the official Python SDK `2.0.0b2`. It remains
 isolated from the mathematical kernel because that SDK release is a beta.

--- a/docs/contributing/issues.md
+++ b/docs/contributing/issues.md
@@ -1,5 +1,7 @@
 # Issue index
 
+[Documentation home](../index.md)
+
 GitHub is the source of truth for implementation issues. This file records the
 small amount of repository context that should remain stable across issue
 updates; it does not duplicate full issue bodies.
@@ -20,12 +22,12 @@ as:
 
 Their descriptions reflect the repository state when filed. The current
 normative behavior is defined by the
-[v0.2 specification](specifications/v0.2.md) and
-[v0.2 conformance suite](conformance-v0.2.md).
+[v0.2 specification](../reference/specifications/v0.2.md) and
+[v0.2 conformance suite](../reference/conformance-v0.2.md).
 
 ## Current implementation
 
-The v0.2 branch implements the verification kernel together with:
+The v0.2 release contract implements the verification kernel together with:
 
 - bounded enumeration experiments and cancellation;
 - implementation-bound canonicalization;
@@ -33,6 +35,12 @@ The v0.2 branch implements the verification kernel together with:
 - exact finite rational convex-hull membership and separation;
 - CLI and MCP `2.0.0b2` adapters;
 - graph/path and integer-matrix reference domains.
+
+The repository also contains provisional M3/M4 work: sealed plugin snapshots,
+durable strategy search with pause/resume and restart recovery, conjecture
+transformations, and verified parameter-region promotion. These features are
+documented by their milestone specifications and ADRs, but are not part of the
+v0.2 conformance contract.
 
 Do not open umbrella issues that merely repeat these release deliverables.
 
@@ -51,4 +59,4 @@ specific unresolved behavior. Each issue should:
 
 Later-roadmap work should become issues only when its dependencies and success
 criteria are concrete. The provisional direction remains in
-[the roadmap](roadmap.md).
+[the roadmap](../explanation/roadmap.md).

--- a/docs/explanation/adr/0001-python-first-control-plane.md
+++ b/docs/explanation/adr/0001-python-first-control-plane.md
@@ -1,5 +1,7 @@
 # ADR 0001: Use a Python-first control plane
 
+[Documentation home](../../index.md) · [Decision log](index.md)
+
 - Status: Accepted for v0.2
 - Date: 2026-07-23
 

--- a/docs/explanation/adr/0002-sealed-plugin-packages.md
+++ b/docs/explanation/adr/0002-sealed-plugin-packages.md
@@ -1,0 +1,81 @@
+# ADR 0002: Seal plugin packages and registry snapshots
+
+[Documentation home](../../index.md) · [Decision log](index.md)
+
+- Status: Accepted for the provisional M3 implementation
+- Date: 2026-07-24
+
+## Decision
+
+Treat an operator-installed Python source package as one sealed implementation
+unit. Installation creates an immutable registry snapshot binding:
+
+- plugin manifest and capability contracts;
+- each declared entrypoint and implementation descriptor;
+- the whole-package source digest for each implementation package;
+- Python runtime, build identity, platform, system, and machine.
+
+Discovery measures package files without importing package code. Capability
+resolution remeasures the source and rejects changed bytes or an incompatible
+runtime before worker execution.
+
+The initial format hashes every regular package file. Declared and imported
+package modules must be Python source; path escape, symlinks, bytecode-only
+module execution, and native extension-module execution are rejected.
+
+## Rationale
+
+An entrypoint string and a digest of one file are not enough to reconstruct
+what Python will import. Sibling modules and package initializers can affect
+behavior. Measuring the package as a unit gives every capability one explicit,
+replayable implementation identity.
+
+Importing a package during discovery would execute operator-installed code
+before validation and make enumeration stateful. Source inspection keeps
+discovery deterministic and side-effect free.
+
+Runtime and platform bindings are included because identical source bytes may
+behave differently under another interpreter or binary dependency environment.
+These bindings are compatibility evidence, not a claim of bit-for-bit
+reproducibility.
+
+## Conformance decision
+
+The generic fault matrix runs against a disposable synthetic package in
+isolated state. Production plugins do not expose inputs that deliberately hang,
+crash, or emit malformed responses. Each suite run uses fresh invocation
+identities and drives the real registry, search, worker, and conjecture
+boundaries.
+
+## Alternatives considered
+
+### Import entrypoints and inspect callables
+
+Rejected because discovery would execute package code and could observe a
+different environment from the worker.
+
+### Hash only the entrypoint file
+
+Rejected because imported sibling modules could change without changing the
+registered digest.
+
+### Build a package manager or container-image pipeline
+
+Deferred. Jacobian needs immutable local identity before it needs remote
+distribution. A container can strengthen host isolation later without changing
+the artifact and capability contract.
+
+### Accept wheels, bytecode, and native modules immediately
+
+Deferred until their complete executable closure can be measured and tested
+across supported platforms.
+
+## Consequences
+
+- Any measured package-file change invalidates capabilities from that package.
+- Dynamically generated or editable package behavior is unsuitable for a
+  replayable installed plugin.
+- Runtime compatibility failures occur before execution.
+- Operators still decide whether code is safe for the host; sealing is not
+  sandboxing.
+- New package formats need their own measurement rules and conformance cases.

--- a/docs/explanation/adr/0003-durable-search-invocations.md
+++ b/docs/explanation/adr/0003-durable-search-invocations.md
@@ -1,0 +1,81 @@
+# ADR 0003: Use SQLite acceptance with immutable search checkpoints
+
+[Documentation home](../../index.md) · [Decision log](index.md)
+
+- Status: Accepted for the provisional M3 implementation
+- Date: 2026-07-24
+
+## Decision
+
+Represent one strategy search with:
+
+- a transactional SQLite idempotency binding and latest-snapshot row;
+- an append-only, digest-linked lifecycle event chain;
+- immutable archive pages, checkpoints, and terminal archives in the artifact
+  store.
+
+One idempotency key binds one exact request digest to one experiment URI.
+Startup recovery pauses interrupted active work at the last committed
+checkpoint. Invalid recovery rows are quarantined independently as `ERROR`.
+
+The reference scheduler accepts one strategy worker and one active coordinator
+per state directory. Multi-process leases and distributed queues are not part
+of this decision.
+
+## Rationale
+
+SQLite provides the two properties the local runtime needs: atomic concurrent
+request acceptance and durable indexed state. Immutable artifacts provide the
+lineage and replay boundary. Keeping the latest snapshot mutable avoids
+reconstructing every read from a long event stream, while the append-only events
+retain audit history.
+
+Opaque strategy state is safe to resume only when its checkpoint is rebound to
+the accepted request, plugin snapshot, implementations, environment, effective
+budget, accounting, and archive pages.
+
+Plugin work may repeat after the last checkpoint if the process dies before
+commit. This is acceptable because repeat execution cannot create a second
+accepted experiment and uncommitted output is not durable lineage.
+
+## Persistence and accounting boundary
+
+An iteration stores its archive page and checkpoint before updating SQLite.
+Wall time is sampled after checkpoint artifact creation and before the metadata
+transaction. This includes artifact persistence in budget enforcement without
+claiming resource measurements the local runtime does not observe.
+
+## Alternatives considered
+
+### In-memory threads only
+
+Rejected because process loss would discard request identity, lineage, and
+opaque strategy state.
+
+### Pure event sourcing
+
+Rejected for the local implementation because every inspect, wait, and control
+operation would need to fold the entire event history. The validated latest
+snapshot is a simpler read model.
+
+### A queue service or PostgreSQL first
+
+Deferred until multiple coordinators or remote workers are justified. Adding a
+distributed system before a lease and failure model exists would weaken, not
+strengthen, invocation identity.
+
+### Exactly-once plugin execution
+
+Rejected as an inaccurate promise. External work can repeat around a crash.
+Jacobian guarantees one accepted invocation and one committed lineage, not that
+an uncommitted child process ran only once.
+
+## Consequences
+
+- A state directory has one active coordinator.
+- Concurrent retries are safe and observable as reuse events.
+- Recovery can continue around one malformed row.
+- Checkpoint and archive identity checks are trust-sensitive and require
+  adversarial tests.
+- A future distributed scheduler must preserve the same request, event,
+  checkpoint, and checker-authority bindings.

--- a/docs/explanation/adr/0004-verified-parameter-regions.md
+++ b/docs/explanation/adr/0004-verified-parameter-regions.md
@@ -1,0 +1,74 @@
+# ADR 0004: Verify parameter regions through immutable subjects
+
+[Documentation home](../../index.md) · [Decision log](index.md)
+
+- Status: Accepted for the provisional M4 implementation
+- Date: 2026-07-24
+
+## Decision
+
+Allow hypothesis plugins to return only `PROPOSED` or `SAMPLED`
+parameter-region evidence. Before verification, store an immutable
+`ParameterRegionSubject` binding:
+
+- the target claim artifact;
+- whether the claimed region is `SUFFICIENT` or `NECESSARY`;
+- canonical exact conditions;
+- cited sample artifacts.
+
+Promote a region only when an authorized certificate verification record:
+
+- binds the claim and subject object digests;
+- includes the exact claim and subject artifact URIs as parents;
+- has conclusion `TRUE`;
+- replays to the identical verification-record URI.
+
+The generic kernel assigns the verified label from the subject kind only after
+those checks. The authorized domain checker defines what the conditions mean
+and whether the certificate proves them.
+
+## Rationale
+
+The plugin that proposes a region is mathematically untrusted and cannot
+authorize its own checker or attach a verified label.
+
+The subject gives a checker one immutable candidate to certify. Requiring exact
+artifact parents as well as object digests closes a carrier-substitution gap:
+two artifacts can contain the same canonical object while recording different
+lineage or summary metadata.
+
+Requiring replay to reproduce the same verification-record URI binds promotion
+to checker identity, executable digest, request, environment, evidence, and
+conclusion without creating a second region-specific trust mechanism.
+
+## Alternatives considered
+
+### Let the plugin emit a verification record
+
+Rejected because it collapses proposal and authorization into the same
+untrusted component.
+
+### Bind only the canonical conditions digest
+
+Rejected because the target claim, sufficient/necessary relation, samples, and
+artifact lineage would remain substitutable.
+
+### Add parameter mathematics to the generic kernel
+
+Rejected because sufficiency and necessity are domain semantics. The kernel
+should enforce evidence and identity boundaries, not reimplement every
+certificate checker.
+
+### Add a separate region-verification service
+
+Rejected because the existing certificate registry, replay service, and
+verification records already provide the required trust boundary.
+
+## Consequences
+
+- Parameter-region proof formats remain checker-defined.
+- Equal payloads in different artifact carriers are not interchangeable for
+  promotion.
+- Sample citations must be explicit workflow evidence and subject parents.
+- Revoked or incompatible checkers cannot create a new promoted result.
+- CLI and MCP promotion remain thin adapters over the same service method.

--- a/docs/explanation/adr/index.md
+++ b/docs/explanation/adr/index.md
@@ -1,0 +1,30 @@
+# Architecture decision log
+
+[Documentation home](../../index.md)
+
+Architecture decision records preserve cross-cutting choices whose rationale
+would otherwise be lost as the implementation changes. Each record states its
+status and release scope; an accepted provisional decision does not extend the
+v0.2 public contract.
+
+| ADR | Decision | Status |
+| --- | --- | --- |
+| [0001](0001-python-first-control-plane.md) | Use a Python-first control plane | Accepted for v0.2 |
+| [0002](0002-sealed-plugin-packages.md) | Seal plugin packages and registry snapshots | Accepted for the provisional M3 implementation |
+| [0003](0003-durable-search-invocations.md) | Use SQLite acceptance with immutable search checkpoints | Accepted for the provisional M3 implementation |
+| [0004](0004-verified-parameter-regions.md) | Verify parameter regions through immutable subjects | Accepted for the provisional M4 implementation |
+
+Add an ADR when a decision changes a trust boundary, durable data model,
+cross-component contract, dependency strategy, or other choice that would be
+costly to reverse. Routine implementation details belong in code, tests, or a
+how-to guide.
+
+When a decision changes, preserve the old record and add a new ADR that marks
+the earlier one as superseded. Do not silently rewrite an accepted decision to
+describe a different architecture.
+
+Related project-control documents:
+
+- [Architecture](../architecture.md)
+- [Roadmap](../roadmap.md)
+- [Threat model](../threat-model.md)

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -1,5 +1,12 @@
 # Architecture
 
+[Documentation home](../index.md)
+
+- Status: Current design map for v0.2 and the provisional M3/M4 implementation
+- Normative sources:
+  [v0.2 specification](../reference/specifications/v0.2.md) and
+  [conformance gate](../reference/conformance-v0.2.md)
+
 ## Purpose
 
 Jacobian separates mathematical discovery from mathematical trust.
@@ -32,6 +39,11 @@ The formal claim may still be a poor translation of the informal conjecture.
 Jacobian records that correspondence and its review status; it does not pretend
 that schema validation can establish it automatically.
 
+The v0.2 kernel and bounded-discovery behavior are the current release
+contract. Sections describing resumable strategy search and conjecture
+workflows document provisional M3/M4 implementations and do not extend v0.2
+conformance.
+
 ## Trust zones
 
 ### Trusted inputs and services
@@ -51,7 +63,7 @@ that schema validation can establish it automatically.
 - Representation transformers
 - SAT, SMT, LP, MIP, and polyhedral solvers
 - Language-model output
-- Model-uploaded code introduced in later milestones
+- Operator-installed plugin code as a source of mathematical claims
 
 A solver or evaluator can produce evidence. It cannot promote its own evidence
 to `VERIFIED`.
@@ -82,12 +94,20 @@ different meaning under another schema or semantics version.
 An immutable, content-addressed record connecting an object to its media type,
 schema, parent artifacts, and a short summary.
 
+Object identity and artifact identity answer different questions. The object
+digest binds canonical payload, schema, semantics, and canonicalizer. The
+artifact URI also binds carrier metadata such as parents and summary. Code that
+authorizes replay or promotion must require the exact artifact URI when lineage
+matters; equal object digests do not make two carriers interchangeable.
+
 ### Run record
 
 Execution metadata such as runtime, seed, environment, limits, logs, and tool
 version. A run record does not change the identity of the mathematical object.
-v0.2 persists verification records and adds durable mutable experiment
-snapshots plus immutable scope, archive-page, and archive-manifest artifacts.
+v0.2 persists verification records and bounded-enumeration snapshots. The
+provisional M3 runtime adds append-only lifecycle events, immutable strategy
+checkpoints, archive pages, and archive manifests around one mutable snapshot
+index.
 
 ### Curated research record
 
@@ -238,11 +258,40 @@ class TransformationChecker(Protocol):
 
 class CertificateChecker(Protocol):
     def verify(self, certificate: JSON) -> Verification: ...
+
+class Proposer(Protocol):
+    def propose(self, request: SearchProposalRequest) -> SearchProposal: ...
+
+class Refiner(Protocol):
+    def refine(self, request: SearchRefinementRequest) -> SearchRefinement: ...
+
+class HypothesisTransformer(Protocol):
+    def transform(
+        self, request: HypothesisRequest
+    ) -> HypothesisResponse: ...
 ```
 
 Search plugins cannot register themselves as trusted checkers. The checker
 registry is operator-managed and binds checker digests to supported claim,
 semantics, and certificate versions.
+
+### Sealed plugin identity
+
+Installation creates one immutable registry snapshot that binds the manifest,
+capability entrypoints, each implementation package digest, runtime and build
+identity, and platform compatibility. Discovery inspects source files without
+importing the package. Capability resolution remeasures the package before
+execution, so a changed file cannot continue under the installed snapshot.
+
+The initial package format hashes regular package files, while declared and
+imported modules must be Python source. Symlinks, traversal outside the
+package, bytecode-only module execution, and native extension-module execution
+are rejected. This protects registry identity; it does not sandbox
+operator-installed code once a worker executes it.
+
+The generic fault matrix runs against a disposable, conformance-only package in
+isolated state. Production plugins are not expected to expose inputs that
+deliberately crash, hang, or emit malformed responses.
 
 ## Search and checker separation
 
@@ -287,6 +336,53 @@ The initial `polytope.separate` backend covers finite rational V-represented
 polytopes. Z3 proposes exact convex weights or an exact separator. Independent
 checkers replay those objects using `Fraction` arithmetic and do not import
 Z3.
+
+## Resumable strategy search
+
+The provisional M3 service keeps coordination deliberately local:
+
+```text
+idempotent request
+    → SQLite acceptance row + append-only event
+    → proposer/evaluator/oracle/refiner child processes
+    → immutable archive page + checkpoint
+    → atomic snapshot update
+    → pause, resume, or terminal archive
+```
+
+An idempotency key binds one exact request digest to one experiment URI.
+Concurrent submissions of that request reuse the accepted experiment; the same
+key cannot be rebound to another request. Plugin work performed after the last
+checkpoint may run again after process loss, but only committed pages and
+checkpoints become durable lineage.
+
+On startup, active experiments are changed to `PAUSED`, while pending
+cancellation becomes `CANCELLED`. A malformed snapshot is moved to `ERROR` and
+recorded in `search_recovery_failures` without preventing unrelated rows from
+recovering. Checkpoint restoration rebinds the request, plugin snapshot,
+implementation digests, effective budget, environment, archive pages, and
+accounting before opaque strategy state is accepted.
+
+The reference scheduler accepts one strategy worker and requires one active
+Jacobian process per state directory. SQLite provides transactional request
+acceptance, not a distributed worker lease.
+
+## Conjecture transformations and parameter regions
+
+The three hypothesis-producing M4 operations share an untrusted
+`HypothesisTransformer`. The service validates source evidence, stores each
+claim and edit as immutable artifacts, deduplicates by content identity, and
+may route a hypothesis through M3 falsification. Generated, repaired, and
+generalized statements remain `UNVERIFIED`.
+
+A parameter-region plugin may return `PROPOSED` or `SAMPLED` evidence only.
+Jacobian commits an immutable `ParameterRegionSubject` binding the target claim,
+region kind, exact conditions, and sample artifacts. Promotion requires an
+authorized certificate record whose exact claim and subject artifact URIs are
+parents of that record. The service replays the certificate and accepts the
+promotion only if replay reproduces the same verification-record URI.
+Mathematical interpretation of the region remains in the authorized checker;
+the generic kernel only enforces bindings and evidence state.
 
 ## MCP boundary
 

--- a/docs/explanation/roadmap.md
+++ b/docs/explanation/roadmap.md
@@ -1,5 +1,12 @@
 # Roadmap
 
+[Documentation home](../index.md)
+
+- Status: Active planning document
+- Scheduling policy: Milestone gates are not promised dates or package versions
+- Related records: [Architecture](architecture.md) and
+  [architecture decision log](adr/index.md)
+
 ## Release and milestone policy
 
 Each milestone is gated by evidence, not by a calendar date. Later milestone
@@ -54,6 +61,10 @@ facet tooling remain optional backend work rather than release-gate claims.
 
 ## M3 — Scalable search
 
+Implementation status: a provisional local single-worker implementation is in
+the repository. It is not part of the v0.2 release contract. Distributed
+execution and multi-process leases remain conditional on measured need.
+
 ### Entry gate
 
 Bounded enumeration and transformation APIs have proved useful in two different
@@ -73,9 +84,11 @@ exact-verification boundaries.
 - Verified-counterexample feedback through the existing witness boundary
 - Candidate nomination that routes every mathematical promotion through the
   existing verification boundary
-- Exact budget, scope, runtime-identity, and resource accounting
+- Exact budget, scope, and runtime identity, with measured wall time and
+  durable operation accounting
 - Resumable, cancellable, and recoverable experiments
-- Local multi-process execution followed by distributed workers when justified
+- Bounded local child-process execution; multi-process scheduling only after a
+  lease model and measured need
 - Resource-bounded local execution for operator-approved generated candidate
   code, without claiming a security sandbox
 - Sealed, versioned plugin packages and immutable registry snapshots binding
@@ -85,13 +98,17 @@ exact-verification boundaries.
   malformed output, timeout, path and symlink attacks, changed implementation
   bytes, and unsupported evidence promotion
 - A no-core-change extension gate exercised by a synthetic third plugin
-- Idempotent, reconstructable worker invocations with append-only lifecycle
+- Idempotent, reconstructable search invocations with append-only lifecycle
   events binding the exact request, plugin and runtime identity, effective
-  policy, inputs, outputs, resource usage, and retry lineage
+  policy, inputs, outputs, configured limits, observed runtimes, and retry
+  lineage
 
-Effective worker authority is the restrictive intersection of the plugin
-contract, operator policy, and invocation request. No layer may widen resource,
-network, filesystem, artifact, or checker authority.
+For authority represented by Jacobian, the effective worker policy is the
+restrictive intersection of the plugin contract, operator policy, and
+invocation request. Local workers inherit the operator process's network and
+filesystem boundary; Jacobian does not widen it and does not claim to narrow it
+without an external OS or container sandbox. No plugin or invocation may widen
+budget, artifact, capability, or checker authority.
 
 Exact enumeration, counterexample-guided refinement, constraint solving,
 parameter sweeps, beam or tree search, evolutionary search, and agent-driven
@@ -103,15 +120,20 @@ records or trust rules into the generic kernel.
 Long-running experiments survive interruption and resumption, retain complete
 lineage, feed independently verified counterexamples into later refinement,
 and route nominated candidates through the verification boundary.
-Sequential reference results are preserved under multi-process execution,
-worker failure, cancellation, and resume. A new sealed plugin passes the
-generic conformance suite without kernel or MCP changes. Concurrent or
+Sequential reference results are preserved across child-process failure,
+cancellation, and resume. If multi-process scheduling is introduced, it must
+preserve the same result and lineage. A new sealed plugin passes the generic
+conformance suite without kernel or MCP changes. Concurrent or
 transport-retried requests create one durable invocation. After process loss,
 an invocation can be reconstructed without chat state and resumed without
 losing or duplicating lineage. Workers cannot widen execution policy or
 influence checker authorization.
 
 ## M4 — Conjecture workflows
+
+Implementation status: the provisional hypothesis-transformation and
+parameter-region promotion paths are in the repository. They remain pre-stable
+and are not part of v0.2 conformance.
 
 ### Entry gate
 
@@ -223,6 +245,6 @@ All releases preserve these invariants:
 
 The cross-release evidence plan is defined in:
 
-- [Testing strategy](testing-strategy.md)
-- [Performance benchmarks](performance-benchmarks.md)
-- [Agent evaluations](agent-evaluations.md)
+- [Testing strategy](../reference/testing-strategy.md)
+- [Performance benchmarks](../reference/performance-benchmarks.md)
+- [Agent evaluations](../reference/agent-evaluations.md)

--- a/docs/explanation/search-runtime.md
+++ b/docs/explanation/search-runtime.md
@@ -1,0 +1,139 @@
+# Durable search runtime
+
+[Documentation home](../index.md)
+
+- Status: Provisional M3 implementation
+- Release scope: Not part of v0.2 conformance
+
+This document describes the operational contract of `SearchService` and
+`search.run`. Mathematical search semantics remain in domain plugins; this
+runtime owns request acceptance, lifecycle state, persistence, accounting, and
+routing to existing verification services.
+
+## Ownership model
+
+Use one active Jacobian process per state directory. SQLite serializes
+transactions inside that process and makes request acceptance durable, but the
+current implementation has no lease protocol for multiple coordinators.
+
+The scheduler accepts `workers = 1`. Values above one fail validation. Plugin
+operations execute in bounded child processes; the coordinator, lifecycle
+threads, and SQLite connection remain local.
+
+## Request acceptance
+
+`SearchRunRequest.idempotency_key` identifies one exact canonical request:
+
+```text
+new key + request digest
+    → one experiment URI
+
+same key + same digest
+    → reuse that experiment URI and append REQUEST_REUSED
+
+same key + different digest
+    → reject before execution
+```
+
+Acceptance uses a SQLite `BEGIN IMMEDIATE` transaction. Concurrent submissions
+cannot create two accepted experiments for the same key. The accepted snapshot
+binds the claim, plugin manifest and registry snapshot, proposer/refiner/
+evaluator implementation digests, effective budget, and environment digest.
+
+## Lifecycle
+
+```text
+PENDING ──► RUNNING ──► COMPLETED
+   │           │  ├──► TIMEOUT
+   │           │  ├──► ERROR
+   │           │  ├──► PAUSE_REQUESTED ──► PAUSED ──► PENDING
+   │           │  └──► CANCEL_REQUESTED ──► CANCELLED
+   └───────────┴─────► CANCEL_REQUESTED
+```
+
+Pause takes effect at a checkpoint boundary. Resume continues the same
+experiment URI, idempotency binding, archive lineage, and accounting. Cancelled
+or timed-out work keeps all committed artifacts and events.
+
+Operational state never supplies a mathematical conclusion. In particular,
+`COMPLETED` with `STRATEGY_COMPLETE` means only that the strategy stopped.
+
+## Durable data
+
+The runtime combines a small mutable index with immutable evidence:
+
+| Data | Storage | Role |
+| --- | --- | --- |
+| Latest experiment snapshot | `search_experiments` SQLite row | Current lifecycle index |
+| Idempotency binding | `search_idempotency` SQLite row | One key/request/experiment mapping |
+| Lifecycle events | Append-only `search_events` rows | Ordered request, operation, control, retry, and recovery history |
+| Recovery failures | `search_recovery_failures` SQLite row | Quarantine evidence for one malformed snapshot |
+| Archive page | Immutable artifact | Candidate, evaluation, counterexample, and nomination records for one iteration |
+| Checkpoint | Immutable artifact | Opaque strategy state plus identity, budget, accounting, and prior-checkpoint link |
+| Terminal archive | Immutable artifact | Root for the completed committed lineage |
+
+SQLite triggers reject lifecycle-event updates and deletes. Event digests bind
+the predecessor so readers can validate the chain.
+
+## Checkpoint commit boundary
+
+For each successful iteration, the runtime:
+
+1. stores candidates, evaluations, witnesses, and nominations;
+2. stores an immutable archive page;
+3. stores an immutable checkpoint;
+4. samples wall time;
+5. commits the new snapshot and lifecycle event in SQLite.
+
+The wall-time sample includes checkpoint artifact creation and excludes the
+following metadata transaction. If artifact persistence crosses the wall
+budget, the experiment becomes `TIMEOUT` even when the proposer reported
+completion.
+
+Operation counts are exact for committed lineage. Wall time is measured at the
+boundary above. The current runtime does not claim CPU, memory, network-byte,
+or filesystem-byte metering.
+
+## Restart recovery
+
+Constructing `SearchService` examines recoverable, cancelled, and unknown
+indexed states in one transaction:
+
+- `PENDING`, `RUNNING`, and `PAUSE_REQUESTED` become `PAUSED`;
+- `CANCEL_REQUESTED` becomes `CANCELLED`;
+- a cancelled run missing its terminal archive receives one;
+- malformed JSON, an invalid indexed state, or a row/snapshot identity or state
+  mismatch is quarantined as `ERROR`.
+
+Quarantine records a digest of the stored bytes and a failure detail, then
+continues with the next row. One corrupt invocation therefore cannot prevent
+unrelated recovery.
+
+Resume validates the checkpoint and archive pages before accepting opaque
+plugin state. The request digest, experiment URI, registry snapshot,
+implementation digests, environment, effective budget, accounting, and page
+lineage must all agree.
+
+Work performed after the last committed checkpoint may execute again after a
+crash. It does not create a second accepted experiment, and only a committed
+page or checkpoint becomes durable lineage.
+
+## Authority and containment
+
+Effective Jacobian-represented authority is the restrictive intersection of
+the plugin contract, operator policy, and invocation request. A plugin or
+request cannot widen budgets, capability selection, artifact bindings, or
+checker authorization.
+
+Child-process time and output limits are operational controls, not a security
+sandbox. Workers inherit the coordinator's network and filesystem boundary.
+Run Jacobian under an OS or container policy when operator-installed code needs
+stronger isolation.
+
+## Related decisions
+
+- [Milestone 3 specification](../reference/milestones/m3-scalable-search.md)
+- [Durable invocation ADR](adr/0003-durable-search-invocations.md)
+- [Plugin conformance kit](../reference/plugin-conformance.md)
+- [Threat model](threat-model.md)
+- [Testing strategy](../reference/testing-strategy.md)

--- a/docs/explanation/threat-model.md
+++ b/docs/explanation/threat-model.md
@@ -1,12 +1,20 @@
 # Threat model
 
+[Documentation home](../index.md)
+
+- Status: Current for v0.2 and the provisional M3/M4 implementation
+- Host boundary: Operator-installed code is trusted not to attack the machine
+- Related records: [Architecture](architecture.md) and
+  [v0.2 conformance gate](../reference/conformance-v0.2.md)
+
 ## Scope
 
-This document defines the v0.2 threats to mathematical integrity,
-artifact integrity, and service availability.
+This document covers the v0.2 release contract and the provisional M3/M4 code
+in the repository. M3/M4 behavior is not part of v0.2 conformance, but it must
+preserve the same mathematical and artifact-integrity boundaries.
 
-The implemented releases accept pure data plus operator-installed local
-plugins and checkers.
+The implemented code accepts pure data plus operator-installed local plugins
+and checkers.
 Jacobian does not provide a security sandbox. Code installed by the operator is
 assumed safe to execute on that machine.
 
@@ -22,6 +30,10 @@ Jacobian protects:
 - the distinction between unverified evidence and verified results;
 - the distinction between execution state and mathematical conclusion;
 - reproducible replay of completed verification records.
+- durable search lineage that cannot be silently rebound to another request,
+  plugin, runtime, checkpoint, or experiment;
+- parameter-region promotion bound to the exact subject and claim artifacts,
+  not merely an equal payload.
 
 Availability is important but secondary to integrity: resource exhaustion may
 produce timeout or error, never a false mathematical conclusion.
@@ -30,8 +42,8 @@ produce timeout or error, never a false mathematical conclusion.
 
 ### Mathematically untrusted problem plugin
 
-v0.2 plugins are operator-installed and trusted not to attack the host. They
-are not trusted to establish mathematical truth. A plugin may:
+Plugins are operator-installed and trusted not to attack the host. They are not
+trusted to establish mathematical truth. A plugin may:
 
 - omit legal semantic objects;
 - misreport arithmetic or coverage;
@@ -51,8 +63,14 @@ Controls:
   bytecode-only or compiled package modules;
 - plugin workers have bounded process/output lifetime for operational
   containment, but run locally with the operator's environment and are not a
-  security sandbox;
+  security sandbox; network and filesystem authority are inherited from the
+  operator process and must be narrowed by an OS or container policy when
+  required;
 - reference plugins are tested against adversarial fixtures.
+
+The deliberate crash, malformed-output, and timeout behaviors used by the
+generic conformance kit exist only in a disposable synthetic package and
+isolated state. They are not a required production-plugin interface.
 
 ### Malformed or ambiguous artifact
 
@@ -88,6 +106,9 @@ Controls:
 - checker-side binding validation before mathematical replay;
 - conjecture repair and generalization replay the cited verification record
   with its authorized checker and require the reproduced record identity;
+- parameter-region promotion requires the exact subject and declared claim
+  artifact URIs in the verification record's parents; equal object digests in
+  different artifact carriers are insufficient;
 - no caller-controlled checker executable.
 
 ### Buggy or compromised checker
@@ -125,7 +146,8 @@ Controls:
 ### Operational failure
 
 Processes may time out, crash, be cancelled, lose output, or exceed resource
-limits.
+limits. Durable metadata may also be truncated, malformed, or internally
+inconsistent after a storage or software failure.
 
 Controls:
 
@@ -134,6 +156,12 @@ Controls:
 - idempotency keys select one durable search invocation, append-only event
   chains preserve retries and runtime identity, and interrupted invocations
   recover from immutable checkpoints;
+- recovery validates a snapshot against its database key and indexed state;
+  malformed rows are quarantined as `ERROR` without stopping unrelated
+  recovery;
+- checkpoint restoration rebinds request, package snapshot, implementation,
+  environment, budget, archive, and accounting identity before opaque strategy
+  state is reused;
 - reached limits downgrade coverage;
 - tool errors cannot be translated into false, infeasible, or exhaustive.
 
@@ -215,6 +243,8 @@ verification tools.
 - Side-channel resistance
 - Multi-tenant authorization
 - Remote identity and signing infrastructure
+- Distributed worker leases or multiple active Jacobian coordinators sharing a
+  state directory
 - Formal verification of the artifact store
 - Proof that a formal statement matches informal mathematical intent
 

--- a/docs/how-to/resume-search.md
+++ b/docs/how-to/resume-search.md
@@ -1,0 +1,57 @@
+# Inspect, pause, and resume a search
+
+[Documentation home](../index.md)
+
+Use these commands when a `search-run` request has returned an experiment URI
+and you need to inspect or control that experiment. Keep the same
+`--state-dir` for every command; the state directory is the durable owner of
+the experiment.
+
+Set the values in your shell:
+
+```sh
+JACOBIAN_STATE=.jacobian
+EXPERIMENT_URI='jacobian:experiment:replace-with-your-id'
+```
+
+Inspect the current snapshot:
+
+```sh
+uv run jacobian --state-dir "$JACOBIAN_STATE" \
+  experiment-inspect "$EXPERIMENT_URI"
+```
+
+Pause a running experiment at its next checkpoint boundary:
+
+```sh
+uv run jacobian --state-dir "$JACOBIAN_STATE" \
+  experiment-pause "$EXPERIMENT_URI"
+```
+
+Resume from the last committed checkpoint:
+
+```sh
+uv run jacobian --state-dir "$JACOBIAN_STATE" \
+  experiment-resume "$EXPERIMENT_URI"
+```
+
+Wait for a terminal or paused snapshot:
+
+```sh
+uv run jacobian --state-dir "$JACOBIAN_STATE" \
+  experiment-wait "$EXPERIMENT_URI" --timeout-seconds 30
+```
+
+If the process was lost, create a new Jacobian process against the same state
+directory and inspect the experiment before resuming it. Recovery uses the
+accepted request, append-only lifecycle events, and the last immutable
+checkpoint; it does not depend on chat history.
+
+One process must own a state directory at a time. The current implementation
+does not provide a distributed lease or queue, so do not point concurrent
+Jacobian processes at the same directory.
+
+See [Durable search runtime](../explanation/search-runtime.md) for the
+checkpoint and recovery model, and
+[M3 scalable search](../reference/milestones/m3-scalable-search.md) for the
+provisional contract.

--- a/docs/how-to/run-plugin-conformance.md
+++ b/docs/how-to/run-plugin-conformance.md
@@ -1,0 +1,51 @@
+# Run the plugin conformance kit
+
+[Documentation home](../index.md)
+
+Run the conformance kit before treating a sealed plugin as compatible with the
+provisional M3 runtime. The target must be disposable: several checks mutate
+the package or create attack paths intentionally.
+
+## Prepare the target
+
+Install the plugin into a fresh `JacobianKernel`, create a minimal claim it can
+search, and construct a `SyntheticPluginConformanceTarget` with:
+
+- the kernel and installed plugin identifier;
+- a bounded `SearchRunRequest`;
+- the plugin entry-point file;
+- a path and external target for the symlink-escape check; and
+- an import marker that would reveal discovery-time execution.
+
+The integration test
+[`test_external_plugin_passes_the_generic_conformance_kit`][conformance-test]
+is the executable example. It installs a synthetic third plugin without
+changing the kernel or MCP adapter.
+
+[conformance-test]: ../../tests/integration/test_plugin_registry_snapshots.py
+
+## Run the checks
+
+Use `require_plugin_conformance` when any failed check should fail the test:
+
+```python
+from jacobian.plugin_conformance import require_plugin_conformance
+
+
+observations = require_plugin_conformance(target)
+for observation in observations:
+    print(observation.check.value, observation.passed, observation.detail)
+```
+
+Use `run_plugin_conformance` instead when a reporting tool needs all
+observations without raising `PluginConformanceError`.
+
+The target passes only when every standard observation passes. The matrix
+covers successful execution, declared failure, malformed output, timeout,
+path and symlink attacks, changed implementation bytes, unsupported evidence
+promotion, and discovery without importing plugin code.
+
+For target fields and exact pass conditions, consult the
+[plugin conformance reference](../reference/plugin-conformance.md). The
+[sealed plugin ADR](../explanation/adr/0002-sealed-plugin-packages.md) explains
+why package identity and discovery are part of the trust boundary.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,95 @@
+# Jacobian documentation
+
+Jacobian's documentation is organized by what the reader is trying to do.
+Start with a tutorial when learning the system, use a how-to guide for a
+specific task, consult reference material for exact contracts, and read the
+explanations for design rationale.
+
+The only current release contract is v0.2 alpha. Documents for M3, M4, M5, and
+v1.0 describe provisional or planned work unless they explicitly say
+otherwise.
+
+## Project control documents
+
+These documents track the design while the public API and artifact formats are
+still pre-stable:
+
+| Question | Document | Status |
+| --- | --- | --- |
+| What does the system currently look like? | [Architecture](explanation/architecture.md) | Current v0.2 design plus labeled provisional M3/M4 sections |
+| What is implemented, provisional, or planned? | [Roadmap](explanation/roadmap.md) | Active milestone plan; gates are not promised release dates |
+| Why were cross-cutting choices made? | [Architecture decision log](explanation/adr/index.md) | Accepted decisions with release scope |
+| Which properties and trust boundaries must hold? | [Threat model](explanation/threat-model.md) | Current for v0.2 and provisional M3/M4 code |
+| What is the supported release contract? | [v0.2 specification](reference/specifications/v0.2.md) and [conformance gate](reference/conformance-v0.2.md) | Normative for `0.2.0a0` |
+| Which later contracts are being exercised? | [M3](reference/milestones/m3-scalable-search.md) and [M4](reference/milestones/m4-conjecture-workflows.md) | Provisional; outside v0.2 conformance |
+
+## Tutorials
+
+Tutorials are guided learning paths. They assume no prior Jacobian experience
+and build toward a complete result.
+
+- [Find and verify a counterexample](tutorials/first-verified-result.md) shows
+  the boundary between an unverified evaluator result and independently
+  verified evidence.
+
+## How-to guides
+
+How-to guides assume you already understand Jacobian's basic model and need to
+complete a specific task.
+
+- [Inspect, pause, and resume a search](how-to/resume-search.md)
+- [Run the plugin conformance kit](how-to/run-plugin-conformance.md)
+
+## Reference
+
+Reference documents define exact interfaces, records, gates, and test
+expectations.
+
+- [Tool surface](reference/tools.md)
+- [v0.2 specification](reference/specifications/v0.2.md)
+- [v0.2 conformance specification](reference/conformance-v0.2.md)
+- [Plugin conformance contract](reference/plugin-conformance.md)
+- [Mathematical scenario catalog](reference/math-scenarios.md)
+- [Reference benchmarks](reference/benchmarks.md)
+- [Performance benchmark protocol](reference/performance-benchmarks.md)
+- [Testing strategy](reference/testing-strategy.md)
+- [Agent evaluation protocol](reference/agent-evaluations.md)
+
+Later-release contracts are provisional:
+
+- [M3 scalable search](reference/milestones/m3-scalable-search.md)
+- [M4 conjecture workflows](reference/milestones/m4-conjecture-workflows.md)
+- [M5 research corpus integration](reference/milestones/m5-research-corpus.md)
+- [v1.0 stability target](reference/specifications/v1.0.md)
+
+## Explanation
+
+Explanation documents describe why Jacobian has its current boundaries and
+how its major parts fit together.
+
+- [Architecture](explanation/architecture.md)
+- [Threat model](explanation/threat-model.md)
+- [Roadmap](explanation/roadmap.md)
+- [Durable search runtime](explanation/search-runtime.md)
+- [Architecture decision log](explanation/adr/index.md)
+- [ADR 0001: Python-first control plane](explanation/adr/0001-python-first-control-plane.md)
+- [ADR 0002: Sealed plugin packages](explanation/adr/0002-sealed-plugin-packages.md)
+- [ADR 0003: Durable search invocations](explanation/adr/0003-durable-search-invocations.md)
+- [ADR 0004: Verified parameter regions](explanation/adr/0004-verified-parameter-regions.md)
+
+## Contributing
+
+Read [CONTRIBUTING.md](../CONTRIBUTING.md) before changing code or public
+documentation. The [issue index](contributing/issues.md) records implementation
+work that has been identified but not necessarily scheduled.
+
+When adding a document, place it according to the reader's need:
+
+- `tutorials/` for a guided learning experience;
+- `how-to/` for completing one task;
+- `reference/` for contracts and lookup material;
+- `explanation/` for design context and decisions.
+
+Do not mix release status. A v0.2 document is normative only when the v0.2
+specification or conformance document says so; milestone documents remain
+provisional until their release is declared.

--- a/docs/reference/agent-evaluations.md
+++ b/docs/reference/agent-evaluations.md
@@ -1,5 +1,7 @@
 # Agent evaluations
 
+[Documentation home](../index.md)
+
 ## Purpose
 
 Jacobian is useful only if it changes research behavior, not merely if its APIs

--- a/docs/reference/benchmarks.md
+++ b/docs/reference/benchmarks.md
@@ -1,5 +1,7 @@
 # Reference benchmarks
 
+[Documentation home](../index.md)
+
 Benchmarks validate the generic kernel; they do not define its public API.
 
 This document defines pass/fail mathematical workloads. Operational speed and

--- a/docs/reference/conformance-v0.2.md
+++ b/docs/reference/conformance-v0.2.md
@@ -1,8 +1,17 @@
 # v0.2 conformance specification
 
+[Documentation home](../index.md)
+
+- Status: Normative release gate for `0.2.0a0`
+- Release specification: [v0.2 bounded discovery](specifications/v0.2.md)
+
 This document defines the complete normative conformance suite for Jacobian
 v0.2. Search, evaluation, canonicalization, transformation proposal, and solver
 output are untrusted unless an authorized checker accepts their bound evidence.
+
+The provisional M3 strategy-search and M4 conjecture APIs present in the
+repository are outside this release gate. They must preserve these invariants,
+but passing their tests does not extend the v0.2 public contract.
 
 ## Result invariants
 

--- a/docs/reference/math-scenarios.md
+++ b/docs/reference/math-scenarios.md
@@ -1,5 +1,7 @@
 # Mathematical scenario catalog
 
+[Documentation home](../index.md)
+
 - Status: Draft
 - Purpose: Exact public fixtures, reference-plugin workloads, and held-out
   model evaluations

--- a/docs/reference/milestones/m3-scalable-search.md
+++ b/docs/reference/milestones/m3-scalable-search.md
@@ -1,6 +1,8 @@
 # Milestone 3 specification: scalable search
 
-- Status: Provisional
+[Documentation home](../../index.md)
+
+- Status: Provisional implementation; outside v0.2 conformance
 - Theme: Run typed search strategies through one durable experiment loop
 
 ## 1. Entry gate
@@ -95,7 +97,7 @@ evaluation envelopes and optional strategy metrics
 proposed counterexamples and verified witness records
 candidate nominations and resulting verification records
 checkpoint state and random-state identity
-scope, budget, timestamps, and resource accounting
+scope, budget, timestamps, measured wall time, and operation accounting
 typed failures, cancellation, timeout, and recovery events
 ```
 
@@ -103,10 +105,23 @@ Strategy metrics may be scalar, vector-valued, ordered, or absent. They cannot
 replace hard validity constraints or assurance labels. A complete experiment
 can be reconstructed without a host transcript.
 
-Worker invocations are idempotent. Concurrent or transport-retried requests
-resolve to one accepted invocation, and append-only lifecycle events bind the
-exact inputs, outputs, runtime identity, effective policy, resource use, and
-retry lineage.
+Search acceptance is idempotent. Concurrent or transport-retried submissions
+with the same idempotency key and request digest resolve to one experiment URI.
+The key cannot be rebound to another request. Append-only lifecycle events bind
+the accepted request, operation inputs and outputs, runtime identity, effective
+policy, configured limits, observed runtimes, and retry lineage.
+
+Plugin work after the last committed checkpoint may execute again after process
+loss. That repeat is an attempt in the same durable invocation, not a second
+accepted experiment. Only atomically committed archive pages, checkpoints, and
+events become lineage.
+
+Wall accounting includes plugin execution and artifact persistence through
+creation of each immutable checkpoint. Jacobian samples the measurement
+immediately after that artifact is created and before the following SQLite
+metadata transaction; lifecycle events record the transaction's ordering.
+Jacobian does not claim CPU, memory, network-byte, or filesystem-byte metering
+that the local runtime does not observe.
 
 ## 6. Plugin packaging and conformance
 
@@ -126,6 +141,15 @@ timeout, path and symlink attacks, changed implementation bytes, and
 unsupported evidence promotion. A synthetic third plugin must pass without
 kernel or MCP changes.
 
+`jacobian.plugin_conformance` provides a standard runner over a sealed,
+conformance-only plugin package in isolated test state, a search request, and
+disposable package attack fixtures. Each suite execution uses a fresh
+idempotency namespace. The runner drives declared search capabilities and the
+conjecture workflow itself, performs registry attacks with fresh fixture state,
+runs every generic check, and reports all failures together. Fault injection
+belongs only in this disposable synthetic package; production plugins do not
+expose conformance crash, malformed-output, or timeout controls.
+
 ## 7. Execution
 
 Scale only as evidence requires:
@@ -137,6 +161,8 @@ Scale only as evidence requires:
 
 The first three stages use ordinary process boundaries, SQLite state, and the
 existing artifact store. Distributed infrastructure is not an M3 requirement.
+The reference scheduler currently accepts exactly one strategy worker; asking
+for more fails validation rather than being silently clamped.
 
 Local workers use explicit wall-clock and output limits, fixed seeds where the
 backend supports them, and recorded environment identities. These are
@@ -144,23 +170,56 @@ operational and reproducibility controls, not a security sandbox. Jacobian does
 not accept arbitrary executable uploads; operators install plugins and checkers
 they consider safe to run locally.
 
-Effective worker authority is the restrictive intersection of the plugin
-contract, operator policy, and invocation request. No layer may widen resource,
-network, filesystem, artifact, or checker authority.
+For authority represented by Jacobian, effective worker policy is the
+restrictive intersection of the plugin contract, operator policy, and
+invocation request. A local worker inherits the network and filesystem boundary
+of the operator process. Jacobian neither widens that boundary nor claims to
+narrow it; operators requiring isolation must launch Jacobian under an
+appropriate OS or container policy. Plugins and requests cannot widen budget,
+artifact, capability, or checker authority.
 
-## 8. Exit gate
+## 8. Implemented scope and limits
+
+The provisional reference implementation provides:
+
+- proposer, evaluator, optional witness-oracle, refiner, and nomination flow;
+- transactional idempotent request acceptance;
+- immutable archive pages, checkpoints, and terminal archives;
+- append-only lifecycle events;
+- pause, resume, cancellation, timeout, and startup recovery;
+- per-row quarantine for malformed recovery state;
+- whole-package plugin snapshots and the synthetic conformance suite.
+
+The scheduler accepts exactly one strategy worker. One active Jacobian process
+must own a state directory; there is no lease protocol for multiple
+coordinators. Plugin calls run in bounded child processes, but network and
+filesystem access are inherited from the operator process. Accounting records
+exact operation counts and measured wall time at the documented checkpoint
+boundary; it does not claim CPU, memory, network-byte, or filesystem-byte
+metering.
+
+Operational detail and rationale are recorded in:
+
+- [Durable search runtime](../../explanation/search-runtime.md)
+- [Sealed plugin package ADR](../../explanation/adr/0002-sealed-plugin-packages.md)
+- [Durable invocation ADR](../../explanation/adr/0003-durable-search-invocations.md)
+- [Plugin conformance kit](../plugin-conformance.md)
+
+## 9. Exit gate
 
 Milestone 3 is complete when:
 
 - a long strategy-neutral search can pause, resume, and reproduce its archive
-  lineage and exact accounting;
+  lineage and measured accounting at the documented persistence boundary;
 - independently verified counterexamples influence subsequent refinement;
 - nominated candidates cross the existing checker boundary;
 - concurrent or retried requests create one durable invocation;
 - process loss can be reconstructed without chat state and resumed without
   losing or duplicating lineage;
+- one malformed persisted invocation is quarantined without preventing
+  unrelated invocations from recovering;
 - a sealed synthetic plugin passes generic conformance without kernel or MCP
   changes;
-- worker timeout, output-limit, and resource-exhaustion tests fail safely;
+- worker timeout and output-limit tests fail safely;
 - workers cannot widen execution policy or checker authority;
 - distributed execution, if present, cannot forge checker authorization.

--- a/docs/reference/milestones/m4-conjecture-workflows.md
+++ b/docs/reference/milestones/m4-conjecture-workflows.md
@@ -1,6 +1,8 @@
 # Milestone 4 specification: conjecture workflows
 
-- Status: Provisional
+[Documentation home](../../index.md)
+
+- Status: Provisional implementation; outside v0.2 conformance
 - Theme: Give agents tools for developing conjectures
 
 ## 1. Entry gate
@@ -10,11 +12,12 @@ constructions, and transformation lineage.
 
 ## 2. Shared plugin operation
 
-All three M4 tools use one optional `HypothesisTransformer` plugin capability.
-The operation is typed as repair, generation, or parameter generalization, but
-the plugin owns its grammar, solver, enumerator, or heuristic. The kernel owns
-schema validation, exact source lineage, deduplication, budgets, and routing
-back into the M3 falsification loop.
+The three hypothesis-producing M4 tools use one optional
+`HypothesisTransformer` plugin capability. The operation is typed as repair,
+generation, or parameter generalization, but the plugin owns its grammar,
+solver, enumerator, or heuristic. The kernel owns schema validation, exact
+source lineage, deduplication, budgets, and routing back into the M3
+falsification loop.
 
 ### `conjecture.repair`
 
@@ -61,9 +64,33 @@ The output separates:
 
 A plugin may report only proposed or sampled region evidence. Sufficient or
 necessary conditions become verified only when a compatible independent
-checker emits a verification record bound to the exact region.
+checker emits a certificate verification record bound to the exact region.
+Jacobian first stores an immutable region subject containing the target claim,
+relation, and canonical conditions. `parameter.region.promote` replays that
+certificate with its authorized checker and accepts only the identical
+verification-record URI before returning a verified sufficient or necessary
+label.
 Artifacts cited as samples must be supplied explicitly as workflow evidence;
 plugin output cannot introduce or relabel unrelated stored artifacts.
+
+### `parameter.region.promote`
+
+Promotion is a kernel verification operation, not a hypothesis-plugin
+capability. It accepts an immutable parameter-region subject URI and a
+verification-record URI. The service requires:
+
+- the subject schema and its declared claim/sample lineage;
+- matching claim and subject semantics;
+- certificate evidence with conclusion `TRUE`;
+- claim and candidate object digests bound to the exact subject payload;
+- the exact subject and declared claim artifact URIs in the verification
+  record's parents;
+- successful replay that reproduces the supplied verification-record URI.
+
+The exact artifact-parent checks matter because two artifacts may have equal
+object digests while carrying different lineage or summary metadata. Promotion
+returns the label implied by the subject's `SUFFICIENT` or `NECESSARY` kind only
+after all checks pass.
 
 ## 3. Workflow
 
@@ -83,13 +110,30 @@ No workflow engine, synthesis framework, or evolutionary-search runtime is
 required. M4 composes immutable artifacts, the installed plugin boundary, and
 the M3 experiment service.
 
-## 4. Exit gate
+## 4. Implemented scope and limits
+
+The provisional implementation provides all three hypothesis transformations,
+exact source-record replay, immutable edit and transformation records,
+request-local deduplication, optional M3 falsification, sampled-evidence
+lineage, and explicit parameter-region promotion through Python, CLI, and MCP
+surfaces.
+
+It does not define a universal conjecture grammar, global novelty measure,
+parameter-region proof format, or domain-independent meaning for sufficient and
+necessary conditions. Authorized domain checkers own that mathematics. M5
+corpus integration remains optional and unimplemented.
+
+See
+[ADR 0004](../../explanation/adr/0004-verified-parameter-regions.md)
+for the immutable subject and exact-carrier decision.
+
+## 5. Exit gate
 
 Milestone 4 is complete when:
 
 - every generated statement has a precise source and transformation record;
-- one synthetic plugin implements all three operations without kernel or MCP
-  changes;
+- one synthetic plugin implements all three hypothesis operations without
+  kernel or MCP changes;
 - generated and repaired statements remain hypotheses;
 - immediate counterexamples are stored with verified witnesses;
 - parameter claims distinguish proved and sampled regions;

--- a/docs/reference/milestones/m5-research-corpus.md
+++ b/docs/reference/milestones/m5-research-corpus.md
@@ -1,5 +1,7 @@
 # Milestone 5 specification: research corpus integration
 
+[Documentation home](../../index.md)
+
 - Status: Provisional
 - Theme: Retrieve prior work without confusing memory with proof
 

--- a/docs/reference/performance-benchmarks.md
+++ b/docs/reference/performance-benchmarks.md
@@ -1,5 +1,7 @@
 # Performance benchmarks
 
+[Documentation home](../index.md)
+
 ## Purpose
 
 Performance benchmarks answer operational questions: how quickly and at what
@@ -238,7 +240,8 @@ Measure:
 - checkpoint, cancellation, crash recovery, and resume time;
 - duplicate work under worker failure;
 - local worker cold start, warm start, and process-limit overhead;
-- single-process versus multi-process scaling efficiency.
+- single-worker baseline cost and, only if a lease-based scheduler is added,
+  multi-process scaling efficiency.
 
 Establish a correct sequential reference run before interpreting parallel
 speedups.

--- a/docs/reference/plugin-conformance.md
+++ b/docs/reference/plugin-conformance.md
@@ -1,0 +1,118 @@
+# Plugin conformance kit
+
+[Documentation home](../index.md)
+
+- Status: Provisional M3 implementation
+- Python API: `jacobian.plugin_conformance`
+
+The conformance kit tests whether an independently installed package crosses
+Jacobian's registry, execution, search, and conjecture boundaries without core
+or MCP changes. It is an executable extension gate, not a second unit-test
+framework.
+
+## Scope
+
+The kit proves that:
+
+- discovery and capability resolution use the sealed installed package;
+- declared capabilities can complete one ordinary strategy search;
+- failure, malformed output, and timeout remain operational states;
+- traversal, symlink, and changed-byte attacks fail closed;
+- an untrusted hypothesis transformer cannot promote evidence.
+
+It does not prove that the plugin's mathematics is correct, that its search is
+complete, or that installed code is safe for the host. Those properties require
+domain tests, authorized checkers, and operator isolation policy.
+
+## Disposable target package
+
+Fault injection belongs in a separate conformance-only package installed into
+isolated test state. Do not expose the conformance selector from a production
+plugin.
+
+The synthetic package declares ordinary `Proposer`, `Refiner`, `Evaluator`, and
+`HypothesisTransformer` capabilities. Its proposer reads
+`state["conformance_case"]` only inside this disposable package:
+
+| Value | Required behavior |
+| --- | --- |
+| `execution-success` | Return a schema-valid finite proposal and complete normally |
+| `declared-failure` | Raise a controlled error containing `declared plugin failure` |
+| `malformed-output` | Return a non-object response |
+| `timeout` | Remain active beyond the supplied wall budget |
+
+The refiner and evaluator return valid ordinary contract responses. The
+hypothesis transformer attempts a verified parameter-region label so the
+workflow can demonstrate fail-closed rejection.
+
+## Runner inputs
+
+`SyntheticPluginConformanceTarget` requires:
+
+- an isolated `JacobianKernel`;
+- the installed synthetic plugin artifact URI;
+- a valid base `SearchRunRequest`;
+- the package implementation file to modify and restore;
+- a disposable in-package symlink path and an outside target;
+- optionally, an import marker written by the package's `__init__.py`.
+
+The current interface is a Python operator/test API:
+
+```python
+from jacobian.plugin_conformance import (
+    SyntheticPluginConformanceTarget,
+    require_plugin_conformance,
+)
+
+target = SyntheticPluginConformanceTarget(
+    kernel=kernel,
+    plugin_id=plugin_id,
+    search_request=request,
+    implementation_file=package / "entry.py",
+    symlink_path=package / "escape.py",
+    symlink_target=outside_file,
+    import_marker=import_marker,
+)
+
+observations = require_plugin_conformance(target)
+```
+
+The runner executes all checks and raises one `PluginConformanceError`
+containing every failure. `run_plugin_conformance` returns the observations
+without raising.
+
+## Standard matrix
+
+| Check | Boundary exercised | Passing result |
+| --- | --- | --- |
+| Execution success | Registry resolution and `SearchService` | Strategy completion with no verification promotion |
+| Declared failure | Worker and search lifecycle | `ERROR` with the declared detail |
+| Malformed output | Worker JSON boundary | `ERROR`; response is not accepted as a proposal |
+| Timeout | Worker and durable budget | `TIMEOUT` with wall-limit stop reason |
+| Path attack | Implementation registration | Traversal is rejected |
+| Symlink attack | Whole-package measurement | Package symlink is rejected |
+| Changed bytes | Capability resolution | Installed snapshot refuses changed source |
+| Evidence promotion | `ConjectureService` | `ERROR`, no hypotheses, `UNVERIFIED` |
+
+Each suite execution creates a fresh idempotency namespace. Repeated runs
+therefore execute proposer, evaluator, and refiner code again instead of
+returning earlier durable search results. The runner removes only the supplied
+disposable import marker and symlink, and restores the implementation file
+after the changed-byte check.
+
+## Discovery without import
+
+An import marker makes the no-import rule observable. Package installation and
+capability resolution must leave the marker absent. The first successful worker
+execution imports the package in its child process and creates the marker.
+
+The registry measures all regular source files in the package, not just the
+selected entrypoint file. A symlink anywhere in that measured package invalidates
+resolution.
+
+## Related decisions
+
+- [Sealed package ADR](../explanation/adr/0002-sealed-plugin-packages.md)
+- [Milestone 3 specification](milestones/m3-scalable-search.md)
+- [Testing strategy](testing-strategy.md)
+- [Threat model](../explanation/threat-model.md)

--- a/docs/reference/specifications/v0.2.md
+++ b/docs/reference/specifications/v0.2.md
@@ -1,7 +1,13 @@
 # v0.2 specification: bounded discovery
 
+[Documentation home](../../index.md)
+
 - Status: Implemented alpha; normative for `0.2.0a0`
 - Theme: Search bounded spaces and verify representation changes
+
+The repository also contains provisional M3/M4 implementations. Their
+milestone documents are design and test targets, not additions to this v0.2
+wire or artifact contract.
 
 ## 1. Scope
 
@@ -144,7 +150,9 @@ resident worker process.
 The alpha experiment store has one live process owner. Do not open the same
 state directory from another Jacobian process while an experiment is running;
 startup recovery treats nonterminal rows as interrupted work. Multi-process
-leases and resumable ownership are M3 work.
+leases remain outside v0.2. The provisional M3 strategy runtime adds
+checkpoint-based restart recovery, but still requires one active coordinator
+per state directory.
 
 Enumeration completeness is not inferred from the absence of candidates. A
 negative mathematical result requires a checked enumeration certificate.

--- a/docs/reference/specifications/v1.0.md
+++ b/docs/reference/specifications/v1.0.md
@@ -1,5 +1,7 @@
 # v1.0 specification: stable research platform
 
+[Documentation home](../../index.md)
+
 - Status: Provisional
 - Theme: Reproducible publication and independent replication
 

--- a/docs/reference/testing-strategy.md
+++ b/docs/reference/testing-strategy.md
@@ -1,5 +1,7 @@
 # Testing strategy
 
+[Documentation home](../index.md)
+
 ## Purpose
 
 Jacobian is a fail-closed verification system. Its tests must establish more
@@ -291,10 +293,20 @@ Required tests:
 - capability resolution is deterministic and version-aware;
 - manifests bind their semantics and implementation digests;
 - a changed implementation cannot retain the old manifest identity;
+- discovery measures a package without importing its code;
+- registry snapshots bind all declared capabilities to the whole-package source
+  digest, runtime/build identity, and platform compatibility;
+- path traversal, symlinks, bytecode-only or native module execution, and
+  changed package bytes fail closed;
 - domain-specific graph, matrix, solver, or proof types never enter the core
   manifest;
 - a manifest cannot authorize, replace, or revoke a checker;
-- two structurally different plugins use the same generic dispatch path.
+- two structurally different plugins use the same generic dispatch path;
+- a disposable synthetic third plugin passes success, declared-failure,
+  malformed-output, timeout, package-attack, and unsupported-promotion checks
+  without kernel or MCP changes;
+- each conformance-suite run uses fresh invocation identities and executes the
+  plugin again rather than reusing prior durable results.
 
 ### Checker registry
 
@@ -372,6 +384,54 @@ Required tests:
 - changing evaluator, scope, limits, seed when semantically relevant, or
   environment invalidates the corresponding cache entry;
 - evaluator and oracle bugs cannot write to the checker registry.
+
+### Durable strategy search
+
+Required tests:
+
+- concurrent submissions with one idempotency key and request digest select one
+  accepted experiment URI;
+- reusing an idempotency key with a different request fails before execution;
+- every lifecycle event binds its predecessor and update/delete attempts fail;
+- process recovery pauses active work at the last committed checkpoint and
+  preserves archive and retry lineage;
+- corrupt JSON, a row/snapshot identity mismatch, and an invalid indexed state
+  are quarantined independently without blocking a valid experiment;
+- restoration rejects changes to request, registry snapshot, proposer, refiner,
+  evaluator, environment, budget, archive, or accounting identity;
+- plugin work after an uncommitted checkpoint may repeat, but committed
+  archive pages and nominations are not duplicated;
+- checkpoint artifact persistence is included in measured wall time, and a
+  strategy cannot report completion after that measurement exceeds the wall
+  budget;
+- `workers > 1` fails validation instead of being silently clamped;
+- pause, cancellation, timeout, strategy completion, candidate limits, and
+  iteration limits remain distinct operational outcomes;
+- verified counterexample feedback cites an authorized verification record,
+  while heuristic feedback remains unverified;
+- workers and plugins cannot authorize a checker or widen any
+  Jacobian-represented budget or capability.
+
+### Conjecture workflows
+
+Required tests:
+
+- repair requires an exact authorized `REFUTES_CLAIM` record for the source
+  claim;
+- parameter generalization requires an exact verified construction source;
+- plugin proposals can produce only proposed or sampled parameter-region
+  evidence and cannot bind a region subject;
+- sampled regions cite only artifacts supplied as workflow evidence;
+- each committed hypothesis records its source, edit, plugin snapshot, and
+  implementation identity;
+- identical claim payloads deduplicate without losing transformation lineage;
+- falsification routes through `search.run` and cannot turn non-falsification
+  into verification;
+- promotion accepts sufficient and necessary labels only after authorized
+  certificate replay reproduces the exact verification-record URI;
+- promotion rejects a same-object/different-artifact subject carrier and a
+  record that omits the exact declared claim or subject parent;
+- CLI, MCP, and Python service paths preserve the same verification boundary.
 
 ### Shrinking
 
@@ -653,29 +713,31 @@ The normative attack matrix is
 unverified; a theorem inferred from the absence of a candidate needs a
 domain-specific completeness certificate and checker.
 
-## Planned-milestone test additions
+## Provisional and planned milestone coverage
 
 ### M3
 
-- deterministic single-worker lineage before concurrency;
-- resumability, idempotency, durable lifecycle, and worker-crash state
-  machines;
-- local worker timeout, output-limit, and dependency-pinning tests;
-- concurrent-retry and duplicate-work tests for every supported execution
-  mode;
-- search never bypasses candidate nomination and v0.2 verification;
-- no strategy-specific score, exhaustion state, or failure becomes a
-  mathematical conclusion.
+The current provisional suite covers deterministic single-worker lineage,
+pause/resume, startup recovery, idempotent concurrent submission, corrupt-row
+quarantine, plugin timeouts, package identity, generic conformance, verified
+counterexample feedback, and candidate nomination through existing verification
+services.
+
+Before an M3 release, add process-kill tests at each persistence boundary and,
+if multi-process or distributed scheduling is introduced, lease-expiry and
+duplicate-acceptance state machines. No strategy-specific score, exhaustion
+state, or failure may become a mathematical conclusion.
 
 ### M4
 
-- generated and repaired conjectures always remain hypotheses;
-- repair requires an authorized verification record for an exact
-  `REFUTES_CLAIM` witness;
-- falsification pipelines cannot self-promote claims;
-- hypothesis plugins cannot label parameter regions as proved;
-- parameter-region certificates bind the original claim and encoding;
-- corpus-free workflows report global novelty as unknown.
+The current provisional suite covers all three hypothesis operations, exact
+source-record replay, duplicate claims, sampled-evidence lineage, optional M3
+falsification, unsupported promotion attempts, and sufficient/necessary region
+promotion through exact certificate replay.
+
+Before an M4 release, add broader cross-domain fixtures and clean-process
+replay for every authorized parameter-region certificate format. Corpus-free
+workflows must continue to report global novelty as unknown.
 
 ### M5
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -1,5 +1,11 @@
 # Tool surface
 
+[Documentation home](../index.md)
+
+- Status: v0.2 surface plus explicitly labeled provisional and planned tools
+- Normative sources: [v0.2 specification](specifications/v0.2.md) and
+  [conformance gate](conformance-v0.2.md)
+
 Jacobian is a general research kernel. Its core tools understand artifacts,
 claims, candidates, predicates, witnesses, certificates, reductions, budgets,
 and provenance. Mathematical meaning is supplied by versioned domain plugins.
@@ -45,7 +51,7 @@ Search strategies share a typed experiment operation:
 | Availability | Tool | Capability |
 | --- | --- | --- |
 | v0.2 | `search.enumerate` | Exhaustively enumerate a bounded candidate class using a domain-provided enumerator and auditable scope. |
-| M3 | `search.run` | Run a typed proposer, evaluator, counterexample, refinement, and nomination loop as a durable experiment. |
+| Provisional M3 | `search.run` | Run a typed proposer, evaluator, counterexample, refinement, and nomination loop as a durable experiment. |
 
 These tools start experiment jobs and return experiment resource handles. They
 do not produce verified conclusions by themselves. Exact enumeration, CEGIS,
@@ -53,9 +59,9 @@ constraint solving, parameter sweeps, beam or tree search, evolutionary search,
 and agent-driven loops are strategies behind the common M3 orchestration
 contract rather than separate kernel tools.
 
-The resident MCP server returns the `search.enumerate` handle immediately. The
-local CLI waits for the bounded experiment and prints its terminal snapshot,
-because a daemon worker cannot outlive a short-lived CLI process.
+The resident MCP server returns `search.enumerate` and `search.run` handles
+immediately. The local CLI waits for the bounded experiment and prints its
+settled snapshot because a worker cannot outlive a short-lived CLI process.
 
 ## Optional domain tools
 
@@ -78,9 +84,10 @@ separately verified:
 
 | Milestone | Tool | Capability |
 | --- | --- | --- |
-| M4 | `conjecture.repair` | Propose nearby claims after a counterexample by changing assumptions, constants, domains, or conclusions. |
-| M4 | `conjecture.generate` | Generate, deduplicate, falsify, and rank candidate statements. |
-| M4 | `parameter.generalize` | Propose parameter regions around a verified construction and preserve proposed, sampled, or independently verified evidence labels. |
+| Provisional M4 | `conjecture.repair` | Propose nearby claims after a counterexample by changing assumptions, constants, domains, or conclusions. |
+| Provisional M4 | `conjecture.generate` | Generate, deduplicate, falsify, and rank candidate statements. |
+| Provisional M4 | `parameter.generalize` | Propose parameter regions around a verified construction and preserve proposed or sampled evidence labels. |
+| Provisional M4 | `parameter.region.promote` | Replay an authorized certificate bound to an immutable region subject before labeling it verified sufficient or necessary. |
 | M5 | `memory.search` | Ask an optional corpus provider for prior experiments, failures, witnesses, certificates, and research episodes with trust labels. |
 | M5 | `abstraction.extract` | Suggest an abstract mathematical explanation for supplied or retrieved artifacts. |
 | M5 | `episode.compare` | Compare failures and propose recurring obstructions or no-go lemmas. |
@@ -90,11 +97,12 @@ The M4 tools operate without a shared corpus. When no M5 provider is
 configured, they deduplicate against supplied or local experiment records and
 report corpus-wide novelty as unknown. Corpus retrieval can suggest inputs to
 any tool but cannot authorize checkers or promote verification status.
-All three M4 tools share one `HypothesisTransformer` plugin operation and may
-route their outputs through `search.run`; Jacobian does not embed a conjecture
-grammar or synthesis framework. Sample artifacts must enter through the tools'
-explicit evidence inputs before a plugin may cite them in a sampled parameter
-region.
+The three hypothesis-producing M4 tools share one `HypothesisTransformer`
+plugin operation and may route their outputs through `search.run`; Jacobian
+does not embed a conjecture grammar or synthesis framework.
+`parameter.region.promote` is a kernel verification operation, not a fourth
+plugin transformation. Sample artifacts must enter through explicit workflow
+evidence before a plugin may cite them in a sampled parameter region.
 
 ## Internal backends
 
@@ -125,9 +133,10 @@ records are all ordinary artifacts and use the artifact resource template.
 reference fixtures. Checker administration remains outside the model-facing
 MCP surface.
 
-v0.2 experiment resources expose durable snapshots and compact artifact
-handles. `experiment.cancel` is a tool because it changes state. Pause and
-resume remain later work.
+Experiment resources expose durable snapshots and compact artifact handles.
+`experiment.cancel`, `experiment.pause`, and `experiment.resume` change
+provisional M3 strategy-search state. Pause takes effect at a committed
+checkpoint; resume continues the same invocation and lineage.
 
 ## Operator actions, not model tools
 

--- a/docs/tutorials/first-verified-result.md
+++ b/docs/tutorials/first-verified-result.md
@@ -1,0 +1,131 @@
+# Find and verify a counterexample
+
+[Documentation home](../index.md)
+
+This tutorial runs one bounded graph experiment from artifact creation through
+independent witness verification. It demonstrates Jacobian's central trust
+boundary: an evaluator may report a mathematical conclusion, but that
+conclusion remains unverified until an authorized checker accepts the exact
+evidence and bindings.
+
+## Prerequisites
+
+Use Python 3.12 and install the locked development environment from the
+repository root:
+
+```sh
+uv sync --dev
+```
+
+## Create the experiment
+
+Save the following as `first_verified_result.py`:
+
+```python
+from pathlib import Path
+
+from jacobian.kernel import JacobianKernel
+
+
+state_dir = Path(".jacobian-tutorial")
+kernel = JacobianKernel(state_dir, install_references=True)
+reference = kernel.references["graph_paths"]
+
+claim = kernel.artifacts.put(
+    schema_uri=reference.claim_schema_uri,
+    semantics_uri=reference.semantics_uri,
+    payload={
+        "claim_schema_version": "1",
+        "domain_id": "jacobian.graph-paths",
+        "domain_version": "1",
+        "semantics_uri": reference.semantics_uri,
+        "quantifiers": [],
+        "predicate": {
+            "name": "intended_paths_complete",
+            "parameters": {"simple": True},
+        },
+        "bounds": {},
+        "required_capabilities": ["Evaluator", "WitnessOracle"],
+        "correspondence_status": "HUMAN_REVIEWED",
+    },
+)
+
+candidate = kernel.artifacts.put(
+    schema_uri=reference.candidate_schema_uri,
+    semantics_uri=reference.semantics_uri,
+    payload={
+        "vertices": ["s", "a", "b", "x", "t1", "t2"],
+        "arcs": [
+            ["s", "a"],
+            ["a", "x"],
+            ["s", "b"],
+            ["b", "x"],
+            ["x", "t1"],
+            ["x", "t2"],
+        ],
+        "source": "s",
+        "terminals": ["t1", "t2"],
+        "intended_paths": [
+            ["s", "a", "x", "t1"],
+            ["s", "b", "x", "t2"],
+        ],
+    },
+)
+
+evaluation = kernel.evaluation.evaluate_batch(
+    claim_uri=claim.artifact_uri,
+    candidate_uris=(candidate.artifact_uri,),
+    plugin_id=reference.plugin_id,
+    profile="EXACT_CANDIDATE",
+    seed=0,
+    wall_seconds=30,
+)
+evaluated = evaluation.items[0].result
+print("evaluation:", evaluated.conclusion.value, evaluated.assurance.verification.value)
+
+found = kernel.witnesses.find(
+    claim_uri=claim.artifact_uri,
+    candidate_uri=candidate.artifact_uri,
+    plugin_id=reference.plugin_id,
+    witness_role="DEFEATS_CANDIDATE",
+    wall_seconds=30,
+)
+assert found.witness_uri is not None
+
+verified = kernel.verification.verify_witness(
+    claim_uri=claim.artifact_uri,
+    candidate_uri=candidate.artifact_uri,
+    witness_uri=found.witness_uri,
+    checker_id=reference.witness_checker_ids["graph.omitted_path"],
+)
+print("verification:", verified.conclusion.value, verified.assurance.verification.value)
+print("witness:", found.witness_uri)
+```
+
+Run it:
+
+```sh
+uv run python first_verified_result.py
+```
+
+The important part of the output is:
+
+```text
+evaluation: FALSE UNVERIFIED
+verification: FALSE VERIFIED
+```
+
+The evaluator found that the proposed path list is incomplete, but its result
+did not cross the evidence boundary. The witness checker independently
+validated an omitted path and produced a verified result bound to the claim,
+candidate, witness, semantics, and checker identity.
+
+## Inspect the durable state
+
+The artifacts and verification record remain under `.jacobian-tutorial/`.
+Running the script again reuses content-addressed artifacts rather than
+changing their identity.
+
+Continue with the [architecture explanation](../explanation/architecture.md)
+to understand the trust zones, or consult the
+[tool reference](../reference/tools.md) for the complete public surface.

--- a/src/jacobian/adapters/mcp/server.py
+++ b/src/jacobian/adapters/mcp/server.py
@@ -22,6 +22,7 @@ from jacobian.contracts.conjectures import (
     ConjectureWorkflowRequest,
     ConjectureWorkflowResult,
     FalsificationPlan,
+    ParameterRegion,
 )
 from jacobian.contracts.discovery import (
     EnumerationBudget,
@@ -85,7 +86,7 @@ class SearchBudgetInput(AdapterModel):
     iterations_max: int = Field(default=10_000, ge=1, le=10_000_000)
     wall_seconds: int = Field(default=300, ge=1, le=86_400)
     batch_size: int = Field(default=32, ge=1, le=4096)
-    workers: int = Field(default=1, ge=1, le=32)
+    workers: int = Field(default=1, ge=1, le=1)
 
 
 class FalsificationPlanInput(AdapterModel):
@@ -819,6 +820,24 @@ def _register_conjecture_tools(
                 wall_seconds=wall_seconds,
                 falsification=_falsification_plan(falsification),
             ),
+        )
+
+    @server.tool(
+        name="parameter.region.promote",
+        description=(
+            "Replay an authorized certificate bound to an immutable parameter "
+            "region before labeling it verified sufficient or necessary."
+        ),
+        structured_output=True,
+    )
+    async def parameter_region_promote(
+        subject_uri: str,
+        verification_record_uri: str,
+    ) -> ParameterRegion:
+        return await asyncio.to_thread(
+            kernel.conjectures.promote_parameter_region,
+            subject_uri=subject_uri,
+            verification_record_uri=verification_record_uri,
         )
 
 

--- a/src/jacobian/cli.py
+++ b/src/jacobian/cli.py
@@ -457,6 +457,19 @@ def parameter_generalize(
     _emit(result.model_dump(mode="json"))
 
 
+@app.command("parameter-region-promote")
+def parameter_region_promote(
+    context: typer.Context,
+    subject_uri: str,
+    verification_record_uri: str,
+) -> None:
+    result = _state(context).kernel.conjectures.promote_parameter_region(
+        subject_uri=subject_uri,
+        verification_record_uri=verification_record_uri,
+    )
+    _emit(result.model_dump(mode="json"))
+
+
 @app.command("transform-apply")
 def transform_apply(
     context: typer.Context,

--- a/src/jacobian/conjectures.py
+++ b/src/jacobian/conjectures.py
@@ -18,6 +18,10 @@ from jacobian.contracts.conjectures import (
     HypothesisRecord,
     HypothesisTransformationRecord,
     NoveltyAssessment,
+    ParameterRegion,
+    ParameterRegionEvidence,
+    ParameterRegionKind,
+    ParameterRegionSubject,
     PluginHypothesisResponse,
 )
 from jacobian.contracts.evidence import WitnessEnvelope, WitnessRole
@@ -49,7 +53,12 @@ class ConjectureError(RuntimeError):
 
 
 class ConjectureService:
-    """Create unverified hypotheses and optionally route them through M3."""
+    """Create unverified hypotheses and optionally route them through M3.
+
+    Hypothesis plugins own domain grammar and heuristics. This service owns
+    exact source/evidence replay, immutable edit lineage, schema validation,
+    deduplication, and the rule that plugin output cannot promote evidence.
+    """
 
     def __init__(
         self,
@@ -80,6 +89,11 @@ class ConjectureService:
             name="jacobian.hypothesis-transformation",
             version="1",
             schema=HypothesisTransformationRecord.model_json_schema(),
+        )
+        self.parameter_region_subject_schema_uri = schemas.register(
+            name="jacobian.parameter-region-subject",
+            version="1",
+            schema=ParameterRegionSubject.model_json_schema(),
         )
 
     def run(
@@ -207,6 +221,99 @@ class ConjectureService:
             hypotheses=hypotheses,
             verification=Verification.UNVERIFIED,
             detail=response.detail,
+        )
+
+    def promote_parameter_region(
+        self,
+        *,
+        subject_uri: str,
+        verification_record_uri: str,
+    ) -> ParameterRegion:
+        """Replay an exact certificate record before promoting a region.
+
+        Promotion requires both object-digest bindings and the exact subject
+        and claim artifact URIs in the verification record's parents. The URI
+        checks prevent substitution of an equal payload carried by different
+        lineage metadata. Replay must reproduce the supplied record URI, which
+        binds the authorized checker, evidence, request, and environment.
+        """
+
+        try:
+            subject_artifact = self.store.get(subject_uri)
+            if (
+                subject_artifact.manifest.schema_uri
+                != self.parameter_region_subject_schema_uri
+            ):
+                raise ConjectureError(
+                    "parameter-region subject uses an unexpected schema"
+                )
+            subject = ParameterRegionSubject.model_validate(subject_artifact.payload)
+            claim = self.store.get(subject.claim_uri)
+            subject_parents = set(subject_artifact.manifest.parents)
+            if subject.claim_uri not in subject_parents or not set(
+                subject.sample_uris
+            ).issubset(subject_parents):
+                raise ConjectureError(
+                    "parameter-region subject is missing its declared lineage"
+                )
+            if claim.manifest.semantics_uri != subject_artifact.manifest.semantics_uri:
+                raise ConjectureError(
+                    "parameter-region subject and target claim semantics differ"
+                )
+            record_artifact = self.store.get(verification_record_uri)
+            record = VerificationRecord.model_validate(record_artifact.payload)
+            record_parents = set(record_artifact.manifest.parents)
+            if subject_artifact.artifact_uri not in record_parents:
+                raise ConjectureError(
+                    "parameter-region verification does not bind the supplied "
+                    "subject artifact"
+                )
+            if subject.claim_uri not in record_parents:
+                raise ConjectureError(
+                    "parameter-region verification does not bind the declared "
+                    "claim artifact"
+                )
+            if record.evidence_kind is not EvidenceKind.CERTIFICATE:
+                raise ConjectureError(
+                    "verified parameter regions require certificate evidence"
+                )
+            if record.conclusion is not Conclusion.TRUE:
+                raise ConjectureError(
+                    "parameter-region certificate must establish a true conclusion"
+                )
+            if record.bindings.claim_digest != claim.manifest.object_digest:
+                raise ConjectureError(
+                    "parameter-region verification binds a different target claim"
+                )
+            if (
+                record.bindings.candidate_digest
+                != subject_artifact.manifest.object_digest
+            ):
+                raise ConjectureError(
+                    "parameter-region verification binds different conditions"
+                )
+            self._replay_verification_record(
+                source=subject_artifact,
+                record_artifact=record_artifact,
+                record=record,
+            )
+        except ConjectureError:
+            raise
+        except (StoreError, ValidationError, ValueError) as exc:
+            raise ConjectureError(str(exc)) from exc
+
+        evidence = (
+            ParameterRegionEvidence.VERIFIED_SUFFICIENT
+            if subject.kind is ParameterRegionKind.SUFFICIENT
+            else ParameterRegionEvidence.VERIFIED_NECESSARY
+        )
+        return ParameterRegion(
+            kind=subject.kind,
+            conditions=subject.conditions,
+            evidence=evidence,
+            sample_uris=subject.sample_uris,
+            subject_uri=subject_artifact.artifact_uri,
+            verification_record_uri=record_artifact.artifact_uri,
         )
 
     def _prepare(
@@ -399,6 +506,7 @@ class ConjectureService:
         elif record.evidence_kind is EvidenceKind.CERTIFICATE:
             replay = self.verification.verify_certificate(
                 certificate_uri=record.evidence_uri,
+                checker_id=record.checker_id,
             )
         else:
             raise ConjectureError(
@@ -490,13 +598,41 @@ class ConjectureService:
                     "generated claim is invalid: " + "; ".join(validation.input.errors)
                 )
             seen_digests.add(claim.object_digest)
+            committed_region = proposal.parameter_region
+            if committed_region is not None:
+                subject = ParameterRegionSubject(
+                    claim_uri=claim.artifact_uri,
+                    kind=committed_region.kind,
+                    conditions=committed_region.conditions,
+                    sample_uris=committed_region.sample_uris,
+                )
+                stored_subject = self.store.put(
+                    schema_uri=self.parameter_region_subject_schema_uri,
+                    semantics_uri=manifest.semantics_uri,
+                    payload=self.schemas.validate(
+                        self.parameter_region_subject_schema_uri,
+                        subject.model_dump(mode="json"),
+                    ),
+                    parents=_deduplicate_uris(
+                        (
+                            claim.artifact_uri,
+                            selected.plugin_id,
+                            capability.registry_snapshot_uri,
+                            *committed_region.sample_uris,
+                        )
+                    ),
+                    summary="immutable parameter-region verification subject",
+                )
+                committed_region = committed_region.model_copy(
+                    update={"subject_uri": stored_subject.artifact_uri}
+                )
             transformation = HypothesisTransformationRecord(
                 operation=selected.operation,
                 source_uri=source.artifact_uri if source is not None else None,
                 target_claim_uri=claim.artifact_uri,
                 edit=proposal.edit,
                 metrics=proposal.metrics,
-                parameter_region=proposal.parameter_region,
+                parameter_region=committed_region,
                 evidence_uris=tuple(artifact.artifact_uri for artifact in evidence),
                 plugin_id=selected.plugin_id,
                 registry_snapshot_uri=capability.registry_snapshot_uri,
@@ -506,9 +642,10 @@ class ConjectureService:
             transformation_parents = (
                 claim.artifact_uri,
                 *parents,
+                *(committed_region.sample_uris if committed_region is not None else ()),
                 *(
-                    proposal.parameter_region.sample_uris
-                    if proposal.parameter_region is not None
+                    (committed_region.subject_uri,)
+                    if committed_region is not None
                     else ()
                 ),
             )
@@ -526,7 +663,7 @@ class ConjectureService:
                 claim_uri=claim.artifact_uri,
                 transformation_uri=stored_transformation.artifact_uri,
                 novelty=NoveltyAssessment.UNKNOWN,
-                parameter_region=proposal.parameter_region,
+                parameter_region=committed_region,
                 detail=proposal.detail,
             )
             if selected.falsification is not None:

--- a/src/jacobian/contracts/conjectures.py
+++ b/src/jacobian/contracts/conjectures.py
@@ -43,6 +43,11 @@ class ParameterRegionEvidence(StrEnum):
     VERIFIED_NECESSARY = "VERIFIED_NECESSARY"
 
 
+class ParameterRegionKind(StrEnum):
+    SUFFICIENT = "SUFFICIENT"
+    NECESSARY = "NECESSARY"
+
+
 class HypothesisEdit(ContractModel):
     kind: str = Field(min_length=1, max_length=128)
     description: str = Field(min_length=1, max_length=512)
@@ -57,9 +62,13 @@ class HypothesisEdit(ContractModel):
 
 
 class ParameterRegion(ContractModel):
+    """Proposed, sampled, or independently verified parameter conditions."""
+
+    kind: ParameterRegionKind
     conditions: dict[str, Any]
     evidence: ParameterRegionEvidence
     sample_uris: tuple[ArtifactUri, ...] = ()
+    subject_uri: ArtifactUri | None = None
     verification_record_uri: ArtifactUri | None = None
 
     @model_validator(mode="after")
@@ -69,18 +78,32 @@ class ParameterRegion(ContractModel):
             ParameterRegionEvidence.VERIFIED_SUFFICIENT,
             ParameterRegionEvidence.VERIFIED_NECESSARY,
         }
-        if verified and self.verification_record_uri is None:
-            raise ValueError("verified parameter regions require a verification record")
+        if verified and (
+            self.subject_uri is None or self.verification_record_uri is None
+        ):
+            raise ValueError(
+                "verified parameter regions require a subject and verification record"
+            )
         if not verified and self.verification_record_uri is not None:
             raise ValueError(
                 "unverified parameter regions cannot cite a verification record"
             )
         if self.evidence is ParameterRegionEvidence.SAMPLED and not self.sample_uris:
             raise ValueError("sampled parameter regions require sample artifacts")
+        if (
+            self.evidence is ParameterRegionEvidence.VERIFIED_SUFFICIENT
+            and self.kind is not ParameterRegionKind.SUFFICIENT
+        ) or (
+            self.evidence is ParameterRegionEvidence.VERIFIED_NECESSARY
+            and self.kind is not ParameterRegionKind.NECESSARY
+        ):
+            raise ValueError("verified parameter-region label differs from its kind")
         return self
 
 
 class PluginHypothesisProposal(ContractModel):
+    """Untrusted hypothesis output that cannot bind or promote verification."""
+
     claim: dict[str, Any]
     edit: HypothesisEdit
     metrics: dict[str, Any] = Field(default_factory=dict)
@@ -98,6 +121,11 @@ class PluginHypothesisProposal(ContractModel):
             raise ValueError(
                 "hypothesis plugins cannot promote parameter-region evidence"
             )
+        if (
+            self.parameter_region is not None
+            and self.parameter_region.subject_uri is not None
+        ):
+            raise ValueError("hypothesis plugins cannot bind parameter-region subjects")
         return self
 
 
@@ -173,6 +201,21 @@ class ConjectureWorkflowRequest(ContractModel):
             raise ValueError(
                 "conjecture generation does not accept a source verification record"
             )
+        return self
+
+
+class ParameterRegionSubject(ContractModel):
+    """Immutable claim, relation, conditions, and samples certified as a unit."""
+
+    subject_version: Literal["1"] = "1"
+    claim_uri: ArtifactUri
+    kind: ParameterRegionKind
+    conditions: dict[str, Any]
+    sample_uris: tuple[ArtifactUri, ...] = ()
+
+    @model_validator(mode="after")
+    def require_canonical_conditions(self) -> Self:
+        canonicalize_json(self.conditions)
         return self
 
 

--- a/src/jacobian/contracts/search.py
+++ b/src/jacobian/contracts/search.py
@@ -43,14 +43,18 @@ class SearchStopReason(StrEnum):
 
 
 class SearchBudget(ContractModel):
+    """Hard strategy limits; the provisional scheduler supports one worker."""
+
     candidates_max: StrictInt = Field(ge=1, le=10_000_000)
     iterations_max: StrictInt = Field(ge=1, le=10_000_000)
     wall_seconds: StrictInt = Field(ge=1, le=86_400)
     batch_size: StrictInt = Field(default=32, ge=1, le=4096)
-    workers: StrictInt = Field(default=1, ge=1, le=32)
+    workers: StrictInt = Field(default=1, ge=1, le=1)
 
 
 class SearchRunRequest(ContractModel):
+    """One canonical request bound durably by its idempotency key."""
+
     request_version: Literal["1"] = "1"
     idempotency_key: IdempotencyKey
     claim_uri: ArtifactUri
@@ -140,6 +144,8 @@ class PluginRefinementResponse(ContractModel):
 
 
 class SearchAccounting(ContractModel):
+    """Committed operation counts and measured checkpoint-boundary wall time."""
+
     proposed_candidates: StrictInt = Field(default=0, ge=0)
     unique_candidates: StrictInt = Field(default=0, ge=0)
     duplicate_candidates: StrictInt = Field(default=0, ge=0)
@@ -176,6 +182,8 @@ class SearchAccounting(ContractModel):
 
 
 class SearchCheckpoint(ContractModel):
+    """Immutable opaque strategy state rebound to all execution identities."""
+
     schema_version: Literal["1"] = "1"
     experiment_uri: ExperimentUri
     request_digest: Sha256Digest
@@ -227,6 +235,8 @@ class SearchArchiveManifest(ContractModel):
 
 
 class SearchExperimentSnapshot(ContractModel):
+    """Mutable lifecycle index whose mathematical assurance stays unverified."""
+
     schema_version: Literal["1"] = "1"
     experiment_uri: ExperimentUri
     kind: Literal["SEARCH"] = "SEARCH"

--- a/src/jacobian/plugin_conformance.py
+++ b/src/jacobian/plugin_conformance.py
@@ -1,0 +1,338 @@
+"""Reusable conformance checks for an operator-installed plugin package."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+from jacobian.contracts.conjectures import (
+    ConjectureOperation,
+    ConjectureWorkflowRequest,
+)
+from jacobian.contracts.discovery import ExperimentState
+from jacobian.contracts.plugins import CapabilityName
+from jacobian.contracts.results import ExecutionStatus, Verification
+from jacobian.contracts.search import (
+    SearchExperimentSnapshot,
+    SearchRunRequest,
+    SearchStopReason,
+)
+from jacobian.plugins.registry import PluginRegistryError
+
+if TYPE_CHECKING:
+    from jacobian.kernel import JacobianKernel
+
+
+class PluginConformanceCheck(StrEnum):
+    EXECUTION_SUCCESS = "execution-success"
+    DECLARED_FAILURE = "declared-failure"
+    MALFORMED_OUTPUT = "malformed-output"
+    TIMEOUT = "timeout"
+    PATH_ATTACK = "path-attack"
+    SYMLINK_ATTACK = "symlink-attack"
+    IMPLEMENTATION_CHANGED = "implementation-changed"
+    EVIDENCE_PROMOTION = "unsupported-evidence-promotion"
+
+
+@dataclass(frozen=True)
+class SyntheticPluginConformanceTarget:
+    """Disposable installed package consumed by the standard matrix.
+
+    This protocol is for a conformance-only package in isolated test state,
+    never for a production plugin. The package's proposer branches on
+    ``state["conformance_case"]`` for the four execution cases. Its other
+    search capabilities satisfy their ordinary contracts, and its hypothesis
+    transformer attempts an unsupported verified parameter-region promotion.
+    """
+
+    kernel: JacobianKernel
+    plugin_id: str
+    search_request: SearchRunRequest
+    implementation_file: Path
+    symlink_path: Path
+    symlink_target: Path
+    import_marker: Path | None = None
+
+    def __post_init__(self) -> None:
+        if self.search_request.plugin_id != self.plugin_id:
+            raise ValueError("conformance search request must target the plugin")
+
+
+@dataclass(frozen=True)
+class PluginConformanceObservation:
+    check: PluginConformanceCheck
+    passed: bool
+    detail: str
+
+
+class PluginConformanceError(AssertionError):
+    """One or more required plugin conformance checks failed."""
+
+    def __init__(
+        self,
+        observations: tuple[PluginConformanceObservation, ...],
+    ) -> None:
+        self.observations = observations
+        failures = (item for item in observations if not item.passed)
+        super().__init__(
+            "; ".join(f"{item.check.value}: {item.detail}" for item in failures)
+        )
+
+
+def run_plugin_conformance(
+    target: SyntheticPluginConformanceTarget,
+) -> tuple[PluginConformanceObservation, ...]:
+    """Run every check against real registry and workflow boundaries.
+
+    A fresh idempotency namespace forces repeated suite calls to execute the
+    plugin again. Checks are independent observations: one failure does not
+    short-circuit the remaining matrix.
+    """
+
+    checks: tuple[
+        tuple[
+            PluginConformanceCheck,
+            Callable[[SyntheticPluginConformanceTarget, str], None],
+        ],
+        ...,
+    ] = (
+        (PluginConformanceCheck.EXECUTION_SUCCESS, _check_execution_success),
+        (PluginConformanceCheck.DECLARED_FAILURE, _check_declared_failure),
+        (PluginConformanceCheck.MALFORMED_OUTPUT, _check_malformed_output),
+        (PluginConformanceCheck.TIMEOUT, _check_timeout),
+        (PluginConformanceCheck.PATH_ATTACK, _check_path_attack),
+        (PluginConformanceCheck.SYMLINK_ATTACK, _check_symlink_attack),
+        (PluginConformanceCheck.EVIDENCE_PROMOTION, _check_evidence_promotion),
+        (
+            PluginConformanceCheck.IMPLEMENTATION_CHANGED,
+            _check_implementation_changed,
+        ),
+    )
+    run_namespace = uuid4().hex
+    observations: list[PluginConformanceObservation] = []
+    try:
+        for check, run in checks:
+            try:
+                run(target, run_namespace)
+            except Exception as exc:
+                observations.append(
+                    PluginConformanceObservation(
+                        check=check,
+                        passed=False,
+                        detail=f"{type(exc).__name__}: {exc}",
+                    )
+                )
+            else:
+                observations.append(
+                    PluginConformanceObservation(
+                        check=check,
+                        passed=True,
+                        detail="passed",
+                    )
+                )
+    finally:
+        if target.import_marker is not None:
+            target.import_marker.unlink(missing_ok=True)
+    return tuple(observations)
+
+
+def require_plugin_conformance(
+    target: SyntheticPluginConformanceTarget,
+) -> tuple[PluginConformanceObservation, ...]:
+    """Run the standard matrix and raise one aggregate error on failure."""
+
+    observations = run_plugin_conformance(target)
+    if any(not observation.passed for observation in observations):
+        raise PluginConformanceError(observations)
+    return observations
+
+
+def _search(
+    target: SyntheticPluginConformanceTarget,
+    check: PluginConformanceCheck,
+    run_namespace: str,
+) -> SearchExperimentSnapshot:
+    request = target.search_request
+    budget = request.budget
+    if check is PluginConformanceCheck.TIMEOUT:
+        budget = budget.model_copy(update={"wall_seconds": 1})
+    idempotency_prefix = request.idempotency_key[:55]
+    selected = request.model_copy(
+        update={
+            "idempotency_key": (f"{idempotency_prefix}:{run_namespace}:{check.value}"),
+            "initial_state": {
+                **request.initial_state,
+                "conformance_case": check.value,
+            },
+            "budget": budget,
+        }
+    )
+    handle = target.kernel.search.start(selected)
+    return target.kernel.search.wait(handle.experiment_uri, timeout_seconds=15)
+
+
+def _check_execution_success(
+    target: SyntheticPluginConformanceTarget,
+    run_namespace: str,
+) -> None:
+    target.kernel.plugins.snapshot(target.plugin_id)
+    for capability in (
+        CapabilityName.PROPOSER,
+        CapabilityName.REFINER,
+        CapabilityName.EVALUATOR,
+        CapabilityName.HYPOTHESIS_TRANSFORMER,
+    ):
+        target.kernel.plugins.resolve(target.plugin_id, capability)
+    if target.import_marker is not None and target.import_marker.exists():
+        raise AssertionError("plugin discovery imported package code")
+
+    snapshot = _search(
+        target,
+        PluginConformanceCheck.EXECUTION_SUCCESS,
+        run_namespace,
+    )
+    if (
+        snapshot.state is not ExperimentState.COMPLETED
+        or snapshot.stop_reason is not SearchStopReason.STRATEGY_COMPLETE
+        or not snapshot.strategy_reported_complete
+    ):
+        raise AssertionError(
+            f"successful search ended as {snapshot.state.value}: {snapshot.detail}"
+        )
+    if target.import_marker is not None and not target.import_marker.exists():
+        raise AssertionError("successful worker execution did not import package code")
+
+
+def _check_declared_failure(
+    target: SyntheticPluginConformanceTarget,
+    run_namespace: str,
+) -> None:
+    snapshot = _search(
+        target,
+        PluginConformanceCheck.DECLARED_FAILURE,
+        run_namespace,
+    )
+    if snapshot.state is not ExperimentState.ERROR:
+        raise AssertionError(f"declared failure ended as {snapshot.state.value}")
+    if "declared plugin failure" not in snapshot.detail:
+        raise AssertionError(f"unexpected declared-failure detail: {snapshot.detail}")
+
+
+def _check_malformed_output(
+    target: SyntheticPluginConformanceTarget,
+    run_namespace: str,
+) -> None:
+    snapshot = _search(
+        target,
+        PluginConformanceCheck.MALFORMED_OUTPUT,
+        run_namespace,
+    )
+    if snapshot.state is not ExperimentState.ERROR:
+        raise AssertionError(f"malformed output ended as {snapshot.state.value}")
+    if "plugin response must be a JSON object" not in snapshot.detail:
+        raise AssertionError(f"unexpected malformed-output detail: {snapshot.detail}")
+
+
+def _check_timeout(
+    target: SyntheticPluginConformanceTarget,
+    run_namespace: str,
+) -> None:
+    snapshot = _search(
+        target,
+        PluginConformanceCheck.TIMEOUT,
+        run_namespace,
+    )
+    if (
+        snapshot.state is not ExperimentState.TIMEOUT
+        or snapshot.stop_reason is not SearchStopReason.WALL_TIME_LIMIT
+    ):
+        raise AssertionError(
+            f"timed execution ended as {snapshot.state.value}: {snapshot.detail}"
+        )
+
+
+def _check_path_attack(
+    target: SyntheticPluginConformanceTarget,
+    _run_namespace: str,
+) -> None:
+    _expect_registry_rejection(
+        lambda: target.kernel.plugins.register_implementation("../escape:run"),
+    )
+
+
+def _check_symlink_attack(
+    target: SyntheticPluginConformanceTarget,
+    _run_namespace: str,
+) -> None:
+    try:
+        target.symlink_path.symlink_to(target.symlink_target)
+        _expect_registry_rejection(
+            lambda: target.kernel.plugins.resolve(
+                target.plugin_id,
+                CapabilityName.PROPOSER,
+            ),
+            match="regular file",
+        )
+    finally:
+        if target.symlink_path.is_symlink():
+            target.symlink_path.unlink()
+
+
+def _check_evidence_promotion(
+    target: SyntheticPluginConformanceTarget,
+    _run_namespace: str,
+) -> None:
+    result = target.kernel.conjectures.run(
+        ConjectureWorkflowRequest(
+            operation=ConjectureOperation.GENERATE,
+            plugin_id=target.plugin_id,
+            source_uri=target.search_request.claim_uri,
+            wall_seconds=5,
+        )
+    )
+    if (
+        result.execution.status is not ExecutionStatus.ERROR
+        or result.verification is not Verification.UNVERIFIED
+        or result.hypotheses
+    ):
+        raise AssertionError("unsupported promotion crossed the evidence boundary")
+    if "cannot promote parameter-region evidence" not in result.detail:
+        raise AssertionError(f"unexpected promotion detail: {result.detail}")
+
+
+def _check_implementation_changed(
+    target: SyntheticPluginConformanceTarget,
+    _run_namespace: str,
+) -> None:
+    original = target.implementation_file.read_bytes()
+    try:
+        target.implementation_file.write_bytes(original + b"\n# changed bytes\n")
+        _expect_registry_rejection(
+            lambda: target.kernel.plugins.resolve(
+                target.plugin_id,
+                CapabilityName.PROPOSER,
+            ),
+            match="bytes changed",
+        )
+    finally:
+        target.implementation_file.write_bytes(original)
+
+
+def _expect_registry_rejection(
+    operation: Callable[[], object],
+    *,
+    match: str | None = None,
+) -> None:
+    try:
+        operation()
+    except PluginRegistryError as exc:
+        if match is not None and match not in str(exc):
+            raise AssertionError(
+                f"registry rejection did not contain {match!r}: {exc}"
+            ) from exc
+        return
+    raise AssertionError("registry accepted an invalid plugin package")

--- a/src/jacobian/plugins/registry.py
+++ b/src/jacobian/plugins/registry.py
@@ -41,7 +41,14 @@ class ResolvedCapability:
 
 
 class PluginRegistry:
-    """Operator-installed plugin metadata without checker authorization."""
+    """Seal operator-installed packages without granting checker authority.
+
+    Installation binds the manifest and every capability to its implementation
+    package digest plus runtime, build, and platform identity. Discovery reads
+    source without importing package code; resolution remeasures it before
+    execution. This establishes implementation identity, not host isolation or
+    mathematical trust.
+    """
 
     def __init__(self, store: ArtifactStore) -> None:
         self.store = store
@@ -115,7 +122,12 @@ class PluginRegistry:
         )
 
     def install(self, plugin_id: str) -> PluginManifest:
-        """Install a manifest after resolving every immutable dependency."""
+        """Validate dependencies and publish one immutable registry snapshot.
+
+        Every capability must resolve to its measured entrypoint, and the
+        snapshot freezes that collection of implementation bindings. Plugin
+        manifests have no field or side channel that can authorize a checker.
+        """
 
         try:
             artifact = self.store.get(plugin_id)

--- a/src/jacobian/search.py
+++ b/src/jacobian/search.py
@@ -75,7 +75,17 @@ class _SearchBudgetExhaustedError(SearchError):
 
 
 class SearchService:
-    """Coordinate untrusted strategies over existing verification boundaries."""
+    """Coordinate untrusted strategies over durable verification boundaries.
+
+    SQLite owns idempotent request acceptance, current lifecycle state, and
+    append-only events. Immutable artifacts own checkpoints and archive
+    lineage. The service may replay work after the last committed checkpoint,
+    but it never derives a mathematical conclusion from strategy completion,
+    timeout, cancellation, or recovery state.
+
+    The reference scheduler assumes one active coordinator per state directory
+    and accepts exactly one strategy worker.
+    """
 
     def __init__(
         self,
@@ -146,7 +156,13 @@ class SearchService:
         return connection
 
     def _initialize_database(self) -> None:
-        """Create metadata tables and recover interrupted runs as paused."""
+        """Create metadata tables and isolate recovery one row at a time.
+
+        Active runs recover as paused, pending cancellation recovers as
+        cancelled, and malformed or index-inconsistent snapshots are
+        quarantined as errors. A corrupt row must not prevent unrelated
+        experiments from recovering.
+        """
 
         archive_recoveries: list[SearchExperimentSnapshot] = []
         with self._connect() as connection:
@@ -175,6 +191,15 @@ class SearchService:
                         REFERENCES search_experiments(experiment_uri)
                         ON DELETE RESTRICT
                 );
+                CREATE TABLE IF NOT EXISTS search_recovery_failures (
+                    experiment_uri TEXT PRIMARY KEY,
+                    detected_at TEXT NOT NULL,
+                    snapshot_digest TEXT NOT NULL,
+                    detail TEXT NOT NULL,
+                    FOREIGN KEY (experiment_uri)
+                        REFERENCES search_experiments(experiment_uri)
+                        ON DELETE RESTRICT
+                );
                 CREATE TRIGGER IF NOT EXISTS search_events_no_update
                 BEFORE UPDATE ON search_events
                 BEGIN
@@ -190,18 +215,39 @@ class SearchService:
             connection.execute("BEGIN IMMEDIATE")
             rows = connection.execute(
                 """
-                SELECT experiment_uri, snapshot_json
+                SELECT experiment_uri, state, snapshot_json
                 FROM search_experiments
                 WHERE state IN (
                     'PENDING', 'RUNNING', 'PAUSE_REQUESTED',
                     'CANCEL_REQUESTED', 'CANCELLED'
                 )
+                OR state NOT IN (
+                    'PENDING', 'RUNNING', 'PAUSE_REQUESTED', 'PAUSED',
+                    'COMPLETED', 'CANCEL_REQUESTED', 'CANCELLED',
+                    'TIMEOUT', 'ERROR'
+                )
                 """
             ).fetchall()
             for row in rows:
-                snapshot = SearchExperimentSnapshot.model_validate(
-                    loads_strict_json(row["snapshot_json"])
-                )
+                try:
+                    snapshot = SearchExperimentSnapshot.model_validate(
+                        loads_strict_json(row["snapshot_json"])
+                    )
+                except (TypeError, ValidationError, ValueError) as exc:
+                    self._quarantine_recovery_snapshot(connection, row, exc)
+                    continue
+                if snapshot.experiment_uri != str(
+                    row["experiment_uri"]
+                ) or snapshot.state.value != str(row["state"]):
+                    self._quarantine_recovery_snapshot(
+                        connection,
+                        row,
+                        ValueError(
+                            "stored search snapshot identity or state differs "
+                            "from its database index"
+                        ),
+                    )
+                    continue
                 if snapshot.state is ExperimentState.CANCELLED:
                     if snapshot.archive_uri is None:
                         archive_recoveries.append(snapshot)
@@ -242,6 +288,56 @@ class SearchService:
                     archive_recoveries.append(recovered)
         for snapshot in archive_recoveries:
             self._commit_recovery_archive(snapshot)
+
+    def _quarantine_recovery_snapshot(
+        self,
+        connection: sqlite3.Connection,
+        row: sqlite3.Row,
+        error: Exception,
+    ) -> None:
+        """Isolate one corrupt row without blocking unrelated recovery."""
+
+        experiment_uri = str(row["experiment_uri"])
+        raw = row["snapshot_json"]
+        if isinstance(raw, bytes):
+            raw_bytes = raw
+        elif isinstance(raw, str):
+            raw_bytes = raw.encode("utf-8")
+        else:
+            raw_bytes = repr(raw).encode("utf-8")
+        snapshot_digest = "sha256:" + hashlib.sha256(raw_bytes).hexdigest()
+        detail = f"stored search snapshot is invalid: {type(error).__name__}"
+        detected_at = _now()
+        connection.execute(
+            """
+            UPDATE search_experiments
+            SET state = 'ERROR'
+            WHERE experiment_uri = ?
+            """,
+            (experiment_uri,),
+        )
+        connection.execute(
+            """
+            INSERT OR REPLACE INTO search_recovery_failures (
+                experiment_uri, detected_at, snapshot_digest, detail
+            ) VALUES (?, ?, ?, ?)
+            """,
+            (experiment_uri, detected_at.isoformat(), snapshot_digest, detail),
+        )
+        try:
+            self._append_event(
+                connection,
+                experiment_uri,
+                event_type="RECOVERY_REJECTED",
+                payload={
+                    "snapshot_digest": snapshot_digest,
+                    "detail": detail,
+                },
+            )
+        except ValidationError:
+            # The quarantine row remains authoritative when the corrupt
+            # experiment identifier cannot itself satisfy the event contract.
+            return
 
     def _commit_recovery_archive(
         self,
@@ -577,7 +673,7 @@ class SearchService:
             iterations_max=min(requested.iterations_max, self.max_iterations),
             wall_seconds=min(requested.wall_seconds, self.max_wall_seconds),
             batch_size=min(requested.batch_size, self.max_batch_size),
-            workers=1,
+            workers=requested.workers,
         )
 
     def _launch(self, experiment_uri: str) -> None:
@@ -1021,6 +1117,10 @@ class SearchService:
                     parents=tuple(checkpoint_parents),
                     summary="immutable search checkpoint",
                 )
+                persisted_accounting = next_accounting.model_copy(
+                    update={"wall_time_ms": _used_wall_ms(accounting, started)}
+                )
+                partial_accounting = persisted_accounting
                 current = self.inspect(experiment_uri)
                 progress = _updated_snapshot(
                     current,
@@ -1028,13 +1128,13 @@ class SearchService:
                     updated_at=_now(),
                     checkpoint_uri=stored_checkpoint.artifact_uri,
                     archive_page_uris=tuple(page_uris),
-                    accounting=next_accounting,
+                    accounting=persisted_accounting,
                     detail=proposal.detail or refinement.detail,
                 )
                 control_state = self._commit_progress(progress)
                 snapshot = self.inspect(experiment_uri)
                 strategy_state = refinement.state
-                accounting = next_accounting
+                accounting = persisted_accounting
                 started = time.monotonic()
                 if control_state == ExperimentState.PAUSED:
                     return
@@ -1045,6 +1145,16 @@ class SearchService:
                         stop_reason=SearchStopReason.CANCELLED,
                         strategy_complete=False,
                         detail="search cancelled",
+                        wall_time_ms=accounting.wall_time_ms,
+                    )
+                    return
+                if accounting.wall_time_ms >= budget.wall_seconds * 1000:
+                    self._finish(
+                        experiment_uri,
+                        state=ExperimentState.TIMEOUT,
+                        stop_reason=SearchStopReason.WALL_TIME_LIMIT,
+                        strategy_complete=False,
+                        detail="search wall-clock budget exhausted",
                         wall_time_ms=accounting.wall_time_ms,
                     )
                     return
@@ -1121,6 +1231,15 @@ class SearchService:
         set[str],
         SearchAccounting,
     ]:
+        """Rebind immutable progress before returning opaque strategy state.
+
+        Archive pages and the checkpoint must agree with the experiment,
+        request, installed registry snapshot, implementation identities,
+        environment, effective budget, and committed accounting. The snapshot's
+        later wall-time sample may exceed the checkpoint payload because it
+        includes checkpoint artifact persistence.
+        """
+
         page_uris = list(snapshot.archive_page_uris)
         seen_uris: set[str] = set()
         nominated_uris: set[str] = set()
@@ -1149,10 +1268,14 @@ class SearchService:
         checkpoint = SearchCheckpoint.model_validate(
             self.store.get(snapshot.checkpoint_uri).payload
         )
+        checkpoint_counts = checkpoint.accounting.model_copy(
+            update={"wall_time_ms": snapshot.accounting.wall_time_ms}
+        )
         if (
             checkpoint.experiment_uri != snapshot.experiment_uri
             or checkpoint.request_digest != snapshot.request_digest
-            or checkpoint.accounting != snapshot.accounting
+            or checkpoint_counts != snapshot.accounting
+            or checkpoint.accounting.wall_time_ms > snapshot.accounting.wall_time_ms
             or checkpoint.effective_budget != snapshot.effective_budget
             or checkpoint.registry_snapshot_uri != snapshot.registry_snapshot_uri
             or checkpoint.proposer_digest != snapshot.proposer_digest
@@ -1166,7 +1289,7 @@ class SearchService:
             page_uris,
             seen_uris,
             nominated_uris,
-            checkpoint.accounting,
+            snapshot.accounting,
         )
 
     def _mark_running(

--- a/src/jacobian/verification.py
+++ b/src/jacobian/verification.py
@@ -396,8 +396,13 @@ class VerificationService:
                 started=started,
             )
 
-    def verify_certificate(self, *, certificate_uri: str) -> ResultEnvelope:
-        """Select and run the unique checker compatible with a certificate."""
+    def verify_certificate(
+        self,
+        *,
+        certificate_uri: str,
+        checker_id: str | None = None,
+    ) -> ResultEnvelope:
+        """Run a specified compatible checker or uniquely select one."""
 
         started = time.monotonic()
         try:
@@ -452,14 +457,25 @@ class VerificationService:
                     "claim, candidate, certificate, and scope semantics differ"
                 )
 
-            checker = self.checker_registry.select_compatible(
-                evidence_kind=EvidenceKind.CERTIFICATE,
-                format_id=certificate.certificate_type,
-                format_version=certificate.format_version,
-                claim_schema_uri=claim.manifest.schema_uri,
-                semantics_uri=candidate.manifest.semantics_uri,
-                candidate_schema_uri=candidate.manifest.schema_uri,
-            )
+            if checker_id is None:
+                checker = self.checker_registry.select_compatible(
+                    evidence_kind=EvidenceKind.CERTIFICATE,
+                    format_id=certificate.certificate_type,
+                    format_version=certificate.format_version,
+                    claim_schema_uri=claim.manifest.schema_uri,
+                    semantics_uri=candidate.manifest.semantics_uri,
+                    candidate_schema_uri=candidate.manifest.schema_uri,
+                )
+            else:
+                checker = self.checker_registry.require_compatible(
+                    checker_id,
+                    evidence_kind=EvidenceKind.CERTIFICATE,
+                    format_id=certificate.certificate_type,
+                    format_version=certificate.format_version,
+                    claim_schema_uri=claim.manifest.schema_uri,
+                    semantics_uri=candidate.manifest.semantics_uri,
+                    candidate_schema_uri=candidate.manifest.schema_uri,
+                )
             request = {
                 "request_version": "1",
                 "claim": self._checker_artifact(claim),

--- a/tests/contract/test_conjecture_contracts.py
+++ b/tests/contract/test_conjecture_contracts.py
@@ -79,8 +79,10 @@ def test_plugin_cannot_promote_parameter_region() -> None:
                 description="widen a finite range",
             ),
             parameter_region=ParameterRegion(
+                kind="SUFFICIENT",
                 conditions={"n": {"minimum": 1}},
                 evidence="VERIFIED_SUFFICIENT",
+                subject_uri=ARTIFACT,
                 verification_record_uri=ARTIFACT,
             ),
         )
@@ -92,6 +94,7 @@ def test_sampled_parameter_region_requires_sample_artifacts() -> None:
         match="sampled parameter regions require sample artifacts",
     ):
         ParameterRegion(
+            kind="SUFFICIENT",
             conditions={"n": {"minimum": 1}},
             evidence="SAMPLED",
         )

--- a/tests/contract/test_plugin_conformance.py
+++ b/tests/contract/test_plugin_conformance.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from jacobian.plugin_conformance import (
+    PluginConformanceCheck,
+    PluginConformanceError,
+    PluginConformanceObservation,
+)
+
+
+def test_plugin_conformance_error_reports_every_failure() -> None:
+    observations = tuple(
+        PluginConformanceObservation(
+            check=check,
+            passed=check
+            not in {
+                PluginConformanceCheck.DECLARED_FAILURE,
+                PluginConformanceCheck.SYMLINK_ATTACK,
+            },
+            detail="fixture failure",
+        )
+        for check in PluginConformanceCheck
+    )
+
+    error = PluginConformanceError(observations)
+
+    assert "declared-failure" in str(error)
+    assert "symlink-attack" in str(error)
+    assert len(error.observations) == len(PluginConformanceCheck)

--- a/tests/contract/test_search_contracts.py
+++ b/tests/contract/test_search_contracts.py
@@ -64,6 +64,16 @@ def _snapshot(**changes: object) -> SearchExperimentSnapshot:
     return SearchExperimentSnapshot.model_validate(values)
 
 
+def test_search_budget_rejects_unimplemented_parallel_workers() -> None:
+    with pytest.raises(ValidationError, match="less than or equal to 1"):
+        SearchBudget(
+            candidates_max=10,
+            iterations_max=5,
+            wall_seconds=30,
+            workers=2,
+        )
+
+
 def test_search_request_requires_complete_counterexample_verification_policy() -> None:
     with pytest.raises(
         ValidationError,

--- a/tests/fixtures/checker_functions.py
+++ b/tests/fixtures/checker_functions.py
@@ -46,3 +46,30 @@ def check_fixture_value_as_true(request: dict[str, Any]) -> dict[str, Any]:
     if decision["accepted"]:
         decision["conclusion"] = "TRUE"
     return decision
+
+
+def check_parameter_region_certificate(request: dict[str, Any]) -> dict[str, Any]:
+    candidate = request["candidate"]["payload"]
+    certificate = request["certificate"]["payload"]
+    proof = certificate.get("payload", {})
+    accepted = (
+        request.get("request_version") == "1"
+        and certificate.get("certificate_type") == "fixture.parameter_region"
+        and certificate.get("format_version") == "1"
+        and certificate.get("bindings") == request.get("expected_bindings")
+        and proof.get("kind") == candidate.get("kind")
+        and proof.get("conditions") == candidate.get("conditions")
+        and candidate.get("claim_uri") == request["claim"]["artifact_uri"]
+    )
+    return {
+        "accepted": accepted,
+        "conclusion": "TRUE" if accepted else "UNKNOWN",
+        "arithmetic": "SYMBOLIC",
+        "method": "CHECKED_CERTIFICATE",
+        "coverage": "EXHAUSTIVE",
+        "detail": (
+            "certificate proves the exact parameter-region subject"
+            if accepted
+            else "certificate does not prove the bound parameter region"
+        ),
+    }

--- a/tests/fixtures/plugin_functions.py
+++ b/tests/fixtures/plugin_functions.py
@@ -237,6 +237,7 @@ def transform_fixture_hypothesis(request: dict[str, Any]) -> dict[str, Any]:
     }
     if operation == "PARAMETER_GENERALIZE":
         proposal["parameter_region"] = {
+            "kind": request["constraints"].get("region_kind", "SUFFICIENT"),
             "conditions": {"n": {"minimum": "1"}},
             "evidence": "SAMPLED",
             "sample_uris": [request["evidence"][-1]["artifact_uri"]],
@@ -267,8 +268,10 @@ def transform_with_unsupported_region_promotion(
                     "description": "unsupported promotion attempt",
                 },
                 "parameter_region": {
+                    "kind": "SUFFICIENT",
                     "conditions": {"n": {"minimum": "1"}},
                     "evidence": "VERIFIED_SUFFICIENT",
+                    "subject_uri": request["evidence"][0]["artifact_uri"],
                     "verification_record_uri": (request["evidence"][0]["artifact_uri"]),
                 },
             }
@@ -284,6 +287,7 @@ def transform_with_unbound_region_sample(
     response = transform_fixture_hypothesis(request)
     for proposal in response["proposals"]:
         proposal["parameter_region"] = {
+            "kind": "SUFFICIENT",
             "conditions": {"n": {"minimum": "1"}},
             "evidence": "SAMPLED",
             "sample_uris": [request["constraints"]["sample_uri"]],

--- a/tests/integration/test_conjecture_workflows.py
+++ b/tests/integration/test_conjecture_workflows.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import hashlib
 from pathlib import Path
 
 import pytest
 
+from jacobian.canonical import canonicalize_json
+from jacobian.conjectures import ConjectureError
 from jacobian.contracts.claims import ClaimSpec
 from jacobian.contracts.conjectures import (
     ConjectureOperation,
@@ -12,8 +15,13 @@ from jacobian.contracts.conjectures import (
     HypothesisTransformationRecord,
     NoveltyAssessment,
     ParameterRegionEvidence,
+    ParameterRegionSubject,
 )
-from jacobian.contracts.evidence import WitnessRole
+from jacobian.contracts.evidence import (
+    CertificateEnvelope,
+    EvidenceBindings,
+    WitnessRole,
+)
 from jacobian.contracts.plugins import PluginManifest
 from jacobian.contracts.results import ExecutionStatus, Verification
 from jacobian.contracts.search import SearchBudget
@@ -338,12 +346,164 @@ def test_parameter_generalization_keeps_sampled_region_unverified(
     assert region is not None
     assert region.evidence is ParameterRegionEvidence.SAMPLED
     assert region.sample_uris == (witness_uri,)
+    assert region.subject_uri is not None
     assert region.verification_record_uri is None
     assert result.hypotheses[0].verification is Verification.UNVERIFIED
     transformation = HypothesisTransformationRecord.model_validate(
         kernel.store.get(result.hypotheses[0].transformation_uri).payload
     )
     assert transformation.parameter_region == region
+
+
+@pytest.mark.parametrize(
+    ("region_kind", "expected_evidence"),
+    [
+        ("SUFFICIENT", ParameterRegionEvidence.VERIFIED_SUFFICIENT),
+        ("NECESSARY", ParameterRegionEvidence.VERIFIED_NECESSARY),
+    ],
+)
+@pytest.mark.subprocess
+def test_parameter_region_promotion_replays_an_exact_authorized_certificate(
+    tmp_path: Path,
+    region_kind: str,
+    expected_evidence: ParameterRegionEvidence,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    claim_uri, plugin_id, checker_id, candidate_schema_uri = _install_hypothesis_plugin(
+        kernel
+    )
+    source_record_uri, _, candidate_uri = _verified_counterexample(
+        kernel,
+        claim_uri=claim_uri,
+        plugin_id=plugin_id,
+        checker_id=checker_id,
+        candidate_schema_uri=candidate_schema_uri,
+        witness_role=WitnessRole.RESCUES_CANDIDATE,
+    )
+    result = kernel.conjectures.run(
+        ConjectureWorkflowRequest(
+            operation=ConjectureOperation.PARAMETER_GENERALIZE,
+            plugin_id=plugin_id,
+            source_uri=candidate_uri,
+            verification_record_uri=source_record_uri,
+            constraints={
+                "claim_template": kernel.store.get(claim_uri).payload,
+                "region_kind": region_kind,
+            },
+        )
+    )
+    region = result.hypotheses[0].parameter_region
+    assert region is not None
+    assert region.subject_uri is not None
+    subject_artifact = kernel.store.get(region.subject_uri)
+    subject = ParameterRegionSubject.model_validate(subject_artifact.payload)
+    target_claim = kernel.store.get(subject.claim_uri)
+    semantics = kernel.store.get(target_claim.manifest.semantics_uri)
+    certificate_schema_uri = kernel.schemas.register(
+        name="fixture.parameter-region-certificate",
+        version="1",
+        schema=CertificateEnvelope.model_json_schema(),
+    )
+    region_checker = kernel.checkers.authorize(
+        name=f"fixture-parameter-region-{region_kind.lower()}-v1",
+        entrypoint=(
+            "tests.fixtures.checker_functions:check_parameter_region_certificate"
+        ),
+        evidence_kind="CERTIFICATE",
+        format_id="fixture.parameter_region",
+        format_version="1",
+        claim_schema_uris=(target_claim.manifest.schema_uri,),
+        semantics_uris=(target_claim.manifest.semantics_uri,),
+        candidate_schema_uris=(kernel.conjectures.parameter_region_subject_schema_uri,),
+        reason="parameter-region promotion conformance fixture",
+    )
+    proof = {
+        "kind": region_kind,
+        "conditions": subject.conditions,
+    }
+    certificate = CertificateEnvelope(
+        certificate_type="fixture.parameter_region",
+        format_version="1",
+        bindings=EvidenceBindings(
+            claim_digest=target_claim.manifest.object_digest,
+            semantics_digest=semantics.manifest.object_digest,
+            candidate_digest=subject_artifact.manifest.object_digest,
+        ),
+        payload_digest=(
+            "sha256:" + hashlib.sha256(canonicalize_json(proof)).hexdigest()
+        ),
+        payload=proof,
+    )
+    stored_certificate = kernel.store.put(
+        schema_uri=certificate_schema_uri,
+        semantics_uri=target_claim.manifest.semantics_uri,
+        payload=certificate.model_dump(mode="json"),
+        parents=(target_claim.artifact_uri, subject_artifact.artifact_uri),
+        summary="parameter-region certificate fixture",
+    )
+    verified = kernel.verification.verify_certificate(
+        certificate_uri=stored_certificate.artifact_uri
+    )
+    assert verified.verification_record_uri is not None
+    kernel.checkers.authorize(
+        name=f"fixture-parameter-region-{region_kind.lower()}-v2",
+        entrypoint=(
+            "tests.fixtures.checker_functions:check_parameter_region_certificate"
+        ),
+        evidence_kind="CERTIFICATE",
+        format_id="fixture.parameter_region",
+        format_version="1",
+        claim_schema_uris=(target_claim.manifest.schema_uri,),
+        semantics_uris=(target_claim.manifest.semantics_uri,),
+        candidate_schema_uris=(kernel.conjectures.parameter_region_subject_schema_uri,),
+        reason="compatible checker must not change recorded-checker replay",
+    )
+
+    promoted = kernel.conjectures.promote_parameter_region(
+        subject_uri=subject_artifact.artifact_uri,
+        verification_record_uri=verified.verification_record_uri,
+    )
+
+    assert promoted.evidence is expected_evidence
+    assert promoted.conditions == region.conditions
+    assert promoted.sample_uris == region.sample_uris
+    assert promoted.subject_uri == region.subject_uri
+    assert promoted.verification_record_uri == verified.verification_record_uri
+
+    substituted_subject = kernel.store.put(
+        schema_uri=kernel.conjectures.parameter_region_subject_schema_uri,
+        semantics_uri=target_claim.manifest.semantics_uri,
+        payload=subject.model_dump(mode="json"),
+        parents=subject_artifact.manifest.parents,
+        summary="same parameter-region payload in a different carrier",
+    )
+    substituted_subject_artifact = kernel.store.get(substituted_subject.artifact_uri)
+    assert (
+        substituted_subject_artifact.manifest.object_digest
+        == subject_artifact.manifest.object_digest
+    )
+    assert substituted_subject.artifact_uri != subject_artifact.artifact_uri
+    with pytest.raises(
+        ConjectureError,
+        match="does not bind the supplied subject artifact",
+    ):
+        kernel.conjectures.promote_parameter_region(
+            subject_uri=substituted_subject.artifact_uri,
+            verification_record_uri=verified.verification_record_uri,
+        )
+
+    kernel.checkers.revoke(
+        region_checker.checker_id,
+        reason="recorded checker revocation must block replay",
+    )
+    with pytest.raises(
+        ConjectureError,
+        match="did not replay with its authorized checker",
+    ):
+        kernel.conjectures.promote_parameter_region(
+            subject_uri=subject_artifact.artifact_uri,
+            verification_record_uri=verified.verification_record_uri,
+        )
 
 
 @pytest.mark.subprocess

--- a/tests/integration/test_mcp_adapter.py
+++ b/tests/integration/test_mcp_adapter.py
@@ -44,6 +44,7 @@ def test_mcp_exposes_v02_tool_surface_and_persistent_resources(
                 "conjecture.repair",
                 "conjecture.generate",
                 "parameter.generalize",
+                "parameter.region.promote",
                 "transform.apply",
                 "transform.verify",
                 "polytope.separate",

--- a/tests/integration/test_plugin_registry_snapshots.py
+++ b/tests/integration/test_plugin_registry_snapshots.py
@@ -1,18 +1,27 @@
 from __future__ import annotations
 
 import os
+import sqlite3
 import sys
 from pathlib import Path
 
 import pytest
 
 import jacobian.plugins.registry as registry_module
+from jacobian.contracts.claims import ClaimSpec
 from jacobian.contracts.plugins import (
     CapabilityName,
     PluginManifest,
     PluginRegistrySnapshot,
 )
+from jacobian.contracts.search import SearchBudget, SearchRunRequest
 from jacobian.kernel import JacobianKernel
+from jacobian.plugin_conformance import (
+    PluginConformanceCheck,
+    SyntheticPluginConformanceTarget,
+    require_plugin_conformance,
+    run_plugin_conformance,
+)
 from jacobian.plugins.registry import PluginRegistryError
 
 pytestmark = pytest.mark.conformance
@@ -22,7 +31,7 @@ def _install_external_plugin(
     kernel: JacobianKernel,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-) -> tuple[str, str, Path]:
+) -> tuple[str, tuple[str, ...], Path, str]:
     package = tmp_path / "external_plugin"
     package.mkdir()
     marker = tmp_path / "imported"
@@ -31,7 +40,65 @@ def _install_external_plugin(
         encoding="utf-8",
     )
     (package / "entry.py").write_text(
-        "def evaluate(request):\n    return {'seen': request.get('request_version')}\n",
+        "\n".join(
+            (
+                "import time",
+                "",
+                "def propose(request):",
+                "    case = request['state'].get('conformance_case')",
+                "    if case == 'declared-failure':",
+                "        raise RuntimeError('declared plugin failure')",
+                "    if case == 'malformed-output':",
+                "        return ['not', 'an', 'object']",
+                "    if case == 'timeout':",
+                "        time.sleep(10)",
+                "    return {",
+                "        'response_version': '1',",
+                "        'candidates': [{'value': 1}],",
+                "        'state': request['state'],",
+                "        'complete': True,",
+                "    }",
+                "",
+                "def refine(request):",
+                "    return {",
+                "        'response_version': '1',",
+                "        'state': request['state'],",
+                "        'nominations': [],",
+                "    }",
+                "",
+                "def evaluate(request):",
+                "    return {",
+                "        'conclusion': 'UNKNOWN',",
+                "        'arithmetic': 'EXACT_INTEGER',",
+                "        'method': 'EXHAUSTIVE_FINITE',",
+                "        'coverage': 'EXHAUSTIVE',",
+                "        'features': {'value': str(request['candidate']['value'])},",
+                "    }",
+                "",
+                "def transform(_request):",
+                "    fake = 'artifact://sha256/' + ('a' * 64)",
+                "    return {",
+                "        'response_version': '1',",
+                "        'proposals': [{",
+                "            'claim': {},",
+                "            'edit': {",
+                "                'kind': 'parameter',",
+                "                'description': 'unsupported promotion',",
+                "            },",
+                "            'parameter_region': {",
+                "                'kind': 'SUFFICIENT',",
+                "                'conditions': {'n': {'minimum': 1}},",
+                "                'evidence': 'VERIFIED_SUFFICIENT',",
+                "                'subject_uri': fake,",
+                "                'verification_record_uri': fake,",
+                "            },",
+                "        }],",
+                "        'state': {},",
+                "        'complete': True,",
+                "    }",
+                "",
+            )
+        ),
         encoding="utf-8",
     )
     monkeypatch.syspath_prepend(str(tmp_path))
@@ -46,7 +113,7 @@ def _install_external_plugin(
     claim_schema_uri = kernel.schemas.register(
         name="external-plugin.claim",
         version="1",
-        schema={"type": "object"},
+        schema=ClaimSpec.model_json_schema(),
     )
     candidate_schema_uri = kernel.schemas.register(
         name="external-plugin.candidate",
@@ -59,8 +126,16 @@ def _install_external_plugin(
         version="1",
         definition={"description": "external plugin snapshot fixture"},
     )
-    entrypoint = "external_plugin.entry:evaluate"
-    implementation_uri = kernel.plugins.register_implementation(entrypoint)
+    entrypoints = {
+        CapabilityName.PROPOSER: "external_plugin.entry:propose",
+        CapabilityName.REFINER: "external_plugin.entry:refine",
+        CapabilityName.EVALUATOR: "external_plugin.entry:evaluate",
+        CapabilityName.HYPOTHESIS_TRANSFORMER: "external_plugin.entry:transform",
+    }
+    implementation_uris = {
+        capability: kernel.plugins.register_implementation(entrypoint)
+        for capability, entrypoint in entrypoints.items()
+    }
     assert not marker.exists()
     manifest = kernel.artifacts.put(
         schema_uri=kernel.reference_installer.manifest_schema_uri,
@@ -72,22 +147,45 @@ def _install_external_plugin(
             claim_schema_uri=claim_schema_uri,
             candidate_schema_uri=candidate_schema_uri,
             capabilities={
-                CapabilityName.EVALUATOR: {
-                    "implementation_uri": implementation_uri,
+                capability: {
+                    "implementation_uri": implementation_uris[capability],
                     "entrypoint": entrypoint,
                     "version": "1",
-                },
-                CapabilityName.TRANSFORMER: {
-                    "implementation_uri": implementation_uri,
-                    "entrypoint": entrypoint,
-                    "version": "1",
-                },
+                }
+                for capability, entrypoint in entrypoints.items()
             },
         ).model_dump(mode="json"),
     )
     kernel.plugins.install(manifest.artifact_uri)
     assert not marker.exists()
-    return manifest.artifact_uri, implementation_uri, marker
+    claim = kernel.artifacts.put(
+        schema_uri=claim_schema_uri,
+        semantics_uri=semantics_uri,
+        payload={
+            "claim_schema_version": "1",
+            "domain_id": "external.plugin",
+            "domain_version": "1",
+            "semantics_uri": semantics_uri,
+            "quantifiers": [],
+            "predicate": {
+                "name": "external_fixture",
+                "parameters": {},
+            },
+            "bounds": {},
+            "required_capabilities": [
+                "Proposer",
+                "Refiner",
+                "Evaluator",
+            ],
+            "correspondence_status": "UNREVIEWED",
+        },
+    )
+    return (
+        manifest.artifact_uri,
+        tuple(implementation_uris.values()),
+        marker,
+        claim.artifact_uri,
+    )
 
 
 @pytest.mark.integration
@@ -97,7 +195,7 @@ def test_registry_snapshot_binds_contract_source_runtime_and_platform(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     kernel = JacobianKernel(tmp_path / "state")
-    plugin_id, implementation_uri, marker = _install_external_plugin(
+    plugin_id, implementation_uris, marker, _ = _install_external_plugin(
         kernel,
         tmp_path,
         monkeypatch,
@@ -117,12 +215,12 @@ def test_registry_snapshot_binds_contract_source_runtime_and_platform(
         CapabilityName.EVALUATOR
     ].implementation_digest.startswith("sha256:")
     assert snapshot.capabilities[
-        CapabilityName.TRANSFORMER
+        CapabilityName.HYPOTHESIS_TRANSFORMER
     ].implementation_digest.startswith("sha256:")
     assert snapshot.runtime_identity.python_version
     assert snapshot.runtime_identity.platform_tag
     assert snapshot.build_identity_digest.startswith("sha256:")
-    assert stored.manifest.parents == tuple(sorted((plugin_id, implementation_uri)))
+    assert stored.manifest.parents == tuple(sorted((plugin_id, *implementation_uris)))
     assert not marker.exists()
 
     resolved = kernel.plugins.resolve(plugin_id, CapabilityName.EVALUATOR)
@@ -131,11 +229,12 @@ def test_registry_snapshot_binds_contract_source_runtime_and_platform(
     execution = kernel.plugin_executor.run(
         entrypoint=resolved.descriptor.entrypoint,
         implementation_digest=resolved.implementation_digest,
-        request={"request_version": "1"},
+        request={"candidate": {"value": 1}},
         timeout_seconds=5,
     )
     assert execution.status.value == "COMPLETED"
-    assert execution.output == {"seen": "1"}
+    assert execution.output is not None
+    assert execution.output["conclusion"] == "UNKNOWN"
     assert marker.exists()
 
 
@@ -145,7 +244,7 @@ def test_registry_snapshot_fails_closed_on_runtime_mismatch(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     kernel = JacobianKernel(tmp_path / "state")
-    plugin_id, _, _ = _install_external_plugin(kernel, tmp_path, monkeypatch)
+    plugin_id, _, _, _ = _install_external_plugin(kernel, tmp_path, monkeypatch)
     installed_runtime = kernel.plugins.snapshot(plugin_id).runtime_identity
     incompatible = installed_runtime.model_copy(
         update={"system": installed_runtime.system + "-different"}
@@ -157,3 +256,71 @@ def test_registry_snapshot_fails_closed_on_runtime_mismatch(
         match="incompatible with this runtime",
     ):
         kernel.plugins.resolve(plugin_id, CapabilityName.EVALUATOR)
+
+
+@pytest.mark.integration
+@pytest.mark.subprocess
+def test_external_plugin_passes_the_generic_conformance_kit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = JacobianKernel(tmp_path / "state")
+    plugin_id, _, _, claim_uri = _install_external_plugin(
+        kernel,
+        tmp_path,
+        monkeypatch,
+    )
+    package = tmp_path / "external_plugin"
+    entrypoint = package / "entry.py"
+    outside = tmp_path / "outside.py"
+    outside.write_text("value = 1\n", encoding="utf-8")
+    target = SyntheticPluginConformanceTarget(
+        kernel=kernel,
+        plugin_id=plugin_id,
+        search_request=SearchRunRequest(
+            idempotency_key="external-conformance-001",
+            claim_uri=claim_uri,
+            plugin_id=plugin_id,
+            budget=SearchBudget(
+                candidates_max=4,
+                iterations_max=4,
+                wall_seconds=5,
+                batch_size=1,
+                workers=1,
+            ),
+        ),
+        implementation_file=entrypoint,
+        symlink_path=package / "escape.py",
+        symlink_target=outside,
+        import_marker=tmp_path / "imported",
+    )
+
+    observations = require_plugin_conformance(target)
+
+    assert all(observation.passed for observation in observations)
+    with sqlite3.connect(kernel.store.db_path) as connection:
+        first_run_count = connection.execute(
+            "SELECT COUNT(*) FROM search_experiments"
+        ).fetchone()
+
+    repeated = require_plugin_conformance(target)
+
+    assert all(observation.passed for observation in repeated)
+    with sqlite3.connect(kernel.store.db_path) as connection:
+        second_run_count = connection.execute(
+            "SELECT COUNT(*) FROM search_experiments"
+        ).fetchone()
+    assert first_run_count == (4,)
+    assert second_run_count == (8,)
+
+    assert target.import_marker is not None
+    target.import_marker.write_text("unexpected discovery import", encoding="utf-8")
+    marker_observations = run_plugin_conformance(target)
+    execution_observation = next(
+        observation
+        for observation in marker_observations
+        if observation.check is PluginConformanceCheck.EXECUTION_SUCCESS
+    )
+    assert not execution_observation.passed
+    assert "plugin discovery imported package code" in execution_observation.detail
+    assert not target.import_marker.exists()

--- a/tests/integration/test_search_orchestration.py
+++ b/tests/integration/test_search_orchestration.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sqlite3
+import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
@@ -123,7 +124,7 @@ def _request(
             iterations_max=8,
             wall_seconds=wall_seconds,
             batch_size=batch_size,
-            workers=4,
+            workers=1,
         ),
     )
 
@@ -170,6 +171,69 @@ def test_search_run_checkpoints_strategy_neutral_lineage(tmp_path: Path) -> None
     )
     assert proposer_event.payload["request_digest"].startswith("sha256:")
     assert proposer_event.payload["output_digest"].startswith("sha256:")
+
+
+@pytest.mark.integration
+def test_checkpoint_persistence_is_included_in_wall_accounting(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    claim_uri, plugin_id = _install_search_plugin(kernel)
+    original_put = kernel.search._put_internal_artifact
+
+    def delayed_put(**kwargs: object) -> object:
+        if kwargs.get("summary") == "immutable search checkpoint":
+            time.sleep(1)
+        return original_put(**kwargs)
+
+    monkeypatch.setattr(kernel.search, "_put_internal_artifact", delayed_put)
+    started = time.monotonic()
+    handle = kernel.search.start(
+        _request(
+            claim_uri,
+            plugin_id,
+            idempotency_key="search-accounting-persistence-001",
+            batch_size=4,
+        )
+    )
+    snapshot = kernel.search.wait(handle.experiment_uri, timeout_seconds=30)
+    elapsed_ms = int((time.monotonic() - started) * 1000)
+
+    assert snapshot.state is ExperimentState.COMPLETED
+    assert snapshot.accounting.wall_time_ms >= elapsed_ms - 400
+
+
+@pytest.mark.integration
+def test_checkpoint_persistence_cannot_complete_past_wall_budget(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    claim_uri, plugin_id = _install_search_plugin(kernel)
+    original_put = kernel.search._put_internal_artifact
+
+    def delayed_put(**kwargs: object) -> object:
+        if kwargs.get("summary") == "immutable search checkpoint":
+            time.sleep(5.1)
+        return original_put(**kwargs)
+
+    monkeypatch.setattr(kernel.search, "_put_internal_artifact", delayed_put)
+    handle = kernel.search.start(
+        _request(
+            claim_uri,
+            plugin_id,
+            idempotency_key="search-accounting-timeout-001",
+            batch_size=4,
+            wall_seconds=5,
+        )
+    )
+    snapshot = kernel.search.wait(handle.experiment_uri, timeout_seconds=30)
+
+    assert snapshot.state is ExperimentState.TIMEOUT
+    assert snapshot.stop_reason is SearchStopReason.WALL_TIME_LIMIT
+    assert snapshot.strategy_reported_complete is False
+    assert snapshot.accounting.wall_time_ms >= 5_000
 
 
 @pytest.mark.integration
@@ -421,6 +485,100 @@ def test_interrupted_cancellation_remains_cancelled_after_recovery(
         "RECOVERED_CANCELLED",
         "RECOVERY_ARCHIVE_COMMITTED",
     ]
+
+
+@pytest.mark.integration
+def test_corrupt_snapshot_is_quarantined_without_blocking_recovery(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    claim_uri, plugin_id = _install_search_plugin(kernel)
+    monkeypatch.setattr(kernel.search, "_launch", lambda _experiment_uri: None)
+    valid = kernel.search.start(
+        _request(
+            claim_uri,
+            plugin_id,
+            idempotency_key="search-recovery-valid-001",
+        )
+    )
+    valid_snapshot = kernel.search.inspect(valid.experiment_uri)
+    corrupt_uri = "experiment://ffffffffffffffffffffffffffffffff"
+    mismatched_uri = "experiment://eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+    invalid_state_uri = "experiment://dddddddddddddddddddddddddddddddd"
+    with sqlite3.connect(kernel.store.db_path) as connection:
+        connection.execute("PRAGMA foreign_keys = ON")
+        connection.execute(
+            """
+            INSERT INTO search_experiments (
+                experiment_uri, state, snapshot_json
+            ) VALUES (?, 'RUNNING', ?)
+            """,
+            (corrupt_uri, b"{"),
+        )
+        connection.execute(
+            """
+            INSERT INTO search_experiments (
+                experiment_uri, state, snapshot_json
+            ) VALUES (?, 'PENDING', ?)
+            """,
+            (
+                mismatched_uri,
+                canonicalize_json(valid_snapshot.model_dump(mode="json")),
+            ),
+        )
+        invalid_state_snapshot = valid_snapshot.model_copy(
+            update={"experiment_uri": invalid_state_uri}
+        )
+        connection.execute(
+            """
+            INSERT INTO search_experiments (
+                experiment_uri, state, snapshot_json
+            ) VALUES (?, 'BROKEN', ?)
+            """,
+            (
+                invalid_state_uri,
+                canonicalize_json(invalid_state_snapshot.model_dump(mode="json")),
+            ),
+        )
+
+    recovered = JacobianKernel(tmp_path)
+
+    assert (
+        recovered.search.inspect(valid.experiment_uri).state is ExperimentState.PAUSED
+    )
+    with sqlite3.connect(recovered.store.db_path) as connection:
+        states = connection.execute(
+            """
+            SELECT experiment_uri, state
+            FROM search_experiments
+            WHERE experiment_uri IN (?, ?, ?)
+            ORDER BY experiment_uri
+            """,
+            (corrupt_uri, mismatched_uri, invalid_state_uri),
+        ).fetchall()
+        failures = connection.execute(
+            """
+            SELECT experiment_uri, snapshot_digest, detail
+            FROM search_recovery_failures
+            WHERE experiment_uri IN (?, ?, ?)
+            ORDER BY experiment_uri
+            """,
+            (corrupt_uri, mismatched_uri, invalid_state_uri),
+        ).fetchall()
+    assert states == [
+        (invalid_state_uri, "ERROR"),
+        (mismatched_uri, "ERROR"),
+        (corrupt_uri, "ERROR"),
+    ]
+    assert len(failures) == 3
+    assert all(str(failure[1]).startswith("sha256:") for failure in failures)
+    assert all("invalid" in str(failure[2]) for failure in failures)
+    assert recovered.search.events(corrupt_uri)[-1].event_type == "RECOVERY_REJECTED"
+    assert recovered.search.events(mismatched_uri)[-1].event_type == "RECOVERY_REJECTED"
+    assert (
+        recovered.search.events(invalid_state_uri)[-1].event_type == "RECOVERY_REJECTED"
+    )
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Problem

The provisional M3 and M4 implementations exercised their main search and conjecture paths, but several infrastructure gates were still documented rather than fully enforced. Requested worker counts implied unsupported parallelism, durable wall-clock accounting omitted checkpoint persistence, and one malformed persisted search row could prevent unrelated runs from recovering. Plugin compatibility also lacked a reusable attack-oriented conformance suite.

For M4, verified parameter regions did not yet have an immutable subject boundary, and certificate replay could select a currently compatible checker instead of the exact checker recorded by the cited verification record. The documentation also mixed release reference, architecture, decisions, and operating guidance in a flat directory, obscuring the boundary between the v0.2 contract and provisional milestones.

## Solution

- Restrict the reference search scheduler to its supported single-worker model, charge checkpoint persistence against the durable wall budget, and quarantine malformed or mismatched recovery rows independently with append-only rejection events.
- Add a reusable synthetic plugin conformance kit covering discovery without import, success, declared failure, malformed output, timeout, path and symlink attacks, changed implementation bytes, and unsupported evidence promotion.
- Introduce immutable parameter-region subjects and require promotion to bind exact subject and claim artifacts, object digests, verification-record parents, certificate evidence, and the recorded active checker. Expose the workflow through the CLI and MCP surface.
- Reorganize the documentation around Diátaxis, while keeping architecture, the roadmap, ADRs, the threat model, and release specifications prominent in the README and documentation home.

The v0.2 specification remains the only current release contract. M3 and M4 artifacts and APIs remain provisional. This does not add a distributed scheduler or a hostile-plugin sandbox.

## Suggested Review Order

1. Search contracts, execution, and recovery behavior.
2. Plugin conformance runner and registry tests.
3. Parameter-region contracts, promotion service, and exact-checker replay tests.
4. CLI and MCP adapters.
5. Documentation structure, ADRs, milestone specifications, and README navigation.

## Testing

```sh
uv sync --dev
uv run pytest                         # 207 passed
uv run ruff check .                   # passed
uv run ruff format --check .          # 102 files already formatted
uv run mypy                           # no issues in 57 source files
uv run deptry .                       # no dependency issues
npx --yes jscpd@5.0.12 --config .jscpd.json .  # 0 clones
uv build                              # sdist and wheel built
git diff --check                      # passed
```

Repository-relative links and anchors were also checked across all 33 Markdown files, including coverage of every document from `docs/index.md`. The quickstart tutorial's fenced example and CLI help flow were exercised directly.

## Trust & Compatibility Impact

This changes provisional search and conjecture artifact contracts and checker replay behavior, but does not change the v0.2 conformance contract.

Search recovery remains fail-closed: corrupted durable state becomes an execution error and cannot produce a mathematical conclusion. Parameter-region promotion now requires exact artifact and digest binding and replays through the checker recorded by the cited verification record; a revoked or incompatible recorded checker blocks promotion even when another compatible checker is installed. Plugin search code remains mathematically untrusted and cannot authorize checkers or promote evidence. The corresponding boundaries are documented in `docs/explanation/threat-model.md` and the new ADRs.

Compatibility notes for the provisional API:

- `SearchBudget.workers` now rejects values greater than one until a real multi-worker scheduler exists.
- `ParameterRegion` now requires an explicit region kind, and promoted evidence records a subject URI.
- `VerificationService.verify_certificate` accepts an optional checker ID; callers that omit it retain unique-compatible-checker selection.
- Documentation paths moved into Diátaxis sections; the README and documentation home contain the canonical replacements.

## Checklist

- [x] Tests pass locally (`uv run pytest`)
- [x] Linting passes (`uv run ruff check .`)
- [x] Type checking passes (`uv run mypy`)
- [x] Formatting passes (`uv run ruff format --check .`)
- [x] Build succeeds (`uv build`)
- [x] Relevant documentation updated
