### PR TITLE
docs: define composable mathematical primitives as the product model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,23 +1,39 @@
 # Repository Guidelines
 
-## Project Purpose and Decision Rules
+## Product Model
 
-Jacobian is a verifier-centric research workbench for bounded, executable
-mathematics. It gives models and researchers a laboratory in which they can
-propose candidates, search finite spaces, receive structured counter-witnesses,
-shrink discoveries, and replay independently checked certificates.
+Jacobian is a verifier-centric workbench for investigating mathematical
+problems, including research-level conjectures, through bounded, executable
+steps. Mathematician agents and human researchers compose small capabilities to
+transform claims, construct and explore mathematical objects, search for
+counterexamples, build candidate proofs, and submit evidence to independent
+checkers.
 
-Jacobian is not a `solve_conjecture` endpoint, a universal mathematics
-ontology, or a replacement for existing SAT, SMT, optimization, and proof
-engines. Search, generation, evaluation, and interpretation may be heuristic
-or wrong. Only an operator-authorized checker may promote evidence to a
-verified result.
+A mathematical primitive is a versioned capability that performs one
+observable operation. It consumes typed artifacts and returns typed artifacts,
+their explicit relationships, any new proof obligations, and the execution,
+assurance, and provenance needed to inspect or replay the step. A primitive may
+search, generate, transform, retrieve, or evaluate; it cannot promote its own
+output to verified evidence.
 
-The generic kernel understands artifacts, claims, candidates, predicates,
-witnesses, certificates, reductions, budgets, and provenance. Mathematical
-semantics belong in versioned domain plugins. Do not add graph-, matrix-,
-routing-, solver-, or proof-system-specific types to the generic core merely
-to satisfy a reference scenario.
+Primitive operations include deriving related claims; constructing,
+enumerating, mutating, or searching mathematical objects; computing properties
+and invariants; partitioning cases; decomposing goals; retrieving and
+instantiating premises; and replaying or cross-checking certificates. This list
+does not define a universal mathematical ontology. Domain plugins define the
+meaning of each operation for their objects and claims.
+
+Proof strategies and research agents compose primitives into workflows.
+External SAT, SMT, CAS, optimization, retrieval, and proof systems connect
+through capability adapters. Prefer a capability ID behind
+`capability.describe` and `capability.invoke` over a new top-level MCP tool.
+
+The kernel owns artifact identity, execution status, assurance, checker
+authorization, budgets, and provenance. Capability adapters own external
+integrations. Domain plugins own mathematical schemas, transformations,
+invariants, witness meanings, and checkers. Agent workflows and skills own
+multi-step exploration policies. Worked cases belong in reference scenarios
+and benchmarks.
 
 ## Fail-Closed Verification Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,9 +31,10 @@ through capability adapters. Prefer a capability ID behind
 The kernel owns artifact identity, execution status, assurance, checker
 authorization, budgets, and provenance. Capability adapters own external
 integrations. Domain plugins own mathematical schemas, transformations,
-invariants, witness meanings, and checkers. Agent workflows and skills own
-multi-step exploration policies. Worked cases belong in reference scenarios
-and benchmarks.
+invariants, witness meanings, and required checker roles. Independent checker
+packages implement replay; operators authorize them. Agent workflows and
+skills own multi-step exploration policies. Worked cases belong in reference
+scenarios and benchmarks.
 
 ## Fail-Closed Verification Rules
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 # Jacobian
 
-Jacobian is a capability-first MCP workbench and research-memory layer for
-agents doing executable mathematics.
+Jacobian is a verifier-centric workbench of composable mathematical primitives
+for mathematician agents and human researchers. It supports research-level
+problems and conjectures by turning an investigation into bounded, executable
+steps that produce inspectable artifacts.
 
-It gives agents and researchers reusable computation, search, retrieval,
-formal-proof, experiment, and verification tools so they can focus on
-mathematical strategy instead of rebuilding infrastructure. The kernel is not a
-`solve_conjecture` endpoint and does not treat model output or solver status as
-mathematical truth.
+A primitive performs one observable operation: transform a claim, construct or
+search mathematical objects, compute an invariant, decompose a goal, retrieve
+a premise, or replay a certificate. Proof strategies compose these operations
+into larger investigations. Jacobian preserves the inputs, outputs,
+relationships, obligations, execution status, assurance, and provenance of
+each step instead of presenting the workflow as one opaque solver call.
 
 The public kernel is domain-agnostic. Graphs, matrices, finite algebra,
 optimization problems, numerical claims, and formal proof goals acquire their
@@ -16,9 +19,9 @@ share the same artifact, evaluation, witness, shrinking, provenance, and
 verification substrate—not that an informal conjecture requires no
 formalization or domain implementation.
 
-Exploration is intentionally low friction. Verification is an optional
-assurance lane for results that must become durable mathematical claims. Its
-central invariant remains:
+Exploration may use models, heuristics, solvers, and external mathematical
+systems through capability adapters. Verification is a separate assurance lane
+for evidence that should become a durable mathematical result:
 
 > Search and evaluation may be wrong. A result becomes verified only when an
 > operator-authorized checker accepts evidence bound to the exact claim,
@@ -70,15 +73,16 @@ CLI or `uv run jacobian-mcp` to start the MCP adapter.
 | Milestone | Theme | Primary outcome |
 | --- | --- | --- |
 | Current release | Verification and bounded discovery | v0.2 alpha stores, evaluates, attacks, shrinks, independently verifies, enumerates structures, verifies representation changes, and computes exact separators |
-| Current product track | Capabilities and research memory | One extensible model-facing API supports fast exploration, optional verification, trust-labeled local episodes, and local or remote MCP hosts |
+| Current product track | Composable mathematical primitives | One extensible model-facing API exposes typed operations for exploration, composition, replay, and optional verification |
 | M3 | Scalable search | Provisional implementation runs typed search strategies through one resumable experiment loop |
-| M4 | Conjecture workflows | Provisional implementation repairs, generates, falsifies, and parametrically generalizes conjectures |
+| M4 | Claim transformation | Decompose broad claim-development workflows into typed generation, repair, ranking, falsification, and parameter-analysis operations |
 | M5 | Federated research corpus | Extend the implemented local episode database with optional cross-project providers, review, retraction, and temporal retrieval |
 | Stability target | Stable research platform | Publish a v1.0 API with formal-checking and collaboration support |
 
-The roadmap is tool-first and database-first. Local capability episodes are
-recorded and searchable without a shared service. Corpus-scale retrieval is an
-optional integration that cannot promote evidence or authorize checkers.
+The roadmap is primitive-first and artifact-first. Agent workflows may compose
+primitives, and completed capability episodes are recorded and searchable
+without a shared service. Corpus-scale retrieval is optional and cannot
+promote evidence or authorize checkers.
 
 The only public release contract is v0.2 alpha (`0.2.0a0`). It includes the
 verification kernel and bounded discovery. The repository also contains
@@ -93,8 +97,8 @@ gates are part of the working project record. Start with:
 
 - [Architecture](docs/explanation/architecture.md) for the system shape and
   verification boundary.
-- [Capability-first product blueprint](docs/explanation/product-blueprint.md)
-  for the agent-facing API, memory, remote host, and A/B evaluation direction.
+- [Product model](docs/explanation/product-blueprint.md) for the primitive
+  contract, ownership boundaries, agent-facing API, and evaluation direction.
 - [Roadmap](docs/explanation/roadmap.md) for active milestone scope and exit
   gates.
 - [Architecture decision log](docs/explanation/adr/index.md) for accepted
@@ -109,13 +113,15 @@ Release contracts and engineering evidence are:
 - [Tool surface](docs/reference/tools.md)
 - [v0.2 specification](docs/reference/specifications/v0.2.md) and
   [conformance gate](docs/reference/conformance-v0.2.md)
-- [M3](docs/reference/milestones/m3-scalable-search.md) and
-  [M4](docs/reference/milestones/m4-conjecture-workflows.md) provisional
-  contracts
+- [M3](docs/reference/milestones/m3-scalable-search.md),
+  [M4](docs/reference/milestones/m4-conjecture-workflows.md), and
+  [M5](docs/reference/milestones/m5-research-corpus.md) provisional contracts
+- [v1.0 stability target](docs/reference/specifications/v1.0.md)
 - [Testing strategy](docs/reference/testing-strategy.md),
   [scenario catalog](docs/reference/math-scenarios.md), and
   [performance benchmark protocol](docs/reference/performance-benchmarks.md)
-- [Plugin conformance contract](docs/reference/plugin-conformance.md)
+- [Plugin conformance contract](docs/reference/plugin-conformance.md) and
+  [agent evaluation protocol](docs/reference/agent-evaluations.md)
 
 The [documentation home](docs/index.md) provides the complete catalog,
 organized into tutorials, how-to guides, reference, and explanation. Read
@@ -125,19 +131,19 @@ documentation placement, and pull-request expectations.
 ## Current status
 
 v0.2 alpha is implemented as a Python package, CLI, and local or remote MCP
-adapter. The capability-first projection exposes one stable
-`capability.describe` discovery tool and one stable `capability.invoke` tool
-backed by an extensible adapter registry and trust-labeled research memory.
+adapter. The compact projection exposes `capability.describe` for discovery
+and `capability.invoke` for execution, backed by an extensible adapter registry
+and trust-labeled research memory.
 Bundled capabilities provide reference-domain exploration and verification,
 Lean checking, and local episode search.
 
-The advanced surface retains eight verification tools alongside bounded enumeration,
-implementation-bound canonicalization, independently verified representation
-changes, persistent experiment resources, and exact finite-polytope evidence.
-Bundled reference domains cover graph paths and bipartiteness, exact integer
-matrices, and bounded Erdős-Straus decomposition tables. A verified
-Erdős-Straus table establishes only its exact finite interval, never the open
-unbounded conjecture.
+The advanced profiles expose the lower-level operations documented in the
+[tool reference](docs/reference/tools.md), including bounded enumeration,
+independently checked representation changes, persistent experiments, and
+exact finite-polytope evidence. Bundled reference domains cover graph paths and
+bipartiteness, exact integer matrices, and bounded Erdős-Straus decomposition
+tables. A verified Erdős-Straus table establishes only its exact finite
+interval, never the open unbounded conjecture.
 
 The provisional M3/M4 code adds sealed plugin snapshots, a strategy-neutral
 `search.run` service, pause and resume from immutable checkpoints, append-only
@@ -155,11 +161,10 @@ Development commands and test-selection guidance live in
 [CONTRIBUTING.md](CONTRIBUTING.md) and the
 [testing strategy](docs/reference/testing-strategy.md).
 
-The MCP adapter is pinned to the official Python SDK `2.0.0b2`. It remains
-isolated from the mathematical kernel because that SDK release is a beta.
-Exact finite-polytope generation uses Z3 rational constraints. Z3 output is
-always unverified until the separate `Fraction`-based checker accepts the
-bound witness or certificate.
+The MCP adapter remains isolated from the mathematical kernel. Exact
+finite-polytope generation uses Z3 rational constraints, but Z3 output remains
+unverified until the separate `Fraction`-based checker accepts the bound
+witness or certificate.
 
 ### Local Codex
 
@@ -196,19 +201,11 @@ capability-enabled runs once the A/B cases are selected.
 
 ### Lean certificates
 
-`lean.verify` binds an exact Lean proposition and proof body into immutable
-claim, candidate, and certificate artifacts, then invokes the ordinary
-authorized `certificate.verify` boundary. Both bundled environments pin Lean
-`4.31.0` commit `68218e876d2a38b1985b8590fff244a83c321783` and run with
-`--trust=0`:
-
-- `CORE` permits no import or axiom and is suitable for self-contained
-  propositions such as elementary induction.
-- `MATHLIB` generates exactly `import Mathlib`, pins mathlib commit
-  `fabf563a7c95a166b8d7b6efca11c8b4dc9d911f`, and permits only the declared
-  standard trust base `Classical.choice`, `Quot.sound`, and `propext`. Its
-  operator-installed checker profile has a 105-second cold-start ceiling;
-  normal checkers retain the 30-second default.
+The `lean.check` capability uses the `lean.verify` compatibility workflow to
+bind an exact proposition and proof body into immutable artifacts, then replay
+them through the authorized `certificate.verify` boundary. The bundled `CORE`
+and `MATHLIB` environments pin Lean, their imports, and their allowed trust
+bases; model-supplied imports and packages are rejected.
 
 Prepare the pinned local runtime with:
 
@@ -219,20 +216,10 @@ lake update
 lake build
 ```
 
-Jacobian selects that exact toolchain explicitly when it runs Lean, so it does
-not depend on the shell's current directory or require a global Elan default.
-If setup is incomplete, confirm the pinned toolchain from any directory with
-`elan run leanprover/lean4:v4.31.0 lean -V`.
-
-The checker rejects user-supplied imports, `sorry`, `admit`, `native_decide`,
-unsafe declarations, and metaprogram execution. It verifies the requested
-toolchain and mathlib commits and parses Lean's actual `#print axioms` result;
-the result must be a subset of the selected environment's allowlist.
-
-This is a trusted local Lean integration, not a broker sandbox. The mathlib
-profile executes the repository's pinned Lake environment with host-local
-runtime access. Arbitrary package ingestion and arbitrary imports are not
-supported.
+The operation and trust-boundary mapping are documented under
+[`lean.check` and `lean.verify`](docs/reference/tools.md). This is a trusted
+local integration, not a broker sandbox; the pinned Lake environment still has
+host-local runtime access.
 
 ## Distribution
 
@@ -244,7 +231,7 @@ TypeScript client or adapter.
 
 ## Initial non-goals
 
-- Natural-language-to-formal-mathematics automation
+- A universal natural-language-to-formal-mathematics translator in the kernel
 - A universal mathematical ontology
 - One opaque generic solver that hides backend semantics
 - Arbitrary model-uploaded executable bundles

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -9,11 +9,9 @@
 
 ## Purpose
 
-Jacobian gives agents reusable mathematical capabilities and durable research
-memory while separating mathematical discovery from mathematical trust. The
-[capability-first product blueprint](product-blueprint.md) defines the
-model-facing product direction; this document describes the underlying kernel
-and trust zones.
+The [product model](product-blueprint.md) defines Jacobian's composable
+mathematical primitives and their intended users. This document describes the
+kernel, ownership boundaries, and trust zones that support that model.
 
 Models, search algorithms, and domain solvers are allowed to be heuristic,
 stochastic, incomplete, and frequently replaced. Verification is performed by
@@ -61,6 +59,21 @@ The v0.2 kernel and bounded-discovery behavior are the current release
 contract. Sections describing resumable strategy search and conjecture
 workflows document provisional M3/M4 implementations and do not extend v0.2
 conformance.
+
+## Ownership boundaries
+
+The kernel owns artifact identity, execution state, assurance, budgets,
+provenance, and checker authorization. Capability adapters translate between
+the primitive contract and external mathematical systems. Domain plugins own
+schemas, transformations, invariants, witness meanings, and required checker
+roles. Independent checker packages implement replay and are authorized by an
+operator, never by the plugin or adapter whose output they check.
+
+Agent workflows and skills own multi-step exploration and proof strategies.
+The kernel may provide durable execution and compatibility façades, but those
+workflows must retain their stage artifacts and assurance labels. Worked cases
+and expected outcomes belong in the scenario and benchmark documents, not in
+generic kernel types.
 
 ## Trust zones
 
@@ -174,7 +187,12 @@ The service validates both schemas and prevents adapters from self-promoting:
 `VERIFIED` requires a valid local verification record whose checked evidence
 is returned with the capability result. Stage-aware diagnostics separate
 invalid input, reference resolution, adapter execution, and checker outcomes.
-Only completed invocations are eligible for research-memory recording.
+Only completed invocations are eligible for research memory recording.
+
+A registered capability should expose one observable mathematical operation.
+Broad tasks are workflows over multiple capability invocations. Current
+composite tools remain available for compatibility, but they do not define the
+granularity expected of new capabilities.
 
 ## Common result model
 
@@ -253,10 +271,12 @@ authorized checker replays them. Such proof certificates may use
 `coverage = NOT_APPLICABLE`; direct finite enumeration must instead report
 `EXHAUSTIVE`.
 
-## Plugin capabilities
+## Domain plugin operations
 
-Domains implement small optional capabilities instead of one mandatory
-`ProblemPlugin` interface:
+Domains implement small optional operations instead of one mandatory
+`ProblemPlugin` interface. The stable v0.2 operations cover problem
+specification, candidate encoding, evaluation, witness search and checking,
+reduction, enumeration, transformation, and certificate replay:
 
 ```python
 class ProblemSpec(Protocol):
@@ -296,7 +316,12 @@ class TransformationChecker(Protocol):
 
 class CertificateChecker(Protocol):
     def verify(self, certificate: JSON) -> Verification: ...
+```
 
+The provisional M3 and M4 operations add strategy and hypothesis
+transformation hooks:
+
+```python
 class Proposer(Protocol):
     def propose(self, request: SearchProposalRequest) -> SearchProposal: ...
 
@@ -312,6 +337,11 @@ class HypothesisTransformer(Protocol):
 Search plugins cannot register themselves as trusted checkers. The checker
 registry is operator-managed and binds checker digests to supported claim,
 semantics, and certificate versions.
+
+These typed plugin operations are dispatched by capability adapters. A plugin
+defines mathematical meaning; an adapter presents an operation through
+`capability.describe` and `capability.invoke`; the kernel enforces the common
+artifact and assurance contract.
 
 ### Sealed plugin identity
 
@@ -405,13 +435,15 @@ The reference scheduler accepts one strategy worker and requires one active
 Jacobian process per state directory. SQLite provides transactional request
 acceptance, not a distributed worker lease.
 
-## Conjecture transformations and parameter regions
+## Claim transformations and parameter regions
 
-The three hypothesis-producing M4 operations share an untrusted
-`HypothesisTransformer`. The service validates source evidence, stores each
-claim and edit as immutable artifacts, deduplicates by content identity, and
-may route a hypothesis through M3 falsification. Generated, repaired, and
-generalized statements remain `UNVERIFIED`.
+The provisional M4 implementation currently projects repair, generation, and
+parameter generalization through one untrusted `HypothesisTransformer`. These
+are compatibility façades while the product contract is decomposed into
+smaller claim derivation, deduplication, scoring, falsification, and parameter
+analysis operations. The service validates source evidence, stores each claim
+and edit as immutable artifacts, and preserves stage lineage. Generated,
+repaired, and generalized statements remain `UNVERIFIED`.
 
 A parameter-region plugin may return `PROPOSED` or `SAMPLED` evidence only.
 Jacobian commits an immutable `ParameterRegionSubject` binding the target claim,

--- a/docs/explanation/product-blueprint.md
+++ b/docs/explanation/product-blueprint.md
@@ -1,22 +1,26 @@
-# Capability-first product blueprint
+# Product model: composable mathematical primitives
 
 [Documentation home](../index.md)
 
 - Status: Active product direction
-- Scope: Agent-facing MCP, local and remote execution, research memory, and
-  optional mathematical assurance
+- Scope: Mathematical primitives, agent workflows, capability adapters,
+  research memory, and optional mathematical assurance
 - Compatibility: v0.2 verification records remain valid; this document changes
   the product entry point, not the meaning of `VERIFIED`
 
 ## Product definition
 
-Jacobian is an agent-facing mathematical capability and research-memory layer.
-It supplies reusable computation, search, solver, formal-proof, retrieval, and
-experiment tools so a model can spend more of its context and reasoning budget
-on strategy rather than rebuilding infrastructure.
+Jacobian is a verifier-centric workbench of composable mathematical primitives
+for mathematician agents and human researchers. It supports research-level
+problems and conjectures through bounded, executable operations whose artifacts
+can be inspected, composed, and replayed.
 
-Verification is an available assurance service. It is not a mandatory prelude
-to exploration and it is not the only reason to use Jacobian.
+The workbench is not one conjecture-solving algorithm. Models and researchers
+choose a strategy and compose operations for transforming claims, constructing
+or searching objects, computing invariants, decomposing goals, retrieving
+premises, and checking evidence. External mathematical systems supply many of
+those operations; Jacobian supplies the common artifact, execution, assurance,
+budget, and provenance model.
 
 The product succeeds when an agent solves held-out tasks more reliably or
 efficiently with Jacobian than the same agent solves them with prompts and a
@@ -24,21 +28,47 @@ general-purpose shell alone. Starting an MCP server, calling a tool, or
 producing a verification record is necessary infrastructure evidence, not
 proof of that product outcome.
 
-## Decision rules
+## Primitive contract
 
-Use these rules when adding a feature:
+The target mathematical primitive contract is a versioned capability with one
+observable operation. It consumes typed artifacts and returns:
 
-1. Expose a mathematical action, not an internal lifecycle step.
-2. Keep large schemas and payloads behind catalogs and resource handles.
-3. Let exploration return useful candidates without requiring a `ClaimSpec`.
-4. Label every result as heuristic, computed, or verified.
-5. Require an authorized local verification record before an adapter may use
-   the verified label.
-6. Record reusable episodes with provenance and their original assurance.
-7. Never turn retrieval rank, solver status, search exhaustion, timeout, or an
-   adapter's self-assessment into proof.
-8. Add a provider through the capability registry without editing the MCP
-   adapter.
+- typed output artifacts;
+- explicit relationships to its inputs;
+- any proof obligations created by the operation;
+- execution status and resource accounting;
+- assurance and the evidence supporting it;
+- enough provenance to replay or compare the step.
+
+Search, generation, transformation, retrieval, and evaluation primitives may
+return useful unverified results. They cannot promote their own output to
+verified evidence. Promotion requires an independently authorized checker bound
+to the exact claim, semantics, candidate, scope, certificate format, and
+checker identity.
+
+Broad actions such as “investigate this conjecture” are workflows, not
+primitives. A workflow may coordinate many primitive calls, but it must expose
+the stage artifacts and preserve their separate assurance labels. Composite
+compatibility tools in the current implementation are convenience façades over
+this model, not templates for adding more monolithic tools.
+
+## Ownership model
+
+The boundaries are intentionally narrow:
+
+- The kernel owns artifact identity, execution status, assurance, checker
+  authorization, budgets, and provenance.
+- Capability adapters connect external SAT, SMT, CAS, optimization, retrieval,
+  and proof systems to the primitive contract.
+- Domain plugins own mathematical schemas, transformations, invariants,
+  witness meanings, and required checker roles.
+- Independent checker packages implement replay; operators authorize them.
+- Agent workflows and skills own multi-step exploration and proof strategies.
+- Reference scenarios and benchmarks own worked examples.
+
+This separation lets a new mathematical operation or external engine appear
+behind a capability ID without changing the MCP server or expanding checker
+authority.
 
 ## System shape
 
@@ -49,7 +79,7 @@ Codex CLI              ChatGPT / remote agent
                    ▼
           MCP capability projection
           capability://catalog
-          capability.invoke
+          capability.describe / capability.invoke
                    │
                    ▼
              CapabilityService
@@ -68,9 +98,10 @@ Codex CLI              ChatGPT / remote agent
           immutable verification record
 ```
 
-The generic capability layer understands an operation ID, JSON schemas,
-supported modes, execution status, assurance, scope, artifacts, and an episode
-handle. Mathematical semantics remain in adapters and domain plugins.
+The generic capability layer must understand an operation ID, JSON schemas,
+supported modes, execution status, assurance, scope, artifact relationships,
+proof obligations, and an episode handle. Mathematical semantics remain in
+adapters and domain plugins.
 
 ## Capability contract
 
@@ -98,6 +129,12 @@ mode, checks any verified record and its complete parent binding against the
 local artifact store, and records the episode. Projected record IDs and
 conclusions must agree with the checked record. `MCPServer` does not need a new
 tool when an Alloy, Lean, SAT/SMT, CAS, or domain adapter is registered.
+
+The current `CapabilityResult` exposes a generic output object and artifact
+URIs. Relationships and proof obligations are therefore still
+operation-specific data inside that output. Before the primitive contract is
+stabilized, they need versioned first-class fields so a workflow can compose
+them without understanding every domain payload.
 
 Deploy an operator-approved adapter package with a repeatable
 `--capability-adapter package.module:factory` option. The factory receives the
@@ -170,54 +207,26 @@ The local Codex profile uses STDIO and the `capabilities` tool profile. It
 advertises one read-only discovery tool and one extensible invocation tool
 rather than every backend operation.
 
-Remote hosts use Streamable HTTP by default. A remote deployment:
+Remote hosts use Streamable HTTP and subject-bound tenant state. Authentication,
+tenant isolation, persistence, and TLS are deployment responsibilities, not
+mathematical primitives. See
+[Deploy the remote MCP server](../how-to/deploy-remote-mcp.md) and the
+[threat model](threat-model.md) for their concrete requirements.
 
-- requires an operator-provisioned bearer-token file unless anonymous
-  development mode is explicitly selected;
-- binds each token to a tenant subject and required scope;
-- routes every tool and resource request to a tenant-specific state root;
-- hashes tenant IDs before constructing filesystem paths;
-- keeps artifact, memory, experiment, plugin, and checker metadata isolated;
-- terminates TLS at a trusted reverse proxy or platform ingress;
-- mounts the state root and token file as separate persistent volume and
-  secret.
+## Product evidence
 
-Static opaque tokens are an initial deployment mechanism, not a complete
-identity platform. Hosted deployments should replace the verifier with their
-OAuth/OIDC policy while preserving the tenant subject contract.
+The immediate product work is to stabilize the primitive contract, make stage
+composition visible, and exercise external adapters without kernel or MCP
+edits. Authenticated hosting, local research memory, and compact tool
+projection support that work; they are not substitutes for useful mathematical
+operations.
 
-## Evaluation
-
-Two benchmark families answer different questions:
-
-- The known-answer MCP pilot checks integration and durable verification.
-- The A/B agent benchmark compares the same model on the same task under a
-  control condition and a Jacobian capability condition.
-
-The A/B runner must:
-
-- ignore user MCP configuration and construct each condition explicitly;
-- fix model, reasoning effort, repository commit, prompt, and budgets;
-- randomize or alternate condition order across repetitions;
-- retain every transcript and report;
-- score mathematical answers with an independent known-answer oracle;
-- measure pass rate, false claims, input/output tokens, wall time, tool calls,
-  shell calls, and generated files;
-- report paired deltas rather than selecting the best run.
-
-One successful MCP transcript does not establish an improvement. A product
-claim requires repeated held-out cases with a better correctness/efficiency
-frontier and no increase in false certification.
-
-## Delivery order
-
-1. Stabilize capability contracts, local memory, and the two lanes.
-2. Keep the compact MCP catalog below the tool-description budget.
-3. Exercise at least one external adapter without a kernel or MCP edit.
-4. Deploy authenticated Streamable HTTP with tenant-isolation tests.
-5. Run paired A/B pilots and use agent feedback to prioritize adapters.
-6. Add cross-project corpus providers only after local episode queries are
-   empirically useful.
+Agent evaluations should measure held-out mathematical tasks, including
+counterexample search, claim transformation, proof decomposition, premise
+retrieval, and independent replay. Cross-project corpus providers should follow
+only after local episode queries are empirically useful. The
+[agent evaluation protocol](../reference/agent-evaluations.md) defines the
+controls, retained evidence, and scoring required for a product claim.
 
 ## Non-goals
 

--- a/docs/explanation/roadmap.md
+++ b/docs/explanation/roadmap.md
@@ -17,20 +17,25 @@ M5 are capability milestones, not promised package versions or compatibility
 releases. Their scope and APIs may change. v1.0 remains a stability target
 rather than the next scheduled release.
 
-## Current product track — Capability workbench
+## Product direction — Composable mathematical primitives
 
 Status: initial implementation in the repository; pre-stable and outside the
-v0.2 conformance contract.
+v0.2 conformance contract. This is a parallel product track built on v0.2's
+artifact and verification model, not an earlier release milestone.
 
 ### Objective
 
-Make Jacobian useful before verification by giving agents one compact,
-extensible API for mathematical tools and local research memory, while keeping
-checker-backed assurance available when a result must be promoted.
+Give mathematician agents and human researchers a compact, extensible set of
+typed mathematical operations that they can inspect and compose. Keep
+checker-backed assurance separate and available when evidence must be promoted.
 
 ### Deliverables
 
 - Model-facing `capability.describe` and `capability.invoke` MCP tools
+- A versioned primitive contract covering typed inputs and outputs,
+  relationships, proof obligations, execution, assurance, and provenance
+- Explicit separation between primitive capabilities and composite workflows
+- Workflow traces that retain stage artifacts and assurance labels
 - Adapter registration without kernel or MCP edits
 - Explicit `EXPLORE` and `VERIFY` lanes
 - Heuristic, computed, and verified assurance labels
@@ -39,7 +44,11 @@ checker-backed assurance available when a result must be promoted.
 - Bearer-token authentication and subject-bound tenant state
 - Container and reverse-proxy deployment guidance
 - Paired control/treatment agent benchmark with transcript-level metrics
-- At least one external Alloy, SAT/SMT, or CAS adapter exercise
+- At least one external Alloy, SAT/SMT, CAS, optimization, retrieval, or proof
+  adapter exercise
+- Held-out agent tasks covering more than verification replay, including
+  object search, claim transformation, proof decomposition, or premise
+  retrieval
 
 ### Exit gate
 
@@ -48,7 +57,9 @@ improves correctness or resource use over the same model without Jacobian,
 without increasing false certification. A synthetic external adapter appears
 through MCP without editing the kernel or MCP server. Authenticated tenant
 tests demonstrate that tools and resources cannot read another tenant's
-artifacts or research episodes.
+artifacts or research episodes. At least one multi-step investigation is
+expressed as a composition of independently invocable primitives whose stage
+artifacts can be replayed.
 
 ## v0.2 — Bounded discovery
 
@@ -66,7 +77,9 @@ bounded candidate classes, and independently verify representation changes.
 - Digest-keyed local artifact store and SQLite registry metadata
 - Immutable verification-record artifacts
 - Operator-managed checker registry
-- Seven generic verification tools
+- The lower-level operations defined by the
+  [v0.2 specification](../reference/specifications/v0.2.md) and cataloged in
+  the [tool reference](../reference/tools.md)
 - A generic plugin capability API
 - At least two structurally different reference plugins and replay checkers
 - CLI and thin MCP adapter
@@ -113,10 +126,14 @@ exact-verification boundaries.
 
 - Typed proposer, evaluator, counterexample, refinement, and candidate
   nomination interfaces
+- Individually invocable proposer, evaluator, counterexample, refinement, and
+  nomination operations; `search.run` remains a durable reference workflow,
+  not the only way to use them
 - Strategy-neutral search state, checkpoints, lineage, and failure archives
 - Verified-counterexample feedback through the existing witness boundary
-- Candidate nomination that routes every mathematical promotion through the
-  existing verification boundary
+- Candidate nomination that can request authorized-checker dispatch; the
+  kernel enforces authorization, while agents and strategies choose which
+  verification operation to request
 - Exact budget, scope, and runtime identity, with measured wall time and
   durable operation accounting
 - Resumable, cancellable, and recoverable experiments
@@ -162,7 +179,7 @@ an invocation can be reconstructed without chat state and resumed without
 losing or duplicating lineage. Workers cannot widen execution policy or
 influence checker authorization.
 
-## M4 — Conjecture workflows
+## M4 — Claim-transformation primitives
 
 Implementation status: the provisional hypothesis-transformation and
 parameter-region promotion paths are in the repository. They remain pre-stable
@@ -175,27 +192,32 @@ their exact transformation lineage.
 
 ### Objective
 
-Give agents tools to turn verified counterexamples and constructions into
-nearby statements, parameter families, and new experiments through the same
-validation and falsification loop used by M3.
+Give mathematician agents and researchers composable operations for turning
+counterexamples, constructions, and partial arguments into nearby statements,
+parameter families, and new experiments.
 
 ### Deliverables
 
-- One typed hypothesis-transformation capability with repair, generation, and
-  parameter-generalization operations
+- Separately invocable claim derivation, generation, deduplication, scoring,
+  bounded falsification, and parameter-analysis operations
+- Compatibility workflows for repair, generation, and parameter
+  generalization that preserve those stage boundaries
 - Plugin-owned conjecture grammars and repair strategies rather than a
   kernel-level synthesis framework
 - Deduplication within the active experiment or supplied reference set
 - Exact proposed, sampled, sufficient, and necessary parameter-region labels;
   only independent checker records may use the verified labels
-- Falsification pipelines for generated statements
+- Agent-composable falsification paths for generated statements
 - Explicit source and transformation records for every proposal
 - Honest `UNKNOWN` novelty when no research-corpus provider is configured
 
 ### Exit gate
 
 Every generated or repaired claim is explicitly labeled as a hypothesis and
-can re-enter the ordinary validation, search, and verification pipeline.
+can re-enter the ordinary validation, search, and verification pipeline. Claim
+generation, deduplication, ranking, and falsification remain independently
+inspectable operations.
+
 Held-out evaluations confirm that failure to falsify a generated statement is
 never reported as verification. Parameter claims distinguish proved, sampled,
 and unknown regions. A synthetic plugin supports repair, generation, and
@@ -205,9 +227,9 @@ parameter generalization without core or MCP changes.
 
 ### Entry gate
 
-The search and conjecture tools have produced enough diverse verified and
-failed experiments for retrieval quality and useful query patterns to be
-measurable.
+The search and claim-transformation operations have produced enough diverse
+verified and failed experiments for retrieval quality and useful query patterns
+to be measurable.
 
 ### Objective
 
@@ -224,15 +246,16 @@ confusing retrieval with proof.
 - Retention quotas, canonical deduplication, and curated promotion
 - Provider-backed novelty checks with explicit corpus and cutoff scope
 - Episode comparison and abstraction suggestions as optional hypothesis tools
-- Certificate simplification as an independent checker-replay workflow
+- A certificate transformation primitive plus an independent checker-replay
+  simplification workflow
 
 ### Exit gate
 
-The conjecture tools operate correctly with no provider configured. When a
-provider is present, retrieval improves a held-out search or repair benchmark
-while preserving trust labels and temporal cutoffs. Retrieved records and
-suggested abstractions never gain verified status through ranking, clustering,
-or ingestion.
+The claim-transformation operations work correctly with no provider
+configured. When a provider is present, retrieval improves a held-out search or
+repair benchmark while preserving trust labels and temporal cutoffs. Retrieved
+records and suggested abstractions never gain verified status through ranking,
+clustering, or ingestion.
 
 ## Stability target — v1.0 research platform
 
@@ -268,6 +291,7 @@ their compatibility and migration suites.
 All releases preserve these invariants:
 
 - Search output is evidence, not proof.
+- Workflows preserve the identity and assurance of each primitive step.
 - A checker cannot be registered by the untrusted plugin it verifies.
 - Artifact identity binds schema and semantics.
 - Operational failure never silently changes a mathematical conclusion.

--- a/docs/how-to/deploy-remote-mcp.md
+++ b/docs/how-to/deploy-remote-mcp.md
@@ -55,7 +55,7 @@ uv run jacobian-mcp \
 
 Do not expose anonymous mode to a network.
 
-## Warm the Mathlib profile
+## Warm the Mathlib profile when serving `lean.check`
 
 Set `JACOBIAN_LEAN_WARMUP=1` on a host that serves `lean.check`. Jacobian then
 checks a small pinned Mathlib theorem in the background when each tenant kernel

--- a/docs/how-to/resume-search.md
+++ b/docs/how-to/resume-search.md
@@ -2,6 +2,9 @@
 
 [Documentation home](../index.md)
 
+This guide covers the provisional M3 search runtime. Its commands and artifact
+formats are outside v0.2 conformance and may change.
+
 Use these commands when a `search-run` request has returned an experiment URI
 and you need to inspect or control that experiment. Keep the same
 `--state-dir` for every command; the state directory is the durable owner of

--- a/docs/how-to/run-plugin-conformance.md
+++ b/docs/how-to/run-plugin-conformance.md
@@ -6,6 +6,10 @@ Run the conformance kit before treating a sealed plugin as compatible with the
 provisional M3 runtime. The target must be disposable: several checks mutate
 the package or create attack paths intentionally.
 
+The kit enforces the plugin ownership boundary: a plugin may define
+mathematical operations and required checker roles, but it cannot authorize
+itself or widen the operator's execution and trust policy.
+
 ## Prepare the target
 
 Install the plugin into a fresh `JacobianKernel`, create a minimal claim it can

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,15 @@ Start with a tutorial when learning the system, use a how-to guide for a
 specific task, consult reference material for exact contracts, and read the
 explanations for design rationale.
 
+Jacobian is a workbench of composable mathematical primitives for
+mathematician agents and human researchers. A primitive performs one bounded,
+observable operation and returns typed artifacts, their relationships and
+obligations, and the execution, assurance, and provenance needed to inspect or
+replay it. Agent workflows compose those operations; only independently
+authorized checkers may promote evidence to a verified result. The
+[product model](explanation/product-blueprint.md) defines these terms and
+ownership boundaries.
+
 The only current release contract is v0.2 alpha. Documents for M3, M4, M5, and
 v1.0 describe provisional or planned work unless they explicitly say
 otherwise.
@@ -16,13 +25,13 @@ still pre-stable:
 
 | Question | Document | Status |
 | --- | --- | --- |
-| What product is Jacobian building? | [Capability-first product blueprint](explanation/product-blueprint.md) | Active product direction |
+| What product is Jacobian building? | [Product model](explanation/product-blueprint.md) | Active product direction |
 | What does the system currently look like? | [Architecture](explanation/architecture.md) | Current v0.2 design plus labeled provisional M3/M4 sections |
 | What is implemented, provisional, or planned? | [Roadmap](explanation/roadmap.md) | Active milestone plan; gates are not promised release dates |
 | Why were cross-cutting choices made? | [Architecture decision log](explanation/adr/index.md) | Accepted decisions with release scope |
 | Which properties and trust boundaries must hold? | [Threat model](explanation/threat-model.md) | Current for v0.2 and provisional M3/M4 code |
 | What is the supported release contract? | [v0.2 specification](reference/specifications/v0.2.md) and [conformance gate](reference/conformance-v0.2.md) | Normative for `0.2.0a0` |
-| Which later contracts are being exercised? | [M3](reference/milestones/m3-scalable-search.md) and [M4](reference/milestones/m4-conjecture-workflows.md) | Provisional; outside v0.2 conformance |
+| Which later contracts are being exercised? | [M3](reference/milestones/m3-scalable-search.md), [M4](reference/milestones/m4-conjecture-workflows.md), and [M5](reference/milestones/m5-research-corpus.md) | Provisional; outside v0.2 conformance |
 
 ## Tutorials
 
@@ -60,7 +69,7 @@ expectations.
 Later-release contracts are provisional:
 
 - [M3 scalable search](reference/milestones/m3-scalable-search.md)
-- [M4 conjecture workflows](reference/milestones/m4-conjecture-workflows.md)
+- [M4 claim-transformation primitives](reference/milestones/m4-conjecture-workflows.md)
 - [M5 federated research corpus](reference/milestones/m5-research-corpus.md)
 - [v1.0 stability target](reference/specifications/v1.0.md)
 
@@ -70,7 +79,7 @@ Explanation documents describe why Jacobian has its current boundaries and
 how its major parts fit together.
 
 - [Architecture](explanation/architecture.md)
-- [Capability-first product blueprint](explanation/product-blueprint.md)
+- [Product model](explanation/product-blueprint.md)
 - [Threat model](explanation/threat-model.md)
 - [Roadmap](explanation/roadmap.md)
 - [Durable search runtime](explanation/search-runtime.md)

--- a/docs/reference/agent-evaluations.md
+++ b/docs/reference/agent-evaluations.md
@@ -192,7 +192,7 @@ failed branches. The agent should resume from the experiment handle, preserve
 lineage, avoid double-promoting duplicate candidates, and route final evidence
 through v0.2 verification.
 
-### EVAL-REPAIR-009 — Nearby conjecture repair
+### EVAL-REPAIR-009 — Nearby claim repair
 
 **Milestone:** M4
 
@@ -326,50 +326,21 @@ scores the durable verification record, evidence, exact bindings, claim, and
 candidate directly from the Jacobian store. Lean cases additionally bind and
 score the selected runtime environment and declared trust base.
 
+`GRAPH-BIP-TRUE-001`, the Lean cases, and `ERDOS-STRAUS-AB-001` are
+runner-level agent cases defined by the benchmark harness. They are not
+component fixtures in the [mathematical scenario catalog](math-scenarios.md);
+that catalog remains the source for the shared mathematical objects they reuse.
+
 Every agent report also records structured observations in four non-scoring
 categories: useful tooling, tooling gaps, domain-knowledge gaps, and concrete
 improvements. The runner writes these observations to a per-case
 `feedback.json`. Feedback is empirical input for tool design; it is not
 mathematical evidence and cannot affect the durable correctness score.
 
-The local profile uses the registry-derived `verification` projection. At its
-introduction this reduced the advertised descriptor from 82,820 characters
-for 19 tools to 4,400 characters for six tools; adding `lean.verify` changed
-the compact surface to seven tools and 4,875 characters. Adding the generic
-`verification.run` workflow and explicit Lean input guidance changed it to
-eight tools and 6,899 characters. Adding the pinned `MATHLIB` environment
-and compact result projection changed that compact descriptor to 7,883
-characters; the corresponding 22-tool descriptor was 103,382 characters.
-
-The capability-first change was remeasured with compact sorted JSON on
-2026-07-24. After adding tool-callable exact schema discovery, the default
-`capabilities` profile advertises two tools in 1,492 characters. Its
-three-entry `capability://catalog` is 2,663 characters, and an exact
-Erdős-Straus `capability.describe` result is 5,347 characters. The
-compatibility `verification` profile is eight tools and 7,171 characters; the
-24-tool `full` profile is 107,034 characters. The default descriptor remains
-well below the 25 KB first-stage target. These are descriptor measurements,
-not model token counts, and must be remeasured when contracts change.
-
-The domain bootstrap projection reduced the serialized `graph_paths` resource
-from 7,317 to 2,402 characters, `matrices` from 7,290 to 2,197, and `lean4`
-from 4,106 to 1,810. The bounded `erdos_straus` bootstrap is 1,906 characters.
-Adding that domain did not change the historical verification descriptors. The
-positive graph workflow response reduced from 6,098 to 1,314 characters. Full
-schemas and workflow results remain available through the canonical registry
-and `full` MCP profile; only model-facing projection changed.
-
-An exploratory local `ERDOS-STRAUS-001` run on 2026-07-24 passed all durable
-scorer checks for the interval \(2\leq n\leq1000\). It used two MCP calls
-(`read_mcp_resource` and `verification.run`), took 97.891 seconds, and reported
-93,325 input tokens, including 69,632 cached input tokens, plus 2,088 output
-tokens. The agent identified the compact domain identity, exact checker
-identity, finite-scope rule, composed workflow, assurance separation, and
-durable URIs as useful. It reported no tooling gaps, domain-knowledge gaps, or
-suggested improvements in that run. This was a dirty-worktree development run
-against commit `990d26a`; it is implementation feedback, not a frozen
-comparative baseline. The total input remains close enough to the 100,000-token
-first-stage target that future multi-case runs should continue to track it.
+Descriptor sizes, transcripts, timing, and token measurements are run
+artifacts, not reference contracts. Store them under the ignored
+`benchmarks/results/` directory and summarize them only from a clean,
+identified tree when making a benchmark claim.
 
 Run the kernel condition with:
 
@@ -420,36 +391,7 @@ product claim. Product conclusions require multiple held-out cases and
 repetitions. Report all runs, use paired deltas, and reject any treatment that
 improves efficiency by increasing unsupported mathematical conclusions.
 
-### Initial A/B development result
-
-One dirty-worktree development pair on 2026-07-24 used Codex CLI `0.144.1`,
-the configured default model, medium reasoning effort, and
-`ERDOS-STRAUS-AB-001`. Both conditions passed their independent scorers.
-
-The first treatment design required cold catalog and domain-contract discovery.
-It used three MCP calls and 116,112 input tokens, compared with 49,907 for its
-control. This exposed a product-interface problem: the agent still had to
-assemble a complete internal `ClaimSpec`.
-
-`reference.solve` was then changed to accept only a reference name, predicate,
-candidate, and witness role; the adapter builds the formal claim internally.
-The targeted rerun produced:
-
-| Metric | Control | Capability treatment | Paired delta |
-| --- | ---: | ---: | ---: |
-| Passed | 1 | 1 | 0 |
-| Elapsed seconds | 38.041 | 26.216 | -11.825 |
-| Input tokens | 49,954 | 51,878 | +1,924 |
-| Output tokens | 1,199 | 387 | -812 |
-| Shell calls | 2 | 0 | -2 |
-| MCP calls | 0 | 1 | +1 |
-
-The treatment also produced a durable verification record that the scorer
-replayed against the complete exact interval. The treatment agent reported no
-tooling gap. The control agent classified writing and running its local exact
-checker as infrastructure work and noted the absence of independent
-verification.
-
-This pair validates the benchmark path and demonstrates why direct,
-task-shaped capabilities matter. One public, easy case with one attempt does
-not establish a general improvement in reasoning, pass rate, or cost.
+Development pairs may validate the harness or reveal interface problems, but
+they are not product evidence. Keep their reports with the run artifacts.
+Publish a comparative result only when the protocol's held-out-case,
+repetition, contamination, and independent-scoring requirements are met.

--- a/docs/reference/math-scenarios.md
+++ b/docs/reference/math-scenarios.md
@@ -2,7 +2,8 @@
 
 [Documentation home](../index.md)
 
-- Status: Draft
+- Status: Active scenario catalog; individual release gates are defined by the
+  applicable specification and conformance document
 - Purpose: Exact public fixtures, reference-plugin workloads, and held-out
   model evaluations
 
@@ -634,10 +635,10 @@ The scenario harness may use exact enumeration, refinement, tree search,
 evolutionary search, or another strategy without changing kernel records or
 trust semantics.
 
-## M4 conjecture-workflow scenarios
+## M4 claim-transformation scenarios
 
-M4 scenarios exercise agent-facing conjecture tools without requiring a
-shared corpus:
+M4 scenarios exercise agent-facing claim-transformation operations without
+requiring a shared corpus:
 
 - mutate a true bounded theorem by dropping one necessary hypothesis, then
   generate and verify a counterexample;
@@ -754,8 +755,8 @@ known.
 
 ## Suggested repository layout
 
-Do not freeze this layout until the v0.2 schemas exist, but keep public inputs
-and hidden oracles separate:
+The v0.2 schemas exist. Any future fixture layout may evolve, but public inputs
+and hidden oracles must remain separate:
 
 ```text
 scenarios/

--- a/docs/reference/milestones/m3-scalable-search.md
+++ b/docs/reference/milestones/m3-scalable-search.md
@@ -145,10 +145,10 @@ kernel or MCP changes.
 conformance-only plugin package in isolated test state, a search request, and
 disposable package attack fixtures. Each suite execution uses a fresh
 idempotency namespace. The runner drives declared search capabilities and the
-conjecture workflow itself, performs registry attacks with fresh fixture state,
-runs every generic check, and reports all failures together. Fault injection
-belongs only in this disposable synthetic package; production plugins do not
-expose conformance crash, malformed-output, or timeout controls.
+hypothesis-transformation operations, performs registry attacks with fresh
+fixture state, runs every generic check, and reports all failures together.
+Fault injection belongs only in this disposable synthetic package; production
+plugins do not expose conformance crash, malformed-output, or timeout controls.
 
 ## 7. Execution
 

--- a/docs/reference/milestones/m4-conjecture-workflows.md
+++ b/docs/reference/milestones/m4-conjecture-workflows.md
@@ -1,23 +1,35 @@
-# Milestone 4 specification: conjecture workflows
+# Milestone 4 specification: claim-transformation primitives
 
 [Documentation home](../../index.md)
 
 - Status: Provisional implementation; outside v0.2 conformance
-- Theme: Give agents tools for developing conjectures
+- Theme: Give mathematician agents and researchers composable operations for
+  developing and challenging claims
 
 ## 1. Entry gate
 
 Scalable search must reliably preserve verified counterexamples,
 constructions, and transformation lineage.
 
-## 2. Shared plugin operation
+## 2. Current implementation and target decomposition
 
-The three hypothesis-producing M4 tools use one optional
-`HypothesisTransformer` plugin capability. The operation is typed as repair,
-generation, or parameter generalization, but the plugin owns its grammar,
-solver, enumerator, or heuristic. The kernel owns schema validation, exact
-source lineage, deduplication, budgets, and routing back into the M3
-falsification loop.
+The provisional implementation exposes three hypothesis-producing commands
+through one optional `HypothesisTransformer` plugin capability. This is the
+current compatibility surface, not the target primitive boundary.
+
+M4 should expose separately composable operations for:
+
+- deriving a claim from a source claim and a typed edit;
+- generating claims under a domain-owned grammar;
+- deduplicating claims within a declared reference set;
+- scoring or ranking hypotheses under a named heuristic;
+- requesting bounded falsification;
+- proposing and checking parameter conditions.
+
+The plugin owns the mathematical grammar, solver, enumerator, and heuristics.
+The kernel owns schema validation, exact source lineage, identity, budgets, and
+authorized-checker dispatch. Agent workflows choose how to compose the
+operations and whether to route a hypothesis into M3 falsification.
 
 ### `conjecture.repair`
 
@@ -37,9 +49,11 @@ operator-authorized checker, must bind the exact source claim, and must cite a
 
 ### `conjecture.generate`
 
-Generate candidate formal statements under a plugin-owned typed grammar,
-deduplicate them within the active experiment or supplied reference set,
-search for immediate counter-witnesses, and rank surviving hypotheses.
+The current command composes four stages: generate candidate formal statements
+under a plugin-owned typed grammar, deduplicate them within the active
+experiment or supplied reference set, request a search for immediate
+counter-witnesses, and rank surviving hypotheses. Each stage must remain
+inspectable and retain its own execution and assurance record.
 
 Interestingness, apparent novelty, and failure to find a counterexample are
 research heuristics, not assurance. Without an M5 corpus provider, global
@@ -92,7 +106,7 @@ object digests while carrying different lineage or summary metadata. Promotion
 returns the label implied by the subject's `SUFFICIENT` or `NECESSARY` kind only
 after all checks pass.
 
-## 3. Workflow
+## 3. Example workflow
 
 ```text
 verified result
@@ -106,13 +120,13 @@ verified result
 The workflow may consult an M5 corpus provider when one is configured, but its
 correctness and verification boundary do not depend on one.
 
-No workflow engine, synthesis framework, or evolutionary-search runtime is
-required. M4 composes immutable artifacts, the installed plugin boundary, and
-the M3 experiment service.
+No kernel-owned synthesis framework or evolutionary-search runtime is required.
+An agent workflow composes immutable artifacts, installed plugin operations,
+and the M3 experiment service.
 
 ## 4. Implemented scope and limits
 
-The provisional implementation provides all three hypothesis transformations,
+The provisional implementation provides the three compatibility commands,
 exact source-record replay, immutable edit and transformation records,
 request-local deduplication, optional M3 falsification, sampled-evidence
 lineage, and explicit parameter-region promotion through Python, CLI, and MCP
@@ -134,6 +148,8 @@ Milestone 4 is complete when:
 - every generated statement has a precise source and transformation record;
 - one synthetic plugin implements all three hypothesis operations without
   kernel or MCP changes;
+- claim derivation, deduplication, scoring, and falsification can be invoked
+  and inspected as distinct stages;
 - generated and repaired statements remain hypotheses;
 - immediate counterexamples are stored with verified witnesses;
 - parameter claims distinguish proved and sampled regions;

--- a/docs/reference/milestones/m5-research-corpus.md
+++ b/docs/reference/milestones/m5-research-corpus.md
@@ -14,7 +14,7 @@ unverified runs to evaluate cross-project retrieval quality.
 ## 2. Integration boundary
 
 Jacobian owns immutable artifacts, verification records, checker authority,
-the local research-memory index, and the experiment ledger required for
+the local research memory index, and the experiment ledger required for
 replay. A federated corpus provider is optional and may run in another process,
 package, or service.
 
@@ -30,7 +30,7 @@ Provider results carry their corpus identity, query, cutoff, source,
 availability, review, retraction, and verification labels. Jacobian validates
 referenced local artifacts independently.
 
-## 3. New tools
+## 3. New primitives and workflows
 
 ### `knowledge.search`
 
@@ -57,9 +57,15 @@ hypothesis artifact with supporting examples and provider provenance.
 
 ### `certificate.simplify`
 
-Minimize a certificate according to format-specific objectives while replaying
-the authorized checker after every accepted change. This tool uses the corpus
-only for discovery; checker replay remains local and authoritative.
+This is a workflow over a format-specific certificate transformation primitive
+and repeated `certificate.verify` calls. It minimizes a certificate while
+replaying the authorized checker after every accepted change. The corpus is
+used only for discovery; checker replay remains local and authoritative.
+
+Outputs from `episode.compare` and `abstraction.extract` are unverified
+hypothesis artifacts. They may feed claim-transformation or falsification
+workflows, but retrieval, comparison, and abstraction do not close a proof
+obligation.
 
 ## 4. Record lifecycle
 

--- a/docs/reference/performance-benchmarks.md
+++ b/docs/reference/performance-benchmarks.md
@@ -246,7 +246,7 @@ Measure:
 Establish a correct sequential reference run before interpreting parallel
 speedups.
 
-### M4 — Conjecture workflows
+### M4 — Claim-transformation primitives
 
 Measure:
 

--- a/docs/reference/testing-strategy.md
+++ b/docs/reference/testing-strategy.md
@@ -412,7 +412,7 @@ Required tests:
 - workers and plugins cannot authorize a checker or widen any
   Jacobian-represented budget or capability.
 
-### Conjecture workflows
+### Claim-transformation workflows
 
 Required tests:
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -6,12 +6,39 @@
 - Normative sources: [v0.2 specification](specifications/v0.2.md) and
   [conformance gate](conformance-v0.2.md)
 
-Jacobian is a general research kernel. Its core tools understand artifacts,
-claims, candidates, predicates, witnesses, certificates, reductions, budgets,
-and provenance. Mathematical meaning is supplied by versioned domain plugins.
+Jacobian is a workbench of composable mathematical primitives. The generic
+kernel understands artifacts, claims, candidates, predicates, witnesses,
+certificates, reductions, budgets, and provenance. Mathematical meaning is
+supplied by versioned domain plugins.
 
 The model-facing surface is layered so adapters are easy to add and a
 heuristic operation cannot masquerade as a verifier.
+
+## Primitives, workflows, and adapters
+
+The target primitive contract is a versioned capability with one observable
+operation. It consumes typed artifacts and returns typed artifacts, explicit
+relationships, new proof obligations when applicable, execution status,
+assurance, and provenance. Agents and proof strategies compose primitives into
+workflows without merging the assurance of their stages.
+
+The current `CapabilityResult` has a typed operation-specific output and
+artifact URIs but no generic first-class relationship or proof-obligation
+fields. Until those fields are versioned, adapters must keep that information
+inside their output schema. This is an active product-contract gap, not a
+property callers should infer.
+
+A capability adapter connects an external engine or domain operation to this
+contract and registers it behind a capability ID. A domain plugin defines the
+mathematical schemas, invariants, transformations, and witness meanings used by
+that operation. An internal backend is an implementation detail used by an
+adapter or plugin. None of these may authorize a checker; checker
+authorization is an operator-controlled kernel action.
+
+Some current lower-level MCP commands are composite compatibility workflows.
+They remain documented because current clients use them, but new mathematical
+operations should normally appear as capability IDs behind
+`capability.describe` and `capability.invoke`.
 
 ## Capability-first MCP surface
 
@@ -40,7 +67,7 @@ local verification record and the checked evidence. The `full` and
 `verification` profiles retain the lower-level tools below for advanced
 clients and compatibility.
 
-## Core v0.2 tools
+## Core v0.2 operation tools
 
 | Tool | Capability |
 | --- | --- |
@@ -51,11 +78,19 @@ clients and compatibility.
 | `witness.verify` | Independently check that a witness is in-domain and has the claimed logical effect on the stated candidate or claim. |
 | `shrink.run` | Reduce a candidate or witness while repeatedly invoking an authorized preservation checker. Report the achieved minimality class. |
 | `certificate.verify` | Independently verify an exhaustive table, SAT/PB proof, LP dual, Farkas certificate, separator, interval proof, Lean proof term, or another registered certificate format. |
-| `lean.verify` | Build a claim-bound Lean certificate in the pinned `CORE` or `MATHLIB` environment and replay it with the authorized kernel checker. This is a workflow over `certificate.verify`, not a second trust boundary. |
-| `verification.run` | Compose artifact storage, claim validation, evaluation, witness search, and authorized witness replay for one bundled domain. Every stage retains its own assurance label. |
 
 `evaluate.batch` is the central experimental interface.
 `witness.verify` and `certificate.verify` are the public trust boundary.
+
+## Current compatibility workflows
+
+These workflows ship in the repository but are not additional v0.2 trust
+boundaries or part of the frozen v0.2 conformance tool list:
+
+| Tool | Composition |
+| --- | --- |
+| `lean.verify` | Used by the `lean.check` capability. It builds a claim-bound Lean certificate in the pinned `CORE` or `MATHLIB` environment, then replays it through `certificate.verify`. |
+| `verification.run` | Composes artifact storage, claim validation, evaluation, witness search, and authorized witness replay for one bundled domain. Every stage retains its own assurance label. |
 
 The local MCP adapter provides `capabilities`, `full`, and `verification`
 projections. The compact verification projection omits unrelated research
@@ -64,7 +99,9 @@ claim contracts and its composite workflow result projects only stage status,
 assurance, evidence, and durable record URIs. Canonical registry schemas,
 artifacts, tool semantics, and checker authority are unchanged.
 
-`lean.verify` never accepts an import string or package path from a model.
+`lean.check` is the capability ID used through `capability.invoke`;
+`lean.verify` is the lower-level compatibility workflow. `lean.verify` never
+accepts an import string or package path from a model.
 `CORE` has no import and authorizes no axioms. `MATHLIB` has one
 operator-pinned `Mathlib` import and an explicit standard trust-base allowlist;
 the checker rejects any additional axiom reported by Lean.
@@ -118,24 +155,27 @@ These are plugin capabilities, not mandatory universal tools. A numerical
 analysis plugin need not implement graph canonicalization; a Lean proof plugin
 need not implement mutation.
 
-## Conjecture and corpus tools
+## Claim-transformation and corpus operations
 
-These tools produce hypotheses or research records unless their outputs are
-separately verified:
+The provisional implementation exposes several named workflow façades. Their
+stage outputs are hypotheses or research records unless separately verified:
 
 | Milestone | Tool | Capability |
 | --- | --- | --- |
 | Provisional M4 | `conjecture.repair` | Propose nearby claims after a counterexample by changing assumptions, constants, domains, or conclusions. |
-| Provisional M4 | `conjecture.generate` | Generate, deduplicate, falsify, and rank candidate statements. |
+| Provisional M4 | `conjecture.generate` | Compatibility workflow that generates candidate statements, deduplicates them, requests bounded falsification, and ranks survivors while retaining stage evidence. |
 | Provisional M4 | `parameter.generalize` | Propose parameter regions around a verified construction and preserve proposed or sampled evidence labels. |
 | Provisional M4 | `parameter.region.promote` | Replay an authorized certificate bound to an immutable region subject before labeling it verified sufficient or necessary. |
-| Current product track | `knowledge.search` | Query locally indexed capability episodes while preserving each record's assurance. |
+| Current product track | `knowledge.search` capability ID | Query locally indexed capability episodes through `capability.invoke` while preserving each record's assurance. |
 | M5 | provider-backed `knowledge.search` | Extend local retrieval with cross-project records, temporal cutoffs, review, and retraction. |
 | M5 | `abstraction.extract` | Suggest an abstract mathematical explanation for supplied or retrieved artifacts. |
 | M5 | `episode.compare` | Compare failures and propose recurring obstructions or no-go lemmas. |
 | M5 | `certificate.simplify` | Minimize a certificate while replaying its authorized checker locally. |
 
-The M4 tools operate without a shared corpus. When no M5 provider is
+The M4 workflows operate without a shared corpus. Their intended primitive
+operations are claim derivation, deduplication, scoring, bounded falsification,
+and parameter analysis; agents may compose them differently from the bundled
+façades. When no M5 provider is
 configured, they deduplicate against supplied or local experiment records and
 report corpus-wide novelty as unknown. Corpus retrieval can suggest inputs to
 any tool but cannot authorize checkers or promote verification status.


### PR DESCRIPTION
## Problem

The documentation described Jacobian through several competing frames: an MCP capability layer, a research-memory service, lower-level verification tools, and broad conjecture workflows. It did not define the atomic mathematical operation that agents and researchers should compose, and some reference material blurred implemented compatibility workflows with the intended capability boundary.

## Solution

- define Jacobian as a verifier-centric workbench of composable mathematical primitives for mathematician agents and human researchers
- specify primitive outputs, ownership boundaries, workflow composition, capability adapters, domain plugins, and independent checker authorization
- distinguish current compatibility workflows such as `verification.run`, `search.run`, and `conjecture.generate` from the target primitive surface
- reframe the roadmap and M4/M5 contracts around separately invocable claim transformation, falsification, retrieval, and certificate operations
- document that first-class relationship and proof-obligation fields are still an implementation gap in `CapabilityResult`
- reconcile `lean.check` with the lower-level `lean.verify` workflow and remove stale tool counts, one-off benchmark logs, and provisional-status drift

No public document was deleted; the existing tutorial, how-to, reference, and explanation structure remains intact.

## Testing

- `git diff --check`
- checked all 31 Markdown files for broken local links; none found
- checked all Markdown files for unclosed fenced code blocks; none found
- reviewed the complete documentation diff against `main`

## Trust & Compatibility Impact

Documentation only. This does not change the verification kernel, checker registry, artifact formats, tool behavior, or v0.2 conformance contract. It clarifies the existing fail-closed boundary and labels the primitive contract and M3-M5 decomposition work as pre-stable product direction.