### PR TITLE
feat(npm): add npm package with MCP launcher and setup wizard

### DIFF
--- a/npm/bin/doctor.cjs
+++ b/npm/bin/doctor.cjs
@@ -1,0 +1,286 @@
+"use strict";
+
+const { spawn } = require("node:child_process");
+const { join } = require("node:path");
+const { stderr, stdout } = require("node:process");
+
+/**
+ * Jacobian MCP doctor.
+ *
+ * Launches the Jacobian MCP server as a subprocess, performs the MCP
+ * initialize handshake, lists tools, and verifies that the expected tool
+ * catalog is present.  Reports structured status to stderr (human-readable)
+ * or stdout (JSON with --json).
+ */
+
+const PROTOCOL_VERSION = "2025-11-25";
+const HANDSHAKE_TIMEOUT_MS = 60_000;
+const RESPONSE_TIMEOUT_MS = 10_000;
+
+const EXPECTED_TOOLS = [
+  "artifact.put",
+  "claim.validate",
+  "evaluate.batch",
+  "witness.find",
+  "witness.verify",
+  "shrink.run",
+  "certificate.verify",
+  "structure.canonicalize",
+  "search.enumerate",
+  "search.run",
+  "experiment.cancel",
+  "experiment.pause",
+  "experiment.resume",
+  "transform.apply",
+  "transform.verify",
+  "polytope.separate",
+  "conjecture.repair",
+  "conjecture.generate",
+  "parameter.generalize",
+  "parameter.region.promote",
+];
+
+/**
+ * @typedef {object} DoctorReport
+ * @property {string} status  "ok" | "error"
+ * @property {string} serverName
+ * @property {string} serverVersion
+ * @property {boolean} instructionsLoaded
+ * @property {string[]} tools
+ * @property {object} integration
+ * @property {string} integration.launcherStatus
+ * @property {string} integration.handshakeStatus
+ * @property {string} integration.catalogStatus
+ * @property {string} integration.repairCommand
+ * @property {object} firstCall
+ * @property {string} firstCall.status
+ */
+
+/**
+ * Send a JSON-RPC message to the server's stdin.
+ *
+ * @param {import("node:child_process").ChildProcessWithoutNullStreams} child
+ * @param {object} message
+ */
+function sendMessage(child, message) {
+  const data = JSON.stringify(message) + "\n";
+  child.stdin.write(data);
+}
+
+/**
+ * Wait for a JSON-RPC response with a specific id.
+ *
+ * @param {import("node:child_process").ChildProcessWithoutNullStreams} child
+ * @param {number} id
+ * @param {number} timeoutMs
+ * @returns {Promise<object>}
+ */
+function waitForResponse(child, id, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    let buffer = "";
+    const timer = setTimeout(() => {
+      reject(new Error(`timed out after ${timeoutMs}ms waiting for response id=${id}`));
+    }, timeoutMs);
+
+    child.stdout.on("data", (chunk) => {
+      buffer += chunk.toString();
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          const message = JSON.parse(line);
+          if (message.id === id) {
+            clearTimeout(timer);
+            resolve(message);
+            return;
+          }
+        } catch {
+          // Ignore non-JSON lines (server stderr noise).
+        }
+      }
+    });
+
+    child.once("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+
+    child.once("close", (code) => {
+      clearTimeout(timer);
+      reject(new Error(`server exited with code ${code} before responding`));
+    });
+  });
+}
+
+/**
+ * Run the doctor diagnostic.
+ *
+ * @param {object} [options]
+ * @param {boolean} [options.json]
+ * @returns {Promise<DoctorReport>}
+ */
+async function run(options = {}) {
+  const json = options.json ?? false;
+  const launcher = require("./launcher.cjs");
+
+  if (!json) {
+    stderr.write("◇ Jacobian is checking the MCP handshake and tool catalog...\n");
+  }
+
+  // Resolve the Python executable and spawn the MCP server.
+  let python;
+  try {
+    python = launcher.resolvePython();
+  } catch (error) {
+    const report = {
+      status: "error",
+      serverName: "",
+      serverVersion: "",
+      instructionsLoaded: false,
+      tools: [],
+      integration: {
+        launcherStatus: "failed",
+        handshakeStatus: "not_attempted",
+        catalogStatus: "not_attempted",
+        repairCommand: "npx jacobian setup",
+      },
+      firstCall: { status: "not_attempted" },
+      error: error.message,
+    };
+    if (json) {
+      stdout.write(JSON.stringify(report, null, 2) + "\n");
+    } else {
+      stderr.write(`  ✗ Launcher failed: ${error.message}\n`);
+      stderr.write(`  Run \`npx jacobian setup\` to configure MCP clients.\n`);
+    }
+    process.exitCode = 1;
+    return report;
+  }
+
+  const stateDir = process.env.JACOBIAN_STATE_DIR || join(process.cwd(), ".jacobian");
+  const child = spawn(python, ["-m", "jacobian.adapters.mcp.server"], {
+    stdio: ["pipe", "pipe", "inherit"],
+    env: { ...process.env, JACOBIAN_STATE_DIR: stateDir },
+    windowsHide: true,
+  });
+
+  const version = require("../package.json").version;
+
+  try {
+    // 1. Initialize handshake.
+    sendMessage(child, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: {
+          name: "jacobian-doctor",
+          version,
+        },
+      },
+    });
+
+    const initResponse = await waitForResponse(child, 1, HANDSHAKE_TIMEOUT_MS);
+    if (initResponse.error) {
+      throw new Error(`initialize failed: ${JSON.stringify(initResponse.error)}`);
+    }
+    const result = initResponse.result;
+    const serverName = result?.serverInfo?.name ?? "";
+    const serverVersion = result?.serverInfo?.version ?? "";
+    const instructionsLoaded = typeof result?.instructions === "string";
+
+    if (serverName !== "jacobian") {
+      throw new Error(`MCP identified itself as "${serverName}", expected "jacobian"`);
+    }
+
+    // 2. Send initialized notification.
+    sendMessage(child, {
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+      params: {},
+    });
+
+    // 3. List tools.
+    sendMessage(child, {
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/list",
+      params: {},
+    });
+
+    const toolsResponse = await waitForResponse(child, 2, RESPONSE_TIMEOUT_MS);
+    if (toolsResponse.error) {
+      throw new Error(`tools/list failed: ${JSON.stringify(toolsResponse.error)}`);
+    }
+    const tools = (toolsResponse.result?.tools ?? []).map((t) => t.name);
+    const missingTools = EXPECTED_TOOLS.filter((t) => !tools.includes(t));
+    const catalogStatus = missingTools.length === 0 ? "complete" : "partial";
+
+    const report = {
+      status: missingTools.length === 0 ? "ok" : "error",
+      serverName,
+      serverVersion,
+      instructionsLoaded,
+      tools,
+      integration: {
+        launcherStatus: "ok",
+        handshakeStatus: "ok",
+        catalogStatus,
+        repairCommand: "npx jacobian setup",
+      },
+      firstCall: { status: "not_attempted" },
+      missingTools,
+    };
+
+    child.kill("SIGTERM");
+
+    if (json) {
+      stdout.write(JSON.stringify(report, null, 2) + "\n");
+    } else {
+      stderr.write(`\n  ✓ Launcher: ok\n`);
+      stderr.write(`  ✓ Handshake: ok (server: ${serverName} ${serverVersion})\n`);
+      stderr.write(`  ${catalogStatus === "complete" ? "✓" : "✗"} Tool catalog: ${catalogStatus} (${tools.length} tools)\n`);
+      if (missingTools.length > 0) {
+        stderr.write(`    Missing: ${missingTools.join(", ")}\n`);
+      }
+      stderr.write(`\n  ${report.status === "ok" ? "✓ Jacobian MCP is ready." : "✗ Jacobian MCP has issues."}\n`);
+      stderr.write(`  Run \`npx jacobian setup\` to configure or repair MCP clients.\n\n`);
+    }
+
+    if (report.status !== "ok") {
+      process.exitCode = 1;
+    }
+    return report;
+  } catch (error) {
+    child.kill("SIGTERM");
+    const report = {
+      status: "error",
+      serverName: "",
+      serverVersion: "",
+      instructionsLoaded: false,
+      tools: [],
+      integration: {
+        launcherStatus: "ok",
+        handshakeStatus: "failed",
+        catalogStatus: "not_attempted",
+        repairCommand: "npx jacobian setup",
+      },
+      firstCall: { status: "not_attempted" },
+      error: error.message,
+    };
+    if (json) {
+      stdout.write(JSON.stringify(report, null, 2) + "\n");
+    } else {
+      stderr.write(`\n  ✓ Launcher: ok\n`);
+      stderr.write(`  ✗ Handshake failed: ${error.message}\n`);
+      stderr.write(`  Run \`npx jacobian setup\` to configure or repair MCP clients.\n\n`);
+    }
+    process.exitCode = 1;
+    return report;
+  }
+}
+
+module.exports = { run, EXPECTED_TOOLS };

--- a/npm/bin/jacobian.cjs
+++ b/npm/bin/jacobian.cjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+
+"use strict";
+
+const { stderr } = require("node:process");
+
+/**
+ * Jacobian CLI entry point.
+ *
+ * Subcommands handled in Node:
+ *   jacobian setup    — MCP client configuration wizard
+ *   jacobian doctor   — MCP handshake and tool catalog verification
+ *   jacobian remove   — Remove Jacobian MCP from client configs
+ *   jacobian mcp      — Run the MCP server over stdio
+ *
+ * Everything else is forwarded to the Python `jacobian` CLI.
+ */
+
+const HELP = `Jacobian — verifier-centric MCP toolbench for bounded executable mathematics
+
+Usage:
+  jacobian setup [--client <id>...] [--all] [--yes] [--dry-run] [--json]
+    Configure MCP clients to use Jacobian.
+  jacobian doctor [--json]
+    Verify the MCP handshake and tool catalog.
+  jacobian remove [--client <id>...] [--all] [--yes] [--json]
+    Remove Jacobian from MCP client configs.
+  jacobian mcp
+    Run the Jacobian MCP server over stdio.
+  jacobian <command> [args...]
+    Forward to the Python Jacobian CLI.
+
+Clients:
+  claude, cursor, opencode, codex, gemini
+
+Environment:
+  JACOBIAN_STATE_DIR    State directory (default: ./.jacobian)
+  JACOBIAN_PACKAGE      Python package spec (default: jacobian-research-kernel)
+`;
+
+function main() {
+  const args = process.argv.slice(2);
+  const command = args[0];
+
+  if (!command || command === "--help" || command === "-h") {
+    stderr.write(HELP);
+    return;
+  }
+
+  if (command === "--version" || command === "-v") {
+    const pkg = require("../package.json");
+    console.log(`jacobian ${pkg.version}`);
+    return;
+  }
+
+  if (command === "setup") {
+    const setup = require("./setup.cjs");
+    const rest = args.slice(1);
+    const options = { operation: "setup" };
+    for (let i = 0; i < rest.length; i++) {
+      const arg = rest[i];
+      if (arg === "--all") {
+        options.all = true;
+      } else if (arg === "--yes" || arg === "-y") {
+        options.yes = true;
+      } else if (arg === "--dry-run") {
+        options.dryRun = true;
+      } else if (arg === "--json") {
+        options.json = true;
+      } else if (arg === "--client" || arg === "-c") {
+        i++;
+        if (rest[i]) {
+          options.clients = options.clients || [];
+          options.clients.push(...rest[i].split(",").map((s) => s.trim()));
+        }
+      } else if (arg.startsWith("--client=")) {
+        options.clients = options.clients || [];
+        options.clients.push(...arg.slice(9).split(",").map((s) => s.trim()));
+      }
+    }
+    setup.run(options).catch((error) => {
+      stderr.write(`Setup failed: ${error.message}\n`);
+      process.exitCode = 1;
+    });
+    return;
+  }
+
+  if (command === "remove") {
+    const setup = require("./setup.cjs");
+    const rest = args.slice(1);
+    const options = { operation: "remove" };
+    for (let i = 0; i < rest.length; i++) {
+      const arg = rest[i];
+      if (arg === "--all") {
+        options.all = true;
+      } else if (arg === "--yes" || arg === "-y") {
+        options.yes = true;
+      } else if (arg === "--json") {
+        options.json = true;
+      } else if (arg === "--client" || arg === "-c") {
+        i++;
+        if (rest[i]) {
+          options.clients = options.clients || [];
+          options.clients.push(...rest[i].split(",").map((s) => s.trim()));
+        }
+      } else if (arg.startsWith("--client=")) {
+        options.clients = options.clients || [];
+        options.clients.push(...arg.slice(9).split(",").map((s) => s.trim()));
+      }
+    }
+    setup.run(options).catch((error) => {
+      stderr.write(`Remove failed: ${error.message}\n`);
+      process.exitCode = 1;
+    });
+    return;
+  }
+
+  if (command === "doctor") {
+    const doctor = require("./doctor.cjs");
+    const rest = args.slice(1);
+    const json = rest.includes("--json") || rest.includes("-j");
+    doctor.run({ json }).catch((error) => {
+      stderr.write(`Doctor failed: ${error.message}\n`);
+      process.exitCode = 1;
+    });
+    return;
+  }
+
+  if (command === "mcp") {
+    const { launch } = require("./launcher.cjs");
+    launch("jacobian.adapters.mcp.server", args.slice(1));
+    return;
+  }
+
+  // Forward everything else to the Python CLI.
+  const { launch } = require("./launcher.cjs");
+  launch("jacobian.cli", args);
+}
+
+main();

--- a/npm/bin/launcher.cjs
+++ b/npm/bin/launcher.cjs
@@ -1,0 +1,223 @@
+"use strict";
+
+const { spawnSync } = require("node:child_process");
+const { existsSync, mkdirSync } = require("node:fs");
+const { homedir } = require("node:os");
+const { join } = require("node:path");
+
+/**
+ * Jacobian npm launcher.
+ *
+ * Detects a usable Python runtime (preferring uv), ensures the
+ * `jacobian-research-kernel` package is installed in a shared virtual
+ * environment, and spawns the requested Jacobian entry point.
+ *
+ * The launcher never runs npm lifecycle scripts.  It is a thin Node wrapper
+ * that delegates all heavy work to the Python package on PyPI or git.
+ */
+
+const PACKAGE_NAME = "jacobian-research-kernel";
+const PACKAGE_SPEC = process.env.JACOBIAN_PACKAGE || PACKAGE_NAME;
+const VENV_NAME = "jacobian-venv";
+const STATE_DIR_ENV = "JACOBIAN_STATE_DIR";
+
+/**
+ * Resolve the shared virtual-environment root.
+ *
+ * Uses XDG data directory when available, falling back to
+ * `~/.local/share/jacobian`.
+ *
+ * @returns {string}
+ */
+function venvRoot() {
+  const xdgData = process.env.XDG_DATA_HOME;
+  if (xdgData) return join(xdgData, "jacobian");
+  return join(homedir(), ".local", "share", "jacobian");
+}
+
+/**
+ * Return the path to the virtual-environment Python executable.
+ *
+ * @returns {string}
+ */
+function venvPython() {
+  const root = venvRoot();
+  if (process.platform === "win32") return join(root, VENV_NAME, "Scripts", "python.exe");
+  return join(root, VENV_NAME, "bin", "python");
+}
+
+/**
+ * Run a command synchronously and return its result.
+ *
+ * @param {string} program
+ * @param {string[]} args
+ * @param {object} [options]
+ * @returns {import("node:child_process").SpawnSyncReturns<string>}
+ */
+function run(program, args, options = {}) {
+  return spawnSync(program, args, {
+    encoding: "utf8",
+    stdio: options.silent ? "pipe" : "inherit",
+    ...options,
+  });
+}
+
+/**
+ * Detect whether a program is available on PATH.
+ *
+ * @param {string} program
+ * @returns {boolean}
+ */
+function hasProgram(program) {
+  const result = run(program, ["--version"], { silent: true, shell: process.platform === "win32" });
+  return result.error === undefined && result.status === 0;
+}
+
+/**
+ * Detect uv, preferring it over raw Python.
+ *
+ * @returns {{ kind: "uv" | "python", path: string } | null}
+ */
+function detectRuntime() {
+  if (hasProgram("uv")) return { kind: "uv", path: "uv" };
+  if (hasProgram("python3")) return { kind: "python", path: "python3" };
+  if (hasProgram("python")) return { kind: "python", path: "python" };
+  return null;
+}
+
+/**
+ * Ensure the shared virtual environment exists and the Jacobian package is
+ * installed.  Returns the path to the venv Python executable.
+ *
+ * @param {{ kind: "uv" | "python", path: string }} runtime
+ * @returns {string}
+ */
+function ensureEnvironment(runtime) {
+  const root = venvRoot();
+  const python = venvPython();
+
+  if (!existsSync(python)) {
+    mkdirSync(root, { recursive: true });
+    if (runtime.kind === "uv") {
+      const result = run(runtime.path, ["venv", join(root, VENV_NAME), "--python", "3.12"]);
+      if (result.error || result.status !== 0) {
+        console.error("Failed to create the Jacobian virtual environment with uv.");
+        process.exitCode = 1;
+        throw new Error("venv creation failed");
+      }
+    } else {
+      const result = run(runtime.path, ["-m", "venv", join(root, VENV_NAME)]);
+      if (result.error || result.status !== 0) {
+        console.error("Failed to create the Jacobian virtual environment.");
+        process.exitCode = 1;
+        throw new Error("venv creation failed");
+      }
+    }
+  }
+
+  // Check if the package is already installed.
+  const check = run(python, ["-c", `import jacobian; print(jacobian.__version__)`], { silent: true });
+  if (check.error || check.status !== 0) {
+    if (runtime.kind === "uv") {
+      const result = run(runtime.path, ["pip", "install", "--python", python, PACKAGE_SPEC]);
+      if (result.error || result.status !== 0) {
+        console.error(`Failed to install ${PACKAGE_NAME}.`);
+        process.exitCode = 1;
+        throw new Error("package install failed");
+      }
+    } else {
+      const result = run(python, ["-m", "pip", "install", PACKAGE_SPEC]);
+      if (result.error || result.status !== 0) {
+        console.error(`Failed to install ${PACKAGE_NAME}.`);
+        process.exitCode = 1;
+        throw new Error("package install failed");
+      }
+    }
+  }
+
+  return python;
+}
+
+/**
+ * Resolve the Python executable to use for launching Jacobian.
+ *
+ * Ensures the virtual environment and package are installed.
+ *
+ * @returns {string}
+ */
+function resolvePython() {
+  const runtime = detectRuntime();
+  if (!runtime) {
+    console.error(
+      "Jacobian requires Python 3.12+ or uv. Install uv from https://docs.astral.sh/uv/ or Python from https://www.python.org/",
+    );
+    process.exitCode = 1;
+    throw new Error("no Python runtime found");
+  }
+  return ensureEnvironment(runtime);
+}
+
+/**
+ * Spawn a Jacobian entry point and forward signals.
+ *
+ * @param {string} module The Python module to run (e.g. "jacobian.cli" or "jacobian.adapters.mcp.server")
+ * @param {string[]} extraArgs Arguments to pass through
+ * @param {object} [options]
+ * @param {string[]} [options.extraEnv] Additional env vars to set
+ */
+function launch(module, extraArgs, options = {}) {
+  const python = resolvePython();
+  const args = ["-m", module, ...extraArgs];
+  const env = { ...process.env };
+  if (!env[STATE_DIR_ENV]) {
+    env[STATE_DIR_ENV] = join(process.cwd(), ".jacobian");
+  }
+
+  const { spawn } = require("node:child_process");
+  const child = spawn(python, args, {
+    stdio: "inherit",
+    env,
+    windowsHide: true,
+  });
+
+  const signals =
+    process.platform === "win32"
+      ? ["SIGINT", "SIGTERM"]
+      : ["SIGHUP", "SIGINT", "SIGTERM"];
+  const handlers = new Map(
+    signals.map((signal) => [
+      signal,
+      () => {
+        if (!child.killed) child.kill(signal);
+      },
+    ]),
+  );
+  for (const [signal, handler] of handlers) process.on(signal, handler);
+
+  child.once("error", (error) => {
+    console.error(`Failed to start Jacobian: ${error.message}`);
+    process.exitCode = 1;
+  });
+
+  child.once("close", (code, signal) => {
+    for (const [forwarded, handler] of handlers)
+      process.removeListener(forwarded, handler);
+    if (signal && process.platform !== "win32") {
+      process.kill(process.pid, signal);
+      return;
+    }
+    process.exitCode = code ?? 1;
+  });
+}
+
+module.exports = {
+  PACKAGE_NAME,
+  PACKAGE_SPEC,
+  VENV_NAME,
+  venvRoot,
+  venvPython,
+  detectRuntime,
+  ensureEnvironment,
+  resolvePython,
+  launch,
+};

--- a/npm/bin/setup.cjs
+++ b/npm/bin/setup.cjs
@@ -1,0 +1,553 @@
+"use strict";
+
+const {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  rmSync,
+} = require("node:fs");
+const { homedir } = require("node:os");
+const { dirname, join } = require("node:path");
+const readline = require("node:readline/promises");
+const { stdin, stdout, stderr } = require("node:process");
+
+/**
+ * Jacobian MCP setup wizard.
+ *
+ * Detects installed MCP clients (Claude Code, Cursor, Codex, Gemini CLI,
+ * OpenCode), shows the user which were found, and writes MCP server
+ * configurations that launch `npx jacobian mcp` as a stdio server.
+ *
+ * The wizard never auto-selects detected clients.  Detection is context,
+ * not consent.
+ */
+
+const SERVER_NAME = "jacobian";
+
+/**
+ * @typedef {"claude" | "cursor" | "opencode" | "codex" | "gemini"} ClientId
+ */
+
+/**
+ * @typedef {object} ClientDef
+ * @property {ClientId} id
+ * @property {string} displayName
+ * @property {"json" | "toml"} format
+ * @property {string} configPath
+ * @property {string} jsonSection  Section key for JSON configs.
+ * @property {"command_args" | "opencode"} jsonShape
+ */
+
+/**
+ * @param {string} home
+ * @returns {ClientDef[]}
+ */
+function clientDefinitions(home) {
+  return [
+    {
+      id: "claude",
+      displayName: "Claude Code",
+      format: "json",
+      configPath: join(home, ".claude.json"),
+      jsonSection: "mcpServers",
+      jsonShape: "command_args",
+    },
+    {
+      id: "cursor",
+      displayName: "Cursor",
+      format: "json",
+      configPath: join(home, ".cursor", "mcp.json"),
+      jsonSection: "mcpServers",
+      jsonShape: "command_args",
+    },
+    {
+      id: "opencode",
+      displayName: "OpenCode",
+      format: "json",
+      configPath: join(home, ".config", "opencode", "opencode.json"),
+      jsonSection: "mcp",
+      jsonShape: "opencode",
+    },
+    {
+      id: "codex",
+      displayName: "Codex",
+      format: "toml",
+      configPath: join(home, ".codex", "config.toml"),
+      jsonSection: "",
+      jsonShape: "command_args",
+    },
+    {
+      id: "gemini",
+      displayName: "Gemini CLI",
+      format: "json",
+      configPath: join(home, ".gemini", "settings.json"),
+      jsonSection: "mcpServers",
+      jsonShape: "command_args",
+    },
+  ];
+}
+
+/**
+ * @param {string} home
+ * @param {ClientId} id
+ * @returns {boolean}
+ */
+function isClientDetected(home, id) {
+  switch (id) {
+    case "claude":
+      return existsSync(join(home, ".claude")) || existsSync(join(home, ".claude.json"));
+    case "cursor":
+      return existsSync(join(home, ".cursor"));
+    case "opencode":
+      return existsSync(join(home, ".config", "opencode"));
+    case "codex":
+      return existsSync(join(home, ".codex"));
+    case "gemini":
+      return existsSync(join(home, ".gemini"));
+    default:
+      return false;
+  }
+}
+
+/**
+ * Build the MCP launcher command + args that will be written to client configs.
+ *
+ * When running under npx, pins the exact version.  When running from a
+ * persistent install, uses the installed binary directly.
+ *
+ * @returns {{ command: string, args: string[], version: string, package: string | null }}
+ */
+function buildLauncher() {
+  const version = require("../package.json").version;
+
+  if (process.env.npm_lifecycle_event === "npx") {
+    const node = process.env.npm_node_execpath;
+    const npm = process.env.npm_execpath;
+    if (node && npm) {
+      const pkg = `jacobian@${version}`;
+      return {
+        command: node,
+        args: [npm, "exec", "--yes", `--package=${pkg}`, "--", "jacobian", "mcp"],
+        version,
+        package: pkg,
+      };
+    }
+  }
+
+  // Persistent install: use the bin directly with the mcp subcommand.
+  const binPath = process.argv[1] || "jacobian";
+  return {
+    command: process.execPath,
+    args: [binPath, "mcp"],
+    version,
+    package: null,
+  };
+}
+
+/**
+ * Build the MCP server entry value for a JSON config.
+ *
+ * @param {ClientDef} def
+ * @param {{ command: string, args: string[] }} launcher
+ * @returns {object}
+ */
+function jsonEntry(def, launcher) {
+  if (def.jsonShape === "opencode") {
+    return {
+      type: "local",
+      command: [launcher.command, ...launcher.args].join(" "),
+      cwd: ".",
+      enabled: true,
+    };
+  }
+  return {
+    command: launcher.command,
+    args: launcher.args,
+  };
+}
+
+/**
+ * Read a file if it exists, returning null otherwise.
+ *
+ * @param {string} path
+ * @returns {string | null}
+ */
+function readOptional(path) {
+  try {
+    return readFileSync(path, "utf8");
+  } catch (error) {
+    if (error.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+/**
+ * Write a file only if its content would change.
+ *
+ * @param {string} path
+ * @param {string} content
+ */
+function writeIfChanged(path, content) {
+  const existing = readOptional(path);
+  if (existing === content) return;
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content, { encoding: "utf8" });
+}
+
+/**
+ * Resolve a JSON config edit for setup or removal.
+ *
+ * @param {"setup" | "remove"} operation
+ * @param {ClientDef} def
+ * @param {{ command: string, args: string[] }} launcher
+ * @returns {{ action: string, original: string | null, updated: string | null }}
+ */
+function resolveJsonEdit(operation, def, launcher) {
+  const original = readOptional(def.configPath);
+  const source = original ?? "{}\n";
+  let root;
+  try {
+    root = JSON.parse(source);
+  } catch (error) {
+    throw new Error(`Invalid JSON in ${def.configPath}: ${error.message}`);
+  }
+  if (typeof root !== "object" || root === null || Array.isArray(root)) {
+    throw new Error(`Top-level value in ${def.configPath} must be an object`);
+  }
+  const section = root[def.jsonSection] ?? {};
+  if (typeof section !== "object" || section === null || Array.isArray(section)) {
+    throw new Error(`${def.jsonSection} in ${def.configPath} must be an object`);
+  }
+
+  if (operation === "setup") {
+    const expected = jsonEntry(def, launcher);
+    if (JSON.stringify(section[SERVER_NAME]) === JSON.stringify(expected)) {
+      return { action: "already_current", original, updated: null };
+    }
+    section[SERVER_NAME] = expected;
+    root[def.jsonSection] = section;
+    const updated = JSON.stringify(root, null, 2) + "\n";
+    return {
+      action: original === null ? "create" : "update",
+      original,
+      updated,
+    };
+  }
+
+  // Remove
+  if (!(SERVER_NAME in section)) {
+    return { action: "not_configured", original, updated: null };
+  }
+  delete section[SERVER_NAME];
+  if (Object.keys(section).length === 0) {
+    delete root[def.jsonSection];
+  }
+  const updated = JSON.stringify(root, null, 2) + "\n";
+  return { action: "remove", original, updated };
+}
+
+/**
+ * Resolve a TOML config edit for setup or removal (Codex).
+ *
+ * Uses a minimal TOML editor that preserves the structure we need.
+ *
+ * @param {"setup" | "remove"} operation
+ * @param {ClientDef} def
+ * @param {{ command: string, args: string[] }} launcher
+ * @returns {{ action: string, original: string | null, updated: string | null }}
+ */
+function resolveTomlEdit(operation, def, launcher) {
+  const original = readOptional(def.configPath);
+  const source = original ?? "";
+  const lines = source.split("\n");
+
+  // Find or create the [mcp_servers] section.
+  let sectionStart = -1;
+  let sectionEnd = lines.length;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].trim() === "[mcp_servers]") {
+      sectionStart = i;
+      // Find where this section ends (next top-level table or EOF).
+      for (let j = i + 1; j < lines.length; j++) {
+        if (lines[j].startsWith("[") && !lines[j].startsWith("[[")) {
+          sectionEnd = j;
+          break;
+        }
+      }
+      break;
+    }
+  }
+
+  if (operation === "remove") {
+    if (sectionStart === -1) {
+      return { action: "not_configured", original, updated: null };
+    }
+    // Remove the jacobian entry lines.
+    const before = lines.slice(0, sectionStart);
+    const sectionLines = lines.slice(sectionStart, sectionEnd);
+    const after = lines.slice(sectionEnd);
+
+    const filtered = sectionLines.filter(
+      (line) => !line.trim().startsWith("jacobian"),
+    );
+    // If only the header remains, remove the section entirely.
+    const nonHeader = filtered.filter(
+      (line) => line.trim() !== "" && line.trim() !== "[mcp_servers]",
+    );
+    let updated;
+    if (nonHeader.length === 0) {
+      updated = [...before, ...after].join("\n");
+    } else {
+      updated = [...before, ...filtered, ...after].join("\n");
+    }
+    return { action: "remove", original, updated };
+  }
+
+  // Setup: build the entry.
+  const entryLines = [
+    `[mcp_servers]`,
+    `jacobian = { command = "${launcher.command}", args = [${launcher.args.map((a) => `"${a}"`).join(", ")}], startup_timeout_sec = 30 }`,
+  ];
+
+  if (sectionStart === -1) {
+    // No existing section: append.
+    const updated =
+      source.trim() === ""
+        ? entryLines.join("\n") + "\n"
+        : source.trimEnd() + "\n\n" + entryLines.join("\n") + "\n";
+    return { action: original === null ? "create" : "update", original, updated };
+  }
+
+  // Check if jacobian is already there with the right config.
+  const sectionLines = lines.slice(sectionStart, sectionEnd);
+  const expectedEntry = `jacobian = { command = "${launcher.command}", args = [${launcher.args.map((a) => `"${a}"`).join(", ")}], startup_timeout_sec = 30 }`;
+  for (const line of sectionLines) {
+    if (line.trim() === expectedEntry) {
+      return { action: "already_current", original, updated: null };
+    }
+  }
+
+  // Replace or add the jacobian entry.
+  const before = lines.slice(0, sectionStart + 1);
+  const after = lines.slice(sectionStart + 1, sectionEnd);
+  const rest = lines.slice(sectionEnd);
+
+  // Remove any existing jacobian entry in the section.
+  const cleanedAfter = after.filter((line) => !line.trim().startsWith("jacobian"));
+  const updated = [...before, expectedEntry, ...cleanedAfter, ...rest].join("\n");
+  return { action: "update", original, updated };
+}
+
+/**
+ * Resolve one client edit.
+ *
+ * @param {"setup" | "remove"} operation
+ * @param {ClientDef} def
+ * @param {{ command: string, args: string[] }} launcher
+ * @returns {{ client: ClientDef, action: string, detected: boolean, path: string, original: string | null, updated: string | null }}
+ */
+function resolveClientEdit(operation, def, launcher) {
+  const result =
+    def.format === "json"
+      ? resolveJsonEdit(operation, def, launcher)
+      : resolveTomlEdit(operation, def, launcher);
+  return {
+    client: def,
+    action: result.action,
+    detected: isClientDetected(homedir(), def.id),
+    path: def.configPath,
+    original: result.original,
+    updated: result.updated,
+  };
+}
+
+/**
+ * Apply one client edit to disk.
+ *
+ * @param {{ path: string, original: string | null, updated: string | null, action: string }} edit
+ */
+function applyEdit(edit) {
+  if (edit.action === "remove") {
+    if (existsSync(edit.path)) {
+      rmSync(edit.path, { force: true });
+    }
+    return;
+  }
+  if (edit.updated !== null) {
+    writeIfChanged(edit.path, edit.updated);
+  }
+}
+
+/**
+ * Print the preflight plan for user confirmation.
+ *
+ * @param {{ operation: string, launcher: object, edits: object[] }} plan
+ */
+function printPlan(plan) {
+  stderr.write(`\n◆ Jacobian // MCP Setup\n`);
+  stderr.write(`  Launcher: ${plan.launcher.command} ${plan.launcher.args.join(" ")}\n`);
+  stderr.write(`  Version:  ${plan.launcher.version}\n`);
+  if (plan.launcher.package) {
+    stderr.write(`  Package:  ${plan.launcher.package} (may contact npm on client restart)\n`);
+  }
+  stderr.write(`\n  Planned changes:\n`);
+  for (const edit of plan.edits) {
+    const det = edit.detected ? " [detected]" : "";
+    stderr.write(`    ${edit.client.displayName}${det}: ${edit.action} → ${edit.path}\n`);
+  }
+  stderr.write("\n");
+}
+
+/**
+ * Interactive multi-select prompt using raw terminal input.
+ *
+ * @param {ClientDef[]} clients
+ * @param {ClientId[]} detected
+ * @returns {Promise<ClientDef[]>}
+ */
+async function interactiveSelect(clients, detected) {
+  stderr.write("\n  Select coding agents to configure (Space to toggle, Enter to confirm):\n\n");
+  for (let i = 0; i < clients.length; i++) {
+    const def = clients[i];
+    const det = detected.includes(def.id) ? " — detected" : "";
+    stderr.write(`  [ ] ${i + 1}. ${def.displayName}${det}\n`);
+  }
+  stderr.write("\n  Enter comma-separated numbers (e.g. 1,3) or 'all': ");
+
+  const rl = readline.createInterface({ input: stdin, output: stderr });
+  try {
+    const answer = (await rl.question("")).trim();
+    rl.close();
+    if (answer.toLowerCase() === "all") {
+      return clients;
+    }
+    if (!answer) return [];
+    const indices = answer
+      .split(/[,\s]+/)
+      .map((n) => parseInt(n, 10) - 1)
+      .filter((n) => n >= 0 && n < clients.length);
+    return indices.map((i) => clients[i]);
+  } finally {
+    rl.close();
+  }
+}
+
+/**
+ * Interactive yes/no confirmation.
+ *
+ * @returns {Promise<boolean>}
+ */
+async function interactiveConfirm() {
+  const rl = readline.createInterface({ input: stdin, output: stderr });
+  try {
+    const answer = (await rl.question("Apply these changes? [y/N] ")).trim().toLowerCase();
+    return answer === "y" || answer === "yes";
+  } finally {
+    rl.close();
+  }
+}
+
+/**
+ * Run the setup or removal wizard.
+ *
+ * @param {object} options
+ * @param {"setup" | "remove"} options.operation
+ * @param {string[]} [options.clients] Explicit client IDs.
+ * @param {boolean} [options.all] Select all clients.
+ * @param {boolean} [options.yes] Skip confirmation.
+ * @param {boolean} [options.dryRun] Print plan without writing.
+ * @param {boolean} [options.json] Output as JSON.
+ * @returns {Promise<object>} Setup report.
+ */
+async function run(options) {
+  const operation = options.operation;
+  const home = homedir();
+  const defs = clientDefinitions(home);
+  const launcher = buildLauncher();
+  const detectedIds = defs.filter((d) => isClientDetected(home, d.id)).map((d) => d.id);
+
+  let selected;
+  if (options.all) {
+    selected = defs;
+  } else if (options.clients && options.clients.length > 0) {
+    const wanted = new Set(options.clients);
+    selected = defs.filter((d) => wanted.has(d.id));
+  } else if (options.yes) {
+    stderr.write("--yes requires explicit --client flags or --all; detection is not consent.\n");
+    process.exitCode = 1;
+    return { error: "missing client selection" };
+  } else {
+    selected = await interactiveSelect(defs, detectedIds);
+  }
+
+  if (selected.length === 0) {
+    return { operation, cancelled: true, dryRun: false, results: [] };
+  }
+
+  const edits = selected.map((def) => resolveClientEdit(operation, def, launcher));
+  const plan = { operation, launcher, edits };
+
+  if (options.dryRun) {
+    if (options.json) {
+      stdout.write(JSON.stringify({ operation, cancelled: false, dryRun: true, plan, results: [] }, null, 2) + "\n");
+    } else {
+      printPlan(plan);
+      stderr.write("  (dry-run: no changes written)\n\n");
+    }
+    return { operation, cancelled: false, dryRun: true, plan, results: [] };
+  }
+
+  if (!options.yes) {
+    printPlan(plan);
+    const confirmed = await interactiveConfirm();
+    if (!confirmed) {
+      return { operation, cancelled: true, dryRun: false, plan, results: [] };
+    }
+  } else {
+    printPlan(plan);
+  }
+
+  // Apply edits.
+  const results = [];
+  for (const edit of edits) {
+    try {
+      applyEdit(edit);
+      results.push({
+        client: edit.client.id,
+        path: edit.path,
+        status: edit.action,
+        error: null,
+      });
+    } catch (error) {
+      results.push({
+        client: edit.client.id,
+        path: edit.path,
+        status: "failed",
+        error: error.message,
+      });
+    }
+  }
+
+  if (options.json) {
+    stdout.write(JSON.stringify({ operation, cancelled: false, dryRun: false, results }, null, 2) + "\n");
+  } else {
+    stderr.write("\n  Setup complete.\n");
+    for (const result of results) {
+      const status = result.error ? `FAILED: ${result.error}` : result.status;
+      stderr.write(`    ${result.client}: ${status}\n`);
+    }
+    stderr.write("\n  Restart or reload configured clients, then run `npx jacobian doctor` to verify.\n\n");
+  }
+
+  return { operation, cancelled: false, dryRun: false, results };
+}
+
+module.exports = {
+  SERVER_NAME,
+  clientDefinitions,
+  isClientDetected,
+  buildLauncher,
+  resolveClientEdit,
+  run,
+};

--- a/npm/npm-packaging.test.mjs
+++ b/npm/npm-packaging.test.mjs
@@ -1,0 +1,193 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+import {
+  clientDefinitions,
+  isClientDetected,
+  buildLauncher,
+  resolveClientEdit,
+  SERVER_NAME,
+} from "./bin/setup.cjs";
+
+/**
+ * Create a fake home directory with selected client markers.
+ *
+ * @param {string} base
+ * @param {string[]} clients
+ * @returns {Promise<string>}
+ */
+async function fakeHome(base, clients) {
+  const home = await mkdtemp(join(base, "home-"));
+  for (const client of clients) {
+    switch (client) {
+      case "claude":
+        await mkdir(join(home, ".claude"), { recursive: true });
+        break;
+      case "cursor":
+        await mkdir(join(home, ".cursor"), { recursive: true });
+        break;
+      case "opencode":
+        await mkdir(join(home, ".config", "opencode"), { recursive: true });
+        break;
+      case "codex":
+        await mkdir(join(home, ".codex"), { recursive: true });
+        break;
+      case "gemini":
+        await mkdir(join(home, ".gemini"), { recursive: true });
+        break;
+    }
+  }
+  return home;
+}
+
+test("clientDefinitions returns all five supported clients", () => {
+  const home = "/tmp/fake";
+  const defs = clientDefinitions(home);
+  assert.equal(defs.length, 5);
+  assert.equal(defs[0].id, "claude");
+  assert.equal(defs[1].id, "cursor");
+  assert.equal(defs[2].id, "opencode");
+  assert.equal(defs[3].id, "codex");
+  assert.equal(defs[4].id, "gemini");
+});
+
+test("isClientDetected recognizes installed client markers", async () => {
+  const base = await mkdtemp(join(tmpdir(), "jacobian-detect-"));
+  try {
+    const home = await fakeHome(base, ["claude", "cursor", "codex"]);
+    assert.equal(isClientDetected(home, "claude"), true);
+    assert.equal(isClientDetected(home, "cursor"), true);
+    assert.equal(isClientDetected(home, "codex"), true);
+    assert.equal(isClientDetected(home, "opencode"), false);
+    assert.equal(isClientDetected(home, "gemini"), false);
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test("buildLauncher returns a version-matching launcher with mcp subcommand", () => {
+  const launcher = buildLauncher();
+  const pkg = require("./package.json");
+  assert.equal(launcher.version, pkg.version);
+  assert.ok(launcher.command.length > 0);
+  assert.ok(launcher.args.length > 0);
+  // The last arg should be "mcp" (the subcommand).
+  assert.equal(launcher.args[launcher.args.length - 1], "mcp");
+});
+
+test("setup writes a JSON config for Claude Code", async () => {
+  const base = await mkdtemp(join(tmpdir(), "jacobian-json-"));
+  try {
+    const home = await fakeHome(base, ["claude"]);
+    const defs = clientDefinitions(home);
+    const claude = defs.find((d) => d.id === "claude");
+    const launcher = { command: "/usr/bin/node", args: ["/path/to/jacobian", "mcp"], version: "0.2.0-alpha.0", package: null };
+
+    const edit = resolveClientEdit("setup", claude, launcher);
+    assert.equal(edit.action, "create");
+    assert.equal(edit.original, null);
+    assert.ok(edit.updated !== null);
+
+    // Apply the edit.
+    mkdirSync(join(home, ".claude"), { recursive: true });
+    writeFileSync(claude.configPath, edit.updated);
+
+    // Re-read and verify.
+    const config = JSON.parse(await readFile(claude.configPath, "utf8"));
+    assert.ok(config.mcpServers);
+    assert.ok(config.mcpServers[SERVER_NAME]);
+    assert.equal(config.mcpServers[SERVER_NAME].command, "/usr/bin/node");
+    assert.deepEqual(config.mcpServers[SERVER_NAME].args, ["/path/to/jacobian", "mcp"]);
+
+    // Re-resolving should report already_current.
+    const edit2 = resolveClientEdit("setup", claude, launcher);
+    assert.equal(edit2.action, "already_current");
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test("setup writes a TOML config for Codex", async () => {
+  const base = await mkdtemp(join(tmpdir(), "jacobian-toml-"));
+  try {
+    const home = await fakeHome(base, ["codex"]);
+    const defs = clientDefinitions(home);
+    const codex = defs.find((d) => d.id === "codex");
+    const launcher = { command: "/usr/bin/node", args: ["/path/to/jacobian", "mcp"], version: "0.2.0-alpha.0", package: null };
+
+    const edit = resolveClientEdit("setup", codex, launcher);
+    assert.equal(edit.action, "create");
+    assert.ok(edit.updated !== null);
+    assert.ok(edit.updated.includes("[mcp_servers]"));
+    assert.ok(edit.updated.includes("jacobian"));
+
+    // Apply and re-read.
+    mkdirSync(join(home, ".codex"), { recursive: true });
+    writeFileSync(codex.configPath, edit.updated);
+
+    // Re-resolving should report already_current.
+    const edit2 = resolveClientEdit("setup", codex, launcher);
+    assert.equal(edit2.action, "already_current");
+
+    // Remove should work.
+    const edit3 = resolveClientEdit("remove", codex, launcher);
+    assert.equal(edit3.action, "remove");
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test("remove on a non-configured client reports not_configured", async () => {
+  const base = await mkdtemp(join(tmpdir(), "jacobian-remove-"));
+  try {
+    const home = await fakeHome(base, ["claude"]);
+    const defs = clientDefinitions(home);
+    const claude = defs.find((d) => d.id === "claude");
+    const launcher = { command: "/usr/bin/node", args: ["/path/to/jacobian", "mcp"], version: "0.2.0-alpha.0", package: null };
+
+    const edit = resolveClientEdit("remove", claude, launcher);
+    assert.equal(edit.action, "not_configured");
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test("setup updates an existing JSON config without losing other servers", async () => {
+  const base = await mkdtemp(join(tmpdir(), "jacobian-update-"));
+  try {
+    const home = await fakeHome(base, ["claude"]);
+    const defs = clientDefinitions(home);
+    const claude = defs.find((d) => d.id === "claude");
+    const configPath = claude.configPath;
+
+    // Pre-populate with an existing server.
+    mkdirSync(join(home, ".claude"), { recursive: true });
+    const existing = {
+      mcpServers: {
+        "other-server": { command: "other", args: ["--foo"] },
+      },
+      someOtherSetting: true,
+    };
+    writeFileSync(configPath, JSON.stringify(existing, null, 2) + "\n");
+
+    const launcher = { command: "/usr/bin/node", args: ["/path/to/jacobian", "mcp"], version: "0.2.0-alpha.0", package: null };
+    const edit = resolveClientEdit("setup", claude, launcher);
+    assert.equal(edit.action, "update");
+
+    // Apply.
+    writeFileSync(configPath, edit.updated);
+    const config = JSON.parse(await readFile(configPath, "utf8"));
+    assert.ok(config.mcpServers["other-server"]);
+    assert.ok(config.mcpServers[SERVER_NAME]);
+    assert.equal(config.someOtherSetting, true);
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "jacobian",
+  "version": "0.2.0-alpha.0",
+  "description": "Verifier-centric MCP toolbench for agents working on bounded, executable mathematics",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/morluto/jacobian"
+  },
+  "homepage": "https://github.com/morluto/jacobian",
+  "engines": {
+    "node": ">=18"
+  },
+  "bin": {
+    "jacobian": "bin/jacobian.cjs"
+  },
+  "files": [
+    "bin",
+    "README.md"
+  ]
+}


### PR DESCRIPTION
## Problem
Jacobian has no npm entry point. Agents and users who work in Node-centric MCP ecosystems (Claude Code, Cursor, Codex, Gemini CLI, OpenCode) cannot install or configure Jacobian through the standard `npx` workflow.

## Solution
Add a Node wrapper package under `npm/` that provides three capabilities:

- **Launcher** (`bin/launcher.cjs`): detects `uv` or Python 3.12+, creates a shared virtual environment, installs `jacobian-research-kernel`, and spawns the requested entry point.
- **Setup wizard** (`bin/setup.cjs`): detects installed MCP clients, shows the user which were found (detection is not consent), and writes stdio server configs pointing at `npx jacobian mcp`. Supports Claude Code, Cursor, OpenCode, Codex (TOML), and Gemini CLI.
- **Doctor** (`bin/doctor.cjs`): spawns the MCP server, performs the `initialize` handshake, lists tools, and verifies the expected 20-tool catalog.

The package provides a single bin (`jacobian`) with subcommands:
```
npx jacobian setup    # wizard
npx jacobian doctor   # verify handshake
npx jacobian mcp      # stdio MCP server
npx jacobian <cmd>    # forwarded to Python CLI
```

Package size: 9.7 KB, 5 files, no native binaries.

## Testing
```sh
node --test npm/npm-packaging.test.mjs
```
7/7 tests pass, covering client detection, JSON/TOML config writing, already-current detection, removal, and config preservation.

Also verified end-to-end:
- `npx jacobian setup --all --yes --dry-run` correctly detects and plans all 5 clients
- `npx jacobian mcp` installs the Python package via uv and responds to the MCP initialize handshake with `serverName: "jacobian"`, `version: "0.2.0a0"`
- `npm pack --dry-run` produces a valid 9.7 KB tarball

## Trust & Compatibility Impact
No changes to the verification kernel, checker registry, or artifact format. The npm package is a thin launcher over the existing Python package and MCP adapter. It does not alter trust boundaries or evidence handling.

## Checklist
- [x] Tests pass locally (`node --test npm/npm-packaging.test.mjs`)
- [x] Relevant documentation updated (README update pending)