### PR TITLE
feat(graphs): add composable graph exploration capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,9 +135,9 @@ documentation placement, and pull-request expectations.
 v0.2 alpha is implemented as a Python package, CLI, and local or remote MCP
 adapter. The compact projection exposes `capability.describe` for discovery
 and `capability.invoke` for execution, backed by an extensible adapter registry
-and trust-labeled research memory.
-Bundled capabilities provide reference-domain exploration and verification,
-Lean checking, and local episode search.
+and trust-labeled research memory. Bundled capabilities provide bounded Graph
+Atlas construction, exact graph-property batches, reference-domain exploration
+and verification, Lean checking, and local episode search.
 
 The advanced profiles expose the lower-level operations documented in the
 [tool reference](docs/reference/tools.md), including bounded enumeration,

--- a/benchmarks/agent_cases/graph-report.schema.json
+++ b/benchmarks/agent_cases/graph-report.schema.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "case_id": {
+      "type": "string"
+    },
+    "assurance": {
+      "enum": ["HEURISTIC", "COMPUTED", "VERIFIED"]
+    },
+    "completeness": {
+      "enum": ["NOT_APPLICABLE", "UNKNOWN", "PARTIAL", "COMPLETE"]
+    },
+    "final_verification": {
+      "enum": ["UNVERIFIED", "VERIFIED"]
+    },
+    "graph_uri": {
+      "type": "string",
+      "pattern": "^artifact://sha256/[0-9a-f]{64}$"
+    },
+    "property_artifact_uri": {
+      "type": "string",
+      "pattern": "^artifact://sha256/[0-9a-f]{64}$"
+    },
+    "properties": {
+      "type": "object",
+      "properties": {
+        "order": {
+          "type": "integer"
+        },
+        "size": {
+          "type": "integer"
+        },
+        "connected": {
+          "type": "boolean"
+        },
+        "bipartite": {
+          "type": "boolean"
+        },
+        "degree_sequence": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        },
+        "triangle_count": {
+          "type": "integer"
+        },
+        "independence_number": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "order",
+        "size",
+        "connected",
+        "bipartite",
+        "degree_sequence",
+        "triangle_count",
+        "independence_number"
+      ],
+      "additionalProperties": false
+    },
+    "limitations": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "feedback": {
+      "type": "object",
+      "properties": {
+        "tooling_strengths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tooling_gaps": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "domain_knowledge_gaps": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "suggested_improvements": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "tooling_strengths",
+        "tooling_gaps",
+        "domain_knowledge_gaps",
+        "suggested_improvements"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "case_id",
+    "assurance",
+    "completeness",
+    "final_verification",
+    "graph_uri",
+    "property_artifact_uri",
+    "properties",
+    "limitations",
+    "feedback"
+  ],
+  "additionalProperties": false
+}

--- a/benchmarks/agent_cases/graph_atlas_path_001.json
+++ b/benchmarks/agent_cases/graph_atlas_path_001.json
@@ -1,0 +1,27 @@
+{
+  "case_id": "GRAPH-ATLAS-PATH-001",
+  "case_type": "graph_capability",
+  "version": "1",
+  "title": "Construct and classify the five-vertex path",
+  "prompt": "Search all Graph Atlas representatives of order 5 for a connected tree with maximum degree at most 2. Then compute order, size, connectedness, bipartiteness, degree sequence, triangle count, and independence number for the returned candidate. Preserve COMPUTED versus VERIFIED exactly.",
+  "required_tools": [
+    "capability.invoke"
+  ],
+  "required_capability_ids": [
+    "graph.search.atlas",
+    "graph.compute.properties"
+  ],
+  "expected": {
+    "assurance": "COMPUTED",
+    "completeness": "COMPLETE",
+    "properties": {
+      "order": 5,
+      "size": 4,
+      "connected": true,
+      "bipartite": true,
+      "degree_sequence": [2, 2, 2, 1, 1],
+      "triangle_count": 0,
+      "independence_number": 3
+    }
+  }
+}

--- a/benchmarks/agent_mcp.py
+++ b/benchmarks/agent_mcp.py
@@ -23,13 +23,28 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+import networkx as nx
+
+from jacobian.schema_registry import SchemaRegistry, SchemaRegistryError
 from jacobian.store import ArtifactStore, StoreError
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 CASES_ROOT = Path(__file__).with_name("agent_cases")
 DEFAULT_RESULTS_ROOT = Path(__file__).with_name("results")
 REPORT_SCHEMA = CASES_ROOT / "report.schema.json"
+GRAPH_REPORT_SCHEMA = CASES_ROOT / "graph-report.schema.json"
 ARTIFACT_PREFIX = "artifact://sha256/"
+PARAMETER_ERROR_CODES = frozenset(
+    {
+        -32602,
+        "INVALID_ARGUMENT",
+        "INVALID_CONSTRAINT_RANGE",
+        "INVALID_PARAMS",
+        "INVALID_REQUEST",
+        "SCHEMA_VALIDATION",
+        "invalid_params",
+    }
+)
 
 SYSTEM_TASK = """\
 Use only the jacobian_local MCP tools and resources for the mathematical work.
@@ -56,6 +71,22 @@ missing domain knowledge, and concrete improvements. Empty feedback lists are
 valid when the run exposed no issue.
 """
 
+GRAPH_SYSTEM_TASK = """\
+Use only the jacobian_local MCP tools for mathematical work. Do not run shell
+commands, read repository files, edit files, or use network retrieval. Describe
+unfamiliar capabilities before invoking them.
+
+Complete public workflow case {case_id}. Set report case_id exactly to
+{case_id}.
+
+{prompt}
+
+Use graph.search.atlas, then graph.compute.properties on one returned graph.
+Report exact durable URIs. NetworkX computation is COMPUTED, not VERIFIED.
+Complete Atlas coverage does not authorize mathematical promotion. State
+limits. Record concise feedback; empty feedback lists are valid.
+"""
+
 
 class BenchmarkError(RuntimeError):
     """The runner or durable benchmark evidence is invalid."""
@@ -72,7 +103,7 @@ def load_cases(selected: Sequence[str]) -> list[dict[str, Any]]:
     cases = [
         _load_json_object(path)
         for path in sorted(CASES_ROOT.glob("*.json"))
-        if path.name != REPORT_SCHEMA.name
+        if not path.name.endswith("schema.json")
     ]
     by_id = {str(case.get("case_id")): case for case in cases}
     if len(by_id) != len(cases):
@@ -115,9 +146,55 @@ def _artifact_uri(value: object, field: str) -> str:
     return value
 
 
-def parse_transcript(path: Path) -> tuple[list[str], dict[str, Any] | None]:
+def _contains_parameter_error(value: object) -> bool:
+    if isinstance(value, Mapping):
+        if value.get("code") in PARAMETER_ERROR_CODES:
+            return True
+        return any(_contains_parameter_error(item) for item in value.values())
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return any(_contains_parameter_error(item) for item in value)
+    return False
+
+
+def _contains_execution_error(value: object) -> bool:
+    if isinstance(value, Mapping):
+        if value.get("status") in {"CANCELLED", "ERROR", "TIMEOUT"}:
+            return True
+        return any(_contains_execution_error(item) for item in value.values())
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return any(_contains_execution_error(item) for item in value)
+    return False
+
+
+def _mcp_text_payload(item: Mapping[str, Any]) -> dict[str, Any] | None:
+    result = item.get("result")
+    if not isinstance(result, dict):
+        return None
+    content = result.get("content")
+    if not isinstance(content, list):
+        return None
+    for block in content:
+        if not isinstance(block, dict) or not isinstance(block.get("text"), str):
+            continue
+        try:
+            payload = json.loads(block["text"])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            return payload
+    return None
+
+
+def parse_transcript(
+    path: Path,
+) -> tuple[list[str], dict[str, Any] | None, dict[str, Any]]:
     calls: list[str] = []
+    successful_calls: list[str] = []
     usage: dict[str, Any] | None = None
+    tool_error_count = 0
+    parameter_error_count = 0
+    capability_ids: list[str] = []
+    capability_invocations: list[dict[str, Any]] = []
     for line in path.read_text(encoding="utf-8").splitlines():
         try:
             event = json.loads(line)
@@ -132,13 +209,62 @@ def parse_transcript(path: Path) -> tuple[list[str], dict[str, Any] | None]:
             and isinstance(item.get("tool"), str)
         ):
             calls.append(item["tool"])
+            result = item.get("result")
+            failed = bool(
+                item.get("status") in {"error", "failed"}
+                or item.get("error")
+                or (isinstance(result, dict) and result.get("isError") is True)
+                or _contains_execution_error(item)
+            )
+            if failed:
+                tool_error_count += 1
+            else:
+                successful_calls.append(item["tool"])
+                arguments = item.get("arguments")
+                response = _mcp_text_payload(item)
+                execution = (
+                    response.get("execution") if isinstance(response, dict) else None
+                )
+                if (
+                    item["tool"] == "capability.invoke"
+                    and isinstance(arguments, dict)
+                    and isinstance(arguments.get("capability_id"), str)
+                    and isinstance(response, dict)
+                    and response.get("capability_id") == arguments["capability_id"]
+                    and isinstance(execution, dict)
+                    and execution.get("status") == "COMPLETED"
+                ):
+                    capability_id = arguments["capability_id"]
+                    capability_ids.append(capability_id)
+                    capability_invocations.append(
+                        {
+                            "capability_id": capability_id,
+                            "input": arguments.get("payload"),
+                            "output": response.get("output"),
+                            "artifact_uris": response.get("artifact_uris"),
+                            "assurance": response.get("assurance"),
+                            "completeness": response.get("completeness"),
+                        }
+                    )
+            if _contains_parameter_error(item):
+                parameter_error_count += 1
         if (
             isinstance(event, dict)
             and event.get("type") == "turn.completed"
             and isinstance(event.get("usage"), dict)
         ):
             usage = event["usage"]
-    return calls, usage
+    return (
+        calls,
+        usage,
+        {
+            "tool_error_count": tool_error_count,
+            "parameter_error_count": parameter_error_count,
+            "successful_tool_calls": successful_calls,
+            "capability_ids": capability_ids,
+            "capability_invocations": capability_invocations,
+        },
+    )
 
 
 def _as_object(value: Any, field: str) -> dict[str, Any]:
@@ -327,13 +453,262 @@ def _check_evidence(
     raise BenchmarkError(f"unsupported evidence kind: {evidence_kind}")
 
 
+def _property_values(value: object) -> dict[str, Any]:
+    properties = _as_object(value, "graph properties")
+    normalized: dict[str, Any] = {}
+    for name, result in properties.items():
+        if isinstance(result, dict) and "value" in result:
+            if result.get("exactness") != "EXACT":
+                raise BenchmarkError(f"graph property {name} is not labeled exact")
+            normalized[name] = result["value"]
+        else:
+            normalized[name] = result
+    return normalized
+
+
+def _require_descriptor(
+    store: ArtifactStore,
+    uri: str,
+    *,
+    kind: str,
+    name: str,
+) -> None:
+    descriptor = _as_object(store.get(uri).payload, f"{name} descriptor")
+    if (
+        descriptor.get("descriptor_version") != "1"
+        or descriptor.get("kind") != kind
+        or descriptor.get("name") != name
+        or descriptor.get("version") != "1"
+    ):
+        raise BenchmarkError(f"artifact does not use {name}@1")
+
+
+def _find_graph_invocations(
+    invocations: Sequence[Mapping[str, Any]],
+    *,
+    graph_uri: str,
+    property_uri: str,
+) -> Mapping[str, Any]:
+    for search_index, search in enumerate(invocations):
+        if search.get("capability_id") != "graph.search.atlas":
+            continue
+        search_output = search.get("output")
+        search_artifacts = search.get("artifact_uris")
+        search_assurance = search.get("assurance")
+        search_completeness = search.get("completeness")
+        if (
+            not isinstance(search_output, dict)
+            or not isinstance(search_artifacts, list)
+            or graph_uri not in search_artifacts
+            or not isinstance(search_output.get("candidates"), list)
+            or not any(
+                isinstance(candidate, dict) and candidate.get("graph_uri") == graph_uri
+                for candidate in search_output["candidates"]
+            )
+            or not isinstance(search_assurance, dict)
+            or search_assurance.get("level") != "COMPUTED"
+            or not isinstance(search_completeness, dict)
+            or search_completeness.get("status") != "COMPLETE"
+        ):
+            continue
+        for computed in invocations[search_index + 1 :]:
+            if computed.get("capability_id") != "graph.compute.properties":
+                continue
+            computed_input = computed.get("input")
+            computed_output = computed.get("output")
+            computed_artifacts = computed.get("artifact_uris")
+            computed_assurance = computed.get("assurance")
+            computed_completeness = computed.get("completeness")
+            if (
+                isinstance(computed_input, dict)
+                and computed_input.get("graph_uri") == graph_uri
+                and isinstance(computed_output, dict)
+                and computed_output.get("graph_uri") == graph_uri
+                and computed_output.get("property_artifact_uri") == property_uri
+                and isinstance(computed_artifacts, list)
+                and graph_uri in computed_artifacts
+                and property_uri in computed_artifacts
+                and isinstance(computed_assurance, dict)
+                and computed_assurance.get("level") == "COMPUTED"
+                and isinstance(computed_completeness, dict)
+                and computed_completeness.get("status") == "COMPLETE"
+            ):
+                return computed
+    raise BenchmarkError(
+        "transcript lacks a successful search-to-property artifact flow"
+    )
+
+
+def _score_graph_capability_run(
+    case: Mapping[str, Any],
+    report: Mapping[str, Any],
+    *,
+    state_dir: Path,
+    tool_calls: Sequence[str],
+    capability_ids: Sequence[str],
+    capability_invocations: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    expected = _as_object(case.get("expected"), "case expected")
+    if report.get("case_id") != case.get("case_id"):
+        raise BenchmarkError("agent report case_id does not match the case")
+    if report.get("assurance") != expected.get("assurance"):
+        raise BenchmarkError("graph computation assurance differs from the case")
+    if report.get("completeness") != expected.get("completeness"):
+        raise BenchmarkError("graph search completeness differs from the case")
+    if report.get("final_verification") != "UNVERIFIED":
+        raise BenchmarkError("computed graph workflow was falsely certified")
+    required_tools = case.get("required_tools")
+    if not isinstance(required_tools, list):
+        raise BenchmarkError("case required_tools must be a list")
+    missing_tools = sorted(set(required_tools) - set(tool_calls))
+    if missing_tools:
+        raise BenchmarkError(
+            f"transcript is missing MCP calls: {', '.join(missing_tools)}"
+        )
+    required_capabilities = case.get("required_capability_ids")
+    if not isinstance(required_capabilities, list):
+        raise BenchmarkError("case required_capability_ids must be a list")
+    missing_capabilities = sorted(set(required_capabilities) - set(capability_ids))
+    if missing_capabilities:
+        raise BenchmarkError(
+            "transcript is missing capability invocations: "
+            + ", ".join(missing_capabilities)
+        )
+
+    graph_uri = _artifact_uri(report.get("graph_uri"), "graph_uri")
+    property_uri = _artifact_uri(
+        report.get("property_artifact_uri"),
+        "property_artifact_uri",
+    )
+    store = ArtifactStore(state_dir)
+    try:
+        graph_artifact = store.get(graph_uri)
+        property_artifact = store.get(property_uri)
+        _require_descriptor(
+            store,
+            graph_artifact.manifest.schema_uri,
+            kind="schema",
+            name="jacobian.simple-undirected-graph",
+        )
+        _require_descriptor(
+            store,
+            graph_artifact.manifest.semantics_uri,
+            kind="semantics",
+            name="jacobian.simple-undirected-graph",
+        )
+        _require_descriptor(
+            store,
+            property_artifact.manifest.schema_uri,
+            kind="schema",
+            name="jacobian.graph-property-batch",
+        )
+        if (
+            property_artifact.manifest.semantics_uri
+            != graph_artifact.manifest.semantics_uri
+        ):
+            raise BenchmarkError("property artifact uses different graph semantics")
+        schemas = SchemaRegistry(store)
+        schemas.validate(graph_artifact.manifest.schema_uri, graph_artifact.payload)
+        schemas.validate(
+            property_artifact.manifest.schema_uri,
+            property_artifact.payload,
+        )
+    except (SchemaRegistryError, StoreError) as exc:
+        raise BenchmarkError(
+            "reported graph artifacts fail contract validation"
+        ) from exc
+    graph_payload = _as_object(graph_artifact.payload, "graph payload")
+    vertices = graph_payload.get("vertices")
+    edges = graph_payload.get("edges")
+    if not isinstance(vertices, list) or not isinstance(edges, list):
+        raise BenchmarkError("graph payload is malformed")
+    if len(set(vertices)) != len(vertices) or any(
+        not isinstance(vertex, str) for vertex in vertices
+    ):
+        raise BenchmarkError("graph vertices are malformed")
+    vertex_set = set(vertices)
+    normalized_edges: list[tuple[str, str]] = []
+    for edge in edges:
+        if (
+            not isinstance(edge, list)
+            or len(edge) != 2
+            or not all(isinstance(endpoint, str) for endpoint in edge)
+        ):
+            raise BenchmarkError("graph edge payload is malformed")
+        source, target = edge
+        if source not in vertex_set or target not in vertex_set or source >= target:
+            raise BenchmarkError("graph edge violates simple-graph semantics")
+        normalized_edges.append((source, target))
+    if len(set(normalized_edges)) != len(normalized_edges):
+        raise BenchmarkError("graph contains duplicate edges")
+    graph = nx.Graph()
+    graph.add_nodes_from(vertices)
+    graph.add_edges_from(normalized_edges)
+    degree_sequence = sorted((degree for _, degree in graph.degree), reverse=True)
+    if (
+        graph.number_of_nodes() != 5
+        or graph.number_of_edges() != 4
+        or not nx.is_connected(graph)
+        or degree_sequence != [2, 2, 2, 1, 1]
+    ):
+        raise BenchmarkError("reported graph is not the five-vertex path")
+
+    if graph_uri not in property_artifact.manifest.parents:
+        raise BenchmarkError("property artifact is not bound to the graph")
+    property_payload = _as_object(property_artifact.payload, "property payload")
+    if property_payload.get("graph_uri") != graph_uri:
+        raise BenchmarkError("property payload names another graph")
+    wanted_properties = _as_object(expected.get("properties"), "expected properties")
+    artifact_properties = _property_values(property_payload.get("properties"))
+    report_properties = _property_values(report.get("properties"))
+    property_invocation = _find_graph_invocations(
+        capability_invocations,
+        graph_uri=graph_uri,
+        property_uri=property_uri,
+    )
+    invocation_output = _as_object(
+        property_invocation.get("output"),
+        "property invocation output",
+    )
+    invocation_properties = _property_values(invocation_output.get("properties"))
+    if (
+        artifact_properties != wanted_properties
+        or report_properties != wanted_properties
+        or invocation_properties != wanted_properties
+    ):
+        raise BenchmarkError("graph properties differ from the frozen oracle")
+    return {
+        "passed": True,
+        "checks": [
+            "computed assurance without false certification",
+            "required multi-call capability sequence",
+            "five-vertex path up to relabeling",
+            "bound exact property artifact",
+        ],
+        "case_id": case["case_id"],
+        "graph_uri": graph_uri,
+        "property_artifact_uri": property_uri,
+    }
+
+
 def score_run(
     case: Mapping[str, Any],
     report: Mapping[str, Any],
     *,
     state_dir: Path,
     tool_calls: Sequence[str],
+    capability_ids: Sequence[str] = (),
+    capability_invocations: Sequence[Mapping[str, Any]] = (),
 ) -> dict[str, Any]:
+    if case.get("case_type") == "graph_capability":
+        return _score_graph_capability_run(
+            case,
+            report,
+            state_dir=state_dir,
+            tool_calls=tool_calls,
+            capability_ids=capability_ids,
+            capability_invocations=capability_invocations,
+        )
     expected = _as_object(case.get("expected"), "case expected")
     checks: list[str] = []
     if report.get("case_id") != case.get("case_id"):
@@ -455,11 +830,22 @@ def _run_case(
     feedback_path = case_root / "feedback.json"
     case_root.mkdir(parents=True)
     state_dir.mkdir()
-    prompt = SYSTEM_TASK.format(
-        agent_contract_uri=f"reference://domain/{case['reference_name']}",
-        case_id=case_id,
-        prompt=case["prompt"],
-    )
+    graph_case = case.get("case_type") == "graph_capability"
+    if graph_case:
+        prompt = GRAPH_SYSTEM_TASK.format(
+            case_id=case_id,
+            prompt=case["prompt"],
+        )
+        report_schema = GRAPH_REPORT_SCHEMA
+        tool_profile = "capabilities"
+    else:
+        prompt = SYSTEM_TASK.format(
+            agent_contract_uri=f"reference://domain/{case['reference_name']}",
+            case_id=case_id,
+            prompt=case["prompt"],
+        )
+        report_schema = REPORT_SCHEMA
+        tool_profile = "verification"
     command = [
         codex_command,
         "exec",
@@ -470,7 +856,7 @@ def _run_case(
         "never",
         "--json",
         "--output-schema",
-        str(REPORT_SCHEMA),
+        str(report_schema),
         "--output-last-message",
         str(report_path),
         "-c",
@@ -483,7 +869,7 @@ def _run_case(
                 "run",
                 "jacobian-mcp",
                 "--tool-profile",
-                "verification",
+                tool_profile,
             ]
         ),
         "-c",
@@ -520,7 +906,7 @@ def _run_case(
     elapsed = time.monotonic() - started
     transcript.write_text(stdout, encoding="utf-8")
     stderr_path.write_text(stderr, encoding="utf-8")
-    tool_calls, usage = parse_transcript(transcript)
+    tool_calls, usage, transcript_metrics = parse_transcript(transcript)
 
     score: dict[str, Any]
     report: dict[str, Any] | None = None
@@ -540,7 +926,9 @@ def _run_case(
                 case,
                 report,
                 state_dir=state_dir,
-                tool_calls=tool_calls,
+                tool_calls=transcript_metrics["successful_tool_calls"],
+                capability_ids=transcript_metrics["capability_ids"],
+                capability_invocations=transcript_metrics["capability_invocations"],
             )
         except (BenchmarkError, OSError, json.JSONDecodeError) as exc:
             score = {"passed": False, "error": str(exc)}
@@ -556,7 +944,14 @@ def _run_case(
         "exit_code": exit_code,
         "tool_calls": tool_calls,
         "tool_call_count": len(tool_calls),
+        **transcript_metrics,
         "usage": usage,
+        "correct": bool(score.get("passed", False)),
+        "false_certification": bool(
+            report is not None
+            and report.get("final_verification") == "VERIFIED"
+            and not score.get("passed", False)
+        ),
         "agent_report": report,
         "score": score,
         "artifacts": {
@@ -635,6 +1030,10 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "passed": result["score"].get("passed", False),
                 "elapsed_seconds": result["elapsed_seconds"],
                 "tool_call_count": result["tool_call_count"],
+                "tool_error_count": result["tool_error_count"],
+                "parameter_error_count": result["parameter_error_count"],
+                "false_certification": result["false_certification"],
+                "usage": result["usage"],
                 "error": result["score"].get("error"),
             }
             for result in results

--- a/docs/explanation/product-blueprint.md
+++ b/docs/explanation/product-blueprint.md
@@ -143,11 +143,15 @@ local artifact store, and records the episode. Projected record IDs and
 conclusions must agree with the checked record. `MCPServer` does not need a new
 tool when an Alloy, Lean, SAT/SMT, CAS, or domain adapter is registered.
 
-The current `CapabilityResult` exposes a generic output object and artifact
-URIs. Relationships and proof obligations are therefore still
-operation-specific data inside that output. Before the primitive contract is
-stabilized, they need versioned first-class fields so a workflow can compose
-them without understanding every domain payload.
+`CapabilityResult` version 2 exposes a generic operation-specific output plus
+first-class scope, completeness, relationships, proof obligations, and artifact
+URIs. The shared layer validates artifact bindings and checker-backed lifecycle
+states; domain adapters still define the mathematical meaning of relation IDs,
+scope parameters, and obligation artifacts.
+
+The [capability workflow evaluation plan](../reference/capability-workflow-evaluations.md)
+defines the first four held-out workflows and the evidence required before
+adding more capability IDs.
 
 Deploy an operator-approved adapter package with a repeatable
 `--capability-adapter package.module:factory` option. The factory receives the
@@ -157,6 +161,10 @@ mathematical trust.
 
 The initial bundled catalog contains:
 
+- `graph.search.atlas` for bounded exact-order construction from NetworkX's
+  maintained Graph Atlas;
+- `graph.compute.properties` for exact batched properties over Jacobian graph
+  artifacts;
 - `reference.solve` for bundled reference-domain exploration and verification;
 - `lean.check` for checker-backed Lean proof replay;
 - `knowledge.search` for trust-labeled local episode retrieval.

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,6 +69,7 @@ expectations.
 - [Performance benchmark protocol](reference/performance-benchmarks.md)
 - [Testing strategy](reference/testing-strategy.md)
 - [Agent evaluation protocol](reference/agent-evaluations.md)
+- [Capability workflow evaluation plan](reference/capability-workflow-evaluations.md)
 
 Later-release contracts are provisional:
 

--- a/docs/reference/agent-evaluations.md
+++ b/docs/reference/agent-evaluations.md
@@ -94,7 +94,14 @@ Primary aggregate metrics are:
 - verified-witness utilization rate;
 - successful recovery rate after a defeating witness;
 - replayable-handoff rate;
-- tokens, tool calls, wall time, and compute conditional on correctness.
+- tokens, tool calls, wall time, and compute conditional on correctness;
+- tool execution errors and parameter/schema errors per run.
+
+The public MCP pilot records elapsed time, token usage, tool-call count, tool
+errors, parameter errors, correctness, and a conservative false-certification
+flag in each result. A claimed verified result that fails durable scoring is
+counted as false certification for triage, even when the immediate cause may
+later prove to be a reporting or binding error.
 
 The initial target for catastrophic false certification is zero. Other release
 thresholds are set only after baseline pilots show the scenario is
@@ -106,6 +113,14 @@ The public motifs and exact facts underlying these evaluations are listed in
 the [Mathematical scenario catalog](math-scenarios.md). Agent-facing cases use
 held-out relabelings, parameter changes, and distractors rather than exposing
 those public answers directly.
+
+The runnable public pilot also includes `GRAPH-ATLAS-PATH-001`, a smoke case
+for the first graph capability slice. It requires separate
+`graph.search.atlas` and `graph.compute.properties` calls, accepts any labeling
+of the five-vertex path, checks the durable graph-to-property relationship, and
+fails a run that promotes exact NetworkX computation to verified evidence.
+This public case validates the harness and tool composition; it is not a
+held-out research benchmark.
 
 ### EVAL-SEM-001 — Complete semantics
 

--- a/docs/reference/capability-workflow-evaluations.md
+++ b/docs/reference/capability-workflow-evaluations.md
@@ -1,0 +1,188 @@
+# Capability workflow evaluation plan
+
+[Documentation home](../index.md)
+
+- Status: Active product evaluation plan; capability IDs remain provisional
+- Scope: Selecting the smallest useful mathematical capability set
+- Compatibility: The v0.2 verification contract remains normative
+
+## Decision
+
+Do not implement a broad vocabulary of mathematical verbs first. Stabilize the
+shared result contract, freeze realistic workflow tasks and independent
+oracles, record a no-new-capability baseline, and then add one vertical slice at
+a time. A capability ID is retained only when agent transcripts show that it
+improves correctness or resource use without increasing false certification.
+
+`CapabilityResult` version 2 therefore makes four composition concerns
+first-class before adding domain operations:
+
+- exact scope, with domain-owned parameters or a scope artifact;
+- completeness as `NOT_APPLICABLE`, `UNKNOWN`, `PARTIAL`, or `COMPLETE`, with
+  a separate assurance level and basis;
+- relationships between exact source and target artifacts;
+- materialized proof obligations and their open or discharged state.
+
+A failed execution cannot report complete coverage. A verified relationship,
+discharged obligation, or verified completeness claim must use the same
+operator-authorized verification record as the verified result. Every
+first-class artifact reference must also appear in `artifact_uris`. The record
+must bind the exact relationship artifacts and relation ID, the exact
+obligation artifact, or an explicit scope artifact with compatible checked
+coverage; sharing an otherwise valid record URI is not enough.
+
+## Initial workflows
+
+The first evaluation set exercises four workflows. These are agent objectives,
+not capability names.
+
+### Challenge a universal finite-graph claim
+
+The agent must formalize the exact claim, construct or retrieve candidate
+graphs, compute relevant properties, search or mutate candidates, and replay a
+counterexample certificate. The oracle includes an explicit graph and an
+independent checker. A tempting failure is to promote a successful solver call
+or a bounded search with no witness.
+
+The open [WOWII Conjecture 194 pull request][wowii-194] is useful workflow
+evidence: it exposes an 18-vertex graph, a graph6 representation, property
+claims, and an immutable Lean proof. It is a public regression source, not a
+hidden answer and not evidence that the upstream pull request has been
+accepted.
+
+### Construct and compare constrained objects
+
+The agent must find at least one object satisfying several exact constraints,
+compare multiple candidates using a mix of exact and approximate properties,
+and preserve the evidence type of each property. Alternative valid strategies
+include solver-backed construction, bounded enumeration, database retrieval,
+and mutation from a seed object.
+
+The initial domain is finite simple graphs because maintained infrastructure is
+available: NetworkX for graph operations, Z3 for constraint models, and
+specialized graph databases or canonical-labeling systems where their pinned
+contracts fit. Jacobian should not reimplement graph traversal, SAT/SMT search,
+or graph isomorphism algorithms.
+
+### Partition a finite domain and verify coverage
+
+The agent proposes cases, refines them if necessary, and independently checks
+that their union equals the declared finite scope. Disjointness is reported
+separately. The negative fixtures include a missing boundary value, overlapping
+cases, a timeout after partial enumeration, and a partition whose prose
+description differs from its executable scope.
+
+This workflow tests whether first-class scope and completeness are useful
+before `case.partition` earns a stable capability contract.
+
+### Decompose a Lean goal and apply retrieved premises
+
+The agent inspects a pinned Lean proof state, proposes alternative
+decompositions, retrieves candidate declarations, applies premises, and asks
+Lean to replay the completed proof. A decomposition remains an unverified
+relationship until the parent-from-children obligation is accepted.
+
+Prefer a thin adapter over a custom Lean protocol. Spike the maintained Lean 4
+[REPL][lean-repl] first; compare [Pantograph][pantograph] when its higher-level
+goal operations materially improve the held-out runs. Do not start new work on
+the deprecated LeanDojo v1 interface; evaluate [LeanDojo v2][leandojo-v2] or a
+current premise-search system separately when retrieval becomes the measured
+bottleneck.
+
+## Capability hypotheses
+
+The workflows justify the following initial experiments:
+
+- `graph.search.atlas`, now implemented as a bounded, exact-order construction
+  slice over NetworkX's maintained Graph Atlas;
+- `graph.compute.properties`, now implemented with batched properties and
+  per-property exactness and backend labels;
+- controlled graph mutation only if construction transcripts need it;
+- finite case partitioning with a replayable coverage artifact;
+- Lean goal-state interaction and premise retrieval, consolidated or split
+  according to tool-call and parameter-error evidence.
+
+Generic `claim.derive`, `goal.decompose`, `premise.apply`, and
+`property.compute` names are design hypotheses, not an initial required API.
+Use the existing transformation and verification machinery for claim edits
+until a held-out workflow demonstrates that a smaller domain-specific
+capability cannot express the task.
+
+## Evaluation construction
+
+Public conjecture repositories and datasets inform task shape and provide
+regression cases, but answer-rich public items are not held out. Create the
+scored cases from private templates or generated variants with:
+
+1. a frozen input bundle visible to the agent;
+2. a hidden, versioned oracle unavailable in the agent workspace;
+3. an independently implemented checker or proof replay;
+4. at least one tempting incomplete, misbound, or semantically mismatched path;
+5. multiple accepted strategies when the mathematics permits them;
+6. a contamination record containing source lineage and cutoff date.
+
+The Formal Conjectures reports on [Erdős 33][erdos-33] and
+[Erdős 707][erdos-707] supply particularly valuable negative patterns. One
+reverses an existential upper-bound statement into a universal lower bound;
+the other shows how admitting `n = 0` flips a formalized variant's truth value.
+The [P5 report for Graph Conjecture 316][graph-316] supplies a small explicit
+counterexample and a warning that “no counterexample through size 8” is only a
+bounded observation.
+
+Measure for each condition and case:
+
+- oracle correctness and false certification;
+- wall time and model token use;
+- tool-call count, tool execution errors, and parameter errors;
+- completion status and completeness label;
+- evidence and verification-record bindings;
+- whether an accepted alternative strategy was rejected by the scorer.
+
+Run a paired control without the new capability and a treatment with it under
+the same model and reasoning budget. Repeat enough times to expose variance.
+Freeze the tree and oracle before the comparison.
+
+## Source policy
+
+Use the supplied research collection according to evidence strength:
+
+| Source class | Use |
+| --- | --- |
+| Lean proofs, checker-ready certificates, explicit objects, and pinned code | Workflow mining, independent reproduction, and public regression |
+| Maintained proof assistants, CAS/solver libraries, and mathematical databases | Adapter candidates; pin and test their exact versions |
+| Curated problem databases and expert forums | Task discovery and premise retrieval; verify status against primary artifacts |
+| Public theorem-proving datasets and benchmarks | Baselines, compatibility, and regression after license and statement-alignment review |
+| Blogs, news, social threads, and shared chats | Lead generation and workflow clues only |
+
+Machine checking proves the formal statement that was checked. It does not by
+itself prove that the formal statement corresponds to the intended informal
+conjecture. Statement correspondence remains a separate relationship and
+review obligation.
+
+## Revised implementation order
+
+1. Freeze these workflow cases, hidden oracle contracts, and baseline metrics.
+2. Stabilize first-class scope, completeness, relationships, and obligations.
+3. Implement the graph construction/property slice using maintained libraries.
+   The first slice uses NetworkX's Graph Atlas and exact graph algorithms;
+   solver-backed construction remains a later comparison for orders outside
+   the atlas.
+4. Run the paired evaluation and keep, split, or consolidate the graph
+   capabilities from transcripts.
+5. Implement finite partition coverage and rerun the evaluation.
+6. Spike the pinned Lean REPL integration, then add decomposition or retrieval
+   only where the measured workflow needs it.
+7. Decompose compatibility workflows only after the new slices preserve their
+   artifacts and assurance boundaries.
+
+This reorders the earlier proposal in one important way: evaluation design and
+baseline collection precede capability implementation, and evaluation runs
+after every vertical slice rather than at the end.
+
+[erdos-33]: https://github.com/google-deepmind/formal-conjectures/issues/1347
+[erdos-707]: https://github.com/google-deepmind/formal-conjectures/issues/1137
+[graph-316]: https://github.com/google-deepmind/formal-conjectures/issues/4133
+[leandojo-v2]: https://github.com/lean-dojo/LeanDojo-v2
+[lean-repl]: https://github.com/leanprover-community/repl
+[pantograph]: https://github.com/leanprover/Pantograph
+[wowii-194]: https://github.com/google-deepmind/formal-conjectures/pull/4542

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -23,11 +23,13 @@ new proof obligations when applicable, execution status, assurance, and
 provenance. Agents and proof strategies compose tools into workflows without
 merging the assurance of their stages.
 
-The current `CapabilityResult` has a typed operation-specific output and
-artifact URIs but no generic first-class relationship or proof-obligation
-fields. Until those fields are versioned, adapters must keep that information
-inside their output schema. This is an active product-contract gap, not a
-property callers should infer.
+`CapabilityResult` version 2 keeps the typed operation-specific output and
+adds first-class scope, completeness, relationship, and proof-obligation
+fields. Mathematical relationship IDs and scope parameters remain
+domain-owned; the shared contract defines their artifact bindings and
+assurance lifecycle without introducing a universal mathematical ontology.
+Checker-backed lifecycle states require exact bindings in the accepted record;
+an adapter cannot reuse an unrelated valid verification record.
 
 A capability adapter connects an external engine or domain operation to this
 contract and registers it behind a capability ID. A domain plugin defines the
@@ -51,9 +53,10 @@ The default local and remote profile advertises two tools:
 | `capability.invoke` | Invoke an installed operation in `EXPLORE` or `VERIFY` mode. Inputs and outputs are validated against the selected descriptor. Completed reusable invocations create trust-labeled research episodes. |
 
 Read `capability://catalog` to discover stable IDs, provider versions, supported
-modes, compact JSON Schemas, and tags. Bundled IDs are `reference.solve`,
-`lean.check`, and `knowledge.search`. Operator-installed adapters appear in the
-same catalog without a new MCP tool. Tool-only clients should call
+modes, compact JSON Schemas, and tags. Bundled IDs are `graph.search.atlas`,
+`graph.compute.properties`, `reference.solve`, `lean.check`, and
+`knowledge.search`. Operator-installed adapters appear in the same catalog
+without a new MCP tool. Tool-only clients should call
 `capability.describe` before invoking an unfamiliar capability rather than
 guessing payload fields.
 

--- a/src/jacobian/builtin_capabilities.py
+++ b/src/jacobian/builtin_capabilities.py
@@ -8,16 +8,24 @@ from jacobian.capabilities import CapabilityInvocationError
 from jacobian.contracts.capabilities import (
     CapabilityAssurance,
     CapabilityAssuranceLevel,
+    CapabilityCompleteness,
+    CapabilityCompletenessStatus,
     CapabilityDescriptor,
     CapabilityDiagnostic,
     CapabilityMode,
     CapabilityRequest,
     CapabilityResult,
+    CapabilityScope,
 )
 from jacobian.contracts.evaluation import EvaluationProfile
 from jacobian.contracts.evidence import WitnessRole
 from jacobian.contracts.lean import LeanEnvironment
-from jacobian.contracts.results import Execution, ExecutionStatus, Verification
+from jacobian.contracts.results import (
+    Coverage,
+    Execution,
+    ExecutionStatus,
+    Verification,
+)
 from jacobian.contracts.workflows import WitnessVerificationWorkflowResult
 from jacobian.lean import LeanService
 from jacobian.memory import ResearchMemory
@@ -325,6 +333,11 @@ def _reference_result(
         witness.witness_uri or witness.certificate_uri if witness is not None else None
     )
     scope_uri = verification.assurance.scope_uri if verification is not None else None
+    exhaustive = (
+        verified
+        and verification is not None
+        and verification.assurance.coverage is Coverage.EXHAUSTIVE
+    )
     artifacts = tuple(
         uri
         for uri in (
@@ -428,7 +441,30 @@ def _reference_result(
                 ),
             },
         },
-        scope=_scope_from_claim(claim_payload),
+        scope=CapabilityScope(
+            description="exact domain, predicate, and bounds supplied to the workflow",
+            parameters=_scope_from_claim(claim_payload),
+            artifact_uri=scope_uri or workflow.claim_uri,
+        ),
+        completeness=CapabilityCompleteness(
+            status=(
+                CapabilityCompletenessStatus.COMPLETE
+                if exhaustive
+                else CapabilityCompletenessStatus.UNKNOWN
+            ),
+            basis=(
+                "authorized checker accepted exhaustive finite coverage"
+                if exhaustive
+                else "candidate evaluation or direct-witness search does not "
+                "establish exhaustive coverage"
+            ),
+            assurance_level=(
+                CapabilityAssuranceLevel.VERIFIED
+                if exhaustive
+                else CapabilityAssuranceLevel.HEURISTIC
+            ),
+            verification_record_uri=(verification_record_uri if exhaustive else None),
+        ),
         assurance=CapabilityAssurance(
             level=(
                 CapabilityAssuranceLevel.VERIFIED

--- a/src/jacobian/capabilities.py
+++ b/src/jacobian/capabilities.py
@@ -16,13 +16,16 @@ from jacobian.contracts.capabilities import (
     CapabilityAssurance,
     CapabilityAssuranceLevel,
     CapabilityCatalog,
+    CapabilityCompletenessStatus,
     CapabilityDescriptor,
     CapabilityDiagnostic,
+    CapabilityObligationStatus,
+    CapabilityRelationshipStatus,
     CapabilityRequest,
     CapabilityResult,
 )
 from jacobian.contracts.memory import ResearchEpisode
-from jacobian.contracts.results import Execution, ExecutionStatus
+from jacobian.contracts.results import Coverage, Execution, ExecutionStatus
 from jacobian.contracts.verification import VerificationRecord
 from jacobian.memory import ResearchMemory
 from jacobian.store import ArtifactStore, StoreError
@@ -187,6 +190,7 @@ class CapabilityService:
                 descriptor.output_schema, result.output
             )
             result = result.model_copy(update={"output": normalized_output})
+        self._validate_artifact_references(result)
         self._validate_verified_result(result)
         if (
             descriptor.records_episode
@@ -198,7 +202,10 @@ class CapabilityService:
                     capability_version=result.capability_version,
                     mode=result.mode,
                     request=normalized_request.input,
-                    result=result.output,
+                    result=result.model_dump(
+                        mode="json",
+                        exclude={"episode_uri"},
+                    ),
                     assurance_level=result.assurance.level,
                     verification_record_uri=(result.assurance.verification_record_uri),
                     artifact_uris=result.artifact_uris,
@@ -209,6 +216,30 @@ class CapabilityService:
             result = result.model_copy(update={"episode_uri": episode_uri})
         _log_invocation(result, started)
         return result
+
+    @staticmethod
+    def _validate_artifact_references(result: CapabilityResult) -> None:
+        exposed = set(result.artifact_uris)
+        referenced: set[str] = set()
+        if result.scope is not None and result.scope.artifact_uri is not None:
+            referenced.add(result.scope.artifact_uri)
+        if result.completeness.verification_record_uri is not None:
+            referenced.add(result.completeness.verification_record_uri)
+        for relationship in result.relationships:
+            referenced.update(relationship.source_artifact_uris)
+            referenced.update(relationship.target_artifact_uris)
+            referenced.update(relationship.obligation_uris)
+            if relationship.verification_record_uri is not None:
+                referenced.add(relationship.verification_record_uri)
+        for obligation in result.obligations:
+            referenced.add(obligation.obligation_uri)
+            if obligation.verification_record_uri is not None:
+                referenced.add(obligation.verification_record_uri)
+        missing = referenced - exposed
+        if missing:
+            raise CapabilityError(
+                "capability result has first-class references missing from artifact_uris"
+            )
 
     def _validate_verified_result(self, result: CapabilityResult) -> None:
         if result.assurance.level is not CapabilityAssuranceLevel.VERIFIED:
@@ -246,6 +277,50 @@ class CapabilityService:
             raise CapabilityError(
                 "verified capability output differs from the checked conclusion"
             )
+        record_parents = set(record_artifact.manifest.parents)
+        for relationship in result.relationships:
+            if relationship.status is not CapabilityRelationshipStatus.VERIFIED:
+                continue
+            bound_artifacts = {
+                *relationship.source_artifact_uris,
+                *relationship.target_artifact_uris,
+                *relationship.obligation_uris,
+            }
+            if not bound_artifacts.issubset(record_parents):
+                raise CapabilityError(
+                    "verified relationship record does not bind its artifacts"
+                )
+            if record_artifact.payload.get("relation_id") != relationship.relation_id:
+                raise CapabilityError(
+                    "verified relationship differs from the checked relation"
+                )
+        for obligation in result.obligations:
+            if obligation.status is not CapabilityObligationStatus.DISCHARGED:
+                continue
+            if (
+                obligation.obligation_uri not in record_parents
+                or record_artifact.payload.get("obligation_uri")
+                != obligation.obligation_uri
+            ):
+                raise CapabilityError(
+                    "discharged obligation differs from the checked obligation"
+                )
+        if (
+            result.completeness.status is CapabilityCompletenessStatus.COMPLETE
+            and result.completeness.assurance_level is CapabilityAssuranceLevel.VERIFIED
+        ):
+            if (
+                result.scope is None
+                or result.scope.artifact_uri is None
+                or result.scope.artifact_uri not in record_parents
+            ):
+                raise CapabilityError(
+                    "verified completeness requires a checker-bound scope artifact"
+                )
+            if record.coverage not in {Coverage.EXHAUSTIVE, Coverage.BOUNDED}:
+                raise CapabilityError(
+                    "verified completeness differs from checked coverage"
+                )
 
 
 def load_capability_adapter(

--- a/src/jacobian/contracts/capabilities.py
+++ b/src/jacobian/contracts/capabilities.py
@@ -37,6 +37,29 @@ class CapabilityAssuranceLevel(StrEnum):
     VERIFIED = "VERIFIED"
 
 
+class CapabilityRelationshipStatus(StrEnum):
+    """Whether a returned mathematical relationship has checker backing."""
+
+    PROPOSED = "PROPOSED"
+    VERIFIED = "VERIFIED"
+
+
+class CapabilityObligationStatus(StrEnum):
+    """Lifecycle of a proof obligation created by a capability."""
+
+    OPEN = "OPEN"
+    DISCHARGED = "DISCHARGED"
+
+
+class CapabilityCompletenessStatus(StrEnum):
+    """How much of the explicitly declared scope an operation covered."""
+
+    NOT_APPLICABLE = "NOT_APPLICABLE"
+    UNKNOWN = "UNKNOWN"
+    PARTIAL = "PARTIAL"
+    COMPLETE = "COMPLETE"
+
+
 class CapabilityDescriptor(ContractModel):
     """One stable operation advertised by an operator-installed adapter."""
 
@@ -98,6 +121,102 @@ class CapabilityAssurance(ContractModel):
         return self
 
 
+class CapabilityScope(ContractModel):
+    """Domain-owned scope parameters, optionally materialized as an artifact."""
+
+    description: str | None = Field(default=None, min_length=1, max_length=512)
+    parameters: dict[str, Any] = Field(default_factory=dict)
+    artifact_uri: ArtifactUri | None = None
+
+    @model_validator(mode="after")
+    def require_explicit_scope(self) -> Self:
+        canonicalize_json(self.parameters)
+        if not self.parameters and self.artifact_uri is None:
+            raise ValueError("scope requires parameters or an artifact URI")
+        return self
+
+
+class CapabilityCompleteness(ContractModel):
+    """Coverage claim over the result's exact declared scope."""
+
+    status: CapabilityCompletenessStatus = CapabilityCompletenessStatus.NOT_APPLICABLE
+    basis: str = Field(min_length=1, max_length=1024)
+    assurance_level: CapabilityAssuranceLevel = CapabilityAssuranceLevel.HEURISTIC
+    verification_record_uri: ArtifactUri | None = None
+
+    @model_validator(mode="after")
+    def bind_verified_completeness(self) -> Self:
+        if (
+            self.assurance_level is CapabilityAssuranceLevel.VERIFIED
+            and self.verification_record_uri is None
+        ):
+            raise ValueError("verified completeness requires a record URI")
+        if (
+            self.assurance_level is not CapabilityAssuranceLevel.VERIFIED
+            and self.verification_record_uri is not None
+        ):
+            raise ValueError("only verified completeness may carry a record URI")
+        if (
+            self.status is not CapabilityCompletenessStatus.COMPLETE
+            and self.assurance_level is CapabilityAssuranceLevel.VERIFIED
+        ):
+            raise ValueError("only complete coverage may be independently verified")
+        return self
+
+
+class CapabilityRelationship(ContractModel):
+    """A domain-owned relationship between exact immutable artifacts."""
+
+    relation_id: CapabilityId
+    source_artifact_uris: tuple[ArtifactUri, ...]
+    target_artifact_uris: tuple[ArtifactUri, ...]
+    status: CapabilityRelationshipStatus = CapabilityRelationshipStatus.PROPOSED
+    obligation_uris: tuple[ArtifactUri, ...] = ()
+    verification_record_uri: ArtifactUri | None = None
+
+    @model_validator(mode="after")
+    def require_bound_endpoints(self) -> Self:
+        if not self.source_artifact_uris or not self.target_artifact_uris:
+            raise ValueError("relationship requires source and target artifacts")
+        if len(set(self.source_artifact_uris)) != len(self.source_artifact_uris):
+            raise ValueError("relationship source artifacts must be unique")
+        if len(set(self.target_artifact_uris)) != len(self.target_artifact_uris):
+            raise ValueError("relationship target artifacts must be unique")
+        if (
+            self.status is CapabilityRelationshipStatus.VERIFIED
+            and self.verification_record_uri is None
+        ):
+            raise ValueError("verified relationship requires a record URI")
+        if (
+            self.status is CapabilityRelationshipStatus.PROPOSED
+            and self.verification_record_uri is not None
+        ):
+            raise ValueError("proposed relationship cannot carry a record URI")
+        return self
+
+
+class CapabilityObligation(ContractModel):
+    """One materialized proof obligation and its checker-backed lifecycle."""
+
+    obligation_uri: ArtifactUri
+    status: CapabilityObligationStatus = CapabilityObligationStatus.OPEN
+    verification_record_uri: ArtifactUri | None = None
+
+    @model_validator(mode="after")
+    def require_record_for_discharge(self) -> Self:
+        if (
+            self.status is CapabilityObligationStatus.DISCHARGED
+            and self.verification_record_uri is None
+        ):
+            raise ValueError("discharged obligation requires a record URI")
+        if (
+            self.status is CapabilityObligationStatus.OPEN
+            and self.verification_record_uri is not None
+        ):
+            raise ValueError("open obligation cannot carry a record URI")
+        return self
+
+
 class CapabilityDiagnostic(ContractModel):
     """Actionable, stage-aware failure information without a truth claim."""
 
@@ -114,13 +233,20 @@ class CapabilityDiagnostic(ContractModel):
 class CapabilityResult(ContractModel):
     """Compact result shared by local, MCP, and remote capability adapters."""
 
-    response_version: Literal["1"] = "1"
+    response_version: Literal["2"] = "2"
     capability_id: CapabilityId
     capability_version: str = Field(min_length=1, max_length=64)
     mode: CapabilityMode
     execution: Execution
     output: dict[str, Any] = Field(default_factory=dict)
-    scope: dict[str, Any] = Field(default_factory=dict)
+    scope: CapabilityScope | None = None
+    completeness: CapabilityCompleteness = Field(
+        default_factory=lambda: CapabilityCompleteness(
+            basis="the operation makes no completeness claim",
+        )
+    )
+    relationships: tuple[CapabilityRelationship, ...] = ()
+    obligations: tuple[CapabilityObligation, ...] = ()
     diagnostics: tuple[CapabilityDiagnostic, ...] = ()
     assurance: CapabilityAssurance
     artifact_uris: tuple[ArtifactUri, ...] = ()
@@ -129,7 +255,6 @@ class CapabilityResult(ContractModel):
     @model_validator(mode="after")
     def enforce_lane_and_canonical_output(self) -> Self:
         canonicalize_json(self.output)
-        canonicalize_json(self.scope)
         if self.execution.status.value == "COMPLETED" and self.diagnostics:
             raise ValueError("completed capability execution cannot carry diagnostics")
         if (
@@ -142,6 +267,46 @@ class CapabilityResult(ContractModel):
             and self.assurance.level is CapabilityAssuranceLevel.VERIFIED
         ):
             raise ValueError("failed capability execution cannot be verified")
+        if (
+            self.completeness.status is CapabilityCompletenessStatus.COMPLETE
+            and self.scope is None
+        ):
+            raise ValueError("complete result requires explicit scope")
+        if (
+            self.execution.status.value != "COMPLETED"
+            and self.completeness.status is CapabilityCompletenessStatus.COMPLETE
+        ):
+            raise ValueError("failed execution cannot be complete")
+        record_uri = self.assurance.verification_record_uri
+        for relationship in self.relationships:
+            if relationship.status is CapabilityRelationshipStatus.VERIFIED:
+                if self.assurance.level is not CapabilityAssuranceLevel.VERIFIED:
+                    raise ValueError(
+                        "verified relationship requires verified result assurance"
+                    )
+                if relationship.verification_record_uri != record_uri:
+                    raise ValueError(
+                        "verified relationship must use the result verification record"
+                    )
+        for obligation in self.obligations:
+            if obligation.status is CapabilityObligationStatus.DISCHARGED:
+                if self.assurance.level is not CapabilityAssuranceLevel.VERIFIED:
+                    raise ValueError(
+                        "discharged obligation requires verified result assurance"
+                    )
+                if obligation.verification_record_uri != record_uri:
+                    raise ValueError(
+                        "discharged obligation must use the result verification record"
+                    )
+        if self.completeness.assurance_level is CapabilityAssuranceLevel.VERIFIED:
+            if self.assurance.level is not CapabilityAssuranceLevel.VERIFIED:
+                raise ValueError(
+                    "verified completeness requires verified result assurance"
+                )
+            if self.completeness.verification_record_uri != record_uri:
+                raise ValueError(
+                    "verified completeness must use the result verification record"
+                )
         return self
 
 

--- a/src/jacobian/graph_capabilities.py
+++ b/src/jacobian/graph_capabilities.py
@@ -1,0 +1,687 @@
+"""NetworkX-backed capabilities for small simple undirected graphs."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any, cast
+
+import networkx as nx
+
+from jacobian.artifacts import ArtifactService
+from jacobian.capabilities import CapabilityInvocationError
+from jacobian.contracts.capabilities import (
+    CapabilityAssurance,
+    CapabilityAssuranceLevel,
+    CapabilityCompleteness,
+    CapabilityCompletenessStatus,
+    CapabilityDescriptor,
+    CapabilityDiagnostic,
+    CapabilityMode,
+    CapabilityRelationship,
+    CapabilityRequest,
+    CapabilityResult,
+    CapabilityScope,
+)
+from jacobian.contracts.results import Execution, ExecutionStatus
+from jacobian.schema_registry import SchemaRegistry
+from jacobian.store import ArtifactStore, StoreError
+
+_ARTIFACT_URI_PATTERN = r"^artifact://sha256/[0-9a-f]{64}$"
+_PROPERTY_NAMES = (
+    "bipartite",
+    "connected",
+    "degree_sequence",
+    "independence_number",
+    "maximum_degree",
+    "minimum_degree",
+    "order",
+    "size",
+    "tree",
+    "triangle_count",
+)
+_CONSTRAINT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "connected": {"type": "boolean"},
+        "bipartite": {"type": "boolean"},
+        "tree": {"type": "boolean"},
+        "triangle_free": {"type": "boolean"},
+        "minimum_edges": {"type": "integer", "minimum": 0},
+        "maximum_edges": {"type": "integer", "minimum": 0},
+        "minimum_degree": {"type": "integer", "minimum": 0},
+        "maximum_degree": {"type": "integer", "minimum": 0},
+        "independence_number": {"type": "integer", "minimum": 0},
+    },
+    "additionalProperties": False,
+}
+
+
+@dataclass(frozen=True)
+class GraphCapabilityResources:
+    store: ArtifactStore
+    artifacts: ArtifactService
+    semantics_uri: str
+    graph_schema_uri: str
+    scope_schema_uri: str
+    property_schema_uri: str
+
+
+def install_graph_capabilities(
+    store: ArtifactStore,
+    schemas: SchemaRegistry,
+    artifacts: ArtifactService,
+) -> tuple[GraphAtlasSearchAdapter, GraphPropertyAdapter]:
+    """Register graph artifact contracts and return the bundled adapters."""
+
+    semantics_uri = store.register_descriptor(
+        kind="semantics",
+        name="jacobian.simple-undirected-graph",
+        version="1",
+        definition={
+            "domain": "finite simple undirected graphs",
+            "vertices": "distinct string labels",
+            "edges": "distinct two-vertex arrays in ascending label order",
+            "atlas_scope": (
+                "networkx.graph_atlas_g representatives with exactly the "
+                "requested order, limited to orders zero through seven"
+            ),
+        },
+    )
+    graph_schema_uri = schemas.register(
+        name="jacobian.simple-undirected-graph",
+        version="1",
+        schema={
+            "type": "object",
+            "properties": {
+                "graph_schema_version": {"const": "1"},
+                "vertices": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "uniqueItems": True,
+                },
+                "edges": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "minItems": 2,
+                        "maxItems": 2,
+                    },
+                    "uniqueItems": True,
+                },
+            },
+            "required": ["graph_schema_version", "vertices", "edges"],
+            "additionalProperties": False,
+        },
+    )
+    scope_schema_uri = schemas.register(
+        name="jacobian.graph-atlas-scope",
+        version="1",
+        schema={
+            "type": "object",
+            "properties": {
+                "scope_schema_version": {"const": "1"},
+                "source": {"const": "networkx.graph_atlas_g"},
+                "backend_version": {"type": "string"},
+                "order": {"type": "integer", "minimum": 0, "maximum": 7},
+                "enumerated_count": {"type": "integer", "minimum": 0},
+            },
+            "required": [
+                "scope_schema_version",
+                "source",
+                "backend_version",
+                "order",
+                "enumerated_count",
+            ],
+            "additionalProperties": False,
+        },
+    )
+    property_schema_uri = schemas.register(
+        name="jacobian.graph-property-batch",
+        version="1",
+        schema={
+            "type": "object",
+            "properties": {
+                "property_schema_version": {"const": "1"},
+                "graph_uri": {
+                    "type": "string",
+                    "pattern": _ARTIFACT_URI_PATTERN,
+                },
+                "backend_version": {"type": "string"},
+                "properties": {"type": "object"},
+            },
+            "required": [
+                "property_schema_version",
+                "graph_uri",
+                "backend_version",
+                "properties",
+            ],
+            "additionalProperties": False,
+        },
+    )
+    resources = GraphCapabilityResources(
+        store=store,
+        artifacts=artifacts,
+        semantics_uri=semantics_uri,
+        graph_schema_uri=graph_schema_uri,
+        scope_schema_uri=scope_schema_uri,
+        property_schema_uri=property_schema_uri,
+    )
+    return GraphAtlasSearchAdapter(resources), GraphPropertyAdapter(resources)
+
+
+class GraphAtlasSearchAdapter:
+    """Search NetworkX's bounded Graph Atlas using exact computed properties."""
+
+    def __init__(self, resources: GraphCapabilityResources) -> None:
+        self.resources = resources
+        self._descriptor = CapabilityDescriptor(
+            capability_id="graph.search.atlas",
+            version="1",
+            title="Search the Graph Atlas",
+            description=(
+                "Search all Graph Atlas representatives of one exact order "
+                "(0-7) using exact NetworkX-computed constraints."
+            ),
+            provider="jacobian.networkx",
+            modes=(CapabilityMode.EXPLORE,),
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "order": {"type": "integer", "minimum": 0, "maximum": 7},
+                    "constraints": _CONSTRAINT_SCHEMA,
+                    "limit": {"type": "integer", "minimum": 1, "maximum": 100},
+                },
+                "required": ["order", "constraints"],
+                "additionalProperties": False,
+            },
+            output_schema={
+                "type": "object",
+                "properties": {
+                    "candidates": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "graph_uri": {
+                                    "type": "string",
+                                    "pattern": _ARTIFACT_URI_PATTERN,
+                                },
+                                "properties": {"type": "object"},
+                            },
+                            "required": ["graph_uri", "properties"],
+                            "additionalProperties": False,
+                        },
+                    },
+                    "match_count": {"type": "integer", "minimum": 0},
+                    "returned_count": {"type": "integer", "minimum": 0},
+                    "truncated": {"type": "boolean"},
+                    "scope_uri": {
+                        "type": "string",
+                        "pattern": _ARTIFACT_URI_PATTERN,
+                    },
+                    "backend": {"const": "networkx.graph_atlas_g"},
+                    "backend_version": {"type": "string"},
+                },
+                "required": [
+                    "candidates",
+                    "match_count",
+                    "returned_count",
+                    "truncated",
+                    "scope_uri",
+                    "backend",
+                    "backend_version",
+                ],
+                "additionalProperties": False,
+            },
+            tags=("graph", "construction", "bounded-search"),
+        )
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        return self._descriptor
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        started = time.monotonic()
+        order = int(request.input["order"])
+        constraints = dict(request.input["constraints"])
+        _validate_constraint_ranges(constraints)
+        limit = int(request.input.get("limit", 10))
+        atlas_graphs = [
+            graph for graph in nx.graph_atlas_g() if graph.number_of_nodes() == order
+        ]
+        scope = self.resources.artifacts.put(
+            schema_uri=self.resources.scope_schema_uri,
+            semantics_uri=self.resources.semantics_uri,
+            payload={
+                "scope_schema_version": "1",
+                "source": "networkx.graph_atlas_g",
+                "backend_version": nx.__version__,
+                "order": order,
+                "enumerated_count": len(atlas_graphs),
+            },
+            summary=f"Graph Atlas representatives of order {order}",
+        )
+        matches: list[tuple[nx.Graph[Any], dict[str, Any]]] = []
+        for graph in atlas_graphs:
+            properties = _compute_all_properties(graph)
+            if _matches_constraints(properties, constraints):
+                matches.append((graph, properties))
+        candidates: list[dict[str, Any]] = []
+        graph_uris: list[str] = []
+        for graph, properties in matches[:limit]:
+            graph_artifact = self.resources.artifacts.put(
+                schema_uri=self.resources.graph_schema_uri,
+                semantics_uri=self.resources.semantics_uri,
+                payload=_graph_payload(graph),
+                parents=(scope.artifact_uri,),
+                summary=f"Graph Atlas candidate of order {order}",
+            )
+            graph_uris.append(graph_artifact.artifact_uri)
+            candidates.append(
+                {
+                    "graph_uri": graph_artifact.artifact_uri,
+                    "properties": properties,
+                }
+            )
+        artifact_uris = (scope.artifact_uri, *graph_uris)
+        relationships = tuple(
+            CapabilityRelationship(
+                relation_id="graph.relation.atlas-member",
+                source_artifact_uris=(scope.artifact_uri,),
+                target_artifact_uris=(graph_uri,),
+            )
+            for graph_uri in graph_uris
+        )
+        return CapabilityResult(
+            capability_id=self.descriptor.capability_id,
+            capability_version=self.descriptor.version,
+            mode=request.mode,
+            execution=Execution(
+                status=ExecutionStatus.COMPLETED,
+                runtime_ms=_runtime_ms(started),
+            ),
+            output={
+                "candidates": candidates,
+                "match_count": len(matches),
+                "returned_count": len(candidates),
+                "truncated": len(matches) > len(candidates),
+                "scope_uri": scope.artifact_uri,
+                "backend": "networkx.graph_atlas_g",
+                "backend_version": nx.__version__,
+            },
+            scope=CapabilityScope(
+                description=(
+                    "all Graph Atlas representatives with the requested exact order"
+                ),
+                parameters={
+                    "source": "networkx.graph_atlas_g",
+                    "backend_version": nx.__version__,
+                    "order": order,
+                },
+                artifact_uri=scope.artifact_uri,
+            ),
+            completeness=CapabilityCompleteness(
+                status=CapabilityCompletenessStatus.COMPLETE,
+                basis=(
+                    "the maintained Graph Atlas provider was scanned to exhaustion; "
+                    "this computation was not independently checked"
+                ),
+                assurance_level=CapabilityAssuranceLevel.COMPUTED,
+            ),
+            relationships=relationships,
+            assurance=CapabilityAssurance(
+                level=CapabilityAssuranceLevel.COMPUTED,
+                basis=(
+                    "deterministic NetworkX Graph Atlas enumeration and exact "
+                    "property filters; no independent checker was invoked"
+                ),
+            ),
+            artifact_uris=artifact_uris,
+        )
+
+
+class GraphPropertyAdapter:
+    """Compute a requested batch of exact properties for one graph artifact."""
+
+    def __init__(self, resources: GraphCapabilityResources) -> None:
+        self.resources = resources
+        self._descriptor = CapabilityDescriptor(
+            capability_id="graph.compute.properties",
+            version="1",
+            title="Compute exact graph properties",
+            description=(
+                "Compute a requested batch of exact NetworkX properties for one "
+                "Jacobian simple-undirected-graph artifact."
+            ),
+            provider="jacobian.networkx",
+            modes=(CapabilityMode.EXPLORE,),
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "graph_uri": {
+                        "type": "string",
+                        "pattern": _ARTIFACT_URI_PATTERN,
+                    },
+                    "properties": {
+                        "type": "array",
+                        "items": {"enum": list(_PROPERTY_NAMES)},
+                        "minItems": 1,
+                        "uniqueItems": True,
+                    },
+                },
+                "required": ["graph_uri", "properties"],
+                "additionalProperties": False,
+            },
+            output_schema={
+                "type": "object",
+                "properties": {
+                    "graph_uri": {
+                        "type": "string",
+                        "pattern": _ARTIFACT_URI_PATTERN,
+                    },
+                    "property_artifact_uri": {
+                        "type": "string",
+                        "pattern": _ARTIFACT_URI_PATTERN,
+                    },
+                    "properties": {"type": "object"},
+                    "backend_version": {"type": "string"},
+                },
+                "required": [
+                    "graph_uri",
+                    "property_artifact_uri",
+                    "properties",
+                    "backend_version",
+                ],
+                "additionalProperties": False,
+            },
+            tags=("graph", "properties", "exact-computation"),
+        )
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        return self._descriptor
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        started = time.monotonic()
+        graph_uri = str(request.input["graph_uri"])
+        graph = _load_graph(self.resources, graph_uri)
+        all_properties = _compute_all_properties(graph)
+        selected = {
+            name: _property_result(name, all_properties[name])
+            for name in sorted(str(item) for item in request.input["properties"])
+        }
+        property_artifact = self.resources.artifacts.put(
+            schema_uri=self.resources.property_schema_uri,
+            semantics_uri=self.resources.semantics_uri,
+            payload={
+                "property_schema_version": "1",
+                "graph_uri": graph_uri,
+                "backend_version": nx.__version__,
+                "properties": selected,
+            },
+            parents=(graph_uri,),
+            summary="exact NetworkX graph-property batch",
+        )
+        return CapabilityResult(
+            capability_id=self.descriptor.capability_id,
+            capability_version=self.descriptor.version,
+            mode=request.mode,
+            execution=Execution(
+                status=ExecutionStatus.COMPLETED,
+                runtime_ms=_runtime_ms(started),
+            ),
+            output={
+                "graph_uri": graph_uri,
+                "property_artifact_uri": property_artifact.artifact_uri,
+                "properties": selected,
+                "backend_version": nx.__version__,
+            },
+            scope=CapabilityScope(
+                description="the requested property batch for one exact graph artifact",
+                parameters={
+                    "graph_uri": graph_uri,
+                    "properties": sorted(
+                        str(item) for item in request.input["properties"]
+                    ),
+                },
+                artifact_uri=graph_uri,
+            ),
+            completeness=CapabilityCompleteness(
+                status=CapabilityCompletenessStatus.COMPLETE,
+                basis=(
+                    "every requested property was computed; no mathematical "
+                    "conclusion or independent verification is claimed"
+                ),
+                assurance_level=CapabilityAssuranceLevel.COMPUTED,
+            ),
+            relationships=(
+                CapabilityRelationship(
+                    relation_id="graph.relation.properties-of",
+                    source_artifact_uris=(graph_uri,),
+                    target_artifact_uris=(property_artifact.artifact_uri,),
+                ),
+            ),
+            assurance=CapabilityAssurance(
+                level=CapabilityAssuranceLevel.COMPUTED,
+                basis=(
+                    "deterministic exact NetworkX algorithms; no independent "
+                    "checker was invoked"
+                ),
+            ),
+            artifact_uris=(graph_uri, property_artifact.artifact_uri),
+        )
+
+
+def _validate_constraint_ranges(constraints: dict[str, Any]) -> None:
+    for lower, upper in (
+        ("minimum_edges", "maximum_edges"),
+        ("minimum_degree", "maximum_degree"),
+    ):
+        if (
+            lower in constraints
+            and upper in constraints
+            and int(constraints[lower]) > int(constraints[upper])
+        ):
+            raise CapabilityInvocationError(
+                CapabilityDiagnostic(
+                    code="INVALID_CONSTRAINT_RANGE",
+                    stage="constraint_validation",
+                    message=f"{lower} cannot exceed {upper}.",
+                    path=f"constraints/{lower}",
+                    hint="Swap the bounds or remove one of them, then retry.",
+                )
+            )
+
+
+def _graph_payload(graph: nx.Graph[Any]) -> dict[str, Any]:
+    labels = {node: f"v{index}" for index, node in enumerate(sorted(graph.nodes))}
+    edges = sorted(
+        [labels[source], labels[target]]
+        if labels[source] < labels[target]
+        else [labels[target], labels[source]]
+        for source, target in graph.edges
+    )
+    return {
+        "graph_schema_version": "1",
+        "vertices": [labels[node] for node in sorted(graph.nodes)],
+        "edges": edges,
+    }
+
+
+def _load_graph(resources: GraphCapabilityResources, graph_uri: str) -> nx.Graph[str]:
+    try:
+        artifact = resources.store.get(graph_uri)
+    except StoreError as exc:
+        raise CapabilityInvocationError(
+            CapabilityDiagnostic(
+                code="GRAPH_ARTIFACT_NOT_FOUND",
+                stage="graph_resolution",
+                message="The requested graph artifact is unavailable.",
+                path="graph_uri",
+                hint="Use a graph URI returned by graph.search.atlas.",
+            )
+        ) from exc
+    if (
+        artifact.manifest.schema_uri != resources.graph_schema_uri
+        or artifact.manifest.semantics_uri != resources.semantics_uri
+        or not isinstance(artifact.payload, dict)
+    ):
+        raise CapabilityInvocationError(
+            CapabilityDiagnostic(
+                code="INCOMPATIBLE_GRAPH_ARTIFACT",
+                stage="graph_validation",
+                message="The artifact is not a compatible simple undirected graph.",
+                path="graph_uri",
+                schema_uri=resources.graph_schema_uri,
+                hint="Use a graph URI returned by graph.search.atlas.",
+            )
+        )
+    payload = artifact.payload
+    vertices = payload.get("vertices")
+    edges = payload.get("edges")
+    if (
+        payload.get("graph_schema_version") != "1"
+        or not isinstance(vertices, list)
+        or not all(isinstance(vertex, str) for vertex in vertices)
+        or len(set(vertices)) != len(vertices)
+        or not isinstance(edges, list)
+    ):
+        raise CapabilityInvocationError(
+            CapabilityDiagnostic(
+                code="INCOMPATIBLE_GRAPH_ARTIFACT",
+                stage="graph_validation",
+                message="The graph artifact payload is malformed.",
+                path="graph_uri",
+                schema_uri=resources.graph_schema_uri,
+                hint="Recreate the graph through its owning capability.",
+            )
+        )
+    vertex_set = set(vertices)
+    normalized_edges: list[tuple[str, str]] = []
+    for edge in edges:
+        if (
+            not isinstance(edge, list)
+            or len(edge) != 2
+            or not all(isinstance(endpoint, str) for endpoint in edge)
+            or edge[0] not in vertex_set
+            or edge[1] not in vertex_set
+            or edge[0] >= edge[1]
+        ):
+            raise CapabilityInvocationError(
+                CapabilityDiagnostic(
+                    code="INCOMPATIBLE_GRAPH_ARTIFACT",
+                    stage="graph_validation",
+                    message="The graph artifact violates simple-graph semantics.",
+                    path="graph_uri",
+                    schema_uri=resources.graph_schema_uri,
+                    hint="Recreate the graph through its owning capability.",
+                )
+            )
+        normalized_edges.append((edge[0], edge[1]))
+    if len(set(normalized_edges)) != len(normalized_edges):
+        raise CapabilityInvocationError(
+            CapabilityDiagnostic(
+                code="INCOMPATIBLE_GRAPH_ARTIFACT",
+                stage="graph_validation",
+                message="The graph artifact contains duplicate edges.",
+                path="graph_uri",
+                schema_uri=resources.graph_schema_uri,
+                hint="Recreate the graph through its owning capability.",
+            )
+        )
+    graph: nx.Graph[str] = nx.Graph()
+    graph.add_nodes_from(vertices)
+    graph.add_edges_from(normalized_edges)
+    return graph
+
+
+def _compute_all_properties(graph: nx.Graph[Any]) -> dict[str, Any]:
+    order = graph.number_of_nodes()
+    degrees = sorted((degree for _, degree in graph.degree), reverse=True)
+    if order:
+        independent_set, independence_number = nx.max_weight_clique(
+            nx.complement(graph),
+            weight=None,
+        )
+        assert len(independent_set) == independence_number
+    else:
+        independence_number = 0
+    return {
+        "order": order,
+        "size": graph.number_of_edges(),
+        "connected": nx.is_connected(graph) if order else False,
+        "bipartite": nx.is_bipartite(graph),
+        "tree": nx.is_tree(graph) if order else False,
+        "degree_sequence": degrees,
+        "minimum_degree": min(degrees) if degrees else None,
+        "maximum_degree": max(degrees) if degrees else None,
+        "triangle_count": (
+            sum(cast(dict[Any, int], nx.triangles(graph)).values()) // 3
+        ),
+        "independence_number": independence_number,
+    }
+
+
+def _matches_constraints(
+    properties: dict[str, Any],
+    constraints: dict[str, Any],
+) -> bool:
+    if (
+        "connected" in constraints
+        and properties["connected"] is not constraints["connected"]
+    ):
+        return False
+    if (
+        "bipartite" in constraints
+        and properties["bipartite"] is not constraints["bipartite"]
+    ):
+        return False
+    if "tree" in constraints and properties["tree"] is not constraints["tree"]:
+        return False
+    if "triangle_free" in constraints and (
+        (properties["triangle_count"] == 0) is not constraints["triangle_free"]
+    ):
+        return False
+    if (
+        "minimum_edges" in constraints
+        and properties["size"] < constraints["minimum_edges"]
+    ):
+        return False
+    if (
+        "maximum_edges" in constraints
+        and properties["size"] > constraints["maximum_edges"]
+    ):
+        return False
+    if "minimum_degree" in constraints and (
+        properties["minimum_degree"] is None
+        or properties["minimum_degree"] < constraints["minimum_degree"]
+    ):
+        return False
+    if "maximum_degree" in constraints and (
+        properties["maximum_degree"] is None
+        or properties["maximum_degree"] > constraints["maximum_degree"]
+    ):
+        return False
+    return not (
+        "independence_number" in constraints
+        and properties["independence_number"] != constraints["independence_number"]
+    )
+
+
+def _property_result(name: str, value: Any) -> dict[str, Any]:
+    backend = (
+        "networkx.max_weight_clique(complement)"
+        if name == "independence_number"
+        else "networkx"
+    )
+    return {
+        "value": value,
+        "exactness": "EXACT",
+        "backend": backend,
+    }
+
+
+def _runtime_ms(started: float) -> int:
+    return max(0, round((time.monotonic() - started) * 1000))

--- a/src/jacobian/kernel.py
+++ b/src/jacobian/kernel.py
@@ -20,6 +20,7 @@ from jacobian.conjectures import ConjectureService
 from jacobian.contracts.lean import LeanEnvironment
 from jacobian.evaluation import EvaluationService
 from jacobian.experiments import ExperimentService
+from jacobian.graph_capabilities import install_graph_capabilities
 from jacobian.lean import LeanService
 from jacobian.memory import ResearchMemory
 from jacobian.plugin_execution import PluginExecutor
@@ -149,6 +150,12 @@ class JacobianKernel:
         self.verification_workflows: VerificationWorkflowService | None = None
         self.capabilities = CapabilityService(self.store, self.memory)
         self.capabilities.register(KnowledgeSearchAdapter(self.memory))
+        for adapter in install_graph_capabilities(
+            self.store,
+            self.schemas,
+            self.artifacts,
+        ):
+            self.capabilities.register(adapter)
         if install_references:
             self.references = self.reference_installer.install_all()
             self.polytope_checkers = self.reference_installer.install_polytope_checkers(

--- a/tests/contract/test_capability_contracts.py
+++ b/tests/contract/test_capability_contracts.py
@@ -6,8 +6,15 @@ from pydantic import ValidationError
 from jacobian.contracts.capabilities import (
     CapabilityAssurance,
     CapabilityAssuranceLevel,
+    CapabilityCompleteness,
+    CapabilityCompletenessStatus,
     CapabilityMode,
+    CapabilityObligation,
+    CapabilityObligationStatus,
+    CapabilityRelationship,
+    CapabilityRelationshipStatus,
     CapabilityResult,
+    CapabilityScope,
 )
 from jacobian.contracts.results import Execution, ExecutionStatus
 
@@ -37,4 +44,104 @@ def test_nonverified_assurance_cannot_smuggle_a_record_uri() -> None:
             level=CapabilityAssuranceLevel.COMPUTED,
             basis="ordinary deterministic computation",
             verification_record_uri=RECORD_URI,
+        )
+
+
+@pytest.mark.contract
+def test_complete_result_requires_an_explicit_scope() -> None:
+    with pytest.raises(
+        ValidationError, match="complete result requires explicit scope"
+    ):
+        CapabilityResult(
+            capability_id="graph.enumerate.nonisomorphic",
+            capability_version="1",
+            mode=CapabilityMode.EXPLORE,
+            execution=Execution(status=ExecutionStatus.COMPLETED),
+            completeness=CapabilityCompleteness(
+                status=CapabilityCompletenessStatus.COMPLETE,
+                basis="enumerator reported exhaustion",
+                assurance_level=CapabilityAssuranceLevel.COMPUTED,
+            ),
+            assurance=CapabilityAssurance(
+                level=CapabilityAssuranceLevel.COMPUTED,
+                basis="deterministic enumeration",
+            ),
+        )
+
+
+@pytest.mark.contract
+def test_failed_execution_cannot_claim_completeness() -> None:
+    with pytest.raises(ValidationError, match="failed execution cannot be complete"):
+        CapabilityResult(
+            capability_id="graph.enumerate.nonisomorphic",
+            capability_version="1",
+            mode=CapabilityMode.EXPLORE,
+            execution=Execution(status=ExecutionStatus.TIMEOUT),
+            scope=CapabilityScope(
+                description="simple graphs on five vertices",
+                parameters={"vertices": 5},
+            ),
+            completeness=CapabilityCompleteness(
+                status=CapabilityCompletenessStatus.COMPLETE,
+                basis="adapter reached its configured limit",
+                assurance_level=CapabilityAssuranceLevel.COMPUTED,
+            ),
+            assurance=CapabilityAssurance(
+                level=CapabilityAssuranceLevel.HEURISTIC,
+                basis="enumeration timed out",
+            ),
+        )
+
+
+@pytest.mark.contract
+def test_verified_relationship_must_use_result_checker_record() -> None:
+    other_record = "artifact://sha256/" + "b" * 64
+    with pytest.raises(
+        ValidationError,
+        match="verified relationship must use the result verification record",
+    ):
+        CapabilityResult(
+            capability_id="claim.derive.specialization",
+            capability_version="1",
+            mode=CapabilityMode.VERIFY,
+            execution=Execution(status=ExecutionStatus.COMPLETED),
+            relationships=(
+                CapabilityRelationship(
+                    relation_id="claim.relation.specialization",
+                    source_artifact_uris=("artifact://sha256/" + "c" * 64,),
+                    target_artifact_uris=("artifact://sha256/" + "d" * 64,),
+                    status=CapabilityRelationshipStatus.VERIFIED,
+                    verification_record_uri=other_record,
+                ),
+            ),
+            assurance=CapabilityAssurance(
+                level=CapabilityAssuranceLevel.VERIFIED,
+                basis="independent checker accepted the relation",
+                verification_record_uri=RECORD_URI,
+            ),
+        )
+
+
+@pytest.mark.contract
+def test_discharged_obligation_requires_verified_result() -> None:
+    with pytest.raises(
+        ValidationError,
+        match="discharged obligation requires verified result assurance",
+    ):
+        CapabilityResult(
+            capability_id="case.partition.finite",
+            capability_version="1",
+            mode=CapabilityMode.EXPLORE,
+            execution=Execution(status=ExecutionStatus.COMPLETED),
+            obligations=(
+                CapabilityObligation(
+                    obligation_uri="artifact://sha256/" + "e" * 64,
+                    status=CapabilityObligationStatus.DISCHARGED,
+                    verification_record_uri=RECORD_URI,
+                ),
+            ),
+            assurance=CapabilityAssurance(
+                level=CapabilityAssuranceLevel.COMPUTED,
+                basis="partition was generated but not independently checked",
+            ),
         )

--- a/tests/integration/test_agent_benchmark.py
+++ b/tests/integration/test_agent_benchmark.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 
 import pytest
 
+from jacobian.contracts.capabilities import CapabilityRequest
 from jacobian.contracts.evidence import WitnessRole
 from jacobian.kernel import JacobianKernel
 
@@ -22,6 +23,100 @@ def _feedback() -> dict[str, list[str]]:
         "domain_knowledge_gaps": [],
         "suggested_improvements": [],
     }
+
+
+@pytest.mark.integration
+def test_graph_capability_scorer_checks_multi_call_artifacts(
+    tmp_path: Path,
+) -> None:
+    case = BENCHMARK["load_cases"](["GRAPH-ATLAS-PATH-001"])[0]
+    kernel = JacobianKernel(tmp_path, install_references=True)
+    searched = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.search.atlas",
+            input={
+                "order": 5,
+                "constraints": {"tree": True, "maximum_degree": 2},
+                "limit": 1,
+            },
+        )
+    )
+    graph_uri = searched.output["candidates"][0]["graph_uri"]
+    computed = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.compute.properties",
+            input={
+                "graph_uri": graph_uri,
+                "properties": list(case["expected"]["properties"]),
+            },
+        )
+    )
+    report = {
+        "case_id": case["case_id"],
+        "assurance": "COMPUTED",
+        "completeness": "COMPLETE",
+        "final_verification": "UNVERIFIED",
+        "graph_uri": graph_uri,
+        "property_artifact_uri": computed.output["property_artifact_uri"],
+        "properties": computed.output["properties"],
+        "limitations": ["Graph Atlas contains graphs only through order 7."],
+        "feedback": _feedback(),
+    }
+
+    score = BENCHMARK["score_run"](
+        case,
+        report,
+        state_dir=tmp_path,
+        tool_calls=["capability.invoke", "capability.invoke"],
+        capability_ids=[
+            "graph.search.atlas",
+            "graph.compute.properties",
+        ],
+        capability_invocations=[
+            {
+                "capability_id": "graph.search.atlas",
+                "input": {
+                    "order": 5,
+                    "constraints": {"tree": True, "maximum_degree": 2},
+                    "limit": 1,
+                },
+                "output": searched.output,
+                "artifact_uris": list(searched.artifact_uris),
+                "assurance": searched.assurance.model_dump(mode="json"),
+                "completeness": searched.completeness.model_dump(mode="json"),
+            },
+            {
+                "capability_id": "graph.compute.properties",
+                "input": {
+                    "graph_uri": graph_uri,
+                    "properties": list(case["expected"]["properties"]),
+                },
+                "output": computed.output,
+                "artifact_uris": list(computed.artifact_uris),
+                "assurance": computed.assurance.model_dump(mode="json"),
+                "completeness": computed.completeness.model_dump(mode="json"),
+            },
+        ],
+    )
+
+    assert score["passed"] is True
+    assert score["case_id"] == case["case_id"]
+
+    with pytest.raises(
+        BENCHMARK["BenchmarkError"],
+        match="successful search-to-property artifact flow",
+    ):
+        BENCHMARK["score_run"](
+            case,
+            report,
+            state_dir=tmp_path,
+            tool_calls=["capability.invoke", "capability.invoke"],
+            capability_ids=[
+                "graph.search.atlas",
+                "graph.compute.properties",
+            ],
+            capability_invocations=[],
+        )
 
 
 def test_transcript_parser_counts_completed_mcp_calls_once(tmp_path: Path) -> None:
@@ -45,6 +140,63 @@ def test_transcript_parser_counts_completed_mcp_calls_once(tmp_path: Path) -> No
             },
         },
         {
+            "type": "item.completed",
+            "item": {
+                "type": "mcp_tool_call",
+                "tool": "capability.invoke",
+                "status": "completed",
+                "result": {
+                    "isError": True,
+                    "content": [{"code": "INVALID_PARAMS"}],
+                },
+            },
+        },
+        {
+            "type": "item.completed",
+            "item": {
+                "type": "mcp_tool_call",
+                "tool": "capability.invoke",
+                "status": "completed",
+                "arguments": {
+                    "capability_id": "graph.search.atlas",
+                },
+                "result": {
+                    "execution": {"status": "ERROR"},
+                    "diagnostics": [{"code": "INVALID_CONSTRAINT_RANGE"}],
+                },
+            },
+        },
+        {
+            "type": "item.completed",
+            "item": {
+                "type": "mcp_tool_call",
+                "tool": "capability.invoke",
+                "status": "completed",
+                "arguments": {
+                    "capability_id": "graph.compute.properties",
+                    "payload": {"graph_uri": "artifact://example"},
+                },
+                "result": {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": json.dumps(
+                                {
+                                    "capability_id": "graph.compute.properties",
+                                    "execution": {"status": "COMPLETED"},
+                                    "output": {"property_artifact_uri": "artifact://p"},
+                                    "artifact_uris": ["artifact://p"],
+                                    "assurance": {"level": "COMPUTED"},
+                                    "completeness": {"status": "COMPLETE"},
+                                }
+                            ),
+                        }
+                    ],
+                    "structured_content": None,
+                },
+            },
+        },
+        {
             "type": "turn.completed",
             "usage": {"input_tokens": 12, "output_tokens": 3},
         },
@@ -54,10 +206,31 @@ def test_transcript_parser_counts_completed_mcp_calls_once(tmp_path: Path) -> No
         encoding="utf-8",
     )
 
-    calls, usage = parse_transcript(transcript)
+    calls, usage, metrics = parse_transcript(transcript)
 
-    assert calls == ["artifact.put"]
+    assert calls == [
+        "artifact.put",
+        "capability.invoke",
+        "capability.invoke",
+        "capability.invoke",
+    ]
     assert usage == {"input_tokens": 12, "output_tokens": 3}
+    assert metrics == {
+        "tool_error_count": 2,
+        "parameter_error_count": 2,
+        "successful_tool_calls": ["artifact.put", "capability.invoke"],
+        "capability_ids": ["graph.compute.properties"],
+        "capability_invocations": [
+            {
+                "capability_id": "graph.compute.properties",
+                "input": {"graph_uri": "artifact://example"},
+                "output": {"property_artifact_uri": "artifact://p"},
+                "artifact_uris": ["artifact://p"],
+                "assurance": {"level": "COMPUTED"},
+                "completeness": {"status": "COMPLETE"},
+            }
+        ],
+    }
 
 
 def test_known_answer_scorer_replays_durable_witness_bindings(

--- a/tests/integration/test_capability_service.py
+++ b/tests/integration/test_capability_service.py
@@ -11,8 +11,11 @@ from jacobian.capabilities import CapabilityError
 from jacobian.contracts.capabilities import (
     CapabilityAssurance,
     CapabilityAssuranceLevel,
+    CapabilityCompletenessStatus,
     CapabilityDescriptor,
     CapabilityMode,
+    CapabilityRelationship,
+    CapabilityRelationshipStatus,
     CapabilityRequest,
     CapabilityResult,
 )
@@ -111,6 +114,80 @@ class ForgedVerifiedAdapter:
 
 
 @dataclass(frozen=True)
+class OmittedRelationshipArtifactAdapter:
+    descriptor = CapabilityDescriptor(
+        capability_id="example.relationship",
+        version="1",
+        title="Return an unbound relationship",
+        description="Adversarial adapter that omits a relationship endpoint.",
+        provider="tests",
+        modes=(CapabilityMode.EXPLORE,),
+        input_schema={"type": "object"},
+        output_schema={"type": "object"},
+    )
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        return CapabilityResult(
+            capability_id=self.descriptor.capability_id,
+            capability_version=self.descriptor.version,
+            mode=request.mode,
+            execution=Execution(status=ExecutionStatus.COMPLETED),
+            relationships=(
+                CapabilityRelationship(
+                    relation_id="example.relation.derived",
+                    source_artifact_uris=("artifact://sha256/" + "a" * 64,),
+                    target_artifact_uris=("artifact://sha256/" + "b" * 64,),
+                ),
+            ),
+            assurance=CapabilityAssurance(
+                level=CapabilityAssuranceLevel.COMPUTED,
+                basis="adapter proposed a relationship",
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class ForgedRelationshipVerificationAdapter:
+    verification_record_uri: str
+    artifact_uris: tuple[str, ...]
+    source_uri: str
+    target_uri: str
+    descriptor = CapabilityDescriptor(
+        capability_id="example.forged-relationship",
+        version="1",
+        title="Mislabel a checked result as a verified relationship",
+        description="Adversarial adapter that reuses an unrelated valid record.",
+        provider="tests",
+        modes=(CapabilityMode.VERIFY,),
+        input_schema={"type": "object"},
+        output_schema={"type": "object"},
+    )
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        return CapabilityResult(
+            capability_id=self.descriptor.capability_id,
+            capability_version=self.descriptor.version,
+            mode=request.mode,
+            execution=Execution(status=ExecutionStatus.COMPLETED),
+            relationships=(
+                CapabilityRelationship(
+                    relation_id="claim.relation.specialization",
+                    source_artifact_uris=(self.source_uri,),
+                    target_artifact_uris=(self.target_uri,),
+                    status=CapabilityRelationshipStatus.VERIFIED,
+                    verification_record_uri=self.verification_record_uri,
+                ),
+            ),
+            assurance=CapabilityAssurance(
+                level=CapabilityAssuranceLevel.VERIFIED,
+                basis="reused a record that did not check this relation",
+                verification_record_uri=self.verification_record_uri,
+            ),
+            artifact_uris=self.artifact_uris,
+        )
+
+
+@dataclass(frozen=True)
 class MisboundVerifiedAdapter:
     verification_record_uri: str
     evidence_uri: str
@@ -161,6 +238,9 @@ def test_external_adapter_invocation_is_recorded_and_retrievable(
     assert result.output == {"value": 42}
     assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
     assert result.episode_uri is not None
+    episode = kernel.store.get(result.episode_uri)
+    assert episode.payload["result"]["response_version"] == "2"
+    assert episode.payload["result"]["completeness"]["status"] == "NOT_APPLICABLE"
     hits = kernel.memory.search(query="double computed").hits
     assert [hit.episode_uri for hit in hits] == [result.episode_uri]
 
@@ -291,7 +371,23 @@ def test_adapter_cannot_promote_without_a_local_verification_record(
 
 
 @pytest.mark.integration
-def test_adapter_cannot_reuse_a_record_without_its_bound_artifacts(
+def test_first_class_relationship_endpoints_must_be_exposed(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    kernel.register_capability(OmittedRelationshipArtifactAdapter())
+
+    with pytest.raises(CapabilityError, match="missing from artifact_uris"):
+        kernel.capabilities.invoke(
+            CapabilityRequest(
+                capability_id="example.relationship",
+                input={},
+            )
+        )
+
+
+@pytest.mark.integration
+def test_adapter_cannot_reuse_a_record_for_unchecked_bindings(
     tmp_path: Path,
 ) -> None:
     kernel = JacobianKernel(tmp_path, install_references=True)
@@ -325,6 +421,23 @@ def test_adapter_cannot_reuse_a_record_without_its_bound_artifacts(
         kernel.capabilities.invoke(
             CapabilityRequest(
                 capability_id="example.misbound",
+                mode=CapabilityMode.VERIFY,
+                input={},
+            )
+        )
+
+    kernel.register_capability(
+        ForgedRelationshipVerificationAdapter(
+            verification_record_uri=record_uri,
+            artifact_uris=legitimate.artifact_uris,
+            source_uri=str(legitimate.output["claim_uri"]),
+            target_uri=str(legitimate.output["candidate_uri"]),
+        )
+    )
+    with pytest.raises(CapabilityError, match="checked relation"):
+        kernel.capabilities.invoke(
+            CapabilityRequest(
+                capability_id="example.forged-relationship",
                 mode=CapabilityMode.VERIFY,
                 input={},
             )
@@ -364,9 +477,15 @@ def test_reference_capability_has_distinct_explore_and_verify_lanes(
     )
 
     assert explored.assurance.level is CapabilityAssuranceLevel.HEURISTIC
+    assert explored.completeness.status is CapabilityCompletenessStatus.UNKNOWN
     assert explored.output["verification_record_uri"] is None
     assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED
     assert verified.assurance.verification_record_uri is not None
+    assert verified.completeness.status is CapabilityCompletenessStatus.COMPLETE
+    assert (
+        verified.completeness.verification_record_uri
+        == verified.assurance.verification_record_uri
+    )
     assert verified.assurance.verification_record_uri in verified.artifact_uris
     assert verified.output["artifacts"]["verification_record"] == (
         verified.assurance.verification_record_uri
@@ -383,7 +502,8 @@ def test_reference_capability_has_distinct_explore_and_verify_lanes(
         in (verified.output["verification"]["checker_detail"])
     )
     assert verified.output["stages"]["independent_verification"] == "COMPLETED"
-    assert "bounds" not in verified.scope
+    assert verified.scope is not None
+    assert "bounds" not in verified.scope.parameters
     assert {hit.assurance_level for hit in kernel.memory.search(limit=10).hits} >= {
         CapabilityAssuranceLevel.HEURISTIC,
         CapabilityAssuranceLevel.VERIFIED,

--- a/tests/integration/test_graph_capabilities.py
+++ b/tests/integration/test_graph_capabilities.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from jacobian.contracts.capabilities import (
+    CapabilityAssuranceLevel,
+    CapabilityCompletenessStatus,
+    CapabilityMode,
+    CapabilityRelationshipStatus,
+    CapabilityRequest,
+)
+from jacobian.contracts.results import ExecutionStatus
+from jacobian.kernel import JacobianKernel
+
+
+@pytest.mark.integration
+def test_graph_atlas_search_is_bounded_complete_and_replayable(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+
+    result = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.search.atlas",
+            input={
+                "order": 5,
+                "constraints": {
+                    "connected": True,
+                    "triangle_free": True,
+                    "independence_number": 3,
+                },
+                "limit": 2,
+            },
+        )
+    )
+
+    assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert result.completeness.status is CapabilityCompletenessStatus.COMPLETE
+    assert result.completeness.assurance_level is CapabilityAssuranceLevel.COMPUTED
+    assert result.scope is not None
+    assert result.scope.artifact_uri in result.artifact_uris
+    assert result.output["match_count"] >= result.output["returned_count"] == 2
+    assert result.output["truncated"] is (
+        result.output["match_count"] > result.output["returned_count"]
+    )
+    assert "conclusion" not in result.output
+
+    for candidate in result.output["candidates"]:
+        graph_uri = candidate["graph_uri"]
+        graph = kernel.store.get(graph_uri)
+        assert graph.payload["graph_schema_version"] == "1"
+        assert len(graph.payload["vertices"]) == 5
+        assert candidate["properties"]["connected"] is True
+        assert candidate["properties"]["triangle_count"] == 0
+        assert candidate["properties"]["independence_number"] == 3
+
+    scope = kernel.store.get(result.scope.artifact_uri)
+    assert scope.payload["source"] == "networkx.graph_atlas_g"
+    assert scope.payload["order"] == 5
+    assert scope.payload["enumerated_count"] > 0
+
+
+@pytest.mark.integration
+def test_graph_atlas_search_reports_no_match_without_a_truth_claim(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+
+    result = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.search.atlas",
+            input={
+                "order": 4,
+                "constraints": {
+                    "tree": True,
+                    "minimum_edges": 6,
+                },
+                "limit": 1,
+            },
+        )
+    )
+
+    assert result.output["match_count"] == 0
+    assert result.output["candidates"] == []
+    assert result.completeness.status is CapabilityCompletenessStatus.COMPLETE
+    assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert "conclusion" not in result.output
+
+
+@pytest.mark.integration
+def test_graph_capabilities_return_actionable_parameter_and_artifact_errors(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+
+    invalid_range = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.search.atlas",
+            input={
+                "order": 5,
+                "constraints": {
+                    "minimum_edges": 5,
+                    "maximum_edges": 4,
+                },
+            },
+        )
+    )
+    assert invalid_range.execution.status is ExecutionStatus.ERROR
+    assert invalid_range.diagnostics[0].code == "INVALID_CONSTRAINT_RANGE"
+    assert invalid_range.diagnostics[0].path == "constraints/minimum_edges"
+    assert invalid_range.episode_uri is None
+
+    missing_graph = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.compute.properties",
+            input={
+                "graph_uri": "artifact://sha256/" + "f" * 64,
+                "properties": ["order"],
+            },
+        )
+    )
+    assert missing_graph.execution.status is ExecutionStatus.ERROR
+    assert missing_graph.diagnostics[0].code == "GRAPH_ARTIFACT_NOT_FOUND"
+    assert missing_graph.episode_uri is None
+
+
+@pytest.mark.integration
+def test_graph_property_batch_materializes_exact_computed_artifact(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+    searched = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.search.atlas",
+            input={
+                "order": 5,
+                "constraints": {"tree": True, "maximum_degree": 2},
+                "limit": 1,
+            },
+        )
+    )
+    graph_uri = searched.output["candidates"][0]["graph_uri"]
+
+    result = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.compute.properties",
+            mode=CapabilityMode.EXPLORE,
+            input={
+                "graph_uri": graph_uri,
+                "properties": [
+                    "order",
+                    "size",
+                    "connected",
+                    "bipartite",
+                    "degree_sequence",
+                    "triangle_count",
+                    "independence_number",
+                ],
+            },
+        )
+    )
+
+    assert result.output["graph_uri"] == graph_uri
+    assert result.output["properties"] == {
+        "bipartite": {
+            "backend": "networkx",
+            "exactness": "EXACT",
+            "value": True,
+        },
+        "connected": {
+            "backend": "networkx",
+            "exactness": "EXACT",
+            "value": True,
+        },
+        "degree_sequence": {
+            "backend": "networkx",
+            "exactness": "EXACT",
+            "value": [2, 2, 2, 1, 1],
+        },
+        "independence_number": {
+            "backend": "networkx.max_weight_clique(complement)",
+            "exactness": "EXACT",
+            "value": 3,
+        },
+        "order": {
+            "backend": "networkx",
+            "exactness": "EXACT",
+            "value": 5,
+        },
+        "size": {
+            "backend": "networkx",
+            "exactness": "EXACT",
+            "value": 4,
+        },
+        "triangle_count": {
+            "backend": "networkx",
+            "exactness": "EXACT",
+            "value": 0,
+        },
+    }
+    assert result.completeness.status is CapabilityCompletenessStatus.COMPLETE
+    assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert len(result.relationships) == 1
+    relationship = result.relationships[0]
+    assert relationship.status is CapabilityRelationshipStatus.PROPOSED
+    assert relationship.source_artifact_uris == (graph_uri,)
+    assert relationship.target_artifact_uris == (
+        result.output["property_artifact_uri"],
+    )
+    property_artifact = kernel.store.get(result.output["property_artifact_uri"])
+    assert property_artifact.manifest.parents == (graph_uri,)

--- a/tests/integration/test_mcp_adapter.py
+++ b/tests/integration/test_mcp_adapter.py
@@ -265,6 +265,8 @@ def test_mcp_capability_profile_describes_and_invokes_exact_domain_contract(
                 descriptor["capability_id"] for descriptor in catalog["capabilities"]
             }
             assert capability_ids == {
+                "graph.compute.properties",
+                "graph.search.atlas",
                 "knowledge.search",
                 "lean.check",
                 "reference.solve",


### PR DESCRIPTION
## Problem

Jacobian's capability result exposed operation-specific output and artifact
URIs, but relationships, proof obligations, scope, and completeness had no
shared contract. Agents therefore could not compose those facts without
understanding each domain payload, and adapters could reuse an unrelated valid
record when presenting a relationship as verified.

The repository also lacked a real bounded mathematical capability slice and an
agent evaluation that checks multi-call composition, artifact dataflow, and
false certification.

## Solution

- introduce `CapabilityResult` version 2 with typed scope, completeness,
  relationships, and obligations
- require first-class artifact references to appear in `artifact_uris`, and
  bind verified lifecycle states to the exact authorized checker record,
  relation, obligation, artifacts, and scope
- add `graph.search.atlas` and `graph.compute.properties` using NetworkX's
  maintained Graph Atlas and exact graph algorithms
- label Graph Atlas coverage and property computation as `COMPUTED`; neither
  capability can promote its own output to `VERIFIED`
- add `GRAPH-ATLAS-PATH-001`, which requires ordered search and property calls,
  checks successful-call URI dataflow and graph/property schemas, and records
  runtime, token use, tool calls, tool errors, parameter errors, correctness,
  and false certification
- document four initial workflows and the evidence-based rollout rule for
  retaining, splitting, or consolidating future capability IDs

The graph slice is intentionally bounded to Graph Atlas orders 0 through 7.
Solver-backed construction, case partitioning, and Lean goal decomposition
remain later vertical slices.

Suggested review order:

1. `8cb3a4e` — result contract and fail-closed bindings
2. `976fa2f` — NetworkX graph capabilities and integration
3. `770d75f` — agent evaluation and durable scorer
4. `63a77ab` — rollout and public documentation

## Testing

```sh
uv run pytest
# 337 passed

uv run ruff check .
uv run ruff format --check .
uv run mypy
uv build
git diff --check origin/main...HEAD
```

The real Codex MCP smoke run for `GRAPH-ATLAS-PATH-001` passed in 50.28
seconds with four tool calls, zero tool errors, zero parameter errors, 1,051
output tokens, and no false certification.

## Trust & Compatibility Impact

`CapabilityResult.response_version` changes from `1` to `2`, and `scope`
changes from an untyped object to `CapabilityScope`. This is an intentional
pre-stable API and persisted-episode format change; external adapters must
return the version 2 result shape.

Checker authorization is unchanged. `VERIFIED` still requires an
operator-authorized independent checker. The new graph capabilities return
`COMPUTED` evidence with proposed relationships, even when Graph Atlas
enumeration is complete or NetworkX returns an exact property.

## Checklist

- [x] Tests pass locally (`uv run pytest`)
- [x] Linting passes (`uv run ruff check .`)
- [x] Type checking passes (`uv run mypy`)
- [x] Formatting passes (`uv run ruff format --check .`)
- [x] Build succeeds (`uv build`)
- [x] Relevant documentation updated
