### PR TITLE
feat: add durable epistemic workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ goals are part of the working project record. Start with:
   planning model.
 - [Architecture decision log](docs/explanation/adr/index.md) for accepted
   cross-cutting decisions and their release scope.
+- [Epistemic workspace ADR](docs/explanation/adr/0005-direct-epistemic-workspaces.md)
+  for the separation between durable working state and mathematical assurance.
 - [Threat model](docs/explanation/threat-model.md) for protected properties,
   trust assumptions, and explicit exclusions.
 - [Durable search runtime](docs/explanation/search-runtime.md) for ownership,
@@ -130,6 +132,13 @@ adapter registry and trust-labeled artifacts. Bundled capabilities cover graph
 construction and properties, reference-domain exploration and verification,
 Lean checking, and local research-memory search.
 
+Three direct operational tools—`workspace.open`, `workspace.write`, and
+`workspace.query`—provide durable, revisioned paper-like working state outside
+the mathematical capability and assurance model. Scratch entries, findings,
+attempts, focus, and append-only lifecycle marks remain agent-authored and
+`UNVERIFIED`. Explicit dependency links support bounded context retrieval and
+derived stale warnings without promoting a claim.
+
 All public capability contracts and artifact formats remain pre-stable unless
 a release specification explicitly says otherwise.
 
@@ -147,12 +156,12 @@ witness or certificate.
 The repository includes a trusted-project Codex profile at
 `.codex/config.toml`. Run Codex from the repository root and inspect
 `jacobian_local` with `/mcp`; the profile starts `uv run jacobian-mcp` over
-STDIO with the compact two-tool capability surface and stores durable local state
-under the ignored `.jacobian/` directory. The profile advertises
-`capability.describe` and `capability.invoke`. Describe an unfamiliar
-capability before invoking it; reference domains include exact predicate and
-candidate schemas plus executable examples. `capability://catalog` remains a
-resource-level catalog for clients that support MCP resources.
+STDIO with a compact five-tool surface and stores durable local state under the
+ignored `.jacobian/` directory. It advertises `capability.describe`,
+`capability.invoke`, and the three direct `workspace.*` tools. Describe an
+unfamiliar mathematical capability before invoking it; direct workspace tools
+publish their own schemas. `capability://catalog` remains a resource-level
+catalog for clients that support MCP resources.
 
 For ChatGPT and other remote clients, the server supports Streamable HTTP and
 SSE, bearer-token authentication, and subject-bound tenant state. Follow

--- a/docs/explanation/adr/0005-direct-epistemic-workspaces.md
+++ b/docs/explanation/adr/0005-direct-epistemic-workspaces.md
@@ -1,0 +1,104 @@
+# ADR 0005: Keep epistemic workspaces separate from capability assurance
+
+[Documentation home](../../index.md) · [Decision log](index.md)
+
+- Status: Accepted for the pre-stable capability workbench
+- Date: 2026-07-25
+- Amended: 2026-07-26 to add paper-like lifecycle marks and derived staleness
+
+## Decision
+
+Implement durable agent working state as an independent `WorkspaceService`, not
+as a mathematical capability adapter. Project it through three direct MCP
+tools alongside the two capability tools:
+
+- `workspace.open`
+- `workspace.write`
+- `workspace.query`
+
+Workspace mutations return operational revision handles. They do not return
+heuristic, computed, or verified mathematical assurance. Every stored finding,
+attempt, and lifecycle mark is explicitly agent-authored and `UNVERIFIED`.
+
+Represent one workspace branch with:
+
+- an immutable, content-addressed revision artifact for every accepted batch;
+- a stable workspace, branch, revision, and item identity;
+- append-only lifecycle marks over immutable finding cards;
+- a transactional SQLite branch head and query index;
+- an idempotency binding for each accepted mutation;
+- optimistic writes bound to the exact current `base_revision`.
+
+The initial implementation creates one pinned `main` branch and exactly one
+canonical problem card; only `workspace.open` may create that card. An agent
+may explicitly mark a non-problem card `ACTIVE`, `CLOSED`, `RETRACTED`,
+`SUPERSEDED`, or `ARCHIVED`. `RETRACTED` and `SUPERSEDED` are invalidation
+roots. Clearing either warning requires an explicit `ACTIVE` mark before a
+later `CLOSED` or `ARCHIVED` mark. Query-time staleness follows only recorded
+dependency and assumption links. Fork, cherry-pick, search, and evidence
+attachment require later contracts and do not acquire implicit behavior from
+this decision.
+
+## Rationale
+
+`CapabilityService` describes mathematical operations whose results have
+heuristic, computed, or verified assurance. Successfully recording a note,
+goal, or attempt is an operational fact, not a mathematical computation.
+Forcing workspace writes through `CapabilityResult` would make a state change
+look like mathematical evidence and would record recursive capability episodes
+for the workspace itself.
+
+The direct tools also make frequent checkpoint and resume operations visible to
+an agent without requiring capability discovery for operational state changes.
+Three tools keep the MCP surface compact while separating mathematical
+instruments from the state used to coordinate them.
+
+The persistence design follows the same local pattern as durable search:
+SQLite provides atomic acceptance and indexed current state, while immutable
+artifacts preserve history and lineage. Pure event replay would make every
+resume query fold the full history. Mutable note rows alone would lose the
+accepted revision boundary.
+
+## Trust boundary
+
+Workspace storage validates structure, identity, scope, and explicit
+references. It does not decide whether:
+
+- a claim is true;
+- an attempt succeeded mathematically;
+- a dependency is semantically complete;
+- two findings are equivalent;
+- a formal proof corresponds to an informal card.
+
+Caller-controlled input cannot set a finding or attempt to `VERIFIED`.
+It also cannot write a derived `STALE` value. `CLOSED` means an agent explicitly
+closed a work item; it does not mean the goal was proved. A completed attempt
+does not close its target automatically. Supersession records a replacement
+pointer but does not establish equivalence or reconnect old dependents.
+Retrieval, focus, pinning, lifecycle marks, and future publication between
+branches must retain the original assurance. A later evidence-attachment
+contract must validate an authorized local verification record and its exact
+formal bindings rather than trusting a caller-supplied evidence label.
+
+## Consequences
+
+- The MCP server advertises five tools rather than two. There are no alternate
+  tool profiles; individual mathematical operations remain behind capability
+  IDs.
+- Workspace revisions and capability research episodes remain distinct data
+  types but may be linked in later revisions through artifact handles.
+- Retry-safe clients must provide an idempotency key and current base revision
+  for every mutation.
+- `RESUME` and `FRONTIER` treat only explicitly `ACTIVE` goals as open.
+  Active-but-stale goals remain visible with their invalidation roots.
+- `CONTEXT` returns a bounded deterministic closure over explicit dependency and
+  assumption links; truncation is reported rather than hidden. `STALE` lists
+  cards downstream of current invalidation roots.
+- Queries read their branch head, cards, marks, attempts, scratch, and focus
+  from one SQLite snapshot. Append order, not caller-controlled wall-clock
+  timestamps, determines the current mark and recent-item order.
+- A stale write fails before indexed workspace state changes. An immutable
+  artifact created during a losing cross-process race may remain unreferenced,
+  but it is never accepted as branch history.
+- Workspace entries are tenant-isolated through the existing per-subject
+  kernel root.

--- a/docs/explanation/adr/index.md
+++ b/docs/explanation/adr/index.md
@@ -13,6 +13,7 @@ stable public contract.
 | [0002](0002-sealed-plugin-packages.md) | Seal plugin packages and registry snapshots | Accepted, pre-stable |
 | [0003](0003-durable-search-invocations.md) | Use SQLite acceptance with immutable search checkpoints | Accepted, pre-stable |
 | [0004](0004-verified-parameter-regions.md) | Verify parameter regions through immutable subjects | Accepted, pre-stable |
+| [0005](0005-direct-epistemic-workspaces.md) | Keep epistemic workspaces separate from capability assurance | Accepted, pre-stable |
 
 Add an ADR when a decision changes a trust boundary, durable data model,
 cross-component contract, dependency strategy, or other choice that would be

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -201,6 +201,27 @@ agent, not by the kernel. A capability may coordinate several backend calls
 when they implement that one operation, but material intermediate artifacts
 and verification obligations remain visible.
 
+### Epistemic workspace
+
+`WorkspaceService` owns durable agent working state independently of
+`CapabilityService`. The direct `workspace.open`, `workspace.write`, and
+`workspace.query` tools return operational revision and item handles rather
+than `CapabilityResult`: a successful write says only that state was accepted.
+
+Each accepted batch creates an immutable revision artifact and atomically
+advances a SQLite branch head from an exact `base_revision`. Findings, attempts,
+scratch entries, focus, and append-only lifecycle marks remain
+`AGENT_RECORDED` and `UNVERIFIED`. `RETRACTED` and `SUPERSEDED` marks produce
+mechanical stale warnings only through explicit dependency and assumption
+links. `CLOSED`, retrieval, pinning, and a `COMPLETED` attempt cannot promote a
+mathematical conclusion.
+
+The initial service has one `main` branch and one canonical problem card.
+`RESUME`, `FRONTIER`, `ATTEMPTS`, `CONTEXT`, and `STALE` are deterministic
+projections over one SQLite read snapshot. `CONTEXT` bounds returned dependency
+closure and reports truncation; it does not infer relevance or omitted
+premises.
+
 ## Common result model
 
 Operational state, mathematical conclusion, and assurance are orthogonal:
@@ -426,6 +447,8 @@ surface is deliberately small:
 
 - `capability.describe` returns the exact contract for an installed capability.
 - `capability.invoke` performs the selected bounded operation.
+- `workspace.open`, `workspace.write`, and `workspace.query` manage
+  agent-authored operational state without mathematical assurance.
 - `capability://catalog` exposes installed capability descriptors.
 - Resources expose large artifacts, traces, and experiment state.
 - Tool responses contain only compact structured summaries and resource URIs.

--- a/docs/explanation/product-blueprint.md
+++ b/docs/explanation/product-blueprint.md
@@ -75,6 +75,8 @@ The boundaries are intentionally narrow:
   authorization, budgets, and provenance.
 - Capability adapters connect external SAT, SMT, CAS, optimization, retrieval,
   and proof systems to the primitive contract.
+- `WorkspaceService` owns durable agent-authored working state without
+  mathematical assurance.
 - Domain plugins own mathematical schemas, transformations, invariants,
   witness meanings, and required checker roles.
 - Independent checker packages implement replay; operators authorize them.
@@ -92,21 +94,23 @@ Codex CLI              ChatGPT / remote agent
     │ STDIO                    │ Streamable HTTP
     └──────────────┬───────────┘
                    ▼
-          MCP capability projection
-          capability://catalog
-          capability.describe / capability.invoke
-                   │
-                   ▼
-             CapabilityService
-       ┌───────────┼──────────────┐
-       │           │              │
-  knowledge     math/solver     experiment
-  and memory     adapters        services
-       │      Lean SAT SMT CAS       │
-       │      Alloy domain tools     │
-       └───────────┼─────────────────┘
-                   │ optional promotion
-                   ▼
+               MCP projection
+         ┌─────────┴─────────┐
+         ▼                   ▼
+ capability://catalog      workspace.open
+ capability.describe      workspace.write
+ capability.invoke        workspace.query
+         │                   │
+         ▼                   ▼
+ CapabilityService       WorkspaceService
+       │                   └─ revisioned unverified notes
+       ├─ knowledge and memory
+       ├─ math/solver adapters
+       │  Lean SAT SMT CAS Alloy domain tools
+       └─ experiment services
+       │
+       │ optional promotion
+       ▼
         authorized checker / proof engine
                    │
                    ▼
@@ -234,6 +238,21 @@ operational status but do not enter research memory. An episode binds:
 original assurance; retrieval never upgrades them. The local store is useful
 without an external corpus provider.
 
+### Agent-authored workspace state
+
+The direct `workspace.open`, `workspace.write`, and `workspace.query` tools
+provide a durable paper-like scratchpad outside `CapabilityService`. A
+workspace starts with one canonical problem card, one `main` branch, and one
+immutable revision. Batch writes append scratch entries, typed findings,
+attempt reports, lifecycle marks, and focus changes against an exact base
+revision.
+
+Every entry and lifecycle mark remains `AGENT_RECORDED` and `UNVERIFIED`.
+`RETRACTED` and `SUPERSEDED` generate deterministic stale warnings only along
+explicit dependency and assumption links. `COMPLETED` does not close a goal,
+and `CLOSED` does not prove it. Query views retrieve bounded operational context
+without inferring missing premises or promoting assurance.
+
 Later corpus providers add cross-project ranking, temporal cutoffs, review,
 retraction, citation, and retention policy. They remain outside checker
 authority.
@@ -242,7 +261,9 @@ authority.
 
 The local Codex host uses STDIO. It exposes `capability://catalog`,
 `capability.describe`, and `capability.invoke` rather than projecting backend
-operations or workflows as additional top-level MCP tools.
+mathematical operations or workflows as additional top-level MCP tools. Three
+direct `workspace.*` tools expose operational working state because a
+successful persistence operation is not a mathematical capability result.
 
 Remote hosts use Streamable HTTP and subject-bound tenant state. Authentication,
 tenant isolation, persistence, and TLS are deployment responsibilities, not

--- a/docs/explanation/threat-model.md
+++ b/docs/explanation/threat-model.md
@@ -44,8 +44,10 @@ Jacobian protects:
   plugin, runtime, checkpoint, or experiment;
 - parameter-region promotion bound to the exact subject and claim artifacts,
   not merely an equal payload.
-- remote tenant separation for artifacts, episodes, experiments, plugins, and
-  checker metadata.
+- durable workspace lineage that cannot be silently rebound to another
+  workspace, branch, base revision, or idempotency request;
+- remote tenant separation for artifacts, episodes, workspaces, experiments,
+  plugins, and checker metadata.
 
 Availability is important but secondary to integrity: resource exhaustion may
 produce timeout or error, never a false mathematical conclusion.
@@ -83,6 +85,38 @@ Controls:
 The deliberate crash, malformed-output, and timeout behaviors used by the
 generic conformance kit exist only in a disposable synthetic package and
 isolated state. They are not a required production-plugin interface.
+
+### Agent-authored workspace state
+
+A model or remote caller may record a false claim, report an unsuccessful
+attempt as complete, cite a missing dependency, create a reference cycle, reuse
+an idempotency key for different content, write from a stale branch head, forge
+a lifecycle label, or create a cyclic supersession chain.
+
+Controls:
+
+- workspace drafts expose no caller-controlled verified or derived-stale field;
+- stored findings, attempts, and lifecycle marks are explicitly agent-authored
+  and unverified;
+- explicit finding references must exist in the same workspace branch;
+- only `workspace.open` may create the branch's singular canonical problem
+  card;
+- new dependency cycles, supersession cycles, self-supersession, and
+  assumption-kind mismatches are rejected;
+- an invalidating `RETRACTED` or `SUPERSEDED` mark cannot be silently cleared
+  by `CLOSED` or `ARCHIVED`; an explicit `ACTIVE` restoration is required;
+- `COMPLETED` attempts do not close goals; only an explicit `CLOSED` mark changes
+  workflow state, and this never assigns a mathematical conclusion;
+- stale warnings derive only from current `RETRACTED` or `SUPERSEDED` roots and
+  explicit dependency or assumption links; absence of a warning says nothing
+  about semantic completeness or truth;
+- every mutation binds an exact request digest to an idempotency key;
+- branch-head comparison and indexed writes commit in one SQLite transaction;
+- each query uses one SQLite read snapshot, and accepted row order rather than
+  caller-controlled timestamps selects current marks and recent entries;
+- immutable revision artifacts bind the accepted parent lineage;
+- workspace retrieval, context packs, focus, marks, and attempt outcomes never
+  authorize a checker or promote assurance.
 
 ### Malformed or ambiguous artifact
 
@@ -169,6 +203,8 @@ Controls:
 - idempotency keys select one durable capability invocation, append-only event
   chains preserve retries and runtime identity, and interrupted invocations
   recover from immutable checkpoints;
+- workspace idempotency keys select one accepted mutation, and optimistic
+  revision conflicts leave indexed workspace state unchanged;
 - recovery validates a snapshot against its database key and indexed state;
   malformed rows are quarantined as `ERROR` without stopping unrelated
   recovery;
@@ -242,6 +278,8 @@ Controls:
 - capability adapters cannot return verified assurance without a valid
   verification record, complete bound parent set, and matching conclusion in
   that tenant's store;
+- workspace tools use the same subject-routed kernel and tenant-local state
+  database as capability and artifact operations;
 - TLS, rate limits, host isolation, and network policy are supplied by the
   deployment platform.
 

--- a/docs/how-to/deploy-remote-mcp.md
+++ b/docs/how-to/deploy-remote-mcp.md
@@ -5,10 +5,11 @@
 Use STDIO for a single local Codex process. Use Streamable HTTP when ChatGPT or
 another remote MCP client must reach Jacobian.
 
-The server exposes `capability.describe` and `capability.invoke`. Clients may
-read installed descriptors from `capability://catalog` and inspect exact
-contracts before invocation. Mathematical operations remain behind namespaced
-capability IDs.
+The server exposes `capability.describe`, `capability.invoke`, and the three
+direct `workspace.*` tools. Clients may read installed descriptors from
+`capability://catalog` and inspect exact contracts before invoking mathematical
+operations, which remain behind namespaced capability IDs. Workspace state is
+subject-bound operational data and never becomes mathematical assurance.
 
 ## Create the auth secret
 
@@ -100,7 +101,8 @@ subject to the same tenant-routing interface.
 
 ## Operational boundaries
 
-- Back up the state volume; artifacts and research episodes live there.
+- Back up the state volume; artifacts, workspaces, and research episodes live
+  there.
 - Run one Jacobian process per state root until a lease model is implemented.
 - Apply CPU, memory, filesystem, and network policy outside Jacobian.
 - Do not interpret HTTP success, solver completion, or an MCP response as a

--- a/docs/reference/agent-evaluations.md
+++ b/docs/reference/agent-evaluations.md
@@ -375,6 +375,30 @@ artifacts, not reference contracts. Store them under the ignored
 `benchmarks/results/` directory and summarize them only from a clean,
 identified tree when making a benchmark claim.
 
+### Workspace context-loss development run
+
+An exploratory two-session run on 2026-07-26 used Codex CLI `0.144.1`,
+`gpt-5.6-terra`, and high reasoning effort. After the mark `summary` alias was
+published, the first session completed `open`, seed `write`, retraction
+`write`, and `CONTEXT` in four calls with no retry. A fresh session completed
+`CONTEXT`, `STALE`, resolution `write`, and `RESUME` in four calls with no
+retry. The target goal stayed visible while active-but-stale and left
+`open_goals` only after an explicit `CLOSED` mark.
+
+The fresh session's initial `CONTEXT` and `STALE` responses totaled 4,899
+characters. An earlier development run's initial `RESUME` and `FRONTIER`
+responses totaled 8,453 characters. The prompts and stored states were not
+identical, so the 42.0% payload difference is interface feedback, not a causal
+efficiency claim. A final alias-heavy smoke completed `open`, `write`, and
+`CONTEXT` in three calls with no retry and retained `UNVERIFIED` assurance.
+
+On the rebased five-tool server, compact sorted JSON over instructions and the
+`tools/list` payload is 24,745 characters. Workspace output schemas are omitted
+from initial tool discovery while complete JSON results remain available from
+calls; this keeps the first-stage descriptor below the 25 KB development
+target. These are dirty-worktree development measurements, not held-out product
+evidence.
+
 Run the kernel condition with:
 
 ```sh

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -6,13 +6,17 @@
 - Normative sources: [v0.2 specification](specifications/v0.2.md) and
   [conformance gate](conformance-v0.2.md)
 
-Jacobian exposes mathematical operations as namespaced capabilities. The
-model-facing MCP surface is deliberately small:
+Jacobian exposes mathematical operations as namespaced capabilities and
+operational working state through three direct workspace tools. The
+model-facing MCP surface contains five tools:
 
 | MCP tool | Purpose |
 | --- | --- |
 | `capability.describe` | Read an installed capability's descriptor and exact input and output schemas. |
 | `capability.invoke` | Invoke an installed capability in `EXPLORE` or `VERIFY` mode. |
+| `workspace.open` | Create one durable agent workspace, canonical problem card, pinned `main` branch, and immutable initial revision. |
+| `workspace.write` | Append scratch, findings, attempts, lifecycle marks, and focus against an exact base revision. |
+| `workspace.query` | Read a deterministic `RESUME`, `FRONTIER`, `ATTEMPTS`, `CONTEXT`, or `STALE` view. |
 
 Read `capability://catalog` to discover installed capability IDs, provider
 versions, supported modes, compact schemas, and tags. Catalog membership means
@@ -22,7 +26,49 @@ support, recommendation, conformance coverage, or authority to return
 
 There are no alternate MCP tool profiles and no public top-level MCP commands
 for individual mathematical operations. Adding a capability does not add a
-new MCP tool.
+new MCP tool. Workspace tools are an explicit operational-state exception:
+successful persistence has no mathematical assurance level.
+
+## Epistemic workspace
+
+`workspace.open` creates exactly one canonical problem card. Only
+`workspace.open` may create that card. Every later mutation carries an
+idempotency key; `workspace.write` advances the branch only when
+`base_revision` is still its current head. Full accepted batches are available
+through the returned immutable `revision_artifact_uri`.
+
+Within a write, entries use unique `client_ref` values. Findings record a
+`kind`, `title`, `body`, and optional explicit dependency or assumption
+references. Attempts record a target, method, operational outcome, and summary.
+`OPEN_GOAL` normalizes to `GOAL`; `SUCCEEDED` normalizes to `COMPLETED`.
+Completion never means `VERIFIED` and never closes a goal automatically.
+
+Append-only margin marks record paper-like lifecycle state:
+
+- `ACTIVE` explicitly reopens or restores a card;
+- `CLOSED` closes a `GOAL` or `OPEN_QUESTION` as workflow state;
+- `RETRACTED` withdraws a card and invalidates explicit dependents;
+- `SUPERSEDED` names a replacement and invalidates old dependents;
+- `ARCHIVED` files a card without invalidating dependents.
+
+Every mark requires `reason`; the unambiguous `summary` input alias normalizes
+to it. A `RETRACTED` or `SUPERSEDED` card must be explicitly restored with
+`ACTIVE` before `CLOSED` or `ARCHIVED` can clear its invalidating state.
+Supersession does not prove equivalence or reconnect dependents.
+
+Workspace drafts cannot set `verification`, `assertion`, or derived `stale`.
+Findings, attempts, marks, focus, and retrieval remain `AGENT_RECORDED` and
+`UNVERIFIED`. Stale warnings follow only current `RETRACTED` or `SUPERSEDED`
+roots through explicit dependency and assumption links; absence of a warning
+says nothing about truth or semantic completeness.
+
+`workspace.query` optionally accepts an exact expected `revision_id`.
+`CONTEXT` additionally requires `target_card_id` and returns a bounded,
+dependency-first closure plus recent target attempts. It reports
+`total_dependency_count` and `truncated`; it does not infer relevance or
+missing premises. Active stale goals remain visible until an explicit
+`CLOSED`, `ARCHIVED`, `RETRACTED`, or `SUPERSEDED` mark changes their workflow
+state.
 
 ## Capability contract
 

--- a/src/jacobian/adapters/mcp/server.py
+++ b/src/jacobian/adapters/mcp/server.py
@@ -11,18 +11,38 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Annotated, Any
 
 from mcp.server.mcpserver.exceptions import ToolError
 from mcp.shared.exceptions import MCPError
 from mcp_types import ToolAnnotations
-from pydantic import AnyHttpUrl
+from pydantic import AnyHttpUrl, Field, StrictInt
 
 from jacobian import __version__
 from jacobian.contracts.capabilities import (
     CapabilityMode,
     CapabilityRequest,
     CapabilityResult,
+)
+from jacobian.contracts.workspaces import (
+    WorkspaceAttemptDraft,
+    WorkspaceBranchId,
+    WorkspaceCardId,
+    WorkspaceFindingDraft,
+    WorkspaceFocusDraft,
+    WorkspaceId,
+    WorkspaceIdempotencyKey,
+    WorkspaceMarkDraft,
+    WorkspaceOpenRequest,
+    WorkspaceOpenResult,
+    WorkspaceQueryRequest,
+    WorkspaceQueryResult,
+    WorkspaceQueryView,
+    WorkspaceRevisionId,
+    WorkspaceScratchDraft,
+    WorkspaceTag,
+    WorkspaceWriteRequest,
+    WorkspaceWriteResult,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -37,13 +57,21 @@ if TYPE_CHECKING:
 
 SERVER_INSTRUCTIONS = (
     "Call capability.describe before the first invocation of an unfamiliar "
-    "capability; do not guess payload fields. Use EXPLORE for low-friction search "
-    "and VERIFY only when a durable checked conclusion is needed. Retrieved memory, "
-    "search, evaluation, and generated evidence are not proof. Only assurance level "
-    "VERIFIED with a local verification record is verified. Operational completion, "
+    "capability passed to capability.invoke; do not guess payload fields. Direct "
+    "workspace.* tools publish their input shape and enforce documented cross-field "
+    "invariants without capability discovery. Use EXPLORE for low-friction search and "
+    "VERIFY only when a durable checked conclusion is needed. Retrieved memory, "
+    "search, evaluation, generated evidence, workspace entries, and lifecycle marks "
+    "are not proof. Only assurance level VERIFIED with a local verification record is "
+    "verified. Writing, retrieving, closing, retracting, superseding, or pinning a "
+    "workspace entry never promotes mathematical assurance. Operational completion, "
     "failure to find a witness, and exhausted or bounded search are not mathematical "
     "conclusions. Follow returned artifact:// and experiment:// resources instead of "
     "requesting large payloads inline."
+)
+
+WORKSPACE_TOOL_NAMES = frozenset(
+    {"workspace.open", "workspace.write", "workspace.query"}
 )
 
 
@@ -63,6 +91,57 @@ def _tool_annotations(
         idempotent_hint=idempotent,
         open_world_hint=False,
     )
+
+
+def _forbid_extra_tool_arguments(server: Any, *tool_names: str) -> None:
+    """Close SDK-generated argument models that otherwise ignore unknown fields."""
+
+    # MCP 2.0.0b2 creates flat function argument models with Pydantic's default
+    # ``extra="ignore"``. Workspace writes must reject the entire request instead of
+    # silently committing a partial batch when a caller misspells a top-level field.
+    manager = server._tool_manager
+    for tool_name in tool_names:
+        tool = manager.get_tool(tool_name)
+        if tool is None:  # pragma: no cover - registration invariant
+            raise RuntimeError(f"workspace tool was not registered: {tool_name}")
+        argument_model = tool.fn_metadata.arg_model
+        argument_model.model_config["extra"] = "forbid"
+        argument_model.model_rebuild(force=True)
+        tool.parameters = argument_model.model_json_schema(by_alias=True)
+
+
+def _publish_workspace_normalization_aliases(server: Any) -> None:
+    """Advertise exactly the input aliases normalized by workspace contracts."""
+
+    tool = server._tool_manager.get_tool("workspace.write")
+    if tool is None:  # pragma: no cover - registration invariant
+        raise RuntimeError("workspace tool was not registered: workspace.write")
+    schema = tool.parameters
+    definitions = schema["$defs"]
+    definitions["WorkspaceFindingKind"]["enum"].remove("PROBLEM")
+    definitions["WorkspaceFindingKind"]["enum"].append("OPEN_GOAL")
+    definitions["WorkspaceAttemptOutcome"]["enum"].append("SUCCEEDED")
+
+    mark_schema = definitions["WorkspaceMarkDraft"]
+    reason_schema = mark_schema["properties"]["reason"]
+    mark_schema["properties"]["summary"] = {
+        **reason_schema,
+        "title": "Summary",
+        "description": (
+            "Input alias for reason. Supplying both summary and reason is rejected."
+        ),
+    }
+    mark_schema["required"].remove("reason")
+    mark_schema["oneOf"] = [
+        {
+            "required": ["reason"],
+            "not": {"required": ["summary"]},
+        },
+        {
+            "required": ["summary"],
+            "not": {"required": ["reason"]},
+        },
+    ]
 
 
 @dataclass(frozen=True, slots=True)
@@ -182,15 +261,21 @@ def create_server(
         try:
             descriptor = descriptors[capability_id]
         except KeyError:
+            hint = (
+                "workspace.* names are direct MCP tools, not capability IDs; call the "
+                "workspace tool directly using its published input schema."
+                if capability_id.startswith("workspace.")
+                else (
+                    "Call capability.describe without a capability_id to list installed "
+                    "capabilities."
+                )
+            )
             return {
                 "error": {
                     "code": "UNKNOWN_CAPABILITY",
                     "stage": "capability_resolution",
                     "message": f"Unknown capability: {capability_id}",
-                    "hint": (
-                        "Call capability.describe without a capability_id to list "
-                        "installed capabilities."
-                    ),
+                    "hint": hint,
                     "available_capability_ids": sorted(descriptors),
                 }
             }
@@ -229,6 +314,228 @@ def create_server(
                 input=payload,
             ),
         )
+
+    @server.tool(
+        name="workspace.open",
+        description=(
+            "Direct tool; do not call capability.describe. Create a durable epistemic "
+            "workspace with one canonical problem, a main branch, and an immutable "
+            "initial revision. Workspace content is agent-authored and UNVERIFIED."
+        ),
+        annotations=_tool_annotations(idempotent=True),
+        structured_output=False,
+    )
+    async def workspace_open(
+        idempotency_key: WorkspaceIdempotencyKey,
+        name: Annotated[str, Field(min_length=1, max_length=128)],
+        problem: Annotated[str, Field(min_length=1, max_length=16_384)],
+        tags: Annotated[
+            list[WorkspaceTag] | None,
+            Field(max_length=16),
+        ] = None,
+        ctx: Context[AppState, Any] | None = None,
+    ) -> WorkspaceOpenResult:
+        active_kernel = _kernel(ctx)
+        return await asyncio.to_thread(
+            active_kernel.workspaces.open,
+            WorkspaceOpenRequest(
+                idempotency_key=idempotency_key,
+                name=name,
+                problem=problem,
+                tags=tuple(tags or ()),
+            ),
+        )
+
+    @server.tool(
+        name="workspace.write",
+        description=(
+            "Direct tool. Do not call capability.describe. Arguments are flat: send "
+            "base_revision (never revision_id) and top-level findings, attempts, marks, "
+            "scratch, or focus (never a batch wrapper). Every draft uses client_ref, "
+            "never ref. Append at an exact base revision. Finding fields are client_ref, "
+            "kind, title, body; optional links are dependency_refs and assumption_refs "
+            "(never depends_on_refs). Attempt fields are client_ref, target_ref, method, "
+            "outcome, summary. Margin marks append an explicit ACTIVE, CLOSED, "
+            "RETRACTED, SUPERSEDED, or ARCHIVED state; only SUPERSEDED carries "
+            "superseded_by_ref, and summary is accepted as an alias for reason. "
+            "References may use a client_ref from the same batch. OPEN_GOAL normalizes "
+            "to GOAL and SUCCEEDED normalizes to COMPLETED. PROBLEM is reserved for "
+            "workspace.open. A RETRACTED or SUPERSEDED card must receive an ACTIVE mark "
+            "before CLOSED or ARCHIVED. Set focus with active_ref/pinned_refs, clear it "
+            "with clear=true, or omit it; focus references finding cards, never "
+            "attempts, marks, or scratch. Never send verification/assertion/stale "
+            "fields: all workspace assertions remain AGENT_RECORDED and UNVERIFIED. "
+            "Canonical batch example: "
+            'findings=[{"client_ref":"C1","kind":"CLAIM","title":"...","body":"..."}], '
+            'attempts=[{"client_ref":"T1","target_ref":"C1","method":"...",'
+            '"outcome":"COMPLETED","summary":"..."}], '
+            'focus={"active_ref":"C1","pinned_refs":["C1"]}.'
+        ),
+        annotations=_tool_annotations(idempotent=True),
+        structured_output=False,
+    )
+    async def workspace_write(
+        workspace_id: Annotated[
+            WorkspaceId,
+            Field(description="workspace:// handle returned by workspace.open"),
+        ],
+        branch_id: Annotated[
+            WorkspaceBranchId,
+            Field(description="branch:// handle returned by workspace.open"),
+        ],
+        base_revision: Annotated[
+            WorkspaceRevisionId,
+            Field(
+                description=(
+                    "Exact current revision:// head returned by workspace.open, "
+                    "workspace.write, or workspace.query."
+                )
+            ),
+        ],
+        idempotency_key: Annotated[
+            WorkspaceIdempotencyKey,
+            Field(
+                description=(
+                    "Caller-chosen key unique to this exact write payload; reuse only "
+                    "to retry the identical request."
+                )
+            ),
+        ],
+        scratch: Annotated[
+            list[WorkspaceScratchDraft] | None,
+            Field(
+                max_length=64,
+                description="Optional unverified scratch entries to append.",
+            ),
+        ] = None,
+        findings: Annotated[
+            list[WorkspaceFindingDraft] | None,
+            Field(
+                max_length=64,
+                description="Optional typed, unverified cards to append.",
+                examples=[
+                    [
+                        {
+                            "client_ref": "C1",
+                            "kind": "CLAIM",
+                            "title": "Candidate conclusion",
+                            "body": "Agent-authored reasoning; still unverified.",
+                        }
+                    ]
+                ],
+            ),
+        ] = None,
+        attempts: Annotated[
+            list[WorkspaceAttemptDraft] | None,
+            Field(
+                max_length=64,
+                description="Optional unverified operational attempts to append.",
+                examples=[
+                    [
+                        {
+                            "client_ref": "T1",
+                            "target_ref": "C1",
+                            "method": "direct",
+                            "outcome": "COMPLETED",
+                            "summary": "The operational attempt finished.",
+                        }
+                    ]
+                ],
+            ),
+        ] = None,
+        marks: Annotated[
+            list[WorkspaceMarkDraft] | None,
+            Field(
+                max_length=64,
+                description=(
+                    "Optional append-only lifecycle marks. CLOSED is workflow state, "
+                    "not proof; RETRACTED and SUPERSEDED deterministically make explicit "
+                    "dependents stale."
+                ),
+                examples=[
+                    [
+                        {
+                            "client_ref": "M1",
+                            "target_ref": "C1",
+                            "state": "RETRACTED",
+                            "reason": "The recorded premise was withdrawn.",
+                        }
+                    ]
+                ],
+            ),
+        ] = None,
+        focus: Annotated[
+            WorkspaceFocusDraft | None,
+            Field(
+                description=(
+                    "Optional explicit focus update: set active_ref/pinned_refs, use "
+                    "clear=true to clear, or omit to preserve current focus."
+                ),
+                examples=[{"active_ref": "C1", "pinned_refs": ["C1"]}],
+            ),
+        ] = None,
+        ctx: Context[AppState, Any] | None = None,
+    ) -> WorkspaceWriteResult:
+        active_kernel = _kernel(ctx)
+        return await asyncio.to_thread(
+            active_kernel.workspaces.write,
+            WorkspaceWriteRequest(
+                idempotency_key=idempotency_key,
+                workspace_id=workspace_id,
+                branch_id=branch_id,
+                base_revision=base_revision,
+                scratch=tuple(scratch or ()),
+                findings=tuple(findings or ()),
+                attempts=tuple(attempts or ()),
+                marks=tuple(marks or ()),
+                focus=focus,
+            ),
+        )
+
+    @server.tool(
+        name="workspace.query",
+        description=(
+            "Direct tool; do not call capability.describe. Read a compact deterministic "
+            "RESUME, FRONTIER, ATTEMPTS, CONTEXT, or STALE view from agent-authored "
+            "workspace state. CONTEXT requires target_card_id and follows only explicit "
+            "dependency/assumption links. Derived staleness is a paper-like warning, "
+            "not a mathematical conclusion. Retrieval preserves UNVERIFIED status."
+        ),
+        annotations=_tool_annotations(read_only=True, idempotent=True),
+        structured_output=False,
+    )
+    async def workspace_query(
+        workspace_id: WorkspaceId,
+        branch_id: WorkspaceBranchId,
+        revision_id: Annotated[
+            WorkspaceRevisionId | None,
+            Field(
+                description=(
+                    "Optional expected branch head revision:// handle. The query "
+                    "fails if the current head differs; omit to read the latest."
+                )
+            ),
+        ] = None,
+        view: WorkspaceQueryView = WorkspaceQueryView.RESUME,
+        target_card_id: WorkspaceCardId | None = None,
+        limit: Annotated[StrictInt, Field(ge=1, le=50)] = 10,
+        ctx: Context[AppState, Any] | None = None,
+    ) -> WorkspaceQueryResult:
+        active_kernel = _kernel(ctx)
+        return await asyncio.to_thread(
+            active_kernel.workspaces.query,
+            WorkspaceQueryRequest(
+                workspace_id=workspace_id,
+                branch_id=branch_id,
+                revision_id=revision_id,
+                view=view,
+                target_card_id=target_card_id,
+                limit=limit,
+            ),
+        )
+
+    _forbid_extra_tool_arguments(server, *WORKSPACE_TOOL_NAMES)
+    _publish_workspace_normalization_aliases(server)
 
     @server.resource(
         "artifact://sha256/{digest}",
@@ -470,6 +777,12 @@ def _public_tool_error(tool_name: str, exc: Exception) -> str:
     from jacobian.experiments import ExperimentNotFoundError
     from jacobian.registry import CheckerNotFoundError
     from jacobian.store import ArtifactNotFoundError
+    from jacobian.workspaces import (
+        WorkspaceConflictError,
+        WorkspaceIdempotencyError,
+        WorkspaceNotFoundError,
+        WorkspaceReferenceError,
+    )
 
     tool_error = exc.__cause__ if isinstance(exc, ToolError) else exc
     if not isinstance(tool_error, Exception):
@@ -492,7 +805,12 @@ def _public_tool_error(tool_name: str, exc: Exception) -> str:
         hint = "Check the state-directory permissions, then retry."
     elif isinstance(
         tool_error,
-        (ArtifactNotFoundError, CheckerNotFoundError, ExperimentNotFoundError),
+        (
+            ArtifactNotFoundError,
+            CheckerNotFoundError,
+            ExperimentNotFoundError,
+            WorkspaceNotFoundError,
+        ),
     ):
         code = "RESOURCE_NOT_FOUND"
         message = "A required Jacobian resource was not found."
@@ -500,10 +818,25 @@ def _public_tool_error(tool_name: str, exc: Exception) -> str:
             "Check the artifact or experiment URI returned by the earlier tool call, "
             "then retry."
         )
+    elif isinstance(tool_error, WorkspaceConflictError):
+        code = "WORKSPACE_CONFLICT"
+        message = str(tool_error)
+        hint = "Query the latest workspace revision, then retry from that exact head."
+    elif isinstance(
+        tool_error,
+        (WorkspaceIdempotencyError, WorkspaceReferenceError),
+    ):
+        code = "INVALID_INPUT"
+        message = str(tool_error)
+        hint = "Check the published workspace tool schema and returned handles."
     elif isinstance(tool_error, ValueError):
         code = "INVALID_INPUT"
         message = "The tool input is not valid for this operation."
-        hint = "Check the tool input schema or call capability.describe, then retry."
+        hint = (
+            "Check the published workspace tool schema, then retry."
+            if tool_name.startswith("workspace.")
+            else "Check the tool input schema or call capability.describe, then retry."
+        )
     else:
         code = "OPERATION_FAILED"
         message = "Jacobian could not complete the operation."

--- a/src/jacobian/contracts/workspaces.py
+++ b/src/jacobian/contracts/workspaces.py
@@ -1,0 +1,731 @@
+"""Versioned contracts for the agent-authored epistemic workspace."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+from typing import Annotated, Literal, Self
+
+from pydantic import (
+    Field,
+    StrictBool,
+    StrictInt,
+    StringConstraints,
+    field_validator,
+    model_validator,
+)
+
+from jacobian.contracts.common import ArtifactUri, Sha256Digest
+from jacobian.contracts.results import ContractModel
+
+WorkspaceId = Annotated[
+    str,
+    StringConstraints(
+        pattern=r"^workspace://[0-9a-f]{32}$",
+        strict=True,
+    ),
+]
+WorkspaceBranchId = Annotated[
+    str,
+    StringConstraints(
+        pattern=r"^branch://[0-9a-f]{32}$",
+        strict=True,
+    ),
+]
+WorkspaceRevisionId = Annotated[
+    str,
+    StringConstraints(
+        pattern=r"^revision://[0-9a-f]{32}$",
+        strict=True,
+    ),
+]
+WorkspaceItemId = Annotated[
+    str,
+    StringConstraints(
+        pattern=r"^(?:card|scratch|attempt|mark)://[0-9a-f]{32}$",
+        strict=True,
+    ),
+]
+WorkspaceCardId = Annotated[
+    str,
+    StringConstraints(
+        pattern=r"^card://[0-9a-f]{32}$",
+        strict=True,
+    ),
+]
+WorkspaceClientRef = Annotated[
+    str,
+    StringConstraints(
+        pattern=r"^[A-Za-z][A-Za-z0-9_.-]{0,63}$",
+        strict=True,
+    ),
+]
+WorkspaceReference = Annotated[
+    str,
+    StringConstraints(
+        pattern=(
+            r"^(?:[A-Za-z][A-Za-z0-9_.-]{0,63}"
+            r"|card://[0-9a-f]{32})$"
+        ),
+        strict=True,
+    ),
+]
+WorkspaceIdempotencyKey = Annotated[
+    str,
+    StringConstraints(
+        pattern=r"^[A-Za-z0-9._:-]{8,128}$",
+        strict=True,
+    ),
+]
+WorkspaceTag = Annotated[
+    str,
+    StringConstraints(
+        pattern=r"^[^\s]{1,64}$",
+        strict=True,
+    ),
+]
+
+
+class WorkspaceFindingKind(StrEnum):
+    PROBLEM = "PROBLEM"
+    ASSUMPTION = "ASSUMPTION"
+    DEFINITION = "DEFINITION"
+    GOAL = "GOAL"
+    FINDING = "FINDING"
+    CLAIM = "CLAIM"
+    EXAMPLE = "EXAMPLE"
+    COUNTEREXAMPLE = "COUNTEREXAMPLE"
+    STRATEGY = "STRATEGY"
+    OBSTACLE = "OBSTACLE"
+    OPEN_QUESTION = "OPEN_QUESTION"
+
+
+class WorkspaceAttemptOutcome(StrEnum):
+    PROPOSED = "PROPOSED"
+    PROMISING = "PROMISING"
+    BLOCKED = "BLOCKED"
+    FAILED = "FAILED"
+    COMPLETED = "COMPLETED"
+
+
+class WorkspaceCardState(StrEnum):
+    """Agent-recorded paper-like lifecycle state, never mathematical assurance."""
+
+    ACTIVE = "ACTIVE"
+    CLOSED = "CLOSED"
+    RETRACTED = "RETRACTED"
+    SUPERSEDED = "SUPERSEDED"
+    ARCHIVED = "ARCHIVED"
+
+
+class WorkspaceRevisionOperation(StrEnum):
+    OPEN = "OPEN"
+    WRITE = "WRITE"
+
+
+class WorkspaceQueryView(StrEnum):
+    RESUME = "RESUME"
+    FRONTIER = "FRONTIER"
+    ATTEMPTS = "ATTEMPTS"
+    CONTEXT = "CONTEXT"
+    STALE = "STALE"
+
+
+class WorkspaceScratchDraft(ContractModel):
+    """One agent-authored, unverified scratch entry."""
+
+    client_ref: WorkspaceClientRef = Field(
+        description=(
+            "A local identifier unique within this write, such as S1. Other entries "
+            "in the same write may cite it before the service assigns a scratch:// ID."
+        )
+    )
+    body: str = Field(
+        min_length=1,
+        max_length=8192,
+        description=(
+            "Unverified scratch text. Assurance is assigned by the service; do not "
+            "send verification or assertion fields."
+        ),
+    )
+    tags: tuple[WorkspaceTag, ...] = Field(
+        default=(),
+        max_length=16,
+        description="Optional unique, whitespace-free tags.",
+    )
+
+    @model_validator(mode="after")
+    def require_unique_tags(self) -> Self:
+        if len(set(self.tags)) != len(self.tags):
+            raise ValueError("scratch tags must be unique")
+        return self
+
+
+class WorkspaceFindingDraft(ContractModel):
+    """One typed, agent-authored, unverified epistemic card."""
+
+    client_ref: WorkspaceClientRef = Field(
+        description=(
+            "A local identifier unique within this write, such as G1 or claim-341. "
+            "Use it from target_ref, dependency_refs, assumption_refs, or focus fields "
+            "in the same batch."
+        )
+    )
+    kind: WorkspaceFindingKind = Field(
+        description=(
+            "Card type. Use GOAL for unfinished work and CLAIM or COUNTEREXAMPLE for "
+            "a result. Use FINDING for a generic observation. PROBLEM is reserved for "
+            "the canonical card created by workspace.open and is rejected by "
+            "workspace.write. OPEN_GOAL is normalized to GOAL."
+        )
+    )
+    title: str = Field(
+        min_length=1,
+        max_length=256,
+        description="Short human-readable card title.",
+    )
+    body: str = Field(
+        min_length=1,
+        max_length=16_384,
+        description=(
+            "Agent-authored content stored as AGENT_RECORDED and UNVERIFIED; do not "
+            "send verification or assertion fields."
+        ),
+    )
+    dependency_refs: tuple[WorkspaceReference, ...] = Field(
+        default=(),
+        max_length=64,
+        description=(
+            "Unique card:// IDs or finding client_ref values from this same write "
+            "whose results this card depends on."
+        ),
+    )
+    assumption_refs: tuple[WorkspaceReference, ...] = Field(
+        default=(),
+        max_length=64,
+        description=(
+            "Unique card:// IDs or finding client_ref values from this same write "
+            "that this card assumes."
+        ),
+    )
+    tags: tuple[WorkspaceTag, ...] = Field(
+        default=(),
+        max_length=16,
+        description="Optional unique, whitespace-free tags.",
+    )
+
+    @field_validator("kind", mode="before")
+    @classmethod
+    def normalize_open_goal_alias(cls, value: object) -> object:
+        return WorkspaceFindingKind.GOAL if value == "OPEN_GOAL" else value
+
+    @model_validator(mode="after")
+    def require_unique_references(self) -> Self:
+        if len(set(self.dependency_refs)) != len(self.dependency_refs):
+            raise ValueError("finding dependency references must be unique")
+        if len(set(self.assumption_refs)) != len(self.assumption_refs):
+            raise ValueError("finding assumption references must be unique")
+        if set(self.dependency_refs) & set(self.assumption_refs):
+            raise ValueError(
+                "a finding reference cannot be both a dependency and an assumption"
+            )
+        if len(set(self.tags)) != len(self.tags):
+            raise ValueError("finding tags must be unique")
+        return self
+
+
+class WorkspaceAttemptDraft(ContractModel):
+    """One operational attempt report; completion is not mathematical verification."""
+
+    client_ref: WorkspaceClientRef = Field(
+        description=(
+            "A local identifier unique within this write, such as T1. The service "
+            "returns its assigned attempt:// ID in id_map."
+        )
+    )
+    target_ref: WorkspaceReference = Field(
+        description=(
+            "The target card:// ID or a finding client_ref introduced in this same "
+            "write. Use target_ref, not target_card_id."
+        )
+    )
+    method: str = Field(
+        min_length=1,
+        max_length=128,
+        description="Short name or description of the attempted method.",
+    )
+    outcome: WorkspaceAttemptOutcome = Field(
+        description=(
+            "Operational status: PROPOSED, PROMISING, BLOCKED, FAILED, or COMPLETED. "
+            "SUCCEEDED is normalized to COMPLETED. A finished attempt never means "
+            "VERIFIED."
+        )
+    )
+    summary: str = Field(
+        min_length=1,
+        max_length=4096,
+        description=(
+            "Agent-authored outcome summary stored as AGENT_RECORDED and UNVERIFIED; "
+            "do not send verification or assertion fields."
+        ),
+    )
+    artifact_uris: tuple[ArtifactUri, ...] = Field(
+        default=(),
+        max_length=32,
+        description="Optional unique artifact:// attachments.",
+    )
+    tags: tuple[WorkspaceTag, ...] = Field(
+        default=(),
+        max_length=16,
+        description="Optional unique, whitespace-free tags.",
+    )
+
+    @field_validator("outcome", mode="before")
+    @classmethod
+    def normalize_succeeded_alias(cls, value: object) -> object:
+        return WorkspaceAttemptOutcome.COMPLETED if value == "SUCCEEDED" else value
+
+    @model_validator(mode="after")
+    def require_unique_attachments(self) -> Self:
+        if len(set(self.artifact_uris)) != len(self.artifact_uris):
+            raise ValueError("attempt artifact URIs must be unique")
+        if len(set(self.tags)) != len(self.tags):
+            raise ValueError("attempt tags must be unique")
+        return self
+
+
+class WorkspaceFocusDraft(ContractModel):
+    """An explicit focus update or clear operation."""
+
+    active_ref: WorkspaceReference | None = Field(
+        default=None,
+        description=(
+            "Set the active card using a card:// ID or a finding client_ref from this "
+            "same write. Focus references identify finding cards only, never an "
+            "attempt or scratch entry."
+        ),
+    )
+    pinned_refs: tuple[WorkspaceReference, ...] = Field(
+        default=(),
+        max_length=32,
+        description=(
+            "Replace pinned cards with these unique card:// IDs or finding client_ref "
+            "values from this same write. A pin is always a finding card, never an "
+            "attempt or scratch entry."
+        ),
+    )
+    clear: StrictBool = Field(
+        default=False,
+        description=(
+            "Set clear=true to remove the active card and all pins. Do not combine it "
+            "with active_ref or pinned_refs; an empty focus object is invalid."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def require_explicit_update_and_unique_pins(self) -> Self:
+        if len(set(self.pinned_refs)) != len(self.pinned_refs):
+            raise ValueError("pinned references must be unique")
+        if self.clear and (self.active_ref is not None or self.pinned_refs):
+            raise ValueError(
+                "focus clear cannot be combined with active_ref or pinned_refs"
+            )
+        if self.active_ref is None and not self.pinned_refs and not self.clear:
+            raise ValueError(
+                "focus update requires active_ref, pinned_refs, or clear=true"
+            )
+        return self
+
+
+class WorkspaceMarkDraft(ContractModel):
+    """One explicit margin mark over a card; it does not alter mathematical assurance."""
+
+    client_ref: WorkspaceClientRef = Field(
+        description=(
+            "A local identifier unique within this write, such as M1. The service "
+            "returns its assigned mark:// ID in id_map."
+        )
+    )
+    target_ref: WorkspaceReference = Field(
+        description=(
+            "The card:// ID to mark or a finding client_ref introduced in this same "
+            "write."
+        )
+    )
+    state: WorkspaceCardState = Field(
+        description=(
+            "Agent-recorded lifecycle state. CLOSED applies only to GOAL or "
+            "OPEN_QUESTION and means work was explicitly closed, not proved. "
+            "RETRACTED and SUPERSEDED invalidate dependent workspace cards without "
+            "assigning a mathematical conclusion. Either invalidating state requires "
+            "an explicit ACTIVE restoration before CLOSED or ARCHIVED. The canonical "
+            "PROBLEM cannot be marked."
+        )
+    )
+    reason: str = Field(
+        min_length=1,
+        max_length=2048,
+        description=(
+            "Why the margin mark was made. The unambiguous input alias summary "
+            "normalizes to reason. Stored as AGENT_RECORDED and UNVERIFIED."
+        ),
+    )
+    superseded_by_ref: WorkspaceReference | None = Field(
+        default=None,
+        description=(
+            "Replacement card:// ID or same-write finding client_ref. Required only "
+            "when state is SUPERSEDED."
+        ),
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_summary_alias(cls, value: object) -> object:
+        if not isinstance(value, dict) or "summary" not in value:
+            return value
+        if "reason" in value:
+            raise ValueError("mark input cannot provide both reason and summary")
+        normalized = dict(value)
+        normalized["reason"] = normalized.pop("summary")
+        return normalized
+
+    @model_validator(mode="after")
+    def bind_replacement_to_superseded_state(self) -> Self:
+        if (
+            self.state is WorkspaceCardState.SUPERSEDED
+            and self.superseded_by_ref is None
+        ):
+            raise ValueError("SUPERSEDED marks require superseded_by_ref")
+        if (
+            self.state is not WorkspaceCardState.SUPERSEDED
+            and self.superseded_by_ref is not None
+        ):
+            raise ValueError("only SUPERSEDED marks may carry superseded_by_ref")
+        return self
+
+
+class WorkspaceOpenRequest(ContractModel):
+    request_version: Literal["1"] = "1"
+    idempotency_key: WorkspaceIdempotencyKey
+    name: str = Field(min_length=1, max_length=128)
+    problem: str = Field(min_length=1, max_length=16_384)
+    tags: tuple[WorkspaceTag, ...] = Field(default=(), max_length=16)
+
+    @model_validator(mode="after")
+    def require_unique_tags(self) -> Self:
+        if len(set(self.tags)) != len(self.tags):
+            raise ValueError("workspace tags must be unique")
+        return self
+
+
+class WorkspaceWriteRequest(ContractModel):
+    request_version: Literal["1"] = "1"
+    idempotency_key: WorkspaceIdempotencyKey
+    workspace_id: WorkspaceId
+    branch_id: WorkspaceBranchId
+    base_revision: WorkspaceRevisionId
+    scratch: tuple[WorkspaceScratchDraft, ...] = Field(
+        default=(),
+        max_length=64,
+        description="Scratch entries to append.",
+    )
+    findings: tuple[WorkspaceFindingDraft, ...] = Field(
+        default=(),
+        max_length=64,
+        description="Typed epistemic cards to append.",
+    )
+    attempts: tuple[WorkspaceAttemptDraft, ...] = Field(
+        default=(),
+        max_length=64,
+        description="Operational attempt reports to append.",
+    )
+    marks: tuple[WorkspaceMarkDraft, ...] = Field(
+        default=(),
+        max_length=64,
+        description=(
+            "Explicit lifecycle marks to append. Marks never promote mathematical "
+            "assurance."
+        ),
+    )
+    focus: WorkspaceFocusDraft | None = Field(
+        default=None,
+        description=(
+            "Optional explicit focus replacement. Use active_ref/pinned_refs to set "
+            "focus or clear=true to clear it; omit focus to leave it unchanged."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def require_one_mutation_and_unique_refs(self) -> Self:
+        if not (
+            self.scratch or self.findings or self.attempts or self.marks or self.focus
+        ):
+            raise ValueError("workspace write requires at least one mutation")
+        if any(
+            finding.kind is WorkspaceFindingKind.PROBLEM for finding in self.findings
+        ):
+            raise ValueError(
+                "only workspace.open may create the canonical PROBLEM card"
+            )
+        refs = [
+            entry.client_ref
+            for entries in (self.scratch, self.findings, self.attempts, self.marks)
+            for entry in entries
+        ]
+        if len(set(refs)) != len(refs):
+            raise ValueError("workspace write client references must be unique")
+        mark_targets = [mark.target_ref for mark in self.marks]
+        if len(set(mark_targets)) != len(mark_targets):
+            raise ValueError(
+                "a workspace write may append at most one mark per target card"
+            )
+        if self.focus is not None:
+            focus_refs = {
+                reference
+                for reference in (
+                    self.focus.active_ref,
+                    *self.focus.pinned_refs,
+                )
+                if reference is not None
+            }
+            nonfinding_refs = (
+                {entry.client_ref for entry in self.scratch}
+                | {entry.client_ref for entry in self.attempts}
+                | {entry.client_ref for entry in self.marks}
+            )
+            if focus_refs & nonfinding_refs:
+                raise ValueError(
+                    "focus references must identify finding cards, not scratch or "
+                    "attempt entries"
+                )
+        return self
+
+
+class WorkspaceQueryRequest(ContractModel):
+    request_version: Literal["1"] = "1"
+    workspace_id: WorkspaceId
+    branch_id: WorkspaceBranchId
+    revision_id: WorkspaceRevisionId | None = Field(
+        default=None,
+        description=(
+            "Optional expected branch head. The query fails closed if the current "
+            "head differs; omit it to read the latest head."
+        ),
+    )
+    view: WorkspaceQueryView
+    target_card_id: WorkspaceCardId | None = None
+    limit: StrictInt = Field(default=10, ge=1, le=50)
+
+    @model_validator(mode="after")
+    def bind_target_to_targeted_views(self) -> Self:
+        if self.view is WorkspaceQueryView.CONTEXT and self.target_card_id is None:
+            raise ValueError("target_card_id is required for the CONTEXT view")
+        if self.target_card_id is not None and self.view not in (
+            WorkspaceQueryView.ATTEMPTS,
+            WorkspaceQueryView.CONTEXT,
+        ):
+            raise ValueError(
+                "target_card_id is only valid for ATTEMPTS or CONTEXT views"
+            )
+        return self
+
+
+class WorkspaceScratchEntry(ContractModel):
+    scratch_id: WorkspaceItemId
+    body: str
+    tags: tuple[str, ...] = ()
+    created_revision: WorkspaceRevisionId
+    created_at: datetime
+
+
+class WorkspaceFinding(ContractModel):
+    card_id: WorkspaceCardId
+    kind: WorkspaceFindingKind
+    title: str
+    body: str
+    dependency_ids: tuple[WorkspaceCardId, ...] = ()
+    assumption_ids: tuple[WorkspaceCardId, ...] = ()
+    tags: tuple[str, ...] = ()
+    assertion: Literal["AGENT_RECORDED"] = "AGENT_RECORDED"
+    verification: Literal["UNVERIFIED"] = "UNVERIFIED"
+    created_revision: WorkspaceRevisionId
+    created_at: datetime
+
+
+class WorkspaceAttempt(ContractModel):
+    attempt_id: WorkspaceItemId
+    target_card_id: WorkspaceCardId
+    method: str
+    outcome: WorkspaceAttemptOutcome
+    summary: str
+    artifact_uris: tuple[ArtifactUri, ...] = ()
+    tags: tuple[str, ...] = ()
+    assertion: Literal["AGENT_RECORDED"] = "AGENT_RECORDED"
+    verification: Literal["UNVERIFIED"] = "UNVERIFIED"
+    created_revision: WorkspaceRevisionId
+    created_at: datetime
+
+
+class WorkspaceMark(ContractModel):
+    mark_id: WorkspaceItemId
+    target_card_id: WorkspaceCardId
+    state: WorkspaceCardState
+    reason: str
+    superseded_by_id: WorkspaceCardId | None = None
+    assertion: Literal["AGENT_RECORDED"] = "AGENT_RECORDED"
+    verification: Literal["UNVERIFIED"] = "UNVERIFIED"
+    created_revision: WorkspaceRevisionId
+    created_at: datetime
+
+
+class WorkspaceFocus(ContractModel):
+    active_item_id: WorkspaceCardId | None = None
+    pinned_item_ids: tuple[WorkspaceCardId, ...] = ()
+    updated_revision: WorkspaceRevisionId
+
+
+class WorkspaceRevision(ContractModel):
+    revision_version: Literal["1"] = "1"
+    revision_id: WorkspaceRevisionId
+    workspace_id: WorkspaceId
+    branch_id: WorkspaceBranchId
+    parent_revision: WorkspaceRevisionId | None = None
+    operation: WorkspaceRevisionOperation
+    request_digest: Sha256Digest
+    scratch: tuple[WorkspaceScratchEntry, ...] = ()
+    findings: tuple[WorkspaceFinding, ...] = ()
+    attempts: tuple[WorkspaceAttempt, ...] = ()
+    marks: tuple[WorkspaceMark, ...] = ()
+    focus: WorkspaceFocus | None = None
+    created_at: datetime
+
+
+class WorkspaceOpenResult(ContractModel):
+    result_version: Literal["1"] = "1"
+    workspace_id: WorkspaceId
+    branch_id: WorkspaceBranchId
+    revision_id: WorkspaceRevisionId
+    revision_artifact_uri: ArtifactUri
+    problem_card_id: WorkspaceCardId
+
+
+class WorkspaceWriteResult(ContractModel):
+    result_version: Literal["1"] = "1"
+    workspace_id: WorkspaceId
+    branch_id: WorkspaceBranchId
+    revision_id: WorkspaceRevisionId
+    revision_artifact_uri: ArtifactUri
+    id_map: dict[WorkspaceClientRef, WorkspaceItemId]
+    scratch_written: StrictInt = Field(ge=0)
+    findings_written: StrictInt = Field(ge=0)
+    attempts_written: StrictInt = Field(ge=0)
+    marks_written: StrictInt = Field(default=0, ge=0)
+    focus_updated: bool
+
+
+class WorkspaceItemSummary(ContractModel):
+    card_id: WorkspaceCardId
+    kind: WorkspaceFindingKind
+    title: str
+    body_excerpt: str
+    dependency_ids: tuple[WorkspaceCardId, ...] = ()
+    assumption_ids: tuple[WorkspaceCardId, ...] = ()
+    tags: tuple[str, ...] = ()
+    state: WorkspaceCardState = WorkspaceCardState.ACTIVE
+    state_reason: str | None = None
+    state_mark_id: WorkspaceItemId | None = None
+    superseded_by_id: WorkspaceCardId | None = None
+    state_revision: WorkspaceRevisionId | None = None
+    state_revision_artifact_uri: ArtifactUri | None = None
+    stale: StrictBool = False
+    stale_due_to_ids: tuple[WorkspaceCardId, ...] = ()
+    verification: Literal["UNVERIFIED"] = "UNVERIFIED"
+    created_revision: WorkspaceRevisionId
+    created_revision_artifact_uri: ArtifactUri
+
+
+class WorkspaceScratchSummary(ContractModel):
+    scratch_id: WorkspaceItemId
+    body_excerpt: str
+    tags: tuple[str, ...] = ()
+    created_revision: WorkspaceRevisionId
+    created_revision_artifact_uri: ArtifactUri
+
+
+class WorkspaceAttemptSummary(ContractModel):
+    attempt_id: WorkspaceItemId
+    target_card_id: WorkspaceCardId
+    method: str
+    outcome: WorkspaceAttemptOutcome
+    summary_excerpt: str
+    artifact_uris: tuple[ArtifactUri, ...] = ()
+    verification: Literal["UNVERIFIED"] = "UNVERIFIED"
+    created_revision: WorkspaceRevisionId
+    created_revision_artifact_uri: ArtifactUri
+
+
+class WorkspaceResumeView(ContractModel):
+    name: str
+    problem: WorkspaceItemSummary
+    active_item: WorkspaceItemSummary | None = None
+    pinned_items: tuple[WorkspaceItemSummary, ...] = ()
+    open_goals: tuple[WorkspaceItemSummary, ...] = ()
+    stale_items: tuple[WorkspaceItemSummary, ...] = ()
+    recent_findings: tuple[WorkspaceItemSummary, ...] = ()
+    recent_attempts: tuple[WorkspaceAttemptSummary, ...] = ()
+    recent_scratch: tuple[WorkspaceScratchSummary, ...] = ()
+
+
+class WorkspaceFrontierItem(ContractModel):
+    goal: WorkspaceItemSummary
+    attempt_count: StrictInt = Field(ge=0)
+    last_attempt: WorkspaceAttemptSummary | None = None
+
+
+class WorkspaceContextView(ContractModel):
+    target: WorkspaceItemSummary
+    dependencies: tuple[WorkspaceItemSummary, ...] = ()
+    recent_attempts: tuple[WorkspaceAttemptSummary, ...] = ()
+    total_dependency_count: StrictInt = Field(ge=0)
+    truncated: StrictBool = False
+
+
+class WorkspaceQueryResult(ContractModel):
+    result_version: Literal["1"] = "1"
+    workspace_id: WorkspaceId
+    branch_id: WorkspaceBranchId
+    revision_id: WorkspaceRevisionId
+    revision_artifact_uri: ArtifactUri
+    view: WorkspaceQueryView
+    warning: Literal[
+        "Workspace content is agent-authored and unverified; retrieval does not "
+        "promote mathematical assurance. Derived staleness follows explicit recorded "
+        "links only."
+    ] = (
+        "Workspace content is agent-authored and unverified; retrieval does not "
+        "promote mathematical assurance. Derived staleness follows explicit recorded "
+        "links only."
+    )
+    resume: WorkspaceResumeView | None = None
+    frontier: tuple[WorkspaceFrontierItem, ...] = ()
+    attempts: tuple[WorkspaceAttemptSummary, ...] = ()
+    context: WorkspaceContextView | None = None
+    stale_items: tuple[WorkspaceItemSummary, ...] = ()
+
+    @model_validator(mode="after")
+    def require_selected_view_payload(self) -> Self:
+        if self.view is WorkspaceQueryView.RESUME and self.resume is None:
+            raise ValueError("RESUME query result requires a resume payload")
+        if self.view is not WorkspaceQueryView.RESUME and self.resume is not None:
+            raise ValueError("only RESUME query results may carry a resume payload")
+        if self.view is not WorkspaceQueryView.FRONTIER and self.frontier:
+            raise ValueError("only FRONTIER query results may carry frontier items")
+        if self.view is not WorkspaceQueryView.ATTEMPTS and self.attempts:
+            raise ValueError("only ATTEMPTS query results may carry attempts")
+        if self.view is WorkspaceQueryView.CONTEXT and self.context is None:
+            raise ValueError("CONTEXT query result requires a context payload")
+        if self.view is not WorkspaceQueryView.CONTEXT and self.context is not None:
+            raise ValueError("only CONTEXT query results may carry a context payload")
+        if self.view is not WorkspaceQueryView.STALE and self.stale_items:
+            raise ValueError("only STALE query results may carry stale items")
+        return self

--- a/src/jacobian/kernel.py
+++ b/src/jacobian/kernel.py
@@ -46,6 +46,7 @@ from jacobian.structures import StructureService
 from jacobian.transformations import TransformationService
 from jacobian.verification import VerificationService
 from jacobian.witnesses import WitnessSearchService
+from jacobian.workspaces import WorkspaceService
 
 
 class JacobianKernel:
@@ -62,6 +63,7 @@ class JacobianKernel:
         self.schemas = SchemaRegistry(self.store)
         self.artifacts = ArtifactService(self.store, self.schemas)
         self.memory = ResearchMemory(self.store, self.schemas)
+        self.workspaces = WorkspaceService(self.store, self.schemas)
         self.plugins = PluginRegistry(self.store)
         self.checkers = CheckerRegistry(self.store.db_path)
         self.claims = ClaimValidationService(

--- a/src/jacobian/workspaces.py
+++ b/src/jacobian/workspaces.py
@@ -1,0 +1,1798 @@
+"""Durable agent-authored working state without mathematical promotion."""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+import uuid
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import TypeVar
+
+from jacobian.canonical import canonicalize_json, loads_strict_json
+from jacobian.contracts.results import ContractModel
+from jacobian.contracts.workspaces import (
+    WorkspaceAttempt,
+    WorkspaceAttemptSummary,
+    WorkspaceCardId,
+    WorkspaceCardState,
+    WorkspaceContextView,
+    WorkspaceFinding,
+    WorkspaceFindingDraft,
+    WorkspaceFindingKind,
+    WorkspaceFocus,
+    WorkspaceFocusDraft,
+    WorkspaceFrontierItem,
+    WorkspaceItemSummary,
+    WorkspaceMark,
+    WorkspaceOpenRequest,
+    WorkspaceOpenResult,
+    WorkspaceQueryRequest,
+    WorkspaceQueryResult,
+    WorkspaceQueryView,
+    WorkspaceResumeView,
+    WorkspaceRevision,
+    WorkspaceRevisionId,
+    WorkspaceRevisionOperation,
+    WorkspaceScratchEntry,
+    WorkspaceScratchSummary,
+    WorkspaceWriteRequest,
+    WorkspaceWriteResult,
+)
+from jacobian.schema_registry import SchemaRegistry
+from jacobian.store import ArtifactStore, StoreError
+
+
+class WorkspaceError(RuntimeError):
+    """Base error for invalid or unavailable workspace operations."""
+
+
+class WorkspaceNotFoundError(WorkspaceError):
+    """The requested workspace, branch, revision, or item does not exist."""
+
+
+class WorkspaceConflictError(WorkspaceError):
+    """A write is based on a branch revision that is no longer current."""
+
+
+class WorkspaceIdempotencyError(WorkspaceError):
+    """An idempotency key was already accepted for another request."""
+
+
+class WorkspaceReferenceError(WorkspaceError):
+    """A workspace entry cites a missing or incompatible explicit reference."""
+
+
+@dataclass(frozen=True, slots=True)
+class _PreparedWrite:
+    revision: WorkspaceRevision
+    revision_artifact_uri: str
+    id_map: dict[str, str]
+
+
+@dataclass(frozen=True, slots=True)
+class _WorkspaceProjection:
+    findings: dict[str, WorkspaceFinding]
+    finding_order: dict[str, int]
+    marks: dict[str, WorkspaceMark]
+    stale_due_to: dict[str, tuple[str, ...]]
+
+
+_ModelT = TypeVar("_ModelT", bound=ContractModel)
+_INVALIDATING_CARD_STATES = frozenset(
+    {
+        WorkspaceCardState.RETRACTED,
+        WorkspaceCardState.SUPERSEDED,
+    }
+)
+
+
+class WorkspaceService:
+    """Persist revisioned epistemic state while keeping every assertion unverified."""
+
+    def __init__(self, store: ArtifactStore, schemas: SchemaRegistry) -> None:
+        self.store = store
+        self.schemas = schemas
+        self.revision_schema_uri = schemas.register(
+            name="jacobian.workspace-revision",
+            version="1",
+            schema=WorkspaceRevision.model_json_schema(),
+        )
+        self.revision_semantics_uri = store.register_descriptor(
+            kind="semantics",
+            name="jacobian.workspace-revision",
+            version="1",
+            definition={
+                "description": (
+                    "agent-authored epistemic workspace state; stored assertions and "
+                    "retrieval views are unverified and cannot promote assurance"
+                )
+            },
+        )
+        self._initialize_database()
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.store.db_path, timeout=30)
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA foreign_keys = ON")
+        return connection
+
+    def _initialize_database(self) -> None:
+        with self._connect() as connection:
+            connection.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS workspaces (
+                    workspace_id TEXT PRIMARY KEY,
+                    name TEXT NOT NULL,
+                    root_branch_id TEXT NOT NULL UNIQUE,
+                    created_at TEXT NOT NULL,
+                    FOREIGN KEY (root_branch_id)
+                        REFERENCES workspace_branches(branch_id)
+                        ON DELETE RESTRICT
+                        DEFERRABLE INITIALLY DEFERRED
+                );
+                CREATE TABLE IF NOT EXISTS workspace_branches (
+                    branch_id TEXT PRIMARY KEY,
+                    workspace_id TEXT NOT NULL,
+                    alias TEXT NOT NULL,
+                    head_revision_id TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    UNIQUE (workspace_id, alias),
+                    FOREIGN KEY (workspace_id)
+                        REFERENCES workspaces(workspace_id)
+                        ON DELETE RESTRICT,
+                    FOREIGN KEY (head_revision_id)
+                        REFERENCES workspace_revisions(revision_id)
+                        ON DELETE RESTRICT
+                        DEFERRABLE INITIALLY DEFERRED
+                );
+                CREATE TABLE IF NOT EXISTS workspace_revisions (
+                    revision_id TEXT PRIMARY KEY,
+                    revision_artifact_uri TEXT NOT NULL UNIQUE,
+                    workspace_id TEXT NOT NULL,
+                    branch_id TEXT NOT NULL,
+                    parent_revision_id TEXT,
+                    request_digest TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    FOREIGN KEY (revision_artifact_uri)
+                        REFERENCES artifacts(artifact_uri)
+                        ON DELETE RESTRICT,
+                    FOREIGN KEY (workspace_id)
+                        REFERENCES workspaces(workspace_id)
+                        ON DELETE RESTRICT,
+                    FOREIGN KEY (branch_id)
+                        REFERENCES workspace_branches(branch_id)
+                        ON DELETE RESTRICT,
+                    FOREIGN KEY (parent_revision_id)
+                        REFERENCES workspace_revisions(revision_id)
+                        ON DELETE RESTRICT
+                );
+                CREATE TABLE IF NOT EXISTS workspace_idempotency (
+                    idempotency_key TEXT PRIMARY KEY,
+                    operation TEXT NOT NULL,
+                    request_digest TEXT NOT NULL,
+                    response_json BLOB NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS workspace_scratch (
+                    scratch_id TEXT PRIMARY KEY,
+                    workspace_id TEXT NOT NULL,
+                    branch_id TEXT NOT NULL,
+                    created_revision_id TEXT NOT NULL,
+                    payload_json BLOB NOT NULL,
+                    created_at TEXT NOT NULL,
+                    FOREIGN KEY (workspace_id)
+                        REFERENCES workspaces(workspace_id)
+                        ON DELETE RESTRICT,
+                    FOREIGN KEY (branch_id)
+                        REFERENCES workspace_branches(branch_id)
+                        ON DELETE RESTRICT,
+                    FOREIGN KEY (created_revision_id)
+                        REFERENCES workspace_revisions(revision_id)
+                        ON DELETE RESTRICT
+                );
+                CREATE TABLE IF NOT EXISTS workspace_findings (
+                    card_id TEXT PRIMARY KEY,
+                    workspace_id TEXT NOT NULL,
+                    branch_id TEXT NOT NULL,
+                    kind TEXT NOT NULL,
+                    created_revision_id TEXT NOT NULL,
+                    payload_json BLOB NOT NULL,
+                    created_at TEXT NOT NULL,
+                    FOREIGN KEY (workspace_id)
+                        REFERENCES workspaces(workspace_id)
+                        ON DELETE RESTRICT,
+                    FOREIGN KEY (branch_id)
+                        REFERENCES workspace_branches(branch_id)
+                        ON DELETE RESTRICT,
+                    FOREIGN KEY (created_revision_id)
+                        REFERENCES workspace_revisions(revision_id)
+                        ON DELETE RESTRICT
+                );
+                CREATE INDEX IF NOT EXISTS workspace_findings_lookup
+                    ON workspace_findings(
+                        workspace_id, branch_id, kind, created_at
+                    );
+                CREATE TABLE IF NOT EXISTS workspace_attempts (
+                    attempt_id TEXT PRIMARY KEY,
+                    workspace_id TEXT NOT NULL,
+                    branch_id TEXT NOT NULL,
+                    target_card_id TEXT NOT NULL,
+                    outcome TEXT NOT NULL,
+                    created_revision_id TEXT NOT NULL,
+                    payload_json BLOB NOT NULL,
+                    created_at TEXT NOT NULL,
+                    FOREIGN KEY (workspace_id)
+                        REFERENCES workspaces(workspace_id)
+                        ON DELETE RESTRICT,
+                    FOREIGN KEY (branch_id)
+                        REFERENCES workspace_branches(branch_id)
+                        ON DELETE RESTRICT,
+                    FOREIGN KEY (target_card_id)
+                        REFERENCES workspace_findings(card_id)
+                        ON DELETE RESTRICT,
+                    FOREIGN KEY (created_revision_id)
+                        REFERENCES workspace_revisions(revision_id)
+                        ON DELETE RESTRICT
+                );
+                CREATE INDEX IF NOT EXISTS workspace_attempts_lookup
+                    ON workspace_attempts(
+                        workspace_id, branch_id, target_card_id, created_at
+                    );
+                CREATE TABLE IF NOT EXISTS workspace_marks (
+                    mark_id TEXT PRIMARY KEY,
+                    workspace_id TEXT NOT NULL,
+                    branch_id TEXT NOT NULL,
+                    target_card_id TEXT NOT NULL,
+                    state TEXT NOT NULL,
+                    created_revision_id TEXT NOT NULL,
+                    payload_json BLOB NOT NULL,
+                    created_at TEXT NOT NULL,
+                    FOREIGN KEY (workspace_id)
+                        REFERENCES workspaces(workspace_id)
+                        ON DELETE RESTRICT,
+                    FOREIGN KEY (branch_id)
+                        REFERENCES workspace_branches(branch_id)
+                        ON DELETE RESTRICT,
+                    FOREIGN KEY (target_card_id)
+                        REFERENCES workspace_findings(card_id)
+                        ON DELETE RESTRICT,
+                    FOREIGN KEY (created_revision_id)
+                        REFERENCES workspace_revisions(revision_id)
+                        ON DELETE RESTRICT
+                );
+                CREATE INDEX IF NOT EXISTS workspace_marks_lookup
+                    ON workspace_marks(
+                        workspace_id, branch_id, target_card_id, created_at
+                    );
+                CREATE TABLE IF NOT EXISTS workspace_focus (
+                    branch_id TEXT PRIMARY KEY,
+                    workspace_id TEXT NOT NULL,
+                    updated_revision_id TEXT NOT NULL,
+                    payload_json BLOB NOT NULL,
+                    FOREIGN KEY (branch_id)
+                        REFERENCES workspace_branches(branch_id)
+                        ON DELETE RESTRICT,
+                    FOREIGN KEY (workspace_id)
+                        REFERENCES workspaces(workspace_id)
+                        ON DELETE RESTRICT,
+                    FOREIGN KEY (updated_revision_id)
+                        REFERENCES workspace_revisions(revision_id)
+                        ON DELETE RESTRICT
+                );
+                """
+            )
+
+    def open(self, request: WorkspaceOpenRequest) -> WorkspaceOpenResult:
+        selected = WorkspaceOpenRequest.model_validate(request)
+        request_digest = _request_digest(
+            WorkspaceRevisionOperation.OPEN,
+            selected.model_dump(mode="json"),
+        )
+        with self._connect() as connection:
+            reused = self._reuse(
+                connection,
+                idempotency_key=selected.idempotency_key,
+                operation=WorkspaceRevisionOperation.OPEN,
+                request_digest=request_digest,
+                result_type=WorkspaceOpenResult,
+            )
+            if reused is not None:
+                return reused
+
+        workspace_id = _opaque_id("workspace")
+        branch_id = _opaque_id("branch")
+        revision_id = _opaque_id("revision")
+        problem_card_id = _opaque_id("card")
+        now = _now()
+        problem = WorkspaceFinding(
+            card_id=problem_card_id,
+            kind=WorkspaceFindingKind.PROBLEM,
+            title=selected.name,
+            body=selected.problem,
+            tags=selected.tags,
+            created_revision=revision_id,
+            created_at=now,
+        )
+        focus = WorkspaceFocus(
+            active_item_id=problem_card_id,
+            pinned_item_ids=(problem_card_id,),
+            updated_revision=revision_id,
+        )
+        revision = WorkspaceRevision(
+            revision_id=revision_id,
+            workspace_id=workspace_id,
+            branch_id=branch_id,
+            operation=WorkspaceRevisionOperation.OPEN,
+            request_digest=request_digest,
+            findings=(problem,),
+            focus=focus,
+            created_at=now,
+        )
+        stored = self.store.put(
+            schema_uri=self.revision_schema_uri,
+            semantics_uri=self.revision_semantics_uri,
+            payload=revision.model_dump(mode="json"),
+            summary=f"open epistemic workspace {selected.name}",
+        )
+        result = WorkspaceOpenResult(
+            workspace_id=workspace_id,
+            branch_id=branch_id,
+            revision_id=revision_id,
+            revision_artifact_uri=stored.artifact_uri,
+            problem_card_id=problem_card_id,
+        )
+
+        with self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            reused = self._reuse(
+                connection,
+                idempotency_key=selected.idempotency_key,
+                operation=WorkspaceRevisionOperation.OPEN,
+                request_digest=request_digest,
+                result_type=WorkspaceOpenResult,
+            )
+            if reused is not None:
+                return reused
+            timestamp = now.isoformat()
+            connection.execute(
+                """
+                INSERT INTO workspaces(
+                    workspace_id, name, root_branch_id, created_at
+                ) VALUES (?, ?, ?, ?)
+                """,
+                (workspace_id, selected.name, branch_id, timestamp),
+            )
+            connection.execute(
+                """
+                INSERT INTO workspace_branches(
+                    branch_id, workspace_id, alias, head_revision_id, created_at
+                ) VALUES (?, ?, 'main', ?, ?)
+                """,
+                (branch_id, workspace_id, revision_id, timestamp),
+            )
+            self._insert_revision(
+                connection,
+                revision,
+                stored.artifact_uri,
+            )
+            self._insert_finding(connection, workspace_id, branch_id, problem)
+            self._upsert_focus(connection, workspace_id, branch_id, focus)
+            self._bind_idempotency(
+                connection,
+                selected.idempotency_key,
+                WorkspaceRevisionOperation.OPEN,
+                request_digest,
+                result,
+            )
+        return result
+
+    def write(self, request: WorkspaceWriteRequest) -> WorkspaceWriteResult:
+        selected = WorkspaceWriteRequest.model_validate(request)
+        request_digest = _request_digest(
+            WorkspaceRevisionOperation.WRITE,
+            selected.model_dump(mode="json"),
+        )
+        with self._connect() as connection:
+            reused = self._reuse(
+                connection,
+                idempotency_key=selected.idempotency_key,
+                operation=WorkspaceRevisionOperation.WRITE,
+                request_digest=request_digest,
+                result_type=WorkspaceWriteResult,
+            )
+            if reused is not None:
+                return reused
+            prepared = self._prepare_write(connection, selected, request_digest)
+
+        result = WorkspaceWriteResult(
+            workspace_id=selected.workspace_id,
+            branch_id=selected.branch_id,
+            revision_id=prepared.revision.revision_id,
+            revision_artifact_uri=prepared.revision_artifact_uri,
+            id_map=prepared.id_map,
+            scratch_written=len(prepared.revision.scratch),
+            findings_written=len(prepared.revision.findings),
+            attempts_written=len(prepared.revision.attempts),
+            marks_written=len(prepared.revision.marks),
+            focus_updated=prepared.revision.focus is not None,
+        )
+
+        with self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            reused = self._reuse(
+                connection,
+                idempotency_key=selected.idempotency_key,
+                operation=WorkspaceRevisionOperation.WRITE,
+                request_digest=request_digest,
+                result_type=WorkspaceWriteResult,
+            )
+            if reused is not None:
+                return reused
+            self._require_head(
+                connection,
+                selected.workspace_id,
+                selected.branch_id,
+                selected.base_revision,
+            )
+            self._insert_revision(
+                connection,
+                prepared.revision,
+                prepared.revision_artifact_uri,
+            )
+            for entry in prepared.revision.scratch:
+                self._insert_scratch(
+                    connection,
+                    selected.workspace_id,
+                    selected.branch_id,
+                    entry,
+                )
+            for finding in prepared.revision.findings:
+                self._insert_finding(
+                    connection,
+                    selected.workspace_id,
+                    selected.branch_id,
+                    finding,
+                )
+            for attempt in prepared.revision.attempts:
+                self._insert_attempt(
+                    connection,
+                    selected.workspace_id,
+                    selected.branch_id,
+                    attempt,
+                )
+            for mark in prepared.revision.marks:
+                self._insert_mark(
+                    connection,
+                    selected.workspace_id,
+                    selected.branch_id,
+                    mark,
+                )
+            if prepared.revision.focus is not None:
+                self._upsert_focus(
+                    connection,
+                    selected.workspace_id,
+                    selected.branch_id,
+                    prepared.revision.focus,
+                )
+            updated = connection.execute(
+                """
+                UPDATE workspace_branches
+                SET head_revision_id = ?
+                WHERE branch_id = ?
+                  AND workspace_id = ?
+                  AND head_revision_id = ?
+                """,
+                (
+                    prepared.revision.revision_id,
+                    selected.branch_id,
+                    selected.workspace_id,
+                    selected.base_revision,
+                ),
+            )
+            if updated.rowcount != 1:
+                raise WorkspaceConflictError(
+                    "workspace branch advanced before the write could commit"
+                )
+            self._bind_idempotency(
+                connection,
+                selected.idempotency_key,
+                WorkspaceRevisionOperation.WRITE,
+                request_digest,
+                result,
+            )
+        return result
+
+    def query(self, request: WorkspaceQueryRequest) -> WorkspaceQueryResult:
+        selected = WorkspaceQueryRequest.model_validate(request)
+        with self._connect() as connection:
+            connection.execute("BEGIN")
+            branch = self._branch_row(
+                connection,
+                selected.workspace_id,
+                selected.branch_id,
+            )
+            revision_id = branch["head_revision_id"]
+            revision_artifact_uri = branch["revision_artifact_uri"]
+            if selected.revision_id is not None and selected.revision_id != revision_id:
+                raise WorkspaceConflictError(
+                    f"query revision_id is stale; current branch head is {revision_id}"
+                )
+            projection = self._projection(connection, selected)
+            if selected.view is WorkspaceQueryView.RESUME:
+                resume = self._resume_view(connection, selected, projection)
+                return WorkspaceQueryResult(
+                    workspace_id=selected.workspace_id,
+                    branch_id=selected.branch_id,
+                    revision_id=revision_id,
+                    revision_artifact_uri=revision_artifact_uri,
+                    view=selected.view,
+                    resume=resume,
+                )
+            if selected.view is WorkspaceQueryView.FRONTIER:
+                frontier = self._frontier_view(connection, selected, projection)
+                return WorkspaceQueryResult(
+                    workspace_id=selected.workspace_id,
+                    branch_id=selected.branch_id,
+                    revision_id=revision_id,
+                    revision_artifact_uri=revision_artifact_uri,
+                    view=selected.view,
+                    frontier=frontier,
+                )
+            if selected.view is WorkspaceQueryView.ATTEMPTS:
+                attempts = self._attempts_view(connection, selected, projection)
+                return WorkspaceQueryResult(
+                    workspace_id=selected.workspace_id,
+                    branch_id=selected.branch_id,
+                    revision_id=revision_id,
+                    revision_artifact_uri=revision_artifact_uri,
+                    view=selected.view,
+                    attempts=attempts,
+                )
+            if selected.view is WorkspaceQueryView.CONTEXT:
+                context = self._context_view(connection, selected, projection)
+                return WorkspaceQueryResult(
+                    workspace_id=selected.workspace_id,
+                    branch_id=selected.branch_id,
+                    revision_id=revision_id,
+                    revision_artifact_uri=revision_artifact_uri,
+                    view=selected.view,
+                    context=context,
+                )
+            stale_items = tuple(
+                self._finding_summary(connection, item, projection)
+                for item in self._ordered_findings(
+                    projection,
+                    lambda item: bool(projection.stale_due_to[item.card_id]),
+                    selected.limit,
+                )
+            )
+            return WorkspaceQueryResult(
+                workspace_id=selected.workspace_id,
+                branch_id=selected.branch_id,
+                revision_id=revision_id,
+                revision_artifact_uri=revision_artifact_uri,
+                view=selected.view,
+                stale_items=stale_items,
+            )
+
+    def _prepare_write(
+        self,
+        connection: sqlite3.Connection,
+        request: WorkspaceWriteRequest,
+        request_digest: str,
+    ) -> _PreparedWrite:
+        branch = self._require_head(
+            connection,
+            request.workspace_id,
+            request.branch_id,
+            request.base_revision,
+        )
+        revision_id = _opaque_id("revision")
+        now = _now()
+        id_map: dict[str, str] = {}
+        for scratch_draft in request.scratch:
+            id_map[scratch_draft.client_ref] = _opaque_id("scratch")
+        for finding_draft in request.findings:
+            id_map[finding_draft.client_ref] = _opaque_id("card")
+        for attempt_draft in request.attempts:
+            id_map[attempt_draft.client_ref] = _opaque_id("attempt")
+        for mark_draft in request.marks:
+            id_map[mark_draft.client_ref] = _opaque_id("mark")
+
+        existing_findings = self._referenced_findings(connection, request)
+        finding_drafts = {
+            finding_draft.client_ref: finding_draft
+            for finding_draft in request.findings
+        }
+
+        def resolve_finding(reference: str) -> WorkspaceFinding | WorkspaceFindingDraft:
+            draft = finding_drafts.get(reference)
+            if draft is not None:
+                return draft
+            existing = existing_findings.get(reference)
+            if existing is None:
+                raise WorkspaceReferenceError(
+                    f"workspace finding reference does not exist: {reference}"
+                )
+            return existing
+
+        findings: list[WorkspaceFinding] = []
+        for finding_draft in request.findings:
+            if finding_draft.kind is WorkspaceFindingKind.PROBLEM:
+                raise WorkspaceReferenceError(
+                    "only workspace.open may create the canonical PROBLEM card"
+                )
+            card_id = id_map[finding_draft.client_ref]
+            dependency_ids = tuple(
+                self._resolved_card_id(reference, id_map, resolve_finding(reference))
+                for reference in finding_draft.dependency_refs
+            )
+            assumption_ids: list[str] = []
+            for reference in finding_draft.assumption_refs:
+                assumption_target = resolve_finding(reference)
+                if assumption_target.kind is not WorkspaceFindingKind.ASSUMPTION:
+                    raise WorkspaceReferenceError(
+                        f"assumption reference is not an ASSUMPTION: {reference}"
+                    )
+                assumption_ids.append(
+                    self._resolved_card_id(reference, id_map, assumption_target)
+                )
+            if card_id in dependency_ids or card_id in assumption_ids:
+                raise WorkspaceReferenceError("a finding cannot depend on itself")
+            findings.append(
+                WorkspaceFinding(
+                    card_id=card_id,
+                    kind=finding_draft.kind,
+                    title=finding_draft.title,
+                    body=finding_draft.body,
+                    dependency_ids=dependency_ids,
+                    assumption_ids=tuple(assumption_ids),
+                    tags=finding_draft.tags,
+                    created_revision=revision_id,
+                    created_at=now,
+                )
+            )
+        _reject_new_dependency_cycles(findings)
+
+        scratch = tuple(
+            WorkspaceScratchEntry(
+                scratch_id=id_map[draft.client_ref],
+                body=draft.body,
+                tags=draft.tags,
+                created_revision=revision_id,
+                created_at=now,
+            )
+            for draft in request.scratch
+        )
+        finding_by_ref: dict[str, WorkspaceFinding | WorkspaceFindingDraft] = {
+            **existing_findings,
+            **finding_drafts,
+        }
+        attempts: list[WorkspaceAttempt] = []
+        attached_artifacts: list[str] = []
+        for attempt_draft in request.attempts:
+            attempt_target = finding_by_ref.get(attempt_draft.target_ref)
+            if attempt_target is None:
+                raise WorkspaceReferenceError(
+                    f"attempt target does not exist: {attempt_draft.target_ref}"
+                )
+            for artifact_uri in attempt_draft.artifact_uris:
+                try:
+                    self.store.get(artifact_uri)
+                except StoreError as exc:
+                    raise WorkspaceReferenceError(
+                        f"attempt artifact does not exist: {artifact_uri}"
+                    ) from exc
+                attached_artifacts.append(artifact_uri)
+            attempts.append(
+                WorkspaceAttempt(
+                    attempt_id=id_map[attempt_draft.client_ref],
+                    target_card_id=self._resolved_card_id(
+                        attempt_draft.target_ref,
+                        id_map,
+                        attempt_target,
+                    ),
+                    method=attempt_draft.method,
+                    outcome=attempt_draft.outcome,
+                    summary=attempt_draft.summary,
+                    artifact_uris=attempt_draft.artifact_uris,
+                    tags=attempt_draft.tags,
+                    created_revision=revision_id,
+                    created_at=now,
+                )
+            )
+
+        current_marks = self._current_marks(
+            connection,
+            request.workspace_id,
+            request.branch_id,
+        )
+        marks: list[WorkspaceMark] = []
+        for mark_draft in request.marks:
+            mark_target = finding_by_ref.get(mark_draft.target_ref)
+            if mark_target is None:
+                raise WorkspaceReferenceError(
+                    f"mark target does not exist: {mark_draft.target_ref}"
+                )
+            if mark_target.kind is WorkspaceFindingKind.PROBLEM:
+                raise WorkspaceReferenceError(
+                    "the canonical PROBLEM card cannot be lifecycle-marked"
+                )
+            if (
+                mark_draft.state is WorkspaceCardState.CLOSED
+                and mark_target.kind
+                not in (WorkspaceFindingKind.GOAL, WorkspaceFindingKind.OPEN_QUESTION)
+            ):
+                raise WorkspaceReferenceError(
+                    "CLOSED marks apply only to GOAL or OPEN_QUESTION cards"
+                )
+            target_card_id = self._resolved_card_id(
+                mark_draft.target_ref,
+                id_map,
+                mark_target,
+            )
+            current_mark = current_marks.get(target_card_id)
+            if (
+                current_mark is not None
+                and current_mark.state in _INVALIDATING_CARD_STATES
+                and mark_draft.state
+                not in {
+                    WorkspaceCardState.ACTIVE,
+                    *_INVALIDATING_CARD_STATES,
+                }
+            ):
+                raise WorkspaceReferenceError(
+                    "a RETRACTED or SUPERSEDED card must be marked ACTIVE before "
+                    "it can be CLOSED or ARCHIVED"
+                )
+            superseded_by_id: str | None = None
+            if mark_draft.superseded_by_ref is not None:
+                replacement = finding_by_ref.get(mark_draft.superseded_by_ref)
+                if replacement is None:
+                    raise WorkspaceReferenceError(
+                        "superseding replacement does not exist: "
+                        f"{mark_draft.superseded_by_ref}"
+                    )
+                superseded_by_id = self._resolved_card_id(
+                    mark_draft.superseded_by_ref,
+                    id_map,
+                    replacement,
+                )
+                if superseded_by_id == target_card_id:
+                    raise WorkspaceReferenceError("a card cannot supersede itself")
+            marks.append(
+                WorkspaceMark(
+                    mark_id=id_map[mark_draft.client_ref],
+                    target_card_id=target_card_id,
+                    state=mark_draft.state,
+                    reason=mark_draft.reason,
+                    superseded_by_id=superseded_by_id,
+                    created_revision=revision_id,
+                    created_at=now,
+                )
+            )
+        _reject_supersession_cycles(
+            current_marks.values(),
+            marks,
+        )
+
+        focus = self._resolve_focus(
+            request.focus,
+            id_map,
+            finding_by_ref,
+            revision_id,
+        )
+        revision = WorkspaceRevision(
+            revision_id=revision_id,
+            workspace_id=request.workspace_id,
+            branch_id=request.branch_id,
+            parent_revision=request.base_revision,
+            operation=WorkspaceRevisionOperation.WRITE,
+            request_digest=request_digest,
+            scratch=scratch,
+            findings=tuple(findings),
+            attempts=tuple(attempts),
+            marks=tuple(marks),
+            focus=focus,
+            created_at=now,
+        )
+        parents = tuple(
+            dict.fromkeys(
+                (
+                    branch["revision_artifact_uri"],
+                    *attached_artifacts,
+                )
+            )
+        )
+        stored = self.store.put(
+            schema_uri=self.revision_schema_uri,
+            semantics_uri=self.revision_semantics_uri,
+            payload=revision.model_dump(mode="json"),
+            parents=parents,
+            summary=(
+                f"workspace revision with {len(scratch)} scratch entries, "
+                f"{len(findings)} findings, {len(attempts)} attempts, and "
+                f"{len(marks)} marks"
+            ),
+        )
+        return _PreparedWrite(
+            revision=revision,
+            revision_artifact_uri=stored.artifact_uri,
+            id_map=id_map,
+        )
+
+    def _referenced_findings(
+        self,
+        connection: sqlite3.Connection,
+        request: WorkspaceWriteRequest,
+    ) -> dict[str, WorkspaceFinding]:
+        references = {
+            reference
+            for draft in request.findings
+            for reference in (*draft.dependency_refs, *draft.assumption_refs)
+            if reference.startswith("card://")
+        }
+        references.update(
+            draft.target_ref
+            for draft in request.attempts
+            if draft.target_ref.startswith("card://")
+        )
+        references.update(
+            reference
+            for draft in request.marks
+            for reference in (draft.target_ref, draft.superseded_by_ref)
+            if reference is not None and reference.startswith("card://")
+        )
+        if request.focus is not None:
+            if (
+                request.focus.active_ref is not None
+                and request.focus.active_ref.startswith("card://")
+            ):
+                references.add(request.focus.active_ref)
+            references.update(
+                reference
+                for reference in request.focus.pinned_refs
+                if reference.startswith("card://")
+            )
+        result: dict[str, WorkspaceFinding] = {}
+        for reference in sorted(references):
+            row = connection.execute(
+                """
+                SELECT payload_json
+                FROM workspace_findings
+                WHERE card_id = ? AND workspace_id = ? AND branch_id = ?
+                """,
+                (reference, request.workspace_id, request.branch_id),
+            ).fetchone()
+            if row is None:
+                raise WorkspaceReferenceError(
+                    f"workspace finding reference does not exist: {reference}"
+                )
+            result[reference] = _model_from_json(
+                WorkspaceFinding,
+                row["payload_json"],
+            )
+        return result
+
+    def _resolve_focus(
+        self,
+        draft: WorkspaceFocusDraft | None,
+        id_map: dict[str, str],
+        findings: dict[str, WorkspaceFinding | WorkspaceFindingDraft],
+        revision_id: WorkspaceRevisionId,
+    ) -> WorkspaceFocus | None:
+        if draft is None:
+            return None
+
+        def resolve(reference: str) -> str:
+            target = findings.get(reference)
+            if target is None:
+                raise WorkspaceReferenceError(
+                    f"focus finding reference does not exist: {reference}"
+                )
+            return self._resolved_card_id(reference, id_map, target)
+
+        return WorkspaceFocus(
+            active_item_id=(
+                resolve(draft.active_ref) if draft.active_ref is not None else None
+            ),
+            pinned_item_ids=tuple(
+                resolve(reference) for reference in draft.pinned_refs
+            ),
+            updated_revision=revision_id,
+        )
+
+    @staticmethod
+    def _resolved_card_id(
+        reference: str,
+        id_map: dict[str, str],
+        target: WorkspaceFinding | WorkspaceFindingDraft,
+    ) -> WorkspaceCardId:
+        if isinstance(target, WorkspaceFinding):
+            return target.card_id
+        return id_map[reference]
+
+    def _require_head(
+        self,
+        connection: sqlite3.Connection,
+        workspace_id: str,
+        branch_id: str,
+        base_revision: str,
+    ) -> sqlite3.Row:
+        branch = self._branch_row(connection, workspace_id, branch_id)
+        if branch["head_revision_id"] != base_revision:
+            raise WorkspaceConflictError(
+                "base_revision is stale; query the workspace and retry from its head"
+            )
+        return branch
+
+    @staticmethod
+    def _branch_row(
+        connection: sqlite3.Connection,
+        workspace_id: str,
+        branch_id: str,
+    ) -> sqlite3.Row:
+        row: sqlite3.Row | None = connection.execute(
+            """
+            SELECT b.head_revision_id, r.revision_artifact_uri, w.name
+            FROM workspace_branches AS b
+            JOIN workspaces AS w ON w.workspace_id = b.workspace_id
+            JOIN workspace_revisions AS r
+              ON r.revision_id = b.head_revision_id
+            WHERE b.workspace_id = ? AND b.branch_id = ?
+            """,
+            (workspace_id, branch_id),
+        ).fetchone()
+        if row is None:
+            raise WorkspaceNotFoundError("workspace branch does not exist")
+        return row
+
+    @staticmethod
+    def _current_marks(
+        connection: sqlite3.Connection,
+        workspace_id: str,
+        branch_id: str,
+    ) -> dict[str, WorkspaceMark]:
+        rows = connection.execute(
+            """
+            SELECT payload_json
+            FROM workspace_marks
+            WHERE workspace_id = ? AND branch_id = ?
+            ORDER BY rowid
+            """,
+            (workspace_id, branch_id),
+        ).fetchall()
+        current: dict[str, WorkspaceMark] = {}
+        for row in rows:
+            mark = _model_from_json(WorkspaceMark, row["payload_json"])
+            current[mark.target_card_id] = mark
+        return current
+
+    def _projection(
+        self,
+        connection: sqlite3.Connection,
+        request: WorkspaceQueryRequest,
+    ) -> _WorkspaceProjection:
+        rows = connection.execute(
+            """
+            SELECT rowid, payload_json
+            FROM workspace_findings
+            WHERE workspace_id = ? AND branch_id = ?
+            ORDER BY rowid
+            """,
+            (request.workspace_id, request.branch_id),
+        ).fetchall()
+        findings: dict[str, WorkspaceFinding] = {}
+        finding_order: dict[str, int] = {}
+        for row in rows:
+            finding = _model_from_json(WorkspaceFinding, row["payload_json"])
+            findings[finding.card_id] = finding
+            finding_order[finding.card_id] = int(row["rowid"])
+        marks = self._current_marks(
+            connection,
+            request.workspace_id,
+            request.branch_id,
+        )
+        root_cache: dict[str, tuple[str, ...]] = {}
+        for card_id in _dependency_postorder(findings, findings):
+            finding = findings[card_id]
+            mark = marks.get(card_id)
+            if mark is not None and mark.state in _INVALIDATING_CARD_STATES:
+                root_cache[card_id] = (card_id,)
+                continue
+            roots: set[str] = set()
+            for reference in (*finding.dependency_ids, *finding.assumption_ids):
+                roots.update(root_cache[reference])
+            root_cache[card_id] = tuple(sorted(roots))
+
+        stale_due_to: dict[str, tuple[str, ...]] = {}
+        for card_id in findings:
+            mark = marks.get(card_id)
+            is_root = mark is not None and mark.state in _INVALIDATING_CARD_STATES
+            stale_due_to[card_id] = () if is_root else root_cache[card_id]
+        return _WorkspaceProjection(
+            findings=findings,
+            finding_order=finding_order,
+            marks=marks,
+            stale_due_to=stale_due_to,
+        )
+
+    @staticmethod
+    def _ordered_findings(
+        projection: _WorkspaceProjection,
+        predicate: Callable[[WorkspaceFinding], bool],
+        limit: int,
+    ) -> tuple[WorkspaceFinding, ...]:
+        ordered = sorted(
+            projection.findings.values(),
+            key=lambda item: projection.finding_order[item.card_id],
+            reverse=True,
+        )
+        return tuple(item for item in ordered if predicate(item))[:limit]
+
+    def _resume_view(
+        self,
+        connection: sqlite3.Connection,
+        request: WorkspaceQueryRequest,
+        projection: _WorkspaceProjection,
+    ) -> WorkspaceResumeView:
+        branch = self._branch_row(
+            connection,
+            request.workspace_id,
+            request.branch_id,
+        )
+        problems = sorted(
+            (
+                finding
+                for finding in projection.findings.values()
+                if finding.kind is WorkspaceFindingKind.PROBLEM
+            ),
+            key=lambda item: projection.finding_order[item.card_id],
+        )
+        if not problems:
+            raise WorkspaceError("workspace has no problem finding")
+        problem = problems[0]
+
+        focus_row = connection.execute(
+            """
+            SELECT payload_json
+            FROM workspace_focus
+            WHERE workspace_id = ? AND branch_id = ?
+            """,
+            (request.workspace_id, request.branch_id),
+        ).fetchone()
+        focus = (
+            _model_from_json(WorkspaceFocus, focus_row["payload_json"])
+            if focus_row is not None
+            else None
+        )
+        active = (
+            projection.findings.get(focus.active_item_id)
+            if focus is not None and focus.active_item_id is not None
+            else None
+        )
+        if focus is not None and focus.active_item_id is not None and active is None:
+            raise WorkspaceError("workspace focus cites an unknown finding")
+        pinned = (
+            tuple(
+                self._finding_summary(
+                    connection,
+                    projection.findings[card_id],
+                    projection,
+                )
+                for card_id in focus.pinned_item_ids
+            )
+            if focus is not None
+            else ()
+        )
+        goals = tuple(
+            self._finding_summary(connection, item, projection)
+            for item in self._ordered_findings(
+                projection,
+                lambda item: (
+                    item.kind
+                    in (WorkspaceFindingKind.GOAL, WorkspaceFindingKind.OPEN_QUESTION)
+                    and (
+                        item.card_id not in projection.marks
+                        or projection.marks[item.card_id].state
+                        is WorkspaceCardState.ACTIVE
+                    )
+                ),
+                request.limit,
+            )
+        )
+        stale_items = tuple(
+            self._finding_summary(connection, item, projection)
+            for item in self._ordered_findings(
+                projection,
+                lambda item: bool(projection.stale_due_to[item.card_id]),
+                request.limit,
+            )
+        )
+        recent_findings = tuple(
+            self._finding_summary(connection, item, projection)
+            for item in self._ordered_findings(
+                projection,
+                lambda item: (
+                    item.kind
+                    not in (
+                        WorkspaceFindingKind.PROBLEM,
+                        WorkspaceFindingKind.GOAL,
+                        WorkspaceFindingKind.OPEN_QUESTION,
+                    )
+                    and (
+                        item.card_id not in projection.marks
+                        or projection.marks[item.card_id].state
+                        is not WorkspaceCardState.ARCHIVED
+                    )
+                ),
+                request.limit,
+            )
+        )
+        attempts = tuple(
+            self._attempt_summary(connection, item)
+            for item in self._attempt_list(connection, request, None, request.limit)
+        )
+        scratch = tuple(
+            self._scratch_summary(connection, item)
+            for item in self._scratch_list(connection, request, request.limit)
+        )
+        return WorkspaceResumeView(
+            name=branch["name"],
+            problem=self._finding_summary(connection, problem, projection),
+            active_item=(
+                self._finding_summary(connection, active, projection)
+                if active is not None
+                else None
+            ),
+            pinned_items=pinned,
+            open_goals=goals,
+            stale_items=stale_items,
+            recent_findings=recent_findings,
+            recent_attempts=attempts,
+            recent_scratch=scratch,
+        )
+
+    def _frontier_view(
+        self,
+        connection: sqlite3.Connection,
+        request: WorkspaceQueryRequest,
+        projection: _WorkspaceProjection,
+    ) -> tuple[WorkspaceFrontierItem, ...]:
+        goals = self._ordered_findings(
+            projection,
+            lambda item: (
+                item.kind
+                in (WorkspaceFindingKind.GOAL, WorkspaceFindingKind.OPEN_QUESTION)
+                and (
+                    item.card_id not in projection.marks
+                    or projection.marks[item.card_id].state is WorkspaceCardState.ACTIVE
+                )
+            ),
+            request.limit,
+        )
+        frontier: list[WorkspaceFrontierItem] = []
+        for goal in goals:
+            attempts = self._attempt_list(connection, request, goal.card_id, 1)
+            count_row = connection.execute(
+                """
+                SELECT COUNT(*) AS count
+                FROM workspace_attempts
+                WHERE workspace_id = ? AND branch_id = ? AND target_card_id = ?
+                """,
+                (request.workspace_id, request.branch_id, goal.card_id),
+            ).fetchone()
+            frontier.append(
+                WorkspaceFrontierItem(
+                    goal=self._finding_summary(connection, goal, projection),
+                    attempt_count=int(count_row["count"]),
+                    last_attempt=(
+                        self._attempt_summary(connection, attempts[0])
+                        if attempts
+                        else None
+                    ),
+                )
+            )
+        return tuple(frontier)
+
+    def _attempts_view(
+        self,
+        connection: sqlite3.Connection,
+        request: WorkspaceQueryRequest,
+        projection: _WorkspaceProjection,
+    ) -> tuple[WorkspaceAttemptSummary, ...]:
+        if (
+            request.target_card_id is not None
+            and request.target_card_id not in projection.findings
+        ):
+            raise WorkspaceNotFoundError("workspace finding does not exist")
+        return tuple(
+            self._attempt_summary(connection, item)
+            for item in self._attempt_list(
+                connection,
+                request,
+                request.target_card_id,
+                request.limit,
+            )
+        )
+
+    def _context_view(
+        self,
+        connection: sqlite3.Connection,
+        request: WorkspaceQueryRequest,
+        projection: _WorkspaceProjection,
+    ) -> WorkspaceContextView:
+        target_card_id = request.target_card_id
+        if target_card_id is None:
+            raise WorkspaceError("CONTEXT query has no target card")
+        target = projection.findings.get(target_card_id)
+        if target is None:
+            raise WorkspaceNotFoundError("workspace finding does not exist")
+
+        ordered_ids = tuple(
+            card_id
+            for card_id in _dependency_postorder(
+                projection.findings,
+                (target_card_id,),
+            )
+            if card_id != target_card_id
+        )
+        dependencies = tuple(
+            self._finding_summary(
+                connection,
+                projection.findings[card_id],
+                projection,
+            )
+            for card_id in ordered_ids[: request.limit]
+        )
+        recent_attempts = tuple(
+            self._attempt_summary(connection, item)
+            for item in self._attempt_list(
+                connection,
+                request,
+                target_card_id,
+                request.limit,
+            )
+        )
+        return WorkspaceContextView(
+            target=self._finding_summary(connection, target, projection),
+            dependencies=dependencies,
+            recent_attempts=recent_attempts,
+            total_dependency_count=len(ordered_ids),
+            truncated=len(ordered_ids) > request.limit,
+        )
+
+    @staticmethod
+    def _attempt_list(
+        connection: sqlite3.Connection,
+        request: WorkspaceQueryRequest,
+        target_card_id: str | None,
+        limit: int,
+    ) -> tuple[WorkspaceAttempt, ...]:
+        target_clause = "AND target_card_id = ?" if target_card_id is not None else ""
+        parameters: list[str | int] = [
+            request.workspace_id,
+            request.branch_id,
+        ]
+        if target_card_id is not None:
+            parameters.append(target_card_id)
+        parameters.append(limit)
+        rows = connection.execute(
+            f"""
+            SELECT payload_json
+            FROM workspace_attempts
+            WHERE workspace_id = ? AND branch_id = ? {target_clause}
+            ORDER BY rowid DESC
+            LIMIT ?
+            """,
+            parameters,
+        ).fetchall()
+        return tuple(
+            _model_from_json(WorkspaceAttempt, row["payload_json"]) for row in rows
+        )
+
+    @staticmethod
+    def _scratch_list(
+        connection: sqlite3.Connection,
+        request: WorkspaceQueryRequest,
+        limit: int,
+    ) -> tuple[WorkspaceScratchEntry, ...]:
+        rows = connection.execute(
+            """
+            SELECT payload_json
+            FROM workspace_scratch
+            WHERE workspace_id = ? AND branch_id = ?
+            ORDER BY rowid DESC
+            LIMIT ?
+            """,
+            (request.workspace_id, request.branch_id, limit),
+        ).fetchall()
+        return tuple(
+            _model_from_json(WorkspaceScratchEntry, row["payload_json"]) for row in rows
+        )
+
+    def _finding_summary(
+        self,
+        connection: sqlite3.Connection,
+        finding: WorkspaceFinding,
+        projection: _WorkspaceProjection,
+    ) -> WorkspaceItemSummary:
+        mark = projection.marks.get(finding.card_id)
+        return _finding_summary(
+            finding,
+            self._revision_artifact_uri(connection, finding.created_revision),
+            mark,
+            (
+                self._revision_artifact_uri(connection, mark.created_revision)
+                if mark is not None
+                else None
+            ),
+            projection.stale_due_to[finding.card_id],
+        )
+
+    def _attempt_summary(
+        self,
+        connection: sqlite3.Connection,
+        attempt: WorkspaceAttempt,
+    ) -> WorkspaceAttemptSummary:
+        return _attempt_summary(
+            attempt,
+            self._revision_artifact_uri(connection, attempt.created_revision),
+        )
+
+    def _scratch_summary(
+        self,
+        connection: sqlite3.Connection,
+        entry: WorkspaceScratchEntry,
+    ) -> WorkspaceScratchSummary:
+        return _scratch_summary(
+            entry,
+            self._revision_artifact_uri(connection, entry.created_revision),
+        )
+
+    @staticmethod
+    def _revision_artifact_uri(
+        connection: sqlite3.Connection,
+        revision_id: str,
+    ) -> str:
+        row = connection.execute(
+            """
+            SELECT revision_artifact_uri
+            FROM workspace_revisions
+            WHERE revision_id = ?
+            """,
+            (revision_id,),
+        ).fetchone()
+        if row is None:
+            raise WorkspaceError("workspace item cites an unknown revision")
+        return str(row["revision_artifact_uri"])
+
+    @staticmethod
+    def _insert_revision(
+        connection: sqlite3.Connection,
+        revision: WorkspaceRevision,
+        artifact_uri: str,
+    ) -> None:
+        connection.execute(
+            """
+            INSERT INTO workspace_revisions(
+                revision_id,
+                revision_artifact_uri,
+                workspace_id,
+                branch_id,
+                parent_revision_id,
+                request_digest,
+                created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                revision.revision_id,
+                artifact_uri,
+                revision.workspace_id,
+                revision.branch_id,
+                revision.parent_revision,
+                revision.request_digest,
+                revision.created_at.isoformat(),
+            ),
+        )
+
+    @staticmethod
+    def _insert_scratch(
+        connection: sqlite3.Connection,
+        workspace_id: str,
+        branch_id: str,
+        entry: WorkspaceScratchEntry,
+    ) -> None:
+        connection.execute(
+            """
+            INSERT INTO workspace_scratch(
+                scratch_id,
+                workspace_id,
+                branch_id,
+                created_revision_id,
+                payload_json,
+                created_at
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                entry.scratch_id,
+                workspace_id,
+                branch_id,
+                entry.created_revision,
+                canonicalize_json(entry.model_dump(mode="json")),
+                entry.created_at.isoformat(),
+            ),
+        )
+
+    @staticmethod
+    def _insert_finding(
+        connection: sqlite3.Connection,
+        workspace_id: str,
+        branch_id: str,
+        finding: WorkspaceFinding,
+    ) -> None:
+        connection.execute(
+            """
+            INSERT INTO workspace_findings(
+                card_id,
+                workspace_id,
+                branch_id,
+                kind,
+                created_revision_id,
+                payload_json,
+                created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                finding.card_id,
+                workspace_id,
+                branch_id,
+                finding.kind.value,
+                finding.created_revision,
+                canonicalize_json(finding.model_dump(mode="json")),
+                finding.created_at.isoformat(),
+            ),
+        )
+
+    @staticmethod
+    def _insert_attempt(
+        connection: sqlite3.Connection,
+        workspace_id: str,
+        branch_id: str,
+        attempt: WorkspaceAttempt,
+    ) -> None:
+        connection.execute(
+            """
+            INSERT INTO workspace_attempts(
+                attempt_id,
+                workspace_id,
+                branch_id,
+                target_card_id,
+                outcome,
+                created_revision_id,
+                payload_json,
+                created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                attempt.attempt_id,
+                workspace_id,
+                branch_id,
+                attempt.target_card_id,
+                attempt.outcome.value,
+                attempt.created_revision,
+                canonicalize_json(attempt.model_dump(mode="json")),
+                attempt.created_at.isoformat(),
+            ),
+        )
+
+    @staticmethod
+    def _insert_mark(
+        connection: sqlite3.Connection,
+        workspace_id: str,
+        branch_id: str,
+        mark: WorkspaceMark,
+    ) -> None:
+        connection.execute(
+            """
+            INSERT INTO workspace_marks(
+                mark_id,
+                workspace_id,
+                branch_id,
+                target_card_id,
+                state,
+                created_revision_id,
+                payload_json,
+                created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                mark.mark_id,
+                workspace_id,
+                branch_id,
+                mark.target_card_id,
+                mark.state.value,
+                mark.created_revision,
+                canonicalize_json(mark.model_dump(mode="json")),
+                mark.created_at.isoformat(),
+            ),
+        )
+
+    @staticmethod
+    def _upsert_focus(
+        connection: sqlite3.Connection,
+        workspace_id: str,
+        branch_id: str,
+        focus: WorkspaceFocus,
+    ) -> None:
+        connection.execute(
+            """
+            INSERT INTO workspace_focus(
+                branch_id, workspace_id, updated_revision_id, payload_json
+            ) VALUES (?, ?, ?, ?)
+            ON CONFLICT(branch_id) DO UPDATE SET
+                updated_revision_id = excluded.updated_revision_id,
+                payload_json = excluded.payload_json
+            """,
+            (
+                branch_id,
+                workspace_id,
+                focus.updated_revision,
+                canonicalize_json(focus.model_dump(mode="json")),
+            ),
+        )
+
+    @staticmethod
+    def _bind_idempotency(
+        connection: sqlite3.Connection,
+        idempotency_key: str,
+        operation: WorkspaceRevisionOperation,
+        request_digest: str,
+        result: WorkspaceOpenResult | WorkspaceWriteResult,
+    ) -> None:
+        connection.execute(
+            """
+            INSERT INTO workspace_idempotency(
+                idempotency_key, operation, request_digest, response_json
+            ) VALUES (?, ?, ?, ?)
+            """,
+            (
+                idempotency_key,
+                operation.value,
+                request_digest,
+                canonicalize_json(result.model_dump(mode="json")),
+            ),
+        )
+
+    @staticmethod
+    def _reuse(
+        connection: sqlite3.Connection,
+        *,
+        idempotency_key: str,
+        operation: WorkspaceRevisionOperation,
+        request_digest: str,
+        result_type: type[_ModelT],
+    ) -> _ModelT | None:
+        row = connection.execute(
+            """
+            SELECT operation, request_digest, response_json
+            FROM workspace_idempotency
+            WHERE idempotency_key = ?
+            """,
+            (idempotency_key,),
+        ).fetchone()
+        if row is None:
+            return None
+        if (
+            row["operation"] != operation.value
+            or row["request_digest"] != request_digest
+        ):
+            raise WorkspaceIdempotencyError(
+                "idempotency key is already bound to a different workspace request"
+            )
+        return _model_from_json(result_type, row["response_json"])
+
+
+def _dependency_postorder(
+    findings: dict[str, WorkspaceFinding],
+    starts: Iterable[str],
+) -> tuple[str, ...]:
+    """Return dependencies before dependents without using Python recursion."""
+
+    state: dict[str, int] = {}
+    ordered: list[str] = []
+    for start in starts:
+        if state.get(start) == 2:
+            continue
+        stack: list[tuple[str, bool]] = [(start, False)]
+        while stack:
+            card_id, expanded = stack.pop()
+            current_state = state.get(card_id, 0)
+            if expanded:
+                if current_state == 1:
+                    state[card_id] = 2
+                    ordered.append(card_id)
+                continue
+            if current_state == 2:
+                continue
+            if current_state == 1:
+                raise WorkspaceError("workspace dependency graph contains a cycle")
+            finding = findings.get(card_id)
+            if finding is None:
+                raise WorkspaceError(
+                    "workspace dependency graph cites an unknown finding"
+                )
+            state[card_id] = 1
+            stack.append((card_id, True))
+            references = sorted(
+                {*finding.dependency_ids, *finding.assumption_ids},
+                reverse=True,
+            )
+            for reference in references:
+                reference_state = state.get(reference, 0)
+                if reference_state == 1:
+                    raise WorkspaceError("workspace dependency graph contains a cycle")
+                if reference_state != 2:
+                    stack.append((reference, False))
+    return tuple(ordered)
+
+
+def _reject_new_dependency_cycles(findings: list[WorkspaceFinding]) -> None:
+    new_ids = {finding.card_id for finding in findings}
+    graph = {
+        finding.card_id: {
+            dependency
+            for dependency in (*finding.dependency_ids, *finding.assumption_ids)
+            if dependency in new_ids
+        }
+        for finding in findings
+    }
+    visiting: set[str] = set()
+    visited: set[str] = set()
+
+    def visit(card_id: str) -> None:
+        if card_id in visiting:
+            raise WorkspaceReferenceError("new workspace findings contain a cycle")
+        if card_id in visited:
+            return
+        visiting.add(card_id)
+        for dependency in graph[card_id]:
+            visit(dependency)
+        visiting.remove(card_id)
+        visited.add(card_id)
+
+    for card_id in graph:
+        visit(card_id)
+
+
+def _reject_supersession_cycles(
+    current_marks: Iterable[WorkspaceMark],
+    new_marks: Iterable[WorkspaceMark],
+) -> None:
+    graph: dict[str, str] = {}
+    for mark in current_marks:
+        if (
+            mark.state is WorkspaceCardState.SUPERSEDED
+            and mark.superseded_by_id is not None
+        ):
+            graph[mark.target_card_id] = mark.superseded_by_id
+    for mark in new_marks:
+        if (
+            mark.state is WorkspaceCardState.SUPERSEDED
+            and mark.superseded_by_id is not None
+        ):
+            graph[mark.target_card_id] = mark.superseded_by_id
+        else:
+            graph.pop(mark.target_card_id, None)
+
+    state: dict[str, int] = {}
+    for start in graph:
+        if state.get(start) == 2:
+            continue
+        path: list[str] = []
+        card_id = start
+        while card_id in graph:
+            current_state = state.get(card_id, 0)
+            if current_state == 1:
+                raise WorkspaceReferenceError(
+                    "workspace supersession marks contain a cycle"
+                )
+            if current_state == 2:
+                break
+            state[card_id] = 1
+            path.append(card_id)
+            card_id = graph[card_id]
+        for visited_card_id in path:
+            state[visited_card_id] = 2
+
+
+def _request_digest(
+    operation: WorkspaceRevisionOperation,
+    payload: dict[str, object],
+) -> str:
+    data = canonicalize_json(
+        {
+            "operation": operation.value,
+            "request": payload,
+        }
+    )
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def _opaque_id(kind: str) -> str:
+    return f"{kind}://{uuid.uuid4().hex}"
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _model_from_json[ModelT: ContractModel](
+    model_type: type[ModelT],
+    payload: bytes,
+) -> ModelT:
+    return model_type.model_validate(loads_strict_json(payload))
+
+
+def _finding_summary(
+    finding: WorkspaceFinding,
+    revision_artifact_uri: str,
+    mark: WorkspaceMark | None,
+    mark_revision_artifact_uri: str | None,
+    stale_due_to_ids: tuple[str, ...],
+) -> WorkspaceItemSummary:
+    return WorkspaceItemSummary(
+        card_id=finding.card_id,
+        kind=finding.kind,
+        title=finding.title,
+        body_excerpt=_excerpt(finding.body, 1024),
+        dependency_ids=finding.dependency_ids,
+        assumption_ids=finding.assumption_ids,
+        tags=finding.tags,
+        state=mark.state if mark is not None else WorkspaceCardState.ACTIVE,
+        state_reason=mark.reason if mark is not None else None,
+        state_mark_id=mark.mark_id if mark is not None else None,
+        superseded_by_id=mark.superseded_by_id if mark is not None else None,
+        state_revision=mark.created_revision if mark is not None else None,
+        state_revision_artifact_uri=mark_revision_artifact_uri,
+        stale=bool(stale_due_to_ids),
+        stale_due_to_ids=stale_due_to_ids,
+        created_revision=finding.created_revision,
+        created_revision_artifact_uri=revision_artifact_uri,
+    )
+
+
+def _attempt_summary(
+    attempt: WorkspaceAttempt,
+    revision_artifact_uri: str,
+) -> WorkspaceAttemptSummary:
+    return WorkspaceAttemptSummary(
+        attempt_id=attempt.attempt_id,
+        target_card_id=attempt.target_card_id,
+        method=attempt.method,
+        outcome=attempt.outcome,
+        summary_excerpt=_excerpt(attempt.summary, 768),
+        artifact_uris=attempt.artifact_uris,
+        created_revision=attempt.created_revision,
+        created_revision_artifact_uri=revision_artifact_uri,
+    )
+
+
+def _scratch_summary(
+    entry: WorkspaceScratchEntry,
+    revision_artifact_uri: str,
+) -> WorkspaceScratchSummary:
+    return WorkspaceScratchSummary(
+        scratch_id=entry.scratch_id,
+        body_excerpt=_excerpt(entry.body, 512),
+        tags=entry.tags,
+        created_revision=entry.created_revision,
+        created_revision_artifact_uri=revision_artifact_uri,
+    )
+
+
+def _excerpt(value: str, limit: int) -> str:
+    if len(value) <= limit:
+        return value
+    return value[: limit - 1] + "…"

--- a/tests/integration/test_mcp_adapter.py
+++ b/tests/integration/test_mcp_adapter.py
@@ -8,22 +8,26 @@ import sys
 from pathlib import Path
 
 import pytest
+from jsonschema import Draft202012Validator
 
 from jacobian.adapters.mcp.server import (
+    WORKSPACE_TOOL_NAMES,
     _public_tool_error,
     create_server,
 )
 
-MCP_TOOL_NAMES = {"capability.describe", "capability.invoke"}
+CAPABILITY_TOOL_NAMES = {"capability.describe", "capability.invoke"}
+MCP_TOOL_NAMES = CAPABILITY_TOOL_NAMES | WORKSPACE_TOOL_NAMES
 
 
 @pytest.mark.integration
-def test_mcp_exposes_only_capability_tools_and_read_only_resources(
+def test_mcp_exposes_capability_and_workspace_tools_with_read_only_resources(
     tmp_path: Path,
 ) -> None:
     server = create_server(tmp_path)
     assert server.instructions is not None
     assert "assurance level VERIFIED" in server.instructions
+    assert "workspace entry never promotes" in server.instructions
 
     async def scenario() -> None:
         from mcp import Client
@@ -32,6 +36,15 @@ def test_mcp_exposes_only_capability_tools_and_read_only_resources(
             listed = await client.list_tools()
             tools = {tool.name: tool for tool in listed.tools}
             assert set(tools) == MCP_TOOL_NAMES
+            descriptor = json.dumps(
+                {
+                    "instructions": server.instructions,
+                    "tools": [tool.model_dump(mode="json") for tool in listed.tools],
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            assert len(descriptor) < 25_000
             assert all(
                 tool.annotations is not None
                 and tool.annotations.open_world_hint is False
@@ -39,6 +52,15 @@ def test_mcp_exposes_only_capability_tools_and_read_only_resources(
             )
             assert tools["capability.describe"].annotations is not None
             assert tools["capability.describe"].annotations.read_only_hint is True
+            assert tools["workspace.open"].annotations is not None
+            assert tools["workspace.open"].annotations.idempotent_hint is True
+            assert tools["workspace.write"].annotations is not None
+            assert tools["workspace.write"].annotations.idempotent_hint is True
+            assert tools["workspace.query"].annotations is not None
+            assert tools["workspace.query"].annotations.read_only_hint is True
+            assert all(
+                tools[name].output_schema is None for name in WORKSPACE_TOOL_NAMES
+            )
 
             catalog_result = await client.read_resource("capability://catalog")
             catalog = json.loads(catalog_result.contents[0].text)
@@ -51,6 +73,302 @@ def test_mcp_exposes_only_capability_tools_and_read_only_resources(
             reference_result = await client.read_resource("reference://catalog")
             references = json.loads(reference_result.contents[0].text)
             assert references["matrices"]["plugin_id"].startswith("artifact://sha256/")
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.integration
+def test_mcp_workspace_schema_aliases_and_fail_closed_round_trip(
+    tmp_path: Path,
+) -> None:
+    server = create_server(tmp_path)
+
+    async def scenario() -> None:
+        from mcp import Client
+
+        async with Client(server, raise_exceptions=True) as client:
+            listed = await client.list_tools()
+            tools = {tool.name: tool for tool in listed.tools}
+            open_schema = tools["workspace.open"].input_schema
+            write_tool = tools["workspace.write"]
+            write_schema = write_tool.input_schema
+            query_schema = tools["workspace.query"].input_schema
+
+            assert open_schema["properties"]["idempotency_key"]["pattern"] == (
+                "^[A-Za-z0-9._:-]{8,128}$"
+            )
+            assert open_schema["properties"]["name"]["maxLength"] == 128
+            assert open_schema["properties"]["problem"]["maxLength"] == 16_384
+            assert open_schema["properties"]["tags"]["anyOf"][0]["maxItems"] == 16
+            assert write_tool.description is not None
+            assert "base_revision (never revision_id)" in write_tool.description
+            assert "never a batch wrapper" in write_tool.description
+            assert "client_ref, never ref" in write_tool.description
+            assert "never depends_on_refs" in write_tool.description
+            assert write_schema["additionalProperties"] is False
+            write_properties = write_schema["properties"]
+            assert write_properties["workspace_id"]["pattern"] == (
+                "^workspace://[0-9a-f]{32}$"
+            )
+            assert write_properties["branch_id"]["pattern"] == (
+                "^branch://[0-9a-f]{32}$"
+            )
+            assert write_properties["base_revision"]["pattern"] == (
+                "^revision://[0-9a-f]{32}$"
+            )
+            for field_name in ("scratch", "findings", "attempts", "marks"):
+                assert write_properties[field_name]["anyOf"][0]["maxItems"] == 64
+            assert query_schema["properties"]["limit"]["minimum"] == 1
+            assert query_schema["properties"]["limit"]["maximum"] == 50
+            assert query_schema["properties"]["workspace_id"]["pattern"] == (
+                "^workspace://[0-9a-f]{32}$"
+            )
+            assert (
+                query_schema["properties"]["target_card_id"]["anyOf"][0]["pattern"]
+                == "^card://[0-9a-f]{32}$"
+            )
+
+            finding_kinds = write_schema["$defs"]["WorkspaceFindingKind"]["enum"]
+            attempt_outcomes = write_schema["$defs"]["WorkspaceAttemptOutcome"]["enum"]
+            assert "OPEN_GOAL" in finding_kinds
+            assert "PROBLEM" not in finding_kinds
+            assert "SUCCEEDED" in attempt_outcomes
+            mark_schema = write_schema["$defs"]["WorkspaceMarkDraft"]
+            assert "summary" in mark_schema["properties"]
+            assert mark_schema["oneOf"]
+
+            alias_payload = {
+                "workspace_id": "workspace://" + ("0" * 32),
+                "branch_id": "branch://" + ("0" * 32),
+                "base_revision": "revision://" + ("0" * 32),
+                "idempotency_key": "schema-aliases-001",
+                "findings": [
+                    {
+                        "client_ref": "G1",
+                        "kind": "OPEN_GOAL",
+                        "title": "Open work",
+                        "body": "A documented finding-kind alias.",
+                    }
+                ],
+                "attempts": [
+                    {
+                        "client_ref": "T1",
+                        "target_ref": "G1",
+                        "method": "direct",
+                        "outcome": "SUCCEEDED",
+                        "summary": "A documented attempt-outcome alias.",
+                    }
+                ],
+                "marks": [
+                    {
+                        "client_ref": "M1",
+                        "target_ref": "G1",
+                        "state": "CLOSED",
+                        "summary": "A documented mark-reason alias.",
+                    }
+                ],
+            }
+            write_validator = Draft202012Validator(write_schema)
+            assert write_validator.is_valid(alias_payload), list(
+                write_validator.iter_errors(alias_payload)
+            )
+            assert not write_validator.is_valid(
+                {
+                    **alias_payload,
+                    "marks": [
+                        {
+                            "client_ref": "M1",
+                            "target_ref": "G1",
+                            "state": "CLOSED",
+                            "reason": "Canonical reason.",
+                            "summary": "Conflicting alias.",
+                        }
+                    ],
+                }
+            )
+            assert not write_validator.is_valid(
+                {
+                    **alias_payload,
+                    "findings": [
+                        {
+                            "client_ref": "P2",
+                            "kind": "PROBLEM",
+                            "title": "Hidden second problem",
+                            "body": "Only workspace.open creates the problem.",
+                        }
+                    ],
+                    "attempts": [],
+                    "marks": [],
+                }
+            )
+
+            misdirected_result = await client.call_tool(
+                "capability.describe",
+                {"capability_id": "workspace.write"},
+            )
+            misdirected = json.loads(misdirected_result.content[0].text)
+            assert misdirected["error"]["code"] == "UNKNOWN_CAPABILITY"
+            assert "direct MCP tool" in misdirected["error"]["hint"]
+
+            opened_result = await client.call_tool(
+                "workspace.open",
+                {
+                    "idempotency_key": "mcp-workspace-open-001",
+                    "name": "MCP workspace",
+                    "problem": "Record a goal and one completed attempt.",
+                },
+            )
+            opened = json.loads(opened_result.content[0].text)
+
+            rejected_result = await client.call_tool(
+                "workspace.write",
+                {
+                    "idempotency_key": "mcp-workspace-unknown-field-001",
+                    "workspace_id": opened["workspace_id"],
+                    "branch_id": opened["branch_id"],
+                    "base_revision": opened["revision_id"],
+                    "cards": [],
+                    "attempts": [
+                        {
+                            "client_ref": "T0",
+                            "target_ref": opened["problem_card_id"],
+                            "method": "must-not-commit",
+                            "outcome": "COMPLETED",
+                            "summary": "Unknown input rejects the entire write.",
+                        }
+                    ],
+                },
+            )
+            assert rejected_result.is_error is True
+
+            second_problem_result = await client.call_tool(
+                "workspace.write",
+                {
+                    "idempotency_key": "mcp-workspace-second-problem-001",
+                    "workspace_id": opened["workspace_id"],
+                    "branch_id": opened["branch_id"],
+                    "base_revision": opened["revision_id"],
+                    "findings": [
+                        {
+                            "client_ref": "P2",
+                            "kind": "PROBLEM",
+                            "title": "Hidden second problem",
+                            "body": "Only workspace.open creates the problem.",
+                        }
+                    ],
+                },
+            )
+            assert second_problem_result.is_error is True
+
+            unchanged_result = await client.call_tool(
+                "workspace.query",
+                {
+                    "workspace_id": opened["workspace_id"],
+                    "branch_id": opened["branch_id"],
+                    "revision_id": opened["revision_id"],
+                    "view": "RESUME",
+                },
+            )
+            unchanged = json.loads(unchanged_result.content[0].text)
+            assert unchanged["revision_id"] == opened["revision_id"]
+            assert unchanged["resume"]["recent_attempts"] == []
+
+            write_result = await client.call_tool(
+                "workspace.write",
+                {
+                    "idempotency_key": "mcp-workspace-write-001",
+                    "workspace_id": opened["workspace_id"],
+                    "branch_id": opened["branch_id"],
+                    "base_revision": opened["revision_id"],
+                    "findings": [
+                        {
+                            "client_ref": "A1",
+                            "kind": "ASSUMPTION",
+                            "title": "Temporary scope",
+                            "body": "Assume a temporary finite scope.",
+                        },
+                        {
+                            "client_ref": "G1",
+                            "kind": "OPEN_GOAL",
+                            "title": "MCP goal",
+                            "body": "Close the remaining case.",
+                            "assumption_refs": ["A1"],
+                        },
+                    ],
+                    "attempts": [
+                        {
+                            "client_ref": "T1",
+                            "target_ref": "G1",
+                            "method": "direct",
+                            "outcome": "SUCCEEDED",
+                            "summary": "The operational attempt completed.",
+                        }
+                    ],
+                    "focus": {"active_ref": "G1", "pinned_refs": ["G1"]},
+                },
+            )
+            written = json.loads(write_result.content[0].text)
+            assert written["findings_written"] == 2
+            assert written["attempts_written"] == 1
+
+            conflicting_mark_result = await client.call_tool(
+                "workspace.write",
+                {
+                    "idempotency_key": "mcp-workspace-mark-conflict-001",
+                    "workspace_id": opened["workspace_id"],
+                    "branch_id": opened["branch_id"],
+                    "base_revision": written["revision_id"],
+                    "marks": [
+                        {
+                            "client_ref": "M0",
+                            "target_ref": written["id_map"]["A1"],
+                            "state": "RETRACTED",
+                            "reason": "Canonical reason.",
+                            "summary": "Conflicting alias.",
+                        }
+                    ],
+                },
+            )
+            assert conflicting_mark_result.is_error is True
+
+            mark_result = await client.call_tool(
+                "workspace.write",
+                {
+                    "idempotency_key": "mcp-workspace-mark-001",
+                    "workspace_id": opened["workspace_id"],
+                    "branch_id": opened["branch_id"],
+                    "base_revision": written["revision_id"],
+                    "marks": [
+                        {
+                            "client_ref": "M1",
+                            "target_ref": written["id_map"]["A1"],
+                            "state": "RETRACTED",
+                            "summary": "The temporary scope was withdrawn.",
+                        }
+                    ],
+                },
+            )
+            marked = json.loads(mark_result.content[0].text)
+            assert marked["marks_written"] == 1
+
+            context_result = await client.call_tool(
+                "workspace.query",
+                {
+                    "workspace_id": opened["workspace_id"],
+                    "branch_id": opened["branch_id"],
+                    "revision_id": marked["revision_id"],
+                    "view": "CONTEXT",
+                    "target_card_id": written["id_map"]["G1"],
+                },
+            )
+            context = json.loads(context_result.content[0].text)["context"]
+            assert context["target"]["kind"] == "GOAL"
+            assert context["target"]["stale"] is True
+            assert context["target"]["stale_due_to_ids"] == [written["id_map"]["A1"]]
+            assert context["target"]["verification"] == "UNVERIFIED"
+            assert context["dependencies"][0]["state"] == "RETRACTED"
+            assert context["recent_attempts"][0]["outcome"] == "COMPLETED"
+            assert context["recent_attempts"][0]["verification"] == "UNVERIFIED"
 
     asyncio.run(scenario())
 
@@ -146,7 +464,9 @@ def test_mcp_protocol_and_authentication_errors_remain_distinct(tmp_path: Path) 
 
 @pytest.mark.integration
 @pytest.mark.subprocess
-def test_mcp_stdio_entrypoint_exposes_only_capability_tools(tmp_path: Path) -> None:
+def test_mcp_stdio_entrypoint_exposes_capability_and_workspace_tools(
+    tmp_path: Path,
+) -> None:
     async def scenario() -> None:
         from mcp import Client, StdioServerParameters, stdio_client
 

--- a/tests/integration/test_remote_mcp.py
+++ b/tests/integration/test_remote_mcp.py
@@ -16,7 +16,13 @@ from jacobian.adapters.mcp.remote import (
     TenantKernelRouter,
     load_static_token_file,
 )
+from jacobian.contracts.workspaces import (
+    WorkspaceOpenRequest,
+    WorkspaceQueryRequest,
+    WorkspaceQueryView,
+)
 from jacobian.store import ArtifactNotFoundError
+from jacobian.workspaces import WorkspaceNotFoundError
 
 
 @pytest.mark.integration
@@ -150,6 +156,29 @@ def test_tenant_router_isolates_artifact_stores(tmp_path: Path) -> None:
     assert alpha.store.root != beta.store.root
     with pytest.raises(ArtifactNotFoundError):
         beta.store.get(stored)
+
+
+@pytest.mark.integration
+def test_tenant_router_isolates_epistemic_workspaces(tmp_path: Path) -> None:
+    router = TenantKernelRouter(tmp_path, install_references=False)
+    alpha = router.kernel_for("alpha")
+    beta = router.kernel_for("beta")
+    opened = alpha.workspaces.open(
+        WorkspaceOpenRequest(
+            idempotency_key="tenant-workspace-open-001",
+            name="alpha workspace",
+            problem="This working state belongs only to alpha.",
+        )
+    )
+
+    with pytest.raises(WorkspaceNotFoundError):
+        beta.workspaces.query(
+            WorkspaceQueryRequest(
+                workspace_id=opened.workspace_id,
+                branch_id=opened.branch_id,
+                view=WorkspaceQueryView.RESUME,
+            )
+        )
 
 
 @pytest.mark.integration

--- a/tests/integration/test_workspaces.py
+++ b/tests/integration/test_workspaces.py
@@ -1,0 +1,1560 @@
+from __future__ import annotations
+
+import sqlite3
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime
+from pathlib import Path
+from threading import Event
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.contracts.workspaces import (
+    WorkspaceAttemptDraft,
+    WorkspaceAttemptOutcome,
+    WorkspaceCardState,
+    WorkspaceFindingDraft,
+    WorkspaceFindingKind,
+    WorkspaceFocusDraft,
+    WorkspaceMarkDraft,
+    WorkspaceOpenRequest,
+    WorkspaceOpenResult,
+    WorkspaceQueryRequest,
+    WorkspaceQueryView,
+    WorkspaceRevision,
+    WorkspaceScratchDraft,
+    WorkspaceWriteRequest,
+)
+from jacobian.kernel import JacobianKernel
+from jacobian.workspaces import (
+    WorkspaceConflictError,
+    WorkspaceIdempotencyError,
+    WorkspaceReferenceError,
+)
+
+
+def _open(
+    kernel: JacobianKernel,
+    *,
+    key: str = "workspace-open-001",
+) -> WorkspaceOpenResult:
+    return kernel.workspaces.open(
+        WorkspaceOpenRequest(
+            idempotency_key=key,
+            name="bounded conjecture",
+            problem="Determine whether P(n) holds for every n in the declared scope.",
+            tags=("bounded",),
+        )
+    )
+
+
+@pytest.mark.integration
+def test_workspace_open_is_idempotent_and_restart_replays_revision(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    request = WorkspaceOpenRequest(
+        idempotency_key="workspace-open-replay-001",
+        name="replay fixture",
+        problem="Prove or refute the fixture claim.",
+    )
+
+    first = kernel.workspaces.open(request)
+    second = kernel.workspaces.open(request)
+
+    assert second == first
+    revision_artifact = kernel.store.get(first.revision_artifact_uri)
+    revision = WorkspaceRevision.model_validate(revision_artifact.payload)
+    assert revision.revision_id == first.revision_id
+    assert revision.parent_revision is None
+    assert revision.findings[0].card_id == first.problem_card_id
+    assert revision.findings[0].verification == "UNVERIFIED"
+    assert revision.focus is not None
+    assert revision.focus.active_item_id == first.problem_card_id
+
+    restarted = JacobianKernel(tmp_path)
+    resume = restarted.workspaces.query(
+        WorkspaceQueryRequest(
+            workspace_id=first.workspace_id,
+            branch_id=first.branch_id,
+            view=WorkspaceQueryView.RESUME,
+        )
+    )
+
+    assert resume.revision_id == first.revision_id
+    assert resume.revision_artifact_uri == first.revision_artifact_uri
+    assert resume.resume is not None
+    assert resume.resume.problem.verification == "UNVERIFIED"
+    assert "retrieval does not promote" in resume.warning
+
+
+@pytest.mark.integration
+def test_workspace_write_cannot_add_a_second_problem(tmp_path: Path) -> None:
+    kernel = JacobianKernel(tmp_path)
+    opened = _open(kernel, key="workspace-open-single-problem-001")
+    problem_draft = WorkspaceFindingDraft(
+        client_ref="P2",
+        kind=WorkspaceFindingKind.PROBLEM,
+        title="Hidden second problem",
+        body="A write must not create another canonical problem.",
+    )
+
+    with pytest.raises(
+        ValidationError,
+        match=r"only workspace\.open may create the canonical PROBLEM",
+    ):
+        WorkspaceWriteRequest(
+            idempotency_key="workspace-write-second-problem-contract-001",
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            base_revision=opened.revision_id,
+            findings=(problem_draft,),
+        )
+
+    bypassed_contract = WorkspaceWriteRequest.model_construct(
+        request_version="1",
+        idempotency_key="workspace-write-second-problem-service-001",
+        workspace_id=opened.workspace_id,
+        branch_id=opened.branch_id,
+        base_revision=opened.revision_id,
+        scratch=(),
+        findings=(problem_draft,),
+        attempts=(),
+        marks=(),
+        focus=None,
+    )
+    with pytest.raises(
+        ValidationError,
+        match=r"only workspace\.open may create the canonical PROBLEM",
+    ):
+        kernel.workspaces.write(bypassed_contract)
+
+    with (
+        pytest.raises(
+            WorkspaceReferenceError,
+            match=r"only workspace\.open may create the canonical PROBLEM",
+        ),
+        kernel.workspaces._connect() as connection,
+    ):
+        kernel.workspaces._prepare_write(
+            connection,
+            bypassed_contract,
+            "sha256:" + ("0" * 64),
+        )
+
+    resumed = kernel.workspaces.query(
+        WorkspaceQueryRequest(
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            view=WorkspaceQueryView.RESUME,
+        )
+    )
+    assert resumed.revision_id == opened.revision_id
+    assert resumed.resume is not None
+    assert resumed.resume.problem.card_id == opened.problem_card_id
+
+
+@pytest.mark.integration
+def test_workspace_write_builds_resume_frontier_and_attempt_views(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    opened = _open(kernel)
+    request = WorkspaceWriteRequest(
+        idempotency_key="workspace-write-batch-001",
+        workspace_id=opened.workspace_id,
+        branch_id=opened.branch_id,
+        base_revision=opened.revision_id,
+        scratch=(
+            WorkspaceScratchDraft(
+                client_ref="S1",
+                body="Try induction, but keep the boundary case separate.",
+                tags=("induction",),
+            ),
+        ),
+        findings=(
+            WorkspaceFindingDraft(
+                client_ref="A1",
+                kind=WorkspaceFindingKind.ASSUMPTION,
+                title="Finite scope",
+                body="The current experiment only concerns n <= 20.",
+            ),
+            WorkspaceFindingDraft(
+                client_ref="G1",
+                kind=WorkspaceFindingKind.GOAL,
+                title="Close the induction step",
+                body="Find a strengthened hypothesis that controls the boundary term.",
+                assumption_refs=("A1",),
+                tags=("frontier",),
+            ),
+            WorkspaceFindingDraft(
+                client_ref="L1",
+                kind=WorkspaceFindingKind.CLAIM,
+                title="Candidate recurrence",
+                body="A stronger recurrence may suffice.",
+                dependency_refs=("G1",),
+            ),
+        ),
+        attempts=(
+            WorkspaceAttemptDraft(
+                client_ref="T1",
+                target_ref="G1",
+                method="ordinary_induction",
+                outcome=WorkspaceAttemptOutcome.BLOCKED,
+                summary="The step requires a bound not present in the hypothesis.",
+            ),
+        ),
+        focus=WorkspaceFocusDraft(active_ref="G1", pinned_refs=("G1", "L1")),
+    )
+
+    written = kernel.workspaces.write(request)
+    reused = kernel.workspaces.write(request)
+
+    assert reused == written
+    assert written.scratch_written == 1
+    assert written.findings_written == 3
+    assert written.attempts_written == 1
+    revision_artifact = kernel.store.get(written.revision_artifact_uri)
+    assert opened.revision_artifact_uri in revision_artifact.manifest.parents
+    revision = WorkspaceRevision.model_validate(revision_artifact.payload)
+    assert revision.parent_revision == opened.revision_id
+    assert {item.verification for item in revision.findings} == {"UNVERIFIED"}
+    assert {item.verification for item in revision.attempts} == {"UNVERIFIED"}
+
+    resume = kernel.workspaces.query(
+        WorkspaceQueryRequest(
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            view=WorkspaceQueryView.RESUME,
+        )
+    )
+    assert resume.resume is not None
+    assert resume.resume.active_item is not None
+    assert resume.resume.active_item.card_id == written.id_map["G1"]
+    assert (
+        resume.resume.active_item.created_revision_artifact_uri
+        == written.revision_artifact_uri
+    )
+    assert {item.card_id for item in resume.resume.pinned_items} == {
+        written.id_map["G1"],
+        written.id_map["L1"],
+    }
+    assert resume.resume.open_goals[0].assumption_ids == (written.id_map["A1"],)
+    assert resume.resume.recent_attempts[0].verification == "UNVERIFIED"
+
+    frontier = kernel.workspaces.query(
+        WorkspaceQueryRequest(
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            view=WorkspaceQueryView.FRONTIER,
+        )
+    )
+    assert len(frontier.frontier) == 1
+    assert frontier.frontier[0].attempt_count == 1
+    assert frontier.frontier[0].last_attempt is not None
+    assert frontier.frontier[0].last_attempt.outcome is WorkspaceAttemptOutcome.BLOCKED
+
+    attempts = kernel.workspaces.query(
+        WorkspaceQueryRequest(
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            view=WorkspaceQueryView.ATTEMPTS,
+            target_card_id=written.id_map["G1"],
+        )
+    )
+    assert [item.attempt_id for item in attempts.attempts] == [written.id_map["T1"]]
+
+
+@pytest.mark.integration
+def test_workspace_rejects_stale_base_without_partial_index_writes(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    opened = _open(kernel)
+    accepted = kernel.workspaces.write(
+        WorkspaceWriteRequest(
+            idempotency_key="workspace-write-accepted-001",
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            base_revision=opened.revision_id,
+            findings=(
+                WorkspaceFindingDraft(
+                    client_ref="G1",
+                    kind=WorkspaceFindingKind.GOAL,
+                    title="Accepted goal",
+                    body="This entry advances the branch.",
+                ),
+            ),
+        )
+    )
+
+    with pytest.raises(WorkspaceConflictError, match="base_revision is stale"):
+        kernel.workspaces.write(
+            WorkspaceWriteRequest(
+                idempotency_key="workspace-write-stale-001",
+                workspace_id=opened.workspace_id,
+                branch_id=opened.branch_id,
+                base_revision=opened.revision_id,
+                findings=(
+                    WorkspaceFindingDraft(
+                        client_ref="G2",
+                        kind=WorkspaceFindingKind.GOAL,
+                        title="Must not commit",
+                        body="This write uses a stale branch head.",
+                    ),
+                ),
+            )
+        )
+
+    with sqlite3.connect(kernel.store.db_path) as connection:
+        finding_count = connection.execute(
+            "SELECT COUNT(*) FROM workspace_findings WHERE workspace_id = ?",
+            (opened.workspace_id,),
+        ).fetchone()[0]
+        revision_count = connection.execute(
+            "SELECT COUNT(*) FROM workspace_revisions WHERE workspace_id = ?",
+            (opened.workspace_id,),
+        ).fetchone()[0]
+    assert finding_count == 2
+    assert revision_count == 2
+    current = kernel.workspaces.query(
+        WorkspaceQueryRequest(
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            view=WorkspaceQueryView.RESUME,
+            revision_id=accepted.revision_id,
+        )
+    )
+    assert current.revision_id == accepted.revision_id
+
+    with pytest.raises(
+        WorkspaceConflictError,
+        match="query revision_id is stale",
+    ):
+        kernel.workspaces.query(
+            WorkspaceQueryRequest(
+                workspace_id=opened.workspace_id,
+                branch_id=opened.branch_id,
+                view=WorkspaceQueryView.RESUME,
+                revision_id=opened.revision_id,
+            )
+        )
+
+
+@pytest.mark.integration
+def test_workspace_rejects_idempotency_rebinding_and_invalid_references(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    opened = _open(kernel, key="workspace-open-binding-001")
+
+    with pytest.raises(WorkspaceIdempotencyError, match="different workspace request"):
+        kernel.workspaces.open(
+            WorkspaceOpenRequest(
+                idempotency_key="workspace-open-binding-001",
+                name="different",
+                problem="This must not reuse the first workspace.",
+            )
+        )
+
+    with pytest.raises(WorkspaceReferenceError, match="does not exist"):
+        kernel.workspaces.write(
+            WorkspaceWriteRequest(
+                idempotency_key="workspace-write-missing-ref-001",
+                workspace_id=opened.workspace_id,
+                branch_id=opened.branch_id,
+                base_revision=opened.revision_id,
+                findings=(
+                    WorkspaceFindingDraft(
+                        client_ref="L1",
+                        kind=WorkspaceFindingKind.CLAIM,
+                        title="Dangling dependency",
+                        body="This finding cites a missing card.",
+                        dependency_refs=("card://00000000000000000000000000000000",),
+                    ),
+                ),
+            )
+        )
+
+    with pytest.raises(WorkspaceReferenceError, match="contain a cycle"):
+        kernel.workspaces.write(
+            WorkspaceWriteRequest(
+                idempotency_key="workspace-write-cycle-001",
+                workspace_id=opened.workspace_id,
+                branch_id=opened.branch_id,
+                base_revision=opened.revision_id,
+                findings=(
+                    WorkspaceFindingDraft(
+                        client_ref="L1",
+                        kind=WorkspaceFindingKind.CLAIM,
+                        title="First",
+                        body="First cyclic claim.",
+                        dependency_refs=("L2",),
+                    ),
+                    WorkspaceFindingDraft(
+                        client_ref="L2",
+                        kind=WorkspaceFindingKind.CLAIM,
+                        title="Second",
+                        body="Second cyclic claim.",
+                        dependency_refs=("L1",),
+                    ),
+                ),
+            )
+        )
+
+
+def test_workspace_drafts_do_not_accept_caller_controlled_verification() -> None:
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        WorkspaceFindingDraft.model_validate(
+            {
+                "client_ref": "L1",
+                "kind": "CLAIM",
+                "title": "Forged",
+                "body": "Caller attempts to self-promote this claim.",
+                "verification": "VERIFIED",
+            }
+        )
+
+
+def test_workspace_drafts_normalize_unambiguous_operational_aliases() -> None:
+    goal = WorkspaceFindingDraft.model_validate(
+        {
+            "client_ref": "G1",
+            "kind": "OPEN_GOAL",
+            "title": "Finish the proof",
+            "body": "This remains agent-authored and unverified.",
+        }
+    )
+    attempt = WorkspaceAttemptDraft.model_validate(
+        {
+            "client_ref": "T1",
+            "target_ref": "G1",
+            "method": "direct",
+            "outcome": "SUCCEEDED",
+            "summary": "The operational attempt finished.",
+        }
+    )
+    mark = WorkspaceMarkDraft.model_validate(
+        {
+            "client_ref": "M1",
+            "target_ref": "G1",
+            "state": "CLOSED",
+            "summary": "The agent explicitly closed this work item.",
+        }
+    )
+
+    assert goal.kind is WorkspaceFindingKind.GOAL
+    assert attempt.outcome is WorkspaceAttemptOutcome.COMPLETED
+    assert mark.reason == "The agent explicitly closed this work item."
+    assert goal.model_dump(mode="json")["kind"] == "GOAL"
+    assert attempt.model_dump(mode="json")["outcome"] == "COMPLETED"
+    assert set(mark.model_dump(mode="json")) == {
+        "client_ref",
+        "target_ref",
+        "state",
+        "reason",
+        "superseded_by_ref",
+    }
+
+
+def test_workspace_finding_kind_accepts_a_generic_finding_card() -> None:
+    finding = WorkspaceFindingDraft(
+        client_ref="F1",
+        kind="FINDING",
+        title="Recorded observation",
+        body="This is a generic agent-authored observation.",
+    )
+
+    assert finding.kind is WorkspaceFindingKind.FINDING
+
+
+def test_workspace_focus_requires_an_explicit_update() -> None:
+    with pytest.raises(
+        ValidationError,
+        match="focus update requires active_ref, pinned_refs, or clear=true",
+    ):
+        WorkspaceFocusDraft()
+
+    with pytest.raises(
+        ValidationError,
+        match="focus clear cannot be combined",
+    ):
+        WorkspaceFocusDraft(active_ref="G1", clear=True)
+
+
+def test_workspace_focus_rejects_attempt_and_scratch_client_refs() -> None:
+    with pytest.raises(
+        ValidationError,
+        match="focus references must identify finding cards",
+    ):
+        WorkspaceWriteRequest(
+            idempotency_key="workspace-write-focus-kind-001",
+            workspace_id="workspace://00000000000000000000000000000000",
+            branch_id="branch://00000000000000000000000000000000",
+            base_revision="revision://00000000000000000000000000000000",
+            attempts=(
+                WorkspaceAttemptDraft(
+                    client_ref="T1",
+                    target_ref="card://00000000000000000000000000000000",
+                    method="direct",
+                    outcome=WorkspaceAttemptOutcome.BLOCKED,
+                    summary="This attempt cannot be focused directly.",
+                ),
+            ),
+            focus=WorkspaceFocusDraft(pinned_refs=("T1",)),
+        )
+
+
+@pytest.mark.integration
+def test_workspace_focus_clear_is_explicit_and_resumable(tmp_path: Path) -> None:
+    kernel = JacobianKernel(tmp_path)
+    opened = _open(kernel, key="workspace-open-focus-clear-001")
+
+    cleared = kernel.workspaces.write(
+        WorkspaceWriteRequest(
+            idempotency_key="workspace-write-focus-clear-001",
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            base_revision=opened.revision_id,
+            focus=WorkspaceFocusDraft(clear=True),
+        )
+    )
+
+    assert cleared.focus_updated is True
+    resume = kernel.workspaces.query(
+        WorkspaceQueryRequest(
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            view=WorkspaceQueryView.RESUME,
+        )
+    )
+    assert resume.resume is not None
+    assert resume.resume.active_item is None
+    assert resume.resume.pinned_items == ()
+
+
+@pytest.mark.integration
+def test_workspace_marks_close_goals_and_propagate_staleness(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    opened = _open(kernel, key="workspace-open-marks-001")
+    seeded = kernel.workspaces.write(
+        WorkspaceWriteRequest(
+            idempotency_key="workspace-write-mark-seed-001",
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            base_revision=opened.revision_id,
+            findings=(
+                WorkspaceFindingDraft(
+                    client_ref="A1",
+                    kind=WorkspaceFindingKind.ASSUMPTION,
+                    title="Finite scope",
+                    body="Only n <= 20 is in scope.",
+                ),
+                WorkspaceFindingDraft(
+                    client_ref="C1",
+                    kind=WorkspaceFindingKind.CLAIM,
+                    title="Checked recurrence",
+                    body="The recurrence held throughout the finite scope.",
+                    assumption_refs=("A1",),
+                ),
+                WorkspaceFindingDraft(
+                    client_ref="G1",
+                    kind=WorkspaceFindingKind.GOAL,
+                    title="Extend the recurrence",
+                    body="Determine whether the recurrence extends beyond the sample.",
+                    dependency_refs=("C1",),
+                ),
+            ),
+            attempts=(
+                WorkspaceAttemptDraft(
+                    client_ref="T1",
+                    target_ref="G1",
+                    method="finite_enumeration",
+                    outcome=WorkspaceAttemptOutcome.COMPLETED,
+                    summary="The bounded enumeration completed.",
+                ),
+            ),
+            focus=WorkspaceFocusDraft(active_ref="G1"),
+        )
+    )
+
+    before_mark = kernel.workspaces.query(
+        WorkspaceQueryRequest(
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            view=WorkspaceQueryView.RESUME,
+        )
+    )
+    assert before_mark.resume is not None
+    assert [item.card_id for item in before_mark.resume.open_goals] == [
+        seeded.id_map["G1"]
+    ]
+
+    retracted = kernel.workspaces.write(
+        WorkspaceWriteRequest(
+            idempotency_key="workspace-write-mark-retract-001",
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            base_revision=seeded.revision_id,
+            marks=(
+                WorkspaceMarkDraft(
+                    client_ref="M2",
+                    target_ref=seeded.id_map["A1"],
+                    state=WorkspaceCardState.RETRACTED,
+                    reason="The finite scope was an exploratory restriction, not a premise.",
+                ),
+            ),
+        )
+    )
+
+    after_retraction = kernel.workspaces.query(
+        WorkspaceQueryRequest(
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            revision_id=retracted.revision_id,
+            view=WorkspaceQueryView.RESUME,
+        )
+    )
+    assert after_retraction.resume is not None
+    assert [item.card_id for item in after_retraction.resume.open_goals] == [
+        seeded.id_map["G1"]
+    ]
+    assert after_retraction.resume.open_goals[0].stale is True
+    stale_frontier = kernel.workspaces.query(
+        WorkspaceQueryRequest(
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            revision_id=retracted.revision_id,
+            view=WorkspaceQueryView.FRONTIER,
+        )
+    )
+    assert [item.goal.card_id for item in stale_frontier.frontier] == [
+        seeded.id_map["G1"]
+    ]
+
+    marked = kernel.workspaces.write(
+        WorkspaceWriteRequest(
+            idempotency_key="workspace-write-mark-close-001",
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            base_revision=retracted.revision_id,
+            marks=(
+                WorkspaceMarkDraft(
+                    client_ref="M1",
+                    target_ref=seeded.id_map["G1"],
+                    state=WorkspaceCardState.CLOSED,
+                    reason="The agent has no remaining work on this bounded subgoal.",
+                ),
+            ),
+        )
+    )
+
+    assert retracted.marks_written == 1
+    assert marked.marks_written == 1
+    assert marked.id_map["M1"].startswith("mark://")
+    retracted_revision = WorkspaceRevision.model_validate(
+        kernel.store.get(retracted.revision_artifact_uri).payload
+    )
+    revision = WorkspaceRevision.model_validate(
+        kernel.store.get(marked.revision_artifact_uri).payload
+    )
+    for stored_revision in (retracted_revision, revision):
+        assert {mark.assertion for mark in stored_revision.marks} == {"AGENT_RECORDED"}
+        assert {mark.verification for mark in stored_revision.marks} == {"UNVERIFIED"}
+
+    resume = kernel.workspaces.query(
+        WorkspaceQueryRequest(
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            revision_id=marked.revision_id,
+            view=WorkspaceQueryView.RESUME,
+        )
+    )
+    assert resume.resume is not None
+    assert resume.resume.open_goals == ()
+    assert {item.card_id for item in resume.resume.stale_items} == {
+        seeded.id_map["C1"],
+        seeded.id_map["G1"],
+    }
+    assert resume.resume.active_item is not None
+    assert resume.resume.active_item.state is WorkspaceCardState.CLOSED
+    assert resume.resume.active_item.stale is True
+    assert resume.resume.active_item.stale_due_to_ids == (seeded.id_map["A1"],)
+
+    frontier = kernel.workspaces.query(
+        WorkspaceQueryRequest(
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            view=WorkspaceQueryView.FRONTIER,
+        )
+    )
+    assert frontier.frontier == ()
+
+    stale = kernel.workspaces.query(
+        WorkspaceQueryRequest(
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            view=WorkspaceQueryView.STALE,
+        )
+    )
+    assert {item.card_id for item in stale.stale_items} == {
+        seeded.id_map["C1"],
+        seeded.id_map["G1"],
+    }
+
+    context = kernel.workspaces.query(
+        WorkspaceQueryRequest(
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            view=WorkspaceQueryView.CONTEXT,
+            target_card_id=seeded.id_map["G1"],
+        )
+    )
+    assert context.context is not None
+    assert context.context.target.card_id == seeded.id_map["G1"]
+    assert [item.card_id for item in context.context.dependencies] == [
+        seeded.id_map["A1"],
+        seeded.id_map["C1"],
+    ]
+    assert context.context.dependencies[0].state is WorkspaceCardState.RETRACTED
+    assert context.context.total_dependency_count == 2
+    assert context.context.truncated is False
+    assert [attempt.attempt_id for attempt in context.context.recent_attempts] == [
+        seeded.id_map["T1"]
+    ]
+
+    restarted = JacobianKernel(tmp_path)
+    replayed = restarted.workspaces.query(
+        WorkspaceQueryRequest(
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            view=WorkspaceQueryView.CONTEXT,
+            target_card_id=seeded.id_map["G1"],
+        )
+    )
+    assert replayed == context
+
+
+@pytest.mark.integration
+def test_workspace_supersession_and_reactivation_are_explicit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    opened = _open(kernel, key="workspace-open-supersede-001")
+    seeded = kernel.workspaces.write(
+        WorkspaceWriteRequest(
+            idempotency_key="workspace-write-supersede-seed-001",
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            base_revision=opened.revision_id,
+            findings=(
+                WorkspaceFindingDraft(
+                    client_ref="A1",
+                    kind=WorkspaceFindingKind.ASSUMPTION,
+                    title="Original scope",
+                    body="Assume n <= 20.",
+                ),
+                WorkspaceFindingDraft(
+                    client_ref="C1",
+                    kind=WorkspaceFindingKind.CLAIM,
+                    title="Scope-dependent claim",
+                    body="This card depends on the original scope.",
+                    assumption_refs=("A1",),
+                ),
+            ),
+        )
+    )
+    monkeypatch.setattr(
+        "jacobian.workspaces._now",
+        lambda: datetime(2030, 1, 1, tzinfo=UTC),
+    )
+    superseded = kernel.workspaces.write(
+        WorkspaceWriteRequest(
+            idempotency_key="workspace-write-supersede-state-001",
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            base_revision=seeded.revision_id,
+            findings=(
+                WorkspaceFindingDraft(
+                    client_ref="A2",
+                    kind=WorkspaceFindingKind.ASSUMPTION,
+                    title="Revised scope",
+                    body="Assume n <= 50.",
+                ),
+            ),
+            marks=(
+                WorkspaceMarkDraft(
+                    client_ref="M1",
+                    target_ref=seeded.id_map["A1"],
+                    state=WorkspaceCardState.SUPERSEDED,
+                    superseded_by_ref="A2",
+                    reason="Replace the exploratory bound with the revised scope.",
+                ),
+            ),
+        )
+    )
+
+    context = kernel.workspaces.query(
+        WorkspaceQueryRequest(
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            view=WorkspaceQueryView.CONTEXT,
+            target_card_id=seeded.id_map["C1"],
+        )
+    )
+    assert context.context is not None
+    original = context.context.dependencies[0]
+    assert original.state is WorkspaceCardState.SUPERSEDED
+    assert original.superseded_by_id == superseded.id_map["A2"]
+    assert context.context.target.stale_due_to_ids == (seeded.id_map["A1"],)
+
+    monkeypatch.setattr(
+        "jacobian.workspaces._now",
+        lambda: datetime(2020, 1, 1, tzinfo=UTC),
+    )
+    reactivated = kernel.workspaces.write(
+        WorkspaceWriteRequest(
+            idempotency_key="workspace-write-reactivate-state-001",
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            base_revision=superseded.revision_id,
+            marks=(
+                WorkspaceMarkDraft(
+                    client_ref="M2",
+                    target_ref=seeded.id_map["A1"],
+                    state=WorkspaceCardState.ACTIVE,
+                    reason="Restore the original scope for a separate bounded argument.",
+                ),
+            ),
+        )
+    )
+    after = kernel.workspaces.query(
+        WorkspaceQueryRequest(
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            revision_id=reactivated.revision_id,
+            view=WorkspaceQueryView.CONTEXT,
+            target_card_id=seeded.id_map["C1"],
+        )
+    )
+    assert after.context is not None
+    assert after.context.target.stale is False
+    assert after.context.dependencies[0].state is WorkspaceCardState.ACTIVE
+    assert after.context.dependencies[0].superseded_by_id is None
+
+
+@pytest.mark.integration
+def test_workspace_query_uses_one_revision_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    opened = _open(kernel, key="workspace-open-query-snapshot-001")
+    projection_started = Event()
+    continue_projection = Event()
+    original_projection = kernel.workspaces._projection
+
+    def paused_projection(
+        connection: sqlite3.Connection,
+        request: WorkspaceQueryRequest,
+    ) -> object:
+        projection_started.set()
+        if not continue_projection.wait(timeout=10):
+            raise AssertionError("test did not release the paused projection")
+        return original_projection(connection, request)
+
+    monkeypatch.setattr(kernel.workspaces, "_projection", paused_projection)
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        pending = pool.submit(
+            kernel.workspaces.query,
+            WorkspaceQueryRequest(
+                workspace_id=opened.workspace_id,
+                branch_id=opened.branch_id,
+                revision_id=opened.revision_id,
+                view=WorkspaceQueryView.RESUME,
+            ),
+        )
+        assert projection_started.wait(timeout=10)
+        advanced = kernel.workspaces.write(
+            WorkspaceWriteRequest(
+                idempotency_key="workspace-write-during-query-001",
+                workspace_id=opened.workspace_id,
+                branch_id=opened.branch_id,
+                base_revision=opened.revision_id,
+                findings=(
+                    WorkspaceFindingDraft(
+                        client_ref="G1",
+                        kind=WorkspaceFindingKind.GOAL,
+                        title="Concurrently appended goal",
+                        body="This must not appear under the old revision handle.",
+                    ),
+                ),
+            )
+        )
+        continue_projection.set()
+        snapshotted = pending.result(timeout=10)
+
+    assert snapshotted.revision_id == opened.revision_id
+    assert snapshotted.resume is not None
+    assert snapshotted.resume.open_goals == ()
+
+    monkeypatch.setattr(kernel.workspaces, "_projection", original_projection)
+    latest = kernel.workspaces.query(
+        WorkspaceQueryRequest(
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            revision_id=advanced.revision_id,
+            view=WorkspaceQueryView.RESUME,
+        )
+    )
+    assert latest.resume is not None
+    assert [item.card_id for item in latest.resume.open_goals] == [
+        advanced.id_map["G1"]
+    ]
+
+
+@pytest.mark.integration
+def test_workspace_recent_views_follow_acceptance_order(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    opened = _open(kernel, key="workspace-open-acceptance-order-001")
+    monkeypatch.setattr(
+        "jacobian.workspaces._now",
+        lambda: datetime(2030, 1, 1, tzinfo=UTC),
+    )
+    first = kernel.workspaces.write(
+        WorkspaceWriteRequest(
+            idempotency_key="workspace-write-acceptance-order-001",
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            base_revision=opened.revision_id,
+            scratch=(WorkspaceScratchDraft(client_ref="S1", body="Accepted first."),),
+            findings=(
+                WorkspaceFindingDraft(
+                    client_ref="G1",
+                    kind=WorkspaceFindingKind.GOAL,
+                    title="Accepted first",
+                    body="This write has a later wall-clock timestamp.",
+                ),
+            ),
+            attempts=(
+                WorkspaceAttemptDraft(
+                    client_ref="T1",
+                    target_ref="G1",
+                    method="first",
+                    outcome=WorkspaceAttemptOutcome.BLOCKED,
+                    summary="Accepted first.",
+                ),
+            ),
+        )
+    )
+    monkeypatch.setattr(
+        "jacobian.workspaces._now",
+        lambda: datetime(2020, 1, 1, tzinfo=UTC),
+    )
+    second = kernel.workspaces.write(
+        WorkspaceWriteRequest(
+            idempotency_key="workspace-write-acceptance-order-002",
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            base_revision=first.revision_id,
+            scratch=(WorkspaceScratchDraft(client_ref="S2", body="Accepted second."),),
+            findings=(
+                WorkspaceFindingDraft(
+                    client_ref="G2",
+                    kind=WorkspaceFindingKind.GOAL,
+                    title="Accepted second",
+                    body="This write has an earlier wall-clock timestamp.",
+                ),
+            ),
+            attempts=(
+                WorkspaceAttemptDraft(
+                    client_ref="T2",
+                    target_ref="G2",
+                    method="second",
+                    outcome=WorkspaceAttemptOutcome.BLOCKED,
+                    summary="Accepted second.",
+                ),
+            ),
+        )
+    )
+
+    resume = kernel.workspaces.query(
+        WorkspaceQueryRequest(
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            revision_id=second.revision_id,
+            view=WorkspaceQueryView.RESUME,
+        )
+    )
+
+    assert resume.resume is not None
+    assert [item.card_id for item in resume.resume.open_goals] == [
+        second.id_map["G2"],
+        first.id_map["G1"],
+    ]
+    assert [item.attempt_id for item in resume.resume.recent_attempts] == [
+        second.id_map["T2"],
+        first.id_map["T1"],
+    ]
+    assert [item.scratch_id for item in resume.resume.recent_scratch] == [
+        second.id_map["S2"],
+        first.id_map["S1"],
+    ]
+
+
+@pytest.mark.integration
+def test_workspace_context_handles_a_deep_dependency_chain(tmp_path: Path) -> None:
+    kernel = JacobianKernel(tmp_path)
+    opened = _open(kernel, key="workspace-open-deep-context-001")
+    revision_id = opened.revision_id
+    previous_card_id: str | None = None
+
+    for batch_index in range(16):
+        findings = []
+        for item_index in range(64):
+            client_ref = f"N{item_index}"
+            if item_index > 0:
+                dependency_refs = (f"N{item_index - 1}",)
+            elif previous_card_id is not None:
+                dependency_refs = (previous_card_id,)
+            else:
+                dependency_refs = ()
+            findings.append(
+                WorkspaceFindingDraft(
+                    client_ref=client_ref,
+                    kind=WorkspaceFindingKind.FINDING,
+                    title=f"Chain item {batch_index}-{item_index}",
+                    body="One explicit link in a deliberately deep paper trail.",
+                    dependency_refs=dependency_refs,
+                )
+            )
+        written = kernel.workspaces.write(
+            WorkspaceWriteRequest(
+                idempotency_key=f"workspace-write-deep-{batch_index:03d}",
+                workspace_id=opened.workspace_id,
+                branch_id=opened.branch_id,
+                base_revision=revision_id,
+                findings=tuple(findings),
+            )
+        )
+        revision_id = written.revision_id
+        previous_card_id = written.id_map["N63"]
+
+    assert previous_card_id is not None
+    context = kernel.workspaces.query(
+        WorkspaceQueryRequest(
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            revision_id=revision_id,
+            view=WorkspaceQueryView.CONTEXT,
+            target_card_id=previous_card_id,
+            limit=1,
+        )
+    )
+    assert context.context is not None
+    assert context.context.total_dependency_count == 1023
+    assert context.context.truncated is True
+    assert len(context.context.dependencies) == 1
+
+
+@pytest.mark.integration
+def test_workspace_supersession_handles_a_deep_chain(tmp_path: Path) -> None:
+    kernel = JacobianKernel(tmp_path)
+    opened = _open(kernel, key="workspace-open-deep-supersession-001")
+    revision_id = opened.revision_id
+    card_ids: list[str] = []
+
+    for batch_start in range(0, 1025, 64):
+        drafts = tuple(
+            WorkspaceFindingDraft(
+                client_ref=f"N{index}",
+                kind=WorkspaceFindingKind.FINDING,
+                title=f"Replacement candidate {index}",
+                body="One card in a deliberately deep replacement trail.",
+            )
+            for index in range(batch_start, min(batch_start + 64, 1025))
+        )
+        written = kernel.workspaces.write(
+            WorkspaceWriteRequest(
+                idempotency_key=(
+                    f"workspace-write-deep-supersession-cards-{batch_start:04d}"
+                ),
+                workspace_id=opened.workspace_id,
+                branch_id=opened.branch_id,
+                base_revision=revision_id,
+                findings=drafts,
+            )
+        )
+        revision_id = written.revision_id
+        card_ids.extend(written.id_map[draft.client_ref] for draft in drafts)
+
+    for batch_start in range(0, 1024, 64):
+        marks = tuple(
+            WorkspaceMarkDraft(
+                client_ref=f"M{index}",
+                target_ref=card_ids[index],
+                state=WorkspaceCardState.SUPERSEDED,
+                reason="The next card replaces this exploratory note.",
+                superseded_by_ref=card_ids[index + 1],
+            )
+            for index in range(batch_start, min(batch_start + 64, 1024))
+        )
+        written = kernel.workspaces.write(
+            WorkspaceWriteRequest(
+                idempotency_key=(
+                    f"workspace-write-deep-supersession-marks-{batch_start:04d}"
+                ),
+                workspace_id=opened.workspace_id,
+                branch_id=opened.branch_id,
+                base_revision=revision_id,
+                marks=marks,
+            )
+        )
+        revision_id = written.revision_id
+
+    context = kernel.workspaces.query(
+        WorkspaceQueryRequest(
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            revision_id=revision_id,
+            view=WorkspaceQueryView.CONTEXT,
+            target_card_id=card_ids[0],
+        )
+    )
+    assert context.context is not None
+    assert context.context.target.state is WorkspaceCardState.SUPERSEDED
+    assert context.context.target.superseded_by_id == card_ids[1]
+
+
+def test_workspace_mark_contracts_fail_closed() -> None:
+    with pytest.raises(
+        ValidationError,
+        match="cannot provide both reason and summary",
+    ):
+        WorkspaceMarkDraft.model_validate(
+            {
+                "client_ref": "M1",
+                "target_ref": "card://00000000000000000000000000000000",
+                "state": "CLOSED",
+                "reason": "Canonical reason.",
+                "summary": "Conflicting alias.",
+            }
+        )
+
+    with pytest.raises(
+        ValidationError,
+        match="SUPERSEDED marks require superseded_by_ref",
+    ):
+        WorkspaceMarkDraft(
+            client_ref="M1",
+            target_ref="card://00000000000000000000000000000000",
+            state=WorkspaceCardState.SUPERSEDED,
+            reason="Missing replacement.",
+        )
+
+    with pytest.raises(
+        ValidationError,
+        match="only SUPERSEDED marks may carry superseded_by_ref",
+    ):
+        WorkspaceMarkDraft(
+            client_ref="M1",
+            target_ref="card://00000000000000000000000000000000",
+            state=WorkspaceCardState.ACTIVE,
+            superseded_by_ref="card://11111111111111111111111111111111",
+            reason="An active mark cannot silently replace a card.",
+        )
+
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        WorkspaceMarkDraft.model_validate(
+            {
+                "client_ref": "M1",
+                "target_ref": "card://00000000000000000000000000000000",
+                "state": "CLOSED",
+                "reason": "Caller attempts to self-promote the mark.",
+                "verification": "VERIFIED",
+            }
+        )
+
+    with pytest.raises(
+        ValidationError,
+        match="target_card_id is required for the CONTEXT view",
+    ):
+        WorkspaceQueryRequest(
+            workspace_id="workspace://00000000000000000000000000000000",
+            branch_id="branch://00000000000000000000000000000000",
+            view=WorkspaceQueryView.CONTEXT,
+        )
+
+
+@pytest.mark.integration
+def test_workspace_context_truncation_and_stale_roots_are_deterministic(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    opened = _open(kernel, key="workspace-open-context-budget-001")
+    seeded = kernel.workspaces.write(
+        WorkspaceWriteRequest(
+            idempotency_key="workspace-write-context-budget-001",
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            base_revision=opened.revision_id,
+            findings=(
+                WorkspaceFindingDraft(
+                    client_ref="A1",
+                    kind=WorkspaceFindingKind.ASSUMPTION,
+                    title="First premise",
+                    body="First explicit premise.",
+                ),
+                WorkspaceFindingDraft(
+                    client_ref="A2",
+                    kind=WorkspaceFindingKind.ASSUMPTION,
+                    title="Second premise",
+                    body="Second explicit premise.",
+                ),
+                WorkspaceFindingDraft(
+                    client_ref="C1",
+                    kind=WorkspaceFindingKind.CLAIM,
+                    title="First consequence",
+                    body="Depends on the first premise.",
+                    assumption_refs=("A1",),
+                ),
+                WorkspaceFindingDraft(
+                    client_ref="C2",
+                    kind=WorkspaceFindingKind.CLAIM,
+                    title="Second consequence",
+                    body="Depends on the second premise.",
+                    assumption_refs=("A2",),
+                ),
+                WorkspaceFindingDraft(
+                    client_ref="G1",
+                    kind=WorkspaceFindingKind.GOAL,
+                    title="Combined goal",
+                    body="Depends on both consequences.",
+                    dependency_refs=("C1", "C2"),
+                ),
+            ),
+        )
+    )
+    marked = kernel.workspaces.write(
+        WorkspaceWriteRequest(
+            idempotency_key="workspace-write-context-roots-001",
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            base_revision=seeded.revision_id,
+            marks=(
+                WorkspaceMarkDraft(
+                    client_ref="M1",
+                    target_ref=seeded.id_map["A1"],
+                    state=WorkspaceCardState.RETRACTED,
+                    reason="Withdraw the first premise.",
+                ),
+                WorkspaceMarkDraft(
+                    client_ref="M2",
+                    target_ref=seeded.id_map["A2"],
+                    state=WorkspaceCardState.RETRACTED,
+                    reason="Withdraw the second premise.",
+                ),
+            ),
+        )
+    )
+
+    result = kernel.workspaces.query(
+        WorkspaceQueryRequest(
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            revision_id=marked.revision_id,
+            view=WorkspaceQueryView.CONTEXT,
+            target_card_id=seeded.id_map["G1"],
+            limit=2,
+        )
+    )
+
+    assert result.context is not None
+    direct_claims = sorted((seeded.id_map["C1"], seeded.id_map["C2"]))
+    assumption_for = {
+        seeded.id_map["C1"]: seeded.id_map["A1"],
+        seeded.id_map["C2"]: seeded.id_map["A2"],
+    }
+    full_order = [
+        item
+        for claim_id in direct_claims
+        for item in (assumption_for[claim_id], claim_id)
+    ]
+    assert [item.card_id for item in result.context.dependencies] == full_order[:2]
+    assert result.context.total_dependency_count == 4
+    assert result.context.truncated is True
+    assert result.context.target.stale_due_to_ids == tuple(
+        sorted((seeded.id_map["A1"], seeded.id_map["A2"]))
+    )
+
+
+@pytest.mark.integration
+def test_workspace_invalid_marks_leave_no_partial_state(tmp_path: Path) -> None:
+    kernel = JacobianKernel(tmp_path)
+    opened = _open(kernel, key="workspace-open-invalid-mark-001")
+    seeded = kernel.workspaces.write(
+        WorkspaceWriteRequest(
+            idempotency_key="workspace-write-invalid-mark-seed-001",
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            base_revision=opened.revision_id,
+            findings=(
+                WorkspaceFindingDraft(
+                    client_ref="A1",
+                    kind=WorkspaceFindingKind.ASSUMPTION,
+                    title="First assumption",
+                    body="First assumption body.",
+                ),
+                WorkspaceFindingDraft(
+                    client_ref="A2",
+                    kind=WorkspaceFindingKind.ASSUMPTION,
+                    title="Second assumption",
+                    body="Second assumption body.",
+                ),
+            ),
+        )
+    )
+
+    invalid_requests = (
+        WorkspaceWriteRequest(
+            idempotency_key="workspace-write-invalid-close-001",
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            base_revision=seeded.revision_id,
+            marks=(
+                WorkspaceMarkDraft(
+                    client_ref="M1",
+                    target_ref=seeded.id_map["A1"],
+                    state=WorkspaceCardState.CLOSED,
+                    reason="An assumption is not an open task.",
+                ),
+            ),
+        ),
+        WorkspaceWriteRequest(
+            idempotency_key="workspace-write-invalid-self-001",
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            base_revision=seeded.revision_id,
+            marks=(
+                WorkspaceMarkDraft(
+                    client_ref="M1",
+                    target_ref=seeded.id_map["A1"],
+                    state=WorkspaceCardState.SUPERSEDED,
+                    superseded_by_ref=seeded.id_map["A1"],
+                    reason="A card cannot replace itself.",
+                ),
+            ),
+        ),
+        WorkspaceWriteRequest(
+            idempotency_key="workspace-write-invalid-problem-001",
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            base_revision=seeded.revision_id,
+            marks=(
+                WorkspaceMarkDraft(
+                    client_ref="M1",
+                    target_ref=opened.problem_card_id,
+                    state=WorkspaceCardState.RETRACTED,
+                    reason="The canonical problem remains immutable.",
+                ),
+            ),
+        ),
+    )
+    for invalid in invalid_requests:
+        with pytest.raises(WorkspaceReferenceError):
+            kernel.workspaces.write(invalid)
+
+    accepted = kernel.workspaces.write(
+        WorkspaceWriteRequest(
+            idempotency_key="workspace-write-valid-supersede-001",
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            base_revision=seeded.revision_id,
+            marks=(
+                WorkspaceMarkDraft(
+                    client_ref="M1",
+                    target_ref=seeded.id_map["A1"],
+                    state=WorkspaceCardState.SUPERSEDED,
+                    superseded_by_ref=seeded.id_map["A2"],
+                    reason="Use the second assumption instead.",
+                ),
+            ),
+        )
+    )
+    with pytest.raises(WorkspaceReferenceError, match=r"supersession.*cycle"):
+        kernel.workspaces.write(
+            WorkspaceWriteRequest(
+                idempotency_key="workspace-write-invalid-cycle-001",
+                workspace_id=opened.workspace_id,
+                branch_id=opened.branch_id,
+                base_revision=accepted.revision_id,
+                marks=(
+                    WorkspaceMarkDraft(
+                        client_ref="M2",
+                        target_ref=seeded.id_map["A2"],
+                        state=WorkspaceCardState.SUPERSEDED,
+                        superseded_by_ref=seeded.id_map["A1"],
+                        reason="This would create a replacement cycle.",
+                    ),
+                ),
+            )
+        )
+
+    with sqlite3.connect(kernel.store.db_path) as connection:
+        revision_count = connection.execute(
+            "SELECT COUNT(*) FROM workspace_revisions WHERE workspace_id = ?",
+            (opened.workspace_id,),
+        ).fetchone()[0]
+        mark_count = connection.execute(
+            "SELECT COUNT(*) FROM workspace_marks WHERE workspace_id = ?",
+            (opened.workspace_id,),
+        ).fetchone()[0]
+    assert revision_count == 3
+    assert mark_count == 1
+
+
+@pytest.mark.integration
+def test_workspace_invalidating_mark_requires_explicit_reactivation(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    opened = _open(kernel, key="workspace-open-explicit-reactivation-001")
+    seeded = kernel.workspaces.write(
+        WorkspaceWriteRequest(
+            idempotency_key="workspace-write-explicit-reactivation-seed-001",
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            base_revision=opened.revision_id,
+            findings=(
+                WorkspaceFindingDraft(
+                    client_ref="A1",
+                    kind=WorkspaceFindingKind.ASSUMPTION,
+                    title="Withdrawn premise",
+                    body="This premise will be explicitly reactivated later.",
+                ),
+                WorkspaceFindingDraft(
+                    client_ref="C1",
+                    kind=WorkspaceFindingKind.CLAIM,
+                    title="Dependent note",
+                    body="This note depends on the withdrawn premise.",
+                    assumption_refs=("A1",),
+                ),
+            ),
+        )
+    )
+    retracted = kernel.workspaces.write(
+        WorkspaceWriteRequest(
+            idempotency_key="workspace-write-explicit-reactivation-retract-001",
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            base_revision=seeded.revision_id,
+            marks=(
+                WorkspaceMarkDraft(
+                    client_ref="M1",
+                    target_ref=seeded.id_map["A1"],
+                    state=WorkspaceCardState.RETRACTED,
+                    reason="Withdraw this premise.",
+                ),
+            ),
+        )
+    )
+
+    with pytest.raises(
+        WorkspaceReferenceError,
+        match="must be marked ACTIVE before",
+    ):
+        kernel.workspaces.write(
+            WorkspaceWriteRequest(
+                idempotency_key="workspace-write-explicit-reactivation-bypass-001",
+                workspace_id=opened.workspace_id,
+                branch_id=opened.branch_id,
+                base_revision=retracted.revision_id,
+                marks=(
+                    WorkspaceMarkDraft(
+                        client_ref="M2",
+                        target_ref=seeded.id_map["A1"],
+                        state=WorkspaceCardState.ARCHIVED,
+                        reason="Archiving must not silently erase the withdrawal.",
+                    ),
+                ),
+            )
+        )
+
+    unchanged = kernel.workspaces.query(
+        WorkspaceQueryRequest(
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            view=WorkspaceQueryView.CONTEXT,
+            target_card_id=seeded.id_map["C1"],
+        )
+    )
+    assert unchanged.revision_id == retracted.revision_id
+    assert unchanged.context is not None
+    assert unchanged.context.target.stale_due_to_ids == (seeded.id_map["A1"],)
+    assert unchanged.context.dependencies[0].state is WorkspaceCardState.RETRACTED
+
+
+@pytest.mark.integration
+def test_workspace_archiving_is_organizational_not_invalidation(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    opened = _open(kernel, key="workspace-open-archive-001")
+    seeded = kernel.workspaces.write(
+        WorkspaceWriteRequest(
+            idempotency_key="workspace-write-archive-seed-001",
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            base_revision=opened.revision_id,
+            findings=(
+                WorkspaceFindingDraft(
+                    client_ref="A1",
+                    kind=WorkspaceFindingKind.ASSUMPTION,
+                    title="Filed premise",
+                    body="This premise remains usable when filed away.",
+                ),
+                WorkspaceFindingDraft(
+                    client_ref="C1",
+                    kind=WorkspaceFindingKind.CLAIM,
+                    title="Dependent claim",
+                    body="This depends on the filed premise.",
+                    assumption_refs=("A1",),
+                ),
+            ),
+        )
+    )
+    archived = kernel.workspaces.write(
+        WorkspaceWriteRequest(
+            idempotency_key="workspace-write-archive-mark-001",
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            base_revision=seeded.revision_id,
+            marks=(
+                WorkspaceMarkDraft(
+                    client_ref="M1",
+                    target_ref=seeded.id_map["A1"],
+                    state=WorkspaceCardState.ARCHIVED,
+                    reason="File this premise away without withdrawing it.",
+                ),
+            ),
+        )
+    )
+
+    context = kernel.workspaces.query(
+        WorkspaceQueryRequest(
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            revision_id=archived.revision_id,
+            view=WorkspaceQueryView.CONTEXT,
+            target_card_id=seeded.id_map["C1"],
+        )
+    )
+    assert context.context is not None
+    assert context.context.target.stale is False
+    assert context.context.dependencies[0].state is WorkspaceCardState.ARCHIVED


### PR DESCRIPTION
## Problem

Agents need durable paper-like working state across context loss, but recording a note, attempt, or completed write is an operational result rather than mathematical evidence. Routing scratchpad state through `CapabilityService` would blur the assurance boundary, while the existing two-tool surface had no way to checkpoint, retract, supersede, or retrieve bounded task context.

## Solution

- Add an independent `WorkspaceService` with immutable revision artifacts, SQLite compare-and-swap branch heads, idempotent mutations, explicit references, focus, scratch entries, findings, and attempt records.
- Add append-only lifecycle marks (`ACTIVE`, `CLOSED`, `RETRACTED`, `SUPERSEDED`, `ARCHIVED`), explicit-link stale propagation, and deterministic `RESUME`, `FRONTIER`, `ATTEMPTS`, `CONTEXT`, and `STALE` views.
- Expose `workspace.open`, `workspace.write`, and `workspace.query` beside `capability.describe` and `capability.invoke`; mathematical operations remain namespaced capabilities.
- Publish strict input schemas and documented aliases while rejecting unknown fields, extra `PROBLEM` cards, stale writes, invalid references, cycles, and assurance-forging fields.
- Preserve tenant isolation and keep the five-tool initial descriptor below the 25 KB development target by omitting workspace output schemas from discovery while returning complete JSON results.
- Document the architectural decision, trust boundary, operating contract, and exploratory Codex/Terra evaluation.

## Testing

```sh
uv sync --dev
uv run pytest  # 371 passed
uv run ruff check .
uv run ruff format --check .
uv run mypy  # 80 source files
uv build
git diff --cached --check
```

Additional validation:

- Focused workspace, MCP, and remote-tenant suite: 35 passed.
- Local Codex CLI `gpt-5.6-terra` high smoke: `workspace.open -> workspace.write -> workspace.query`, three successful calls with no retry; aliases normalized, stale propagation was correct, and returned assurance remained `UNVERIFIED`.
- Compact sorted server instructions plus `tools/list`: 24,745 characters.

## Trust & Compatibility Impact

This adds a pre-stable public workspace API and revision artifact schema, and expands the MCP surface from two tools to five. It does not change checker authorization or permit workspace state to promote assurance. Findings, attempts, marks, focus, stale warnings, and retrieval remain `AGENT_RECORDED` / `UNVERIFIED`; `COMPLETED` and `CLOSED` are workflow state, not proof. The boundary is recorded in ADR 0005 and `docs/explanation/threat-model.md`.

## Checklist

- [x] Tests pass locally (`uv run pytest`)
- [x] Linting passes (`uv run ruff check .`)
- [x] Type checking passes (`uv run mypy`)
- [x] Formatting passes (`uv run ruff format --check .`)
- [x] Build succeeds (`uv build`)
- [x] Relevant documentation updated
