### PR TITLE
feat: add verified finite partitioning and paired capability evals

### DIFF
--- a/benchmarks/ab_cases/finite_partition_ab_001.json
+++ b/benchmarks/ab_cases/finite_partition_ab_001.json
@@ -1,0 +1,11 @@
+{
+  "case_id": "FINITE-PARTITION-AB-001",
+  "version": "1",
+  "task_type": "finite_partition",
+  "title": "Partition a finite domain by residue class",
+  "prompt": "Partition the exact universe [\"0\", \"1\", \"2\", \"3\", \"4\", \"5\", \"6\", \"7\", \"8\", \"9\", \"10\", \"11\"] into three named, pairwise-disjoint cases according to the integer's residue modulo 3. Return every case and member. The conclusion is TRUE only if the cases cover the exact universe without overlap.",
+  "expected": {
+    "universe": ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"],
+    "conclusion": "TRUE"
+  }
+}

--- a/benchmarks/ab_cases/graph-report.schema.json
+++ b/benchmarks/ab_cases/graph-report.schema.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "case_id": {"type": "string"},
+    "conclusion": {"enum": ["TRUE", "FALSE", "UNKNOWN"]},
+    "assurance": {"enum": ["SELF_CHECKED", "COMPUTED", "VERIFIED"]},
+    "final_verification": {"enum": ["UNVERIFIED", "VERIFIED"]},
+    "graph": {
+      "type": "object",
+      "properties": {
+        "vertices": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "edges": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {"type": "string"},
+            "minItems": 2,
+            "maxItems": 2
+          }
+        }
+      },
+      "required": ["vertices", "edges"],
+      "additionalProperties": false
+    },
+    "properties": {
+      "type": "object",
+      "properties": {
+        "order": {"type": ["integer", "null"]},
+        "size": {"type": ["integer", "null"]},
+        "connected": {"type": ["boolean", "null"]},
+        "bipartite": {"type": ["boolean", "null"]},
+        "tree": {"type": ["boolean", "null"]},
+        "triangle_count": {"type": ["integer", "null"]},
+        "minimum_degree": {"type": ["integer", "null"]},
+        "maximum_degree": {"type": ["integer", "null"]},
+        "degree_sequence": {
+          "type": ["array", "null"],
+          "items": {"type": "integer"}
+        },
+        "independence_number": {"type": ["integer", "null"]}
+      },
+      "required": [
+        "order",
+        "size",
+        "connected",
+        "bipartite",
+        "tree",
+        "triangle_count",
+        "minimum_degree",
+        "maximum_degree",
+        "degree_sequence",
+        "independence_number"
+      ],
+      "additionalProperties": false
+    },
+    "graph_uri": {
+      "type": ["string", "null"],
+      "pattern": "^artifact://sha256/[0-9a-f]{64}$"
+    },
+    "property_artifact_uri": {
+      "type": ["string", "null"],
+      "pattern": "^artifact://sha256/[0-9a-f]{64}$"
+    },
+    "limitations": {"type": "array", "items": {"type": "string"}},
+    "feedback": {
+      "type": "object",
+      "properties": {
+        "reasoning_focus": {"type": "array", "items": {"type": "string"}},
+        "infrastructure_work": {"type": "array", "items": {"type": "string"}},
+        "tooling_gaps": {"type": "array", "items": {"type": "string"}}
+      },
+      "required": ["reasoning_focus", "infrastructure_work", "tooling_gaps"],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "case_id",
+    "conclusion",
+    "assurance",
+    "final_verification",
+    "graph",
+    "properties",
+    "graph_uri",
+    "property_artifact_uri",
+    "limitations",
+    "feedback"
+  ],
+  "additionalProperties": false
+}

--- a/benchmarks/ab_cases/graph_counterexample_ab_001.json
+++ b/benchmarks/ab_cases/graph_counterexample_ab_001.json
@@ -7,6 +7,7 @@
   "expected": {
     "conclusion": "FALSE",
     "constraints": {
+      "order": 6,
       "connected": true,
       "triangle_free": true,
       "minimum_degree": 2,

--- a/benchmarks/ab_cases/graph_counterexample_ab_001.json
+++ b/benchmarks/ab_cases/graph_counterexample_ab_001.json
@@ -1,0 +1,23 @@
+{
+  "case_id": "GRAPH-COUNTEREXAMPLE-AB-001",
+  "version": "1",
+  "task_type": "graph",
+  "title": "Challenge a false universal graph claim",
+  "prompt": "Challenge the claim that every connected triangle-free simple graph on 6 vertices with minimum degree at least 2 is bipartite. If false, return one explicit counterexample and exact values for order, connected, bipartite, minimum_degree, and triangle_count. Set conclusion to FALSE exactly when the supplied graph is a counterexample.",
+  "expected": {
+    "conclusion": "FALSE",
+    "constraints": {
+      "connected": true,
+      "triangle_free": true,
+      "minimum_degree": 2,
+      "bipartite": false
+    },
+    "properties": [
+      "order",
+      "connected",
+      "bipartite",
+      "minimum_degree",
+      "triangle_count"
+    ]
+  }
+}

--- a/benchmarks/ab_cases/graph_path_ab_001.json
+++ b/benchmarks/ab_cases/graph_path_ab_001.json
@@ -7,6 +7,7 @@
   "expected": {
     "conclusion": "TRUE",
     "constraints": {
+      "order": 6,
       "connected": true,
       "tree": true,
       "maximum_degree": 2

--- a/benchmarks/ab_cases/graph_path_ab_001.json
+++ b/benchmarks/ab_cases/graph_path_ab_001.json
@@ -1,0 +1,25 @@
+{
+  "case_id": "GRAPH-PATH-AB-001",
+  "version": "1",
+  "task_type": "graph",
+  "title": "Construct a bounded path witness",
+  "prompt": "Construct one simple undirected graph on exactly 6 vertices that is connected, is a tree, and has maximum degree 2. Return its explicit vertices and edges and exact values for order, size, connected, tree, maximum_degree, bipartite, triangle_count, and independence_number. This is a bounded construction task, not a proof about all graphs.",
+  "expected": {
+    "conclusion": "TRUE",
+    "constraints": {
+      "connected": true,
+      "tree": true,
+      "maximum_degree": 2
+    },
+    "properties": [
+      "order",
+      "size",
+      "connected",
+      "tree",
+      "maximum_degree",
+      "bipartite",
+      "triangle_count",
+      "independence_number"
+    ]
+  }
+}

--- a/benchmarks/ab_cases/partition-report.schema.json
+++ b/benchmarks/ab_cases/partition-report.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "case_id": {"type": "string"},
+    "conclusion": {"enum": ["TRUE", "FALSE", "UNKNOWN"]},
+    "assurance": {"enum": ["SELF_CHECKED", "COMPUTED", "VERIFIED"]},
+    "final_verification": {"enum": ["UNVERIFIED", "VERIFIED"]},
+    "cases": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "case_id": {"type": "string"},
+          "members": {"type": "array", "items": {"type": "string"}}
+        },
+        "required": ["case_id", "members"],
+        "additionalProperties": false
+      }
+    },
+    "scope_uri": {
+      "type": ["string", "null"],
+      "pattern": "^artifact://sha256/[0-9a-f]{64}$"
+    },
+    "claim_uri": {
+      "type": ["string", "null"],
+      "pattern": "^artifact://sha256/[0-9a-f]{64}$"
+    },
+    "partition_uri": {
+      "type": ["string", "null"],
+      "pattern": "^artifact://sha256/[0-9a-f]{64}$"
+    },
+    "certificate_uri": {
+      "type": ["string", "null"],
+      "pattern": "^artifact://sha256/[0-9a-f]{64}$"
+    },
+    "verification_record_uri": {
+      "type": ["string", "null"],
+      "pattern": "^artifact://sha256/[0-9a-f]{64}$"
+    },
+    "limitations": {"type": "array", "items": {"type": "string"}},
+    "feedback": {
+      "type": "object",
+      "properties": {
+        "reasoning_focus": {"type": "array", "items": {"type": "string"}},
+        "infrastructure_work": {"type": "array", "items": {"type": "string"}},
+        "tooling_gaps": {"type": "array", "items": {"type": "string"}}
+      },
+      "required": ["reasoning_focus", "infrastructure_work", "tooling_gaps"],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "case_id",
+    "conclusion",
+    "assurance",
+    "final_verification",
+    "cases",
+    "scope_uri",
+    "claim_uri",
+    "partition_uri",
+    "certificate_uri",
+    "verification_record_uri",
+    "limitations",
+    "feedback"
+  ],
+  "additionalProperties": false
+}

--- a/benchmarks/agent_ab.py
+++ b/benchmarks/agent_ab.py
@@ -22,7 +22,7 @@ import time
 from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from jacobian.contracts.verification import VerificationRecord
 from jacobian.eval_graph_oracle import (
@@ -270,30 +270,58 @@ def _score_partition_report(
             or report.get("final_verification") != "VERIFIED"
         ):
             raise BenchmarkError("partition treatment was not independently verified")
-        record_uri = report.get("verification_record_uri")
-        if not isinstance(record_uri, str):
-            raise BenchmarkError("partition treatment omitted verification record")
+        reported_uris = {field: report.get(field) for field in uri_fields}
+        if not all(isinstance(uri, str) for uri in reported_uris.values()):
+            raise BenchmarkError("partition treatment omitted checked artifacts")
+        store = ArtifactStore(state_dir)
         try:
+            artifacts = {
+                field: store.get(cast(str, uri)) for field, uri in reported_uris.items()
+            }
             record = VerificationRecord.model_validate(
-                ArtifactStore(state_dir).get(record_uri).payload
+                artifacts["verification_record_uri"].payload
             )
         except (StoreError, ValueError) as exc:
             raise BenchmarkError(
-                "partition verification record is unavailable"
+                "partition verification artifacts are unavailable"
             ) from exc
         if (
             record.conclusion.value != "TRUE"
             or record.coverage.value != "EXHAUSTIVE"
             or record.relation_id != "case.relation.partitions"
+            or record.evidence_uri != reported_uris["certificate_uri"]
+            or record.obligation_uri != reported_uris["claim_uri"]
+            or record.bindings.claim_digest
+            != artifacts["claim_uri"].manifest.object_digest
+            or record.bindings.candidate_digest
+            != artifacts["partition_uri"].manifest.object_digest
+            or record.bindings.scope_digest
+            != artifacts["scope_uri"].manifest.object_digest
         ):
-            raise BenchmarkError("partition record differs from checked coverage")
+            raise BenchmarkError("partition record is not bound to reported artifacts")
         if not any(
             invocation.get("capability_id") == "case.partition.finite"
             and isinstance(invocation.get("assurance"), Mapping)
             and invocation["assurance"].get("level") == "VERIFIED"
+            and invocation.get("input")
+            == {
+                "universe": universe,
+                "cases": cases,
+                "require_disjoint": True,
+            }
+            and isinstance(invocation.get("output"), Mapping)
+            and all(
+                invocation["output"].get(field) == uri
+                for field, uri in reported_uris.items()
+            )
+            and isinstance(invocation.get("artifact_uris"), Sequence)
+            and not isinstance(invocation["artifact_uris"], (str, bytes))
+            and set(reported_uris.values()).issubset(invocation["artifact_uris"])
             for invocation in capability_invocations
         ):
-            raise BenchmarkError("partition treatment lacks verified capability trace")
+            raise BenchmarkError(
+                "partition treatment lacks an exact verified capability trace"
+            )
     else:
         raise BenchmarkError(f"unknown condition: {condition}")
     return {

--- a/benchmarks/agent_ab.py
+++ b/benchmarks/agent_ab.py
@@ -278,7 +278,9 @@ def _score_partition_report(
                 ArtifactStore(state_dir).get(record_uri).payload
             )
         except (StoreError, ValueError) as exc:
-            raise BenchmarkError("partition verification record is unavailable") from exc
+            raise BenchmarkError(
+                "partition verification record is unavailable"
+            ) from exc
         if (
             record.conclusion.value != "TRUE"
             or record.coverage.value != "EXHAUSTIVE"
@@ -300,7 +302,9 @@ def _score_partition_report(
         "checks": [
             "hidden exact finite oracle",
             "coverage and disjointness",
-            "checker-backed treatment" if condition == "treatment" else "control isolation",
+            "checker-backed treatment"
+            if condition == "treatment"
+            else "control isolation",
         ],
     }
 
@@ -368,7 +372,9 @@ def _score_graph_report(
             "independent graph witness oracle",
             "exact property vector",
             "fail-closed assurance",
-            "durable treatment dataflow" if condition == "treatment" else "control isolation",
+            "durable treatment dataflow"
+            if condition == "treatment"
+            else "control isolation",
         ],
     }
 
@@ -388,7 +394,9 @@ def _score_graph_artifacts(
         property_artifact = store.get(property_uri)
         schemas = SchemaRegistry(store)
         schemas.validate(graph_artifact.manifest.schema_uri, graph_artifact.payload)
-        schemas.validate(property_artifact.manifest.schema_uri, property_artifact.payload)
+        schemas.validate(
+            property_artifact.manifest.schema_uri, property_artifact.payload
+        )
     except (SchemaRegistryError, StoreError) as exc:
         raise BenchmarkError("graph treatment artifacts fail validation") from exc
     try:
@@ -405,15 +413,16 @@ def _score_graph_artifacts(
         raise BenchmarkError("property artifact is malformed")
     computed = compute_properties(graph)
     try:
-        check_reported_properties(computed, property_payload.get("properties"), requested)
+        check_reported_properties(
+            computed, property_payload.get("properties"), requested
+        )
     except GraphOracleError as exc:
         raise BenchmarkError(str(exc)) from exc
     found_search = False
     found_compute = False
     for invocation in capability_invocations:
-        if (
-            invocation.get("capability_id") == "graph.search.atlas"
-            and graph_uri in (invocation.get("artifact_uris") or [])
+        if invocation.get("capability_id") == "graph.search.atlas" and graph_uri in (
+            invocation.get("artifact_uris") or []
         ):
             found_search = True
         if (
@@ -752,7 +761,9 @@ def _condition_summary(results: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
             + int(result.get("shell_call_count", 0))
             for result in results
         ),
-        "tool_error_count": sum(int(result.get("tool_error_count", 0)) for result in results),
+        "tool_error_count": sum(
+            int(result.get("tool_error_count", 0)) for result in results
+        ),
         "parameter_error_count": sum(
             int(result.get("parameter_error_count", 0)) for result in results
         ),

--- a/benchmarks/agent_ab.py
+++ b/benchmarks/agent_ab.py
@@ -25,11 +25,22 @@ from pathlib import Path
 from typing import Any
 
 from jacobian.contracts.verification import VerificationRecord
+from jacobian.eval_graph_oracle import (
+    GraphOracleError,
+    check_constraints,
+    check_reported_properties,
+    compute_properties,
+    normalize_graph,
+)
+from jacobian.eval_telemetry import parse_agent_transcript as parse_transcript
+from jacobian.schema_registry import SchemaRegistry, SchemaRegistryError
 from jacobian.store import ArtifactStore, StoreError
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 CASES_ROOT = Path(__file__).with_name("ab_cases")
 REPORT_SCHEMA = CASES_ROOT / "report.schema.json"
+GRAPH_REPORT_SCHEMA = CASES_ROOT / "graph-report.schema.json"
+PARTITION_REPORT_SCHEMA = CASES_ROOT / "partition-report.schema.json"
 DEFAULT_RESULTS_ROOT = Path(__file__).with_name("results") / "ab"
 CONDITIONS = ("control", "treatment")
 
@@ -61,6 +72,35 @@ reference.solve in VERIFY mode. Its payload uses reference_name
 returns that assurance, and copy its exact verification_record_uri.
 """
 
+GRAPH_CONTROL_INSTRUCTIONS = """\
+Jacobian and all MCP servers are unavailable. You may write and run local code
+in the empty workspace. Return one explicit simple undirected graph satisfying
+the constraints. Report SELF_CHECKED, UNVERIFIED, and null artifact URIs.
+Set graph-property fields not requested by the case to null.
+"""
+
+GRAPH_TREATMENT_INSTRUCTIONS = """\
+Use only jacobian_local for mathematical computation. Do not use shell commands
+or create programs. Describe and invoke graph.search.atlas, then invoke
+graph.compute.properties on one returned graph. Return that graph and its exact
+properties. Copy the exact inline graph payload returned by graph.search.atlas;
+do not substitute an isomorphic relabeling. Report COMPUTED, UNVERIFIED, and the
+durable graph/property URIs.
+Set graph-property fields not requested by the case to null.
+"""
+
+PARTITION_CONTROL_INSTRUCTIONS = """\
+Jacobian and all MCP servers are unavailable. Construct the requested cases
+directly. Report SELF_CHECKED, UNVERIFIED, and null artifact URIs.
+"""
+
+PARTITION_TREATMENT_INSTRUCTIONS = """\
+Use only jacobian_local for mathematical work. Describe and invoke
+case.partition.finite in VERIFY mode with the exact universe and cases. Do not
+use shell commands or create programs. Copy the returned durable URIs. Report
+VERIFIED only when the capability returns VERIFIED assurance.
+"""
+
 
 class BenchmarkError(RuntimeError):
     """The A/B runner, report, or known-answer evidence is invalid."""
@@ -77,7 +117,7 @@ def load_cases(selected: Sequence[str]) -> list[dict[str, Any]]:
     cases = [
         _load_json_object(path)
         for path in sorted(CASES_ROOT.glob("*.json"))
-        if path.name != REPORT_SCHEMA.name
+        if not path.name.endswith(".schema.json")
     ]
     indexed = {str(case.get("case_id")): case for case in cases}
     if len(indexed) != len(cases):
@@ -90,43 +130,6 @@ def load_cases(selected: Sequence[str]) -> list[dict[str, Any]]:
     return [indexed[case_id] for case_id in selected]
 
 
-def parse_transcript(path: Path) -> dict[str, Any]:
-    mcp_calls: list[str] = []
-    shell_calls: list[str] = []
-    usage: dict[str, Any] | None = None
-    for line in path.read_text(encoding="utf-8").splitlines():
-        try:
-            event = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        if not isinstance(event, dict):
-            continue
-        item = event.get("item")
-        if (
-            event.get("type") == "item.completed"
-            and isinstance(item, dict)
-            and item.get("type") == "mcp_tool_call"
-            and isinstance(item.get("tool"), str)
-        ):
-            mcp_calls.append(item["tool"])
-        if (
-            event.get("type") == "item.completed"
-            and isinstance(item, dict)
-            and item.get("type") == "command_execution"
-        ):
-            command = item.get("command")
-            shell_calls.append(command if isinstance(command, str) else "")
-        if event.get("type") == "turn.completed" and isinstance(
-            event.get("usage"), dict
-        ):
-            usage = event["usage"]
-    return {
-        "mcp_calls": mcp_calls,
-        "shell_calls": shell_calls,
-        "usage": usage,
-    }
-
-
 def score_report(
     case: Mapping[str, Any],
     report: Mapping[str, Any],
@@ -134,7 +137,26 @@ def score_report(
     condition: str,
     state_dir: Path,
     mcp_calls: Sequence[str],
+    capability_invocations: Sequence[Mapping[str, Any]] = (),
 ) -> dict[str, Any]:
+    if case.get("task_type") == "graph":
+        return _score_graph_report(
+            case,
+            report,
+            condition=condition,
+            state_dir=state_dir,
+            mcp_calls=mcp_calls,
+            capability_invocations=capability_invocations,
+        )
+    if case.get("task_type") == "finite_partition":
+        return _score_partition_report(
+            case,
+            report,
+            condition=condition,
+            state_dir=state_dir,
+            mcp_calls=mcp_calls,
+            capability_invocations=capability_invocations,
+        )
     expected_value = case.get("expected")
     if not isinstance(expected_value, dict):
         raise BenchmarkError("case expected must be an object")
@@ -180,6 +202,231 @@ def score_report(
     else:
         raise BenchmarkError(f"unknown condition: {condition}")
     return {"passed": True, "checks": checks}
+
+
+def _score_partition_report(
+    case: Mapping[str, Any],
+    report: Mapping[str, Any],
+    *,
+    condition: str,
+    state_dir: Path,
+    mcp_calls: Sequence[str],
+    capability_invocations: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    expected = case.get("expected")
+    if not isinstance(expected, Mapping):
+        raise BenchmarkError("partition expected must be an object")
+    if (
+        report.get("case_id") != case.get("case_id")
+        or report.get("conclusion") != "TRUE"
+    ):
+        raise BenchmarkError("partition report has the wrong case or conclusion")
+    universe = expected.get("universe")
+    cases = report.get("cases")
+    if not isinstance(universe, list) or not isinstance(cases, list):
+        raise BenchmarkError("partition report is malformed")
+    memberships: dict[str, str] = {}
+    for item in cases:
+        if (
+            not isinstance(item, Mapping)
+            or not isinstance(item.get("case_id"), str)
+            or not isinstance(item.get("members"), list)
+        ):
+            raise BenchmarkError("partition case is malformed")
+        for member in item["members"]:
+            if not isinstance(member, str) or member in memberships:
+                raise BenchmarkError("partition cases overlap or are malformed")
+            memberships[member] = item["case_id"]
+    if set(memberships) != set(universe):
+        raise BenchmarkError("partition does not cover the hidden finite oracle")
+    reported_groups = {
+        frozenset(str(member) for member in item["members"]) for item in cases
+    }
+    expected_groups = {
+        frozenset(value for value in universe if int(value) % 3 == residue)
+        for residue in range(3)
+    }
+    if reported_groups != expected_groups:
+        raise BenchmarkError("partition cases do not match residue classes")
+    if report.get("false_certification") is True:
+        raise BenchmarkError("partition report declared false certification")
+    uri_fields = (
+        "scope_uri",
+        "claim_uri",
+        "partition_uri",
+        "certificate_uri",
+        "verification_record_uri",
+    )
+    if condition == "control":
+        if mcp_calls or report.get("assurance") != "SELF_CHECKED":
+            raise BenchmarkError("partition control isolation failed")
+        if report.get("final_verification") != "UNVERIFIED" or any(
+            report.get(field) is not None for field in uri_fields
+        ):
+            raise BenchmarkError("partition control falsely projected verification")
+    elif condition == "treatment":
+        if (
+            report.get("assurance") != "VERIFIED"
+            or report.get("final_verification") != "VERIFIED"
+        ):
+            raise BenchmarkError("partition treatment was not independently verified")
+        record_uri = report.get("verification_record_uri")
+        if not isinstance(record_uri, str):
+            raise BenchmarkError("partition treatment omitted verification record")
+        try:
+            record = VerificationRecord.model_validate(
+                ArtifactStore(state_dir).get(record_uri).payload
+            )
+        except (StoreError, ValueError) as exc:
+            raise BenchmarkError("partition verification record is unavailable") from exc
+        if (
+            record.conclusion.value != "TRUE"
+            or record.coverage.value != "EXHAUSTIVE"
+            or record.relation_id != "case.relation.partitions"
+        ):
+            raise BenchmarkError("partition record differs from checked coverage")
+        if not any(
+            invocation.get("capability_id") == "case.partition.finite"
+            and isinstance(invocation.get("assurance"), Mapping)
+            and invocation["assurance"].get("level") == "VERIFIED"
+            for invocation in capability_invocations
+        ):
+            raise BenchmarkError("partition treatment lacks verified capability trace")
+    else:
+        raise BenchmarkError(f"unknown condition: {condition}")
+    return {
+        "passed": True,
+        "false_certification": False,
+        "checks": [
+            "hidden exact finite oracle",
+            "coverage and disjointness",
+            "checker-backed treatment" if condition == "treatment" else "control isolation",
+        ],
+    }
+
+
+def _score_graph_report(
+    case: Mapping[str, Any],
+    report: Mapping[str, Any],
+    *,
+    condition: str,
+    state_dir: Path,
+    mcp_calls: Sequence[str],
+    capability_invocations: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    expected = case.get("expected")
+    if not isinstance(expected, Mapping):
+        raise BenchmarkError("graph case expected must be an object")
+    if report.get("case_id") != case.get("case_id"):
+        raise BenchmarkError("report case_id differs from graph case")
+    if report.get("conclusion") != expected.get("conclusion"):
+        raise BenchmarkError("graph conclusion differs from hidden oracle")
+    if report.get("final_verification") != "UNVERIFIED":
+        raise BenchmarkError("computed graph result was falsely certified")
+    graph = report.get("graph")
+    try:
+        properties = compute_properties(graph)
+        check_constraints(properties, expected.get("constraints"))
+        check_reported_properties(
+            properties,
+            report.get("properties"),
+            expected.get("properties"),
+        )
+    except GraphOracleError as exc:
+        raise BenchmarkError(str(exc)) from exc
+
+    graph_uri = report.get("graph_uri")
+    property_uri = report.get("property_artifact_uri")
+    if condition == "control":
+        if mcp_calls:
+            raise BenchmarkError("control condition used an MCP tool")
+        if report.get("assurance") != "SELF_CHECKED":
+            raise BenchmarkError("graph control assurance must be SELF_CHECKED")
+        if graph_uri is not None or property_uri is not None:
+            raise BenchmarkError("graph control reported Jacobian artifacts")
+    elif condition == "treatment":
+        if report.get("assurance") != "COMPUTED":
+            raise BenchmarkError("graph treatment assurance must be COMPUTED")
+        if "capability.invoke" not in mcp_calls:
+            raise BenchmarkError("graph treatment did not invoke capabilities")
+        if not isinstance(graph_uri, str) or not isinstance(property_uri, str):
+            raise BenchmarkError("graph treatment omitted durable artifacts")
+        _score_graph_artifacts(
+            state_dir=state_dir,
+            graph=graph,
+            graph_uri=graph_uri,
+            property_uri=property_uri,
+            requested=expected.get("properties"),
+            capability_invocations=capability_invocations,
+        )
+    else:
+        raise BenchmarkError(f"unknown condition: {condition}")
+    return {
+        "passed": True,
+        "false_certification": False,
+        "checks": [
+            "independent graph witness oracle",
+            "exact property vector",
+            "fail-closed assurance",
+            "durable treatment dataflow" if condition == "treatment" else "control isolation",
+        ],
+    }
+
+
+def _score_graph_artifacts(
+    *,
+    state_dir: Path,
+    graph: object,
+    graph_uri: str,
+    property_uri: str,
+    requested: object,
+    capability_invocations: Sequence[Mapping[str, Any]],
+) -> None:
+    store = ArtifactStore(state_dir)
+    try:
+        graph_artifact = store.get(graph_uri)
+        property_artifact = store.get(property_uri)
+        schemas = SchemaRegistry(store)
+        schemas.validate(graph_artifact.manifest.schema_uri, graph_artifact.payload)
+        schemas.validate(property_artifact.manifest.schema_uri, property_artifact.payload)
+    except (SchemaRegistryError, StoreError) as exc:
+        raise BenchmarkError("graph treatment artifacts fail validation") from exc
+    try:
+        durable_graph = normalize_graph(graph_artifact.payload)
+        reported_graph = normalize_graph(graph)
+    except GraphOracleError as exc:
+        raise BenchmarkError(str(exc)) from exc
+    if durable_graph != reported_graph:
+        raise BenchmarkError("reported graph differs from durable graph artifact")
+    if graph_uri not in property_artifact.manifest.parents:
+        raise BenchmarkError("property artifact is not bound to graph artifact")
+    property_payload = property_artifact.payload
+    if not isinstance(property_payload, Mapping):
+        raise BenchmarkError("property artifact is malformed")
+    computed = compute_properties(graph)
+    try:
+        check_reported_properties(computed, property_payload.get("properties"), requested)
+    except GraphOracleError as exc:
+        raise BenchmarkError(str(exc)) from exc
+    found_search = False
+    found_compute = False
+    for invocation in capability_invocations:
+        if (
+            invocation.get("capability_id") == "graph.search.atlas"
+            and graph_uri in (invocation.get("artifact_uris") or [])
+        ):
+            found_search = True
+        if (
+            found_search
+            and invocation.get("capability_id") == "graph.compute.properties"
+            and isinstance(invocation.get("input"), Mapping)
+            and invocation["input"].get("graph_uri") == graph_uri
+            and property_uri in (invocation.get("artifact_uris") or [])
+        ):
+            found_compute = True
+            break
+    if not found_compute:
+        raise BenchmarkError("treatment lacks ordered search-to-property dataflow")
 
 
 def _score_erdos_record(
@@ -231,6 +478,7 @@ def _codex_command(
     state_dir: Path,
     model: str | None,
     reasoning_effort: str,
+    report_schema: Path = REPORT_SCHEMA,
 ) -> list[str]:
     command = [
         codex_command,
@@ -246,7 +494,7 @@ def _codex_command(
         "never",
         "--json",
         "--output-schema",
-        str(REPORT_SCHEMA),
+        str(report_schema),
         "--output-last-message",
         str(report_path),
         "-c",
@@ -310,9 +558,24 @@ def _run_condition(
     condition_root.mkdir(parents=True)
     workspace.mkdir()
     state_dir.mkdir()
-    condition_instructions = (
-        CONTROL_INSTRUCTIONS if condition == "control" else TREATMENT_INSTRUCTIONS
-    )
+    is_graph = case.get("task_type") == "graph"
+    is_partition = case.get("task_type") == "finite_partition"
+    if is_graph:
+        condition_instructions = (
+            GRAPH_CONTROL_INSTRUCTIONS
+            if condition == "control"
+            else GRAPH_TREATMENT_INSTRUCTIONS
+        )
+    elif is_partition:
+        condition_instructions = (
+            PARTITION_CONTROL_INSTRUCTIONS
+            if condition == "control"
+            else PARTITION_TREATMENT_INSTRUCTIONS
+        )
+    else:
+        condition_instructions = (
+            CONTROL_INSTRUCTIONS if condition == "control" else TREATMENT_INSTRUCTIONS
+        )
     prompt = condition_instructions + "\n" + COMMON_PROMPT.format(**case)
     command = _codex_command(
         codex_command=codex_command,
@@ -322,6 +585,13 @@ def _run_condition(
         state_dir=state_dir,
         model=model,
         reasoning_effort=reasoning_effort,
+        report_schema=(
+            GRAPH_REPORT_SCHEMA
+            if is_graph
+            else PARTITION_REPORT_SCHEMA
+            if is_partition
+            else REPORT_SCHEMA
+        ),
     )
     started = time.monotonic()
     started_at = _timestamp()
@@ -363,6 +633,7 @@ def _run_condition(
                 condition=condition,
                 state_dir=state_dir,
                 mcp_calls=telemetry["mcp_calls"],
+                capability_invocations=telemetry["capability_invocations"],
             )
         except (BenchmarkError, OSError, json.JSONDecodeError) as exc:
             score = {"passed": False, "error": str(exc)}
@@ -378,12 +649,30 @@ def _run_condition(
         "usage": telemetry["usage"],
         "mcp_calls": telemetry["mcp_calls"],
         "mcp_call_count": len(telemetry["mcp_calls"]),
+        "tool_error_count": telemetry["tool_error_count"],
+        "parameter_error_count": telemetry["parameter_error_count"],
         "shell_calls": telemetry["shell_calls"],
         "shell_call_count": len(telemetry["shell_calls"]),
         "workspace_file_count": sum(
             1 for path in workspace.rglob("*") if path.is_file()
         ),
         "agent_report": report,
+        "false_certification": bool(
+            (
+                is_graph
+                and isinstance(report, dict)
+                and (
+                    report.get("assurance") == "VERIFIED"
+                    or report.get("final_verification") == "VERIFIED"
+                )
+            )
+            or (
+                is_partition
+                and isinstance(report, dict)
+                and report.get("final_verification") == "VERIFIED"
+                and report.get("verification_record_uri") is None
+            )
+        ),
         "score": score,
     }
     (condition_root / "result.json").write_text(
@@ -423,6 +712,10 @@ def summarize_pairs(results: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
                 - int(control["shell_call_count"]),
                 "mcp_call_delta": int(treatment["mcp_call_count"])
                 - int(control["mcp_call_count"]),
+                "tool_error_delta": int(treatment.get("tool_error_count", 0))
+                - int(control.get("tool_error_count", 0)),
+                "parameter_error_delta": int(treatment.get("parameter_error_count", 0))
+                - int(control.get("parameter_error_count", 0)),
             }
         )
     condition_summary = {
@@ -453,6 +746,18 @@ def _condition_summary(results: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
         ),
         "median_output_tokens": statistics.median(
             _usage_value(result, "output_tokens") for result in results
+        ),
+        "median_tool_calls": statistics.median(
+            int(result.get("mcp_call_count", 0))
+            + int(result.get("shell_call_count", 0))
+            for result in results
+        ),
+        "tool_error_count": sum(int(result.get("tool_error_count", 0)) for result in results),
+        "parameter_error_count": sum(
+            int(result.get("parameter_error_count", 0)) for result in results
+        ),
+        "false_certification_count": sum(
+            bool(result.get("false_certification")) for result in results
         ),
     }
 

--- a/benchmarks/agent_ab.py
+++ b/benchmarks/agent_ab.py
@@ -226,6 +226,7 @@ def _score_partition_report(
     if not isinstance(universe, list) or not isinstance(cases, list):
         raise BenchmarkError("partition report is malformed")
     memberships: dict[str, str] = {}
+    case_ids: set[str] = set()
     for item in cases:
         if (
             not isinstance(item, Mapping)
@@ -233,10 +234,16 @@ def _score_partition_report(
             or not isinstance(item.get("members"), list)
         ):
             raise BenchmarkError("partition case is malformed")
+        case_id = item["case_id"]
+        if not case_id or case_id in case_ids:
+            raise BenchmarkError(
+                "partition case identifiers must be distinct and non-empty"
+            )
+        case_ids.add(case_id)
         for member in item["members"]:
             if not isinstance(member, str) or member in memberships:
                 raise BenchmarkError("partition cases overlap or are malformed")
-            memberships[member] = item["case_id"]
+            memberships[member] = case_id
     if set(memberships) != set(universe):
         raise BenchmarkError("partition does not cover the hidden finite oracle")
     reported_groups = {

--- a/benchmarks/agent_mcp.py
+++ b/benchmarks/agent_mcp.py
@@ -25,6 +25,7 @@ from typing import Any
 
 import networkx as nx
 
+from jacobian.eval_telemetry import parse_agent_transcript
 from jacobian.schema_registry import SchemaRegistry, SchemaRegistryError
 from jacobian.store import ArtifactStore, StoreError
 
@@ -34,17 +35,6 @@ DEFAULT_RESULTS_ROOT = Path(__file__).with_name("results")
 REPORT_SCHEMA = CASES_ROOT / "report.schema.json"
 GRAPH_REPORT_SCHEMA = CASES_ROOT / "graph-report.schema.json"
 ARTIFACT_PREFIX = "artifact://sha256/"
-PARAMETER_ERROR_CODES = frozenset(
-    {
-        -32602,
-        "INVALID_ARGUMENT",
-        "INVALID_CONSTRAINT_RANGE",
-        "INVALID_PARAMS",
-        "INVALID_REQUEST",
-        "SCHEMA_VALIDATION",
-        "invalid_params",
-    }
-)
 
 SYSTEM_TASK = """\
 Use only the jacobian_local MCP tools and resources for the mathematical work.
@@ -146,123 +136,22 @@ def _artifact_uri(value: object, field: str) -> str:
     return value
 
 
-def _contains_parameter_error(value: object) -> bool:
-    if isinstance(value, Mapping):
-        if value.get("code") in PARAMETER_ERROR_CODES:
-            return True
-        return any(_contains_parameter_error(item) for item in value.values())
-    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
-        return any(_contains_parameter_error(item) for item in value)
-    return False
-
-
-def _contains_execution_error(value: object) -> bool:
-    if isinstance(value, Mapping):
-        if value.get("status") in {"CANCELLED", "ERROR", "TIMEOUT"}:
-            return True
-        return any(_contains_execution_error(item) for item in value.values())
-    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
-        return any(_contains_execution_error(item) for item in value)
-    return False
-
-
-def _mcp_text_payload(item: Mapping[str, Any]) -> dict[str, Any] | None:
-    result = item.get("result")
-    if not isinstance(result, dict):
-        return None
-    content = result.get("content")
-    if not isinstance(content, list):
-        return None
-    for block in content:
-        if not isinstance(block, dict) or not isinstance(block.get("text"), str):
-            continue
-        try:
-            payload = json.loads(block["text"])
-        except json.JSONDecodeError:
-            continue
-        if isinstance(payload, dict):
-            return payload
-    return None
-
-
 def parse_transcript(
     path: Path,
 ) -> tuple[list[str], dict[str, Any] | None, dict[str, Any]]:
-    calls: list[str] = []
-    successful_calls: list[str] = []
-    usage: dict[str, Any] | None = None
-    tool_error_count = 0
-    parameter_error_count = 0
-    capability_ids: list[str] = []
-    capability_invocations: list[dict[str, Any]] = []
-    for line in path.read_text(encoding="utf-8").splitlines():
-        try:
-            event = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        item = event.get("item") if isinstance(event, dict) else None
-        if (
-            isinstance(event, dict)
-            and event.get("type") == "item.completed"
-            and isinstance(item, dict)
-            and item.get("type") == "mcp_tool_call"
-            and isinstance(item.get("tool"), str)
-        ):
-            calls.append(item["tool"])
-            result = item.get("result")
-            failed = bool(
-                item.get("status") in {"error", "failed"}
-                or item.get("error")
-                or (isinstance(result, dict) and result.get("isError") is True)
-                or _contains_execution_error(item)
-            )
-            if failed:
-                tool_error_count += 1
-            else:
-                successful_calls.append(item["tool"])
-                arguments = item.get("arguments")
-                response = _mcp_text_payload(item)
-                execution = (
-                    response.get("execution") if isinstance(response, dict) else None
-                )
-                if (
-                    item["tool"] == "capability.invoke"
-                    and isinstance(arguments, dict)
-                    and isinstance(arguments.get("capability_id"), str)
-                    and isinstance(response, dict)
-                    and response.get("capability_id") == arguments["capability_id"]
-                    and isinstance(execution, dict)
-                    and execution.get("status") == "COMPLETED"
-                ):
-                    capability_id = arguments["capability_id"]
-                    capability_ids.append(capability_id)
-                    capability_invocations.append(
-                        {
-                            "capability_id": capability_id,
-                            "input": arguments.get("payload"),
-                            "output": response.get("output"),
-                            "artifact_uris": response.get("artifact_uris"),
-                            "assurance": response.get("assurance"),
-                            "completeness": response.get("completeness"),
-                        }
-                    )
-            if _contains_parameter_error(item):
-                parameter_error_count += 1
-        if (
-            isinstance(event, dict)
-            and event.get("type") == "turn.completed"
-            and isinstance(event.get("usage"), dict)
-        ):
-            usage = event["usage"]
+    telemetry = parse_agent_transcript(path)
     return (
-        calls,
-        usage,
+        telemetry["mcp_calls"],
+        telemetry["usage"],
         {
-            "tool_error_count": tool_error_count,
-            "parameter_error_count": parameter_error_count,
-            "successful_tool_calls": successful_calls,
-            "capability_ids": capability_ids,
-            "capability_invocations": capability_invocations,
+            key: telemetry[key]
+            for key in (
+                "tool_error_count",
+                "parameter_error_count",
+                "successful_tool_calls",
+                "capability_ids",
+                "capability_invocations",
+            )
         },
     )
 
@@ -641,7 +530,7 @@ def _score_graph_capability_run(
         normalized_edges.append((source, target))
     if len(set(normalized_edges)) != len(normalized_edges):
         raise BenchmarkError("graph contains duplicate edges")
-    graph = nx.Graph()
+    graph: nx.Graph[str] = nx.Graph()
     graph.add_nodes_from(vertices)
     graph.add_edges_from(normalized_edges)
     degree_sequence = sorted((degree for _, degree in graph.degree), reverse=True)

--- a/benchmarks/lean_repl_pin.json
+++ b/benchmarks/lean_repl_pin.json
@@ -1,0 +1,7 @@
+{
+  "repository": "https://github.com/leanprover-community/repl.git",
+  "tag": "v4.31.0",
+  "commit": "0cc60263319308000bbaa5354427f775fe3dc7d0",
+  "lean_version": "4.31.0",
+  "lean_commit": "68218e876d2a38b1985b8590fff244a83c321783"
+}

--- a/benchmarks/lean_repl_spike.py
+++ b/benchmarks/lean_repl_spike.py
@@ -79,10 +79,14 @@ def run_tasks(repl: Path) -> dict[str, Any]:
             )
             sorries = command_response.get("sorries")
             if not isinstance(sorries, list) or len(sorries) != 1:
-                raise ReplSpikeError(f"{task['task_id']} did not expose one proof state")
+                raise ReplSpikeError(
+                    f"{task['task_id']} did not expose one proof state"
+                )
             proof_state = sorries[0].get("proofState")
             if not isinstance(proof_state, int):
-                raise ReplSpikeError(f"{task['task_id']} returned an invalid proof state")
+                raise ReplSpikeError(
+                    f"{task['task_id']} returned an invalid proof state"
+                )
             traces: list[dict[str, Any]] = []
             for tactic in task["tactics"]:
                 response, elapsed = _exchange(
@@ -128,9 +132,7 @@ def run_tasks(repl: Path) -> dict[str, Any]:
         "task_count": len(task_results),
         "completed_count": sum(result["completed"] for result in task_results),
         "parameter_error_count": sum(
-            "message" in trace
-            for result in task_results
-            for trace in result["tactics"]
+            "message" in trace for result in task_results for trace in result["tactics"]
         ),
         "elapsed_seconds": round(time.monotonic() - started, 6),
         "return_code": return_code,

--- a/benchmarks/lean_repl_spike.py
+++ b/benchmarks/lean_repl_spike.py
@@ -60,6 +60,21 @@ def _exchange(
     return response, time.monotonic() - started
 
 
+def _response_errors(response: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    message = response.get("message")
+    if isinstance(message, str):
+        errors.append(message)
+    messages = response.get("messages")
+    if isinstance(messages, list):
+        for item in messages:
+            if not isinstance(item, Mapping) or item.get("severity") != "error":
+                continue
+            data = item.get("data")
+            errors.append(data if isinstance(data, str) else repr(item))
+    return errors
+
+
 def run_tasks(repl: Path) -> dict[str, Any]:
     started = time.monotonic()
     process = subprocess.Popen(
@@ -77,6 +92,11 @@ def run_tasks(repl: Path) -> dict[str, Any]:
                 process,
                 {"cmd": task["command"]},
             )
+            command_errors = _response_errors(command_response)
+            if command_errors:
+                raise ReplSpikeError(
+                    f"{task['task_id']} command failed: {'; '.join(command_errors)}"
+                )
             sorries = command_response.get("sorries")
             if not isinstance(sorries, list) or len(sorries) != 1:
                 raise ReplSpikeError(
@@ -93,6 +113,12 @@ def run_tasks(repl: Path) -> dict[str, Any]:
                     process,
                     {"tactic": tactic, "proofState": proof_state},
                 )
+                response_errors = _response_errors(response)
+                if response_errors:
+                    raise ReplSpikeError(
+                        f"{task['task_id']} tactic failed: "
+                        + "; ".join(response_errors)
+                    )
                 next_state = response.get("proofState")
                 goals = response.get("goals")
                 if not isinstance(next_state, int) or not isinstance(goals, list):
@@ -104,6 +130,7 @@ def run_tasks(repl: Path) -> dict[str, Any]:
                         "tactic": tactic,
                         "elapsed_seconds": round(elapsed, 6),
                         "goal_count": len(goals),
+                        "error_count": len(response_errors),
                     }
                 )
                 proof_state = next_state
@@ -132,7 +159,9 @@ def run_tasks(repl: Path) -> dict[str, Any]:
         "task_count": len(task_results),
         "completed_count": sum(result["completed"] for result in task_results),
         "parameter_error_count": sum(
-            "message" in trace for result in task_results for trace in result["tactics"]
+            trace["error_count"]
+            for result in task_results
+            for trace in result["tactics"]
         ),
         "elapsed_seconds": round(time.monotonic() - started, 6),
         "return_code": return_code,

--- a/benchmarks/lean_repl_spike.py
+++ b/benchmarks/lean_repl_spike.py
@@ -1,0 +1,178 @@
+"""Measure the pinned Lean REPL as an exploratory goal-state transport."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import time
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import IO, Any
+
+TASKS: tuple[dict[str, Any], ...] = (
+    {
+        "task_id": "CONJUNCTION-DECOMPOSITION",
+        "command": "example (P Q : Prop) (hP : P) (hQ : Q) : P ∧ Q := by sorry",
+        "tactics": ("constructor", "exact hP", "exact hQ"),
+        "expected_first_goal_count": 2,
+    },
+    {
+        "task_id": "LOCAL-PREMISE-APPLICATION",
+        "command": "example (P Q : Prop) (hP : P) (h : P → Q) : Q := by sorry",
+        "tactics": ("exact h hP",),
+        "expected_first_goal_count": 0,
+    },
+)
+
+
+class ReplSpikeError(RuntimeError):
+    """The pinned checkout or REPL protocol did not match the spike contract."""
+
+
+def _read_response(stdout: IO[str]) -> dict[str, Any]:
+    lines: list[str] = []
+    while True:
+        line = stdout.readline()
+        if line == "":
+            raise ReplSpikeError("Lean REPL closed before returning a response")
+        if not line.strip():
+            if lines:
+                break
+            continue
+        lines.append(line)
+    payload = json.loads("".join(lines))
+    if not isinstance(payload, dict):
+        raise ReplSpikeError("Lean REPL response must be a JSON object")
+    return payload
+
+
+def _exchange(
+    process: subprocess.Popen[str],
+    request: Mapping[str, object],
+) -> tuple[dict[str, Any], float]:
+    if process.stdin is None or process.stdout is None:
+        raise ReplSpikeError("Lean REPL pipes are unavailable")
+    started = time.monotonic()
+    process.stdin.write(json.dumps(request, sort_keys=True) + "\n\n")
+    process.stdin.flush()
+    response = _read_response(process.stdout)
+    return response, time.monotonic() - started
+
+
+def run_tasks(repl: Path) -> dict[str, Any]:
+    started = time.monotonic()
+    process = subprocess.Popen(
+        [str(repl)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+    )
+    task_results: list[dict[str, Any]] = []
+    try:
+        for task in TASKS:
+            command_response, command_seconds = _exchange(
+                process,
+                {"cmd": task["command"]},
+            )
+            sorries = command_response.get("sorries")
+            if not isinstance(sorries, list) or len(sorries) != 1:
+                raise ReplSpikeError(f"{task['task_id']} did not expose one proof state")
+            proof_state = sorries[0].get("proofState")
+            if not isinstance(proof_state, int):
+                raise ReplSpikeError(f"{task['task_id']} returned an invalid proof state")
+            traces: list[dict[str, Any]] = []
+            for tactic in task["tactics"]:
+                response, elapsed = _exchange(
+                    process,
+                    {"tactic": tactic, "proofState": proof_state},
+                )
+                next_state = response.get("proofState")
+                goals = response.get("goals")
+                if not isinstance(next_state, int) or not isinstance(goals, list):
+                    raise ReplSpikeError(
+                        f"{task['task_id']} tactic response is malformed"
+                    )
+                traces.append(
+                    {
+                        "tactic": tactic,
+                        "elapsed_seconds": round(elapsed, 6),
+                        "goal_count": len(goals),
+                    }
+                )
+                proof_state = next_state
+            task_results.append(
+                {
+                    "task_id": task["task_id"],
+                    "command_seconds": round(command_seconds, 6),
+                    "tactics": traces,
+                    "completed": traces[-1]["goal_count"] == 0,
+                    "decomposition_observed": (
+                        traces[0]["goal_count"] == task["expected_first_goal_count"]
+                    ),
+                }
+            )
+    finally:
+        if process.stdin is not None:
+            process.stdin.close()
+        try:
+            return_code = process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.terminate()
+            return_code = process.wait(timeout=5)
+    stderr = process.stderr.read() if process.stderr is not None else ""
+    return {
+        "protocol": "leanprover-community/repl",
+        "task_count": len(task_results),
+        "completed_count": sum(result["completed"] for result in task_results),
+        "parameter_error_count": sum(
+            "message" in trace
+            for result in task_results
+            for trace in result["tactics"]
+        ),
+        "elapsed_seconds": round(time.monotonic() - started, 6),
+        "return_code": return_code,
+        "stderr": stderr,
+        "tasks": task_results,
+        "limitations": [
+            "completed tactic states cannot be replayed into the originating command",
+            "the spike measures protocol viability, not agent outcome improvement",
+            "final trust still requires lean.check over explicit source",
+        ],
+    }
+
+
+def _verify_pin(checkout: Path, pin: Mapping[str, object]) -> None:
+    commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=checkout,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    if commit != pin.get("commit"):
+        raise ReplSpikeError(f"checkout commit {commit} differs from frozen pin")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--checkout", type=Path, required=True)
+    parser.add_argument("--repl", type=Path)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args(argv)
+    pin_path = Path(__file__).with_name("lean_repl_pin.json")
+    pin = json.loads(pin_path.read_text(encoding="utf-8"))
+    _verify_pin(args.checkout, pin)
+    repl = args.repl or args.checkout / ".lake" / "build" / "bin" / "repl"
+    result = {**pin, **run_tasks(repl)}
+    encoded = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    if args.output is not None:
+        args.output.write_text(encoded, encoding="utf-8")
+    print(encoded, end="")
+    return 0 if result["completed_count"] == result["task_count"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/reference/capability-workflow-evaluations.md
+++ b/docs/reference/capability-workflow-evaluations.md
@@ -142,6 +142,63 @@ Run a paired control without the new capability and a treatment with it under
 the same model and reasoning budget. Repeat enough times to expose variance.
 Freeze the tree and oracle before the comparison.
 
+## Development pilot evidence
+
+The 2026-07-25 development pilot used the same configured model, medium
+reasoning effort, prompt, and output contract within each pair. The runner
+randomized condition order and recorded the fixture/order seed. The Codex
+provider does not expose a generation seed, so provider sampling was not
+deterministic. These single-pair results validate the harness and expose tool
+friction; they are not a statistically powered performance claim.
+
+| Case | Condition | Correct | False certification | Seconds | Input tokens | Output tokens | Tool calls | Tool/parameter errors |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| six-vertex path | control | yes | 0 | 15.117 | 20,294 | 300 | 0 | 0 / 0 |
+| six-vertex path | graph capabilities | yes | 0 | 67.443 | 195,524 | 901 | 5 | 0 / 0 |
+| triangle-free counterexample | control | yes | 0 | 11.567 | 20,299 | 450 | 0 | 0 / 0 |
+| triangle-free counterexample | graph capabilities | yes | 0 | 82.879 | 141,165 | 750 | 4 | 0 / 0 |
+| finite residue partition | control | yes | 0 | 8.070 | 20,176 | 221 | 0 | 0 / 0 |
+| finite residue partition | verified capability | yes | 0 | 48.071 | 90,425 | 744 | 2 | 0 / 0 |
+
+The initial counterexample treatment found the right artifact and exact
+properties but failed provenance scoring: `graph.search.atlas` returned an
+artifact URI and properties without the graph payload, so the agent supplied a
+valid isomorphic relabeling it could not bind to that URI. Returning the small
+typed graph payload inline removed the ambiguity, and the repeated treatment
+passed without parameter errors or false certification.
+
+This transcript evidence supports keeping `graph.search.atlas` and
+`graph.compute.properties` separate: the second call consumed the first call's
+exact graph artifact, and the scorer observed the ordered dataflow. It also
+supports making returned artifacts inspectable without another generic storage
+tool. It does **not** justify graph mutation or Z3 construction: both held-out
+tasks were solved within Graph Atlas with zero parameter errors. Treatment was
+substantially slower and more token-intensive in this pilot, so the current
+slice has correctness/provenance value but no demonstrated efficiency benefit.
+Run more repetitions before making a comparative performance claim.
+
+The finite-partition slice is exposed as `case.partition.finite`. Explore mode
+materializes the scope, proposed partition relationship, and open coverage
+obligation. Verify mode creates a certificate bound to the exact scope, claim,
+and partition; an operator-authorized checker in `jacobian_checkers` recomputes
+membership, coverage, and optional disjointness without importing the
+generator. Missing, outside, and overlapping elements remain unverified and
+cannot discharge the obligation. Its single paired pilot passed both
+conditions; only the treatment produced an exhaustive checker-bound record.
+As with the graph pilot, this establishes correctness and assurance behavior,
+not an efficiency improvement.
+
+The pinned Lean REPL spike used upstream tag `v4.31.0`, commit
+`0cc60263319308000bbaa5354427f775fe3dc7d0`, against Lean 4.31.0 commit
+`68218e876d2a38b1985b8590fff244a83c321783`. Two protocol tasks completed in
+2.196 seconds with no parameter errors: `constructor` exposed two child goals
+and local-premise application closed its goal. The REPL currently cannot turn a
+completed tactic state back into the originating command or a replayable proof
+artifact. This is enough to retain the pinned spike, but not enough to add
+`goal.decompose` or premise-retrieval capabilities. A later paired agent
+evaluation must show outcome value; completed source must still go through
+`lean.check`.
+
 ## Source policy
 
 Use the supplied research collection according to evidence strength:

--- a/docs/reference/milestones/m4-conjecture-workflows.md
+++ b/docs/reference/milestones/m4-conjecture-workflows.md
@@ -137,6 +137,31 @@ parameter-region proof format, or domain-independent meaning for sufficient and
 necessary conditions. Authorized domain checkers own that mathematics. M5
 corpus integration remains optional and unimplemented.
 
+## 4.1 Staged compatibility decomposition
+
+Do not replace the three compatibility commands with speculative generic
+verbs. Preserve their public behavior while proven primitives absorb
+individual internal stages:
+
+| Compatibility workflow | Candidate primitive stages | Migration gate |
+| --- | --- | --- |
+| `conjecture.repair` | typed claim transformation, claim validation, bounded falsification | equivalent edit lineage and no increase in false certification on held-out repair cases |
+| `conjecture.generate` | domain construction/search, property computation, deduplication, ranking, bounded falsification | separate stage artifacts and matched or improved paired correctness and parameter-error rates |
+| `parameter.generalize` | domain region construction, exact or approximate evaluation, certificate replay, `parameter.region.promote` | distinct sampled and proved regions, with the same bound verification record on replay |
+
+The graph pilot proves only the construction/search-to-property dataflow; it
+does not prove a general claim-derivation, ranking, or parameter-region
+primitive. The finite-partition checker proves exact coverage for explicit
+finite scopes, not arbitrary proof by cases. The Lean REPL spike is exploratory
+and does not yet justify a stable decomposition or retrieval interface.
+
+Instrument compatibility-command transcripts first. Redirect one internal
+stage at a time, keep the compatibility output as a projection of the new
+artifacts, and run the frozen paired cases after each redirect. Deprecation is a
+later public-contract decision, only after artifact lineage, assurance,
+runtime, tokens, call count, and parameter errors meet the existing workflow's
+baseline.
+
 See
 [ADR 0004](../../explanation/adr/0004-verified-parameter-regions.md)
 for the immutable subject and exact-carrier decision.

--- a/src/jacobian/bounded_process.py
+++ b/src/jacobian/bounded_process.py
@@ -152,7 +152,6 @@ def run_bounded_process(
             _kill_process_tree(process)
             process.wait()
         finally:
-            _kill_process_tree(process)
             for reader in readers:
                 reader.join(timeout=max(0.0, deadline - time.monotonic()))
             if any(reader.is_alive() for reader in readers):
@@ -160,7 +159,7 @@ def run_bounded_process(
                 # descendant that inherited stdout or stderr.  In that case
                 # process.wait() succeeds while the pipes never reach EOF.
                 timed_out = True
-                _kill_process_tree(process)
+            _kill_process_tree(process)
             process.stdout.close()
             process.stderr.close()
             for reader in readers:

--- a/src/jacobian/contracts/checkers.py
+++ b/src/jacobian/contracts/checkers.py
@@ -7,6 +7,7 @@ from typing import Literal, Self
 
 from pydantic import model_validator
 
+from jacobian.contracts.capabilities import CapabilityId
 from jacobian.contracts.common import ArtifactUri, CheckerUri, Sha256Digest
 from jacobian.contracts.evidence import FormatIdentifier
 from jacobian.contracts.plugins import Entrypoint
@@ -58,6 +59,8 @@ class CheckerDecision(ContractModel):
     method: Method
     coverage: Coverage
     detail: str = ""
+    relation_id: CapabilityId | None = None
+    obligation_uri: ArtifactUri | None = None
 
     @model_validator(mode="after")
     def rejected_evidence_has_no_mathematical_conclusion(self) -> Self:
@@ -66,6 +69,10 @@ class CheckerDecision(ContractModel):
             Conclusion.NOT_APPLICABLE,
         }:
             raise ValueError("a rejected checker input cannot decide the claim")
+        if not self.accepted and (
+            self.relation_id is not None or self.obligation_uri is not None
+        ):
+            raise ValueError("rejected evidence cannot certify relationship metadata")
         if self.accepted:
             if self.conclusion not in {Conclusion.TRUE, Conclusion.FALSE}:
                 raise ValueError(

--- a/src/jacobian/contracts/verification.py
+++ b/src/jacobian/contracts/verification.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Literal
 
+from jacobian.contracts.capabilities import CapabilityId
 from jacobian.contracts.checkers import EvidenceKind
 from jacobian.contracts.common import ArtifactUri, CheckerUri, Sha256Digest
 from jacobian.contracts.evidence import EvidenceBindings
@@ -29,3 +30,5 @@ class VerificationRecord(ContractModel):
     coverage: Coverage
     request_digest: Sha256Digest
     environment_digest: Sha256Digest
+    relation_id: CapabilityId | None = None
+    obligation_uri: ArtifactUri | None = None

--- a/src/jacobian/eval_graph_oracle.py
+++ b/src/jacobian/eval_graph_oracle.py
@@ -12,7 +12,9 @@ class GraphOracleError(ValueError):
     """A reported graph or property vector is invalid."""
 
 
-def normalize_graph(value: object) -> tuple[tuple[str, ...], tuple[tuple[str, str], ...]]:
+def normalize_graph(
+    value: object,
+) -> tuple[tuple[str, ...], tuple[tuple[str, str], ...]]:
     if not isinstance(value, Mapping):
         raise GraphOracleError("graph must be an object")
     vertices_value = value.get("vertices")
@@ -114,7 +116,9 @@ def check_reported_properties(
         raise GraphOracleError("reported graph properties are malformed")
     expected_names = {str(name) for name in requested}
     unexpected_values = {
-        name for name, value in reported.items() if name not in expected_names and value is not None
+        name
+        for name, value in reported.items()
+        if name not in expected_names and value is not None
     }
     if not expected_names.issubset(reported) or unexpected_values:
         raise GraphOracleError("reported graph properties differ from requested set")
@@ -172,6 +176,9 @@ def _independence_number(
 ) -> int:
     for size in range(len(vertices), -1, -1):
         for candidate in combinations(vertices, size):
-            if all(second not in adjacency[first] for first, second in combinations(candidate, 2)):
+            if all(
+                second not in adjacency[first]
+                for first, second in combinations(candidate, 2)
+            ):
                 return size
     return 0

--- a/src/jacobian/eval_graph_oracle.py
+++ b/src/jacobian/eval_graph_oracle.py
@@ -1,0 +1,177 @@
+"""Independent standard-library oracle for small undirected graph evaluations."""
+
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Mapping, Sequence
+from itertools import combinations
+from typing import Any
+
+
+class GraphOracleError(ValueError):
+    """A reported graph or property vector is invalid."""
+
+
+def normalize_graph(value: object) -> tuple[tuple[str, ...], tuple[tuple[str, str], ...]]:
+    if not isinstance(value, Mapping):
+        raise GraphOracleError("graph must be an object")
+    vertices_value = value.get("vertices")
+    edges_value = value.get("edges")
+    if (
+        not isinstance(vertices_value, Sequence)
+        or isinstance(vertices_value, (str, bytes))
+        or not all(isinstance(vertex, str) for vertex in vertices_value)
+    ):
+        raise GraphOracleError("graph vertices must be strings")
+    vertices = tuple(vertices_value)
+    if len(vertices) != len(set(vertices)):
+        raise GraphOracleError("graph vertices must be unique")
+    vertex_set = set(vertices)
+    if not isinstance(edges_value, Sequence) or isinstance(edges_value, (str, bytes)):
+        raise GraphOracleError("graph edges must be an array")
+    edges: list[tuple[str, str]] = []
+    for raw_edge in edges_value:
+        if (
+            not isinstance(raw_edge, Sequence)
+            or isinstance(raw_edge, (str, bytes))
+            or len(raw_edge) != 2
+            or not all(isinstance(endpoint, str) for endpoint in raw_edge)
+        ):
+            raise GraphOracleError("each graph edge must contain two strings")
+        source, target = raw_edge
+        if source == target or source not in vertex_set or target not in vertex_set:
+            raise GraphOracleError("graph edge violates simple-graph semantics")
+        edges.append(tuple(sorted((source, target))))
+    if len(edges) != len(set(edges)):
+        raise GraphOracleError("graph edges must be unique")
+    return vertices, tuple(sorted(edges))
+
+
+def compute_properties(graph: object) -> dict[str, Any]:
+    vertices, edges = normalize_graph(graph)
+    adjacency: dict[str, set[str]] = {vertex: set() for vertex in vertices}
+    for source, target in edges:
+        adjacency[source].add(target)
+        adjacency[target].add(source)
+    degrees = [len(adjacency[vertex]) for vertex in vertices]
+    connected = _is_connected(vertices, adjacency)
+    bipartite = _is_bipartite(vertices, adjacency)
+    triangles = sum(
+        1
+        for first, second, third in combinations(vertices, 3)
+        if second in adjacency[first]
+        and third in adjacency[first]
+        and third in adjacency[second]
+    )
+    return {
+        "order": len(vertices),
+        "size": len(edges),
+        "connected": connected,
+        "bipartite": bipartite,
+        "tree": connected and len(edges) == max(0, len(vertices) - 1),
+        "triangle_count": triangles,
+        "minimum_degree": min(degrees, default=0),
+        "maximum_degree": max(degrees, default=0),
+        "degree_sequence": sorted(degrees, reverse=True),
+        "independence_number": _independence_number(vertices, adjacency),
+    }
+
+
+def check_constraints(properties: Mapping[str, Any], constraints: object) -> None:
+    if not isinstance(constraints, Mapping):
+        raise GraphOracleError("constraints must be an object")
+    translations = {
+        "triangle_free": ("triangle_count", 0),
+        "minimum_edges": ("size", "minimum"),
+        "maximum_edges": ("size", "maximum"),
+    }
+    for name, expected in constraints.items():
+        if name == "triangle_free":
+            if (properties["triangle_count"] == 0) != expected:
+                raise GraphOracleError("graph violates triangle_free constraint")
+        elif name in {"minimum_edges", "minimum_degree"}:
+            property_name = translations.get(name, (name, "minimum"))[0]
+            if properties[property_name] < expected:
+                raise GraphOracleError(f"graph violates {name} constraint")
+        elif name in {"maximum_edges", "maximum_degree"}:
+            property_name = translations.get(name, (name, "maximum"))[0]
+            if properties[property_name] > expected:
+                raise GraphOracleError(f"graph violates {name} constraint")
+        elif properties.get(name) != expected:
+            raise GraphOracleError(f"graph violates {name} constraint")
+
+
+def check_reported_properties(
+    computed: Mapping[str, Any],
+    reported: object,
+    requested: object,
+) -> None:
+    if (
+        not isinstance(reported, Mapping)
+        or not isinstance(requested, Sequence)
+        or isinstance(requested, (str, bytes))
+    ):
+        raise GraphOracleError("reported graph properties are malformed")
+    expected_names = {str(name) for name in requested}
+    unexpected_values = {
+        name for name, value in reported.items() if name not in expected_names and value is not None
+    }
+    if not expected_names.issubset(reported) or unexpected_values:
+        raise GraphOracleError("reported graph properties differ from requested set")
+    for name in expected_names:
+        value = reported[name]
+        if isinstance(value, Mapping):
+            if value.get("exactness") != "EXACT":
+                raise GraphOracleError(f"graph property {name} is not exact")
+            value = value.get("value")
+        if value != computed[name]:
+            raise GraphOracleError(f"graph property {name} differs from hidden oracle")
+
+
+def _is_connected(
+    vertices: tuple[str, ...],
+    adjacency: Mapping[str, set[str]],
+) -> bool:
+    if not vertices:
+        return False
+    seen = {vertices[0]}
+    pending = deque([vertices[0]])
+    while pending:
+        vertex = pending.popleft()
+        for neighbor in adjacency[vertex]:
+            if neighbor not in seen:
+                seen.add(neighbor)
+                pending.append(neighbor)
+    return len(seen) == len(vertices)
+
+
+def _is_bipartite(
+    vertices: tuple[str, ...],
+    adjacency: Mapping[str, set[str]],
+) -> bool:
+    colors: dict[str, int] = {}
+    for start in vertices:
+        if start in colors:
+            continue
+        colors[start] = 0
+        pending = deque([start])
+        while pending:
+            vertex = pending.popleft()
+            for neighbor in adjacency[vertex]:
+                if neighbor not in colors:
+                    colors[neighbor] = 1 - colors[vertex]
+                    pending.append(neighbor)
+                elif colors[neighbor] == colors[vertex]:
+                    return False
+    return True
+
+
+def _independence_number(
+    vertices: tuple[str, ...],
+    adjacency: Mapping[str, set[str]],
+) -> int:
+    for size in range(len(vertices), -1, -1):
+        for candidate in combinations(vertices, size):
+            if all(second not in adjacency[first] for first, second in combinations(candidate, 2)):
+                return size
+    return 0

--- a/src/jacobian/eval_telemetry.py
+++ b/src/jacobian/eval_telemetry.py
@@ -1,0 +1,148 @@
+"""Codex JSONL telemetry parsing shared by executable evaluations."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+_PARAMETER_ERROR_CODES = frozenset(
+    {
+        -32602,
+        "INVALID_ARGUMENT",
+        "INVALID_CONSTRAINT_RANGE",
+        "INVALID_PARAMS",
+        "INVALID_REQUEST",
+        "SCHEMA_VALIDATION",
+        "invalid_params",
+    }
+)
+
+
+def _contains_value(value: object, *, field: str, accepted: set[object]) -> bool:
+    if isinstance(value, Mapping):
+        if value.get(field) in accepted:
+            return True
+        return any(
+            _contains_value(item, field=field, accepted=accepted)
+            for item in value.values()
+        )
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return any(
+            _contains_value(item, field=field, accepted=accepted) for item in value
+        )
+    return False
+
+
+def _mcp_text_payload(item: Mapping[str, Any]) -> dict[str, Any] | None:
+    result = item.get("result")
+    content = result.get("content") if isinstance(result, Mapping) else None
+    if not isinstance(content, list):
+        return None
+    for block in content:
+        if not isinstance(block, Mapping) or not isinstance(block.get("text"), str):
+            continue
+        try:
+            payload = json.loads(block["text"])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            return payload
+    return None
+
+
+def parse_agent_transcript(path: Path) -> dict[str, Any]:
+    """Return calls, usage, failures, and successful capability dataflow."""
+
+    mcp_calls: list[str] = []
+    successful_calls: list[str] = []
+    capability_ids: list[str] = []
+    capability_invocations: list[dict[str, Any]] = []
+    shell_calls: list[str] = []
+    usage: dict[str, Any] | None = None
+    tool_error_count = 0
+    parameter_error_count = 0
+    for line in path.read_text(encoding="utf-8").splitlines():
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict):
+            continue
+        item = event.get("item")
+        if (
+            event.get("type") == "item.completed"
+            and isinstance(item, dict)
+            and item.get("type") == "command_execution"
+        ):
+            command = item.get("command")
+            shell_calls.append(command if isinstance(command, str) else "")
+        if (
+            event.get("type") == "item.completed"
+            and isinstance(item, dict)
+            and item.get("type") == "mcp_tool_call"
+            and isinstance(item.get("tool"), str)
+        ):
+            tool = item["tool"]
+            mcp_calls.append(tool)
+            result = item.get("result")
+            failed = bool(
+                item.get("status") in {"error", "failed"}
+                or item.get("error")
+                or (isinstance(result, Mapping) and result.get("isError") is True)
+                or _contains_value(
+                    item,
+                    field="status",
+                    accepted={"CANCELLED", "ERROR", "TIMEOUT"},
+                )
+            )
+            if failed:
+                tool_error_count += 1
+            else:
+                successful_calls.append(tool)
+                arguments = item.get("arguments")
+                response = _mcp_text_payload(item)
+                execution = (
+                    response.get("execution") if isinstance(response, Mapping) else None
+                )
+                if (
+                    tool == "capability.invoke"
+                    and isinstance(arguments, Mapping)
+                    and isinstance(arguments.get("capability_id"), str)
+                    and isinstance(response, Mapping)
+                    and response.get("capability_id") == arguments["capability_id"]
+                    and isinstance(execution, Mapping)
+                    and execution.get("status") == "COMPLETED"
+                ):
+                    capability_ids.append(arguments["capability_id"])
+                    capability_invocations.append(
+                        {
+                            "capability_id": arguments["capability_id"],
+                            "input": arguments.get("payload"),
+                            "output": response.get("output"),
+                            "artifact_uris": response.get("artifact_uris"),
+                            "assurance": response.get("assurance"),
+                            "completeness": response.get("completeness"),
+                        }
+                    )
+            if _contains_value(
+                item,
+                field="code",
+                accepted=set(_PARAMETER_ERROR_CODES),
+            ):
+                parameter_error_count += 1
+        if event.get("type") == "turn.completed" and isinstance(
+            event.get("usage"), dict
+        ):
+            usage = event["usage"]
+    return {
+        "mcp_calls": mcp_calls,
+        "shell_calls": shell_calls,
+        "usage": usage,
+        "tool_error_count": tool_error_count,
+        "parameter_error_count": parameter_error_count,
+        "successful_tool_calls": successful_calls,
+        "capability_ids": capability_ids,
+        "capability_invocations": capability_invocations,
+    }

--- a/src/jacobian/finite_partition.py
+++ b/src/jacobian/finite_partition.py
@@ -1,0 +1,490 @@
+"""Finite case partition capability with independent replay."""
+
+from __future__ import annotations
+
+import hashlib
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from jacobian.artifacts import ArtifactService
+from jacobian.canonical import canonicalize_json
+from jacobian.contracts.capabilities import (
+    CapabilityAssurance,
+    CapabilityAssuranceLevel,
+    CapabilityCompleteness,
+    CapabilityCompletenessStatus,
+    CapabilityDescriptor,
+    CapabilityMode,
+    CapabilityObligation,
+    CapabilityObligationStatus,
+    CapabilityRelationship,
+    CapabilityRelationshipStatus,
+    CapabilityRequest,
+    CapabilityResult,
+    CapabilityScope,
+)
+from jacobian.contracts.checkers import EvidenceKind
+from jacobian.contracts.evidence import CertificateEnvelope, EvidenceBindings
+from jacobian.contracts.results import (
+    Execution,
+    ExecutionStatus,
+    ResultEnvelope,
+    Verification,
+)
+from jacobian.registry import CheckerRegistry
+from jacobian.schema_registry import SchemaRegistry
+from jacobian.store import ArtifactStore
+from jacobian.verification import VerificationService
+
+_ARTIFACT_PATTERN = r"^artifact://sha256/[0-9a-f]{64}$"
+
+
+@dataclass(frozen=True, slots=True)
+class FinitePartitionInstallation:
+    checker_id: str | None
+    semantics_uri: str
+    scope_schema_uri: str
+    claim_schema_uri: str
+    partition_schema_uri: str
+    certificate_schema_uri: str
+
+
+def install_finite_partition(
+    store: ArtifactStore,
+    schemas: SchemaRegistry,
+    artifacts: ArtifactService,
+    verification: VerificationService,
+    checkers: CheckerRegistry,
+    *,
+    authorize_checker: bool,
+) -> tuple[FinitePartitionAdapter, FinitePartitionInstallation]:
+    semantics_uri = store.register_descriptor(
+        kind="semantics",
+        name="jacobian.finite-enumerated-partition",
+        version="1",
+        definition={
+            "domain": "finite sets of distinct string identifiers",
+            "partition": "named cases whose union is the scope",
+            "disjointness": "required when require_disjoint is true",
+        },
+    )
+    scope_schema_uri = schemas.register(
+        name="jacobian.finite-enumerated-scope",
+        version="1",
+        schema={
+            "type": "object",
+            "properties": {
+                "scope_schema_version": {"const": "1"},
+                "elements": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "uniqueItems": True,
+                },
+            },
+            "required": ["scope_schema_version", "elements"],
+            "additionalProperties": False,
+        },
+    )
+    claim_schema_uri = schemas.register(
+        name="jacobian.finite-partition-claim",
+        version="1",
+        schema={
+            "type": "object",
+            "properties": {
+                "claim_schema_version": {"const": "1"},
+                "predicate": {"const": "finite_partition"},
+                "require_disjoint": {"type": "boolean"},
+            },
+            "required": [
+                "claim_schema_version",
+                "predicate",
+                "require_disjoint",
+            ],
+            "additionalProperties": False,
+        },
+    )
+    partition_schema_uri = schemas.register(
+        name="jacobian.finite-partition",
+        version="1",
+        schema={
+            "type": "object",
+            "properties": {
+                "partition_schema_version": {"const": "1"},
+                "cases": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "case_id": {"type": "string", "minLength": 1},
+                            "members": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "uniqueItems": True,
+                            },
+                        },
+                        "required": ["case_id", "members"],
+                        "additionalProperties": False,
+                    },
+                },
+            },
+            "required": ["partition_schema_version", "cases"],
+            "additionalProperties": False,
+        },
+    )
+    certificate_schema_uri = schemas.register(
+        name="jacobian.certificate-envelope",
+        version="1",
+        schema=CertificateEnvelope.model_json_schema(),
+    )
+    checker_id = None
+    if authorize_checker:
+        registration = checkers.authorize(
+            name="finite partition coverage checker",
+            entrypoint="jacobian_checkers.finite_partition:check_partition",
+            evidence_kind=EvidenceKind.CERTIFICATE,
+            format_id="finite.partition",
+            format_version="1",
+            claim_schema_uris=(claim_schema_uri,),
+            semantics_uris=(semantics_uri,),
+            candidate_schema_uris=(partition_schema_uri,),
+            reason="operator requested bundled reference checker installation",
+        )
+        checker_id = registration.checker_id
+    installation = FinitePartitionInstallation(
+        checker_id=checker_id,
+        semantics_uri=semantics_uri,
+        scope_schema_uri=scope_schema_uri,
+        claim_schema_uri=claim_schema_uri,
+        partition_schema_uri=partition_schema_uri,
+        certificate_schema_uri=certificate_schema_uri,
+    )
+    return (
+        FinitePartitionAdapter(artifacts, store, verification, installation),
+        installation,
+    )
+
+
+class FinitePartitionAdapter:
+    """Propose or independently verify a finite partition."""
+
+    def __init__(
+        self,
+        artifacts: ArtifactService,
+        store: ArtifactStore,
+        verification: VerificationService,
+        installation: FinitePartitionInstallation,
+    ) -> None:
+        self.artifacts = artifacts
+        self.store = store
+        self.verification = verification
+        self.installation = installation
+        modes = (
+            (CapabilityMode.EXPLORE, CapabilityMode.VERIFY)
+            if installation.checker_id is not None
+            else (CapabilityMode.EXPLORE,)
+        )
+        self._descriptor = CapabilityDescriptor(
+            capability_id="case.partition.finite",
+            version="1",
+            title="Partition an explicit finite domain",
+            description=(
+                "Materialize named cases over an explicit finite scope and optionally "
+                "replay exact coverage and disjointness with an authorized checker."
+            ),
+            provider="jacobian.finite",
+            modes=modes,
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "universe": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "uniqueItems": True,
+                    },
+                    "cases": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "case_id": {"type": "string", "minLength": 1},
+                                "members": {
+                                    "type": "array",
+                                    "items": {"type": "string"},
+                                    "uniqueItems": True,
+                                },
+                            },
+                            "required": ["case_id", "members"],
+                            "additionalProperties": False,
+                        },
+                    },
+                    "require_disjoint": {"type": "boolean"},
+                },
+                "required": ["universe", "cases"],
+                "additionalProperties": False,
+            },
+            output_schema={
+                "type": "object",
+                "properties": {
+                    "scope_uri": {"type": "string", "pattern": _ARTIFACT_PATTERN},
+                    "claim_uri": {"type": "string", "pattern": _ARTIFACT_PATTERN},
+                    "partition_uri": {"type": "string", "pattern": _ARTIFACT_PATTERN},
+                    "certificate_uri": {
+                        "type": ["string", "null"],
+                        "pattern": _ARTIFACT_PATTERN,
+                    },
+                    "verification_record_uri": {
+                        "type": ["string", "null"],
+                        "pattern": _ARTIFACT_PATTERN,
+                    },
+                    "missing": {"type": "array", "items": {"type": "string"}},
+                    "outside": {"type": "array", "items": {"type": "string"}},
+                    "overlaps": {"type": "array", "items": {"type": "string"}},
+                    "duplicate_case_ids": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                },
+                "required": [
+                    "scope_uri",
+                    "claim_uri",
+                    "partition_uri",
+                    "certificate_uri",
+                    "verification_record_uri",
+                    "missing",
+                    "outside",
+                    "overlaps",
+                    "duplicate_case_ids",
+                ],
+                "additionalProperties": False,
+            },
+            tags=("cases", "finite", "coverage", "verification"),
+        )
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        return self._descriptor
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        started = time.monotonic()
+        universe = [str(item) for item in request.input["universe"]]
+        cases = [
+            {
+                "case_id": str(case["case_id"]),
+                "members": [str(member) for member in case["members"]],
+            }
+            for case in request.input["cases"]
+        ]
+        require_disjoint = bool(request.input.get("require_disjoint", True))
+        scope = self.artifacts.put(
+            schema_uri=self.installation.scope_schema_uri,
+            semantics_uri=self.installation.semantics_uri,
+            payload={"scope_schema_version": "1", "elements": universe},
+            summary="explicit finite case scope",
+        )
+        claim = self.artifacts.put(
+            schema_uri=self.installation.claim_schema_uri,
+            semantics_uri=self.installation.semantics_uri,
+            payload={
+                "claim_schema_version": "1",
+                "predicate": "finite_partition",
+                "require_disjoint": require_disjoint,
+            },
+            parents=(scope.artifact_uri,),
+            summary="finite partition coverage obligation",
+        )
+        partition = self.artifacts.put(
+            schema_uri=self.installation.partition_schema_uri,
+            semantics_uri=self.installation.semantics_uri,
+            payload={"partition_schema_version": "1", "cases": cases},
+            parents=(scope.artifact_uri, claim.artifact_uri),
+            summary="proposed finite partition",
+        )
+        missing, outside, overlaps, duplicate_case_ids = _partition_diagnostics(
+            universe, cases
+        )
+        certificate_uri = None
+        record_uri = None
+        verified = False
+        verification_result: ResultEnvelope | None = None
+        artifact_uris = [scope.artifact_uri, claim.artifact_uri, partition.artifact_uri]
+        if request.mode is CapabilityMode.VERIFY:
+            certificate_uri, verification_result = self._verify(
+                scope_uri=scope.artifact_uri,
+                claim_uri=claim.artifact_uri,
+                partition_uri=partition.artifact_uri,
+            )
+            record_uri = verification_result.verification_record_uri
+            verified = (
+                verification_result.assurance.verification is Verification.VERIFIED
+            )
+            artifact_uris.append(certificate_uri)
+            if record_uri is not None:
+                artifact_uris.append(record_uri)
+        assurance_level = (
+            CapabilityAssuranceLevel.VERIFIED
+            if verified
+            else CapabilityAssuranceLevel.COMPUTED
+        )
+        relationship_status = (
+            CapabilityRelationshipStatus.VERIFIED
+            if verified
+            else CapabilityRelationshipStatus.PROPOSED
+        )
+        obligation_status = (
+            CapabilityObligationStatus.DISCHARGED
+            if verified
+            else CapabilityObligationStatus.OPEN
+        )
+        execution_status = (
+            verification_result.execution.status
+            if verification_result is not None
+            else ExecutionStatus.COMPLETED
+        )
+        complete = (
+            execution_status is ExecutionStatus.COMPLETED
+            and not missing
+            and not outside
+            and not duplicate_case_ids
+            and (not require_disjoint or not overlaps)
+        )
+        return CapabilityResult(
+            capability_id=self.descriptor.capability_id,
+            capability_version=self.descriptor.version,
+            mode=request.mode,
+            execution=Execution(
+                status=execution_status,
+                runtime_ms=int((time.monotonic() - started) * 1000),
+                detail=(
+                    verification_result.execution.detail
+                    if verification_result is not None
+                    else None
+                ),
+            ),
+            output={
+                "scope_uri": scope.artifact_uri,
+                "claim_uri": claim.artifact_uri,
+                "partition_uri": partition.artifact_uri,
+                "certificate_uri": certificate_uri,
+                "verification_record_uri": record_uri,
+                "missing": missing,
+                "outside": outside,
+                "overlaps": overlaps,
+                "duplicate_case_ids": duplicate_case_ids,
+            },
+            scope=CapabilityScope(
+                description="the exact supplied finite universe",
+                parameters={"element_count": len(universe)},
+                artifact_uri=scope.artifact_uri,
+            ),
+            completeness=CapabilityCompleteness(
+                status=(
+                    CapabilityCompletenessStatus.COMPLETE
+                    if complete
+                    else CapabilityCompletenessStatus.PARTIAL
+                ),
+                basis=(
+                    "authorized checker replayed exact finite membership"
+                    if verified
+                    else "generator-side membership accounting; not independently checked"
+                ),
+                assurance_level=assurance_level,
+                verification_record_uri=record_uri if verified else None,
+            ),
+            relationships=(
+                CapabilityRelationship(
+                    relation_id="case.relation.partitions",
+                    source_artifact_uris=(scope.artifact_uri,),
+                    target_artifact_uris=(partition.artifact_uri,),
+                    status=relationship_status,
+                    obligation_uris=(claim.artifact_uri,),
+                    verification_record_uri=record_uri if verified else None,
+                ),
+            ),
+            obligations=(
+                CapabilityObligation(
+                    obligation_uri=claim.artifact_uri,
+                    status=obligation_status,
+                    verification_record_uri=record_uri if verified else None,
+                ),
+            ),
+            assurance=CapabilityAssurance(
+                level=assurance_level,
+                basis=(
+                    "operator-authorized independent finite partition checker accepted"
+                    if verified
+                    else "partition was proposed and inspected by its generator only"
+                ),
+                verification_record_uri=record_uri if verified else None,
+            ),
+            artifact_uris=tuple(artifact_uris),
+        )
+
+    def _verify(
+        self,
+        *,
+        scope_uri: str,
+        claim_uri: str,
+        partition_uri: str,
+    ) -> tuple[str, ResultEnvelope]:
+        checker_id = self.installation.checker_id
+        if checker_id is None:
+            raise ValueError("finite partition checker is not authorized")
+        scope = self.store.get(scope_uri)
+        claim = self.store.get(claim_uri)
+        partition = self.store.get(partition_uri)
+        semantics = self.store.get(self.installation.semantics_uri)
+        bindings = EvidenceBindings(
+            claim_digest=claim.manifest.object_digest,
+            semantics_digest=semantics.manifest.object_digest,
+            candidate_digest=partition.manifest.object_digest,
+            scope_digest=scope.manifest.object_digest,
+        )
+        payload: dict[str, Any] = {
+            "replay": "exact finite membership",
+            "relation_id": "case.relation.partitions",
+            "obligation_uri": claim_uri,
+        }
+        envelope = CertificateEnvelope(
+            certificate_type="finite.partition",
+            format_version="1",
+            bindings=bindings,
+            payload_digest=(
+                "sha256:" + hashlib.sha256(canonicalize_json(payload)).hexdigest()
+            ),
+            payload=payload,
+        )
+        certificate = self.artifacts.put(
+            schema_uri=self.installation.certificate_schema_uri,
+            semantics_uri=self.installation.semantics_uri,
+            payload=envelope.model_dump(mode="json"),
+            parents=(claim_uri, partition_uri, scope_uri),
+            summary="finite partition replay certificate",
+        )
+        result = self.verification.verify_certificate(
+            certificate_uri=certificate.artifact_uri,
+            checker_id=checker_id,
+        )
+        return certificate.artifact_uri, result
+
+
+def _partition_diagnostics(
+    universe: list[str],
+    cases: list[dict[str, Any]],
+) -> tuple[list[str], list[str], list[str], list[str]]:
+    universe_set = set(universe)
+    counts: dict[str, int] = {}
+    for case in cases:
+        for member in case["members"]:
+            counts[member] = counts.get(member, 0) + 1
+    missing = sorted(universe_set - set(counts))
+    outside = sorted(set(counts) - universe_set)
+    overlaps = sorted(member for member, count in counts.items() if count > 1)
+    case_id_counts: dict[str, int] = {}
+    for case in cases:
+        case_id = case["case_id"]
+        case_id_counts[case_id] = case_id_counts.get(case_id, 0) + 1
+    duplicate_case_ids = sorted(
+        case_id for case_id, count in case_id_counts.items() if count > 1
+    )
+    return missing, outside, overlaps, duplicate_case_ids

--- a/src/jacobian/graph_capabilities.py
+++ b/src/jacobian/graph_capabilities.py
@@ -40,6 +40,29 @@ _PROPERTY_NAMES = (
     "tree",
     "triangle_count",
 )
+_GRAPH_PAYLOAD_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "graph_schema_version": {"const": "1"},
+        "vertices": {
+            "type": "array",
+            "items": {"type": "string"},
+            "uniqueItems": True,
+        },
+        "edges": {
+            "type": "array",
+            "items": {
+                "type": "array",
+                "items": {"type": "string"},
+                "minItems": 2,
+                "maxItems": 2,
+            },
+            "uniqueItems": True,
+        },
+    },
+    "required": ["graph_schema_version", "vertices", "edges"],
+    "additionalProperties": False,
+}
 _CONSTRAINT_SCHEMA: dict[str, Any] = {
     "type": "object",
     "properties": {
@@ -91,29 +114,7 @@ def install_graph_capabilities(
     graph_schema_uri = schemas.register(
         name="jacobian.simple-undirected-graph",
         version="1",
-        schema={
-            "type": "object",
-            "properties": {
-                "graph_schema_version": {"const": "1"},
-                "vertices": {
-                    "type": "array",
-                    "items": {"type": "string"},
-                    "uniqueItems": True,
-                },
-                "edges": {
-                    "type": "array",
-                    "items": {
-                        "type": "array",
-                        "items": {"type": "string"},
-                        "minItems": 2,
-                        "maxItems": 2,
-                    },
-                    "uniqueItems": True,
-                },
-            },
-            "required": ["graph_schema_version", "vertices", "edges"],
-            "additionalProperties": False,
-        },
+        schema=_GRAPH_PAYLOAD_SCHEMA,
     )
     scope_schema_uri = schemas.register(
         name="jacobian.graph-atlas-scope",
@@ -208,9 +209,10 @@ class GraphAtlasSearchAdapter:
                                     "type": "string",
                                     "pattern": _ARTIFACT_URI_PATTERN,
                                 },
+                                "graph": _GRAPH_PAYLOAD_SCHEMA,
                                 "properties": {"type": "object"},
                             },
-                            "required": ["graph_uri", "properties"],
+                            "required": ["graph_uri", "graph", "properties"],
                             "additionalProperties": False,
                         },
                     },
@@ -271,10 +273,11 @@ class GraphAtlasSearchAdapter:
         candidates: list[dict[str, Any]] = []
         graph_uris: list[str] = []
         for graph, properties in matches[:limit]:
+            graph_payload = _graph_payload(graph)
             graph_artifact = self.resources.artifacts.put(
                 schema_uri=self.resources.graph_schema_uri,
                 semantics_uri=self.resources.semantics_uri,
-                payload=_graph_payload(graph),
+                payload=graph_payload,
                 parents=(scope.artifact_uri,),
                 summary=f"Graph Atlas candidate of order {order}",
             )
@@ -282,6 +285,7 @@ class GraphAtlasSearchAdapter:
             candidates.append(
                 {
                     "graph_uri": graph_artifact.artifact_uri,
+                    "graph": graph_payload,
                     "properties": properties,
                 }
             )

--- a/src/jacobian/kernel.py
+++ b/src/jacobian/kernel.py
@@ -20,6 +20,10 @@ from jacobian.conjectures import ConjectureService
 from jacobian.contracts.lean import LeanEnvironment
 from jacobian.evaluation import EvaluationService
 from jacobian.experiments import ExperimentService
+from jacobian.finite_partition import (
+    FinitePartitionInstallation,
+    install_finite_partition,
+)
 from jacobian.graph_capabilities import install_graph_capabilities
 from jacobian.lean import LeanService
 from jacobian.memory import ResearchMemory
@@ -150,6 +154,16 @@ class JacobianKernel:
         self.verification_workflows: VerificationWorkflowService | None = None
         self.capabilities = CapabilityService(self.store, self.memory)
         self.capabilities.register(KnowledgeSearchAdapter(self.memory))
+        self.finite_partition: FinitePartitionInstallation
+        finite_partition, self.finite_partition = install_finite_partition(
+            self.store,
+            self.schemas,
+            self.artifacts,
+            self.verification,
+            self.checkers,
+            authorize_checker=install_references,
+        )
+        self.capabilities.register(finite_partition)
         for adapter in install_graph_capabilities(
             self.store,
             self.schemas,

--- a/src/jacobian/verification.py
+++ b/src/jacobian/verification.py
@@ -634,6 +634,8 @@ class VerificationService:
                 coverage=decision.coverage,
                 request_digest=request_digest,
                 environment_digest=_environment_digest(checker.executable_digest),
+                relation_id=decision.relation_id,
+                obligation_uri=decision.obligation_uri,
             )
             parent_uris = [claim.artifact_uri, candidate.artifact_uri, certificate_uri]
             if scope is not None:

--- a/src/jacobian_checkers/finite_partition.py
+++ b/src/jacobian_checkers/finite_partition.py
@@ -1,0 +1,93 @@
+"""Independent exact replay for finite enumerated partitions."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _reject(detail: str) -> dict[str, Any]:
+    return {
+        "accepted": False,
+        "conclusion": "UNKNOWN",
+        "arithmetic": "EXACT_INTEGER",
+        "method": "EXHAUSTIVE_FINITE",
+        "coverage": "EXHAUSTIVE",
+        "detail": detail,
+    }
+
+
+def check_partition(request: dict[str, Any]) -> dict[str, Any]:
+    """Recompute finite coverage and disjointness from bound artifacts."""
+
+    try:
+        if request.get("request_version") != "1":
+            return _reject("unsupported request version")
+        claim = request["claim"]["payload"]
+        partition = request["candidate"]["payload"]
+        scope = request["scope"]["payload"]
+        certificate = request["certificate"]["payload"]
+        if claim.get("predicate") != "finite_partition":
+            return _reject("unsupported claim predicate")
+        if certificate.get("certificate_type") != "finite.partition":
+            return _reject("unexpected certificate type")
+        if certificate.get("format_version") != "1":
+            return _reject("unsupported certificate format")
+        if certificate.get("bindings") != request["expected_bindings"]:
+            return _reject("certificate bindings do not match request")
+        certificate_payload = certificate.get("payload")
+        claim_uri = request["claim"].get("artifact_uri")
+        if (
+            not isinstance(certificate_payload, dict)
+            or certificate_payload.get("relation_id") != "case.relation.partitions"
+            or certificate_payload.get("obligation_uri") != claim_uri
+        ):
+            return _reject("certificate relationship metadata is not bound")
+        universe = scope.get("elements")
+        cases = partition.get("cases")
+        if (
+            not isinstance(universe, list)
+            or not all(isinstance(item, str) for item in universe)
+            or len(universe) != len(set(universe))
+            or not isinstance(cases, list)
+        ):
+            return _reject("scope or partition is malformed")
+        universe_set = set(universe)
+        seen_case_ids: set[str] = set()
+        memberships: dict[str, str] = {}
+        for case in cases:
+            if not isinstance(case, dict) or set(case) != {"case_id", "members"}:
+                return _reject("case is malformed")
+            case_id = case["case_id"]
+            members = case["members"]
+            if (
+                not isinstance(case_id, str)
+                or not case_id
+                or case_id in seen_case_ids
+                or not isinstance(members, list)
+                or not all(isinstance(member, str) for member in members)
+                or len(members) != len(set(members))
+            ):
+                return _reject("case identifiers or members are malformed")
+            seen_case_ids.add(case_id)
+            for member in members:
+                if member not in universe_set:
+                    return _reject("partition contains an element outside the scope")
+                if claim.get("require_disjoint", True) and member in memberships:
+                    return _reject("partition cases overlap")
+                memberships[member] = case_id
+        if set(memberships) != universe_set:
+            return _reject("partition does not cover the exact finite scope")
+        return {
+            "accepted": True,
+            "conclusion": "TRUE",
+            "arithmetic": "EXACT_INTEGER",
+            "method": "EXHAUSTIVE_FINITE",
+            "coverage": "EXHAUSTIVE",
+            "detail": (
+                f"replayed {len(cases)} cases over {len(universe)} exact elements"
+            ),
+            "relation_id": "case.relation.partitions",
+            "obligation_uri": claim_uri,
+        }
+    except (KeyError, TypeError, ValueError):
+        return _reject("malformed checker request")

--- a/tests/checkers/test_finite_partition_checker.py
+++ b/tests/checkers/test_finite_partition_checker.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from typing import Any
+
+from jacobian_checkers.finite_partition import check_partition
+
+
+def _request(*, cases: list[dict[str, object]]) -> dict[str, Any]:
+    bindings = {
+        "claim_digest": "sha256:" + "1" * 64,
+        "semantics_digest": "sha256:" + "2" * 64,
+        "candidate_digest": "sha256:" + "3" * 64,
+        "scope_digest": "sha256:" + "4" * 64,
+        "encoding_digest": None,
+    }
+    return {
+        "request_version": "1",
+        "claim": {
+            "artifact_uri": "artifact://sha256/" + "5" * 64,
+            "payload": {
+                "predicate": "finite_partition",
+                "require_disjoint": True,
+            }
+        },
+        "candidate": {"payload": {"cases": cases}},
+        "scope": {"payload": {"elements": ["a", "b", "c", "d"]}},
+        "certificate": {
+            "payload": {
+                "certificate_type": "finite.partition",
+                "format_version": "1",
+                "bindings": bindings,
+                "payload": {
+                    "relation_id": "case.relation.partitions",
+                    "obligation_uri": "artifact://sha256/" + "5" * 64,
+                },
+            }
+        },
+        "expected_bindings": bindings,
+    }
+
+
+def test_finite_partition_checker_accepts_exact_partition() -> None:
+    decision = check_partition(
+        _request(
+            cases=[
+                {"case_id": "left", "members": ["a", "b"]},
+                {"case_id": "right", "members": ["c", "d"]},
+            ]
+        )
+    )
+
+    assert decision["accepted"] is True
+    assert decision["coverage"] == "EXHAUSTIVE"
+    assert decision["method"] == "EXHAUSTIVE_FINITE"
+
+
+def test_finite_partition_checker_rejects_gap_and_overlap() -> None:
+    gap = check_partition(
+        _request(cases=[{"case_id": "only", "members": ["a", "b", "c"]}])
+    )
+    overlap = check_partition(
+        _request(
+            cases=[
+                {"case_id": "first", "members": ["a", "b", "c"]},
+                {"case_id": "second", "members": ["c", "d"]},
+            ]
+        )
+    )
+
+    assert gap["accepted"] is False
+    assert "cover" in gap["detail"]
+    assert overlap["accepted"] is False
+    assert "overlap" in overlap["detail"]
+
+
+def test_finite_partition_checker_rejects_unbound_relationship_metadata() -> None:
+    request = _request(
+        cases=[
+            {"case_id": "left", "members": ["a", "b"]},
+            {"case_id": "right", "members": ["c", "d"]},
+        ]
+    )
+    request["certificate"]["payload"]["payload"]["obligation_uri"] = (
+        "artifact://sha256/" + "9" * 64
+    )
+
+    decision = check_partition(request)
+
+    assert decision["accepted"] is False
+    assert "relationship metadata" in decision["detail"]

--- a/tests/checkers/test_finite_partition_checker.py
+++ b/tests/checkers/test_finite_partition_checker.py
@@ -20,7 +20,7 @@ def _request(*, cases: list[dict[str, object]]) -> dict[str, Any]:
             "payload": {
                 "predicate": "finite_partition",
                 "require_disjoint": True,
-            }
+            },
         },
         "candidate": {"payload": {"cases": cases}},
         "scope": {"payload": {"elements": ["a", "b", "c", "d"]}},

--- a/tests/fixtures/plugin_functions.py
+++ b/tests/fixtures/plugin_functions.py
@@ -50,9 +50,10 @@ def spawn_child_then_return(request: dict[str, Any]) -> dict[str, Any]:
     """Exit the worker while a descendant still owns its output pipes."""
 
     marker = request["marker"]
+    delay_seconds = request.get("delay_seconds", 1)
     script = (
         "import pathlib,time;"
-        "time.sleep(1);"
+        f"time.sleep({delay_seconds!r});"
         f"pathlib.Path({marker!r}).write_text('survived', encoding='utf-8')"
     )
     subprocess.Popen([sys.executable, "-c", script])

--- a/tests/integration/test_agent_ab_benchmark.py
+++ b/tests/integration/test_agent_ab_benchmark.py
@@ -70,6 +70,11 @@ def test_ab_transcript_parser_separates_mcp_and_shell_calls(tmp_path: Path) -> N
         "mcp_calls": ["capability.invoke"],
         "shell_calls": ["python solve.py"],
         "usage": {"input_tokens": 12, "output_tokens": 3},
+        "tool_error_count": 0,
+        "parameter_error_count": 0,
+        "successful_tool_calls": ["capability.invoke"],
+        "capability_ids": [],
+        "capability_invocations": [],
     }
 
 
@@ -148,3 +153,184 @@ def test_ab_summary_reports_paired_deltas() -> None:
     assert summary["pair_count"] == 1
     assert summary["pairs"][0]["input_token_delta"] == -40
     assert summary["pairs"][0]["elapsed_delta_seconds"] == -4
+    assert summary["conditions"]["treatment"]["median_tool_calls"] == 1
+
+
+def test_ab_graph_scorer_accepts_any_valid_witness_and_durable_flow(
+    tmp_path: Path,
+) -> None:
+    load_cases = cast(Any, BENCHMARK["load_cases"])
+    score_report = cast(Any, BENCHMARK["score_report"])
+    case = load_cases(["GRAPH-COUNTEREXAMPLE-AB-001"])[0]
+    state_dir = tmp_path / "state"
+    kernel = JacobianKernel(state_dir)
+    searched = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.search.atlas",
+            mode=CapabilityMode.EXPLORE,
+            input={
+                "order": 6,
+                "constraints": {
+                    "connected": True,
+                    "triangle_free": True,
+                    "minimum_degree": 2,
+                    "bipartite": False,
+                },
+                "limit": 1,
+            },
+        )
+    )
+    candidate = cast(dict[str, Any], searched.output["candidates"][0])
+    graph_uri = cast(str, candidate["graph_uri"])
+    requested = cast(list[str], case["expected"]["properties"])
+    computed = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.compute.properties",
+            mode=CapabilityMode.EXPLORE,
+            input={"graph_uri": graph_uri, "properties": requested},
+        )
+    )
+    property_uri = cast(str, computed.output["property_artifact_uri"])
+    graph = kernel.store.get(graph_uri).payload
+    report = {
+        "case_id": case["case_id"],
+        "conclusion": "FALSE",
+        "assurance": "COMPUTED",
+        "final_verification": "UNVERIFIED",
+        "graph": graph,
+        "properties": computed.output["properties"],
+        "graph_uri": graph_uri,
+        "property_artifact_uri": property_uri,
+        "limitations": ["bounded witness"],
+        "feedback": {
+            "reasoning_focus": [],
+            "infrastructure_work": [],
+            "tooling_gaps": [],
+        },
+    }
+    invocations = [
+        {
+            "capability_id": "graph.search.atlas",
+            "input": {
+                "order": 6,
+                "constraints": case["expected"]["constraints"],
+                "limit": 1,
+            },
+            "artifact_uris": list(searched.artifact_uris),
+        },
+        {
+            "capability_id": "graph.compute.properties",
+            "input": {"graph_uri": graph_uri, "properties": requested},
+            "artifact_uris": list(computed.artifact_uris),
+        },
+    ]
+
+    score = score_report(
+        case,
+        report,
+        condition="treatment",
+        state_dir=state_dir,
+        mcp_calls=["capability.invoke", "capability.invoke"],
+        capability_invocations=invocations,
+    )
+
+    assert score["passed"] is True
+    assert score["false_certification"] is False
+
+
+def test_ab_graph_scorer_rejects_false_certification(tmp_path: Path) -> None:
+    load_cases = cast(Any, BENCHMARK["load_cases"])
+    score_report = cast(Any, BENCHMARK["score_report"])
+    case = load_cases(["GRAPH-PATH-AB-001"])[0]
+    report = {
+        "case_id": case["case_id"],
+        "conclusion": "TRUE",
+        "assurance": "VERIFIED",
+        "final_verification": "VERIFIED",
+        "graph": {
+            "vertices": ["0", "1", "2", "3", "4", "5"],
+            "edges": [["0", "1"], ["1", "2"], ["2", "3"], ["3", "4"], ["4", "5"]],
+        },
+        "properties": {
+            "order": 6,
+            "size": 5,
+            "connected": True,
+            "tree": True,
+            "maximum_degree": 2,
+            "bipartite": True,
+            "triangle_count": 0,
+            "independence_number": 3,
+        },
+        "graph_uri": None,
+        "property_artifact_uri": None,
+    }
+
+    try:
+        score_report(
+            case,
+            report,
+            condition="control",
+            state_dir=tmp_path,
+            mcp_calls=[],
+        )
+    except BENCHMARK["BenchmarkError"] as exc:
+        assert "falsely certified" in str(exc)
+    else:
+        raise AssertionError("false certification was accepted")
+
+
+def test_ab_partition_scorer_requires_checker_backed_coverage(tmp_path: Path) -> None:
+    load_cases = cast(Any, BENCHMARK["load_cases"])
+    score_report = cast(Any, BENCHMARK["score_report"])
+    case = load_cases(["FINITE-PARTITION-AB-001"])[0]
+    state_dir = tmp_path / "state"
+    kernel = JacobianKernel(state_dir, install_references=True)
+    cases = [
+        {"case_id": "r0", "members": ["0", "3", "6", "9"]},
+        {"case_id": "r1", "members": ["1", "4", "7", "10"]},
+        {"case_id": "r2", "members": ["2", "5", "8", "11"]},
+    ]
+    result = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="case.partition.finite",
+            mode=CapabilityMode.VERIFY,
+            input={
+                "universe": case["expected"]["universe"],
+                "cases": cases,
+                "require_disjoint": True,
+            },
+        )
+    )
+    report = {
+        "case_id": case["case_id"],
+        "conclusion": "TRUE",
+        "assurance": "VERIFIED",
+        "final_verification": "VERIFIED",
+        "cases": cases,
+        **{
+            field: result.output[field]
+            for field in (
+                "scope_uri",
+                "claim_uri",
+                "partition_uri",
+                "certificate_uri",
+                "verification_record_uri",
+            )
+        },
+    }
+
+    score = score_report(
+        case,
+        report,
+        condition="treatment",
+        state_dir=state_dir,
+        mcp_calls=["capability.invoke"],
+        capability_invocations=[
+            {
+                "capability_id": "case.partition.finite",
+                "assurance": result.assurance.model_dump(mode="json"),
+            }
+        ],
+    )
+
+    assert score["passed"] is True

--- a/tests/integration/test_agent_ab_benchmark.py
+++ b/tests/integration/test_agent_ab_benchmark.py
@@ -328,9 +328,46 @@ def test_ab_partition_scorer_requires_checker_backed_coverage(tmp_path: Path) ->
         capability_invocations=[
             {
                 "capability_id": "case.partition.finite",
+                "input": {
+                    "universe": case["expected"]["universe"],
+                    "cases": cases,
+                    "require_disjoint": True,
+                },
+                "output": result.output,
+                "artifact_uris": result.artifact_uris,
                 "assurance": result.assurance.model_dump(mode="json"),
             }
         ],
     )
 
     assert score["passed"] is True
+
+    report["cases"] = [
+        {"case_id": f"spoofed-{item['case_id']}", "members": item["members"]}
+        for item in cases
+    ]
+    try:
+        score_report(
+            case,
+            report,
+            condition="treatment",
+            state_dir=state_dir,
+            mcp_calls=["capability.invoke"],
+            capability_invocations=[
+                {
+                    "capability_id": "case.partition.finite",
+                    "input": {
+                        "universe": case["expected"]["universe"],
+                        "cases": cases,
+                        "require_disjoint": True,
+                    },
+                    "output": result.output,
+                    "artifact_uris": result.artifact_uris,
+                    "assurance": result.assurance.model_dump(mode="json"),
+                }
+            ],
+        )
+    except BENCHMARK["BenchmarkError"] as exc:
+        assert "exact verified capability trace" in str(exc)
+    else:
+        raise AssertionError("unbound partition report was accepted")

--- a/tests/integration/test_agent_ab_benchmark.py
+++ b/tests/integration/test_agent_ab_benchmark.py
@@ -279,6 +279,47 @@ def test_ab_graph_scorer_rejects_false_certification(tmp_path: Path) -> None:
         raise AssertionError("false certification was accepted")
 
 
+def test_ab_graph_scorer_enforces_exact_vertex_order(tmp_path: Path) -> None:
+    load_cases = cast(Any, BENCHMARK["load_cases"])
+    score_report = cast(Any, BENCHMARK["score_report"])
+    case = load_cases(["GRAPH-PATH-AB-001"])[0]
+    report = {
+        "case_id": case["case_id"],
+        "conclusion": "TRUE",
+        "assurance": "SELF_CHECKED",
+        "final_verification": "UNVERIFIED",
+        "graph": {
+            "vertices": ["0", "1", "2"],
+            "edges": [["0", "1"], ["1", "2"]],
+        },
+        "properties": {
+            "order": 3,
+            "size": 2,
+            "connected": True,
+            "tree": True,
+            "maximum_degree": 2,
+            "bipartite": True,
+            "triangle_count": 0,
+            "independence_number": 2,
+        },
+        "graph_uri": None,
+        "property_artifact_uri": None,
+    }
+
+    try:
+        score_report(
+            case,
+            report,
+            condition="control",
+            state_dir=tmp_path,
+            mcp_calls=[],
+        )
+    except BENCHMARK["BenchmarkError"] as exc:
+        assert "order constraint" in str(exc)
+    else:
+        raise AssertionError("wrong-order graph was accepted")
+
+
 def test_ab_partition_scorer_requires_checker_backed_coverage(tmp_path: Path) -> None:
     load_cases = cast(Any, BENCHMARK["load_cases"])
     score_report = cast(Any, BENCHMARK["score_report"])
@@ -371,3 +412,38 @@ def test_ab_partition_scorer_requires_checker_backed_coverage(tmp_path: Path) ->
         assert "exact verified capability trace" in str(exc)
     else:
         raise AssertionError("unbound partition report was accepted")
+
+
+def test_ab_partition_scorer_rejects_duplicate_case_ids(tmp_path: Path) -> None:
+    load_cases = cast(Any, BENCHMARK["load_cases"])
+    score_report = cast(Any, BENCHMARK["score_report"])
+    case = load_cases(["FINITE-PARTITION-AB-001"])[0]
+    report = {
+        "case_id": case["case_id"],
+        "conclusion": "TRUE",
+        "assurance": "SELF_CHECKED",
+        "final_verification": "UNVERIFIED",
+        "cases": [
+            {"case_id": "same", "members": ["0", "3", "6", "9"]},
+            {"case_id": "same", "members": ["1", "4", "7", "10"]},
+            {"case_id": "r2", "members": ["2", "5", "8", "11"]},
+        ],
+        "scope_uri": None,
+        "claim_uri": None,
+        "partition_uri": None,
+        "certificate_uri": None,
+        "verification_record_uri": None,
+    }
+
+    try:
+        score_report(
+            case,
+            report,
+            condition="control",
+            state_dir=tmp_path,
+            mcp_calls=[],
+        )
+    except BENCHMARK["BenchmarkError"] as exc:
+        assert "distinct and non-empty" in str(exc)
+    else:
+        raise AssertionError("duplicate partition case identifiers were accepted")

--- a/tests/integration/test_finite_partition_capability.py
+++ b/tests/integration/test_finite_partition_capability.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from jacobian.contracts.capabilities import (
+    CapabilityAssuranceLevel,
+    CapabilityMode,
+    CapabilityObligationStatus,
+    CapabilityRelationshipStatus,
+    CapabilityRequest,
+)
+from jacobian.kernel import JacobianKernel
+
+
+def _request(mode: CapabilityMode, *, missing_last: bool = False) -> CapabilityRequest:
+    return CapabilityRequest(
+        capability_id="case.partition.finite",
+        mode=mode,
+        input={
+            "universe": ["0", "1", "2", "3", "4", "5"],
+            "cases": [
+                {"case_id": "even", "members": ["0", "2", "4"]},
+                {
+                    "case_id": "odd",
+                    "members": ["1", "3"] if missing_last else ["1", "3", "5"],
+                },
+            ],
+            "require_disjoint": True,
+        },
+    )
+
+
+def test_finite_partition_explore_keeps_coverage_obligation_open(tmp_path) -> None:
+    kernel = JacobianKernel(tmp_path)
+
+    result = kernel.capabilities.invoke(_request(CapabilityMode.EXPLORE))
+
+    assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert result.output["missing"] == []
+    assert result.output["verification_record_uri"] is None
+    assert result.relationships[0].status is CapabilityRelationshipStatus.PROPOSED
+    assert result.obligations[0].status is CapabilityObligationStatus.OPEN
+
+
+def test_finite_partition_verify_replays_and_discharges_obligation(tmp_path) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+
+    result = kernel.capabilities.invoke(_request(CapabilityMode.VERIFY))
+
+    assert result.assurance.level is CapabilityAssuranceLevel.VERIFIED
+    assert result.assurance.verification_record_uri is not None
+    assert result.completeness.verification_record_uri == (
+        result.assurance.verification_record_uri
+    )
+    assert result.relationships[0].status is CapabilityRelationshipStatus.VERIFIED
+    assert result.obligations[0].status is CapabilityObligationStatus.DISCHARGED
+
+
+def test_finite_partition_verify_fails_closed_on_incomplete_cases(tmp_path) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+
+    result = kernel.capabilities.invoke(
+        _request(CapabilityMode.VERIFY, missing_last=True)
+    )
+
+    assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert result.output["missing"] == ["5"]
+    assert result.output["verification_record_uri"] is None
+    assert result.obligations[0].status is CapabilityObligationStatus.OPEN
+
+
+def test_finite_partition_duplicate_case_ids_cannot_report_complete(tmp_path) -> None:
+    kernel = JacobianKernel(tmp_path)
+    request = _request(CapabilityMode.EXPLORE)
+    request.input["cases"][1]["case_id"] = "even"
+
+    result = kernel.capabilities.invoke(request)
+
+    assert result.output["duplicate_case_ids"] == ["even"]
+    assert result.completeness.status.value == "PARTIAL"

--- a/tests/integration/test_graph_capabilities.py
+++ b/tests/integration/test_graph_capabilities.py
@@ -50,6 +50,7 @@ def test_graph_atlas_search_is_bounded_complete_and_replayable(
     for candidate in result.output["candidates"]:
         graph_uri = candidate["graph_uri"]
         graph = kernel.store.get(graph_uri)
+        assert candidate["graph"] == graph.payload
         assert graph.payload["graph_schema_version"] == "1"
         assert len(graph.payload["vertices"]) == 5
         assert candidate["properties"]["connected"] is True

--- a/tests/integration/test_mcp_adapter.py
+++ b/tests/integration/test_mcp_adapter.py
@@ -265,6 +265,7 @@ def test_mcp_capability_profile_describes_and_invokes_exact_domain_contract(
                 descriptor["capability_id"] for descriptor in catalog["capabilities"]
             }
             assert capability_ids == {
+                "case.partition.finite",
                 "graph.compute.properties",
                 "graph.search.atlas",
                 "knowledge.search",

--- a/tests/integration/test_plugin_execution.py
+++ b/tests/integration/test_plugin_execution.py
@@ -142,13 +142,13 @@ def test_plugin_deadline_covers_descendant_held_output_pipes(tmp_path: Path) -> 
 
     result = PluginExecutor().run(
         entrypoint="tests.fixtures.plugin_functions:spawn_child_then_return",
-        request={"marker": str(marker)},
-        timeout_seconds=0.2,
+        request={"marker": str(marker), "delay_seconds": 3},
+        timeout_seconds=2,
     )
     elapsed = time.monotonic() - start
     time.sleep(1.2)
 
-    assert elapsed < 1
+    assert elapsed < 3
     assert result.status.value == "TIMEOUT"
     assert result.output is None
     assert not marker.exists()

--- a/tests/unit/test_graph_oracle.py
+++ b/tests/unit/test_graph_oracle.py
@@ -42,9 +42,7 @@ def test_graph_oracle_computes_path_properties_without_networkx() -> None:
 
 
 def test_graph_oracle_rejects_wrong_exact_property() -> None:
-    properties = compute_properties(
-        {"vertices": ["a", "b"], "edges": [["a", "b"]]}
-    )
+    properties = compute_properties({"vertices": ["a", "b"], "edges": [["a", "b"]]})
 
     with pytest.raises(GraphOracleError, match="differs from hidden oracle"):
         check_reported_properties(

--- a/tests/unit/test_graph_oracle.py
+++ b/tests/unit/test_graph_oracle.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import pytest
+
+from jacobian.eval_graph_oracle import (
+    GraphOracleError,
+    check_constraints,
+    check_reported_properties,
+    compute_properties,
+)
+
+
+def test_graph_oracle_computes_path_properties_without_networkx() -> None:
+    graph = {
+        "vertices": ["a", "b", "c", "d", "e", "f"],
+        "edges": [["a", "b"], ["b", "c"], ["c", "d"], ["d", "e"], ["e", "f"]],
+    }
+
+    properties = compute_properties(graph)
+
+    assert properties == {
+        "order": 6,
+        "size": 5,
+        "connected": True,
+        "bipartite": True,
+        "tree": True,
+        "triangle_count": 0,
+        "minimum_degree": 1,
+        "maximum_degree": 2,
+        "degree_sequence": [2, 2, 2, 2, 1, 1],
+        "independence_number": 3,
+    }
+    check_constraints(
+        properties,
+        {"connected": True, "tree": True, "maximum_degree": 2},
+    )
+    check_reported_properties(
+        properties,
+        {"order": 6, "tree": True, "independence_number": 3},
+        ["order", "tree", "independence_number"],
+    )
+
+
+def test_graph_oracle_rejects_wrong_exact_property() -> None:
+    properties = compute_properties(
+        {"vertices": ["a", "b"], "edges": [["a", "b"]]}
+    )
+
+    with pytest.raises(GraphOracleError, match="differs from hidden oracle"):
+        check_reported_properties(
+            properties,
+            {"order": {"value": 3, "exactness": "EXACT"}},
+            ["order"],
+        )

--- a/tests/unit/test_lean_repl_spike.py
+++ b/tests/unit/test_lean_repl_spike.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import runpy
+from pathlib import Path
+from typing import Any, cast
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SPIKE = runpy.run_path(str(PROJECT_ROOT / "benchmarks" / "lean_repl_spike.py"))
+
+
+def test_repl_error_extraction_covers_protocol_and_lean_messages() -> None:
+    response_errors = cast(Any, SPIKE["_response_errors"])
+
+    assert response_errors({"message": "Unknown proof state."}) == [
+        "Unknown proof state."
+    ]
+    assert response_errors(
+        {
+            "messages": [
+                {"severity": "warning", "data": "declaration uses sorry"},
+                {"severity": "error", "data": "type mismatch"},
+            ]
+        }
+    ) == ["type mismatch"]


### PR DESCRIPTION
## Summary

This adds the first evidence-driven capability slice from the mathematical workflow plan. `case.partition.finite` materializes an explicit finite scope, cases, a coverage obligation, and a replayable certificate; VERIFY mode promotes the relationship only when the operator-authorized independent checker accepts evidence bound to the exact scope, claim, partition, certificate, and checker.

The branch also adds paired control/treatment evaluations for two six-vertex graph workflows and one finite-partition workflow. Hidden standard-library oracles score mathematical correctness, exact task scope, false certification, artifact provenance, runtime, token use, tool calls, and parameter errors. A provenance failure observed in the graph pilot led `graph.search.atlas` to return its small typed graph payload with the durable artifact URI.

A pinned `leanprover-community/repl` spike exercises conjunction decomposition and local premise application. It remains an experiment: the branch does not add stable goal-decomposition or premise-retrieval capabilities because the REPL cannot replay completed tactic states into the originating command and no paired agent improvement has been measured. Graph mutation and Z3 construction are likewise deferred because the held-out graph tasks did not require them.

## Evaluation evidence

The 2026-07-25 development pilots used the same configured model, reasoning budget, prompt, and output contract within each pair. All six control/treatment runs passed with no false certification or parameter errors. Treatments were substantially slower and more token-intensive, so these single-pair runs establish harness and provenance behavior, not a performance advantage. Exact measurements and limitations are recorded in `docs/reference/capability-workflow-evaluations.md`.

The pinned Lean REPL v4.31.0 spike completed 2/2 tasks with zero reported protocol errors.

## Compatibility

The public API and artifact formats are pre-stable. This adds optional relationship metadata to checker decisions and verification records, and a new provisional capability ID. Existing verification promotion rules remain fail-closed.

## Validation

- `uv run pytest` — 349 passed before the final scorer-hardening regressions
- focused scorer, checker, capability, telemetry, graph-oracle, and Lean-spike tests — passed
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed
- `uv run mypy` — passed
- `uv build` — passed
- pinned Lean REPL spike — 2/2 completed
- `git diff --check origin/main...HEAD` — passed

## Suggested review order

1. `src/jacobian_checkers/finite_partition.py` and verification-record binding changes
2. `src/jacobian/finite_partition.py`
3. hidden oracles and paired scorer in `benchmarks/agent_ab.py`
4. evaluation decisions and limitations in the reference documentation