### PR TITLE
fix(dx): improve agent-facing MCP verification workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,10 @@ documentation placement, and pull-request expectations.
 
 v0.2 alpha is implemented as a Python package, CLI, and local or remote MCP
 adapter. The capability-first projection exposes one stable
-`capability.invoke` tool backed by a discoverable adapter registry and
-trust-labeled research memory. Bundled capabilities provide reference-domain
-exploration and verification, Lean checking, and local episode search.
+`capability.describe` discovery tool and one stable `capability.invoke` tool
+backed by an extensible adapter registry and trust-labeled research memory.
+Bundled capabilities provide reference-domain exploration and verification,
+Lean checking, and local episode search.
 
 The advanced surface retains eight verification tools alongside bounded enumeration,
 implementation-bound canonicalization, independently verified representation
@@ -141,8 +142,10 @@ The repository includes a trusted-project Codex profile at
 `jacobian_local` with `/mcp`; the profile starts `uv run jacobian-mcp` over
 STDIO with the compact `capabilities` profile and stores durable local state
 under the ignored `.jacobian/` directory. The profile advertises
-`capability.invoke`; `capability://catalog` supplies the installed operations,
-schemas, and supported `EXPLORE` or `VERIFY` lanes. Start
+`capability.describe` and `capability.invoke`. Describe an unfamiliar
+capability before invoking it; reference domains include exact predicate and
+candidate schemas plus executable examples. `capability://catalog` remains a
+resource-level catalog for clients that support MCP resources. Start
 `uv run jacobian-mcp --tool-profile full` when the research, transformation,
 and experiment tools or complete wire results are needed.
 

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -164,12 +164,17 @@ All local workflows remain available when no provider is configured.
 declares a stable operation ID, version, supported `EXPLORE` and `VERIFY`
 modes, input and output JSON Schemas, and discovery metadata. The MCP
 projection exposes the registry through `capability://catalog` and
-`capability.invoke`, so a new Alloy, Lean, SAT/SMT, CAS, or domain adapter does
-not require another MCP tool or a generic-core type.
+the tool-callable `capability.describe` and `capability.invoke` pair, so a new
+Alloy, Lean, SAT/SMT, CAS, or domain adapter does not require another MCP tool
+or a generic-core type. Domain descriptions project exact schemas, binding
+rules, and executable examples without moving mathematical semantics into the
+generic kernel.
 
 The service validates both schemas and prevents adapters from self-promoting:
 `VERIFIED` requires a valid local verification record whose checked evidence
-is returned with the capability result.
+is returned with the capability result. Stage-aware diagnostics separate
+invalid input, reference resolution, adapter execution, and checker outcomes.
+Only completed invocations are eligible for research-memory recording.
 
 ## Common result model
 

--- a/docs/explanation/product-blueprint.md
+++ b/docs/explanation/product-blueprint.md
@@ -144,8 +144,10 @@ The lower-level v0.2 verification tools remain available through the `full` and
 
 ## Database-first memory
 
-Every reusable capability invocation is stored as an immutable research
-episode and indexed locally. An episode binds:
+Every operationally completed, reusable capability invocation is stored as an
+immutable research episode and indexed locally. Invalid requests,
+infrastructure errors, timeouts, and cancellations are returned with their
+operational status but do not enter research memory. An episode binds:
 
 - capability and adapter version;
 - exact request and result;
@@ -165,7 +167,8 @@ authority.
 ## Local and remote hosts
 
 The local Codex profile uses STDIO and the `capabilities` tool profile. It
-advertises one extensible tool rather than every backend operation.
+advertises one read-only discovery tool and one extensible invocation tool
+rather than every backend operation.
 
 Remote hosts use Streamable HTTP by default. A remote deployment:
 

--- a/docs/explanation/roadmap.md
+++ b/docs/explanation/roadmap.md
@@ -30,7 +30,7 @@ checker-backed assurance available when a result must be promoted.
 
 ### Deliverables
 
-- One model-facing `capability.invoke` MCP tool and discoverable catalog
+- Model-facing `capability.describe` and `capability.invoke` MCP tools
 - Adapter registration without kernel or MCP edits
 - Explicit `EXPLORE` and `VERIFY` lanes
 - Heuristic, computed, and verified assurance labels

--- a/docs/how-to/deploy-remote-mcp.md
+++ b/docs/how-to/deploy-remote-mcp.md
@@ -55,6 +55,19 @@ uv run jacobian-mcp \
 
 Do not expose anonymous mode to a network.
 
+## Warm the Mathlib profile
+
+Set `JACOBIAN_LEAN_WARMUP=1` on a host that serves `lean.check`. Jacobian then
+checks a small pinned Mathlib theorem in the background when each tenant kernel
+is first used. This warms Lean and filesystem caches without delaying MCP
+startup.
+
+Lean results are cached only for an exact content-addressed certificate and
+the currently active checker digest. The bounded in-memory cache holds 128
+entries; a changed proof, statement, environment, checker, or authorization
+state cannot reuse an entry. `capability.describe` for `lean.check` reports the
+configured checker timeouts and cache policy.
+
 ## Container deployment
 
 Build the repository image:

--- a/docs/reference/agent-evaluations.md
+++ b/docs/reference/agent-evaluations.md
@@ -342,10 +342,12 @@ and compact result projection changed that compact descriptor to 7,883
 characters; the corresponding 22-tool descriptor was 103,382 characters.
 
 The capability-first change was remeasured with compact sorted JSON on
-2026-07-24. The default `capabilities` profile advertises one tool in 779
-characters. Its three-entry `capability://catalog` is 2,663 characters. The
+2026-07-24. After adding tool-callable exact schema discovery, the default
+`capabilities` profile advertises two tools in 1,492 characters. Its
+three-entry `capability://catalog` is 2,663 characters, and an exact
+Erdős-Straus `capability.describe` result is 5,347 characters. The
 compatibility `verification` profile is eight tools and 7,171 characters; the
-23-tool `full` profile is 105,187 characters. The default descriptor remains
+24-tool `full` profile is 107,034 characters. The default descriptor remains
 well below the 25 KB first-stage target. These are descriptor measurements,
 not model token counts, and must be remeasured when contracts change.
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -15,16 +15,24 @@ heuristic operation cannot masquerade as a verifier.
 
 ## Capability-first MCP surface
 
-The default local and remote profile advertises one tool:
+The default local and remote profile advertises two tools:
 
 | Tool | Capability |
 | --- | --- |
-| `capability.invoke` | Invoke an installed operation in `EXPLORE` or `VERIFY` mode. Inputs and outputs are validated against the selected descriptor. Reusable invocations create trust-labeled research episodes. |
+| `capability.describe` | Read an installed capability's exact schema. `reference.solve` descriptions add domain predicate and candidate schemas, binding rules, and executable examples. |
+| `capability.invoke` | Invoke an installed operation in `EXPLORE` or `VERIFY` mode. Inputs and outputs are validated against the selected descriptor. Completed reusable invocations create trust-labeled research episodes. |
 
 Read `capability://catalog` to discover stable IDs, provider versions, supported
 modes, compact JSON Schemas, and tags. Bundled IDs are `reference.solve`,
 `lean.check`, and `knowledge.search`. Operator-installed adapters appear in the
-same catalog without a new MCP tool.
+same catalog without a new MCP tool. Tool-only clients should call
+`capability.describe` before invoking an unfamiliar capability rather than
+guessing payload fields.
+
+Failed invocations carry stage-aware diagnostics with a stable code, JSON path
+when available, schema URI when applicable, and a corrective hint. Invalid
+requests, adapter failures, timeouts, and cancellations do not become research
+episodes and never carry a mathematical conclusion.
 
 `EXPLORE` returns heuristic or computed assurance and does not require a formal
 claim or checker. `VERIFY` may promote a result only when it carries a valid

--- a/src/jacobian/adapters/mcp/server.py
+++ b/src/jacobian/adapters/mcp/server.py
@@ -63,6 +63,7 @@ from jacobian.contracts.transformations import (
 )
 from jacobian.contracts.witness_search import WitnessFindResult
 from jacobian.contracts.workflows import WitnessVerificationWorkflowResult
+from jacobian_checkers.matrices import MAX_ENUMERATED_MATRICES
 
 if TYPE_CHECKING:
     from mcp.server import MCPServer
@@ -240,6 +241,8 @@ def create_server(  # noqa: C901
 
     @asynccontextmanager
     async def lifespan(_server: MCPServer[AppState]) -> AsyncIterator[AppState]:
+        if kernel is not None:
+            _start_lean_warmup(kernel)
         yield AppState(kernel=kernel, tenant_router=tenant_router)
 
     server: MCPServer[AppState] = MCPServer(
@@ -317,6 +320,24 @@ def create_server(  # noqa: C901
                         "message": str(exc),
                         "available_reference_names": sorted(active_kernel.references),
                     }
+        elif capability_id == "lean.check" and active_kernel.lean_checkers:
+            catalog = reference_catalog(
+                active_kernel.references,
+                polytope=active_kernel.polytope,
+                polytope_checkers=active_kernel.polytope_checkers,
+                lean=active_kernel.lean_checkers,
+            )
+            lean_contract = _reference_domain_contract(
+                active_kernel,
+                "lean4",
+                catalog,
+            )
+            response["runtime"] = lean_contract["runtime"]
+            response["cache"] = {
+                "key": "exact content-addressed certificate and active checker digest",
+                "max_entries": 128,
+                "warmup_environment_variable": "JACOBIAN_LEAN_WARMUP=1",
+            }
         return response
 
     @server.tool(
@@ -1244,10 +1265,17 @@ def _kernel(ctx: Context[AppState, Any] | None) -> JacobianKernel:
 
         access_token = get_access_token()
         subject = access_token.subject if access_token is not None else None
-        return state.tenant_router.kernel_for(subject)
+        kernel = state.tenant_router.kernel_for(subject)
+        _start_lean_warmup(kernel)
+        return kernel
     if state.kernel is None:
         raise RuntimeError("MCP lifespan has no kernel")
     return state.kernel
+
+
+def _start_lean_warmup(kernel: JacobianKernel) -> None:
+    if kernel.lean is not None and os.environ.get("JACOBIAN_LEAN_WARMUP") == "1":
+        kernel.lean.start_mathlib_warmup()
 
 
 def _resource_kernel(
@@ -1569,6 +1597,20 @@ def _reference_domain_contract(
                 "The predicate parameters define the claim scope. The candidate is "
                 "a separate checked object; repeated scope fields must agree exactly. "
                 "Never substitute aliases or silently choose one copy."
+            ),
+            "verification_limits": (
+                {
+                    "maximize_absolute_determinant": {
+                        "max_enumerated_candidates": MAX_ENUMERATED_MATRICES,
+                        "scope_cardinality": "len(entries) ** (rows * cols)",
+                        "on_excess": "REJECTED_WITHOUT_CONCLUSION",
+                        "checker_timeout_seconds": (
+                            kernel.verification.checker_timeout_seconds
+                        ),
+                    }
+                }
+                if name == "matrices"
+                else {}
             ),
             "invocation_examples": _reference_invocation_examples(name),
             "workflow": {

--- a/src/jacobian/adapters/mcp/server.py
+++ b/src/jacobian/adapters/mcp/server.py
@@ -74,8 +74,8 @@ if TYPE_CHECKING:
 
 
 SERVER_INSTRUCTIONS = (
-    "When a capability ID and input are known, invoke it directly; otherwise start "
-    "with capability://catalog. Use "
+    "Call capability.describe before the first invocation of an unfamiliar "
+    "capability or reference domain; do not guess payload fields. Use "
     "EXPLORE for low-friction search and VERIFY only when a durable checked conclusion "
     "is needed. Advanced clients may inspect reference://catalog for lower-level domain "
     "contracts and assurance.verification details. Retrieved memory, search, evaluation, "
@@ -87,7 +87,7 @@ SERVER_INSTRUCTIONS = (
     "large payloads inline."
 )
 
-CAPABILITY_TOOL_NAMES = frozenset({"capability.invoke"})
+CAPABILITY_TOOL_NAMES = frozenset({"capability.describe", "capability.invoke"})
 VERIFICATION_TOOL_NAMES = frozenset(
     {
         "artifact.put",
@@ -257,10 +257,74 @@ def create_server(  # noqa: C901
     )
 
     @server.tool(
+        name="capability.describe",
+        description=(
+            "Read an installed capability's exact input schema. For reference.solve, "
+            "provide reference_name to receive its predicate schema, candidate schema, "
+            "binding rule, and executable examples. Call this before guessing fields."
+        ),
+        annotations=_tool_annotations(read_only=True, idempotent=True),
+        structured_output=structured_output,
+    )
+    async def capability_describe(
+        capability_id: str | None = None,
+        reference_name: str | None = None,
+        ctx: Context[AppState, Any] | None = None,
+    ) -> dict[str, Any]:
+        active_kernel = _kernel(ctx)
+        capability_catalog = active_kernel.capabilities.catalog()
+        descriptors = {
+            item.capability_id: item for item in capability_catalog.capabilities
+        }
+        if capability_id is None:
+            return capability_catalog.model_dump(mode="json")
+        try:
+            descriptor = descriptors[capability_id]
+        except KeyError:
+            return {
+                "error": {
+                    "code": "UNKNOWN_CAPABILITY",
+                    "stage": "capability_resolution",
+                    "message": f"Unknown capability: {capability_id}",
+                    "available_capability_ids": sorted(descriptors),
+                }
+            }
+        response: dict[str, Any] = {"capability": descriptor.model_dump(mode="json")}
+        if capability_id == "reference.solve":
+            catalog = reference_catalog(
+                active_kernel.references,
+                polytope=active_kernel.polytope,
+                polytope_checkers=active_kernel.polytope_checkers,
+                lean=active_kernel.lean_checkers,
+            )
+            if reference_name is None:
+                response["available_reference_names"] = sorted(
+                    name
+                    for name, entry in catalog.items()
+                    if "agent_contract_uri" in entry and name != "lean4"
+                )
+            else:
+                try:
+                    response["domain"] = _reference_domain_contract(
+                        active_kernel,
+                        reference_name,
+                        catalog,
+                    )
+                except ValueError as exc:
+                    response["error"] = {
+                        "code": "UNKNOWN_REFERENCE",
+                        "stage": "reference_resolution",
+                        "message": str(exc),
+                        "available_reference_names": sorted(active_kernel.references),
+                    }
+        return response
+
+    @server.tool(
         name="capability.invoke",
         description=(
             "Invoke an installed mathematical capability in the fast EXPLORE or "
-            "checker-backed VERIFY lane. Read capability://catalog first."
+            "checker-backed VERIFY lane. Call capability.describe first for exact "
+            "payload fields; do not guess aliases."
         ),
         annotations=_tool_annotations(),
         structured_output=structured_output,
@@ -1501,6 +1565,12 @@ def _reference_domain_contract(
                 ),
             },
             "candidate_schema": _compact_schema(candidate_schema),
+            "binding_rule": (
+                "The predicate parameters define the claim scope. The candidate is "
+                "a separate checked object; repeated scope fields must agree exactly. "
+                "Never substitute aliases or silently choose one copy."
+            ),
+            "invocation_examples": _reference_invocation_examples(name),
             "workflow": {
                 "assurance_rule": (
                     "Evaluation and witness search are UNVERIFIED. Only an "
@@ -1559,6 +1629,132 @@ def _reference_domain_contract(
             },
         }
     raise ValueError(f"reference domain has no agent contract: {name}")
+
+
+def _reference_invocation_examples(name: str) -> list[dict[str, Any]]:
+    if name == "graph_paths":
+        return [
+            {
+                "capability_id": "reference.solve",
+                "mode": "VERIFY",
+                "payload": {
+                    "reference_name": "graph_paths",
+                    "predicate": {
+                        "name": "intended_paths_complete",
+                        "parameters": {"simple": True},
+                    },
+                    "candidate": {
+                        "vertices": ["s", "a", "b", "x", "t1", "t2"],
+                        "arcs": [
+                            ["s", "a"],
+                            ["a", "x"],
+                            ["s", "b"],
+                            ["b", "x"],
+                            ["x", "t1"],
+                            ["x", "t2"],
+                        ],
+                        "source": "s",
+                        "terminals": ["t1", "t2"],
+                        "intended_paths": [
+                            ["s", "a", "x", "t1"],
+                            ["s", "b", "x", "t2"],
+                        ],
+                    },
+                    "witness_role": "DEFEATS_CANDIDATE",
+                },
+            },
+            {
+                "capability_id": "reference.solve",
+                "mode": "VERIFY",
+                "payload": {
+                    "reference_name": "graph_paths",
+                    "predicate": {
+                        "name": "is_bipartite",
+                        "parameters": {},
+                    },
+                    "candidate": {
+                        "vertices": ["a", "b", "c", "d"],
+                        "arcs": [
+                            ["a", "b"],
+                            ["b", "c"],
+                            ["c", "d"],
+                            ["d", "a"],
+                        ],
+                    },
+                    "witness_role": "SUPPORTS_CLAIM",
+                },
+            },
+        ]
+    if name == "matrices":
+        return [
+            {
+                "capability_id": "reference.solve",
+                "mode": "VERIFY",
+                "payload": {
+                    "reference_name": "matrices",
+                    "predicate": {
+                        "name": "is_nonsingular",
+                        "parameters": {},
+                    },
+                    "candidate": {
+                        "rows": 2,
+                        "cols": 2,
+                        "entries": [["2", "4"], ["1", "2"]],
+                    },
+                    "witness_role": "DEFEATS_CANDIDATE",
+                },
+            },
+            {
+                "capability_id": "reference.solve",
+                "mode": "VERIFY",
+                "payload": {
+                    "reference_name": "matrices",
+                    "predicate": {
+                        "name": "maximize_absolute_determinant",
+                        "parameters": {
+                            "scope": {
+                                "rows": 3,
+                                "cols": 3,
+                                "entries": [-1, 1],
+                            }
+                        },
+                    },
+                    "candidate": {
+                        "rows": 3,
+                        "cols": 3,
+                        "entries": [
+                            [-1, -1, -1],
+                            [-1, -1, 1],
+                            [-1, 1, -1],
+                        ],
+                    },
+                    "witness_role": "SUPPORTS_CLAIM",
+                },
+            },
+        ]
+    if name == "erdos_straus":
+        return [
+            {
+                "capability_id": "reference.solve",
+                "mode": "VERIFY",
+                "payload": {
+                    "reference_name": "erdos_straus",
+                    "predicate": {
+                        "name": "erdos_straus_range",
+                        "parameters": {
+                            "lower_bound": 2,
+                            "upper_bound": 20,
+                        },
+                    },
+                    "candidate": {
+                        "lower_bound": 2,
+                        "upper_bound": 20,
+                    },
+                    "witness_role": "SUPPORTS_CLAIM",
+                },
+            }
+        ]
+    return []
 
 
 def _project_tool_profile(

--- a/src/jacobian/builtin_capabilities.py
+++ b/src/jacobian/builtin_capabilities.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from typing import Any
 
+from jacobian.capabilities import CapabilityInvocationError
 from jacobian.contracts.capabilities import (
     CapabilityAssurance,
     CapabilityAssuranceLevel,
     CapabilityDescriptor,
+    CapabilityDiagnostic,
     CapabilityMode,
     CapabilityRequest,
     CapabilityResult,
@@ -19,6 +21,7 @@ from jacobian.contracts.results import Execution, ExecutionStatus, Verification
 from jacobian.contracts.workflows import WitnessVerificationWorkflowResult
 from jacobian.lean import LeanService
 from jacobian.memory import ResearchMemory
+from jacobian.schema_registry import SchemaValidationError
 from jacobian.workflows import VerificationWorkflowService
 
 _OBJECT_SCHEMA: dict[str, Any] = {"type": "object"}
@@ -153,7 +156,19 @@ class ReferenceSolveAdapter:
         try:
             reference = self.workflows.references[reference_name]
         except KeyError as exc:
-            raise ValueError(f"unknown reference domain: {reference_name}") from exc
+            raise CapabilityInvocationError(
+                CapabilityDiagnostic(
+                    code="UNKNOWN_REFERENCE",
+                    stage="reference_resolution",
+                    message=f"Unknown reference domain: {reference_name}",
+                    path="reference_name",
+                    actual_type="string",
+                    hint=(
+                        "Call capability.describe for reference.solve without a "
+                        "reference_name to list installed domains."
+                    ),
+                )
+            ) from exc
         claim_payload = {
             "claim_schema_version": "1",
             "domain_id": reference.domain_id,
@@ -165,6 +180,20 @@ class ReferenceSolveAdapter:
             "required_capabilities": list(reference.available_capabilities),
             "correspondence_status": "UNREVIEWED",
         }
+        _validate_reference_payload(
+            self.workflows,
+            schema_uri=reference.claim_schema_uri,
+            payload=claim_payload,
+            code="INVALID_CLAIM",
+            stage="claim_validation",
+        )
+        _validate_reference_payload(
+            self.workflows,
+            schema_uri=reference.candidate_schema_uri,
+            payload=payload["candidate"],
+            code="INVALID_CANDIDATE",
+            stage="candidate_validation",
+        )
         arguments = {
             "reference_name": reference_name,
             "claim_payload": claim_payload,
@@ -299,6 +328,7 @@ def _reference_result(
             workflow.candidate_uri,
             evidence_uri,
             scope_uri,
+            verification_record_uri,
         )
         if uri is not None
     )
@@ -349,6 +379,43 @@ def _reference_result(
             "candidate_uri": workflow.candidate_uri,
             "evidence_uri": evidence_uri,
             "verification_record_uri": (verification_record_uri),
+            "artifacts": {
+                "claim": workflow.claim_uri,
+                "candidate": workflow.candidate_uri,
+                "evidence": evidence_uri,
+                "scope": scope_uri,
+                "verification_record": verification_record_uri,
+            },
+            "verification": (
+                {
+                    "arithmetic": verification.assurance.arithmetic.value,
+                    "method": verification.assurance.method.value,
+                    "coverage": verification.assurance.coverage.value,
+                    "checker_id": verification.assurance.checker_id,
+                    "checker_digest": verification.assurance.checker_digest,
+                    "scope_uri": verification.assurance.scope_uri,
+                }
+                if verification is not None
+                else None
+            ),
+            "stages": {
+                "claim_validation": workflow.claim_validation.execution.status.value,
+                "evaluation": (
+                    workflow.evaluation.execution.status.value
+                    if workflow.evaluation is not None
+                    else "NOT_RUN"
+                ),
+                "witness_search": (
+                    witness.result.execution.status.value
+                    if witness is not None
+                    else "NOT_RUN"
+                ),
+                "independent_verification": (
+                    verification.execution.status.value
+                    if verification is not None
+                    else "NOT_RUN"
+                ),
+            },
         },
         scope=_scope_from_claim(claim_payload),
         assurance=CapabilityAssurance(
@@ -374,5 +441,34 @@ def _scope_from_claim(claim: object) -> dict[str, Any]:
     return {
         key: claim[key]
         for key in ("domain_id", "domain_version", "predicate", "bounds")
-        if key in claim
+        if key in claim and claim[key] not in ({}, [], None)
     }
+
+
+def _validate_reference_payload(
+    workflows: VerificationWorkflowService,
+    *,
+    schema_uri: str,
+    payload: object,
+    code: str,
+    stage: str,
+) -> None:
+    try:
+        workflows.artifacts.schemas.validate(schema_uri, payload)
+    except SchemaValidationError as exc:
+        path, separator, message = str(exc).partition(": ")
+        raise CapabilityInvocationError(
+            CapabilityDiagnostic(
+                code=code,
+                stage=stage,
+                message=message if separator else str(exc),
+                path=path if separator else None,
+                schema_uri=schema_uri,
+                expected=f"payload conforming to {schema_uri}",
+                actual_type=type(payload).__name__,
+                hint=(
+                    "Call capability.describe with this reference_name and use the "
+                    "advertised domain schema and invocation example exactly."
+                ),
+            )
+        ) from exc

--- a/src/jacobian/builtin_capabilities.py
+++ b/src/jacobian/builtin_capabilities.py
@@ -268,10 +268,14 @@ class LeanCheckAdapter:
             execution=checked.result.execution,
             output={
                 "conclusion": checked.result.conclusion.value,
+                "execution": checked.result.execution.model_dump(mode="json"),
+                "input": checked.result.input.model_dump(mode="json"),
+                "diagnostics": list(checked.result.input.errors),
                 "claim_uri": checked.claim_uri,
                 "candidate_uri": checked.candidate_uri,
                 "certificate_uri": checked.certificate_uri,
                 "verification_record_uri": checked.result.verification_record_uri,
+                "cache_hit": checked.cache_hit,
             },
             assurance=CapabilityAssurance(
                 level=(
@@ -388,6 +392,13 @@ def _reference_result(
             },
             "verification": (
                 {
+                    "execution": verification.execution.model_dump(mode="json"),
+                    "input": verification.input.model_dump(mode="json"),
+                    "checker_detail": (
+                        verification.input.errors[0]
+                        if verification.input.errors
+                        else verification.execution.detail
+                    ),
                     "arithmetic": verification.assurance.arithmetic.value,
                     "method": verification.assurance.method.value,
                     "coverage": verification.assurance.coverage.value,

--- a/src/jacobian/capabilities.py
+++ b/src/jacobian/capabilities.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import importlib
+import logging
 import re
+import time
 from typing import TYPE_CHECKING, Protocol, cast
 
 from jsonschema import Draft202012Validator
@@ -15,6 +17,7 @@ from jacobian.contracts.capabilities import (
     CapabilityAssuranceLevel,
     CapabilityCatalog,
     CapabilityDescriptor,
+    CapabilityDiagnostic,
     CapabilityRequest,
     CapabilityResult,
 )
@@ -28,10 +31,19 @@ if TYPE_CHECKING:
     from jacobian.kernel import JacobianKernel
 
 _ENTRYPOINT_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_.]*:[A-Za-z_][A-Za-z0-9_]*$")
+_LOGGER = logging.getLogger(__name__)
 
 
 class CapabilityError(RuntimeError):
     """A capability descriptor, request, or assurance boundary is invalid."""
+
+
+class CapabilityInvocationError(RuntimeError):
+    """An expected adapter failure that is safe to return to a model."""
+
+    def __init__(self, diagnostic: CapabilityDiagnostic) -> None:
+        super().__init__(diagnostic.message)
+        self.diagnostic = diagnostic
 
 
 class CapabilityAdapter(Protocol):
@@ -69,6 +81,7 @@ class CapabilityService:
         )
 
     def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        started = time.monotonic()
         try:
             adapter = self._adapters[request.capability_id]
         except KeyError as exc:
@@ -80,22 +93,45 @@ class CapabilityService:
             raise CapabilityError(
                 f"{request.capability_id} does not support {request.mode.value}"
             )
-        normalized_input = _validate_payload(descriptor.input_schema, request.input)
+        try:
+            normalized_input = _validate_payload(descriptor.input_schema, request.input)
+        except CapabilityError as exc:
+            result = _failed_result(
+                descriptor=descriptor,
+                request=request,
+                diagnostic=CapabilityDiagnostic(
+                    code="INVALID_REQUEST",
+                    stage="capability_input_validation",
+                    message=str(exc),
+                    path=_error_path(exc),
+                    expected="input matching the capability descriptor JSON Schema",
+                    actual_type="object",
+                    hint="Call capability.describe and follow the advertised input schema.",
+                ),
+            )
+            _log_invocation(result, started)
+            return result
         normalized_request = request.model_copy(update={"input": normalized_input})
         try:
             result = CapabilityResult.model_validate(adapter.invoke(normalized_request))
+        except CapabilityInvocationError as exc:
+            result = _failed_result(
+                descriptor=descriptor,
+                request=request,
+                diagnostic=exc.diagnostic,
+            )
         except Exception as exc:
-            result = CapabilityResult(
-                capability_id=descriptor.capability_id,
-                capability_version=descriptor.version,
-                mode=request.mode,
-                execution=Execution(
-                    status=ExecutionStatus.ERROR,
-                    detail=f"capability adapter failed: {type(exc).__name__}",
-                ),
-                assurance=CapabilityAssurance(
-                    level=CapabilityAssuranceLevel.HEURISTIC,
-                    basis="adapter execution failed; no mathematical conclusion",
+            result = _failed_result(
+                descriptor=descriptor,
+                request=request,
+                diagnostic=CapabilityDiagnostic(
+                    code="ADAPTER_EXECUTION_FAILED",
+                    stage="adapter_execution",
+                    message=f"Capability adapter failed: {type(exc).__name__}",
+                    hint=(
+                        "Retry only if the service is healthy; this result carries "
+                        "no mathematical conclusion."
+                    ),
                 ),
             )
         if (
@@ -104,10 +140,16 @@ class CapabilityService:
             or result.mode is not request.mode
         ):
             raise CapabilityError("adapter result identity differs from its request")
-        normalized_output = _validate_payload(descriptor.output_schema, result.output)
-        result = result.model_copy(update={"output": normalized_output})
+        if result.execution.status is ExecutionStatus.COMPLETED:
+            normalized_output = _validate_payload(
+                descriptor.output_schema, result.output
+            )
+            result = result.model_copy(update={"output": normalized_output})
         self._validate_verified_result(result)
-        if descriptor.records_episode:
+        if (
+            descriptor.records_episode
+            and result.execution.status is ExecutionStatus.COMPLETED
+        ):
             episode_uri = self.memory.record(
                 ResearchEpisode(
                     capability_id=result.capability_id,
@@ -123,6 +165,7 @@ class CapabilityService:
                 )
             )
             result = result.model_copy(update={"episode_uri": episode_uri})
+        _log_invocation(result, started)
         return result
 
     def _validate_verified_result(self, result: CapabilityResult) -> None:
@@ -217,4 +260,65 @@ def _episode_summary(result: CapabilityResult) -> str:
         f"{result.capability_id} {result.mode.value.lower()} "
         f"{result.execution.status.value.lower()} "
         f"({result.assurance.level.value.lower()})"
+    )
+
+
+def _failed_result(
+    *,
+    descriptor: CapabilityDescriptor,
+    request: CapabilityRequest,
+    diagnostic: CapabilityDiagnostic,
+) -> CapabilityResult:
+    return CapabilityResult(
+        capability_id=descriptor.capability_id,
+        capability_version=descriptor.version,
+        mode=request.mode,
+        execution=Execution(
+            status=ExecutionStatus.ERROR,
+            detail=diagnostic.message,
+        ),
+        output={"error": diagnostic.model_dump(mode="json", exclude_none=True)},
+        diagnostics=(diagnostic,),
+        assurance=CapabilityAssurance(
+            level=CapabilityAssuranceLevel.HEURISTIC,
+            basis="execution or input failure; no mathematical conclusion",
+        ),
+    )
+
+
+def _error_path(exc: Exception) -> str | None:
+    path, separator, _ = str(exc).partition(": ")
+    return path if separator else None
+
+
+def _log_invocation(result: CapabilityResult, started: float) -> None:
+    elapsed_ms = round((time.monotonic() - started) * 1000)
+    diagnostic_codes = (
+        ",".join(diagnostic.code for diagnostic in result.diagnostics) or "-"
+    )
+    _LOGGER.info(
+        (
+            "capability invocation capability_id=%s version=%s mode=%s "
+            "status=%s assurance=%s elapsed_ms=%d diagnostics=%s episode=%s"
+        ),
+        result.capability_id,
+        result.capability_version,
+        result.mode.value,
+        result.execution.status.value,
+        result.assurance.level.value,
+        elapsed_ms,
+        diagnostic_codes,
+        result.episode_uri or "-",
+        extra={
+            "jacobian_capability_id": result.capability_id,
+            "jacobian_capability_version": result.capability_version,
+            "jacobian_mode": result.mode.value,
+            "jacobian_execution_status": result.execution.status.value,
+            "jacobian_assurance_level": result.assurance.level.value,
+            "jacobian_elapsed_ms": elapsed_ms,
+            "jacobian_diagnostic_codes": tuple(
+                diagnostic.code for diagnostic in result.diagnostics
+            ),
+            "jacobian_episode_uri": result.episode_uri,
+        },
     )

--- a/src/jacobian/contracts/capabilities.py
+++ b/src/jacobian/contracts/capabilities.py
@@ -98,6 +98,19 @@ class CapabilityAssurance(ContractModel):
         return self
 
 
+class CapabilityDiagnostic(ContractModel):
+    """Actionable, stage-aware failure information without a truth claim."""
+
+    code: str = Field(pattern=r"^[A-Z][A-Z0-9_]{2,63}$")
+    stage: str = Field(pattern=r"^[a-z][a-z0-9_]{1,63}$")
+    message: str = Field(min_length=1, max_length=1024)
+    path: str | None = Field(default=None, max_length=512)
+    schema_uri: ArtifactUri | None = None
+    expected: str | None = Field(default=None, max_length=1024)
+    actual_type: str | None = Field(default=None, max_length=128)
+    hint: str | None = Field(default=None, max_length=1024)
+
+
 class CapabilityResult(ContractModel):
     """Compact result shared by local, MCP, and remote capability adapters."""
 
@@ -108,6 +121,7 @@ class CapabilityResult(ContractModel):
     execution: Execution
     output: dict[str, Any] = Field(default_factory=dict)
     scope: dict[str, Any] = Field(default_factory=dict)
+    diagnostics: tuple[CapabilityDiagnostic, ...] = ()
     assurance: CapabilityAssurance
     artifact_uris: tuple[ArtifactUri, ...] = ()
     episode_uri: ArtifactUri | None = None
@@ -116,6 +130,8 @@ class CapabilityResult(ContractModel):
     def enforce_lane_and_canonical_output(self) -> Self:
         canonicalize_json(self.output)
         canonicalize_json(self.scope)
+        if self.execution.status.value == "COMPLETED" and self.diagnostics:
+            raise ValueError("completed capability execution cannot carry diagnostics")
         if (
             self.assurance.level is CapabilityAssuranceLevel.VERIFIED
             and self.mode is not CapabilityMode.VERIFY

--- a/src/jacobian/contracts/lean.py
+++ b/src/jacobian/contracts/lean.py
@@ -35,3 +35,4 @@ class LeanVerifyResult(ContractModel):
     candidate_uri: ArtifactUri
     certificate_uri: ArtifactUri
     result: ResultEnvelope
+    cache_hit: bool = False

--- a/src/jacobian/lean.py
+++ b/src/jacobian/lean.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 import hashlib
+import logging
+import threading
+import weakref
+from collections import OrderedDict
 
 from jacobian.artifacts import ArtifactService
 from jacobian.canonical import canonicalize_json
@@ -13,9 +17,15 @@ from jacobian.contracts.lean import (
     LeanEnvironment,
     LeanVerifyResult,
 )
+from jacobian.contracts.results import Execution, ExecutionStatus, ResultEnvelope
+from jacobian.contracts.verification import VerificationRecord
 from jacobian.references import LeanCheckerInstallation
-from jacobian.store import ArtifactStore
+from jacobian.registry import CheckerRegistryError
+from jacobian.store import ArtifactStore, StoreError
 from jacobian.verification import VerificationService
+
+_LOGGER = logging.getLogger(__name__)
+_RESULT_CACHE_SIZE = 128
 
 
 class LeanService:
@@ -32,6 +42,12 @@ class LeanService:
         self.artifacts = artifacts
         self.verification = verification
         self.installations = installations
+        self._cache: OrderedDict[str, tuple[str, ResultEnvelope]] = OrderedDict()
+        self._cache_lock = threading.Lock()
+        self._certificate_locks: weakref.WeakValueDictionary[str, threading.Lock] = (
+            weakref.WeakValueDictionary()
+        )
+        self._warmup_started = False
 
     def verify(
         self,
@@ -101,13 +117,116 @@ class LeanService:
             parents=(claim.artifact_uri, candidate.artifact_uri),
             summary=f"{environment.value} Lean proof certificate",
         )
-        result = self.verification.verify_certificate(
-            certificate_uri=certificate.artifact_uri,
-            timeout_seconds=installation.checker_timeout_seconds,
-        )
+        with self._cache_lock:
+            certificate_lock = self._certificate_locks.setdefault(
+                certificate.artifact_uri,
+                threading.Lock(),
+            )
+        with certificate_lock:
+            result = self._cached_result(
+                certificate_uri=certificate.artifact_uri,
+                installation=installation,
+            )
+            cache_hit = result is not None
+            if result is None:
+                result = self.verification.verify_certificate(
+                    certificate_uri=certificate.artifact_uri,
+                    checker_id=installation.checker_id,
+                    timeout_seconds=installation.checker_timeout_seconds,
+                )
+                if result.execution.status is ExecutionStatus.COMPLETED:
+                    try:
+                        registration = (
+                            self.verification.checker_registry.require_active(
+                                installation.checker_id
+                            )
+                        )
+                    except CheckerRegistryError:
+                        pass
+                    else:
+                        with self._cache_lock:
+                            self._cache[certificate.artifact_uri] = (
+                                registration.executable_digest,
+                                result,
+                            )
+                            self._cache.move_to_end(certificate.artifact_uri)
+                            while len(self._cache) > _RESULT_CACHE_SIZE:
+                                self._cache.popitem(last=False)
         return LeanVerifyResult(
             claim_uri=claim.artifact_uri,
             candidate_uri=candidate.artifact_uri,
             certificate_uri=certificate.artifact_uri,
             result=result,
+            cache_hit=cache_hit,
+        )
+
+    def start_mathlib_warmup(self) -> bool:
+        """Warm the pinned Mathlib runtime once without delaying server startup."""
+
+        with self._cache_lock:
+            if self._warmup_started:
+                return False
+            self._warmup_started = True
+        thread = threading.Thread(
+            target=self._warm_mathlib,
+            name="jacobian-lean-mathlib-warmup",
+            daemon=True,
+        )
+        thread.start()
+        return True
+
+    def _warm_mathlib(self) -> None:
+        try:
+            self.verify(
+                statement="1 + 1 = 2",
+                proof="rfl",
+                environment=LeanEnvironment.MATHLIB,
+            )
+        except Exception:
+            _LOGGER.exception("Lean Mathlib warm-up failed")
+
+    def _cached_result(
+        self,
+        *,
+        certificate_uri: str,
+        installation: LeanCheckerInstallation,
+    ) -> ResultEnvelope | None:
+        with self._cache_lock:
+            cached = self._cache.get(certificate_uri)
+            if cached is not None:
+                self._cache.move_to_end(certificate_uri)
+        if cached is None:
+            return None
+        checker_digest, result = cached
+        try:
+            registration = self.verification.checker_registry.require_active(
+                installation.checker_id
+            )
+            if registration.executable_digest != checker_digest:
+                return None
+            certificate_artifact = self.store.get(certificate_uri)
+            certificate = CertificateEnvelope.model_validate(
+                certificate_artifact.payload
+            )
+            if result.verification_record_uri is not None:
+                record = VerificationRecord.model_validate(
+                    self.store.get(result.verification_record_uri).payload
+                )
+                if (
+                    record.checker_id != installation.checker_id
+                    or record.checker_digest != checker_digest
+                    or record.evidence_uri != certificate_uri
+                    or record.bindings != certificate.bindings
+                ):
+                    return None
+        except (CheckerRegistryError, StoreError, ValueError):
+            return None
+        return result.model_copy(
+            update={
+                "execution": Execution(
+                    status=ExecutionStatus.COMPLETED,
+                    runtime_ms=0,
+                    detail="reused exact certificate result from active-checker cache",
+                )
+            }
         )

--- a/src/jacobian/plugins/matrices.py
+++ b/src/jacobian/plugins/matrices.py
@@ -17,6 +17,8 @@ from copy import deepcopy
 from fractions import Fraction
 from typing import Any, cast
 
+MAX_SEARCHED_MATRICES = 65_536
+
 # ---------------------------------------------------------------------------
 # Canonical helpers
 # ---------------------------------------------------------------------------
@@ -605,6 +607,14 @@ def find_witness(request: dict[str, Any]) -> dict[str, Any]:
         scope_errors = _validate_scope(scope)
         if scope_errors:
             return _rejected(scope_errors, start)
+        if _scope_total(scope) > MAX_SEARCHED_MATRICES:
+            return _rejected(
+                [
+                    "scope exceeds witness search limit of "
+                    f"{MAX_SEARCHED_MATRICES} candidates"
+                ],
+                start,
+            )
 
         best_value = Fraction(-1)
         best_index = -1

--- a/src/jacobian/verification.py
+++ b/src/jacobian/verification.py
@@ -353,6 +353,7 @@ class VerificationService:
                 execution=Execution(
                     status=ExecutionStatus.COMPLETED,
                     runtime_ms=runtime_ms,
+                    detail=decision.detail,
                 ),
                 input=InputValidation(status=InputStatus.ACCEPTED),
                 conclusion=decision.conclusion,
@@ -555,6 +556,7 @@ class VerificationService:
                 execution=Execution(
                     status=ExecutionStatus.COMPLETED,
                     runtime_ms=runtime_ms,
+                    detail=decision.detail,
                 ),
                 input=InputValidation(status=InputStatus.ACCEPTED),
                 conclusion=decision.conclusion,

--- a/src/jacobian_checkers/matrices.py
+++ b/src/jacobian_checkers/matrices.py
@@ -8,7 +8,7 @@ from fractions import Fraction
 from typing import Any
 
 _INTEGER = re.compile(r"^-?(?:0|[1-9][0-9]*)$")
-_MAX_ENUMERATED_MATRICES = 4096
+MAX_ENUMERATED_MATRICES = 65_536
 
 
 def _reject(
@@ -204,7 +204,7 @@ def check_maximizer_witness(request: dict[str, Any]) -> dict[str, Any]:
                 method="EXHAUSTIVE_FINITE",
             )
         total = len(values) ** (rows * cols)
-        if total > _MAX_ENUMERATED_MATRICES:
+        if total > MAX_ENUMERATED_MATRICES:
             return _reject(
                 "scope exceeds the independent checker limit",
                 method="EXHAUSTIVE_FINITE",
@@ -218,9 +218,14 @@ def check_maximizer_witness(request: dict[str, Any]) -> dict[str, Any]:
             )
         proposed = _parse_matrix(inner.get("matrix"))
         candidate = _parse_matrix(request["candidate"]["payload"])
-        if candidate != proposed:
+        if len(candidate) != rows or len(candidate[0]) != cols:
             return _reject(
-                "proposed maximizer is not the bound candidate",
+                "candidate dimensions do not match scope",
+                method="EXHAUSTIVE_FINITE",
+            )
+        if any(entry not in values for row in candidate for entry in row):
+            return _reject(
+                "candidate entry is outside scope",
                 method="EXHAUSTIVE_FINITE",
             )
         if len(proposed) != rows or len(proposed[0]) != cols:
@@ -247,9 +252,14 @@ def check_maximizer_witness(request: dict[str, Any]) -> dict[str, Any]:
             ]
             maximum = max(maximum, abs(_determinant(matrix)))
         proposed_value = abs(_determinant(proposed))
-        if proposed_value != maximum or declared != maximum:
+        candidate_value = abs(_determinant(candidate))
+        if (
+            proposed_value != maximum
+            or candidate_value != maximum
+            or declared != maximum
+        ):
             return _reject(
-                "proposed matrix is not a scoped maximizer",
+                "proposed matrix or bound candidate is not a scoped maximizer",
                 method="EXHAUSTIVE_FINITE",
             )
         return {
@@ -317,7 +327,7 @@ def check_maxdet_enumeration(request: dict[str, Any]) -> dict[str, Any]:
                 method="EXHAUSTIVE_FINITE",
             )
         total = len(values) ** (rows * cols)
-        if total > _MAX_ENUMERATED_MATRICES:
+        if total > MAX_ENUMERATED_MATRICES:
             return _reject(
                 "scope exceeds the independent checker limit",
                 method="EXHAUSTIVE_FINITE",

--- a/tests/checkers/test_matrix_checkers.py
+++ b/tests/checkers/test_matrix_checkers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from jacobian_checkers import matrices as matrix_checkers
 from jacobian_checkers.matrices import (
     check_kernel_vector,
     check_maxdet_enumeration,
@@ -152,7 +153,35 @@ def test_maximizer_witness_checker_replays_scope() -> None:
 
 
 @pytest.mark.contract
-def test_maximizer_witness_checker_rejects_different_bound_candidate() -> None:
+def test_maximizer_witness_checker_accepts_an_alternative_bound_maximizer() -> None:
+    bindings = _bindings()
+    proposed = {
+        "rows": 3,
+        "cols": 3,
+        "entries": [[1, 1, 0], [1, 0, 1], [0, 1, 1]],
+    }
+    alternative = {
+        "rows": 3,
+        "cols": 3,
+        "entries": [[1, 0, 1], [0, 1, 1], [1, 1, 0]],
+    }
+
+    decision = check_maximizer_witness(
+        _maximizer_request(
+            scope={"rows": 3, "cols": 3, "entries": [0, 1]},
+            candidate=alternative,
+            proposed=proposed,
+            objective_value=2,
+            bindings=bindings,
+        )
+    )
+
+    assert decision["accepted"] is True
+    assert decision["conclusion"] == "TRUE"
+
+
+@pytest.mark.contract
+def test_maximizer_witness_checker_rejects_nonmaximal_bound_candidate() -> None:
     bindings = {
         "claim_digest": "sha256:" + "a" * 64,
         "semantics_digest": "sha256:" + "b" * 64,
@@ -203,6 +232,106 @@ def test_maximizer_witness_checker_rejects_different_bound_candidate() -> None:
     )
 
     assert decision["accepted"] is False
+
+
+@pytest.mark.contract
+def test_maximizer_witness_checker_replays_all_65536_matrices() -> None:
+    matrix = {
+        "rows": 4,
+        "cols": 4,
+        "entries": [
+            [1, 1, 1, 1],
+            [1, -1, 1, -1],
+            [1, 1, -1, -1],
+            [1, -1, -1, 1],
+        ],
+    }
+
+    decision = check_maximizer_witness(
+        _maximizer_request(
+            scope={"rows": 4, "cols": 4, "entries": [-1, 1]},
+            candidate=matrix,
+            proposed=matrix,
+            objective_value=16,
+            bindings=_bindings(),
+        )
+    )
+
+    assert decision["accepted"] is True
+    assert decision["detail"] == "replayed all 65536 matrices in the declared scope"
+
+
+@pytest.mark.contract
+def test_maximizer_witness_checker_rejects_over_budget_before_enumeration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unexpected_determinant(_: list[list[int]]) -> int:
+        raise AssertionError("over-budget scope must not be enumerated")
+
+    monkeypatch.setattr(matrix_checkers, "_determinant", unexpected_determinant)
+    matrix = {
+        "rows": 5,
+        "cols": 5,
+        "entries": [[1] * 5 for _ in range(5)],
+    }
+
+    decision = check_maximizer_witness(
+        _maximizer_request(
+            scope={"rows": 5, "cols": 5, "entries": [-1, 1]},
+            candidate=matrix,
+            proposed=matrix,
+            objective_value=0,
+            bindings=_bindings(),
+        )
+    )
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+    assert decision["detail"] == "scope exceeds the independent checker limit"
+
+
+def _bindings() -> dict[str, object]:
+    return {
+        "claim_digest": "sha256:" + "a" * 64,
+        "semantics_digest": "sha256:" + "b" * 64,
+        "candidate_digest": "sha256:" + "c" * 64,
+        "scope_digest": None,
+        "encoding_digest": None,
+    }
+
+
+def _maximizer_request(
+    *,
+    scope: dict[str, object],
+    candidate: dict[str, object],
+    proposed: dict[str, object],
+    objective_value: int,
+    bindings: dict[str, object],
+) -> dict[str, object]:
+    return {
+        "request_version": "1",
+        "claim": {
+            "payload": {
+                "predicate": "maximize_absolute_determinant",
+                "scope": scope,
+            }
+        },
+        "candidate": {"payload": candidate},
+        "witness": {
+            "payload": {
+                "witness_format": "matrix.maximizer",
+                "format_version": "1",
+                "role": "SUPPORTS_CLAIM",
+                "bindings": bindings,
+                "payload": {
+                    "matrix": proposed,
+                    "objective_value": {"num": str(objective_value), "den": "1"},
+                    "index": 0,
+                },
+            }
+        },
+        "expected_bindings": bindings,
+    }
 
 
 def _witness_request(

--- a/tests/integration/test_agent_benchmark.py
+++ b/tests/integration/test_agent_benchmark.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 import json
 import runpy
+import shutil
 from pathlib import Path
 from typing import Any, cast
+
+import pytest
 
 from jacobian.contracts.evidence import WitnessRole
 from jacobian.kernel import JacobianKernel
@@ -226,6 +229,11 @@ def test_known_answer_scorer_accepts_verified_positive_witness(
     assert score["passed"] is True
 
 
+@pytest.mark.integration
+@pytest.mark.skipif(
+    shutil.which("lean") is None,
+    reason="Lean is not installed",
+)
 def test_known_answer_scorer_accepts_bound_lean_certificate(
     tmp_path: Path,
 ) -> None:

--- a/tests/integration/test_capability_service.py
+++ b/tests/integration/test_capability_service.py
@@ -251,10 +251,78 @@ def test_reference_capability_has_distinct_explore_and_verify_lanes(
     assert explored.output["verification_record_uri"] is None
     assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED
     assert verified.assurance.verification_record_uri is not None
+    assert verified.assurance.verification_record_uri in verified.artifact_uris
+    assert verified.output["artifacts"]["verification_record"] == (
+        verified.assurance.verification_record_uri
+    )
+    assert verified.output["verification"]["checker_id"].startswith("checker://sha256/")
+    assert verified.output["verification"]["arithmetic"] == "EXACT_INTEGER"
+    assert verified.output["stages"]["independent_verification"] == "COMPLETED"
+    assert "bounds" not in verified.scope
     assert {hit.assurance_level for hit in kernel.memory.search(limit=10).hits} >= {
         CapabilityAssuranceLevel.HEURISTIC,
         CapabilityAssuranceLevel.VERIFIED,
     }
+
+
+@pytest.mark.integration
+def test_invalid_reference_candidate_is_actionable_and_not_remembered(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+
+    result = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="reference.solve",
+            mode=CapabilityMode.VERIFY,
+            input={
+                "reference_name": "erdos_straus",
+                "predicate": {
+                    "name": "erdos_straus_range",
+                    "parameters": {"lower_bound": 2, "upper_bound": 20},
+                },
+                "candidate": {"minimum": 2, "maximum": 20},
+                "witness_role": "SUPPORTS_CLAIM",
+            },
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.assurance.level is CapabilityAssuranceLevel.HEURISTIC
+    assert result.assurance.verification_record_uri is None
+    assert result.episode_uri is None
+    assert result.diagnostics[0].code == "INVALID_CANDIDATE"
+    assert result.diagnostics[0].stage == "candidate_validation"
+    assert result.diagnostics[0].path == "$"
+    assert result.diagnostics[0].schema_uri is not None
+    assert "capability.describe" in result.diagnostics[0].hint
+    assert result.output["error"]["code"] == "INVALID_CANDIDATE"
+    assert kernel.memory.search(limit=10).hits == ()
+
+
+@pytest.mark.integration
+def test_unknown_reference_error_is_classified_and_not_remembered(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+
+    result = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="reference.solve",
+            input={
+                "reference_name": "not-installed",
+                "predicate": {"name": "anything", "parameters": {}},
+                "candidate": {},
+                "witness_role": "SUPPORTS_CLAIM",
+            },
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.diagnostics[0].code == "UNKNOWN_REFERENCE"
+    assert result.diagnostics[0].stage == "reference_resolution"
+    assert result.episode_uri is None
+    assert kernel.memory.search(limit=10).hits == ()
 
 
 @pytest.mark.integration

--- a/tests/integration/test_capability_service.py
+++ b/tests/integration/test_capability_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -14,7 +15,15 @@ from jacobian.contracts.capabilities import (
     CapabilityRequest,
     CapabilityResult,
 )
-from jacobian.contracts.results import Execution, ExecutionStatus
+from jacobian.contracts.checkers import CheckerDecision
+from jacobian.contracts.results import (
+    Arithmetic,
+    Conclusion,
+    Coverage,
+    Execution,
+    ExecutionStatus,
+    Method,
+)
 from jacobian.kernel import JacobianKernel
 
 
@@ -257,6 +266,15 @@ def test_reference_capability_has_distinct_explore_and_verify_lanes(
     )
     assert verified.output["verification"]["checker_id"].startswith("checker://sha256/")
     assert verified.output["verification"]["arithmetic"] == "EXACT_INTEGER"
+    assert verified.output["verification"]["input"] == {
+        "status": "ACCEPTED",
+        "errors": [],
+        "warnings": [],
+    }
+    assert (
+        "checked exact three-unit-fraction decompositions"
+        in (verified.output["verification"]["checker_detail"])
+    )
     assert verified.output["stages"]["independent_verification"] == "COMPLETED"
     assert "bounds" not in verified.scope
     assert {hit.assurance_level for hit in kernel.memory.search(limit=10).hits} >= {
@@ -344,3 +362,114 @@ def test_lean_capability_returns_bound_verified_result(tmp_path: Path) -> None:
     assert result.assurance.level is CapabilityAssuranceLevel.VERIFIED
     assert result.assurance.verification_record_uri is not None
     assert result.output["conclusion"] == "TRUE"
+
+
+@pytest.mark.integration
+def test_reference_capability_projects_checker_rejection_detail(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+    monkeypatch.setattr(
+        kernel.verification,
+        "_run_checker",
+        lambda **_: CheckerDecision(
+            accepted=False,
+            conclusion=Conclusion.UNKNOWN,
+            arithmetic=Arithmetic.EXACT_INTEGER,
+            method=Method.EXHAUSTIVE_FINITE,
+            coverage=Coverage.EXHAUSTIVE,
+            detail="candidate is not globally maximal",
+        ),
+    )
+
+    result = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="reference.solve",
+            mode=CapabilityMode.VERIFY,
+            input={
+                "reference_name": "matrices",
+                "predicate": {
+                    "name": "maximize_absolute_determinant",
+                    "parameters": {"scope": {"rows": 2, "cols": 2, "entries": [-1, 1]}},
+                },
+                "candidate": {
+                    "rows": 2,
+                    "cols": 2,
+                    "entries": [[1, 1], [1, -1]],
+                },
+                "witness_role": "SUPPORTS_CLAIM",
+            },
+        )
+    )
+
+    assert result.assurance.level is CapabilityAssuranceLevel.HEURISTIC
+    assert result.output["verification"]["input"]["status"] == "REJECTED"
+    assert result.output["verification"]["input"]["errors"] == [
+        "candidate is not globally maximal"
+    ]
+    assert (
+        result.output["verification"]["checker_detail"]
+        == "candidate is not globally maximal"
+    )
+
+
+@pytest.mark.integration
+def test_reference_checker_timeout_is_projected_and_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+
+    def time_out(**_: object) -> CheckerDecision:
+        raise subprocess.TimeoutExpired(cmd=["checker"], timeout=1)
+
+    monkeypatch.setattr(kernel.verification, "_run_checker", time_out)
+    result = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="reference.solve",
+            mode=CapabilityMode.VERIFY,
+            input={
+                "reference_name": "matrices",
+                "predicate": {
+                    "name": "maximize_absolute_determinant",
+                    "parameters": {"scope": {"rows": 2, "cols": 2, "entries": [-1, 1]}},
+                },
+                "candidate": {
+                    "rows": 2,
+                    "cols": 2,
+                    "entries": [[1, 1], [1, -1]],
+                },
+                "witness_role": "SUPPORTS_CLAIM",
+            },
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.TIMEOUT
+    assert result.output["conclusion"] == "UNKNOWN"
+    assert result.output["verification"]["execution"]["detail"] == "checker timed out"
+    assert result.assurance.verification_record_uri is None
+
+
+@pytest.mark.integration
+def test_lean_capability_projects_repairable_checker_diagnostics(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+
+    result = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="lean.check",
+            mode=CapabilityMode.VERIFY,
+            input={
+                "statement": "1 + 1 = 2",
+                "proof": "sorry",
+                "environment": "CORE",
+            },
+        )
+    )
+
+    assert result.output["input"]["status"] == "REJECTED"
+    assert "forbidden Lean command" in result.output["input"]["errors"][0]
+    assert result.output["diagnostics"] == result.output["input"]["errors"]
+    assert result.assurance.verification_record_uri is None

--- a/tests/integration/test_capability_service.py
+++ b/tests/integration/test_capability_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shutil
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
@@ -344,6 +345,10 @@ def test_unknown_reference_error_is_classified_and_not_remembered(
 
 
 @pytest.mark.integration
+@pytest.mark.skipif(
+    shutil.which("lean") is None,
+    reason="Lean is not installed",
+)
 def test_lean_capability_returns_bound_verified_result(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path, install_references=True)
 

--- a/tests/integration/test_lean.py
+++ b/tests/integration/test_lean.py
@@ -3,13 +3,22 @@ from __future__ import annotations
 import asyncio
 import json
 import shutil
+import threading
 from pathlib import Path
 
 import pytest
 
 from jacobian.adapters.mcp.server import ToolProfile, create_server
+from jacobian.contracts.checkers import CheckerDecision
 from jacobian.contracts.lean import LeanEnvironment
-from jacobian.contracts.results import Conclusion, InputStatus, Verification
+from jacobian.contracts.results import (
+    Arithmetic,
+    Conclusion,
+    Coverage,
+    InputStatus,
+    Method,
+    Verification,
+)
 from jacobian.kernel import JacobianKernel
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
@@ -147,3 +156,84 @@ def test_core_lean_rejects_untrusted_or_invalid_proofs(
     assert rejected.result.conclusion is Conclusion.UNKNOWN
     assert rejected.result.assurance.verification is Verification.UNVERIFIED
     assert rejected.result.verification_record_uri is None
+
+
+def test_lean_reuses_only_an_exact_active_checker_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+    assert kernel.lean is not None
+    calls = 0
+
+    def accept(**_: object) -> CheckerDecision:
+        nonlocal calls
+        calls += 1
+        return CheckerDecision(
+            accepted=True,
+            conclusion=Conclusion.TRUE,
+            arithmetic=Arithmetic.SYMBOLIC,
+            method=Method.CHECKED_CERTIFICATE,
+            coverage=Coverage.NOT_APPLICABLE,
+            detail="accepted by test checker",
+        )
+
+    def unexpected_selector(**_: object) -> object:
+        raise AssertionError("Lean must use its explicitly installed checker")
+
+    monkeypatch.setattr(kernel.verification, "_run_checker", accept)
+    monkeypatch.setattr(kernel.checkers, "select_compatible", unexpected_selector)
+    first = kernel.lean.verify(statement="1 + 1 = 2", proof="rfl")
+    repeated = kernel.lean.verify(statement="1 + 1 = 2", proof="rfl")
+    changed = kernel.lean.verify(statement="2 + 2 = 4", proof="rfl")
+
+    assert calls == 2
+    assert first.cache_hit is False
+    assert repeated.cache_hit is True
+    assert repeated.result.verification_record_uri == (
+        first.result.verification_record_uri
+    )
+    assert changed.cache_hit is False
+
+
+def test_lean_cache_does_not_reuse_a_revoked_checker_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+    assert kernel.lean is not None
+    monkeypatch.setattr(
+        kernel.verification,
+        "_run_checker",
+        lambda **_: CheckerDecision(
+            accepted=True,
+            conclusion=Conclusion.TRUE,
+            arithmetic=Arithmetic.SYMBOLIC,
+            method=Method.CHECKED_CERTIFICATE,
+            coverage=Coverage.NOT_APPLICABLE,
+            detail="accepted by test checker",
+        ),
+    )
+    first = kernel.lean.verify(statement="1 + 1 = 2", proof="rfl")
+    checker_id = kernel.lean_checkers[LeanEnvironment.CORE].checker_id
+    kernel.checkers.revoke(checker_id, reason="cache trust-boundary test")
+
+    repeated = kernel.lean.verify(statement="1 + 1 = 2", proof="rfl")
+
+    assert first.result.assurance.verification is Verification.VERIFIED
+    assert repeated.cache_hit is False
+    assert repeated.result.assurance.verification is Verification.UNVERIFIED
+
+
+def test_mathlib_warmup_starts_only_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+    assert kernel.lean is not None
+    warmed = threading.Event()
+    monkeypatch.setattr(kernel.lean, "_warm_mathlib", warmed.set)
+
+    assert kernel.lean.start_mathlib_warmup() is True
+    assert warmed.wait(timeout=2)
+    assert kernel.lean.start_mathlib_warmup() is False

--- a/tests/integration/test_mcp_adapter.py
+++ b/tests/integration/test_mcp_adapter.py
@@ -300,6 +300,42 @@ def test_mcp_capability_profile_describes_and_invokes_exact_domain_contract(
                 item["payload"]["predicate"]["name"]
                 for item in graph_contract["invocation_examples"]
             } == set(graph_contract["claim_contract"]["predicates"])
+            matrix_description = await client.call_tool(
+                "capability.describe",
+                {
+                    "capability_id": "reference.solve",
+                    "reference_name": "matrices",
+                },
+            )
+            matrix_contract = json.loads(matrix_description.content[0].text)["domain"]
+            matrix_limit = matrix_contract["verification_limits"][
+                "maximize_absolute_determinant"
+            ]
+            assert matrix_limit["max_enumerated_candidates"] == 65536
+            assert matrix_limit["scope_cardinality"] == (
+                "len(entries) ** (rows * cols)"
+            )
+            assert matrix_limit["on_excess"] == "REJECTED_WITHOUT_CONCLUSION"
+            lean_description = await client.call_tool(
+                "capability.describe",
+                {"capability_id": "lean.check"},
+            )
+            lean_contract = json.loads(lean_description.content[0].text)
+            assert (
+                lean_contract["runtime"]["profiles"]["CORE"]["checker_timeout_seconds"]
+                == 30
+            )
+            assert (
+                lean_contract["runtime"]["profiles"]["MATHLIB"][
+                    "checker_timeout_seconds"
+                ]
+                == 105
+            )
+            assert lean_contract["cache"]["max_entries"] == 128
+            assert (
+                lean_contract["cache"]["warmup_environment_variable"]
+                == "JACOBIAN_LEAN_WARMUP=1"
+            )
 
             invoked = await client.call_tool(
                 "capability.invoke",

--- a/tests/integration/test_mcp_adapter.py
+++ b/tests/integration/test_mcp_adapter.py
@@ -39,6 +39,7 @@ def test_mcp_exposes_v02_tool_surface_and_persistent_resources(
             listed = await client.list_tools()
             tools = {tool.name: tool for tool in listed.tools}
             assert set(tools) == {
+                "capability.describe",
                 "capability.invoke",
                 "artifact.put",
                 "claim.validate",
@@ -240,7 +241,7 @@ def test_mcp_exposes_v02_tool_surface_and_persistent_resources(
 
 
 @pytest.mark.integration
-def test_mcp_capability_profile_has_one_extensible_tool_and_catalog(
+def test_mcp_capability_profile_describes_and_invokes_exact_domain_contract(
     tmp_path: Path,
 ) -> None:
     async def scenario() -> None:
@@ -252,7 +253,10 @@ def test_mcp_capability_profile_has_one_extensible_tool_and_catalog(
         ) as client:
             listed = await client.list_tools()
             assert {tool.name for tool in listed.tools} == CAPABILITY_TOOL_NAMES
-            assert listed.tools[0].output_schema is None
+            assert all(tool.output_schema is None for tool in listed.tools)
+            tools = {tool.name: tool for tool in listed.tools}
+            assert tools["capability.describe"].annotations is not None
+            assert tools["capability.describe"].annotations.read_only_hint is True
 
             resource = await client.read_resource("capability://catalog")
             catalog = json.loads(resource.contents[0].text)
@@ -265,6 +269,38 @@ def test_mcp_capability_profile_has_one_extensible_tool_and_catalog(
                 "reference.solve",
             }
 
+            described = await client.call_tool(
+                "capability.describe",
+                {
+                    "capability_id": "reference.solve",
+                    "reference_name": "erdos_straus",
+                },
+            )
+            contract = json.loads(described.content[0].text)
+            assert contract["capability"]["capability_id"] == "reference.solve"
+            assert set(contract["domain"]["claim_contract"]["predicates"]) == {
+                "erdos_straus_range"
+            }
+            example = contract["domain"]["invocation_examples"][0]
+            assert example["capability_id"] == "reference.solve"
+            assert example["mode"] == "VERIFY"
+            assert example["payload"]["candidate"] == {
+                "lower_bound": 2,
+                "upper_bound": 20,
+            }
+            graph_description = await client.call_tool(
+                "capability.describe",
+                {
+                    "capability_id": "reference.solve",
+                    "reference_name": "graph_paths",
+                },
+            )
+            graph_contract = json.loads(graph_description.content[0].text)["domain"]
+            assert {
+                item["payload"]["predicate"]["name"]
+                for item in graph_contract["invocation_examples"]
+            } == set(graph_contract["claim_contract"]["predicates"])
+
             invoked = await client.call_tool(
                 "capability.invoke",
                 {
@@ -276,6 +312,11 @@ def test_mcp_capability_profile_has_one_extensible_tool_and_catalog(
             projection = json.loads(invoked.content[0].text)
             assert projection["assurance"]["level"] == "COMPUTED"
             assert projection["output"]["hits"] == []
+
+            verified = await client.call_tool("capability.invoke", example)
+            verification = json.loads(verified.content[0].text)
+            assert verification["execution"]["status"] == "COMPLETED"
+            assert verification["assurance"]["level"] == "VERIFIED"
 
     asyncio.run(scenario())
 

--- a/tests/reference/test_matrix_plugin.py
+++ b/tests/reference/test_matrix_plugin.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from fractions import Fraction
 from typing import Any
 
+import pytest
+
+from jacobian.plugins import matrices as matrix_plugin
 from jacobian.plugins.matrices import (
     evaluate,
     find_witness,
@@ -186,6 +189,26 @@ def test_find_witness_maxdet_requires_supporting_role() -> None:
     )
 
     assert resp["input"]["status"] == "REJECTED"
+
+
+def test_find_witness_maxdet_rejects_over_budget_before_search(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unexpected_iterator(_: dict[str, object]) -> object:
+        raise AssertionError("over-budget scope must not be enumerated")
+
+    monkeypatch.setattr(matrix_plugin, "_scope_iterator", unexpected_iterator)
+    claim = {
+        "predicate": "maximize_absolute_determinant",
+        "scope": {"rows": 5, "cols": 5, "entries": [-1, 1]},
+    }
+
+    response = find_witness({"claim": claim, "witness_role": "SUPPORTS_CLAIM"})
+
+    assert response["input"]["status"] == "REJECTED"
+    assert response["input"]["errors"] == [
+        "scope exceeds witness search limit of 65536 candidates"
+    ]
 
 
 def test_materialize_maxdet_scope_count() -> None:


### PR DESCRIPTION
## Problem

Agents using the compact MCP capability surface lacked exact domain schemas, checker limits, and actionable verification diagnostics. Matrix maximizer verification also depended on the searcher's first enumerated optimum, and repeated Mathlib checks paid the full cold-start cost.

## Changes

- add capability-first discovery with exact reference-domain contracts and invocation examples
- expose Matrix checker cardinality limits and Lean runtime/cache policy through `capability.describe`
- project verification input errors, execution details, checker feedback, and Lean diagnostics to agents
- accept any bound Matrix candidate that independently reaches the global maximum
- raise exhaustive Matrix verification to 65,536 candidates with pre-enumeration search/checker budget gates
- add exact-certificate Lean result caching bound to the active checker digest, bounded LRU storage, per-certificate synchronization, and optional Mathlib warm-up
- explicitly select the installed Lean checker so stale historical registrations cannot disrupt current verification
- document remote Mathlib warm-up configuration

## Normative impact

The Matrix maximizer checker now accepts mathematically equivalent optimal candidates instead of requiring identity with the search witness. Its exhaustive scope limit increases from 4,096 to 65,536 candidates. Over-limit scopes, checker timeouts, rejected Lean proofs, stale checker registrations, and cache-binding mismatches remain fail-closed and cannot produce verified conclusions.

## Validation

- `uv run pytest` (278 passed)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`
- `git diff --check`
- public Streamable HTTP MCP regression through the Tailscale Funnel
  - 4x4 Matrix, 65,536 cases: TRUE / VERIFIED
  - uncached Mathlib proof: TRUE / VERIFIED
  - exact repeated Mathlib proof: cache hit / VERIFIED
