### PR TITLE
feat: add capability-first agent workbench

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -2,7 +2,7 @@
 
 [mcp_servers.jacobian_local]
 command = "uv"
-args = ["run", "jacobian-mcp", "--tool-profile", "verification"]
+args = ["run", "jacobian-mcp", "--tool-profile", "capabilities"]
 cwd = "."
 enabled = true
 required = true

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.jacobian
+.venv
+benchmarks/results
+build
+dist
+lean/.lake
+__pycache__

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
 # Jacobian local state directory for artifact store and metadata.
 # Default: .jacobian (relative to working directory)
 JACOBIAN_STATE_DIR=.jacobian
+
+# Remote hosts should pass the token file and public URL as jacobian-mcp
+# arguments. Do not put bearer tokens in this environment file.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+
+WORKDIR /app
+
+COPY pyproject.toml uv.lock README.md ./
+COPY src ./src
+COPY lean ./lean
+
+RUN uv sync --locked --no-dev
+
+EXPOSE 8000
+VOLUME ["/var/lib/jacobian"]
+
+ENTRYPOINT ["uv", "run", "jacobian-mcp"]
+CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,5 @@ RUN uv sync --locked --no-dev
 EXPOSE 8000
 VOLUME ["/var/lib/jacobian"]
 
-ENTRYPOINT ["uv", "run", "jacobian-mcp"]
+ENTRYPOINT ["uv", "run", "--no-sync", "jacobian-mcp"]
 CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ authorized `certificate.verify` boundary. Both bundled environments pin Lean
 - `MATHLIB` generates exactly `import Mathlib`, pins mathlib commit
   `fabf563a7c95a166b8d7b6efca11c8b4dc9d911f`, and permits only the declared
   standard trust base `Classical.choice`, `Quot.sound`, and `propext`. Its
-  operator-installed checker profile has a 75-second cold-start ceiling;
+  operator-installed checker profile has a 105-second cold-start ceiling;
   normal checkers retain the 30-second default.
 
 Prepare the pinned local runtime with:

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Jacobian
 
-Jacobian is a verifier-centric MCP toolbench for agents working on bounded,
-executable mathematics.
+Jacobian is a capability-first MCP workbench and research-memory layer for
+agents doing executable mathematics.
 
-It gives agents and researchers executable tools with which to propose
-candidates, search large spaces, receive structured counter-witnesses, repair
-claims, and replay exact certificates. The kernel is not a
+It gives agents and researchers reusable computation, search, retrieval,
+formal-proof, experiment, and verification tools so they can focus on
+mathematical strategy instead of rebuilding infrastructure. The kernel is not a
 `solve_conjecture` endpoint and does not treat model output or solver status as
 mathematical truth.
 
@@ -16,7 +16,9 @@ share the same artifact, evaluation, witness, shrinking, provenance, and
 verification substrate—not that an informal conjecture requires no
 formalization or domain implementation.
 
-The central invariant is:
+Exploration is intentionally low friction. Verification is an optional
+assurance lane for results that must become durable mathematical claims. Its
+central invariant remains:
 
 > Search and evaluation may be wrong. A result becomes verified only when an
 > operator-authorized checker accepts evidence bound to the exact claim,
@@ -42,15 +44,15 @@ CLI or `uv run jacobian-mcp` to start the MCP adapter.
 | Milestone | Theme | Primary outcome |
 | --- | --- | --- |
 | Current release | Verification and bounded discovery | v0.2 alpha stores, evaluates, attacks, shrinks, independently verifies, enumerates structures, verifies representation changes, and computes exact separators |
+| Current product track | Capabilities and research memory | One extensible model-facing API supports fast exploration, optional verification, trust-labeled local episodes, and local or remote MCP hosts |
 | M3 | Scalable search | Provisional implementation runs typed search strategies through one resumable experiment loop |
 | M4 | Conjecture workflows | Provisional implementation repairs, generates, falsifies, and parametrically generalizes conjectures |
-| M5 | Research corpus integration | Retrieve prior solutions, failures, witnesses, and certificates through an optional provider |
+| M5 | Federated research corpus | Extend the implemented local episode database with optional cross-project providers, review, retraction, and temporal retrieval |
 | Stability target | Stable research platform | Publish a v1.0 API with formal-checking and collaboration support |
 
-The roadmap is tool-first: search and conjecture workflows remain useful
-without a shared corpus service. Jacobian records its own experiments for
-replay and lineage; corpus-scale retrieval is an optional integration that
-cannot promote evidence or authorize checkers.
+The roadmap is tool-first and database-first. Local capability episodes are
+recorded and searchable without a shared service. Corpus-scale retrieval is an
+optional integration that cannot promote evidence or authorize checkers.
 
 The only public release contract is v0.2 alpha (`0.2.0a0`). It includes the
 verification kernel and bounded discovery. The repository also contains
@@ -65,6 +67,8 @@ gates are part of the working project record. Start with:
 
 - [Architecture](docs/explanation/architecture.md) for the system shape and
   verification boundary.
+- [Capability-first product blueprint](docs/explanation/product-blueprint.md)
+  for the agent-facing API, memory, remote host, and A/B evaluation direction.
 - [Roadmap](docs/explanation/roadmap.md) for active milestone scope and exit
   gates.
 - [Architecture decision log](docs/explanation/adr/index.md) for accepted
@@ -94,8 +98,13 @@ documentation placement, and pull-request expectations.
 
 ## Current status
 
-v0.2 alpha is implemented as a local Python package, CLI, and MCP adapter. It
-offers eight verification tools alongside bounded enumeration,
+v0.2 alpha is implemented as a Python package, CLI, and local or remote MCP
+adapter. The capability-first projection exposes one stable
+`capability.invoke` tool backed by a discoverable adapter registry and
+trust-labeled research memory. Bundled capabilities provide reference-domain
+exploration and verification, Lean checking, and local episode search.
+
+The advanced surface retains eight verification tools alongside bounded enumeration,
 implementation-bound canonicalization, independently verified representation
 changes, persistent experiment resources, and exact finite-polytope evidence.
 Bundled reference domains cover graph paths and bipartiteness, exact integer
@@ -130,18 +139,18 @@ bound witness or certificate.
 The repository includes a trusted-project Codex profile at
 `.codex/config.toml`. Run Codex from the repository root and inspect
 `jacobian_local` with `/mcp`; the profile starts `uv run jacobian-mcp` over
-STDIO with the compact `verification` tool profile and stores durable local
-state under the ignored `.jacobian/` directory. The profile projects eight
-verification tools from the canonical registry and omits redundant MCP output
-schemas. Domain resources expose compact claim contracts instead of repeating
-the canonical stored schemas, and composite workflows return a concise stage
-projection while leaving all durable artifacts unchanged. Start
+STDIO with the compact `capabilities` profile and stores durable local state
+under the ignored `.jacobian/` directory. The profile advertises
+`capability.invoke`; `capability://catalog` supplies the installed operations,
+schemas, and supported `EXPLORE` or `VERIFY` lanes. Start
 `uv run jacobian-mcp --tool-profile full` when the research, transformation,
 and experiment tools or complete wire results are needed.
 
-This profile is local development configuration. It does not expose an HTTP
-endpoint or provide remote authentication, tenant isolation, or hosted-service
-authorization.
+For ChatGPT and other remote clients, the server supports Streamable HTTP and
+SSE, bearer-token authentication, and subject-bound tenant state. Follow
+[Deploy the remote MCP server](docs/how-to/deploy-remote-mcp.md). Static tokens
+are an initial controlled-deployment mechanism, not a full hosted identity
+platform.
 
 The public known-answer agent pilot launches a real Codex CLI against this
 profile and validates the resulting durable verification records rather than
@@ -153,6 +162,8 @@ uv run python benchmarks/agent_mcp.py
 
 Raw transcripts, isolated Jacobian state, reports, structured agent feedback,
 and scores are written to the ignored `benchmarks/results/` directory.
+Use `uv run python benchmarks/agent_ab.py` for paired no-Jacobian versus
+capability-enabled runs once the A/B cases are selected.
 
 ### Lean certificates
 
@@ -200,7 +211,7 @@ TypeScript client or adapter.
 
 - Natural-language-to-formal-mathematics automation
 - A universal mathematical ontology
-- A generic public `solver.solve` tool
+- One opaque generic solver that hides backend semantics
 - Arbitrary model-uploaded executable bundles
 - Distributed search infrastructure
 - A theorem prover or SAT/MIP solver implemented from scratch

--- a/README.md
+++ b/README.md
@@ -95,9 +95,13 @@ documentation placement, and pull-request expectations.
 ## Current status
 
 v0.2 alpha is implemented as a local Python package, CLI, and MCP adapter. It
-offers seven verification tools alongside bounded enumeration,
+offers eight verification tools alongside bounded enumeration,
 implementation-bound canonicalization, independently verified representation
 changes, persistent experiment resources, and exact finite-polytope evidence.
+Bundled reference domains cover graph paths and bipartiteness, exact integer
+matrices, and bounded Erdős-Straus decomposition tables. A verified
+Erdős-Straus table establishes only its exact finite interval, never the open
+unbounded conjecture.
 
 The provisional M3/M4 code adds sealed plugin snapshots, a strategy-neutral
 `search.run` service, pause and resume from immutable checkpoints, append-only
@@ -147,8 +151,8 @@ trusting the model's summary:
 uv run python benchmarks/agent_mcp.py
 ```
 
-Raw transcripts, isolated Jacobian state, reports, and scores are written to
-the ignored `benchmarks/results/` directory.
+Raw transcripts, isolated Jacobian state, reports, structured agent feedback,
+and scores are written to the ignored `benchmarks/results/` directory.
 
 ### Lean certificates
 

--- a/benchmarks/ab_cases/erdos_straus_ab_001.json
+++ b/benchmarks/ab_cases/erdos_straus_ab_001.json
@@ -1,0 +1,14 @@
+{
+  "case_id": "ERDOS-STRAUS-AB-001",
+  "version": "1",
+  "reference_name": "erdos_straus",
+  "title": "Bounded Erdős-Straus decision",
+  "prompt": "Determine whether every integer n from 2 through 120 inclusive has positive integer x, y, z satisfying 4/n = 1/x + 1/y + 1/z. Check the complete finite interval, report the number of checked integers and the first failure if one exists, and do not generalize beyond the interval.",
+  "expected": {
+    "conclusion": "TRUE",
+    "lower_bound": 2,
+    "upper_bound": 120,
+    "checked_count": 119,
+    "first_failure": null
+  }
+}

--- a/benchmarks/ab_cases/report.schema.json
+++ b/benchmarks/ab_cases/report.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "case_id": {"type": "string"},
+    "conclusion": {"enum": ["TRUE", "FALSE", "UNKNOWN"]},
+    "checked_count": {"type": "integer", "minimum": 0},
+    "first_failure": {"type": ["integer", "null"]},
+    "assurance": {
+      "enum": ["SELF_CHECKED", "HEURISTIC", "COMPUTED", "VERIFIED"]
+    },
+    "verification_record_uri": {
+      "type": ["string", "null"],
+      "pattern": "^artifact://sha256/[0-9a-f]{64}$"
+    },
+    "limitations": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "feedback": {
+      "type": "object",
+      "properties": {
+        "reasoning_focus": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "infrastructure_work": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "tooling_gaps": {
+          "type": "array",
+          "items": {"type": "string"}
+        }
+      },
+      "required": ["reasoning_focus", "infrastructure_work", "tooling_gaps"],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "case_id",
+    "conclusion",
+    "checked_count",
+    "first_failure",
+    "assurance",
+    "verification_record_uri",
+    "limitations",
+    "feedback"
+  ],
+  "additionalProperties": false
+}

--- a/benchmarks/agent_ab.py
+++ b/benchmarks/agent_ab.py
@@ -1,0 +1,556 @@
+"""Run paired no-tool and Jacobian-capability Codex evaluations.
+
+This benchmark measures whether Jacobian changes agent outcomes. It is
+separate from ``agent_mcp.py``, which validates MCP and checker integration.
+
+Run a three-pair pilot with:
+
+    uv run python benchmarks/agent_ab.py --case ERDOS-STRAUS-AB-001
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import random
+import shutil
+import statistics
+import subprocess
+import time
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from jacobian.contracts.verification import VerificationRecord
+from jacobian.store import ArtifactStore, StoreError
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+CASES_ROOT = Path(__file__).with_name("ab_cases")
+REPORT_SCHEMA = CASES_ROOT / "report.schema.json"
+DEFAULT_RESULTS_ROOT = Path(__file__).with_name("results") / "ab"
+CONDITIONS = ("control", "treatment")
+
+COMMON_PROMPT = """\
+Complete mathematical evaluation case {case_id}.
+
+{prompt}
+
+Return only the required JSON report. Record what work concerned mathematical
+strategy in feedback.reasoning_focus, what work concerned constructing or
+operating infrastructure in feedback.infrastructure_work, and missing
+capabilities in feedback.tooling_gaps. Empty lists are valid. Do not claim
+anything beyond the exact finite scope.
+"""
+
+CONTROL_INSTRUCTIONS = """\
+Jacobian and all MCP servers are unavailable in this condition. You may create
+and run local code in the empty workspace to perform the finite check. Report
+assurance as SELF_CHECKED and verification_record_uri as null.
+"""
+
+TREATMENT_INSTRUCTIONS = """\
+Use the jacobian_local MCP server for all mathematical computation. Do not use
+shell commands or create programs. Call capability.invoke directly with
+reference.solve in VERIFY mode. Its payload uses reference_name
+"erdos_straus", predicate {name: "erdos_straus_range", parameters:
+{lower_bound: 2, upper_bound: 120}}, candidate {lower_bound: 2, upper_bound:
+120}, and witness_role "SUPPORTS_CLAIM". Report VERIFIED only if the capability
+returns that assurance, and copy its exact verification_record_uri.
+"""
+
+
+class BenchmarkError(RuntimeError):
+    """The A/B runner, report, or known-answer evidence is invalid."""
+
+
+def _load_json_object(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise BenchmarkError(f"{path} must contain a JSON object")
+    return payload
+
+
+def load_cases(selected: Sequence[str]) -> list[dict[str, Any]]:
+    cases = [
+        _load_json_object(path)
+        for path in sorted(CASES_ROOT.glob("*.json"))
+        if path.name != REPORT_SCHEMA.name
+    ]
+    indexed = {str(case.get("case_id")): case for case in cases}
+    if len(indexed) != len(cases):
+        raise BenchmarkError("A/B case IDs must be unique")
+    if not selected or selected == ["all"]:
+        return cases
+    missing = sorted(set(selected) - set(indexed))
+    if missing:
+        raise BenchmarkError(f"unknown A/B cases: {', '.join(missing)}")
+    return [indexed[case_id] for case_id in selected]
+
+
+def parse_transcript(path: Path) -> dict[str, Any]:
+    mcp_calls: list[str] = []
+    shell_calls: list[str] = []
+    usage: dict[str, Any] | None = None
+    for line in path.read_text(encoding="utf-8").splitlines():
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict):
+            continue
+        item = event.get("item")
+        if (
+            event.get("type") == "item.completed"
+            and isinstance(item, dict)
+            and item.get("type") == "mcp_tool_call"
+            and isinstance(item.get("tool"), str)
+        ):
+            mcp_calls.append(item["tool"])
+        if (
+            event.get("type") == "item.completed"
+            and isinstance(item, dict)
+            and item.get("type") == "command_execution"
+        ):
+            command = item.get("command")
+            shell_calls.append(command if isinstance(command, str) else "")
+        if event.get("type") == "turn.completed" and isinstance(
+            event.get("usage"), dict
+        ):
+            usage = event["usage"]
+    return {
+        "mcp_calls": mcp_calls,
+        "shell_calls": shell_calls,
+        "usage": usage,
+    }
+
+
+def score_report(
+    case: Mapping[str, Any],
+    report: Mapping[str, Any],
+    *,
+    condition: str,
+    state_dir: Path,
+    mcp_calls: Sequence[str],
+) -> dict[str, Any]:
+    expected_value = case.get("expected")
+    if not isinstance(expected_value, dict):
+        raise BenchmarkError("case expected must be an object")
+    expected = expected_value
+    for field in ("case_id", "conclusion", "checked_count", "first_failure"):
+        wanted = case.get(field) if field == "case_id" else expected.get(field)
+        if report.get(field) != wanted:
+            raise BenchmarkError(f"report {field} differs from the known answer")
+    feedback = report.get("feedback")
+    if (
+        not isinstance(feedback, dict)
+        or set(feedback) != {"reasoning_focus", "infrastructure_work", "tooling_gaps"}
+        or not all(
+            isinstance(value, list) and all(isinstance(item, str) for item in value)
+            for value in feedback.values()
+        )
+    ):
+        raise BenchmarkError("report feedback has an invalid structure")
+
+    checks = ["known finite answer", "structured workload feedback"]
+    if condition == "control":
+        if mcp_calls:
+            raise BenchmarkError("control condition used an MCP tool")
+        if report.get("assurance") != "SELF_CHECKED":
+            raise BenchmarkError("control assurance must be SELF_CHECKED")
+        if report.get("verification_record_uri") is not None:
+            raise BenchmarkError("control condition reported a verification record")
+        checks.append("no-Jacobian control isolation")
+    elif condition == "treatment":
+        if "capability.invoke" not in mcp_calls:
+            raise BenchmarkError("treatment did not invoke a Jacobian capability")
+        if report.get("assurance") != "VERIFIED":
+            raise BenchmarkError("treatment did not report verified assurance")
+        record_uri = report.get("verification_record_uri")
+        if not isinstance(record_uri, str):
+            raise BenchmarkError("treatment omitted its verification record")
+        _score_erdos_record(
+            state_dir=state_dir,
+            record_uri=record_uri,
+            expected=expected,
+        )
+        checks.append("durable bounded verification record")
+    else:
+        raise BenchmarkError(f"unknown condition: {condition}")
+    return {"passed": True, "checks": checks}
+
+
+def _score_erdos_record(
+    *,
+    state_dir: Path,
+    record_uri: str,
+    expected: Mapping[str, Any],
+) -> None:
+    store = ArtifactStore(state_dir)
+    try:
+        record = VerificationRecord.model_validate(store.get(record_uri).payload)
+        evidence = store.get(record.evidence_uri)
+    except (StoreError, ValueError) as exc:
+        raise BenchmarkError("treatment verification record is unavailable") from exc
+    if record.conclusion.value != expected.get("conclusion"):
+        raise BenchmarkError("verification record has the wrong conclusion")
+    payload = evidence.payload
+    if not isinstance(payload, dict):
+        raise BenchmarkError("verified evidence is malformed")
+    witness = payload.get("payload")
+    table = witness.get("decompositions") if isinstance(witness, dict) else None
+    if not isinstance(table, list):
+        raise BenchmarkError("verified decomposition table is missing")
+    lower = int(expected["lower_bound"])
+    upper = int(expected["upper_bound"])
+    seen: set[int] = set()
+    for row in table:
+        if not isinstance(row, dict):
+            raise BenchmarkError("verified decomposition row is malformed")
+        try:
+            n, x, y, z = (int(row[key]) for key in ("n", "x", "y", "z"))
+        except (KeyError, TypeError, ValueError) as exc:
+            raise BenchmarkError("verified decomposition row is malformed") from exc
+        if min(x, y, z) <= 0:
+            raise BenchmarkError("verified denominator is not positive")
+        if 4 * x * y * z != n * (x * y + x * z + y * z):
+            raise BenchmarkError("verified decomposition identity fails")
+        seen.add(n)
+    if seen != set(range(lower, upper + 1)):
+        raise BenchmarkError("verified evidence has the wrong finite scope")
+
+
+def _codex_command(
+    *,
+    codex_command: str,
+    condition: str,
+    workspace: Path,
+    report_path: Path,
+    state_dir: Path,
+    model: str | None,
+    reasoning_effort: str,
+) -> list[str]:
+    command = [
+        codex_command,
+        "exec",
+        "--ephemeral",
+        "--ignore-user-config",
+        "--skip-git-repo-check",
+        "--sandbox",
+        "workspace-write",
+        "--cd",
+        str(workspace),
+        "--color",
+        "never",
+        "--json",
+        "--output-schema",
+        str(REPORT_SCHEMA),
+        "--output-last-message",
+        str(report_path),
+        "-c",
+        "model_reasoning_effort=" + json.dumps(reasoning_effort),
+    ]
+    if condition == "treatment":
+        uv_command = shutil.which("uv")
+        if uv_command is None:
+            raise BenchmarkError("uv is required for the treatment MCP server")
+        server_args = [
+            "run",
+            "--project",
+            str(PROJECT_ROOT),
+            "jacobian-mcp",
+            "--tool-profile",
+            "capabilities",
+            "--state-dir",
+            str(state_dir),
+        ]
+        command.extend(
+            [
+                "-c",
+                "mcp_servers.jacobian_local.command=" + json.dumps(uv_command),
+                "-c",
+                "mcp_servers.jacobian_local.args=" + json.dumps(server_args),
+                "-c",
+                "mcp_servers.jacobian_local.cwd=" + json.dumps(str(PROJECT_ROOT)),
+                "-c",
+                "mcp_servers.jacobian_local.enabled=true",
+                "-c",
+                "mcp_servers.jacobian_local.required=true",
+                "-c",
+                "mcp_servers.jacobian_local.startup_timeout_sec=30",
+                "-c",
+                "mcp_servers.jacobian_local.tool_timeout_sec=360",
+            ]
+        )
+    if model is not None:
+        command.extend(["--model", model])
+    command.append("-")
+    return command
+
+
+def _run_condition(
+    case: dict[str, Any],
+    *,
+    condition: str,
+    repetition: int,
+    pair_root: Path,
+    codex_command: str,
+    model: str | None,
+    reasoning_effort: str,
+    timeout_seconds: int,
+) -> dict[str, Any]:
+    condition_root = pair_root / condition
+    workspace = condition_root / "workspace"
+    state_dir = condition_root / "state"
+    transcript = condition_root / "transcript.jsonl"
+    stderr_path = condition_root / "codex.stderr.log"
+    report_path = condition_root / "agent-report.json"
+    condition_root.mkdir(parents=True)
+    workspace.mkdir()
+    state_dir.mkdir()
+    condition_instructions = (
+        CONTROL_INSTRUCTIONS if condition == "control" else TREATMENT_INSTRUCTIONS
+    )
+    prompt = condition_instructions + "\n" + COMMON_PROMPT.format(**case)
+    command = _codex_command(
+        codex_command=codex_command,
+        condition=condition,
+        workspace=workspace,
+        report_path=report_path,
+        state_dir=state_dir,
+        model=model,
+        reasoning_effort=reasoning_effort,
+    )
+    started = time.monotonic()
+    started_at = _timestamp()
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=workspace,
+            env=dict(os.environ),
+            input=prompt,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+        exit_code: int | None = completed.returncode
+        stdout = completed.stdout
+        stderr = completed.stderr
+        operational_error = None
+    except subprocess.TimeoutExpired as exc:
+        exit_code = None
+        stdout = exc.stdout if isinstance(exc.stdout, str) else ""
+        stderr = exc.stderr if isinstance(exc.stderr, str) else ""
+        operational_error = f"Codex exceeded {timeout_seconds} seconds"
+    elapsed = time.monotonic() - started
+    transcript.write_text(stdout, encoding="utf-8")
+    stderr_path.write_text(stderr, encoding="utf-8")
+    telemetry = parse_transcript(transcript)
+    report: dict[str, Any] | None = None
+    if operational_error is not None:
+        score = {"passed": False, "error": operational_error}
+    elif exit_code != 0:
+        score = {"passed": False, "error": f"Codex exited with status {exit_code}"}
+    else:
+        try:
+            report = _load_json_object(report_path)
+            score = score_report(
+                case,
+                report,
+                condition=condition,
+                state_dir=state_dir,
+                mcp_calls=telemetry["mcp_calls"],
+            )
+        except (BenchmarkError, OSError, json.JSONDecodeError) as exc:
+            score = {"passed": False, "error": str(exc)}
+    result = {
+        "case_id": case["case_id"],
+        "case_version": case["version"],
+        "condition": condition,
+        "repetition": repetition,
+        "started_at": started_at,
+        "completed_at": _timestamp(),
+        "elapsed_seconds": round(elapsed, 3),
+        "exit_code": exit_code,
+        "usage": telemetry["usage"],
+        "mcp_calls": telemetry["mcp_calls"],
+        "mcp_call_count": len(telemetry["mcp_calls"]),
+        "shell_calls": telemetry["shell_calls"],
+        "shell_call_count": len(telemetry["shell_calls"]),
+        "workspace_file_count": sum(
+            1 for path in workspace.rglob("*") if path.is_file()
+        ),
+        "agent_report": report,
+        "score": score,
+    }
+    (condition_root / "result.json").write_text(
+        json.dumps(result, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return result
+
+
+def summarize_pairs(results: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    by_key: dict[tuple[str, int], dict[str, Mapping[str, Any]]] = {}
+    for result in results:
+        key = (str(result["case_id"]), int(result["repetition"]))
+        by_key.setdefault(key, {})[str(result["condition"])] = result
+    pairs: list[dict[str, Any]] = []
+    for (case_id, repetition), conditions in sorted(by_key.items()):
+        if set(conditions) != set(CONDITIONS):
+            continue
+        control = conditions["control"]
+        treatment = conditions["treatment"]
+        pairs.append(
+            {
+                "case_id": case_id,
+                "repetition": repetition,
+                "control_passed": bool(control["score"].get("passed")),
+                "treatment_passed": bool(treatment["score"].get("passed")),
+                "elapsed_delta_seconds": round(
+                    float(treatment["elapsed_seconds"])
+                    - float(control["elapsed_seconds"]),
+                    3,
+                ),
+                "input_token_delta": _usage_value(treatment, "input_tokens")
+                - _usage_value(control, "input_tokens"),
+                "output_token_delta": _usage_value(treatment, "output_tokens")
+                - _usage_value(control, "output_tokens"),
+                "shell_call_delta": int(treatment["shell_call_count"])
+                - int(control["shell_call_count"]),
+                "mcp_call_delta": int(treatment["mcp_call_count"])
+                - int(control["mcp_call_count"]),
+            }
+        )
+    condition_summary = {
+        condition: _condition_summary(
+            [result for result in results if result["condition"] == condition]
+        )
+        for condition in CONDITIONS
+    }
+    return {
+        "pair_count": len(pairs),
+        "conditions": condition_summary,
+        "pairs": pairs,
+    }
+
+
+def _condition_summary(results: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    if not results:
+        return {"runs": 0}
+    return {
+        "runs": len(results),
+        "pass_rate": sum(bool(result["score"].get("passed")) for result in results)
+        / len(results),
+        "median_elapsed_seconds": statistics.median(
+            float(result["elapsed_seconds"]) for result in results
+        ),
+        "median_input_tokens": statistics.median(
+            _usage_value(result, "input_tokens") for result in results
+        ),
+        "median_output_tokens": statistics.median(
+            _usage_value(result, "output_tokens") for result in results
+        ),
+    }
+
+
+def _usage_value(result: Mapping[str, Any], field: str) -> int:
+    usage = result.get("usage")
+    value = usage.get(field, 0) if isinstance(usage, dict) else 0
+    return int(value) if isinstance(value, int | float) else 0
+
+
+def _timestamp() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _run_text(command: Sequence[str]) -> str:
+    completed = subprocess.run(
+        command,
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=30,
+    )
+    return completed.stdout.strip()
+
+
+def _digest_file(path: Path) -> str:
+    return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Run paired Codex control and Jacobian capability evaluations."
+    )
+    parser.add_argument("--case", action="append", default=[])
+    parser.add_argument("--repetitions", type=int, default=3)
+    parser.add_argument("--model")
+    parser.add_argument(
+        "--reasoning-effort",
+        choices=("low", "medium", "high"),
+        default="medium",
+    )
+    parser.add_argument("--codex-command", default="codex")
+    parser.add_argument("--timeout-seconds", type=int, default=600)
+    parser.add_argument("--order-seed", type=int, default=0)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_RESULTS_ROOT)
+    args = parser.parse_args(argv)
+    if args.repetitions < 1:
+        parser.error("--repetitions must be positive")
+    cases = load_cases(args.case)
+    run_id = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    run_root = args.output_dir.resolve() / run_id
+    run_root.mkdir(parents=True)
+    metadata = {
+        "benchmark": "jacobian-agent-capability-ab",
+        "repository_commit": _run_text(["git", "rev-parse", "HEAD"]),
+        "repository_dirty": bool(_run_text(["git", "status", "--porcelain"])),
+        "dependency_lock_digest": _digest_file(PROJECT_ROOT / "uv.lock"),
+        "codex_version": _run_text([args.codex_command, "--version"]),
+        "requested_model": args.model or "configured-default",
+        "reasoning_effort": args.reasoning_effort,
+        "order_seed": args.order_seed,
+    }
+    randomizer = random.Random(args.order_seed)
+    results: list[dict[str, Any]] = []
+    for case in cases:
+        for repetition in range(1, args.repetitions + 1):
+            order = list(CONDITIONS)
+            randomizer.shuffle(order)
+            pair_root = (
+                run_root / str(case["case_id"]).lower() / f"repetition-{repetition:02d}"
+            )
+            for condition in order:
+                results.append(
+                    _run_condition(
+                        case,
+                        condition=condition,
+                        repetition=repetition,
+                        pair_root=pair_root,
+                        codex_command=args.codex_command,
+                        model=args.model,
+                        reasoning_effort=args.reasoning_effort,
+                        timeout_seconds=args.timeout_seconds,
+                    )
+                )
+    summary = {
+        **metadata,
+        "run_id": run_id,
+        "started_conditions": len(results),
+        **summarize_pairs(results),
+    }
+    (run_root / "summary.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0 if all(result["score"].get("passed") for result in results) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/agent_cases/erdos_straus_001.json
+++ b/benchmarks/agent_cases/erdos_straus_001.json
@@ -1,0 +1,25 @@
+{
+  "case_id": "ERDOS-STRAUS-001",
+  "version": "1",
+  "reference_name": "erdos_straus",
+  "title": "Verified bounded Erdős-Straus range",
+  "prompt": "Using the bundled erdos_straus reference domain, verify the bounded statement that every integer n from 2 through 1000 inclusive has positive integer x, y, z satisfying 4/n = 1/x + 1/y + 1/z. Use the exact candidate range [2, 1000] and a SUPPORTS_CLAIM witness. Report only the bounded conclusion; do not generalize it to the open conjecture. In feedback, record which exposed tools and domain-contract facts made the run efficient, what was missing or confusing, and concrete tool or domain-knowledge improvements.",
+  "required_tools": [
+    "verification.run"
+  ],
+  "expected": {
+    "domain_id": "jacobian.erdos-straus",
+    "predicate": "erdos_straus_range",
+    "parameters": {
+      "lower_bound": 2,
+      "upper_bound": 1000
+    },
+    "conclusion": "TRUE",
+    "witness_format": "erdos_straus.decomposition_table",
+    "candidate": {
+      "kind": "integer_range",
+      "lower_bound": 2,
+      "upper_bound": 1000
+    }
+  }
+}

--- a/benchmarks/agent_cases/report.schema.json
+++ b/benchmarks/agent_cases/report.schema.json
@@ -41,6 +41,42 @@
       "items": {
         "type": "string"
       }
+    },
+    "feedback": {
+      "type": "object",
+      "properties": {
+        "tooling_strengths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tooling_gaps": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "domain_knowledge_gaps": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "suggested_improvements": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "tooling_strengths",
+        "tooling_gaps",
+        "domain_knowledge_gaps",
+        "suggested_improvements"
+      ],
+      "additionalProperties": false
     }
   },
   "required": [
@@ -54,7 +90,8 @@
     "evidence_uri",
     "verification_record_uri",
     "witness_summary",
-    "limitations"
+    "limitations",
+    "feedback"
   ],
   "additionalProperties": false
 }

--- a/benchmarks/agent_mcp.py
+++ b/benchmarks/agent_mcp.py
@@ -477,6 +477,16 @@ def _run_case(
         "mcp_servers.jacobian_local.env.JACOBIAN_STATE_DIR="
         + json.dumps(str(state_dir)),
         "-c",
+        "mcp_servers.jacobian_local.args="
+        + json.dumps(
+            [
+                "run",
+                "jacobian-mcp",
+                "--tool-profile",
+                "verification",
+            ]
+        ),
+        "-c",
         "model_reasoning_effort=" + json.dumps(reasoning_effort),
     ]
     if model is not None:

--- a/benchmarks/agent_mcp.py
+++ b/benchmarks/agent_mcp.py
@@ -40,8 +40,8 @@ witness search as
 UNVERIFIED. A decisive result is VERIFIED only after the compatible independent
 checker accepts the exact bound evidence. Do not reread returned evidence or
 verification-record resources merely to prepare the final report; the benchmark
-scorer validates them directly. For graph_paths and matrices cases, use
-verification.run instead of manually calling its five component tools.
+scorer validates them directly. For bundled witness cases, use verification.run
+instead of manually calling its five component tools.
 
 Complete public known-answer case {case_id}. Set report case_id exactly to
 {case_id}.
@@ -51,6 +51,9 @@ Complete public known-answer case {case_id}. Set report case_id exactly to
 Return the required JSON report. Report the exact durable URIs returned by the
 tools. Do not infer verification from operational completion, exhaustive
 evaluation, or failure to find a witness. State any remaining limitations.
+Record concise feedback grounded in this run: useful tooling, tooling gaps,
+missing domain knowledge, and concrete improvements. Empty feedback lists are
+valid when the run exposed no issue.
 """
 
 
@@ -213,6 +216,12 @@ def _check_candidate(
         if not isinstance(proof, str) or not proof.strip():
             raise BenchmarkError("Lean candidate proof is empty")
         return
+    if kind == "integer_range":
+        if actual.get("lower_bound") != expected.get("lower_bound") or actual.get(
+            "upper_bound"
+        ) != expected.get("upper_bound"):
+            raise BenchmarkError("candidate integer range differs from the case")
+        return
     raise BenchmarkError(f"unsupported candidate expectation kind: {kind!r}")
 
 
@@ -234,6 +243,10 @@ def _check_claim(
         raise BenchmarkError("claim domain differs from the case")
     if predicate.get("name") != expected.get("predicate"):
         raise BenchmarkError("claim predicate differs from the case")
+    if "parameters" in expected and predicate.get("parameters") != expected.get(
+        "parameters"
+    ):
+        raise BenchmarkError("claim predicate parameters differ from the case")
 
 
 def _check_evidence(
@@ -251,6 +264,50 @@ def _check_evidence(
             and evidence.get("payload") not in accepted_payloads
         ):
             raise BenchmarkError("witness payload does not match the public oracle")
+        if expected.get("witness_format") == "erdos_straus.decomposition_table":
+            payload = _as_object(evidence.get("payload"), "witness payload")
+            table = payload.get("decompositions")
+            if not isinstance(table, list):
+                raise BenchmarkError("Erdős-Straus witness table is missing")
+            expected_candidate = _as_object(
+                expected.get("candidate"),
+                "expected candidate",
+            )
+            expected_ns = set(
+                range(
+                    int(expected_candidate["lower_bound"]),
+                    int(expected_candidate["upper_bound"]) + 1,
+                )
+            )
+            actual_ns: set[int] = set()
+            for row_value in table:
+                row = _as_object(row_value, "Erdős-Straus witness row")
+                try:
+                    n, x, y, z = (
+                        int(row["n"]),
+                        int(row["x"]),
+                        int(row["y"]),
+                        int(row["z"]),
+                    )
+                except (KeyError, TypeError, ValueError) as exc:
+                    raise BenchmarkError(
+                        "Erdős-Straus witness row is malformed"
+                    ) from exc
+                if min(x, y, z) <= 0:
+                    raise BenchmarkError(
+                        "Erdős-Straus witness has a nonpositive denominator"
+                    )
+                if 4 * x * y * z != n * (x * y + x * z + y * z):
+                    raise BenchmarkError(
+                        "Erdős-Straus witness fails the exact identity"
+                    )
+                if n in actual_ns:
+                    raise BenchmarkError("Erdős-Straus witness contains duplicate n")
+                actual_ns.add(n)
+            if actual_ns != expected_ns:
+                raise BenchmarkError(
+                    "Erdős-Straus witness does not cover the exact range"
+                )
         return evidence_kind
     if evidence_kind == "CERTIFICATE":
         if evidence.get("certificate_type") != expected.get("certificate_type"):
@@ -290,6 +347,21 @@ def score_run(
     if report.get("final_verification") != "VERIFIED":
         raise BenchmarkError("final result was not reported as VERIFIED")
     checks.append("agent assurance labels")
+
+    feedback = _as_object(report.get("feedback"), "agent feedback")
+    feedback_fields = {
+        "tooling_strengths",
+        "tooling_gaps",
+        "domain_knowledge_gaps",
+        "suggested_improvements",
+    }
+    if set(feedback) != feedback_fields or not all(
+        isinstance(feedback[field], list)
+        and all(isinstance(item, str) for item in feedback[field])
+        for field in feedback_fields
+    ):
+        raise BenchmarkError("agent feedback has an invalid structure")
+    checks.append("structured agent feedback")
 
     required_tools = case.get("required_tools")
     if not isinstance(required_tools, list) or not all(
@@ -380,6 +452,7 @@ def _run_case(
     transcript = case_root / "transcript.jsonl"
     stderr_path = case_root / "codex.stderr.log"
     report_path = case_root / "agent-report.json"
+    feedback_path = case_root / "feedback.json"
     case_root.mkdir(parents=True)
     state_dir.mkdir()
     prompt = SYSTEM_TASK.format(
@@ -448,6 +521,11 @@ def _run_case(
     else:
         try:
             report = _load_json_object(report_path)
+            feedback = _as_object(report.get("feedback"), "agent feedback")
+            feedback_path.write_text(
+                json.dumps(feedback, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
             score = score_run(
                 case,
                 report,
@@ -476,6 +554,7 @@ def _run_case(
             "transcript": str(transcript.relative_to(run_root)),
             "stderr": str(stderr_path.relative_to(run_root)),
             "agent_report": str(report_path.relative_to(run_root)),
+            "feedback": str(feedback_path.relative_to(run_root)),
         },
     }
     (case_root / "result.json").write_text(

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -9,14 +9,32 @@
 
 ## Purpose
 
-Jacobian separates mathematical discovery from mathematical trust.
+Jacobian gives agents reusable mathematical capabilities and durable research
+memory while separating mathematical discovery from mathematical trust. The
+[capability-first product blueprint](product-blueprint.md) defines the
+model-facing product direction; this document describes the underlying kernel
+and trust zones.
 
 Models, search algorithms, and domain solvers are allowed to be heuristic,
 stochastic, incomplete, and frequently replaced. Verification is performed by
 small, operator-authorized checkers against versioned formal claims and domain
 semantics.
 
-The durable product is the replayable verification contract:
+The agent-facing product has two lanes:
+
+```text
+agent
+  │
+  ├── EXPLORE ──► retrieval, computation, search, solver, candidate, witness
+  │                    │
+  │                    └── HEURISTIC or COMPUTED + research episode
+  │
+  └── VERIFY  ──► the same capability + authorized checker/proof engine
+                       │
+                       └── VERIFIED + immutable verification record
+```
+
+The durable trust contract behind the optional verification lane is:
 
 ```text
 informal statement
@@ -109,34 +127,49 @@ provisional M3 runtime adds append-only lifecycle events, immutable strategy
 checkpoints, archive pages, and archive manifests around one mutable snapshot
 index.
 
-### Curated research record
+### Research episode
 
-A provider-curated reference to an experiment or external source, introduced
-by the optional M5 research-corpus integration. Raw runs never become trusted
-knowledge merely because they were stored, indexed, retrieved, or reviewed.
-The source artifact and verification records remain immutable.
+An immutable, locally indexed record of one capability request and result,
+including adapter version, mode, assurance, artifact lineage, summary, tags,
+and timestamp. Raw runs never become trusted knowledge merely because they
+were stored, indexed, retrieved, or reviewed. Source artifacts and
+verification records remain immutable.
 
-## Optional research-corpus integration
+## Research memory and optional corpus integration
 
-Jacobian's experiment ledger is part of the toolbench: it preserves the local
-lineage and evidence needed to resume and replay work. Corpus-scale indexing,
-ranking, and cross-project retrieval are separate, optional capabilities:
+Jacobian's research memory and experiment ledger are part of the workbench:
+they preserve local episodes, lineage, and evidence needed to retrieve, resume,
+and replay work. Corpus-scale ranking and cross-project retrieval are separate,
+optional capabilities:
 
 ```text
 agent
   │ MCP tools
   ▼
-Jacobian search, conjecture, and verification tools
+Jacobian capabilities and local research memory
   │                         ▲
   │ versioned episodes      │ trust-labeled retrieval
   ▼                         │
 optional research-corpus provider
 ```
 
-The provider may suggest records, motifs, or hypotheses. It is outside the
-verification trust boundary and cannot mutate artifacts, register checkers, or
-promote evidence. Conjecture workflows remain available when no provider is
-configured.
+The local `knowledge.search` adapter and any external provider may suggest
+records, motifs, or hypotheses. Retrieval is outside the verification trust
+boundary and cannot mutate artifacts, register checkers, or promote evidence.
+All local workflows remain available when no provider is configured.
+
+## Model-facing capability API
+
+`CapabilityService` is a registry of operator-installed adapters. Each adapter
+declares a stable operation ID, version, supported `EXPLORE` and `VERIFY`
+modes, input and output JSON Schemas, and discovery metadata. The MCP
+projection exposes the registry through `capability://catalog` and
+`capability.invoke`, so a new Alloy, Lean, SAT/SMT, CAS, or domain adapter does
+not require another MCP tool or a generic-core type.
+
+The service validates both schemas and prevents adapters from self-promoting:
+`VERIFIED` requires a valid local verification record whose checked evidence
+is returned with the capability result.
 
 ## Common result model
 

--- a/docs/explanation/product-blueprint.md
+++ b/docs/explanation/product-blueprint.md
@@ -1,0 +1,226 @@
+# Capability-first product blueprint
+
+[Documentation home](../index.md)
+
+- Status: Active product direction
+- Scope: Agent-facing MCP, local and remote execution, research memory, and
+  optional mathematical assurance
+- Compatibility: v0.2 verification records remain valid; this document changes
+  the product entry point, not the meaning of `VERIFIED`
+
+## Product definition
+
+Jacobian is an agent-facing mathematical capability and research-memory layer.
+It supplies reusable computation, search, solver, formal-proof, retrieval, and
+experiment tools so a model can spend more of its context and reasoning budget
+on strategy rather than rebuilding infrastructure.
+
+Verification is an available assurance service. It is not a mandatory prelude
+to exploration and it is not the only reason to use Jacobian.
+
+The product succeeds when an agent solves held-out tasks more reliably or
+efficiently with Jacobian than the same agent solves them with prompts and a
+general-purpose shell alone. Starting an MCP server, calling a tool, or
+producing a verification record is necessary infrastructure evidence, not
+proof of that product outcome.
+
+## Decision rules
+
+Use these rules when adding a feature:
+
+1. Expose a mathematical action, not an internal lifecycle step.
+2. Keep large schemas and payloads behind catalogs and resource handles.
+3. Let exploration return useful candidates without requiring a `ClaimSpec`.
+4. Label every result as heuristic, computed, or verified.
+5. Require an authorized local verification record before an adapter may use
+   the verified label.
+6. Record reusable episodes with provenance and their original assurance.
+7. Never turn retrieval rank, solver status, search exhaustion, timeout, or an
+   adapter's self-assessment into proof.
+8. Add a provider through the capability registry without editing the MCP
+   adapter.
+
+## System shape
+
+```text
+Codex CLI              ChatGPT / remote agent
+    │ STDIO                    │ Streamable HTTP
+    └──────────────┬───────────┘
+                   ▼
+          MCP capability projection
+          capability://catalog
+          capability.invoke
+                   │
+                   ▼
+             CapabilityService
+       ┌───────────┼──────────────┐
+       │           │              │
+  knowledge     math/solver     experiment
+  and memory     adapters        services
+       │      Lean SAT SMT CAS       │
+       │      Alloy domain tools     │
+       └───────────┼─────────────────┘
+                   │ optional promotion
+                   ▼
+        authorized checker / proof engine
+                   │
+                   ▼
+          immutable verification record
+```
+
+The generic capability layer understands an operation ID, JSON schemas,
+supported modes, execution status, assurance, scope, artifacts, and an episode
+handle. Mathematical semantics remain in adapters and domain plugins.
+
+## Capability contract
+
+An adapter registers one `CapabilityDescriptor` and implements:
+
+```python
+class CapabilityAdapter(Protocol):
+    @property
+    def descriptor(self) -> CapabilityDescriptor: ...
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult: ...
+```
+
+The descriptor declares:
+
+- stable capability ID and version;
+- provider and concise model-facing description;
+- supported `EXPLORE` and `VERIFY` modes;
+- closed input and output JSON Schemas;
+- read-only and episode-recording behavior;
+- discovery tags.
+
+`CapabilityService` validates both sides of the call, enforces identity and
+mode, checks any verified record and its complete parent binding against the
+local artifact store, and records the episode. Projected record IDs and
+conclusions must agree with the checked record. `MCPServer` does not need a new
+tool when an Alloy, Lean, SAT/SMT, CAS, or domain adapter is registered.
+
+Deploy an operator-approved adapter package with a repeatable
+`--capability-adapter package.module:factory` option. The factory receives the
+tenant's `JacobianKernel` and returns a `CapabilityAdapter`. Loading Python code
+is an operator action, never a model tool; it establishes availability, not
+mathematical trust.
+
+The initial bundled catalog contains:
+
+- `reference.solve` for bundled reference-domain exploration and verification;
+- `lean.check` for checker-backed Lean proof replay;
+- `knowledge.search` for trust-labeled local episode retrieval.
+
+These are reference adapters, not a closed ontology.
+
+## Two lanes
+
+### Explore
+
+`EXPLORE` is the default. It may evaluate, search, query memory, call solvers,
+generate candidates, or find witnesses. It does not run a checker merely to
+make an intermediate result usable.
+
+Explore results use:
+
+- `HEURISTIC` when the result depends on search, an untrusted plugin, a model,
+  sampling, or an unchecked witness;
+- `COMPUTED` for a deterministic operation whose software contract is tested
+  but which does not establish a promoted mathematical claim.
+
+### Verify
+
+`VERIFY` is requested for a durable theorem, counterexample, equivalence,
+optimality, exhaustive scope, or reusable database fact. The adapter may invoke
+an authorized checker or formal proof engine.
+
+An adapter cannot create verified authority. `CapabilityService` accepts
+`VERIFIED` only when the result names a valid local verification-record
+artifact and exposes its checked evidence. Failure falls closed to a
+non-verified result or operational error.
+
+The lower-level v0.2 verification tools remain available through the `full` and
+`verification` MCP profiles for advanced workflows and replay.
+
+## Database-first memory
+
+Every reusable capability invocation is stored as an immutable research
+episode and indexed locally. An episode binds:
+
+- capability and adapter version;
+- exact request and result;
+- exploration or verification mode;
+- assurance label and verification record, when present;
+- artifact lineage;
+- timestamp, summary, and tags.
+
+`knowledge.search` queries the local index. Retrieved records retain their
+original assurance; retrieval never upgrades them. The local store is useful
+without an external corpus provider.
+
+Later corpus providers add cross-project ranking, temporal cutoffs, review,
+retraction, citation, and retention policy. They remain outside checker
+authority.
+
+## Local and remote hosts
+
+The local Codex profile uses STDIO and the `capabilities` tool profile. It
+advertises one extensible tool rather than every backend operation.
+
+Remote hosts use Streamable HTTP by default. A remote deployment:
+
+- requires an operator-provisioned bearer-token file unless anonymous
+  development mode is explicitly selected;
+- binds each token to a tenant subject and required scope;
+- routes every tool and resource request to a tenant-specific state root;
+- hashes tenant IDs before constructing filesystem paths;
+- keeps artifact, memory, experiment, plugin, and checker metadata isolated;
+- terminates TLS at a trusted reverse proxy or platform ingress;
+- mounts the state root and token file as separate persistent volume and
+  secret.
+
+Static opaque tokens are an initial deployment mechanism, not a complete
+identity platform. Hosted deployments should replace the verifier with their
+OAuth/OIDC policy while preserving the tenant subject contract.
+
+## Evaluation
+
+Two benchmark families answer different questions:
+
+- The known-answer MCP pilot checks integration and durable verification.
+- The A/B agent benchmark compares the same model on the same task under a
+  control condition and a Jacobian capability condition.
+
+The A/B runner must:
+
+- ignore user MCP configuration and construct each condition explicitly;
+- fix model, reasoning effort, repository commit, prompt, and budgets;
+- randomize or alternate condition order across repetitions;
+- retain every transcript and report;
+- score mathematical answers with an independent known-answer oracle;
+- measure pass rate, false claims, input/output tokens, wall time, tool calls,
+  shell calls, and generated files;
+- report paired deltas rather than selecting the best run.
+
+One successful MCP transcript does not establish an improvement. A product
+claim requires repeated held-out cases with a better correctness/efficiency
+frontier and no increase in false certification.
+
+## Delivery order
+
+1. Stabilize capability contracts, local memory, and the two lanes.
+2. Keep the compact MCP catalog below the tool-description budget.
+3. Exercise at least one external adapter without a kernel or MCP edit.
+4. Deploy authenticated Streamable HTTP with tenant-isolation tests.
+5. Run paired A/B pilots and use agent feedback to prioritize adapters.
+6. Add cross-project corpus providers only after local episode queries are
+   empirically useful.
+
+## Non-goals
+
+- A universal `solve_conjecture` endpoint
+- Reimplementing Lean, Alloy, SAT/SMT, CAS, or optimization engines
+- Treating a caller's self-review as independent verification
+- Requiring verification for every computation or retrieval
+- Letting a database entry become true because it is popular or highly ranked
+- Claiming process isolation from a Python child process or bearer token alone

--- a/docs/explanation/roadmap.md
+++ b/docs/explanation/roadmap.md
@@ -17,6 +17,39 @@ M5 are capability milestones, not promised package versions or compatibility
 releases. Their scope and APIs may change. v1.0 remains a stability target
 rather than the next scheduled release.
 
+## Current product track — Capability workbench
+
+Status: initial implementation in the repository; pre-stable and outside the
+v0.2 conformance contract.
+
+### Objective
+
+Make Jacobian useful before verification by giving agents one compact,
+extensible API for mathematical tools and local research memory, while keeping
+checker-backed assurance available when a result must be promoted.
+
+### Deliverables
+
+- One model-facing `capability.invoke` MCP tool and discoverable catalog
+- Adapter registration without kernel or MCP edits
+- Explicit `EXPLORE` and `VERIFY` lanes
+- Heuristic, computed, and verified assurance labels
+- Local searchable research episodes with immutable provenance
+- Streamable HTTP and SSE transports
+- Bearer-token authentication and subject-bound tenant state
+- Container and reverse-proxy deployment guidance
+- Paired control/treatment agent benchmark with transcript-level metrics
+- At least one external Alloy, SAT/SMT, or CAS adapter exercise
+
+### Exit gate
+
+A held-out, repeated A/B evaluation shows that the capability condition
+improves correctness or resource use over the same model without Jacobian,
+without increasing false certification. A synthetic external adapter appears
+through MCP without editing the kernel or MCP server. Authenticated tenant
+tests demonstrate that tools and resources cannot read another tenant's
+artifacts or research episodes.
+
 ## v0.2 — Bounded discovery
 
 Status: implemented in `0.2.0a0`.
@@ -168,7 +201,7 @@ never reported as verification. Parameter claims distinguish proved, sampled,
 and unknown regions. A synthetic plugin supports repair, generation, and
 parameter generalization without core or MCP changes.
 
-## M5 — Research corpus integration
+## M5 — Federated research corpus
 
 ### Entry gate
 
@@ -178,12 +211,13 @@ measurable.
 
 ### Objective
 
-Let agents retrieve prior mathematical work without turning Jacobian into a
-monolithic knowledge platform or confusing retrieval with proof.
+Extend the implemented local research memory with cross-project mathematical
+work without turning Jacobian into a monolithic knowledge platform or
+confusing retrieval with proof.
 
 ### Deliverables
 
-- A versioned research-episode export and provider interface
+- Versioned research-episode export from the local episode database
 - An optional reference provider rather than a required kernel dependency
 - Structural, textual, metadata, ancestry, and temporal retrieval
 - Trust, review, source, retraction, and availability labels

--- a/docs/explanation/threat-model.md
+++ b/docs/explanation/threat-model.md
@@ -2,16 +2,17 @@
 
 [Documentation home](../index.md)
 
-- Status: Current for v0.2 and the provisional M3/M4 implementation
+- Status: Current for v0.2 and provisional capability, M3, and M4 code
 - Host boundary: Operator-installed code is trusted not to attack the machine
 - Related records: [Architecture](architecture.md) and
   [v0.2 conformance gate](../reference/conformance-v0.2.md)
 
 ## Scope
 
-This document covers the v0.2 release contract and the provisional M3/M4 code
-in the repository. M3/M4 behavior is not part of v0.2 conformance, but it must
-preserve the same mathematical and artifact-integrity boundaries.
+This document covers the v0.2 release contract and provisional capability,
+M3, and M4 code in the repository. Later behavior is not part of v0.2
+conformance, but it must preserve the same mathematical and artifact-integrity
+boundaries.
 
 The implemented code accepts pure data plus operator-installed local plugins
 and checkers.
@@ -34,6 +35,8 @@ Jacobian protects:
   plugin, runtime, checkpoint, or experiment;
 - parameter-region promotion bound to the exact subject and claim artifacts,
   not merely an equal payload.
+- remote tenant separation for artifacts, episodes, experiments, plugins, and
+  checker metadata.
 
 Availability is important but secondary to integrity: resource exhaustion may
 produce timeout or error, never a false mathematical conclusion.
@@ -209,6 +212,34 @@ Controls:
   equality and inequality;
 - changed coefficients, margins, bindings, or scopes are rejected.
 
+### Remote client or tenant
+
+A remote caller may omit authentication, present an invalid token, choose a
+malicious tenant string, guess another tenant's content-addressed URI, or try
+to use an adapter to self-promote evidence.
+
+Controls:
+
+- remote transports fail closed unless a token file is configured or the
+  operator explicitly selects anonymous development mode;
+- opaque tokens are compared in constant time and bind an authenticated
+  subject plus required scope;
+- tenant IDs are syntax-checked and hashed before they contribute to a state
+  path;
+- tool and resource handlers route through the same authenticated subject;
+- each subject receives a separate artifact store and SQLite metadata
+  database;
+- capability adapters cannot return verified assurance without a valid
+  verification record, complete bound parent set, and matching conclusion in
+  that tenant's store;
+- TLS, rate limits, host isolation, and network policy are supplied by the
+  deployment platform.
+
+Static bearer tokens do not provide rotation without restart, delegated
+authorization, user consent, or a full identity lifecycle. They are an initial
+controlled-deployment mechanism. Hosted deployments should replace the token
+verifier with OAuth/OIDC while retaining subject-bound tenant routing.
+
 ## Trust assumptions
 
 The implemented releases assume:
@@ -241,8 +272,8 @@ verification tools.
 - Hostile executable plugin code
 - Kernel or hypervisor compromise
 - Side-channel resistance
-- Multi-tenant authorization
-- Remote identity and signing infrastructure
+- v0.2 conformance for multi-tenant authorization
+- Hosted OAuth/OIDC lifecycle and remote signing infrastructure
 - Distributed worker leases or multiple active Jacobian coordinators sharing a
   state directory
 - Formal verification of the artifact store

--- a/docs/how-to/deploy-remote-mcp.md
+++ b/docs/how-to/deploy-remote-mcp.md
@@ -1,0 +1,94 @@
+# Deploy the remote MCP server
+
+[Documentation home](../index.md)
+
+Use STDIO for a single local Codex process. Use Streamable HTTP when ChatGPT or
+another remote MCP client must reach Jacobian.
+
+## Create the auth secret
+
+Create a JSON file outside the repository:
+
+```json
+{
+  "tokens": [
+    {
+      "tenant_id": "research-team-a",
+      "token": "replace-with-at-least-32-random-characters",
+      "scopes": ["jacobian:use"]
+    }
+  ]
+}
+```
+
+Treat this as a secret. Rotate a token by replacing the file and restarting the
+server. Do not put tokens in prompts, source control, command-line arguments,
+or Jacobian artifacts.
+
+## Start Streamable HTTP
+
+```sh
+uv run jacobian-mcp \
+  --transport streamable-http \
+  --tool-profile capabilities \
+  --host 127.0.0.1 \
+  --port 8000 \
+  --path /mcp \
+  --state-dir /var/lib/jacobian \
+  --auth-tokens-file /run/secrets/jacobian-tokens.json \
+  --public-base-url https://math-tools.example.org
+```
+
+Put a TLS-terminating reverse proxy in front of `127.0.0.1:8000`. The public
+URL must route `/mcp` without stripping the path. Each authenticated subject is
+mapped to a separate hashed directory below
+`/var/lib/jacobian/tenants/`.
+
+For a disposable local transport test only:
+
+```sh
+uv run jacobian-mcp \
+  --transport streamable-http \
+  --tool-profile capabilities \
+  --allow-anonymous
+```
+
+Do not expose anonymous mode to a network.
+
+## Container deployment
+
+Build the repository image:
+
+```sh
+docker build -t jacobian:local .
+```
+
+Run it with a persistent state volume and read-only secret mount:
+
+```sh
+docker run --rm -p 127.0.0.1:8000:8000 \
+  -v jacobian-state:/var/lib/jacobian \
+  -v "$PWD/tokens.json:/run/secrets/jacobian-tokens.json:ro" \
+  jacobian:local \
+  --transport streamable-http \
+  --tool-profile capabilities \
+  --host 0.0.0.0 \
+  --port 8000 \
+  --state-dir /var/lib/jacobian \
+  --auth-tokens-file /run/secrets/jacobian-tokens.json \
+  --public-base-url https://math-tools.example.org
+```
+
+The initial static-token verifier is suitable for controlled deployments. A
+hosted service should integrate its OAuth/OIDC verifier and map the validated
+subject to the same tenant-routing interface.
+
+## Operational boundaries
+
+- Back up the state volume; artifacts and research episodes live there.
+- Run one Jacobian process per state root until a lease model is implemented.
+- Apply CPU, memory, filesystem, and network policy outside Jacobian.
+- Do not interpret HTTP success, solver completion, or an MCP response as a
+  verified mathematical result.
+- Use the `full` profile only for trusted advanced clients that need the
+  lower-level tool surface.

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ still pre-stable:
 
 | Question | Document | Status |
 | --- | --- | --- |
+| What product is Jacobian building? | [Capability-first product blueprint](explanation/product-blueprint.md) | Active product direction |
 | What does the system currently look like? | [Architecture](explanation/architecture.md) | Current v0.2 design plus labeled provisional M3/M4 sections |
 | What is implemented, provisional, or planned? | [Roadmap](explanation/roadmap.md) | Active milestone plan; gates are not promised release dates |
 | Why were cross-cutting choices made? | [Architecture decision log](explanation/adr/index.md) | Accepted decisions with release scope |
@@ -39,6 +40,7 @@ complete a specific task.
 
 - [Inspect, pause, and resume a search](how-to/resume-search.md)
 - [Run the plugin conformance kit](how-to/run-plugin-conformance.md)
+- [Deploy the remote MCP server](how-to/deploy-remote-mcp.md)
 
 ## Reference
 
@@ -59,7 +61,7 @@ Later-release contracts are provisional:
 
 - [M3 scalable search](reference/milestones/m3-scalable-search.md)
 - [M4 conjecture workflows](reference/milestones/m4-conjecture-workflows.md)
-- [M5 research corpus integration](reference/milestones/m5-research-corpus.md)
+- [M5 federated research corpus](reference/milestones/m5-research-corpus.md)
 - [v1.0 stability target](reference/specifications/v1.0.md)
 
 ## Explanation
@@ -68,6 +70,7 @@ Explanation documents describe why Jacobian has its current boundaries and
 how its major parts fit together.
 
 - [Architecture](explanation/architecture.md)
+- [Capability-first product blueprint](explanation/product-blueprint.md)
 - [Threat model](explanation/threat-model.md)
 - [Roadmap](explanation/roadmap.md)
 - [Durable search runtime](explanation/search-runtime.md)

--- a/docs/reference/agent-evaluations.md
+++ b/docs/reference/agent-evaluations.md
@@ -338,18 +338,22 @@ for 19 tools to 4,400 characters for six tools; adding `lean.verify` changed
 the compact surface to seven tools and 4,875 characters. Adding the generic
 `verification.run` workflow and explicit Lean input guidance changed it to
 eight tools and 6,899 characters. Adding the pinned `MATHLIB` environment
-and compact result projection changed the current compact descriptor to 7,883
-characters; the corresponding full 22-tool descriptor is 103,382 characters.
-The compact descriptor remains below the 25 KB first-stage target.
-These are descriptor measurements, not model token counts, and must be
-remeasured when contracts change.
+and compact result projection changed that compact descriptor to 7,883
+characters; the corresponding 22-tool descriptor was 103,382 characters.
+
+The capability-first change was remeasured with compact sorted JSON on
+2026-07-24. The default `capabilities` profile advertises one tool in 779
+characters. Its three-entry `capability://catalog` is 2,663 characters. The
+compatibility `verification` profile is eight tools and 7,171 characters; the
+23-tool `full` profile is 105,187 characters. The default descriptor remains
+well below the 25 KB first-stage target. These are descriptor measurements,
+not model token counts, and must be remeasured when contracts change.
 
 The domain bootstrap projection reduced the serialized `graph_paths` resource
 from 7,317 to 2,402 characters, `matrices` from 7,290 to 2,197, and `lean4`
 from 4,106 to 1,810. The bounded `erdos_straus` bootstrap is 1,906 characters.
-Adding that domain did not change the tool descriptors: the compact profile
-remains 7,883 characters and the full profile remains 103,382. The positive
-graph workflow response reduced from 6,098 to 1,314 characters. The full
+Adding that domain did not change the historical verification descriptors. The
+positive graph workflow response reduced from 6,098 to 1,314 characters. Full
 schemas and workflow results remain available through the canonical registry
 and `full` MCP profile; only model-facing projection changed.
 
@@ -380,3 +384,70 @@ This is an initial known-answer integration pilot, not the held-out comparative
 evaluation described above. It currently has no no-tool baseline, model seed
 control, hidden oracle, or multi-attempt aggregate. Results must therefore be
 reported per run and must not be used as a capability or performance claim.
+
+## Executable capability A/B pilot
+
+`benchmarks/agent_ab.py` implements the control/treatment comparison separately
+from the integration pilot. It launches Codex with `--ignore-user-config` so a
+personal or project MCP server cannot leak into the control condition.
+
+For every case and repetition:
+
+- control receives an empty writable workspace, no MCP configuration, and may
+  construct its own local computation;
+- treatment receives the same task and model settings plus only the compact
+  `capabilities` MCP profile;
+- condition order is shuffled from a recorded seed;
+- both conditions use the same structured report schema and independent
+  known-answer scorer;
+- treatment verification records and exact finite evidence are replayed from
+  its isolated Jacobian state;
+- raw transcript, stderr, report, usage, MCP calls, shell calls, generated-file
+  count, and elapsed time are retained;
+- the summary reports per-condition pass rate and paired token, time, shell,
+  and MCP-call deltas.
+
+Run the default three-pair pilot with:
+
+```sh
+uv run python benchmarks/agent_ab.py --case ERDOS-STRAUS-AB-001
+```
+
+The initial public case is an executable harness check, not a sufficient
+product claim. Product conclusions require multiple held-out cases and
+repetitions. Report all runs, use paired deltas, and reject any treatment that
+improves efficiency by increasing unsupported mathematical conclusions.
+
+### Initial A/B development result
+
+One dirty-worktree development pair on 2026-07-24 used Codex CLI `0.144.1`,
+the configured default model, medium reasoning effort, and
+`ERDOS-STRAUS-AB-001`. Both conditions passed their independent scorers.
+
+The first treatment design required cold catalog and domain-contract discovery.
+It used three MCP calls and 116,112 input tokens, compared with 49,907 for its
+control. This exposed a product-interface problem: the agent still had to
+assemble a complete internal `ClaimSpec`.
+
+`reference.solve` was then changed to accept only a reference name, predicate,
+candidate, and witness role; the adapter builds the formal claim internally.
+The targeted rerun produced:
+
+| Metric | Control | Capability treatment | Paired delta |
+| --- | ---: | ---: | ---: |
+| Passed | 1 | 1 | 0 |
+| Elapsed seconds | 38.041 | 26.216 | -11.825 |
+| Input tokens | 49,954 | 51,878 | +1,924 |
+| Output tokens | 1,199 | 387 | -812 |
+| Shell calls | 2 | 0 | -2 |
+| MCP calls | 0 | 1 | +1 |
+
+The treatment also produced a durable verification record that the scorer
+replayed against the complete exact interval. The treatment agent reported no
+tooling gap. The control agent classified writing and running its local exact
+checker as infrastructure work and noted the absence of independent
+verification.
+
+This pair validates the benchmark path and demonstrates why direct,
+task-shaped capabilities matter. One public, easy case with one attempt does
+not establish a general improvement in reasoning, pass rate, or cost.

--- a/docs/reference/agent-evaluations.md
+++ b/docs/reference/agent-evaluations.md
@@ -318,12 +318,19 @@ status.
 
 `benchmarks/agent_mcp.py` runs the public `PATH-CLOSURE-001`,
 `MAT-KERNEL-001`, `GRAPH-BIP-TRUE-001`, `LEAN-NAT-INDUCTION-001`, and
-`LEAN-SQRT2-001` cases through a real Codex CLI using the project
+`LEAN-SQRT2-001` cases, plus the bounded `ERDOS-STRAUS-001` research pilot,
+through a real Codex CLI using the project
 `jacobian_local` MCP profile. Each case receives an isolated state directory.
 The runner retains the raw JSONL transcript and structured agent report, then
 scores the durable verification record, evidence, exact bindings, claim, and
 candidate directly from the Jacobian store. Lean cases additionally bind and
 score the selected runtime environment and declared trust base.
+
+Every agent report also records structured observations in four non-scoring
+categories: useful tooling, tooling gaps, domain-knowledge gaps, and concrete
+improvements. The runner writes these observations to a per-case
+`feedback.json`. Feedback is empirical input for tool design; it is not
+mathematical evidence and cannot affect the durable correctness score.
 
 The local profile uses the registry-derived `verification` projection. At its
 introduction this reduced the advertised descriptor from 82,820 characters
@@ -339,10 +346,24 @@ remeasured when contracts change.
 
 The domain bootstrap projection reduced the serialized `graph_paths` resource
 from 7,317 to 2,402 characters, `matrices` from 7,290 to 2,197, and `lean4`
-from 4,106 to 1,810. The positive graph workflow response reduced from 6,098
-to 1,314 characters. The full schemas and workflow results remain available
-through the canonical registry and `full` MCP profile; only model-facing
-projection changed.
+from 4,106 to 1,810. The bounded `erdos_straus` bootstrap is 1,906 characters.
+Adding that domain did not change the tool descriptors: the compact profile
+remains 7,883 characters and the full profile remains 103,382. The positive
+graph workflow response reduced from 6,098 to 1,314 characters. The full
+schemas and workflow results remain available through the canonical registry
+and `full` MCP profile; only model-facing projection changed.
+
+An exploratory local `ERDOS-STRAUS-001` run on 2026-07-24 passed all durable
+scorer checks for the interval \(2\leq n\leq1000\). It used two MCP calls
+(`read_mcp_resource` and `verification.run`), took 97.891 seconds, and reported
+93,325 input tokens, including 69,632 cached input tokens, plus 2,088 output
+tokens. The agent identified the compact domain identity, exact checker
+identity, finite-scope rule, composed workflow, assurance separation, and
+durable URIs as useful. It reported no tooling gaps, domain-knowledge gaps, or
+suggested improvements in that run. This was a dirty-worktree development run
+against commit `990d26a`; it is implementation feedback, not a frozen
+comparative baseline. The total input remains close enough to the 100,000-token
+first-stage target that future multi-case runs should continue to track it.
 
 Run the kernel condition with:
 

--- a/docs/reference/benchmarks.md
+++ b/docs/reference/benchmarks.md
@@ -58,11 +58,20 @@ It should test that the kernel does not assume:
 - every search uses mutation;
 - witnesses have the same representation as candidates.
 
-## Third-domain candidate: finite magmas
+## Reference C: bounded Erdős-Straus decompositions
+
+The third bundled plugin verifies finite intervals of the Erdős-Straus
+unit-fraction statement. `ERDOS-STRAUS-001` binds the interval, a complete
+decomposition table, and exact integer replay. Its checker is independent of
+the table-generation routine. The case tests positive exhaustive witnesses and
+the requirement that a bounded result not be generalized to the open
+conjecture.
+
+## Later-domain candidate: finite magmas
 
 `MAGMA-IMPL-001` adds finite operation tables, equational-law evaluation, and a
-model-plus-assignment witness. It is the preferred third plugin after the v0.2
-capability surface is stable.
+model-plus-assignment witness. It remains a candidate after the v0.2 capability
+surface is stable.
 
 ## Historical end-to-end episodes
 

--- a/docs/reference/math-scenarios.md
+++ b/docs/reference/math-scenarios.md
@@ -356,6 +356,48 @@ There are \(2^9=512\) labeled candidates. A complete labeled enumeration finds
 
 This is the initial non-graph reference-plugin optimization workload.
 
+### ERDOS-STRAUS-001 — Bounded unit-fraction verification
+
+**Bounded claim**
+
+For every integer \(n\) in the exact closed interval \(2\leq n\leq1000\),
+there are positive integers \(x,y,z\) such that
+
+\[
+\frac4n=\frac1x+\frac1y+\frac1z.
+\]
+
+This is a finite executable instance of the Erdős-Straus conjecture. It is not
+a proof of the unbounded conjecture.
+
+**Evidence**
+
+The search plugin proposes one row \((n,x,y,z)\) for every integer in the
+interval. The independent checker requires exactly the declared set of
+\(n\)-values, rejects duplicates and nonpositive denominators, and checks each
+row using only the integer identity
+
+\[
+4xyz=n(xy+xz+yz).
+\]
+
+**Capabilities**
+
+- `evaluate.batch` performs unverified exact bounded search;
+- `witness.find` proposes a complete decomposition table;
+- `witness.verify` independently replays every row and the exact interval;
+- `verification.run` composes those stages without merging their assurance
+  labels.
+
+**Adversarial variants**
+
+- omit one value of \(n\) while claiming exhaustive coverage;
+- duplicate one valid row to preserve the row count;
+- use a valid table for a nearby upper bound;
+- accept zero or negative denominators;
+- promote timeout or failure to find a row into a counterexample;
+- report the finite result as a proof of the full conjecture.
+
 ### MAGMA-IMPL-001 — A finite countermodel to a false implication
 
 **Claim**

--- a/docs/reference/milestones/m5-research-corpus.md
+++ b/docs/reference/milestones/m5-research-corpus.md
@@ -1,21 +1,22 @@
-# Milestone 5 specification: research corpus integration
+# Milestone 5 specification: federated research corpus
 
 [Documentation home](../../index.md)
 
 - Status: Provisional
-- Theme: Retrieve prior work without confusing memory with proof
+- Theme: Extend local memory without confusing retrieval with proof
 
 ## 1. Entry gate
 
-The search and conjecture tools must have produced a sufficiently diverse
-corpus of verified successes, verified failures, and unverified runs to
-evaluate retrieval quality and establish useful query patterns.
+The local capability-episode database must have produced a sufficiently
+diverse corpus of verified successes, verified failures, computed results, and
+unverified runs to evaluate cross-project retrieval quality.
 
 ## 2. Integration boundary
 
-Jacobian owns immutable artifacts, verification records, checker authority, and
-the local experiment ledger required for replay. A corpus provider is optional
-and may run in another process, package, or service.
+Jacobian owns immutable artifacts, verification records, checker authority,
+the local research-memory index, and the experiment ledger required for
+replay. A federated corpus provider is optional and may run in another process,
+package, or service.
 
 The provider may ingest versioned research episodes and return ranked records.
 It cannot:
@@ -31,9 +32,10 @@ referenced local artifacts independently.
 
 ## 3. New tools
 
-### `memory.search`
+### `knowledge.search`
 
-Retrieve prior records using independently selectable indexes:
+The local implementation retrieves trust-labeled capability episodes. M5
+extends it with independently selectable provider indexes:
 
 - natural-language text;
 - normalized formula structure and quantifier skeleton;

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -10,8 +10,27 @@ Jacobian is a general research kernel. Its core tools understand artifacts,
 claims, candidates, predicates, witnesses, certificates, reductions, budgets,
 and provenance. Mathematical meaning is supplied by versioned domain plugins.
 
-The public tool surface is layered so a heuristic operation cannot masquerade
-as a verifier.
+The model-facing surface is layered so adapters are easy to add and a
+heuristic operation cannot masquerade as a verifier.
+
+## Capability-first MCP surface
+
+The default local and remote profile advertises one tool:
+
+| Tool | Capability |
+| --- | --- |
+| `capability.invoke` | Invoke an installed operation in `EXPLORE` or `VERIFY` mode. Inputs and outputs are validated against the selected descriptor. Reusable invocations create trust-labeled research episodes. |
+
+Read `capability://catalog` to discover stable IDs, provider versions, supported
+modes, compact JSON Schemas, and tags. Bundled IDs are `reference.solve`,
+`lean.check`, and `knowledge.search`. Operator-installed adapters appear in the
+same catalog without a new MCP tool.
+
+`EXPLORE` returns heuristic or computed assurance and does not require a formal
+claim or checker. `VERIFY` may promote a result only when it carries a valid
+local verification record and the checked evidence. The `full` and
+`verification` profiles retain the lower-level tools below for advanced
+clients and compatibility.
 
 ## Core v0.2 tools
 
@@ -30,8 +49,8 @@ as a verifier.
 `evaluate.batch` is the central experimental interface.
 `witness.verify` and `certificate.verify` are the public trust boundary.
 
-The local MCP adapter provides `full` and `verification` projections from this
-same registry. The compact verification projection omits unrelated research
+The local MCP adapter provides `capabilities`, `full`, and `verification`
+projections. The compact verification projection omits unrelated research
 tools and redundant output schemas. Its bootstrap resources project minimal
 claim contracts and its composite workflow result projects only stage status,
 assurance, evidence, and durable record URIs. Canonical registry schemas,
@@ -102,7 +121,8 @@ separately verified:
 | Provisional M4 | `conjecture.generate` | Generate, deduplicate, falsify, and rank candidate statements. |
 | Provisional M4 | `parameter.generalize` | Propose parameter regions around a verified construction and preserve proposed or sampled evidence labels. |
 | Provisional M4 | `parameter.region.promote` | Replay an authorized certificate bound to an immutable region subject before labeling it verified sufficient or necessary. |
-| M5 | `memory.search` | Ask an optional corpus provider for prior experiments, failures, witnesses, certificates, and research episodes with trust labels. |
+| Current product track | `knowledge.search` | Query locally indexed capability episodes while preserving each record's assurance. |
+| M5 | provider-backed `knowledge.search` | Extend local retrieval with cross-project records, temporal cutoffs, review, and retraction. |
 | M5 | `abstraction.extract` | Suggest an abstract mathematical explanation for supplied or retrieved artifacts. |
 | M5 | `episode.compare` | Compare failures and propose recurring obstructions or no-go lemmas. |
 | M5 | `certificate.simplify` | Minimize a certificate while replaying its authorized checker locally. |
@@ -134,6 +154,7 @@ Read-only discovery and large-object access use MCP resources:
 
 ```text
 artifact://sha256/<digest>
+capability://catalog
 reference://catalog
 experiment://<id>
 experiment://<id>/accounting

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "jacobian-research-kernel"
 version = "0.2.0a0"
-description = "A verifier-centric research kernel for bounded, executable mathematics"
+description = "A capability-first MCP workbench for executable mathematics"
 readme = "README.md"
 requires-python = ">=3.12,<3.14"
 license = { text = "Apache-2.0" }

--- a/src/jacobian/adapters/mcp/remote.py
+++ b/src/jacobian/adapters/mcp/remote.py
@@ -1,0 +1,139 @@
+"""Authentication and tenant routing for remote MCP transports."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import re
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from mcp.server.auth.provider import AccessToken
+
+from jacobian.kernel import JacobianKernel
+
+_TENANT_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+
+
+@dataclass(frozen=True, slots=True)
+class StaticTokenGrant:
+    tenant_id: str
+    token: str
+    scopes: tuple[str, ...] = ("jacobian:use",)
+
+    def __post_init__(self) -> None:
+        if not _TENANT_PATTERN.fullmatch(self.tenant_id):
+            raise ValueError("tenant_id has an invalid format")
+        if len(self.token) < 32:
+            raise ValueError("remote bearer tokens must contain at least 32 characters")
+        if not self.scopes:
+            raise ValueError("a remote token grant requires at least one scope")
+
+
+class StaticTokenVerifier:
+    """Verify operator-provisioned opaque bearer tokens without logging them."""
+
+    def __init__(self, grants: tuple[StaticTokenGrant, ...]) -> None:
+        if not grants:
+            raise ValueError("at least one token grant is required")
+        if len({grant.tenant_id for grant in grants}) != len(grants):
+            raise ValueError("tenant IDs in the token file must be unique")
+        if len({grant.token for grant in grants}) != len(grants):
+            raise ValueError("bearer tokens in the token file must be unique")
+        self._grants = grants
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        for grant in self._grants:
+            if hmac.compare_digest(token, grant.token):
+                return AccessToken(
+                    token=token,
+                    client_id=f"jacobian-tenant:{grant.tenant_id}",
+                    scopes=list(grant.scopes),
+                    subject=grant.tenant_id,
+                )
+        return None
+
+
+class TenantKernelRouter:
+    """Create one isolated kernel root per authenticated subject."""
+
+    def __init__(
+        self,
+        root: str | Path,
+        *,
+        install_references: bool = True,
+        allow_anonymous: bool = False,
+        capability_adapter_entrypoints: tuple[str, ...] = (),
+    ) -> None:
+        self.root = Path(root)
+        self.install_references = install_references
+        self.allow_anonymous = allow_anonymous
+        self.capability_adapter_entrypoints = capability_adapter_entrypoints
+        self._kernels: dict[str, JacobianKernel] = {}
+        self._lock = threading.Lock()
+
+    def kernel_for(self, subject: str | None) -> JacobianKernel:
+        tenant = subject
+        if tenant is None:
+            if not self.allow_anonymous:
+                raise PermissionError("authenticated tenant subject is required")
+            tenant = "anonymous"
+        if not _TENANT_PATTERN.fullmatch(tenant):
+            raise PermissionError("authenticated tenant subject is invalid")
+        tenant_key = hashlib.sha256(tenant.encode("utf-8")).hexdigest()
+        with self._lock:
+            kernel = self._kernels.get(tenant_key)
+            if kernel is None:
+                kernel = JacobianKernel(
+                    self.root / "tenants" / tenant_key,
+                    install_references=self.install_references,
+                    capability_adapter_entrypoints=(
+                        self.capability_adapter_entrypoints
+                    ),
+                )
+                self._kernels[tenant_key] = kernel
+            return kernel
+
+
+def load_static_token_file(path: str | Path) -> tuple[StaticTokenGrant, ...]:
+    """Load a strict JSON token file intended to be mounted as a secret."""
+
+    selected = Path(path)
+    try:
+        payload: Any = json.loads(selected.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError("cannot read the remote auth token file") from exc
+    if not isinstance(payload, dict) or set(payload) != {"tokens"}:
+        raise ValueError("token file must contain only a tokens array")
+    records = payload["tokens"]
+    if not isinstance(records, list):
+        raise ValueError("token file tokens must be an array")
+    grants: list[StaticTokenGrant] = []
+    for record in records:
+        if not isinstance(record, dict) or not set(record) <= {
+            "tenant_id",
+            "token",
+            "scopes",
+        }:
+            raise ValueError("token grants contain unsupported fields")
+        tenant_id = record.get("tenant_id")
+        token = record.get("token")
+        scopes = record.get("scopes", ["jacobian:use"])
+        if (
+            not isinstance(tenant_id, str)
+            or not isinstance(token, str)
+            or not isinstance(scopes, list)
+            or not all(isinstance(scope, str) and scope for scope in scopes)
+        ):
+            raise ValueError("token grant fields have invalid types")
+        grants.append(
+            StaticTokenGrant(
+                tenant_id=tenant_id,
+                token=token,
+                scopes=tuple(scopes),
+            )
+        )
+    return tuple(grants)

--- a/src/jacobian/adapters/mcp/server.py
+++ b/src/jacobian/adapters/mcp/server.py
@@ -14,10 +14,15 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any, cast
 
 from mcp_types import ToolAnnotations
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import AnyHttpUrl, BaseModel, ConfigDict, Field
 
 from jacobian import __version__
 from jacobian.contracts.artifacts import ArtifactPutResult
+from jacobian.contracts.capabilities import (
+    CapabilityMode,
+    CapabilityRequest,
+    CapabilityResult,
+)
 from jacobian.contracts.claims import ClaimValidationResult
 from jacobian.contracts.conjectures import (
     ConjectureOperation,
@@ -63,22 +68,26 @@ if TYPE_CHECKING:
     from mcp.server import MCPServer
     from mcp.server.mcpserver import Context
 
+    from jacobian.adapters.mcp.remote import TenantKernelRouter
     from jacobian.kernel import JacobianKernel
     from jacobian.workflows import VerificationWorkflowService
 
 
 SERVER_INSTRUCTIONS = (
-    "When a bundled domain name is known, read reference://domain/{name} directly; "
-    "otherwise use reference://catalog to discover its agent_contract_uri. Copy claim "
-    "required_capabilities only from that plugin's available_capabilities list. Treat "
-    "search, evaluation, generated witnesses, conjectures, transformations, and "
-    "polytope evidence as unverified unless the returned assurance.verification field "
-    "is VERIFIED. Operational completion, failure to find a witness, and exhausted or "
-    "bounded search are not mathematical proof. Use witness.verify, certificate.verify, "
-    "or transform.verify for independent replay, and follow returned artifact:// and "
-    "experiment:// resource URIs instead of asking tools to inline large content."
+    "When a capability ID and input are known, invoke it directly; otherwise start "
+    "with capability://catalog. Use "
+    "EXPLORE for low-friction search and VERIFY only when a durable checked conclusion "
+    "is needed. Advanced clients may inspect reference://catalog for lower-level domain "
+    "contracts and assurance.verification details. Retrieved memory, search, evaluation, "
+    "generated witnesses, conjectures, "
+    "transformations, and polytope evidence are not proof. Only assurance level VERIFIED "
+    "with a local verification record is verified. Operational completion, failure to "
+    "find a witness, and exhausted or bounded search are not mathematical conclusions. "
+    "Follow returned artifact:// and experiment:// resources instead of requesting "
+    "large payloads inline."
 )
 
+CAPABILITY_TOOL_NAMES = frozenset({"capability.invoke"})
 VERIFICATION_TOOL_NAMES = frozenset(
     {
         "artifact.put",
@@ -113,6 +122,7 @@ NON_VERIFICATION_TOOL_NAMES = frozenset(
 
 class ToolProfile(StrEnum):
     FULL = "full"
+    CAPABILITIES = "capabilities"
     VERIFICATION = "verification"
 
 
@@ -173,22 +183,29 @@ class OperationBudget(AdapterModel):
 
 @dataclass(frozen=True, slots=True)
 class AppState:
-    kernel: JacobianKernel
+    kernel: JacobianKernel | None
+    tenant_router: TenantKernelRouter | None = None
 
 
-def create_server(
+def create_server(  # noqa: C901
     state_dir: str | Path | None = None,
     *,
     install_references: bool = True,
     tool_profile: ToolProfile | str = ToolProfile.FULL,
+    tenant_isolation: bool = False,
+    allow_anonymous: bool = False,
+    token_verifier: Any | None = None,
+    auth: Any | None = None,
+    capability_adapter_entrypoints: tuple[str, ...] = (),
 ) -> MCPServer[AppState]:
-    """Create the thin MCP adapter over one local Jacobian kernel."""
+    """Create a local or tenant-routed adapter over the Jacobian kernel."""
 
     # Keep ``--help`` and ``--version`` independent of the MCP runtime's
     # heavier imports and shutdown hooks.
     from mcp.server import MCPServer
     from mcp.server.mcpserver import Context
 
+    from jacobian.adapters.mcp.remote import TenantKernelRouter
     from jacobian.kernel import JacobianKernel
     from jacobian.references import reference_catalog
 
@@ -201,23 +218,68 @@ def create_server(
     selected_profile = ToolProfile(tool_profile)
     structured_output = selected_profile is ToolProfile.FULL
     configured_root = _configured_root(state_dir)
-    kernel = JacobianKernel(
-        configured_root,
-        install_references=install_references,
+    kernel = (
+        None
+        if tenant_isolation
+        else JacobianKernel(
+            configured_root,
+            install_references=install_references,
+            capability_adapter_entrypoints=capability_adapter_entrypoints,
+        )
+    )
+    tenant_router = (
+        TenantKernelRouter(
+            configured_root,
+            install_references=install_references,
+            allow_anonymous=allow_anonymous,
+            capability_adapter_entrypoints=capability_adapter_entrypoints,
+        )
+        if tenant_isolation
+        else None
     )
 
     @asynccontextmanager
     async def lifespan(_server: MCPServer[AppState]) -> AsyncIterator[AppState]:
-        yield AppState(kernel=kernel)
+        yield AppState(kernel=kernel, tenant_router=tenant_router)
 
     server: MCPServer[AppState] = MCPServer(
         name="jacobian",
-        title="Jacobian Research Kernel",
-        description=("Verifier-centric tools for bounded executable mathematics"),
+        title="Jacobian Mathematical Workbench",
+        description=(
+            "Capability-first mathematical tools, research memory, and optional "
+            "verification"
+        ),
         instructions=SERVER_INSTRUCTIONS,
         version=__version__,
         lifespan=lifespan,
+        token_verifier=token_verifier,
+        auth=auth,
     )
+
+    @server.tool(
+        name="capability.invoke",
+        description=(
+            "Invoke an installed mathematical capability in the fast EXPLORE or "
+            "checker-backed VERIFY lane. Read capability://catalog first."
+        ),
+        annotations=_tool_annotations(),
+        structured_output=structured_output,
+    )
+    async def capability_invoke(
+        capability_id: str,
+        payload: dict[str, Any],
+        mode: CapabilityMode = CapabilityMode.EXPLORE,
+        ctx: Context[AppState, Any] | None = None,
+    ) -> CapabilityResult:
+        active_kernel = _kernel(ctx)
+        return await asyncio.to_thread(
+            active_kernel.capabilities.invoke,
+            CapabilityRequest(
+                capability_id=capability_id,
+                mode=mode,
+                input=payload,
+            ),
+        )
 
     @server.tool(
         name="artifact.put",
@@ -638,7 +700,6 @@ def create_server(
 
     _register_conjecture_tools(
         server,
-        kernel,
         structured_output=structured_output,
     )
 
@@ -731,8 +792,9 @@ def create_server(
     async def artifact_resource(
         digest: str,
     ) -> str:
+        active_kernel = _resource_kernel(kernel, tenant_router)
         artifact = await asyncio.to_thread(
-            kernel.store.get,
+            active_kernel.store.get,
             f"artifact://sha256/{digest}",
         )
         return json.dumps(
@@ -746,18 +808,35 @@ def create_server(
         )
 
     @server.resource(
+        "capability://catalog",
+        name="capability-catalog",
+        description=(
+            "Installed model-facing operations, supported lanes, and compact schemas."
+        ),
+        mime_type="application/json",
+    )
+    async def capability_catalog_resource() -> str:
+        active_kernel = _resource_kernel(kernel, tenant_router)
+        return json.dumps(
+            active_kernel.capabilities.catalog().model_dump(mode="json"),
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+
+    @server.resource(
         "reference://catalog",
         name="reference-catalog",
         description="Installed reference plugin, schema, and checker IDs.",
         mime_type="application/json",
     )
     async def reference_catalog_resource() -> str:
+        active_kernel = _resource_kernel(kernel, tenant_router)
         return json.dumps(
             reference_catalog(
-                kernel.references,
-                polytope=kernel.polytope,
-                polytope_checkers=kernel.polytope_checkers,
-                lean=kernel.lean_checkers,
+                active_kernel.references,
+                polytope=active_kernel.polytope,
+                polytope_checkers=active_kernel.polytope_checkers,
+                lean=active_kernel.lean_checkers,
             ),
             ensure_ascii=False,
             sort_keys=True,
@@ -771,15 +850,18 @@ def create_server(
         ),
         mime_type="application/json",
     )
-    async def reference_domain_resource(name: str) -> str:
+    async def reference_domain_resource(
+        name: str,
+    ) -> str:
+        active_kernel = _resource_kernel(kernel, tenant_router)
         catalog = reference_catalog(
-            kernel.references,
-            polytope=kernel.polytope,
-            polytope_checkers=kernel.polytope_checkers,
-            lean=kernel.lean_checkers,
+            active_kernel.references,
+            polytope=active_kernel.polytope,
+            polytope_checkers=active_kernel.polytope_checkers,
+            lean=active_kernel.lean_checkers,
         )
         return json.dumps(
-            _reference_domain_contract(kernel, name, catalog),
+            _reference_domain_contract(active_kernel, name, catalog),
             ensure_ascii=False,
             sort_keys=True,
         )
@@ -790,10 +872,13 @@ def create_server(
         description="Read the latest durable experiment snapshot.",
         mime_type="application/json",
     )
-    async def experiment_resource(experiment_id: str) -> str:
+    async def experiment_resource(
+        experiment_id: str,
+    ) -> str:
+        active_kernel = _resource_kernel(kernel, tenant_router)
         snapshot = await asyncio.to_thread(
             _inspect_experiment,
-            kernel,
+            active_kernel,
             f"experiment://{experiment_id}",
         )
         return json.dumps(
@@ -808,10 +893,13 @@ def create_server(
         description="Read durable enumeration accounting and assurance labels.",
         mime_type="application/json",
     )
-    async def experiment_accounting_resource(experiment_id: str) -> str:
+    async def experiment_accounting_resource(
+        experiment_id: str,
+    ) -> str:
+        active_kernel = _resource_kernel(kernel, tenant_router)
         snapshot = await asyncio.to_thread(
             _inspect_experiment,
-            kernel,
+            active_kernel,
             f"experiment://{experiment_id}",
         )
         coverage = getattr(snapshot, "coverage", None)
@@ -838,15 +926,18 @@ def create_server(
         description="Read the current enumeration scope artifact, when available.",
         mime_type="application/json",
     )
-    async def experiment_scope_resource(experiment_id: str) -> str:
+    async def experiment_scope_resource(
+        experiment_id: str,
+    ) -> str:
+        active_kernel = _resource_kernel(kernel, tenant_router)
         snapshot = await asyncio.to_thread(
             _inspect_experiment,
-            kernel,
+            active_kernel,
             f"experiment://{experiment_id}",
         )
         return await asyncio.to_thread(
             _experiment_scope_content,
-            kernel,
+            active_kernel,
             snapshot,
         )
 
@@ -856,10 +947,13 @@ def create_server(
         description="Read the immutable archive manifest and page handles.",
         mime_type="application/json",
     )
-    async def experiment_archive_resource(experiment_id: str) -> str:
+    async def experiment_archive_resource(
+        experiment_id: str,
+    ) -> str:
+        active_kernel = _resource_kernel(kernel, tenant_router)
         snapshot = await asyncio.to_thread(
             _inspect_experiment,
-            kernel,
+            active_kernel,
             f"experiment://{experiment_id}",
         )
         if snapshot.archive_uri is None:
@@ -871,7 +965,10 @@ def create_server(
                 },
                 sort_keys=True,
             )
-        archive = await asyncio.to_thread(kernel.store.get, snapshot.archive_uri)
+        archive = await asyncio.to_thread(
+            active_kernel.store.get,
+            snapshot.archive_uri,
+        )
         return json.dumps(
             {
                 "experiment_uri": snapshot.experiment_uri,
@@ -890,7 +987,6 @@ def create_server(
 
 def _register_conjecture_tools(
     server: MCPServer[AppState],
-    kernel: JacobianKernel,
     *,
     structured_output: bool,
 ) -> None:
@@ -913,7 +1009,9 @@ def _register_conjecture_tools(
         max_hypotheses: int = 8,
         wall_seconds: int = 60,
         falsification: FalsificationPlanInput | None = None,
+        ctx: Context[AppState, Any] | None = None,
     ) -> ConjectureWorkflowResult:
+        kernel = _kernel(ctx)
         return await asyncio.to_thread(
             kernel.conjectures.run,
             ConjectureWorkflowRequest(
@@ -949,7 +1047,9 @@ def _register_conjecture_tools(
         max_hypotheses: int = 8,
         wall_seconds: int = 60,
         falsification: FalsificationPlanInput | None = None,
+        ctx: Context[AppState, Any] | None = None,
     ) -> ConjectureWorkflowResult:
+        kernel = _kernel(ctx)
         return await asyncio.to_thread(
             kernel.conjectures.run,
             ConjectureWorkflowRequest(
@@ -985,7 +1085,9 @@ def _register_conjecture_tools(
         max_hypotheses: int = 8,
         wall_seconds: int = 60,
         falsification: FalsificationPlanInput | None = None,
+        ctx: Context[AppState, Any] | None = None,
     ) -> ConjectureWorkflowResult:
+        kernel = _kernel(ctx)
         return await asyncio.to_thread(
             kernel.conjectures.run,
             ConjectureWorkflowRequest(
@@ -1014,7 +1116,9 @@ def _register_conjecture_tools(
     async def parameter_region_promote(
         subject_uri: str,
         verification_record_uri: str,
+        ctx: Context[AppState, Any] | None = None,
     ) -> ParameterRegion:
+        kernel = _kernel(ctx)
         return await asyncio.to_thread(
             kernel.conjectures.promote_parameter_region,
             subject_uri=subject_uri,
@@ -1071,7 +1175,36 @@ def _kernel(ctx: Context[AppState, Any] | None) -> JacobianKernel:
     state = ctx.request_context.lifespan_context
     if not isinstance(state, AppState):
         raise RuntimeError("MCP lifespan state is invalid")
+    if state.tenant_router is not None:
+        from mcp.server.auth.middleware.auth_context import get_access_token
+
+        access_token = get_access_token()
+        subject = access_token.subject if access_token is not None else None
+        return state.tenant_router.kernel_for(subject)
+    if state.kernel is None:
+        raise RuntimeError("MCP lifespan has no kernel")
     return state.kernel
+
+
+def _resource_kernel(
+    kernel: JacobianKernel | None,
+    tenant_router: TenantKernelRouter | None,
+) -> JacobianKernel:
+    """Route resources through the same auth context as tools.
+
+    MCP 2.0.0b2 does not inject ``Context`` into static resources, but its HTTP
+    authentication middleware still scopes the access token with a contextvar.
+    """
+
+    if tenant_router is not None:
+        from mcp.server.auth.middleware.auth_context import get_access_token
+
+        access_token = get_access_token()
+        subject = access_token.subject if access_token is not None else None
+        return tenant_router.kernel_for(subject)
+    if kernel is None:
+        raise RuntimeError("MCP lifespan has no resource kernel")
+    return kernel
 
 
 def _configured_root(state_dir: str | Path | None) -> Path:
@@ -1374,9 +1507,10 @@ def _reference_domain_contract(
                     "authorized compatible checker may return VERIFIED."
                 ),
                 "witness": [
-                    "call verification.run once with the claim and candidate payloads",
-                    "inspect each returned stage separately",
-                    "accept a decisive result only when verification is VERIFIED",
+                    "call capability.invoke with reference.solve, the predicate, "
+                    "candidate, and witness role",
+                    "use EXPLORE for candidates or VERIFY for a durable conclusion",
+                    "advanced clients may call verification.run with a full claim",
                 ],
             },
         }
@@ -1432,14 +1566,19 @@ def _project_tool_profile(
     profile: ToolProfile,
 ) -> None:
     if profile is ToolProfile.VERIFICATION:
+        for tool_name in sorted(CAPABILITY_TOOL_NAMES):
+            server.remove_tool(tool_name)
         for tool_name in sorted(NON_VERIFICATION_TOOL_NAMES):
+            server.remove_tool(tool_name)
+    elif profile is ToolProfile.CAPABILITIES:
+        for tool_name in sorted(VERIFICATION_TOOL_NAMES | NON_VERIFICATION_TOOL_NAMES):
             server.remove_tool(tool_name)
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(
         prog="jacobian-mcp",
-        description="Run the Jacobian MCP server over stdio.",
+        description="Run the Jacobian MCP server locally or over remote HTTP.",
     )
     parser.add_argument(
         "--version",
@@ -1449,11 +1588,109 @@ def main() -> None:
     parser.add_argument(
         "--tool-profile",
         choices=tuple(profile.value for profile in ToolProfile),
-        default=ToolProfile.FULL.value,
+        default=ToolProfile.CAPABILITIES.value,
         help="project the canonical tool registry for a specific host workflow",
     )
+    parser.add_argument(
+        "--transport",
+        choices=("stdio", "streamable-http", "sse"),
+        default="stdio",
+    )
+    parser.add_argument(
+        "--state-dir",
+        type=Path,
+        help="state root; defaults to JACOBIAN_STATE_DIR or .jacobian",
+    )
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument("--path", default="/mcp")
+    parser.add_argument(
+        "--stateless-http",
+        action="store_true",
+        help="use stateless Streamable HTTP sessions",
+    )
+    parser.add_argument(
+        "--auth-tokens-file",
+        type=Path,
+        help="JSON secret mapping opaque bearer tokens to tenant IDs",
+    )
+    parser.add_argument(
+        "--public-base-url",
+        help="public issuer/resource base URL advertised to remote clients",
+    )
+    parser.add_argument(
+        "--allow-anonymous",
+        action="store_true",
+        help="development only: permit unauthenticated remote requests",
+    )
+    parser.add_argument(
+        "--capability-adapter",
+        action="append",
+        default=[],
+        help="operator-approved package.module:factory entrypoint; repeatable",
+    )
     args = parser.parse_args()
-    create_server(tool_profile=args.tool_profile).run("stdio")
+    args.path = args.path if args.path.startswith("/") else f"/{args.path}"
+    if args.transport == "stdio":
+        if args.auth_tokens_file is not None or args.allow_anonymous:
+            parser.error("remote authentication options cannot be used with stdio")
+        create_server(
+            state_dir=args.state_dir,
+            tool_profile=args.tool_profile,
+            capability_adapter_entrypoints=tuple(args.capability_adapter),
+        ).run("stdio")
+        return
+
+    if args.auth_tokens_file is None and not args.allow_anonymous:
+        parser.error(
+            "remote transports require --auth-tokens-file or explicit --allow-anonymous"
+        )
+    token_verifier = None
+    auth = None
+    if args.auth_tokens_file is not None:
+        from mcp.server.auth.settings import AuthSettings
+
+        from jacobian.adapters.mcp.remote import (
+            StaticTokenVerifier,
+            load_static_token_file,
+        )
+
+        public_base_url = str(
+            args.public_base_url or f"http://{args.host}:{args.port}"
+        ).rstrip("/")
+        token_verifier = StaticTokenVerifier(
+            load_static_token_file(args.auth_tokens_file)
+        )
+        auth = AuthSettings(
+            issuer_url=AnyHttpUrl(public_base_url),
+            resource_server_url=AnyHttpUrl(f"{public_base_url}{args.path}"),
+            required_scopes=["jacobian:use"],
+        )
+    server = create_server(
+        state_dir=args.state_dir,
+        tool_profile=args.tool_profile,
+        tenant_isolation=True,
+        allow_anonymous=args.allow_anonymous,
+        token_verifier=token_verifier,
+        auth=auth,
+        capability_adapter_entrypoints=tuple(args.capability_adapter),
+    )
+    if args.transport == "streamable-http":
+        server.run(
+            "streamable-http",
+            host=args.host,
+            port=args.port,
+            streamable_http_path=args.path,
+            stateless_http=args.stateless_http,
+        )
+    else:
+        server.run(
+            "sse",
+            host=args.host,
+            port=args.port,
+            sse_path=args.path,
+            message_path="/messages/",
+        )
 
 
 if __name__ == "__main__":

--- a/src/jacobian/builtin_capabilities.py
+++ b/src/jacobian/builtin_capabilities.py
@@ -1,0 +1,378 @@
+"""Bundled adapters for memory, reference domains, and Lean."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from jacobian.contracts.capabilities import (
+    CapabilityAssurance,
+    CapabilityAssuranceLevel,
+    CapabilityDescriptor,
+    CapabilityMode,
+    CapabilityRequest,
+    CapabilityResult,
+)
+from jacobian.contracts.evaluation import EvaluationProfile
+from jacobian.contracts.evidence import WitnessRole
+from jacobian.contracts.lean import LeanEnvironment
+from jacobian.contracts.results import Execution, ExecutionStatus, Verification
+from jacobian.contracts.workflows import WitnessVerificationWorkflowResult
+from jacobian.lean import LeanService
+from jacobian.memory import ResearchMemory
+from jacobian.workflows import VerificationWorkflowService
+
+_OBJECT_SCHEMA: dict[str, Any] = {"type": "object"}
+
+
+class KnowledgeSearchAdapter:
+    def __init__(self, memory: ResearchMemory) -> None:
+        self.memory = memory
+        self._descriptor = CapabilityDescriptor(
+            capability_id="knowledge.search",
+            version="1",
+            title="Search research memory",
+            description=(
+                "Retrieve trust-labeled prior capability episodes; retrieval does "
+                "not promote their mathematical assurance."
+            ),
+            provider="jacobian.memory",
+            modes=(CapabilityMode.EXPLORE,),
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string", "maxLength": 512},
+                    "capability_id": {"type": "string"},
+                    "assurance_level": {"enum": ["HEURISTIC", "COMPUTED", "VERIFIED"]},
+                    "limit": {"type": "integer", "minimum": 1, "maximum": 100},
+                },
+                "additionalProperties": False,
+            },
+            output_schema=_OBJECT_SCHEMA,
+            read_only=True,
+            records_episode=False,
+            tags=("memory", "retrieval"),
+        )
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        return self._descriptor
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        selected = request.input
+        result = self.memory.search(
+            query=str(selected.get("query", "")),
+            capability_id=(
+                str(selected["capability_id"]) if "capability_id" in selected else None
+            ),
+            assurance_level=selected.get("assurance_level"),
+            limit=int(selected.get("limit", 10)),
+        )
+        return CapabilityResult(
+            capability_id=self.descriptor.capability_id,
+            capability_version=self.descriptor.version,
+            mode=request.mode,
+            execution=Execution(status=ExecutionStatus.COMPLETED),
+            output=result.model_dump(mode="json"),
+            assurance=CapabilityAssurance(
+                level=CapabilityAssuranceLevel.COMPUTED,
+                basis=(
+                    "deterministic local index query; each hit retains its own "
+                    "assurance label"
+                ),
+            ),
+        )
+
+
+class ReferenceSolveAdapter:
+    def __init__(self, workflows: VerificationWorkflowService) -> None:
+        self.workflows = workflows
+        self._descriptor = CapabilityDescriptor(
+            capability_id="reference.solve",
+            version="1",
+            title="Explore or verify a bundled reference domain",
+            description=(
+                "Evaluate one candidate and seek a witness; VERIFY additionally "
+                "replays found evidence with the authorized checker."
+            ),
+            provider="jacobian.references",
+            modes=(CapabilityMode.EXPLORE, CapabilityMode.VERIFY),
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "reference_name": {"type": "string", "minLength": 1},
+                    "predicate": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string", "minLength": 1},
+                            "parameters": {"type": "object"},
+                        },
+                        "required": ["name"],
+                        "additionalProperties": False,
+                    },
+                    "candidate": {"type": "object"},
+                    "witness_role": {
+                        "enum": [
+                            "DEFEATS_CANDIDATE",
+                            "RESCUES_CANDIDATE",
+                            "SUPPORTS_CLAIM",
+                            "REFUTES_CLAIM",
+                        ]
+                    },
+                    "profile": {"enum": ["FAST", "EXACT_CANDIDATE"]},
+                    "seed": {"type": "integer"},
+                    "evaluation_wall_seconds": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 86400,
+                    },
+                    "witness_wall_seconds": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 86400,
+                    },
+                },
+                "required": [
+                    "reference_name",
+                    "predicate",
+                    "candidate",
+                    "witness_role",
+                ],
+                "additionalProperties": False,
+            },
+            output_schema=_OBJECT_SCHEMA,
+            tags=("reference", "search", "verification"),
+        )
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        return self._descriptor
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        payload = request.input
+        reference_name = str(payload["reference_name"])
+        try:
+            reference = self.workflows.references[reference_name]
+        except KeyError as exc:
+            raise ValueError(f"unknown reference domain: {reference_name}") from exc
+        claim_payload = {
+            "claim_schema_version": "1",
+            "domain_id": reference.domain_id,
+            "domain_version": reference.domain_version,
+            "semantics_uri": reference.semantics_uri,
+            "quantifiers": [],
+            "predicate": payload["predicate"],
+            "bounds": {},
+            "required_capabilities": list(reference.available_capabilities),
+            "correspondence_status": "UNREVIEWED",
+        }
+        arguments = {
+            "reference_name": reference_name,
+            "claim_payload": claim_payload,
+            "candidate_payload": payload["candidate"],
+            "witness_role": WitnessRole(str(payload["witness_role"])),
+            "profile": EvaluationProfile(str(payload.get("profile", "FAST"))),
+            "seed": int(payload.get("seed", 0)),
+            "evaluation_wall_seconds": int(payload.get("evaluation_wall_seconds", 60)),
+            "witness_wall_seconds": int(payload.get("witness_wall_seconds", 300)),
+        }
+        workflow = (
+            self.workflows.explore_witness(**arguments)
+            if request.mode is CapabilityMode.EXPLORE
+            else self.workflows.verify_witness(**arguments)
+        )
+        return _reference_result(
+            request,
+            self.descriptor,
+            workflow,
+            claim_payload=claim_payload,
+        )
+
+
+class LeanCheckAdapter:
+    def __init__(self, lean: LeanService) -> None:
+        self.lean = lean
+        self._descriptor = CapabilityDescriptor(
+            capability_id="lean.check",
+            version="1",
+            title="Check a Lean proof",
+            description=(
+                "Compile and replay one proposition with the pinned CORE or MATHLIB "
+                "kernel profile."
+            ),
+            provider="jacobian.lean4",
+            modes=(CapabilityMode.VERIFY,),
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "statement": {"type": "string", "minLength": 1, "maxLength": 2000},
+                    "proof": {"type": "string", "minLength": 1, "maxLength": 20000},
+                    "environment": {"enum": ["CORE", "MATHLIB"]},
+                },
+                "required": ["statement", "proof"],
+                "additionalProperties": False,
+            },
+            output_schema=_OBJECT_SCHEMA,
+            tags=("lean", "proof", "verification"),
+        )
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        return self._descriptor
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        payload = request.input
+        checked = self.lean.verify(
+            statement=str(payload["statement"]),
+            proof=str(payload["proof"]),
+            environment=LeanEnvironment(str(payload.get("environment", "CORE"))),
+        )
+        verified = (
+            checked.result.assurance.verification is Verification.VERIFIED
+            and checked.result.verification_record_uri is not None
+        )
+        evidence = (checked.certificate_uri,)
+        scope_uri = checked.result.assurance.scope_uri
+        return CapabilityResult(
+            capability_id=self.descriptor.capability_id,
+            capability_version=self.descriptor.version,
+            mode=request.mode,
+            execution=checked.result.execution,
+            output={
+                "conclusion": checked.result.conclusion.value,
+                "claim_uri": checked.claim_uri,
+                "candidate_uri": checked.candidate_uri,
+                "certificate_uri": checked.certificate_uri,
+                "verification_record_uri": checked.result.verification_record_uri,
+            },
+            assurance=CapabilityAssurance(
+                level=(
+                    CapabilityAssuranceLevel.VERIFIED
+                    if verified
+                    else CapabilityAssuranceLevel.HEURISTIC
+                ),
+                basis=(
+                    "accepted by the pinned Lean checker"
+                    if verified
+                    else "Lean checker did not accept the supplied proof"
+                ),
+                verification_record_uri=checked.result.verification_record_uri,
+            ),
+            artifact_uris=(
+                checked.claim_uri,
+                checked.candidate_uri,
+                *evidence,
+                *((scope_uri,) if scope_uri is not None else ()),
+            ),
+        )
+
+
+def _reference_result(
+    request: CapabilityRequest,
+    descriptor: CapabilityDescriptor,
+    workflow: WitnessVerificationWorkflowResult,
+    *,
+    claim_payload: dict[str, Any],
+) -> CapabilityResult:
+    evaluation = (
+        workflow.evaluation.items[0]
+        if workflow.evaluation is not None and workflow.evaluation.items
+        else None
+    )
+    witness = workflow.witness_search
+    verification = workflow.verification
+    verification_record_uri = (
+        verification.verification_record_uri if verification is not None else None
+    )
+    verified = (
+        verification is not None
+        and verification.assurance.verification is Verification.VERIFIED
+        and verification_record_uri is not None
+    )
+    evidence_uri = (
+        witness.witness_uri or witness.certificate_uri if witness is not None else None
+    )
+    scope_uri = verification.assurance.scope_uri if verification is not None else None
+    artifacts = tuple(
+        uri
+        for uri in (
+            workflow.claim_uri,
+            workflow.candidate_uri,
+            evidence_uri,
+            scope_uri,
+        )
+        if uri is not None
+    )
+    execution = (
+        verification.execution
+        if verification is not None
+        else (
+            witness.result.execution
+            if witness is not None
+            else (
+                workflow.evaluation.execution
+                if workflow.evaluation is not None
+                else Execution(
+                    status=ExecutionStatus.ERROR,
+                    detail="workflow stopped before evaluation",
+                )
+            )
+        )
+    )
+    return CapabilityResult(
+        capability_id=descriptor.capability_id,
+        capability_version=descriptor.version,
+        mode=request.mode,
+        execution=execution,
+        output={
+            "claim_valid": workflow.claim_validation.valid,
+            "conclusion": (
+                verification.conclusion.value
+                if verification is not None
+                else (
+                    evaluation.result.conclusion.value
+                    if evaluation is not None
+                    else "UNKNOWN"
+                )
+            ),
+            "evaluation": (
+                {
+                    "conclusion": evaluation.result.conclusion.value,
+                    "objectives": evaluation.objectives,
+                    "features": evaluation.features,
+                    "detail": evaluation.detail,
+                }
+                if evaluation is not None
+                else None
+            ),
+            "witness_status": witness.status.value if witness is not None else None,
+            "claim_uri": workflow.claim_uri,
+            "candidate_uri": workflow.candidate_uri,
+            "evidence_uri": evidence_uri,
+            "verification_record_uri": (verification_record_uri),
+        },
+        scope=_scope_from_claim(claim_payload),
+        assurance=CapabilityAssurance(
+            level=(
+                CapabilityAssuranceLevel.VERIFIED
+                if verified
+                else CapabilityAssuranceLevel.HEURISTIC
+            ),
+            basis=(
+                "authorized independent checker accepted the discovered evidence"
+                if verified
+                else "plugin evaluation and witness search without checker promotion"
+            ),
+            verification_record_uri=verification_record_uri if verified else None,
+        ),
+        artifact_uris=artifacts,
+    )
+
+
+def _scope_from_claim(claim: object) -> dict[str, Any]:
+    if not isinstance(claim, dict):
+        return {}
+    return {
+        key: claim[key]
+        for key in ("domain_id", "domain_version", "predicate", "bounds")
+        if key in claim
+    }

--- a/src/jacobian/capabilities.py
+++ b/src/jacobian/capabilities.py
@@ -1,0 +1,220 @@
+"""Extensible model-facing capability registry and invocation service."""
+
+from __future__ import annotations
+
+import importlib
+import re
+from typing import TYPE_CHECKING, Protocol, cast
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+
+from jacobian.canonical import canonicalize_json, loads_strict_json
+from jacobian.contracts.capabilities import (
+    CapabilityAssurance,
+    CapabilityAssuranceLevel,
+    CapabilityCatalog,
+    CapabilityDescriptor,
+    CapabilityRequest,
+    CapabilityResult,
+)
+from jacobian.contracts.memory import ResearchEpisode
+from jacobian.contracts.results import Execution, ExecutionStatus
+from jacobian.contracts.verification import VerificationRecord
+from jacobian.memory import ResearchMemory
+from jacobian.store import ArtifactStore, StoreError
+
+if TYPE_CHECKING:
+    from jacobian.kernel import JacobianKernel
+
+_ENTRYPOINT_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_.]*:[A-Za-z_][A-Za-z0-9_]*$")
+
+
+class CapabilityError(RuntimeError):
+    """A capability descriptor, request, or assurance boundary is invalid."""
+
+
+class CapabilityAdapter(Protocol):
+    """Operator-installed adapter; registration requires no MCP changes."""
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor: ...
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult: ...
+
+
+class CapabilityService:
+    """Validate, dispatch, trust-check, and remember mathematical operations."""
+
+    def __init__(self, store: ArtifactStore, memory: ResearchMemory) -> None:
+        self.store = store
+        self.memory = memory
+        self._adapters: dict[str, CapabilityAdapter] = {}
+
+    def register(self, adapter: CapabilityAdapter) -> None:
+        descriptor = adapter.descriptor
+        if descriptor.capability_id in self._adapters:
+            raise CapabilityError(
+                f"duplicate capability ID: {descriptor.capability_id}"
+            )
+        _validator(descriptor.input_schema)
+        _validator(descriptor.output_schema)
+        self._adapters[descriptor.capability_id] = adapter
+
+    def catalog(self) -> CapabilityCatalog:
+        return CapabilityCatalog(
+            capabilities=tuple(
+                self._adapters[name].descriptor for name in sorted(self._adapters)
+            )
+        )
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        try:
+            adapter = self._adapters[request.capability_id]
+        except KeyError as exc:
+            raise CapabilityError(
+                f"unknown capability: {request.capability_id}"
+            ) from exc
+        descriptor = adapter.descriptor
+        if request.mode not in descriptor.modes:
+            raise CapabilityError(
+                f"{request.capability_id} does not support {request.mode.value}"
+            )
+        normalized_input = _validate_payload(descriptor.input_schema, request.input)
+        normalized_request = request.model_copy(update={"input": normalized_input})
+        try:
+            result = CapabilityResult.model_validate(adapter.invoke(normalized_request))
+        except Exception as exc:
+            result = CapabilityResult(
+                capability_id=descriptor.capability_id,
+                capability_version=descriptor.version,
+                mode=request.mode,
+                execution=Execution(
+                    status=ExecutionStatus.ERROR,
+                    detail=f"capability adapter failed: {type(exc).__name__}",
+                ),
+                assurance=CapabilityAssurance(
+                    level=CapabilityAssuranceLevel.HEURISTIC,
+                    basis="adapter execution failed; no mathematical conclusion",
+                ),
+            )
+        if (
+            result.capability_id != descriptor.capability_id
+            or result.capability_version != descriptor.version
+            or result.mode is not request.mode
+        ):
+            raise CapabilityError("adapter result identity differs from its request")
+        normalized_output = _validate_payload(descriptor.output_schema, result.output)
+        result = result.model_copy(update={"output": normalized_output})
+        self._validate_verified_result(result)
+        if descriptor.records_episode:
+            episode_uri = self.memory.record(
+                ResearchEpisode(
+                    capability_id=result.capability_id,
+                    capability_version=result.capability_version,
+                    mode=result.mode,
+                    request=normalized_request.input,
+                    result=result.output,
+                    assurance_level=result.assurance.level,
+                    verification_record_uri=(result.assurance.verification_record_uri),
+                    artifact_uris=result.artifact_uris,
+                    summary=_episode_summary(result),
+                    tags=descriptor.tags,
+                )
+            )
+            result = result.model_copy(update={"episode_uri": episode_uri})
+        return result
+
+    def _validate_verified_result(self, result: CapabilityResult) -> None:
+        if result.assurance.level is not CapabilityAssuranceLevel.VERIFIED:
+            return
+        record_uri = result.assurance.verification_record_uri
+        assert record_uri is not None
+        try:
+            record_artifact = self.store.get(record_uri)
+            record = VerificationRecord.model_validate(record_artifact.payload)
+        except (StoreError, ValueError) as exc:
+            raise CapabilityError(
+                "verified capability result has no valid local verification record"
+            ) from exc
+        if record.evidence_uri not in result.artifact_uris:
+            raise CapabilityError(
+                "verified capability result does not expose its checked evidence"
+            )
+        missing_parents = set(record_artifact.manifest.parents) - set(
+            result.artifact_uris
+        )
+        if missing_parents:
+            raise CapabilityError(
+                "verified capability result omits verification-bound artifacts"
+            )
+        projected_record = result.output.get("verification_record_uri")
+        if projected_record is not None and projected_record != record_uri:
+            raise CapabilityError(
+                "verified capability output projects a different verification record"
+            )
+        projected_conclusion = result.output.get("conclusion")
+        if (
+            projected_conclusion is not None
+            and projected_conclusion != record.conclusion.value
+        ):
+            raise CapabilityError(
+                "verified capability output differs from the checked conclusion"
+            )
+
+
+def load_capability_adapter(
+    entrypoint: str,
+    kernel: JacobianKernel,
+) -> CapabilityAdapter:
+    """Load one operator-approved ``factory(kernel)`` adapter entrypoint."""
+
+    if not _ENTRYPOINT_PATTERN.fullmatch(entrypoint):
+        raise CapabilityError("capability adapter entrypoint has an invalid format")
+    module_name, attribute_name = entrypoint.split(":", 1)
+    try:
+        module = importlib.import_module(module_name)
+        factory = getattr(module, attribute_name)
+        adapter = factory(kernel)
+        descriptor = adapter.descriptor
+        invoke = adapter.invoke
+    except (AttributeError, ImportError, TypeError) as exc:
+        raise CapabilityError(
+            f"cannot load capability adapter entrypoint: {entrypoint}"
+        ) from exc
+    if not isinstance(descriptor, CapabilityDescriptor) or not callable(invoke):
+        raise CapabilityError("capability adapter does not implement the protocol")
+    return cast(CapabilityAdapter, adapter)
+
+
+def _validator(schema: dict[str, object]) -> Draft202012Validator:
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError as exc:
+        raise CapabilityError("capability JSON Schema is invalid") from exc
+    return Draft202012Validator(schema)
+
+
+def _validate_payload(
+    schema: dict[str, object],
+    payload: dict[str, object],
+) -> dict[str, object]:
+    normalized = loads_strict_json(canonicalize_json(payload))
+    assert isinstance(normalized, dict)
+    errors = sorted(
+        _validator(schema).iter_errors(normalized),
+        key=lambda error: tuple(str(part) for part in error.absolute_path),
+    )
+    if errors:
+        first = errors[0]
+        location = "/".join(str(part) for part in first.absolute_path) or "$"
+        raise CapabilityError(f"{location}: {first.message}")
+    return normalized
+
+
+def _episode_summary(result: CapabilityResult) -> str:
+    return (
+        f"{result.capability_id} {result.mode.value.lower()} "
+        f"{result.execution.status.value.lower()} "
+        f"({result.assurance.level.value.lower()})"
+    )

--- a/src/jacobian/contracts/capabilities.py
+++ b/src/jacobian/contracts/capabilities.py
@@ -1,0 +1,134 @@
+"""Model-facing contracts for extensible mathematical capabilities."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Annotated, Any, Literal, Self
+
+from pydantic import Field, StringConstraints, model_validator
+
+from jacobian.canonical import canonicalize_json
+from jacobian.contracts.common import ArtifactUri
+from jacobian.contracts.results import ContractModel, Execution
+
+CapabilityId = Annotated[
+    str,
+    StringConstraints(
+        pattern=r"^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)+$",
+        min_length=3,
+        max_length=128,
+        strict=True,
+    ),
+]
+
+
+class CapabilityMode(StrEnum):
+    """The low-friction exploration and explicit verification lanes."""
+
+    EXPLORE = "EXPLORE"
+    VERIFY = "VERIFY"
+
+
+class CapabilityAssuranceLevel(StrEnum):
+    """Coarse model-facing assurance without hiding the detailed result record."""
+
+    HEURISTIC = "HEURISTIC"
+    COMPUTED = "COMPUTED"
+    VERIFIED = "VERIFIED"
+
+
+class CapabilityDescriptor(ContractModel):
+    """One stable operation advertised by an operator-installed adapter."""
+
+    descriptor_version: Literal["1"] = "1"
+    capability_id: CapabilityId
+    version: str = Field(min_length=1, max_length=64)
+    title: str = Field(min_length=1, max_length=128)
+    description: str = Field(min_length=1, max_length=512)
+    provider: str = Field(min_length=1, max_length=128)
+    modes: tuple[CapabilityMode, ...]
+    input_schema: dict[str, Any]
+    output_schema: dict[str, Any]
+    read_only: bool = False
+    records_episode: bool = True
+    tags: tuple[str, ...] = ()
+
+    @model_validator(mode="after")
+    def require_modes_and_canonical_schemas(self) -> Self:
+        if not self.modes:
+            raise ValueError("a capability must support at least one mode")
+        if len(set(self.modes)) != len(self.modes):
+            raise ValueError("capability modes must be unique")
+        canonicalize_json(self.input_schema)
+        canonicalize_json(self.output_schema)
+        return self
+
+
+class CapabilityRequest(ContractModel):
+    request_version: Literal["1"] = "1"
+    capability_id: CapabilityId
+    mode: CapabilityMode = CapabilityMode.EXPLORE
+    input: dict[str, Any]
+
+    @model_validator(mode="after")
+    def require_canonical_input(self) -> Self:
+        canonicalize_json(self.input)
+        return self
+
+
+class CapabilityAssurance(ContractModel):
+    level: CapabilityAssuranceLevel
+    basis: str = Field(min_length=1, max_length=1024)
+    verification_record_uri: ArtifactUri | None = None
+
+    @model_validator(mode="after")
+    def bind_verified_assurance(self) -> Self:
+        if (
+            self.level is CapabilityAssuranceLevel.VERIFIED
+            and self.verification_record_uri is None
+        ):
+            raise ValueError("verified capability assurance requires a record URI")
+        if (
+            self.level is not CapabilityAssuranceLevel.VERIFIED
+            and self.verification_record_uri is not None
+        ):
+            raise ValueError(
+                "only verified capability assurance may carry a record URI"
+            )
+        return self
+
+
+class CapabilityResult(ContractModel):
+    """Compact result shared by local, MCP, and remote capability adapters."""
+
+    response_version: Literal["1"] = "1"
+    capability_id: CapabilityId
+    capability_version: str = Field(min_length=1, max_length=64)
+    mode: CapabilityMode
+    execution: Execution
+    output: dict[str, Any] = Field(default_factory=dict)
+    scope: dict[str, Any] = Field(default_factory=dict)
+    assurance: CapabilityAssurance
+    artifact_uris: tuple[ArtifactUri, ...] = ()
+    episode_uri: ArtifactUri | None = None
+
+    @model_validator(mode="after")
+    def enforce_lane_and_canonical_output(self) -> Self:
+        canonicalize_json(self.output)
+        canonicalize_json(self.scope)
+        if (
+            self.assurance.level is CapabilityAssuranceLevel.VERIFIED
+            and self.mode is not CapabilityMode.VERIFY
+        ):
+            raise ValueError("the exploration lane cannot return verified assurance")
+        if (
+            self.execution.status.value != "COMPLETED"
+            and self.assurance.level is CapabilityAssuranceLevel.VERIFIED
+        ):
+            raise ValueError("failed capability execution cannot be verified")
+        return self
+
+
+class CapabilityCatalog(ContractModel):
+    catalog_version: Literal["1"] = "1"
+    capabilities: tuple[CapabilityDescriptor, ...]

--- a/src/jacobian/contracts/memory.py
+++ b/src/jacobian/contracts/memory.py
@@ -1,0 +1,47 @@
+"""Trust-labeled research-memory contracts."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import Field, StrictInt
+
+from jacobian.contracts.capabilities import (
+    CapabilityAssuranceLevel,
+    CapabilityId,
+    CapabilityMode,
+)
+from jacobian.contracts.common import ArtifactUri
+from jacobian.contracts.results import ContractModel
+
+
+class ResearchEpisode(ContractModel):
+    episode_version: Literal["1"] = "1"
+    capability_id: CapabilityId
+    capability_version: str = Field(min_length=1, max_length=64)
+    mode: CapabilityMode
+    request: dict[str, Any]
+    result: dict[str, Any]
+    assurance_level: CapabilityAssuranceLevel
+    verification_record_uri: ArtifactUri | None = None
+    artifact_uris: tuple[ArtifactUri, ...] = ()
+    summary: str = Field(default="", max_length=1024)
+    tags: tuple[str, ...] = ()
+
+
+class MemoryHit(ContractModel):
+    episode_uri: ArtifactUri
+    capability_id: CapabilityId
+    mode: CapabilityMode
+    assurance_level: CapabilityAssuranceLevel
+    summary: str
+    tags: tuple[str, ...] = ()
+    created_at: datetime
+    score: StrictInt = Field(ge=0, le=1000)
+
+
+class MemorySearchResult(ContractModel):
+    query: str
+    hits: tuple[MemoryHit, ...]
+    cutoff: datetime | None = None

--- a/src/jacobian/kernel.py
+++ b/src/jacobian/kernel.py
@@ -5,12 +5,23 @@ from __future__ import annotations
 from pathlib import Path
 
 from jacobian.artifacts import ArtifactService
+from jacobian.builtin_capabilities import (
+    KnowledgeSearchAdapter,
+    LeanCheckAdapter,
+    ReferenceSolveAdapter,
+)
+from jacobian.capabilities import (
+    CapabilityAdapter,
+    CapabilityService,
+    load_capability_adapter,
+)
 from jacobian.claims import ClaimValidationService
 from jacobian.conjectures import ConjectureService
 from jacobian.contracts.lean import LeanEnvironment
 from jacobian.evaluation import EvaluationService
 from jacobian.experiments import ExperimentService
 from jacobian.lean import LeanService
+from jacobian.memory import ResearchMemory
 from jacobian.plugin_execution import PluginExecutor
 from jacobian.plugins.registry import PluginRegistry
 from jacobian.polytope import PolytopeService
@@ -40,10 +51,12 @@ class JacobianKernel:
         root: str | Path,
         *,
         install_references: bool = False,
+        capability_adapter_entrypoints: tuple[str, ...] = (),
     ) -> None:
         self.store = ArtifactStore(root)
         self.schemas = SchemaRegistry(self.store)
         self.artifacts = ArtifactService(self.store, self.schemas)
+        self.memory = ResearchMemory(self.store, self.schemas)
         self.plugins = PluginRegistry(self.store)
         self.checkers = CheckerRegistry(self.store.db_path)
         self.claims = ClaimValidationService(
@@ -134,6 +147,8 @@ class JacobianKernel:
         self.lean_checkers: dict[LeanEnvironment, LeanCheckerInstallation] = {}
         self.lean: LeanService | None = None
         self.verification_workflows: VerificationWorkflowService | None = None
+        self.capabilities = CapabilityService(self.store, self.memory)
+        self.capabilities.register(KnowledgeSearchAdapter(self.memory))
         if install_references:
             self.references = self.reference_installer.install_all()
             self.polytope_checkers = self.reference_installer.install_polytope_checkers(
@@ -157,3 +172,14 @@ class JacobianKernel:
                 self.verification,
                 self.references,
             )
+            self.capabilities.register(
+                ReferenceSolveAdapter(self.verification_workflows)
+            )
+            self.capabilities.register(LeanCheckAdapter(self.lean))
+        for entrypoint in capability_adapter_entrypoints:
+            self.capabilities.register(load_capability_adapter(entrypoint, self))
+
+    def register_capability(self, adapter: CapabilityAdapter) -> None:
+        """Install an operator-owned adapter without changing the kernel or MCP."""
+
+        self.capabilities.register(adapter)

--- a/src/jacobian/kernel.py
+++ b/src/jacobian/kernel.py
@@ -97,7 +97,7 @@ class JacobianKernel:
         self.verification = VerificationService(
             self.store,
             self.checkers,
-            checker_timeout_seconds=75,
+            checker_timeout_seconds=105,
         )
         self.witnesses = WitnessSearchService(
             self.store,

--- a/src/jacobian/memory.py
+++ b/src/jacobian/memory.py
@@ -1,0 +1,188 @@
+"""Local searchable research episodes with explicit trust labels."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime
+from typing import Any
+
+from jacobian.contracts.capabilities import (
+    CapabilityAssuranceLevel,
+    CapabilityMode,
+)
+from jacobian.contracts.memory import MemoryHit, MemorySearchResult, ResearchEpisode
+from jacobian.schema_registry import SchemaRegistry
+from jacobian.store import ArtifactStore
+
+
+class ResearchMemory:
+    """Index immutable capability episodes without promoting retrieved content."""
+
+    def __init__(self, store: ArtifactStore, schemas: SchemaRegistry) -> None:
+        self.store = store
+        self.schemas = schemas
+        self.episode_schema_uri = schemas.register(
+            name="jacobian.research-episode",
+            version="1",
+            schema=ResearchEpisode.model_json_schema(),
+        )
+        self.episode_semantics_uri = store.register_descriptor(
+            kind="semantics",
+            name="jacobian.research-episode",
+            version="1",
+            definition={
+                "description": (
+                    "trust-labeled model and tool activity; retrieval never promotes "
+                    "mathematical assurance"
+                )
+            },
+        )
+        self._initialize_database()
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.store.db_path, timeout=30)
+        connection.row_factory = sqlite3.Row
+        return connection
+
+    def _initialize_database(self) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS research_episodes (
+                    episode_uri TEXT PRIMARY KEY,
+                    capability_id TEXT NOT NULL,
+                    mode TEXT NOT NULL,
+                    assurance_level TEXT NOT NULL,
+                    summary TEXT NOT NULL,
+                    tags_json TEXT NOT NULL,
+                    search_text TEXT NOT NULL,
+                    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+                )
+                """
+            )
+            connection.execute(
+                """
+                CREATE INDEX IF NOT EXISTS research_episodes_lookup
+                ON research_episodes(capability_id, assurance_level, created_at)
+                """
+            )
+
+    def record(self, episode: ResearchEpisode) -> str:
+        normalized = self.schemas.validate(
+            self.episode_schema_uri,
+            episode.model_dump(mode="json"),
+        )
+        stored = self.store.put(
+            schema_uri=self.episode_schema_uri,
+            semantics_uri=self.episode_semantics_uri,
+            payload=normalized,
+            parents=tuple(
+                dict.fromkeys(
+                    (
+                        *episode.artifact_uris,
+                        *(
+                            (episode.verification_record_uri,)
+                            if episode.verification_record_uri is not None
+                            else ()
+                        ),
+                    )
+                )
+            ),
+            summary=episode.summary,
+        )
+        search_text = " ".join(
+            (
+                episode.capability_id,
+                episode.summary,
+                " ".join(episode.tags),
+                json.dumps(episode.request, sort_keys=True),
+                json.dumps(episode.result, sort_keys=True),
+            )
+        ).casefold()
+        with self._connect() as connection:
+            connection.execute(
+                """
+                INSERT OR IGNORE INTO research_episodes(
+                    episode_uri,
+                    capability_id,
+                    mode,
+                    assurance_level,
+                    summary,
+                    tags_json,
+                    search_text
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    stored.artifact_uri,
+                    episode.capability_id,
+                    episode.mode.value,
+                    episode.assurance_level.value,
+                    episode.summary,
+                    json.dumps(list(episode.tags), sort_keys=True),
+                    search_text,
+                ),
+            )
+        return stored.artifact_uri
+
+    def search(
+        self,
+        *,
+        query: str = "",
+        capability_id: str | None = None,
+        assurance_level: CapabilityAssuranceLevel | str | None = None,
+        cutoff: datetime | None = None,
+        limit: int = 10,
+    ) -> MemorySearchResult:
+        if len(query) > 512:
+            raise ValueError("memory query exceeds 512 characters")
+        if not 1 <= limit <= 100:
+            raise ValueError("memory search limit must be between 1 and 100")
+        clauses: list[str] = []
+        parameters: list[Any] = []
+        terms = [term.casefold() for term in query.split() if term]
+        for term in terms:
+            clauses.append("search_text LIKE ? ESCAPE '\\'")
+            parameters.append(f"%{_escape_like(term)}%")
+        if capability_id is not None:
+            clauses.append("capability_id = ?")
+            parameters.append(capability_id)
+        if assurance_level is not None:
+            selected = CapabilityAssuranceLevel(assurance_level)
+            clauses.append("assurance_level = ?")
+            parameters.append(selected.value)
+        if cutoff is not None:
+            clauses.append("created_at <= ?")
+            parameters.append(cutoff.isoformat())
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        parameters.append(limit)
+        with self._connect() as connection:
+            rows = connection.execute(
+                f"""
+                SELECT episode_uri, capability_id, mode, assurance_level,
+                       summary, tags_json, created_at
+                FROM research_episodes
+                {where}
+                ORDER BY created_at DESC, episode_uri
+                LIMIT ?
+                """,
+                parameters,
+            ).fetchall()
+        hits = tuple(
+            MemoryHit(
+                episode_uri=row["episode_uri"],
+                capability_id=row["capability_id"],
+                mode=CapabilityMode(row["mode"]),
+                assurance_level=CapabilityAssuranceLevel(row["assurance_level"]),
+                summary=row["summary"],
+                tags=tuple(json.loads(row["tags_json"])),
+                created_at=datetime.fromisoformat(row["created_at"]),
+                score=(1000 if terms else 500),
+            )
+            for row in rows
+        )
+        return MemorySearchResult(query=query, hits=hits, cutoff=cutoff)
+
+
+def _escape_like(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")

--- a/src/jacobian/plugins/erdos_straus.py
+++ b/src/jacobian/plugins/erdos_straus.py
@@ -1,0 +1,179 @@
+"""Search-side support for bounded Erdős-Straus verification."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from typing import Any, TypeGuard
+
+_MIN_N = 2
+_MAX_N = 10_000
+
+
+def _is_int(value: object) -> TypeGuard[int]:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _claim_view(payload: dict[str, Any]) -> dict[str, Any]:
+    predicate = payload.get("predicate")
+    if not isinstance(predicate, dict):
+        return payload
+    parameters = predicate.get("parameters", {})
+    return {
+        "predicate": predicate.get("name"),
+        **(parameters if isinstance(parameters, dict) else {}),
+    }
+
+
+def _validate_range(payload: dict[str, Any]) -> list[str]:
+    lower = payload.get("lower_bound")
+    upper = payload.get("upper_bound")
+    if not _is_int(lower) or not _is_int(upper):
+        return ["lower_bound and upper_bound must be integers"]
+    if lower < _MIN_N:
+        return [f"lower_bound must be at least {_MIN_N}"]
+    if upper < lower:
+        return ["upper_bound must be at least lower_bound"]
+    if upper > _MAX_N:
+        return [f"upper_bound exceeds the reference limit of {_MAX_N}"]
+    return []
+
+
+def validate_claim(payload: dict[str, Any]) -> list[str]:
+    if payload.get("predicate") != "erdos_straus_range":
+        return ["unsupported Erdős-Straus claim predicate"]
+    return _validate_range(payload)
+
+
+def validate_candidate(payload: dict[str, Any]) -> list[str]:
+    return _validate_range(payload)
+
+
+def _validate_candidate_for_claim(
+    claim: dict[str, Any],
+    candidate: dict[str, Any],
+) -> list[str]:
+    errors = validate_candidate(candidate)
+    if errors:
+        return errors
+    if (
+        candidate["lower_bound"] != claim["lower_bound"]
+        or candidate["upper_bound"] != claim["upper_bound"]
+    ):
+        return ["candidate range must exactly match the claim range"]
+    return []
+
+
+def _decompose(n: int) -> tuple[int, int, int] | None:
+    """Find ordered positive denominators using exact rational arithmetic."""
+
+    for x in range(n // 4 + 1, (3 * n) // 4 + 1):
+        remaining = Fraction(4, n) - Fraction(1, x)
+        if remaining <= 0:
+            continue
+        y_min = max(x, remaining.denominator // remaining.numerator + 1)
+        y_max = (2 * remaining.denominator) // remaining.numerator
+        for y in range(y_min, y_max + 1):
+            last = remaining - Fraction(1, y)
+            if last > 0 and last.denominator % last.numerator == 0:
+                z = last.denominator // last.numerator
+                return x, y, z
+    return None
+
+
+def _decomposition_table(
+    lower: int,
+    upper: int,
+) -> tuple[list[dict[str, int]], int | None]:
+    table: list[dict[str, int]] = []
+    for n in range(lower, upper + 1):
+        decomposition = _decompose(n)
+        if decomposition is None:
+            return table, n
+        x, y, z = decomposition
+        table.append({"n": n, "x": x, "y": y, "z": z})
+    return table, None
+
+
+def evaluate_capability(request: dict[str, Any]) -> dict[str, Any]:
+    """Evaluate a bounded range without granting verification authority."""
+
+    claim = _claim_view(request.get("claim", {}))
+    candidate = request.get("candidate")
+    errors = validate_claim(claim)
+    if not isinstance(candidate, dict):
+        errors.append("candidate must be an object")
+    elif not errors:
+        errors.extend(_validate_candidate_for_claim(claim, candidate))
+    if errors:
+        raise ValueError("; ".join(errors))
+    assert isinstance(candidate, dict)
+
+    lower = candidate["lower_bound"]
+    upper = candidate["upper_bound"]
+    table, missing = _decomposition_table(lower, upper)
+    complete = missing is None
+    return {
+        "response_version": "1",
+        "conclusion": "TRUE" if complete else "UNKNOWN",
+        "arithmetic": "EXACT_INTEGER",
+        "method": "EXHAUSTIVE_FINITE" if complete else "BOUNDED_SEARCH",
+        "coverage": "EXHAUSTIVE" if complete else "BOUNDED",
+        "objectives": {
+            "range_size": upper - lower + 1,
+            "decompositions_found": len(table),
+        },
+        "features": {
+            "lower_bound": lower,
+            "upper_bound": upper,
+        },
+        "failure_classifications": ([] if complete else ["decomposition_not_found"]),
+        "detail": (
+            f"exact decompositions found for every n in [{lower}, {upper}]"
+            if complete
+            else f"search did not find a decomposition for n={missing}"
+        ),
+    }
+
+
+def find_witness_capability(request: dict[str, Any]) -> dict[str, Any]:
+    """Propose a complete bounded decomposition table as unverified evidence."""
+
+    claim = _claim_view(request.get("claim", {}))
+    candidate = request.get("candidate")
+    role = request.get("witness_role")
+    errors = validate_claim(claim)
+    if role != "SUPPORTS_CLAIM":
+        errors.append("erdos_straus_range supports only SUPPORTS_CLAIM witnesses")
+    if not isinstance(candidate, dict):
+        errors.append("candidate must be an object")
+    elif not errors:
+        errors.extend(_validate_candidate_for_claim(claim, candidate))
+    if errors:
+        raise ValueError("; ".join(errors))
+    assert isinstance(candidate, dict)
+
+    lower = candidate["lower_bound"]
+    upper = candidate["upper_bound"]
+    table, missing = _decomposition_table(lower, upper)
+    if missing is not None:
+        return {
+            "response_version": "1",
+            "status": "NOT_FOUND_WITHIN_SCOPE",
+            "arithmetic": "EXACT_INTEGER",
+            "coverage": "BOUNDED",
+            "detail": (
+                f"search found {len(table)} decompositions but none for n={missing}; "
+                "this is not a counterexample"
+            ),
+        }
+    return {
+        "response_version": "1",
+        "status": "FOUND",
+        "witness": {"decompositions": table},
+        "witness_format": "erdos_straus.decomposition_table",
+        "format_version": "1",
+        "role": "SUPPORTS_CLAIM",
+        "arithmetic": "EXACT_INTEGER",
+        "coverage": "EXHAUSTIVE",
+        "detail": f"complete proposed decomposition table for [{lower}, {upper}]",
+    }

--- a/src/jacobian/references.py
+++ b/src/jacobian/references.py
@@ -1,4 +1,4 @@
-"""Operator bootstrap for the two v0.2 reference domains."""
+"""Operator bootstrap for the bundled v0.2 reference domains."""
 
 from __future__ import annotations
 
@@ -104,7 +104,12 @@ class ReferenceInstaller:
     def install_all(self) -> dict[str, ReferenceInstallation]:
         graph = self.install_graph_paths()
         matrix = self.install_matrices()
-        return {graph.name: graph, matrix.name: matrix}
+        erdos_straus = self.install_erdos_straus()
+        return {
+            graph.name: graph,
+            matrix.name: matrix,
+            erdos_straus.name: erdos_straus,
+        }
 
     def install_polytope_checkers(
         self,
@@ -531,6 +536,88 @@ class ReferenceInstaller:
             representation_semantics_uris={"row_major": row_major_semantics},
         )
 
+    def install_erdos_straus(self) -> ReferenceInstallation:
+        domain = "jacobian.erdos-straus"
+        semantics = self.store.register_descriptor(
+            kind="semantics",
+            name=domain,
+            version="1",
+            definition={
+                "description": (
+                    "bounded Erdős-Straus claims over every integer n in one "
+                    "closed interval"
+                ),
+                "equation": "4/n = 1/x + 1/y + 1/z",
+                "variables": "positive integers n, x, y, z",
+                "scope_rule": (
+                    "a verified result covers only the exact finite interval "
+                    "bound to the claim and candidate"
+                ),
+                "checker_identity": "4*x*y*z = n*(x*y + x*z + y*z)",
+                "reference_limit": 10_000,
+            },
+        )
+        range_schema = _erdos_straus_range_schema()
+        claim_schema = self.schemas.register(
+            name=f"{domain}.claim",
+            version="1",
+            schema=_claim_schema(
+                predicate_parameters={"erdos_straus_range": range_schema}
+            ),
+        )
+        candidate_schema = self.schemas.register(
+            name=f"{domain}.candidate",
+            version="1",
+            schema={
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                **range_schema,
+            },
+        )
+        capabilities = self._capabilities(
+            {
+                "Evaluator": ("jacobian.plugins.erdos_straus:evaluate_capability"),
+                "WitnessOracle": (
+                    "jacobian.plugins.erdos_straus:find_witness_capability"
+                ),
+            }
+        )
+        plugin_id = self._install_manifest(
+            domain=domain,
+            semantics_uri=semantics,
+            claim_schema_uri=claim_schema,
+            candidate_schema_uri=candidate_schema,
+            capabilities=capabilities,
+        )
+        witness_checkers = {
+            "erdos_straus.decomposition_table": self._authorize_checker(
+                name="bounded Erdős-Straus decomposition-table checker",
+                entrypoint=("jacobian_checkers.erdos_straus:check_decomposition_table"),
+                evidence_kind="WITNESS",
+                format_id="erdos_straus.decomposition_table",
+                claim_schema=claim_schema,
+                semantics=semantics,
+                candidate_schema=candidate_schema,
+            )
+        }
+        return ReferenceInstallation(
+            name="erdos_straus",
+            domain_id=domain,
+            domain_version="1",
+            available_capabilities=tuple(sorted(capabilities)),
+            plugin_id=plugin_id,
+            semantics_uri=semantics,
+            claim_schema_uri=claim_schema,
+            candidate_schema_uri=candidate_schema,
+            witness_schema_uri=self.witness_schema_uri,
+            certificate_schema_uri=self.certificate_schema_uri,
+            witness_checker_ids=witness_checkers,
+            certificate_checker_ids={},
+            preservation_checker_ids={},
+            transformation_checker_ids={},
+            representation_schema_uris={},
+            representation_semantics_uris={},
+        )
+
     def _capabilities(
         self,
         entrypoints: dict[str, str],
@@ -731,6 +818,18 @@ def _matrix_scope_schema() -> dict[str, Any]:
             },
         },
         "required": ["rows", "cols", "entries"],
+        "additionalProperties": False,
+    }
+
+
+def _erdos_straus_range_schema() -> dict[str, Any]:
+    return {
+        "type": "object",
+        "properties": {
+            "lower_bound": {"type": "integer", "minimum": 2, "maximum": 10_000},
+            "upper_bound": {"type": "integer", "minimum": 2, "maximum": 10_000},
+        },
+        "required": ["lower_bound", "upper_bound"],
         "additionalProperties": False,
     }
 

--- a/src/jacobian/references.py
+++ b/src/jacobian/references.py
@@ -174,7 +174,7 @@ class ReferenceInstaller:
                     "Quot.sound",
                     "propext",
                 ),
-                75,
+                105,
             ),
         }
         installations: dict[LeanEnvironment, LeanCheckerInstallation] = {}

--- a/src/jacobian/workflows.py
+++ b/src/jacobian/workflows.py
@@ -17,7 +17,7 @@ from jacobian.witnesses import WitnessSearchService
 
 
 class VerificationWorkflowService:
-    """Compose discovery stages without creating another verification authority."""
+    """Compose exploration and verification without creating new authority."""
 
     def __init__(
         self,
@@ -48,6 +48,57 @@ class VerificationWorkflowService:
         seed: int = 0,
         evaluation_wall_seconds: int = 60,
         witness_wall_seconds: int = 300,
+    ) -> WitnessVerificationWorkflowResult:
+        return self._run_witness(
+            reference_name=reference_name,
+            claim_payload=claim_payload,
+            candidate_payload=candidate_payload,
+            witness_role=witness_role,
+            profile=profile,
+            seed=seed,
+            evaluation_wall_seconds=evaluation_wall_seconds,
+            witness_wall_seconds=witness_wall_seconds,
+            verify=True,
+        )
+
+    def explore_witness(
+        self,
+        *,
+        reference_name: str,
+        claim_payload: dict[str, Any],
+        candidate_payload: dict[str, Any],
+        witness_role: WitnessRole,
+        profile: EvaluationProfile = EvaluationProfile.FAST,
+        seed: int = 0,
+        evaluation_wall_seconds: int = 60,
+        witness_wall_seconds: int = 300,
+    ) -> WitnessVerificationWorkflowResult:
+        """Run the fast lane and leave proposed evidence explicitly unverified."""
+
+        return self._run_witness(
+            reference_name=reference_name,
+            claim_payload=claim_payload,
+            candidate_payload=candidate_payload,
+            witness_role=witness_role,
+            profile=profile,
+            seed=seed,
+            evaluation_wall_seconds=evaluation_wall_seconds,
+            witness_wall_seconds=witness_wall_seconds,
+            verify=False,
+        )
+
+    def _run_witness(
+        self,
+        *,
+        reference_name: str,
+        claim_payload: dict[str, Any],
+        candidate_payload: dict[str, Any],
+        witness_role: WitnessRole,
+        profile: EvaluationProfile,
+        seed: int,
+        evaluation_wall_seconds: int,
+        witness_wall_seconds: int,
+        verify: bool,
     ) -> WitnessVerificationWorkflowResult:
         try:
             reference = self.references[reference_name]
@@ -92,6 +143,14 @@ class VerificationWorkflowService:
             wall_seconds=witness_wall_seconds,
         )
         if found.witness_uri is None:
+            return WitnessVerificationWorkflowResult(
+                claim_uri=claim.artifact_uri,
+                candidate_uri=candidate.artifact_uri,
+                claim_validation=validation,
+                evaluation=evaluation,
+                witness_search=found,
+            )
+        if not verify:
             return WitnessVerificationWorkflowResult(
                 claim_uri=claim.artifact_uri,
                 candidate_uri=candidate.artifact_uri,

--- a/src/jacobian_checkers/erdos_straus.py
+++ b/src/jacobian_checkers/erdos_straus.py
@@ -1,0 +1,111 @@
+"""Independent exact checker for bounded Erdős-Straus evidence."""
+
+from __future__ import annotations
+
+from typing import Any, TypeGuard
+
+_MIN_N = 2
+_MAX_N = 10_000
+
+
+def _reject(detail: str) -> dict[str, Any]:
+    return {
+        "accepted": False,
+        "conclusion": "UNKNOWN",
+        "arithmetic": "EXACT_INTEGER",
+        "method": "EXHAUSTIVE_FINITE",
+        "coverage": "EXHAUSTIVE",
+        "detail": detail,
+    }
+
+
+def _is_int(value: object) -> TypeGuard[int]:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _claim_view(payload: dict[str, Any]) -> dict[str, Any]:
+    predicate = payload.get("predicate")
+    if not isinstance(predicate, dict):
+        return payload
+    parameters = predicate.get("parameters", {})
+    return {
+        "predicate": predicate.get("name"),
+        **(parameters if isinstance(parameters, dict) else {}),
+    }
+
+
+def _parse_range(payload: dict[str, Any]) -> tuple[int, int] | None:
+    lower = payload.get("lower_bound")
+    upper = payload.get("upper_bound")
+    if (
+        not _is_int(lower)
+        or not _is_int(upper)
+        or lower < _MIN_N
+        or upper < lower
+        or upper > _MAX_N
+    ):
+        return None
+    return lower, upper
+
+
+def check_decomposition_table(request: dict[str, Any]) -> dict[str, Any]:
+    """Check one exact decomposition for every integer in the declared range."""
+
+    try:
+        if request.get("request_version") != "1":
+            return _reject("unsupported request version")
+        claim = _claim_view(request["claim"]["payload"])
+        candidate = request["candidate"]["payload"]
+        witness = request["witness"]["payload"]
+        if claim.get("predicate") != "erdos_straus_range":
+            return _reject("unsupported claim predicate")
+        claim_range = _parse_range(claim)
+        candidate_range = _parse_range(candidate)
+        if claim_range is None or candidate_range is None:
+            return _reject("claim or candidate range is malformed")
+        if claim_range != candidate_range:
+            return _reject("candidate range does not exactly match the claim")
+        if witness.get("witness_format") != "erdos_straus.decomposition_table":
+            return _reject("unexpected witness format")
+        if witness.get("format_version") != "1":
+            return _reject("unsupported witness format version")
+        if witness.get("role") != "SUPPORTS_CLAIM":
+            return _reject("witness role does not support the claim")
+        if witness.get("bindings") != request["expected_bindings"]:
+            return _reject("witness bindings do not match the request")
+
+        table = witness.get("payload", {}).get("decompositions")
+        if not isinstance(table, list):
+            return _reject("decomposition table must be a list")
+        parsed: dict[int, tuple[int, int, int]] = {}
+        for row in table:
+            if not isinstance(row, dict) or set(row) != {"n", "x", "y", "z"}:
+                return _reject("decomposition row is malformed")
+            n, x, y, z = row["n"], row["x"], row["y"], row["z"]
+            if not all(_is_int(value) for value in (n, x, y, z)):
+                return _reject("decomposition values must be integers")
+            if x <= 0 or y <= 0 or z <= 0:
+                return _reject("decomposition denominators must be positive")
+            if n in parsed:
+                return _reject("decomposition table contains duplicate n values")
+            if 4 * x * y * z != n * (x * y + x * z + y * z):
+                return _reject(f"decomposition identity fails for n={n}")
+            parsed[n] = (x, y, z)
+
+        lower, upper = claim_range
+        expected = set(range(lower, upper + 1))
+        if set(parsed) != expected:
+            return _reject("decomposition table is incomplete or outside the range")
+        return {
+            "accepted": True,
+            "conclusion": "TRUE",
+            "arithmetic": "EXACT_INTEGER",
+            "method": "EXHAUSTIVE_FINITE",
+            "coverage": "EXHAUSTIVE",
+            "detail": (
+                f"checked exact three-unit-fraction decompositions for every n "
+                f"in [{lower}, {upper}]"
+            ),
+        }
+    except (KeyError, TypeError, ValueError):
+        return _reject("malformed checker request")

--- a/src/jacobian_checkers/lean4.py
+++ b/src/jacobian_checkers/lean4.py
@@ -214,7 +214,7 @@ def _run_lean(
         lake = _elan_executable("lake")
         command = [lake, "env", "lean"]
         memory_mb = "8192"
-        timeout_seconds = 60
+        timeout_seconds = 90
         cwd_context = tempfile.TemporaryDirectory(prefix="jacobian-lean-home-")
         cwd = runtime
         process_environment = {

--- a/tests/checkers/test_erdos_straus_checker.py
+++ b/tests/checkers/test_erdos_straus_checker.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import pytest
+
+from jacobian_checkers.erdos_straus import check_decomposition_table
+
+
+def _request(
+    table: list[dict[str, int]],
+    *,
+    lower: int = 2,
+    upper: int = 4,
+) -> dict[str, object]:
+    bindings = {
+        "claim_digest": "sha256:" + "a" * 64,
+        "semantics_digest": "sha256:" + "b" * 64,
+        "candidate_digest": "sha256:" + "c" * 64,
+        "scope_digest": None,
+        "encoding_digest": None,
+    }
+    return {
+        "request_version": "1",
+        "claim": {
+            "payload": {
+                "predicate": {
+                    "name": "erdos_straus_range",
+                    "parameters": {
+                        "lower_bound": lower,
+                        "upper_bound": upper,
+                    },
+                }
+            }
+        },
+        "candidate": {
+            "payload": {
+                "lower_bound": lower,
+                "upper_bound": upper,
+            }
+        },
+        "witness": {
+            "payload": {
+                "witness_format": "erdos_straus.decomposition_table",
+                "format_version": "1",
+                "role": "SUPPORTS_CLAIM",
+                "bindings": bindings,
+                "payload": {"decompositions": table},
+            }
+        },
+        "expected_bindings": bindings,
+    }
+
+
+@pytest.mark.contract
+def test_checker_accepts_complete_exact_table() -> None:
+    decision = check_decomposition_table(
+        _request(
+            [
+                {"n": 2, "x": 1, "y": 2, "z": 2},
+                {"n": 3, "x": 1, "y": 4, "z": 12},
+                {"n": 4, "x": 2, "y": 3, "z": 6},
+            ]
+        )
+    )
+
+    assert decision["accepted"] is True
+    assert decision["conclusion"] == "TRUE"
+    assert decision["coverage"] == "EXHAUSTIVE"
+
+
+@pytest.mark.contract
+@pytest.mark.parametrize(
+    "table",
+    [
+        [
+            {"n": 2, "x": 1, "y": 2, "z": 2},
+            {"n": 3, "x": 1, "y": 4, "z": 12},
+        ],
+        [
+            {"n": 2, "x": 1, "y": 2, "z": 2},
+            {"n": 3, "x": 1, "y": 4, "z": 11},
+            {"n": 4, "x": 2, "y": 3, "z": 6},
+        ],
+        [
+            {"n": 2, "x": 1, "y": 2, "z": 2},
+            {"n": 3, "x": 1, "y": 4, "z": 12},
+            {"n": 3, "x": 1, "y": 4, "z": 12},
+            {"n": 4, "x": 2, "y": 3, "z": 6},
+        ],
+    ],
+)
+def test_checker_rejects_incomplete_invalid_or_duplicate_table(
+    table: list[dict[str, int]],
+) -> None:
+    decision = check_decomposition_table(_request(table))
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+@pytest.mark.contract
+def test_checker_rejects_range_substitution() -> None:
+    request = _request(
+        [
+            {"n": 2, "x": 1, "y": 2, "z": 2},
+            {"n": 3, "x": 1, "y": 4, "z": 12},
+            {"n": 4, "x": 2, "y": 3, "z": 6},
+        ]
+    )
+    request["candidate"]["payload"]["upper_bound"] = 5
+
+    assert check_decomposition_table(request)["accepted"] is False

--- a/tests/contract/test_capability_contracts.py
+++ b/tests/contract/test_capability_contracts.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.contracts.capabilities import (
+    CapabilityAssurance,
+    CapabilityAssuranceLevel,
+    CapabilityMode,
+    CapabilityResult,
+)
+from jacobian.contracts.results import Execution, ExecutionStatus
+
+RECORD_URI = "artifact://sha256/" + "a" * 64
+
+
+@pytest.mark.contract
+def test_explore_lane_cannot_claim_verified_assurance() -> None:
+    with pytest.raises(ValidationError, match="exploration lane"):
+        CapabilityResult(
+            capability_id="example.solve",
+            capability_version="1",
+            mode=CapabilityMode.EXPLORE,
+            execution=Execution(status=ExecutionStatus.COMPLETED),
+            assurance=CapabilityAssurance(
+                level=CapabilityAssuranceLevel.VERIFIED,
+                basis="untrusted adapter claim",
+                verification_record_uri=RECORD_URI,
+            ),
+        )
+
+
+@pytest.mark.contract
+def test_nonverified_assurance_cannot_smuggle_a_record_uri() -> None:
+    with pytest.raises(ValidationError, match="only verified"):
+        CapabilityAssurance(
+            level=CapabilityAssuranceLevel.COMPUTED,
+            basis="ordinary deterministic computation",
+            verification_record_uri=RECORD_URI,
+        )

--- a/tests/end_to_end/test_reference_kernel.py
+++ b/tests/end_to_end/test_reference_kernel.py
@@ -171,6 +171,55 @@ def test_matrix_kernel_witness_and_independent_replay(tmp_path: Path) -> None:
 
 
 @pytest.mark.end_to_end
+def test_erdos_straus_range_witness_and_independent_replay(tmp_path: Path) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+    reference = kernel.references["erdos_straus"]
+    claim = kernel.artifacts.put(
+        schema_uri=reference.claim_schema_uri,
+        semantics_uri=reference.semantics_uri,
+        payload={
+            "claim_schema_version": "1",
+            "domain_id": "jacobian.erdos-straus",
+            "domain_version": "1",
+            "semantics_uri": reference.semantics_uri,
+            "quantifiers": [],
+            "predicate": {
+                "name": "erdos_straus_range",
+                "parameters": {"lower_bound": 2, "upper_bound": 1000},
+            },
+            "bounds": {},
+            "required_capabilities": ["Evaluator", "WitnessOracle"],
+            "correspondence_status": "HUMAN_REVIEWED",
+        },
+    )
+    candidate = kernel.artifacts.put(
+        schema_uri=reference.candidate_schema_uri,
+        semantics_uri=reference.semantics_uri,
+        payload={"lower_bound": 2, "upper_bound": 1000},
+    )
+
+    found = kernel.witnesses.find(
+        claim_uri=claim.artifact_uri,
+        candidate_uri=candidate.artifact_uri,
+        plugin_id=reference.plugin_id,
+        witness_role="SUPPORTS_CLAIM",
+        wall_seconds=30,
+    )
+    assert found.witness_uri is not None
+    verified = kernel.verification.verify_witness(
+        claim_uri=claim.artifact_uri,
+        candidate_uri=candidate.artifact_uri,
+        witness_uri=found.witness_uri,
+        checker_id=reference.witness_checker_ids["erdos_straus.decomposition_table"],
+    )
+
+    assert verified.conclusion.value == "TRUE"
+    assert verified.assurance.arithmetic.value == "EXACT_INTEGER"
+    assert verified.assurance.coverage.value == "EXHAUSTIVE"
+    assert verified.assurance.verification.value == "VERIFIED"
+
+
+@pytest.mark.end_to_end
 def test_matrix_maxdet_certificate_replays_full_scope(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path, install_references=True)
     reference = kernel.references["matrices"]

--- a/tests/fixtures/capability_functions.py
+++ b/tests/fixtures/capability_functions.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from jacobian.contracts.capabilities import (
+    CapabilityAssurance,
+    CapabilityAssuranceLevel,
+    CapabilityDescriptor,
+    CapabilityMode,
+    CapabilityRequest,
+    CapabilityResult,
+)
+from jacobian.contracts.results import Execution, ExecutionStatus
+
+
+@dataclass(frozen=True)
+class FixtureAdapter:
+    descriptor = CapabilityDescriptor(
+        capability_id="fixture.increment",
+        version="1",
+        title="Increment an integer",
+        description="External fixture adapter loaded through an operator entrypoint.",
+        provider="tests.fixture",
+        modes=(CapabilityMode.EXPLORE,),
+        input_schema={
+            "type": "object",
+            "properties": {"value": {"type": "integer"}},
+            "required": ["value"],
+            "additionalProperties": False,
+        },
+        output_schema={"type": "object"},
+    )
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        return CapabilityResult(
+            capability_id=self.descriptor.capability_id,
+            capability_version=self.descriptor.version,
+            mode=request.mode,
+            execution=Execution(status=ExecutionStatus.COMPLETED),
+            output={"value": int(request.input["value"]) + 1},
+            assurance=CapabilityAssurance(
+                level=CapabilityAssuranceLevel.COMPUTED,
+                basis="fixture integer arithmetic",
+            ),
+        )
+
+
+def create_adapter(_kernel: Any) -> FixtureAdapter:
+    return FixtureAdapter()

--- a/tests/integration/test_agent_ab_benchmark.py
+++ b/tests/integration/test_agent_ab_benchmark.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import json
+import runpy
+from pathlib import Path
+from typing import Any, cast
+
+from jacobian.contracts.capabilities import CapabilityMode, CapabilityRequest
+from jacobian.kernel import JacobianKernel
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+BENCHMARK = runpy.run_path(str(PROJECT_ROOT / "benchmarks" / "agent_ab.py"))
+
+
+def _report(
+    *,
+    assurance: str,
+    verification_record_uri: str | None,
+) -> dict[str, Any]:
+    return {
+        "case_id": "ERDOS-STRAUS-AB-001",
+        "conclusion": "TRUE",
+        "checked_count": 119,
+        "first_failure": None,
+        "assurance": assurance,
+        "verification_record_uri": verification_record_uri,
+        "limitations": ["finite interval only"],
+        "feedback": {
+            "reasoning_focus": ["bounded interpretation"],
+            "infrastructure_work": [],
+            "tooling_gaps": [],
+        },
+    }
+
+
+def test_ab_transcript_parser_separates_mcp_and_shell_calls(tmp_path: Path) -> None:
+    parse_transcript = cast(Any, BENCHMARK["parse_transcript"])
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text(
+        "\n".join(
+            json.dumps(event)
+            for event in (
+                {
+                    "type": "item.completed",
+                    "item": {
+                        "type": "command_execution",
+                        "command": "python solve.py",
+                    },
+                },
+                {
+                    "type": "item.completed",
+                    "item": {
+                        "type": "mcp_tool_call",
+                        "tool": "capability.invoke",
+                    },
+                },
+                {
+                    "type": "turn.completed",
+                    "usage": {"input_tokens": 12, "output_tokens": 3},
+                },
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    telemetry = parse_transcript(transcript)
+
+    assert telemetry == {
+        "mcp_calls": ["capability.invoke"],
+        "shell_calls": ["python solve.py"],
+        "usage": {"input_tokens": 12, "output_tokens": 3},
+    }
+
+
+def test_ab_scorer_accepts_control_and_durable_treatment(tmp_path: Path) -> None:
+    load_cases = cast(Any, BENCHMARK["load_cases"])
+    score_report = cast(Any, BENCHMARK["score_report"])
+    case = load_cases(["ERDOS-STRAUS-AB-001"])[0]
+
+    control = score_report(
+        case,
+        _report(assurance="SELF_CHECKED", verification_record_uri=None),
+        condition="control",
+        state_dir=tmp_path / "unused",
+        mcp_calls=[],
+    )
+    assert control["passed"] is True
+
+    state_dir = tmp_path / "treatment"
+    kernel = JacobianKernel(state_dir, install_references=True)
+    result = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="reference.solve",
+            mode=CapabilityMode.VERIFY,
+            input={
+                "reference_name": "erdos_straus",
+                "predicate": {
+                    "name": "erdos_straus_range",
+                    "parameters": {"lower_bound": 2, "upper_bound": 120},
+                },
+                "candidate": {"lower_bound": 2, "upper_bound": 120},
+                "witness_role": "SUPPORTS_CLAIM",
+                "evaluation_wall_seconds": 30,
+                "witness_wall_seconds": 30,
+            },
+        )
+    )
+    record_uri = result.assurance.verification_record_uri
+    assert record_uri is not None
+    treatment = score_report(
+        case,
+        _report(assurance="VERIFIED", verification_record_uri=record_uri),
+        condition="treatment",
+        state_dir=state_dir,
+        mcp_calls=["capability.invoke"],
+    )
+    assert treatment["passed"] is True
+
+
+def test_ab_summary_reports_paired_deltas() -> None:
+    summarize_pairs = cast(Any, BENCHMARK["summarize_pairs"])
+    results = [
+        {
+            "case_id": "C",
+            "repetition": 1,
+            "condition": "control",
+            "score": {"passed": True},
+            "elapsed_seconds": 10,
+            "usage": {"input_tokens": 100, "output_tokens": 20},
+            "shell_call_count": 2,
+            "mcp_call_count": 0,
+        },
+        {
+            "case_id": "C",
+            "repetition": 1,
+            "condition": "treatment",
+            "score": {"passed": True},
+            "elapsed_seconds": 6,
+            "usage": {"input_tokens": 60, "output_tokens": 10},
+            "shell_call_count": 0,
+            "mcp_call_count": 1,
+        },
+    ]
+
+    summary = summarize_pairs(results)
+
+    assert summary["pair_count"] == 1
+    assert summary["pairs"][0]["input_token_delta"] == -40
+    assert summary["pairs"][0]["elapsed_delta_seconds"] == -4

--- a/tests/integration/test_agent_benchmark.py
+++ b/tests/integration/test_agent_benchmark.py
@@ -12,6 +12,15 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 BENCHMARK = runpy.run_path(str(PROJECT_ROOT / "benchmarks" / "agent_mcp.py"))
 
 
+def _feedback() -> dict[str, list[str]]:
+    return {
+        "tooling_strengths": ["one composed verification workflow"],
+        "tooling_gaps": [],
+        "domain_knowledge_gaps": [],
+        "suggested_improvements": [],
+    }
+
+
 def test_transcript_parser_counts_completed_mcp_calls_once(tmp_path: Path) -> None:
     parse_transcript = cast(Any, BENCHMARK["parse_transcript"])
     transcript = tmp_path / "transcript.jsonl"
@@ -122,6 +131,7 @@ def test_known_answer_scorer_replays_durable_witness_bindings(
         "verification_record_uri": verified.verification_record_uri,
         "witness_summary": "omitted path",
         "limitations": ["one direct witness only"],
+        "feedback": _feedback(),
     }
 
     score = score_run(
@@ -134,6 +144,7 @@ def test_known_answer_scorer_replays_durable_witness_bindings(
     assert score["passed"] is True
     assert score["checks"] == [
         "agent assurance labels",
+        "structured agent feedback",
         "required MCP tool sequence",
         "known case claim and candidate",
         "known-answer evidence and verification record",
@@ -202,6 +213,7 @@ def test_known_answer_scorer_accepts_verified_positive_witness(
         "verification_record_uri": verified.verification_record_uri,
         "witness_summary": "complete two-coloring",
         "limitations": ["exact finite graph only"],
+        "feedback": _feedback(),
     }
 
     score = score_run(
@@ -246,6 +258,65 @@ def test_known_answer_scorer_accepts_bound_lean_certificate(
         "verification_record_uri": verified.result.verification_record_uri,
         "witness_summary": "Lean kernel certificate",
         "limitations": ["pinned core Lean only"],
+        "feedback": _feedback(),
+    }
+
+    score = score_run(
+        case,
+        report,
+        state_dir=tmp_path,
+        tool_calls=case["required_tools"],
+    )
+
+    assert score["passed"] is True
+
+
+def test_known_answer_scorer_accepts_bounded_erdos_straus_table(
+    tmp_path: Path,
+) -> None:
+    load_cases = cast(Any, BENCHMARK["load_cases"])
+    score_run = cast(Any, BENCHMARK["score_run"])
+    case = next(case for case in load_cases(["ERDOS-STRAUS-001"]) if case["case_id"])
+    kernel = JacobianKernel(tmp_path, install_references=True)
+    assert kernel.verification_workflows is not None
+    result = kernel.verification_workflows.verify_witness(
+        reference_name="erdos_straus",
+        claim_payload={
+            "claim_schema_version": "1",
+            "domain_id": "jacobian.erdos-straus",
+            "domain_version": "1",
+            "semantics_uri": kernel.references["erdos_straus"].semantics_uri,
+            "quantifiers": [],
+            "predicate": {
+                "name": "erdos_straus_range",
+                "parameters": {"lower_bound": 2, "upper_bound": 1000},
+            },
+            "bounds": {},
+            "required_capabilities": ["Evaluator", "WitnessOracle"],
+            "correspondence_status": "HUMAN_REVIEWED",
+        },
+        candidate_payload={"lower_bound": 2, "upper_bound": 1000},
+        witness_role=WitnessRole.SUPPORTS_CLAIM,
+        evaluation_wall_seconds=30,
+        witness_wall_seconds=30,
+    )
+    assert result.witness_search is not None
+    assert result.witness_search.witness_uri is not None
+    assert result.verification is not None
+    assert result.verification.verification_record_uri is not None
+    report = {
+        "case_id": case["case_id"],
+        "conclusion": "TRUE",
+        "evaluation_verification": "UNVERIFIED",
+        "witness_search_verification": "UNVERIFIED",
+        "final_verification": "VERIFIED",
+        "claim_uri": result.claim_uri,
+        "candidate_uri": result.candidate_uri,
+        "evidence_uri": result.witness_search.witness_uri,
+        "verification_record_uri": result.verification.verification_record_uri,
+        "witness_summary": "complete bounded decomposition table",
+        "limitations": ["verified only for 2 <= n <= 1000"],
+        "feedback": _feedback(),
     }
 
     score = score_run(

--- a/tests/integration/test_capability_service.py
+++ b/tests/integration/test_capability_service.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from jacobian.capabilities import CapabilityError
+from jacobian.contracts.capabilities import (
+    CapabilityAssurance,
+    CapabilityAssuranceLevel,
+    CapabilityDescriptor,
+    CapabilityMode,
+    CapabilityRequest,
+    CapabilityResult,
+)
+from jacobian.contracts.results import Execution, ExecutionStatus
+from jacobian.kernel import JacobianKernel
+
+
+@dataclass(frozen=True)
+class ComputedAdapter:
+    descriptor = CapabilityDescriptor(
+        capability_id="example.double",
+        version="1",
+        title="Double an integer",
+        description="Small adapter used to prove no MCP or kernel edit is required.",
+        provider="tests",
+        modes=(CapabilityMode.EXPLORE,),
+        input_schema={
+            "type": "object",
+            "properties": {"value": {"type": "integer"}},
+            "required": ["value"],
+            "additionalProperties": False,
+        },
+        output_schema={
+            "type": "object",
+            "properties": {"value": {"type": "integer"}},
+            "required": ["value"],
+            "additionalProperties": False,
+        },
+        tags=("test",),
+    )
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        return CapabilityResult(
+            capability_id=self.descriptor.capability_id,
+            capability_version=self.descriptor.version,
+            mode=request.mode,
+            execution=Execution(status=ExecutionStatus.COMPLETED),
+            output={"value": int(request.input["value"]) * 2},
+            assurance=CapabilityAssurance(
+                level=CapabilityAssuranceLevel.COMPUTED,
+                basis="deterministic integer arithmetic",
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class ForgedVerifiedAdapter:
+    descriptor = CapabilityDescriptor(
+        capability_id="example.forged",
+        version="1",
+        title="Forge a result",
+        description="Adversarial adapter used to test the assurance boundary.",
+        provider="tests",
+        modes=(CapabilityMode.VERIFY,),
+        input_schema={"type": "object"},
+        output_schema={"type": "object"},
+    )
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        return CapabilityResult(
+            capability_id=self.descriptor.capability_id,
+            capability_version=self.descriptor.version,
+            mode=request.mode,
+            execution=Execution(status=ExecutionStatus.COMPLETED),
+            assurance=CapabilityAssurance(
+                level=CapabilityAssuranceLevel.VERIFIED,
+                basis="adapter says so",
+                verification_record_uri="artifact://sha256/" + "f" * 64,
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class MisboundVerifiedAdapter:
+    verification_record_uri: str
+    evidence_uri: str
+    descriptor = CapabilityDescriptor(
+        capability_id="example.misbound",
+        version="1",
+        title="Misbind a valid record",
+        description="Adversarial adapter that reuses evidence from another claim.",
+        provider="tests",
+        modes=(CapabilityMode.VERIFY,),
+        input_schema={"type": "object"},
+        output_schema={"type": "object"},
+    )
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        return CapabilityResult(
+            capability_id=self.descriptor.capability_id,
+            capability_version=self.descriptor.version,
+            mode=request.mode,
+            execution=Execution(status=ExecutionStatus.COMPLETED),
+            output={
+                "conclusion": "FALSE",
+                "verification_record_uri": self.verification_record_uri,
+            },
+            assurance=CapabilityAssurance(
+                level=CapabilityAssuranceLevel.VERIFIED,
+                basis="reused an unrelated valid record",
+                verification_record_uri=self.verification_record_uri,
+            ),
+            artifact_uris=(self.evidence_uri,),
+        )
+
+
+@pytest.mark.integration
+def test_external_adapter_invocation_is_recorded_and_retrievable(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    kernel.register_capability(ComputedAdapter())
+
+    result = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="example.double",
+            input={"value": 21},
+        )
+    )
+
+    assert result.output == {"value": 42}
+    assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert result.episode_uri is not None
+    hits = kernel.memory.search(query="double computed").hits
+    assert [hit.episode_uri for hit in hits] == [result.episode_uri]
+
+
+@pytest.mark.integration
+def test_external_adapter_loads_from_an_operator_entrypoint(tmp_path: Path) -> None:
+    kernel = JacobianKernel(
+        tmp_path,
+        capability_adapter_entrypoints=(
+            "tests.fixtures.capability_functions:create_adapter",
+        ),
+    )
+
+    result = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="fixture.increment",
+            input={"value": 4},
+        )
+    )
+
+    assert result.output == {"value": 5}
+
+
+@pytest.mark.integration
+def test_adapter_cannot_promote_without_a_local_verification_record(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    kernel.register_capability(ForgedVerifiedAdapter())
+
+    with pytest.raises(CapabilityError, match="verification record"):
+        kernel.capabilities.invoke(
+            CapabilityRequest(
+                capability_id="example.forged",
+                mode=CapabilityMode.VERIFY,
+                input={},
+            )
+        )
+
+
+@pytest.mark.integration
+def test_adapter_cannot_reuse_a_record_without_its_bound_artifacts(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+    legitimate = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="reference.solve",
+            mode=CapabilityMode.VERIFY,
+            input={
+                "reference_name": "erdos_straus",
+                "predicate": {
+                    "name": "erdos_straus_range",
+                    "parameters": {"lower_bound": 2, "upper_bound": 5},
+                },
+                "candidate": {"lower_bound": 2, "upper_bound": 5},
+                "witness_role": "SUPPORTS_CLAIM",
+            },
+        )
+    )
+    record_uri = legitimate.assurance.verification_record_uri
+    assert record_uri is not None
+    record = kernel.store.get(record_uri)
+    evidence_uri = str(record.payload["evidence_uri"])
+    kernel.register_capability(
+        MisboundVerifiedAdapter(
+            verification_record_uri=record_uri,
+            evidence_uri=evidence_uri,
+        )
+    )
+
+    with pytest.raises(CapabilityError, match="bound artifacts"):
+        kernel.capabilities.invoke(
+            CapabilityRequest(
+                capability_id="example.misbound",
+                mode=CapabilityMode.VERIFY,
+                input={},
+            )
+        )
+
+
+@pytest.mark.integration
+def test_reference_capability_has_distinct_explore_and_verify_lanes(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+    payload = {
+        "reference_name": "erdos_straus",
+        "predicate": {
+            "name": "erdos_straus_range",
+            "parameters": {"lower_bound": 2, "upper_bound": 20},
+        },
+        "candidate": {"lower_bound": 2, "upper_bound": 20},
+        "witness_role": "SUPPORTS_CLAIM",
+        "evaluation_wall_seconds": 30,
+        "witness_wall_seconds": 30,
+    }
+
+    explored = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="reference.solve",
+            mode=CapabilityMode.EXPLORE,
+            input=payload,
+        )
+    )
+    verified = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="reference.solve",
+            mode=CapabilityMode.VERIFY,
+            input=payload,
+        )
+    )
+
+    assert explored.assurance.level is CapabilityAssuranceLevel.HEURISTIC
+    assert explored.output["verification_record_uri"] is None
+    assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED
+    assert verified.assurance.verification_record_uri is not None
+    assert {hit.assurance_level for hit in kernel.memory.search(limit=10).hits} >= {
+        CapabilityAssuranceLevel.HEURISTIC,
+        CapabilityAssuranceLevel.VERIFIED,
+    }
+
+
+@pytest.mark.integration
+def test_lean_capability_returns_bound_verified_result(tmp_path: Path) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+
+    result = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="lean.check",
+            mode=CapabilityMode.VERIFY,
+            input={
+                "statement": "1 + 1 = 2",
+                "proof": "rfl",
+                "environment": "CORE",
+            },
+        )
+    )
+
+    assert result.assurance.level is CapabilityAssuranceLevel.VERIFIED
+    assert result.assurance.verification_record_uri is not None
+    assert result.output["conclusion"] == "TRUE"

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -25,7 +25,7 @@ def test_project_codex_profile_starts_the_local_stdio_server() -> None:
             "run",
             "jacobian-mcp",
             "--tool-profile",
-            "verification",
+            "capabilities",
         ],
         "cwd": ".",
         "enabled": True,

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -63,7 +63,7 @@ def test_cli_init_reports_reference_domains_and_polytope_formats(
     assert catalog["lean4"]["profiles"]["MATHLIB"]["mathlib_commit"] == (
         "fabf563a7c95a166b8d7b6efca11c8b4dc9d911f"
     )
-    assert catalog["lean4"]["profiles"]["MATHLIB"]["checker_timeout_seconds"] == 75
+    assert catalog["lean4"]["profiles"]["MATHLIB"]["checker_timeout_seconds"] == 105
 
 
 @pytest.mark.integration

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -47,11 +47,15 @@ def test_cli_init_reports_reference_domains_and_polytope_formats(
     assert result.exit_code == 0
     catalog = json.loads(result.stdout)
     assert set(catalog) == {
+        "erdos_straus",
         "graph_paths",
         "matrices",
         "finite_polytopes",
         "lean4",
     }
+    assert catalog["erdos_straus"]["witness_checker_ids"][
+        "erdos_straus.decomposition_table"
+    ].startswith("checker://sha256/")
     assert catalog["finite_polytopes"]["certificate_checker_id"].startswith(
         "checker://sha256/"
     )

--- a/tests/integration/test_lean.py
+++ b/tests/integration/test_lean.py
@@ -42,7 +42,7 @@ def test_mathlib_sqrt_two_proof_creates_bound_verification_record(
 ) -> None:
     kernel = JacobianKernel(tmp_path, install_references=True)
     assert kernel.lean is not None
-    assert kernel.lean_checkers[LeanEnvironment.MATHLIB].checker_timeout_seconds == 75
+    assert kernel.lean_checkers[LeanEnvironment.MATHLIB].checker_timeout_seconds == 105
 
     verified = kernel.lean.verify(
         environment=LeanEnvironment.MATHLIB,

--- a/tests/integration/test_mcp_adapter.py
+++ b/tests/integration/test_mcp_adapter.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 
 from jacobian.adapters.mcp.server import (
+    CAPABILITY_TOOL_NAMES,
     VERIFICATION_TOOL_NAMES,
     ToolProfile,
     create_server,
@@ -38,6 +39,7 @@ def test_mcp_exposes_v02_tool_surface_and_persistent_resources(
             listed = await client.list_tools()
             tools = {tool.name: tool for tool in listed.tools}
             assert set(tools) == {
+                "capability.invoke",
                 "artifact.put",
                 "claim.validate",
                 "evaluate.batch",
@@ -238,6 +240,47 @@ def test_mcp_exposes_v02_tool_surface_and_persistent_resources(
 
 
 @pytest.mark.integration
+def test_mcp_capability_profile_has_one_extensible_tool_and_catalog(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        from mcp import Client
+
+        async with Client(
+            create_server(tmp_path, tool_profile=ToolProfile.CAPABILITIES),
+            raise_exceptions=True,
+        ) as client:
+            listed = await client.list_tools()
+            assert {tool.name for tool in listed.tools} == CAPABILITY_TOOL_NAMES
+            assert listed.tools[0].output_schema is None
+
+            resource = await client.read_resource("capability://catalog")
+            catalog = json.loads(resource.contents[0].text)
+            capability_ids = {
+                descriptor["capability_id"] for descriptor in catalog["capabilities"]
+            }
+            assert capability_ids == {
+                "knowledge.search",
+                "lean.check",
+                "reference.solve",
+            }
+
+            invoked = await client.call_tool(
+                "capability.invoke",
+                {
+                    "capability_id": "knowledge.search",
+                    "mode": "EXPLORE",
+                    "payload": {"query": "counterexample", "limit": 5},
+                },
+            )
+            projection = json.loads(invoked.content[0].text)
+            assert projection["assurance"]["level"] == "COMPUTED"
+            assert projection["output"]["hits"] == []
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.integration
 def test_mcp_verification_profile_projects_compact_tools_and_domain_contract(
     tmp_path: Path,
 ) -> None:
@@ -267,7 +310,7 @@ def test_mcp_verification_profile_projects_compact_tools_and_domain_contract(
             ]
             assert contract["candidate_schema"]["properties"]["vertices"]
             assert contract["workflow"]["witness"][0].startswith(
-                "call verification.run"
+                "call capability.invoke"
             )
             claim_payload = {
                 **contract["claim_contract"]["base"],

--- a/tests/integration/test_mcp_adapter.py
+++ b/tests/integration/test_mcp_adapter.py
@@ -109,6 +109,25 @@ def test_mcp_exposes_v02_tool_surface_and_persistent_resources(
                 "Transformer",
                 "WitnessOracle",
             ]
+            erdos_straus = catalog["erdos_straus"]
+            assert erdos_straus["agent_contract_uri"] == (
+                "reference://domain/erdos_straus"
+            )
+            assert erdos_straus["domain_id"] == "jacobian.erdos-straus"
+            assert erdos_straus["available_capabilities"] == [
+                "Evaluator",
+                "WitnessOracle",
+            ]
+            erdos_contract_result = await client.read_resource(
+                "reference://domain/erdos_straus"
+            )
+            erdos_contract = json.loads(erdos_contract_result.contents[0].text)
+            assert set(erdos_contract["claim_contract"]["predicates"]) == {
+                "erdos_straus_range"
+            }
+            assert erdos_contract["semantics"]["checker_identity"] == (
+                "4*x*y*z = n*(x*y + x*z + y*z)"
+            )
             assert catalog["finite_polytopes"]["certificate_checker_id"].startswith(
                 "checker://sha256/"
             )

--- a/tests/integration/test_remote_mcp.py
+++ b/tests/integration/test_remote_mcp.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from jacobian.adapters.mcp.remote import (
+    StaticTokenGrant,
+    StaticTokenVerifier,
+    TenantKernelRouter,
+    load_static_token_file,
+)
+from jacobian.store import ArtifactNotFoundError
+
+
+@pytest.mark.integration
+def test_static_tokens_bind_distinct_authenticated_subjects() -> None:
+    verifier = StaticTokenVerifier(
+        (
+            StaticTokenGrant(tenant_id="alpha", token="a" * 32),
+            StaticTokenGrant(tenant_id="beta", token="b" * 32),
+        )
+    )
+
+    alpha = asyncio.run(verifier.verify_token("a" * 32))
+    beta = asyncio.run(verifier.verify_token("b" * 32))
+    unknown = asyncio.run(verifier.verify_token("c" * 32))
+
+    assert alpha is not None and alpha.subject == "alpha"
+    assert beta is not None and beta.subject == "beta"
+    assert unknown is None
+
+
+@pytest.mark.integration
+def test_tenant_router_isolates_artifact_stores(tmp_path: Path) -> None:
+    router = TenantKernelRouter(tmp_path, install_references=False)
+    alpha = router.kernel_for("alpha")
+    beta = router.kernel_for("beta")
+    stored = alpha.store.register_descriptor(
+        kind="semantics",
+        name="alpha-only",
+        version="1",
+        definition={"value": 1},
+    )
+
+    assert alpha.store.root != beta.store.root
+    with pytest.raises(ArtifactNotFoundError):
+        beta.store.get(stored)
+
+
+@pytest.mark.integration
+def test_token_file_is_strict_and_remote_cli_fails_closed(
+    tmp_path: Path,
+) -> None:
+    token_file = tmp_path / "tokens.json"
+    token_file.write_text(
+        json.dumps(
+            {
+                "tokens": [
+                    {
+                        "tenant_id": "alpha",
+                        "token": "a" * 32,
+                        "scopes": ["jacobian:use"],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert load_static_token_file(token_file)[0].tenant_id == "alpha"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "jacobian.adapters.mcp.server",
+            "--transport",
+            "streamable-http",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert completed.returncode != 0
+    assert "require --auth-tokens-file" in completed.stderr
+
+
+@pytest.mark.integration
+@pytest.mark.subprocess
+def test_authenticated_streamable_http_isolates_tenant_memory(
+    tmp_path: Path,
+) -> None:
+    token_file = tmp_path / "tokens.json"
+    token_file.write_text(
+        json.dumps(
+            {
+                "tokens": [
+                    {"tenant_id": "alpha", "token": "a" * 32},
+                    {"tenant_id": "beta", "token": "b" * 32},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    with socket.socket() as reserved:
+        reserved.bind(("127.0.0.1", 0))
+        port = int(reserved.getsockname()[1])
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "jacobian.adapters.mcp.server",
+            "--transport",
+            "streamable-http",
+            "--tool-profile",
+            "capabilities",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--state-dir",
+            str(tmp_path / "state"),
+            "--auth-tokens-file",
+            str(token_file),
+            "--public-base-url",
+            f"http://127.0.0.1:{port}",
+            "--capability-adapter",
+            "tests.fixtures.capability_functions:create_adapter",
+        ],
+        cwd=Path.cwd(),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        _wait_for_port(port, process)
+        asyncio.run(_remote_tenant_scenario(port))
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=5)
+
+
+async def _remote_tenant_scenario(port: int) -> None:
+    import httpx2
+    from mcp import Client
+    from mcp.client.streamable_http import streamable_http_client
+
+    url = f"http://127.0.0.1:{port}/mcp"
+
+    async def invoke(token: str, *, create: bool) -> int:
+        async with (
+            httpx2.AsyncClient(
+                headers={"Authorization": f"Bearer {token}"},
+                trust_env=False,
+            ) as http,
+            Client(
+                streamable_http_client(url, http_client=http),
+                raise_exceptions=True,
+            ) as client,
+        ):
+            catalog = await client.read_resource("capability://catalog")
+            assert "fixture.increment" in catalog.contents[0].text
+            if create:
+                await client.call_tool(
+                    "capability.invoke",
+                    {
+                        "capability_id": "fixture.increment",
+                        "mode": "EXPLORE",
+                        "payload": {"value": 4},
+                    },
+                )
+            searched = await client.call_tool(
+                "capability.invoke",
+                {
+                    "capability_id": "knowledge.search",
+                    "mode": "EXPLORE",
+                    "payload": {"query": "fixture.increment"},
+                },
+            )
+            payload = json.loads(searched.content[0].text)
+            assert payload["execution"]["status"] == "COMPLETED", payload["execution"]
+            assert "hits" in payload["output"], payload
+            return len(payload["output"]["hits"])
+
+    assert await invoke("a" * 32, create=True) == 1
+    assert await invoke("b" * 32, create=False) == 0
+
+
+def _wait_for_port(port: int, process: subprocess.Popen[str]) -> None:
+    deadline = time.monotonic() + 20
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            stderr = process.stderr.read() if process.stderr is not None else ""
+            raise AssertionError(f"remote MCP server exited early: {stderr}")
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+                return
+        except OSError:
+            time.sleep(0.1)
+    raise AssertionError("remote MCP server did not start")

--- a/tests/reference/test_erdos_straus_plugin.py
+++ b/tests/reference/test_erdos_straus_plugin.py
@@ -1,0 +1,87 @@
+"""Public-behavior tests for bounded Erdős-Straus search."""
+
+from __future__ import annotations
+
+from jacobian.plugins.erdos_straus import (
+    evaluate_capability,
+    find_witness_capability,
+    validate_candidate,
+    validate_claim,
+)
+
+
+def _claim(lower: int = 2, upper: int = 100) -> dict[str, object]:
+    return {
+        "predicate": "erdos_straus_range",
+        "lower_bound": lower,
+        "upper_bound": upper,
+    }
+
+
+def _candidate(lower: int = 2, upper: int = 100) -> dict[str, int]:
+    return {"lower_bound": lower, "upper_bound": upper}
+
+
+def test_validate_bounded_range() -> None:
+    assert validate_claim(_claim()) == []
+    assert validate_candidate(_candidate()) == []
+    assert validate_claim(_claim(1, 100))
+    assert validate_candidate(_candidate(10, 9))
+    assert validate_candidate(_candidate(2, 10_001))
+
+
+def test_evaluate_finds_every_decomposition_through_1000() -> None:
+    response = evaluate_capability(
+        {
+            "claim": _claim(2, 1000),
+            "candidate": _candidate(2, 1000),
+        }
+    )
+
+    assert response["conclusion"] == "TRUE"
+    assert response["coverage"] == "EXHAUSTIVE"
+    assert response["objectives"] == {
+        "range_size": 999,
+        "decompositions_found": 999,
+    }
+
+
+def test_find_witness_returns_complete_exact_table() -> None:
+    response = find_witness_capability(
+        {
+            "claim": _claim(2, 100),
+            "candidate": _candidate(2, 100),
+            "witness_role": "SUPPORTS_CLAIM",
+        }
+    )
+
+    assert response["status"] == "FOUND"
+    assert response["witness_format"] == "erdos_straus.decomposition_table"
+    table = response["witness"]["decompositions"]
+    assert [row["n"] for row in table] == list(range(2, 101))
+    assert all(
+        4 * row["x"] * row["y"] * row["z"]
+        == row["n"] * (row["x"] * row["y"] + row["x"] * row["z"] + row["y"] * row["z"])
+        for row in table
+    )
+
+
+def test_find_witness_rejects_wrong_role_or_range() -> None:
+    for request in (
+        {
+            "claim": _claim(),
+            "candidate": _candidate(),
+            "witness_role": "DEFEATS_CANDIDATE",
+        },
+        {
+            "claim": _claim(2, 100),
+            "candidate": _candidate(2, 99),
+            "witness_role": "SUPPORTS_CLAIM",
+        },
+    ):
+        try:
+            find_witness_capability(request)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("invalid witness request was accepted")

--- a/tests/reference/test_reference_claim_schemas.py
+++ b/tests/reference/test_reference_claim_schemas.py
@@ -82,3 +82,20 @@ def test_graph_candidate_schema_rejects_incomplete_arc(tmp_path: Path) -> None:
                 "arcs": [["s"]],
             },
         )
+
+
+def test_erdos_straus_claim_requires_a_bounded_range(tmp_path: Path) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+    reference = kernel.references["erdos_straus"]
+
+    with pytest.raises(ArtifactValidationError, match="upper_bound"):
+        kernel.artifacts.put(
+            schema_uri=reference.claim_schema_uri,
+            semantics_uri=reference.semantics_uri,
+            payload=_claim_payload(
+                domain_id="jacobian.erdos-straus",
+                semantics_uri=reference.semantics_uri,
+                predicate="erdos_straus_range",
+                parameters={"lower_bound": 2},
+            ),
+        )


### PR DESCRIPTION
## Problem

Jacobian's MCP entry point was verifier-centric and exposed internal workflow steps. Agents still had to reconstruct schemas and infrastructure before doing mathematical work, and there was no authenticated remote host or paired evaluation of whether the tools improve agent performance.

## Changes

- add a capability-first API with one extensible `capability.invoke` MCP tool
- add explicit `EXPLORE` and checker-backed `VERIFY` lanes
- add trust-labeled local research episodes and `knowledge.search`
- add bundled `reference.solve` and `lean.check` capabilities
- support operator-installed adapters without kernel or MCP edits
- add authenticated Streamable HTTP/SSE transport with subject-bound tenant state
- add Docker and remote deployment guidance
- add a paired no-Jacobian versus capability-enabled Codex A/B benchmark
- add bounded Erdős-Straus search, checking, fixtures, and benchmark coverage
- retain the advanced verification and full MCP profiles for compatibility

## Trust and compatibility

This changes the default agent-facing product entry point but does not change the meaning of `VERIFIED`. A capability can report verified assurance only when a valid local verification record, complete bound parent set, checked evidence, and projected conclusion agree. Retrieval, search, solver output, timeout, and incomplete enumeration remain non-proof.

The capability contracts and remote deployment surface are pre-stable and outside the v0.2 conformance contract. Existing v0.2 verification records and lower-level profiles remain available.

## Evaluation

The initial public A/B harness case passed in both conditions. After simplifying `reference.solve`, the capability condition used one MCP call and no shell commands, completed in 26.216s versus 38.041s, and emitted 387 versus 1,199 output tokens. It used 1,924 more input tokens. This is a one-case development result, not a general reasoning-performance claim.

## Validation

- `uv run pytest -n 0` (`250 passed`)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`
- `git diff --check`
- relative Markdown link validation across 30 files
- Docker image build through the configured proxy
- offline container `--version` and `--help`
- authenticated Streamable HTTP smoke test: unauthorized `401`, verified Erdős-Straus invocation, and alpha/beta research-memory isolation
