### PR TITLE
feat(mcp): expose exact provider runtime identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ goals are part of the working project record. Start with:
 Release contracts and engineering evidence are:
 
 - [Tool surface](docs/reference/tools.md)
+- [Provider runtime contract](docs/reference/provider-runtime.md) for
+  availability, exact backend identity, install tiers, and local measurement.
 - [v0.2 specification](docs/reference/specifications/v0.2.md) and
   [conformance gate](docs/reference/conformance-v0.2.md)
 - [Testing strategy](docs/reference/testing-strategy.md),

--- a/docs/contributing/atomic-capability-portfolio.md
+++ b/docs/contributing/atomic-capability-portfolio.md
@@ -252,6 +252,14 @@ Complete this once, before adding several backends:
 This groundwork changes packaging and descriptors, not the mathematical
 assurance model and not the top-level MCP tool count.
 
+The initial availability, identity, install-tier, and measurement contract is
+implemented in the
+[provider runtime reference](../reference/provider-runtime.md). It covers
+source-tree, Python RECORD, and executable identities; fail-closed catalog
+registration; compact result provenance; and the repeatable
+`provider-measure` command. Provider-specific subprocess hardening and
+reproduction measurements remain part of each later backend slice.
+
 ## Wave 1: Lean discovery experiment
 
 Treat these names as contract sketches:

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -189,6 +189,15 @@ rather than placing every schema in the agent's initial context. Domain
 descriptions project exact schemas, binding rules, and executable examples
 without moving mathematical semantics into the generic kernel.
 
+Registration also enforces the
+[provider runtime contract](../reference/provider-runtime.md). The catalog
+contains only adapters whose exact source tree, Python distribution manifest,
+or executable identity is available and healthy. Descriptor metadata records
+the provider version, digest coverage, platform, installation tier, license,
+features, and fixed checker identities. Invocation results bind the selected
+provider and digest without treating operational provenance as mathematical
+assurance.
+
 The service validates both schemas and prevents adapters from self-promoting:
 `VERIFIED` requires a valid local verification record whose checked evidence
 is returned with the capability result. Stage-aware diagnostics separate

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,6 +55,7 @@ Reference documents define exact interfaces, records, gates, and test
 expectations.
 
 - [Tool surface](reference/tools.md)
+- [Provider runtime contract](reference/provider-runtime.md)
 - [v0.2 specification](reference/specifications/v0.2.md)
 - [v0.2 conformance specification](reference/conformance-v0.2.md)
 - [Plugin conformance contract](reference/plugin-conformance.md)

--- a/docs/reference/provider-runtime.md
+++ b/docs/reference/provider-runtime.md
@@ -1,0 +1,112 @@
+# Provider runtime contract
+
+Jacobian advertises a capability only when its exact provider runtime is
+installed and passes its local health probe. Provider availability is a catalog
+condition. An absent optional backend is not left for the agent to discover
+during invocation.
+
+This contract describes operational provenance. It does not change
+mathematical assurance: an available provider, successful measurement, solver
+status, or package digest is never evidence that a mathematical claim is
+`VERIFIED`.
+
+## Descriptor metadata
+
+Every registered `CapabilityDescriptor` carries `provider_runtime`:
+
+| Field | Meaning |
+| --- | --- |
+| `provider` | Stable provider family selected for this operation |
+| `availability` | `AVAILABLE` for catalog entries; `UNAVAILABLE` is load-time state only |
+| `version` | Exact installed provider version |
+| `digest` | SHA-256 identity with the coverage declared by `digest_kind` |
+| `digest_kind` | `SOURCE_TREE`, `PYTHON_DISTRIBUTION_RECORD`, or `EXECUTABLE` |
+| `platform` | Current Python platform tag |
+| `install_tier` | `T0`, `T1`, `T2`, or `T3` deployment rule |
+| `license_id` and `license_files` | Declared license and installed license-file paths |
+| `features` | Health-probed feature flags used by the adapter |
+| `checker_ids` | Exact authorized checker identities, when the operation has fixed checkers |
+| `configuration` | Canonical provider-specific data, such as Lean profiles |
+
+`PYTHON_DISTRIBUTION_RECORD` hashes a canonical ordering of the installed
+distribution's RECORD paths, recorded hashes, and sizes. It identifies the
+installed manifest; the digest kind deliberately does not claim that Jacobian
+rehashes every package byte at startup. `SOURCE_TREE` covers the source package
+used by an entrypoint. `EXECUTABLE` covers the executable bytes.
+
+The result repeats the selected `provider` and `provider_digest`. This binds the
+invocation to the exact descriptor runtime without repeating all discovery
+metadata in every response. Provider metadata remains separate from execution
+status, conclusion, evidence type, and assurance.
+
+## Availability
+
+`CapabilityService.register` rejects descriptors without runtime identity and
+descriptors whose runtime is `UNAVAILABLE`. Built-in locked Python providers
+must import, expose the required feature symbols, and have a hashed
+distribution RECORD. The Lean probe validates the pinned Lean version and
+commit, resolves and hashes the actual executable, and validates the pinned
+Mathlib checkout before `lean.check` is registered.
+
+If the separately managed Lean runtime is absent or unhealthy, the kernel still
+starts, `lean.check` is absent from `capability://catalog`, and no invocation is
+attempted. Explicit operator-installed adapters fail registration instead of
+silently falling back to another provider.
+
+Source-backed adapters can construct metadata without importing their
+implementation:
+
+```python
+from jacobian.contracts.capabilities import CapabilityInstallTier
+from jacobian.provider_runtime import source_provider_runtime
+
+runtime = source_provider_runtime(
+    "example.provider",
+    version="1",
+    entrypoint="example_adapter:create_adapter",
+    install_tier=CapabilityInstallTier.T1,
+    license_id="MIT",
+    license_files=("LICENSE",),
+    features=("exact-example-operation",),
+)
+```
+
+The adapter places `runtime` in its descriptor. Registration remains
+fail-closed if the source identity cannot be resolved.
+
+## Repeatable measurement
+
+Measure the provider selected for one installed capability:
+
+```sh
+uv run jacobian --no-install-references \
+  provider-measure graph.compute.properties
+```
+
+The JSON result records:
+
+- current installed bytes;
+- cold-start elapsed time and peak resident memory;
+- a small provider-specific reproduction elapsed time and peak resident
+  memory;
+- cold-install status, elapsed time, and temporary installed bytes.
+
+Cold install is skipped by default because it performs network and filesystem
+work. Request it explicitly:
+
+```sh
+uv run jacobian --no-install-references \
+  provider-measure graph.compute.properties --include-cold-install
+```
+
+For Python-distribution providers, the cold-install probe uses a temporary
+target and a fresh `uv` cache, installs the exact recorded version without
+dependencies, and deletes the temporary files afterward. Source-tree and T3
+providers without a safe automated installer report `SKIPPED` rather than
+guessing an install source. Probes use bounded subprocess timeouts, bounded
+output, sanitized environments, generic public errors, and temporary
+directories.
+
+Measurements are machine-local observations. Compare records only when the
+provider digest, platform, probe contract, and environment are appropriate for
+the decision being made.

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -83,6 +83,12 @@ inputs and returns a typed result with:
 - assurance and any remaining proof obligations;
 - provider and execution provenance.
 
+Installed descriptors expose the exact provider version, digest kind and
+digest, platform, install tier, license metadata, detected features, and fixed
+checker identities. Results repeat the selected provider and provider digest.
+The [provider runtime contract](provider-runtime.md) defines health probing,
+fail-closed registration, and repeatable local measurement.
+
 Backend-call atomicity is not required. An adapter may coordinate several
 backend calls when they jointly implement one coherent operation, but it must
 not hide mathematically useful intermediate artifacts, failures, relationships,

--- a/src/jacobian/adapters/mcp/server.py
+++ b/src/jacobian/adapters/mcp/server.py
@@ -281,7 +281,6 @@ def create_server(
             }
         response: dict[str, Any] = {"capability": descriptor.model_dump(mode="json")}
         if capability_id == "lean.check" and active_kernel.lean_checkers:
-            response["runtime"] = _lean_runtime_metadata(active_kernel)
             response["cache"] = {
                 "key": "exact content-addressed certificate and active checker digest",
                 "max_entries": 128,
@@ -879,24 +878,6 @@ def _experiment_scope_content(kernel: JacobianKernel, snapshot: Any) -> str:
         ensure_ascii=False,
         sort_keys=True,
     )
-
-
-def _lean_runtime_metadata(kernel: JacobianKernel) -> dict[str, Any]:
-    return {
-        "profiles": {
-            environment.value: {
-                "semantics_uri": installation.semantics_uri,
-                "import_name": installation.import_name,
-                "mathlib_commit": installation.mathlib_commit,
-                "allowed_axioms": installation.allowed_axioms,
-                "checker_timeout_seconds": installation.checker_timeout_seconds,
-            }
-            for environment, installation in sorted(
-                kernel.lean_checkers.items(),
-                key=lambda item: item[0].value,
-            )
-        }
-    }
 
 
 def main() -> None:

--- a/src/jacobian/atomic_capabilities.py
+++ b/src/jacobian/atomic_capabilities.py
@@ -38,6 +38,7 @@ from jacobian.contracts.results import (
 )
 from jacobian.contracts.shrinking import ShrinkResult
 from jacobian.contracts.witness_search import WitnessFindResult
+from jacobian.provider_runtime import known_provider_runtime
 from jacobian.store import ArtifactStore, StoreError
 
 if TYPE_CHECKING:
@@ -78,13 +79,15 @@ class AtomicServiceAdapter:
         unverified_basis: str = "deterministic local service result",
         read_only: bool = False,
         tags: tuple[str, ...] = (),
+        provider: str = "jacobian.kernel",
     ) -> None:
         self._descriptor = CapabilityDescriptor(
             capability_id=capability_id,
             version="1",
             title=title,
             description=description,
-            provider="jacobian.kernel",
+            provider=provider,
+            provider_runtime=known_provider_runtime(provider, features=tags),
             modes=modes,
             input_schema=input_schema,
             output_schema=output_schema,

--- a/src/jacobian/atomic_domain_capabilities.py
+++ b/src/jacobian/atomic_domain_capabilities.py
@@ -131,6 +131,7 @@ def build_domain_adapters(
             output_schema=PolytopeSeparateResult.model_json_schema(),
             invoke=lambda p: kernel.polytope.separate(PolytopeSeparateRequest(**p)),
             tags=("polytope", "exact"),
+            provider="jacobian.z3",
         ),
         adapter(
             capability_id="parameter.region.promote",

--- a/src/jacobian/builtin_capabilities.py
+++ b/src/jacobian/builtin_capabilities.py
@@ -9,6 +9,7 @@ from jacobian.contracts.capabilities import (
     CapabilityAssuranceLevel,
     CapabilityDescriptor,
     CapabilityMode,
+    CapabilityProviderRuntime,
     CapabilityRequest,
     CapabilityResult,
 )
@@ -20,6 +21,7 @@ from jacobian.contracts.results import (
 )
 from jacobian.lean import LeanService
 from jacobian.memory import ResearchMemory
+from jacobian.provider_runtime import known_provider_runtime
 
 _OBJECT_SCHEMA: dict[str, Any] = {"type": "object"}
 
@@ -36,6 +38,10 @@ class KnowledgeSearchAdapter:
                 "not promote their mathematical assurance."
             ),
             provider="jacobian.memory",
+            provider_runtime=known_provider_runtime(
+                "jacobian.memory",
+                features=("memory", "retrieval"),
+            ),
             modes=(CapabilityMode.EXPLORE,),
             input_schema={
                 "type": "object",
@@ -84,7 +90,11 @@ class KnowledgeSearchAdapter:
 
 
 class LeanCheckAdapter:
-    def __init__(self, lean: LeanService) -> None:
+    def __init__(
+        self,
+        lean: LeanService,
+        provider_runtime: CapabilityProviderRuntime,
+    ) -> None:
         self.lean = lean
         self._descriptor = CapabilityDescriptor(
             capability_id="lean.check",
@@ -95,6 +105,7 @@ class LeanCheckAdapter:
                 "kernel profile."
             ),
             provider="jacobian.lean4",
+            provider_runtime=provider_runtime,
             modes=(CapabilityMode.VERIFY,),
             input_schema={
                 "type": "object",

--- a/src/jacobian/capabilities.py
+++ b/src/jacobian/capabilities.py
@@ -20,6 +20,7 @@ from jacobian.contracts.capabilities import (
     CapabilityDescriptor,
     CapabilityDiagnostic,
     CapabilityObligationStatus,
+    CapabilityProviderAvailability,
     CapabilityRelationshipStatus,
     CapabilityRequest,
     CapabilityResult,
@@ -71,6 +72,18 @@ class CapabilityService:
         if descriptor.capability_id in self._adapters:
             raise CapabilityError(
                 f"duplicate capability ID: {descriptor.capability_id}"
+            )
+        if descriptor.provider_runtime is None:
+            raise CapabilityError(
+                f"capability {descriptor.capability_id} has no provider runtime identity"
+            )
+        if (
+            descriptor.provider_runtime.availability
+            is not CapabilityProviderAvailability.AVAILABLE
+        ):
+            raise CapabilityError(
+                f"capability {descriptor.capability_id} is unavailable: "
+                f"{descriptor.provider_runtime.diagnostic}"
             )
         _validator(descriptor.input_schema)
         _validator(descriptor.output_schema)
@@ -127,6 +140,7 @@ class CapabilityService:
                     "available_modes": [mode.value for mode in descriptor.modes],
                 },
             )
+            result = result.model_copy(update=_provider_provenance(descriptor))
             _log_invocation(result, started)
             return result
         try:
@@ -185,6 +199,19 @@ class CapabilityService:
             or result.mode is not request.mode
         ):
             raise CapabilityError("adapter result identity differs from its request")
+        if result.provider is not None and result.provider != descriptor.provider:
+            raise CapabilityError(
+                "adapter result provider runtime differs from its descriptor"
+            )
+        provenance = _provider_provenance(descriptor)
+        if (
+            result.provider_digest is not None
+            and result.provider_digest != provenance["provider_digest"]
+        ):
+            raise CapabilityError(
+                "adapter result provider runtime differs from its descriptor"
+            )
+        result = result.model_copy(update=provenance)
         if result.execution.status is ExecutionStatus.COMPLETED:
             normalized_output = _validate_payload(
                 descriptor.output_schema, result.output
@@ -386,6 +413,7 @@ def _failed_result(
     request: CapabilityRequest,
     diagnostic: CapabilityDiagnostic,
 ) -> CapabilityResult:
+    provenance = _provider_provenance(descriptor)
     return CapabilityResult(
         capability_id=descriptor.capability_id,
         capability_version=descriptor.version,
@@ -400,7 +428,26 @@ def _failed_result(
             level=CapabilityAssuranceLevel.HEURISTIC,
             basis="execution or input failure; no mathematical conclusion",
         ),
+        provider=provenance["provider"],
+        provider_digest=provenance["provider_digest"],
     )
+
+
+def _provider_provenance(
+    descriptor: CapabilityDescriptor,
+) -> dict[str, str]:
+    if descriptor.provider_runtime is None:
+        raise CapabilityError(
+            f"capability {descriptor.capability_id} has no provider runtime identity"
+        )
+    if descriptor.provider_runtime.digest is None:
+        raise CapabilityError(
+            f"capability {descriptor.capability_id} has no provider runtime digest"
+        )
+    return {
+        "provider": descriptor.provider,
+        "provider_digest": descriptor.provider_runtime.digest,
+    }
 
 
 def _resolution_failure(

--- a/src/jacobian/cli.py
+++ b/src/jacobian/cli.py
@@ -28,6 +28,7 @@ from jacobian.experiments import ExperimentError, ExperimentNotFoundError
 from jacobian.implementation import ImplementationError
 from jacobian.kernel import JacobianKernel
 from jacobian.plugins.registry import PluginRegistryError
+from jacobian.provider_measurements import measure_provider
 from jacobian.references import reference_catalog
 from jacobian.registry import (
     CheckerCompatibilityError,
@@ -272,6 +273,43 @@ def initialize(context: typer.Context) -> None:
             universal_algebra=state.kernel.universal_algebra,
             lean=state.kernel.lean_checkers,
         )
+    )
+
+
+@app.command("provider-measure")
+def provider_measure(
+    context: typer.Context,
+    capability_id: str,
+    include_cold_install: Annotated[
+        bool,
+        typer.Option(
+            "--include-cold-install/--skip-cold-install",
+            help=(
+                "Install into a temporary target with a fresh uv cache; "
+                "may require network access."
+            ),
+        ),
+    ] = False,
+) -> None:
+    """Measure the exact provider advertised for one installed capability."""
+
+    descriptors = {
+        descriptor.capability_id: descriptor
+        for descriptor in _state(context).kernel.capabilities.catalog().capabilities
+    }
+    try:
+        runtime = descriptors[capability_id].provider_runtime
+    except KeyError as exc:
+        raise CapabilityError(f"capability {capability_id!r} is not installed") from exc
+    if runtime is None:
+        raise CapabilityError(
+            f"capability {capability_id!r} has no provider runtime identity"
+        )
+    _emit(
+        measure_provider(
+            runtime,
+            include_cold_install=include_cold_install,
+        ).model_dump(mode="json")
     )
 
 

--- a/src/jacobian/contracts/capabilities.py
+++ b/src/jacobian/contracts/capabilities.py
@@ -8,7 +8,7 @@ from typing import Annotated, Any, Literal, Self
 from pydantic import Field, StringConstraints, model_validator
 
 from jacobian.canonical import canonicalize_json
-from jacobian.contracts.common import ArtifactUri
+from jacobian.contracts.common import ArtifactUri, CheckerUri, Sha256Digest
 from jacobian.contracts.results import ContractModel, Execution
 
 CapabilityId = Annotated[
@@ -27,6 +27,90 @@ class CapabilityMode(StrEnum):
 
     EXPLORE = "EXPLORE"
     VERIFY = "VERIFY"
+
+
+class CapabilityInstallTier(StrEnum):
+    """Operational cost and isolation required to install one provider."""
+
+    T0 = "T0"
+    T1 = "T1"
+    T2 = "T2"
+    T3 = "T3"
+
+
+class CapabilityProviderAvailability(StrEnum):
+    """Whether this exact provider runtime is callable in the current process."""
+
+    AVAILABLE = "AVAILABLE"
+    UNAVAILABLE = "UNAVAILABLE"
+
+
+class CapabilityProviderDigestKind(StrEnum):
+    """What immutable provider material the runtime digest covers."""
+
+    SOURCE_TREE = "SOURCE_TREE"
+    PYTHON_DISTRIBUTION_RECORD = "PYTHON_DISTRIBUTION_RECORD"
+    EXECUTABLE = "EXECUTABLE"
+
+
+class CapabilityProviderRuntime(ContractModel):
+    """Exact runtime identity and operator-facing availability metadata."""
+
+    runtime_version: Literal["1"] = "1"
+    provider: str = Field(
+        pattern=r"^[a-z0-9]+(?:[._-][a-z0-9]+)*$",
+        min_length=3,
+        max_length=128,
+    )
+    availability: CapabilityProviderAvailability
+    version: str | None = Field(default=None, min_length=1, max_length=128)
+    digest: Sha256Digest | None = None
+    digest_kind: CapabilityProviderDigestKind | None = None
+    platform: str = Field(min_length=1, max_length=128)
+    install_tier: CapabilityInstallTier
+    license_id: str = Field(min_length=1, max_length=128)
+    license_files: tuple[str, ...] = ()
+    features: tuple[str, ...] = ()
+    checker_ids: tuple[CheckerUri, ...] = ()
+    configuration: dict[str, Any] = Field(default_factory=dict)
+    diagnostic: str | None = Field(default=None, min_length=1, max_length=512)
+
+    @model_validator(mode="after")
+    def validate_runtime_identity(self) -> Self:
+        if self.availability is CapabilityProviderAvailability.AVAILABLE:
+            if self.version is None or self.digest is None or self.digest_kind is None:
+                raise ValueError(
+                    "available provider runtime requires version, digest, "
+                    "and digest kind"
+                )
+            if self.diagnostic is not None:
+                raise ValueError(
+                    "available provider runtime cannot carry an unavailable diagnostic"
+                )
+        elif self.diagnostic is None:
+            raise ValueError("unavailable provider runtime requires a diagnostic")
+        if len(set(self.features)) != len(self.features):
+            raise ValueError("provider features must be unique")
+        if len(set(self.checker_ids)) != len(self.checker_ids):
+            raise ValueError("provider checker IDs must be unique")
+        if len(set(self.license_files)) != len(self.license_files):
+            raise ValueError("provider license files must be unique")
+        for feature in self.features:
+            if not feature or len(feature) > 128:
+                raise ValueError("provider features must contain 1 to 128 characters")
+        for license_file in self.license_files:
+            path = license_file.replace("\\", "/")
+            if (
+                not path
+                or len(path) > 256
+                or path.startswith("/")
+                or any(part in {"", ".", ".."} for part in path.split("/"))
+            ):
+                raise ValueError(
+                    "provider license files must be normalized relative paths"
+                )
+        canonicalize_json(self.configuration)
+        return self
 
 
 class CapabilityAssuranceLevel(StrEnum):
@@ -69,6 +153,7 @@ class CapabilityDescriptor(ContractModel):
     title: str = Field(min_length=1, max_length=128)
     description: str = Field(min_length=1, max_length=512)
     provider: str = Field(min_length=1, max_length=128)
+    provider_runtime: CapabilityProviderRuntime | None = None
     modes: tuple[CapabilityMode, ...]
     input_schema: dict[str, Any]
     output_schema: dict[str, Any]
@@ -84,6 +169,11 @@ class CapabilityDescriptor(ContractModel):
             raise ValueError("capability modes must be unique")
         canonicalize_json(self.input_schema)
         canonicalize_json(self.output_schema)
+        if (
+            self.provider_runtime is not None
+            and self.provider_runtime.provider != self.provider
+        ):
+            raise ValueError("descriptor provider must match provider runtime identity")
         return self
 
 
@@ -231,7 +321,7 @@ class CapabilityDiagnostic(ContractModel):
 
 
 class CapabilityResult(ContractModel):
-    """Compact result shared by local, MCP, and remote capability adapters."""
+    """Capability invocation result."""
 
     response_version: Literal["2"] = "2"
     capability_id: CapabilityId
@@ -251,6 +341,8 @@ class CapabilityResult(ContractModel):
     assurance: CapabilityAssurance
     artifact_uris: tuple[ArtifactUri, ...] = ()
     episode_uri: ArtifactUri | None = None
+    provider: str | None = Field(default=None, min_length=1, max_length=128)
+    provider_digest: Sha256Digest | None = None
 
     @model_validator(mode="after")
     def enforce_lane_and_canonical_output(self) -> Self:

--- a/src/jacobian/contracts/provider_measurements.py
+++ b/src/jacobian/contracts/provider_measurements.py
@@ -1,0 +1,57 @@
+"""Operator-facing measurements for installed capability providers."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Literal, Self
+
+from pydantic import Field, model_validator
+
+from jacobian.contracts.capabilities import (
+    CapabilityProviderAvailability,
+    CapabilityProviderRuntime,
+)
+from jacobian.contracts.results import ContractModel
+
+
+class ProviderMeasurementStatus(StrEnum):
+    COMPLETED = "COMPLETED"
+    SKIPPED = "SKIPPED"
+    ERROR = "ERROR"
+
+
+class ProviderMeasurementSample(ContractModel):
+    status: ProviderMeasurementStatus
+    seconds: float | None = Field(default=None, ge=0)
+    peak_rss_bytes: int | None = Field(default=None, ge=0)
+    output_bytes: int | None = Field(default=None, ge=0)
+    detail: str | None = Field(default=None, min_length=1, max_length=512)
+
+    @model_validator(mode="after")
+    def bind_measurement_status(self) -> Self:
+        if self.status is ProviderMeasurementStatus.COMPLETED and self.seconds is None:
+            raise ValueError("completed provider measurement requires elapsed seconds")
+        if (
+            self.status is not ProviderMeasurementStatus.COMPLETED
+            and self.detail is None
+        ):
+            raise ValueError("incomplete provider measurement requires a detail")
+        return self
+
+
+class ProviderMeasurement(ContractModel):
+    measurement_version: Literal["1"] = "1"
+    provider_runtime: CapabilityProviderRuntime
+    installed_bytes: int = Field(ge=0)
+    cold_install: ProviderMeasurementSample
+    cold_start: ProviderMeasurementSample
+    reproduction_case: ProviderMeasurementSample
+
+    @model_validator(mode="after")
+    def require_available_provider(self) -> Self:
+        if (
+            self.provider_runtime.availability
+            is not CapabilityProviderAvailability.AVAILABLE
+        ):
+            raise ValueError("only an available provider runtime can be measured")
+        return self

--- a/src/jacobian/finite_partition.py
+++ b/src/jacobian/finite_partition.py
@@ -32,6 +32,7 @@ from jacobian.contracts.results import (
     ResultEnvelope,
     Verification,
 )
+from jacobian.provider_runtime import known_provider_runtime
 from jacobian.registry import CheckerRegistry
 from jacobian.schema_registry import SchemaRegistry
 from jacobian.store import ArtifactStore
@@ -193,6 +194,15 @@ class FinitePartitionAdapter:
                 "replay exact coverage and disjointness with an authorized checker."
             ),
             provider="jacobian.finite",
+            provider_runtime=known_provider_runtime(
+                "jacobian.finite",
+                features=("finite-partition",),
+                checker_ids=(
+                    (installation.checker_id,)
+                    if installation.checker_id is not None
+                    else ()
+                ),
+            ),
             modes=modes,
             input_schema={
                 "type": "object",

--- a/src/jacobian/graph_capabilities.py
+++ b/src/jacobian/graph_capabilities.py
@@ -38,6 +38,7 @@ from jacobian.contracts.graph_invariants import (
     GraphNeighborhoodIndependenceRequest,
 )
 from jacobian.contracts.results import Execution, ExecutionStatus
+from jacobian.provider_runtime import known_provider_runtime
 from jacobian.registry import CheckerRegistry
 from jacobian.schema_registry import SchemaRegistry
 from jacobian.store import ArtifactStore, StoreError
@@ -278,6 +279,10 @@ class GraphAtlasSearchAdapter:
                 "(0-7) using exact NetworkX-computed constraints."
             ),
             provider="jacobian.networkx",
+            provider_runtime=known_provider_runtime(
+                "jacobian.networkx",
+                features=("graph-atlas", "simple-undirected-graphs"),
+            ),
             modes=(CapabilityMode.EXPLORE,),
             input_schema={
                 "type": "object",
@@ -452,6 +457,10 @@ class GraphPropertyAdapter:
                 "Jacobian simple-undirected-graph artifact."
             ),
             provider="jacobian.networkx",
+            provider_runtime=known_provider_runtime(
+                "jacobian.networkx",
+                features=("graph-properties", "simple-undirected-graphs"),
+            ),
             modes=(CapabilityMode.EXPLORE,),
             input_schema={
                 "type": "object",
@@ -585,6 +594,15 @@ class GraphNeighborhoodIndependenceAdapter:
                 "Neighborhoods are limited to 24 vertices."
             ),
             provider="jacobian.networkx",
+            provider_runtime=known_provider_runtime(
+                "jacobian.networkx",
+                features=("neighborhood-independence", "simple-undirected-graphs"),
+                checker_ids=(
+                    (resources.neighborhood_checker_id,)
+                    if resources.neighborhood_checker_id is not None
+                    else ()
+                ),
+            ),
             modes=(CapabilityMode.EXPLORE,),
             input_schema=GraphNeighborhoodIndependenceRequest.model_json_schema(),
             output_schema=GraphNeighborhoodIndependenceOutput.model_json_schema(),

--- a/src/jacobian/kernel.py
+++ b/src/jacobian/kernel.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 from jacobian.artifacts import ArtifactService
@@ -17,6 +18,7 @@ from jacobian.capabilities import (
 )
 from jacobian.claims import ClaimValidationService
 from jacobian.conjectures import ConjectureService
+from jacobian.contracts.capabilities import CapabilityProviderAvailability
 from jacobian.contracts.lean import LeanEnvironment
 from jacobian.evaluation import EvaluationService
 from jacobian.experiment_router import ExperimentRouter
@@ -35,6 +37,7 @@ from jacobian.polynomial_capabilities import (
     install_polynomial_capabilities,
 )
 from jacobian.polytope import PolytopeService
+from jacobian.provider_runtime import lean_provider_runtime
 from jacobian.references import (
     LeanCheckerInstallation,
     PolytopeCheckerInstallation,
@@ -55,6 +58,8 @@ from jacobian.universal_algebra_capabilities import (
 from jacobian.verification import VerificationService
 from jacobian.witnesses import WitnessSearchService
 from jacobian.workspaces import WorkspaceService
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class JacobianKernel:
@@ -216,13 +221,42 @@ class JacobianKernel:
                 point_schema_uri=self.polytope.point_schema_uri,
             )
             self.lean_checkers = self.reference_installer.install_lean_checkers()
-            self.lean = LeanService(
-                self.store,
-                self.artifacts,
-                self.verification,
-                self.lean_checkers,
+            profiles = {
+                environment.value: {
+                    "semantics_uri": installation.semantics_uri,
+                    "import_name": installation.import_name,
+                    "mathlib_commit": installation.mathlib_commit,
+                    "allowed_axioms": list(installation.allowed_axioms),
+                    "checker_timeout_seconds": (installation.checker_timeout_seconds),
+                }
+                for environment, installation in sorted(
+                    self.lean_checkers.items(),
+                    key=lambda item: item[0].value,
+                )
+            }
+            runtime = lean_provider_runtime(
+                profiles=profiles,
+                checker_ids=tuple(
+                    installation.checker_id
+                    for _, installation in sorted(
+                        self.lean_checkers.items(),
+                        key=lambda item: item[0].value,
+                    )
+                ),
             )
-            self.capabilities.register(LeanCheckAdapter(self.lean))
+            if runtime.availability is CapabilityProviderAvailability.AVAILABLE:
+                self.lean = LeanService(
+                    self.store,
+                    self.artifacts,
+                    self.verification,
+                    self.lean_checkers,
+                )
+                self.capabilities.register(LeanCheckAdapter(self.lean, runtime))
+            else:
+                _LOGGER.warning(
+                    "lean.check is not installed: %s",
+                    runtime.diagnostic,
+                )
         for entrypoint in capability_adapter_entrypoints:
             self.capabilities.register(load_capability_adapter(entrypoint, self))
 

--- a/src/jacobian/polynomial_capabilities.py
+++ b/src/jacobian/polynomial_capabilities.py
@@ -54,6 +54,7 @@ from jacobian.contracts.polynomials import (
     SparseRationalPolynomial,
 )
 from jacobian.contracts.results import ContractModel, Execution, ExecutionStatus
+from jacobian.provider_runtime import known_provider_runtime
 from jacobian.registry import CheckerRegistry
 from jacobian.schema_registry import SchemaRegistry
 from jacobian.store import ArtifactStore, StoredArtifact, StoreError
@@ -216,6 +217,10 @@ class PolynomialMapEvaluationAdapter:
                 "square polynomial map over QQ."
             ),
             provider="jacobian.sympy",
+            provider_runtime=known_provider_runtime(
+                "jacobian.sympy",
+                features=("rational-polynomial-evaluation",),
+            ),
             modes=(CapabilityMode.EXPLORE,),
             input_schema=PolynomialEvaluationRequest.model_json_schema(),
             output_schema=PolynomialEvaluationOutput.model_json_schema(),
@@ -290,6 +295,15 @@ class PolynomialJacobianAdapter:
                 "square polynomial map over QQ."
             ),
             provider="jacobian.sympy",
+            provider_runtime=known_provider_runtime(
+                "jacobian.sympy",
+                features=("symbolic-jacobian", "rational-polynomials"),
+                checker_ids=(
+                    (resources.installation.jacobian_checker_id,)
+                    if resources.installation.jacobian_checker_id is not None
+                    else ()
+                ),
+            ),
             modes=(CapabilityMode.EXPLORE,),
             input_schema=PolynomialJacobianRequest.model_json_schema(),
             output_schema=PolynomialJacobianOutput.model_json_schema(),
@@ -445,6 +459,15 @@ class PolynomialCollisionAdapter:
                 "and materialize an unverified candidate collision witness."
             ),
             provider="jacobian.artifact-comparison",
+            provider_runtime=known_provider_runtime(
+                "jacobian.artifact-comparison",
+                features=("polynomial-collision-witness",),
+                checker_ids=(
+                    (resources.installation.collision_checker_id,)
+                    if resources.installation.collision_checker_id is not None
+                    else ()
+                ),
+            ),
             modes=(CapabilityMode.EXPLORE,),
             input_schema=PolynomialCollisionRequest.model_json_schema(),
             output_schema=PolynomialCollisionOutput.model_json_schema(),

--- a/src/jacobian/provider_measurements.py
+++ b/src/jacobian/provider_measurements.py
@@ -1,0 +1,301 @@
+"""Repeatable local measurements for exact installed provider identities."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.metadata
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+from jacobian.contracts.capabilities import CapabilityProviderRuntime
+from jacobian.contracts.provider_measurements import (
+    ProviderMeasurement,
+    ProviderMeasurementSample,
+    ProviderMeasurementStatus,
+)
+
+_PROBE_TIMEOUT_SECONDS = 120
+_COLD_INSTALL_TIMEOUT_SECONDS = 600
+_MAX_DIAGNOSTIC_BYTES = 64 * 1024
+_PYTHON_PROBE = r"""
+import json
+import resource
+import sys
+import time
+
+provider = sys.argv[1]
+operation = sys.argv[2]
+started = time.perf_counter()
+
+if provider == "jacobian.networkx":
+    import networkx as backend
+    if operation == "reproduction":
+        graph = backend.path_graph(32)
+        assert backend.is_connected(graph)
+elif provider == "jacobian.sympy":
+    import sympy as backend
+    if operation == "reproduction":
+        x, y = backend.symbols("x y")
+        matrix = backend.Matrix([x**2 + y, x * y])
+        assert matrix.jacobian((x, y)).shape == (2, 2)
+elif provider == "jacobian.z3":
+    import z3 as backend
+    if operation == "reproduction":
+        x = backend.Real("x")
+        solver = backend.Solver()
+        solver.add(x == 1)
+        assert solver.check() == backend.sat
+else:
+    import jacobian.canonical as backend
+    if operation == "reproduction":
+        assert backend.canonicalize_json({"value": 1})
+
+elapsed = time.perf_counter() - started
+rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+if sys.platform != "darwin":
+    rss *= 1024
+print(json.dumps({"seconds": elapsed, "peak_rss_bytes": rss}))
+"""
+_EXTERNAL_PROBE = r"""
+import json
+import resource
+import subprocess
+import sys
+import time
+
+started = time.perf_counter()
+process = subprocess.run(
+    sys.argv[1:],
+    check=True,
+    capture_output=True,
+    timeout=105,
+)
+elapsed = time.perf_counter() - started
+rss = resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss
+if sys.platform != "darwin":
+    rss *= 1024
+print(json.dumps({
+    "seconds": elapsed,
+    "peak_rss_bytes": rss,
+    "output_bytes": len(process.stdout) + len(process.stderr),
+}))
+"""
+
+
+def _process_environment() -> dict[str, str]:
+    names = (
+        "HOME",
+        "PATH",
+        "ELAN_HOME",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "NO_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "no_proxy",
+        "SSL_CERT_FILE",
+    )
+    return {
+        **{name: os.environ[name] for name in names if name in os.environ},
+        "LC_ALL": "C.UTF-8",
+        "PYTHONHASHSEED": "0",
+    }
+
+
+def _measure_command(command: list[str]) -> ProviderMeasurementSample:
+    try:
+        process = subprocess.run(
+            command,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=_PROBE_TIMEOUT_SECONDS,
+            env=_process_environment(),
+        )
+        if len(process.stdout.encode()) > _MAX_DIAGNOSTIC_BYTES:
+            raise RuntimeError("provider probe output exceeded 64 KiB")
+        payload = json.loads(process.stdout)
+        return ProviderMeasurementSample(
+            status=ProviderMeasurementStatus.COMPLETED,
+            seconds=float(payload["seconds"]),
+            peak_rss_bytes=int(payload["peak_rss_bytes"]),
+            output_bytes=(
+                int(payload["output_bytes"])
+                if "output_bytes" in payload
+                else len(process.stdout.encode())
+            ),
+        )
+    except (
+        KeyError,
+        OSError,
+        RuntimeError,
+        ValueError,
+        json.JSONDecodeError,
+        subprocess.SubprocessError,
+    ):
+        return ProviderMeasurementSample(
+            status=ProviderMeasurementStatus.ERROR,
+            detail="The provider measurement failed.",
+        )
+
+
+def _python_probe(
+    runtime: CapabilityProviderRuntime,
+    operation: str,
+) -> ProviderMeasurementSample:
+    return _measure_command(
+        [sys.executable, "-c", _PYTHON_PROBE, runtime.provider, operation]
+    )
+
+
+def _lean_probe(*, reproduction: bool) -> ProviderMeasurementSample:
+    from jacobian_checkers import lean4
+
+    try:
+        executable, _ = lean4.inspect_runtime(require_mathlib=False)
+    except RuntimeError:
+        return ProviderMeasurementSample(
+            status=ProviderMeasurementStatus.ERROR,
+            detail="The pinned Lean runtime is unavailable.",
+        )
+    if not reproduction:
+        command = [str(executable), "-V"]
+        return _measure_command([sys.executable, "-c", _EXTERNAL_PROBE, *command])
+    with tempfile.TemporaryDirectory(prefix="jacobian-lean-measure-") as directory:
+        source = Path(directory) / "Main.lean"
+        source.write_text(
+            "theorem jacobian_provider_probe : (1 : Nat) = 1 := by rfl\n",
+            encoding="utf-8",
+        )
+        command = [str(executable), str(source)]
+        return _measure_command([sys.executable, "-c", _EXTERNAL_PROBE, *command])
+
+
+def _file_size(path: Path) -> int:
+    try:
+        if path.is_file() and not path.is_symlink():
+            return path.stat().st_size
+    except OSError:
+        return 0
+    return 0
+
+
+def _tree_size(root: Path) -> int:
+    return sum(_file_size(path) for path in root.rglob("*"))
+
+
+def _installed_bytes(runtime: CapabilityProviderRuntime) -> int:
+    distribution_name = runtime.configuration.get("distribution")
+    if isinstance(distribution_name, str):
+        distribution = importlib.metadata.distribution(distribution_name)
+        total = 0
+        for package_path in distribution.files or ():
+            total += _file_size(Path(str(distribution.locate_file(package_path))))
+        return total
+    if runtime.provider == "jacobian.lean4":
+        from jacobian_checkers import lean4
+
+        executable, mathlib = lean4.inspect_runtime(require_mathlib=True)
+        roots = {executable.parent.parent.resolve()}
+        if mathlib is not None:
+            roots.add(mathlib.resolve())
+        return sum(_tree_size(root) for root in roots)
+    module = importlib.import_module("jacobian")
+    module_path = Path(str(module.__file__)).resolve().parent
+    return _tree_size(module_path)
+
+
+def _cold_install_spec(runtime: CapabilityProviderRuntime) -> str | None:
+    distribution_name = runtime.configuration.get("distribution")
+    if isinstance(distribution_name, str) and runtime.version is not None:
+        return f"{distribution_name}=={runtime.version}"
+    return None
+
+
+def _measure_cold_install(
+    runtime: CapabilityProviderRuntime,
+    *,
+    enabled: bool,
+) -> ProviderMeasurementSample:
+    if not enabled:
+        return ProviderMeasurementSample(
+            status=ProviderMeasurementStatus.SKIPPED,
+            detail="Cold install was not requested.",
+        )
+    spec = _cold_install_spec(runtime)
+    uv = shutil.which("uv")
+    if spec is None or uv is None:
+        return ProviderMeasurementSample(
+            status=ProviderMeasurementStatus.SKIPPED,
+            detail="This provider has no automated cold-install probe.",
+        )
+    with tempfile.TemporaryDirectory(prefix="jacobian-provider-install-") as directory:
+        root = Path(directory)
+        target = root / "target"
+        environment = {
+            **_process_environment(),
+            "UV_CACHE_DIR": str(root / "cache"),
+        }
+        started = time.perf_counter()
+        try:
+            subprocess.run(
+                [
+                    uv,
+                    "pip",
+                    "install",
+                    "--python",
+                    sys.executable,
+                    "--target",
+                    str(target),
+                    "--no-deps",
+                    spec,
+                ],
+                cwd=Path.cwd(),
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=_COLD_INSTALL_TIMEOUT_SECONDS,
+                env=environment,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return ProviderMeasurementSample(
+                status=ProviderMeasurementStatus.ERROR,
+                detail="The cold install measurement failed.",
+            )
+        return ProviderMeasurementSample(
+            status=ProviderMeasurementStatus.COMPLETED,
+            seconds=time.perf_counter() - started,
+            output_bytes=_tree_size(target),
+        )
+
+
+def measure_provider(
+    runtime: CapabilityProviderRuntime,
+    *,
+    include_cold_install: bool = False,
+) -> ProviderMeasurement:
+    """Measure one exact available runtime without changing the capability catalog."""
+
+    if runtime.provider == "jacobian.lean4":
+        cold_start = _lean_probe(reproduction=False)
+        reproduction = _lean_probe(reproduction=True)
+    else:
+        cold_start = _python_probe(runtime, "cold-start")
+        reproduction = _python_probe(runtime, "reproduction")
+    return ProviderMeasurement(
+        provider_runtime=runtime,
+        installed_bytes=_installed_bytes(runtime),
+        cold_install=_measure_cold_install(
+            runtime,
+            enabled=include_cold_install,
+        ),
+        cold_start=cold_start,
+        reproduction_case=reproduction,
+    )

--- a/src/jacobian/provider_runtime.py
+++ b/src/jacobian/provider_runtime.py
@@ -1,0 +1,340 @@
+"""Fail-closed runtime identity probes for capability providers."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import importlib.metadata
+import sysconfig
+from collections.abc import Mapping
+from functools import cache
+from pathlib import Path
+from typing import Any
+
+from jacobian.contracts.capabilities import (
+    CapabilityInstallTier,
+    CapabilityProviderAvailability,
+    CapabilityProviderDigestKind,
+    CapabilityProviderRuntime,
+)
+from jacobian.implementation import ImplementationError, package_source_digest
+
+
+class ProviderRuntimeError(RuntimeError):
+    """Raised when a required provider identity cannot be inspected safely."""
+
+
+@cache
+def _platform_tag() -> str:
+    return sysconfig.get_platform()
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def _distribution_record_digest(
+    distribution: importlib.metadata.Distribution,
+) -> str:
+    rows: list[str] = []
+    hashed = 0
+    for package_path in sorted(distribution.files or (), key=str):
+        file_hash = package_path.hash
+        if file_hash is None:
+            hash_value = "-"
+        else:
+            hash_value = f"{file_hash.mode}:{file_hash.value}"
+            hashed += 1
+        size = "-" if package_path.size is None else str(package_path.size)
+        rows.append(f"{package_path}\0{hash_value}\0{size}\n")
+    if not rows or not hashed:
+        raise ProviderRuntimeError(
+            "the installed Python distribution has no hashed RECORD manifest"
+        )
+    digest = hashlib.sha256("".join(rows).encode()).hexdigest()
+    return f"sha256:{digest}"
+
+
+def _license_files(
+    distribution: importlib.metadata.Distribution,
+) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            str(package_path).replace("\\", "/")
+            for package_path in distribution.files or ()
+            if "license" in package_path.name.lower()
+        )
+    )
+
+
+@cache
+def _jacobian_identity() -> tuple[str, str, tuple[str, ...]]:
+    try:
+        distribution = importlib.metadata.distribution("jacobian-research-kernel")
+        digest = package_source_digest("jacobian.capabilities:CapabilityService")
+    except (importlib.metadata.PackageNotFoundError, ImplementationError) as exc:
+        raise ProviderRuntimeError(
+            "the Jacobian source runtime could not be identified"
+        ) from exc
+    return distribution.version, digest, _license_files(distribution)
+
+
+@cache
+def _python_distribution_identity(
+    distribution_name: str,
+    import_name: str,
+    required_attributes: tuple[str, ...],
+) -> tuple[str, str, tuple[str, ...]]:
+    try:
+        module = importlib.import_module(import_name)
+        for attribute in required_attributes:
+            getattr(module, attribute)
+        distribution = importlib.metadata.distribution(distribution_name)
+        digest = _distribution_record_digest(distribution)
+    except (
+        AttributeError,
+        ImportError,
+        importlib.metadata.PackageNotFoundError,
+        ProviderRuntimeError,
+    ) as exc:
+        raise ProviderRuntimeError(
+            f"the {distribution_name} provider is not installed and healthy"
+        ) from exc
+    return distribution.version, digest, _license_files(distribution)
+
+
+def _unavailable_runtime(
+    *,
+    provider: str,
+    install_tier: CapabilityInstallTier,
+    license_id: str,
+    diagnostic: str,
+) -> CapabilityProviderRuntime:
+    return CapabilityProviderRuntime(
+        provider=provider,
+        availability=CapabilityProviderAvailability.UNAVAILABLE,
+        platform=_platform_tag(),
+        install_tier=install_tier,
+        license_id=license_id,
+        diagnostic=diagnostic,
+    )
+
+
+def jacobian_provider_runtime(
+    provider: str,
+    *,
+    features: tuple[str, ...] = (),
+    checker_ids: tuple[str, ...] = (),
+    configuration: Mapping[str, Any] | None = None,
+) -> CapabilityProviderRuntime:
+    """Identify a source-backed provider implemented inside Jacobian."""
+
+    try:
+        version, digest, license_files = _jacobian_identity()
+    except ProviderRuntimeError:
+        return _unavailable_runtime(
+            provider=provider,
+            install_tier=CapabilityInstallTier.T0,
+            license_id="MIT",
+            diagnostic="The Jacobian source runtime could not be identified.",
+        )
+    return CapabilityProviderRuntime(
+        provider=provider,
+        availability=CapabilityProviderAvailability.AVAILABLE,
+        version=version,
+        digest=digest,
+        digest_kind=CapabilityProviderDigestKind.SOURCE_TREE,
+        platform=_platform_tag(),
+        install_tier=CapabilityInstallTier.T0,
+        license_id="MIT",
+        license_files=license_files,
+        features=features,
+        checker_ids=checker_ids,
+        configuration=dict(configuration or {}),
+    )
+
+
+def source_provider_runtime(
+    provider: str,
+    *,
+    version: str,
+    entrypoint: str,
+    install_tier: CapabilityInstallTier,
+    license_id: str,
+    license_files: tuple[str, ...] = (),
+    features: tuple[str, ...] = (),
+    checker_ids: tuple[str, ...] = (),
+    configuration: Mapping[str, Any] | None = None,
+) -> CapabilityProviderRuntime:
+    """Identify an operator-installed source package without importing its code."""
+
+    try:
+        digest = package_source_digest(entrypoint)
+    except ImplementationError:
+        return _unavailable_runtime(
+            provider=provider,
+            install_tier=install_tier,
+            license_id=license_id,
+            diagnostic="The provider source package could not be identified.",
+        )
+    return CapabilityProviderRuntime(
+        provider=provider,
+        availability=CapabilityProviderAvailability.AVAILABLE,
+        version=version,
+        digest=digest,
+        digest_kind=CapabilityProviderDigestKind.SOURCE_TREE,
+        platform=_platform_tag(),
+        install_tier=install_tier,
+        license_id=license_id,
+        license_files=license_files,
+        features=features,
+        checker_ids=checker_ids,
+        configuration={
+            "entrypoint": entrypoint,
+            **dict(configuration or {}),
+        },
+    )
+
+
+def python_distribution_provider_runtime(
+    provider: str,
+    *,
+    distribution_name: str,
+    import_name: str,
+    required_attributes: tuple[str, ...],
+    install_tier: CapabilityInstallTier,
+    license_id: str,
+    features: tuple[str, ...] = (),
+    checker_ids: tuple[str, ...] = (),
+    configuration: Mapping[str, Any] | None = None,
+) -> CapabilityProviderRuntime:
+    """Identify one installed Python distribution without trusting an import alone."""
+
+    try:
+        version, digest, license_files = _python_distribution_identity(
+            distribution_name,
+            import_name,
+            required_attributes,
+        )
+    except ProviderRuntimeError:
+        return _unavailable_runtime(
+            provider=provider,
+            install_tier=install_tier,
+            license_id=license_id,
+            diagnostic=(
+                f"The {distribution_name} provider is not installed and healthy."
+            ),
+        )
+    return CapabilityProviderRuntime(
+        provider=provider,
+        availability=CapabilityProviderAvailability.AVAILABLE,
+        version=version,
+        digest=digest,
+        digest_kind=CapabilityProviderDigestKind.PYTHON_DISTRIBUTION_RECORD,
+        platform=_platform_tag(),
+        install_tier=install_tier,
+        license_id=license_id,
+        license_files=license_files,
+        features=features,
+        checker_ids=checker_ids,
+        configuration={
+            "distribution": distribution_name,
+            **dict(configuration or {}),
+        },
+    )
+
+
+def known_provider_runtime(
+    provider: str,
+    *,
+    features: tuple[str, ...] = (),
+    checker_ids: tuple[str, ...] = (),
+    configuration: Mapping[str, Any] | None = None,
+) -> CapabilityProviderRuntime:
+    """Resolve runtime identity for a built-in provider family."""
+
+    if provider == "jacobian.networkx":
+        return python_distribution_provider_runtime(
+            provider,
+            distribution_name="networkx",
+            import_name="networkx",
+            required_attributes=("Graph", "graph_atlas_g"),
+            install_tier=CapabilityInstallTier.T0,
+            license_id="BSD-3-Clause",
+            features=features,
+            checker_ids=checker_ids,
+            configuration=configuration,
+        )
+    if provider == "jacobian.sympy":
+        return python_distribution_provider_runtime(
+            provider,
+            distribution_name="sympy",
+            import_name="sympy",
+            required_attributes=("Matrix", "Poly"),
+            install_tier=CapabilityInstallTier.T0,
+            license_id="BSD-3-Clause",
+            features=features,
+            checker_ids=checker_ids,
+            configuration=configuration,
+        )
+    if provider == "jacobian.z3":
+        return python_distribution_provider_runtime(
+            provider,
+            distribution_name="z3-solver",
+            import_name="z3",
+            required_attributes=("Real", "Solver"),
+            install_tier=CapabilityInstallTier.T0,
+            license_id="MIT",
+            features=features,
+            checker_ids=checker_ids,
+            configuration=configuration,
+        )
+    return jacobian_provider_runtime(
+        provider,
+        features=features,
+        checker_ids=checker_ids,
+        configuration=configuration,
+    )
+
+
+def lean_provider_runtime(
+    *,
+    profiles: Mapping[str, Mapping[str, Any]],
+    checker_ids: tuple[str, ...],
+) -> CapabilityProviderRuntime:
+    """Inspect the separately managed pinned Lean/Mathlib runtime."""
+
+    from jacobian_checkers import lean4
+
+    require_mathlib = any(
+        profile.get("mathlib_commit") is not None for profile in profiles.values()
+    )
+    try:
+        executable, _ = lean4.inspect_runtime(require_mathlib=require_mathlib)
+        digest = _sha256_file(executable)
+    except (OSError, RuntimeError):
+        return _unavailable_runtime(
+            provider="jacobian.lean4",
+            install_tier=CapabilityInstallTier.T3,
+            license_id="Apache-2.0",
+            diagnostic=(
+                f"The pinned Lean {lean4.LEAN_VERSION} runtime is unavailable."
+            ),
+        )
+    return CapabilityProviderRuntime(
+        provider="jacobian.lean4",
+        availability=CapabilityProviderAvailability.AVAILABLE,
+        version=lean4.LEAN_VERSION,
+        digest=digest,
+        digest_kind=CapabilityProviderDigestKind.EXECUTABLE,
+        platform=_platform_tag(),
+        install_tier=CapabilityInstallTier.T3,
+        license_id="Apache-2.0",
+        features=tuple(sorted(profiles)),
+        checker_ids=checker_ids,
+        configuration={"profiles": dict(profiles)},
+    )

--- a/src/jacobian/universal_algebra_capabilities.py
+++ b/src/jacobian/universal_algebra_capabilities.py
@@ -48,6 +48,7 @@ from jacobian.contracts.universal_algebra import (
     UniversalAlgebraEvaluationOutput,
     UniversalAlgebraEvaluationRequest,
 )
+from jacobian.provider_runtime import known_provider_runtime
 from jacobian.registry import CheckerRegistry
 from jacobian.schema_registry import SchemaRegistry
 from jacobian.store import ArtifactStore
@@ -179,6 +180,15 @@ class UniversalAlgebraEvaluateLawsAdapter:
                 "valuation."
             ),
             provider="jacobian.finite-table",
+            provider_runtime=known_provider_runtime(
+                "jacobian.finite-table",
+                features=("finite-magma-law-evaluation",),
+                checker_ids=(
+                    (resources.installation.evaluation_checker_id,)
+                    if resources.installation.evaluation_checker_id is not None
+                    else ()
+                ),
+            ),
             modes=(CapabilityMode.EXPLORE,),
             input_schema=UniversalAlgebraEvaluationRequest.model_json_schema(),
             output_schema=UniversalAlgebraEvaluationOutput.model_json_schema(),
@@ -343,6 +353,10 @@ class UniversalAlgebraSearchCountermodelAdapter:
                 "magma satisfying every source law and falsifying one target law."
             ),
             provider="jacobian.z3",
+            provider_runtime=known_provider_runtime(
+                "jacobian.z3",
+                features=("finite-magma-countermodel-search",),
+            ),
             modes=(CapabilityMode.EXPLORE,),
             input_schema=UniversalAlgebraCountermodelSearchRequest.model_json_schema(),
             output_schema=UniversalAlgebraCountermodelSearchOutput.model_json_schema(),

--- a/src/jacobian_checkers/lean4.py
+++ b/src/jacobian_checkers/lean4.py
@@ -245,6 +245,46 @@ def _mathlib_runtime() -> Path:
     return runtime
 
 
+def inspect_runtime(*, require_mathlib: bool) -> tuple[Path, Path | None]:
+    """Validate the pinned runtime and return the exact executable and profile root."""
+
+    command = _lean_command("lean")
+    _validate_lean(command)
+    if len(command) == 1:
+        executable = Path(command[0])
+    else:
+        environment = {
+            "ELAN_TOOLCHAIN": LEAN_TOOLCHAIN,
+            **({"PATH": os.environ["PATH"]} if "PATH" in os.environ else {}),
+            **({"HOME": os.environ["HOME"]} if "HOME" in os.environ else {}),
+            **(
+                {"ELAN_HOME": os.environ["ELAN_HOME"]}
+                if "ELAN_HOME" in os.environ
+                else {}
+            ),
+        }
+        try:
+            resolved = subprocess.run(
+                [command[0], "which", "lean"],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=5,
+                env=environment,
+            ).stdout.strip()
+        except subprocess.SubprocessError as exc:
+            raise _LeanSetupError(
+                f"The pinned Lean {LEAN_VERSION} executable could not be resolved."
+            ) from exc
+        executable = Path(resolved)
+    if not executable.is_file():
+        raise _LeanSetupError(
+            f"The pinned Lean {LEAN_VERSION} executable is unavailable."
+        )
+    mathlib_runtime = _mathlib_runtime() if require_mathlib else None
+    return executable, mathlib_runtime
+
+
 def _run_lean(
     source: str,
     *,

--- a/tests/contract/test_provider_runtime.py
+++ b/tests/contract/test_provider_runtime.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.contracts.capabilities import (
+    CapabilityDescriptor,
+    CapabilityInstallTier,
+    CapabilityMode,
+    CapabilityProviderAvailability,
+    CapabilityProviderDigestKind,
+    CapabilityProviderRuntime,
+)
+from jacobian.contracts.provider_measurements import (
+    ProviderMeasurementSample,
+    ProviderMeasurementStatus,
+)
+
+
+def _runtime(**updates: object) -> CapabilityProviderRuntime:
+    values: dict[str, object] = {
+        "provider": "tests.fixture",
+        "availability": CapabilityProviderAvailability.AVAILABLE,
+        "version": "1.2.3",
+        "digest": "sha256:" + "a" * 64,
+        "digest_kind": CapabilityProviderDigestKind.PYTHON_DISTRIBUTION_RECORD,
+        "platform": "linux-x86_64",
+        "install_tier": CapabilityInstallTier.T1,
+        "license_id": "MIT",
+        "license_files": ("fixture.dist-info/licenses/LICENSE",),
+        "features": ("exact-arithmetic",),
+        "checker_ids": ("checker://sha256/" + "b" * 64,),
+    }
+    values.update(updates)
+    return CapabilityProviderRuntime(**values)
+
+
+def test_available_provider_requires_exact_version_and_digest() -> None:
+    with pytest.raises(
+        ValidationError,
+        match="available provider runtime requires version, digest, and digest kind",
+    ):
+        _runtime(version=None, digest=None, digest_kind=None)
+
+
+def test_provider_metadata_rejects_duplicate_features_and_checker_ids() -> None:
+    with pytest.raises(ValidationError, match="provider features must be unique"):
+        _runtime(features=("exact-arithmetic", "exact-arithmetic"))
+    checker_id = "checker://sha256/" + "b" * 64
+    with pytest.raises(ValidationError, match="provider checker IDs must be unique"):
+        _runtime(checker_ids=(checker_id, checker_id))
+
+
+def test_unavailable_provider_requires_a_public_diagnostic() -> None:
+    with pytest.raises(
+        ValidationError,
+        match="unavailable provider runtime requires a diagnostic",
+    ):
+        _runtime(
+            availability=CapabilityProviderAvailability.UNAVAILABLE,
+            version=None,
+            digest=None,
+            digest_kind=None,
+        )
+
+
+def test_descriptor_provider_must_match_runtime_identity() -> None:
+    with pytest.raises(ValidationError, match="descriptor provider must match"):
+        CapabilityDescriptor(
+            capability_id="fixture.increment",
+            version="1",
+            title="Increment",
+            description="Increment one integer.",
+            provider="tests.other",
+            provider_runtime=_runtime(),
+            modes=(CapabilityMode.EXPLORE,),
+            input_schema={"type": "object"},
+            output_schema={"type": "object"},
+        )
+
+
+def test_measurement_status_cannot_hide_missing_elapsed_time() -> None:
+    with pytest.raises(
+        ValidationError,
+        match="completed provider measurement requires elapsed seconds",
+    ):
+        ProviderMeasurementSample(status=ProviderMeasurementStatus.COMPLETED)
+
+    with pytest.raises(
+        ValidationError,
+        match="incomplete provider measurement requires a detail",
+    ):
+        ProviderMeasurementSample(status=ProviderMeasurementStatus.SKIPPED)

--- a/tests/fixtures/capability_functions.py
+++ b/tests/fixtures/capability_functions.py
@@ -7,11 +7,13 @@ from jacobian.contracts.capabilities import (
     CapabilityAssurance,
     CapabilityAssuranceLevel,
     CapabilityDescriptor,
+    CapabilityInstallTier,
     CapabilityMode,
     CapabilityRequest,
     CapabilityResult,
 )
 from jacobian.contracts.results import Execution, ExecutionStatus
+from jacobian.provider_runtime import source_provider_runtime
 
 
 @dataclass(frozen=True)
@@ -22,6 +24,14 @@ class FixtureAdapter:
         title="Increment an integer",
         description="External fixture adapter loaded through an operator entrypoint.",
         provider="tests.fixture",
+        provider_runtime=source_provider_runtime(
+            "tests.fixture",
+            version="1",
+            entrypoint="tests.fixtures.capability_functions:create_adapter",
+            install_tier=CapabilityInstallTier.T0,
+            license_id="MIT",
+            features=("integer-increment",),
+        ),
         modes=(CapabilityMode.EXPLORE,),
         input_schema={
             "type": "object",

--- a/tests/integration/test_capability_service.py
+++ b/tests/integration/test_capability_service.py
@@ -11,7 +11,11 @@ from jacobian.contracts.capabilities import (
     CapabilityAssurance,
     CapabilityAssuranceLevel,
     CapabilityDescriptor,
+    CapabilityInstallTier,
     CapabilityMode,
+    CapabilityProviderAvailability,
+    CapabilityProviderDigestKind,
+    CapabilityProviderRuntime,
     CapabilityRelationship,
     CapabilityRelationshipStatus,
     CapabilityRequest,
@@ -23,6 +27,17 @@ from jacobian.contracts.results import (
 )
 from jacobian.kernel import JacobianKernel
 
+TEST_RUNTIME = CapabilityProviderRuntime(
+    provider="tests",
+    availability=CapabilityProviderAvailability.AVAILABLE,
+    version="1",
+    digest="sha256:" + "a" * 64,
+    digest_kind=CapabilityProviderDigestKind.SOURCE_TREE,
+    platform="any",
+    install_tier=CapabilityInstallTier.T0,
+    license_id="MIT",
+)
+
 
 @dataclass(frozen=True)
 class ComputedAdapter:
@@ -32,6 +47,7 @@ class ComputedAdapter:
         title="Double an integer",
         description="Small adapter used to prove no MCP or kernel edit is required.",
         provider="tests",
+        provider_runtime=TEST_RUNTIME,
         modes=(CapabilityMode.EXPLORE,),
         input_schema={
             "type": "object",
@@ -70,6 +86,7 @@ class CrashingAdapter:
         title="Crash during execution",
         description="Fixture for testing public adapter-failure diagnostics.",
         provider="tests",
+        provider_runtime=TEST_RUNTIME,
         modes=(CapabilityMode.EXPLORE,),
         input_schema={"type": "object"},
         output_schema={"type": "object"},
@@ -80,6 +97,35 @@ class CrashingAdapter:
 
 
 @dataclass(frozen=True)
+class ForgedProviderAdapter:
+    descriptor = CapabilityDescriptor(
+        capability_id="example.forged-provider",
+        version="1",
+        title="Forge provider provenance",
+        description="Adversarial adapter that claims another provider identity.",
+        provider="tests",
+        provider_runtime=TEST_RUNTIME,
+        modes=(CapabilityMode.EXPLORE,),
+        input_schema={"type": "object"},
+        output_schema={"type": "object"},
+    )
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        return CapabilityResult(
+            capability_id=self.descriptor.capability_id,
+            capability_version=self.descriptor.version,
+            mode=request.mode,
+            execution=Execution(status=ExecutionStatus.COMPLETED),
+            assurance=CapabilityAssurance(
+                level=CapabilityAssuranceLevel.COMPUTED,
+                basis="fixture computation",
+            ),
+            provider="tests.other",
+            provider_digest="sha256:" + "b" * 64,
+        )
+
+
+@dataclass(frozen=True)
 class ForgedVerifiedAdapter:
     descriptor = CapabilityDescriptor(
         capability_id="example.forged",
@@ -87,6 +133,7 @@ class ForgedVerifiedAdapter:
         title="Forge a result",
         description="Adversarial adapter used to test the assurance boundary.",
         provider="tests",
+        provider_runtime=TEST_RUNTIME,
         modes=(CapabilityMode.VERIFY,),
         input_schema={"type": "object"},
         output_schema={"type": "object"},
@@ -114,6 +161,7 @@ class OmittedRelationshipArtifactAdapter:
         title="Return an unbound relationship",
         description="Adversarial adapter that omits a relationship endpoint.",
         provider="tests",
+        provider_runtime=TEST_RUNTIME,
         modes=(CapabilityMode.EXPLORE,),
         input_schema={"type": "object"},
         output_schema={"type": "object"},
@@ -151,6 +199,7 @@ class ForgedRelationshipVerificationAdapter:
         title="Mislabel a checked result as a verified relationship",
         description="Adversarial adapter that reuses an unrelated valid record.",
         provider="tests",
+        provider_runtime=TEST_RUNTIME,
         modes=(CapabilityMode.VERIFY,),
         input_schema={"type": "object"},
         output_schema={"type": "object"},
@@ -190,6 +239,7 @@ class MisboundVerifiedAdapter:
         title="Misbind a valid record",
         description="Adversarial adapter that reuses evidence from another claim.",
         provider="tests",
+        provider_runtime=TEST_RUNTIME,
         modes=(CapabilityMode.VERIFY,),
         input_schema={"type": "object"},
         output_schema={"type": "object"},
@@ -325,6 +375,23 @@ def test_adapter_failure_does_not_expose_internal_exception_text(
     )
     assert "fixture" not in result.execution.detail
     assert "RuntimeError" not in result.execution.detail
+
+
+@pytest.mark.integration
+def test_adapter_cannot_forge_provider_provenance(tmp_path: Path) -> None:
+    kernel = JacobianKernel(tmp_path)
+    kernel.register_capability(ForgedProviderAdapter())
+
+    with pytest.raises(
+        CapabilityError,
+        match="provider runtime differs from its descriptor",
+    ):
+        kernel.capabilities.invoke(
+            CapabilityRequest(
+                capability_id="example.forged-provider",
+                input={},
+            )
+        )
 
 
 @pytest.mark.integration

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -64,8 +64,34 @@ def test_cli_help_exposes_v02_operations() -> None:
         "transform-apply",
         "transform-verify",
         "polytope-separate",
+        "provider-measure",
     ):
         assert command in result.stdout
+
+
+@pytest.mark.integration
+def test_cli_measures_exact_provider_without_implicit_cold_install(
+    tmp_path: Path,
+) -> None:
+    result = CliRunner().invoke(
+        app,
+        [
+            "--state-dir",
+            str(tmp_path),
+            "--no-install-references",
+            "provider-measure",
+            "graph.compute.properties",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    measurement = json.loads(result.stdout)
+    assert measurement["provider_runtime"]["provider"] == "jacobian.networkx"
+    assert measurement["installed_bytes"] > 0
+    assert measurement["cold_install"]["status"] == "SKIPPED"
+    assert measurement["cold_start"]["status"] == "COMPLETED"
+    assert measurement["cold_start"]["peak_rss_bytes"] > 0
+    assert measurement["reproduction_case"]["status"] == "COMPLETED"
 
 
 @pytest.mark.integration

--- a/tests/integration/test_mcp_adapter.py
+++ b/tests/integration/test_mcp_adapter.py
@@ -68,7 +68,25 @@ def test_mcp_exposes_capability_and_workspace_tools_with_read_only_resources(
                 descriptor["capability_id"] for descriptor in catalog["capabilities"]
             }
             assert "knowledge.search" in capability_ids
-            assert "lean.check" in capability_ids
+            assert all(
+                descriptor["provider_runtime"]["availability"] == "AVAILABLE"
+                for descriptor in catalog["capabilities"]
+            )
+            if "lean.check" in capability_ids:
+                lean_result = await client.call_tool(
+                    "capability.describe",
+                    {"capability_id": "lean.check"},
+                )
+                lean_contract = json.loads(lean_result.content[0].text)
+                lean_runtime = lean_contract["capability"]["provider_runtime"]
+                assert lean_runtime["install_tier"] == "T3"
+                assert (
+                    lean_runtime["configuration"]["profiles"]["MATHLIB"][
+                        "mathlib_commit"
+                    ]
+                    == "fabf563a7c95a166b8d7b6efca11c8b4dc9d911f"
+                )
+                assert "runtime" not in lean_contract
 
             reference_result = await client.read_resource("reference://catalog")
             references = json.loads(reference_result.contents[0].text)
@@ -384,6 +402,9 @@ def test_mcp_describes_and_invokes_capabilities(tmp_path: Path) -> None:
             )
             contract = json.loads(described.content[0].text)
             assert contract["capability"]["capability_id"] == "knowledge.search"
+            assert contract["capability"]["provider_runtime"]["digest"].startswith(
+                "sha256:"
+            )
 
             result = await client.call_tool(
                 "capability.invoke",
@@ -396,6 +417,9 @@ def test_mcp_describes_and_invokes_capabilities(tmp_path: Path) -> None:
             response = json.loads(result.content[0].text)
             assert response["execution"]["status"] == "COMPLETED"
             assert response["assurance"]["level"] == "COMPUTED"
+            runtime = contract["capability"]["provider_runtime"]
+            assert response["provider"] == runtime["provider"]
+            assert response["provider_digest"] == runtime["digest"]
 
             unknown = await client.call_tool(
                 "capability.invoke",

--- a/tests/integration/test_provider_runtime_integration.py
+++ b/tests/integration/test_provider_runtime_integration.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from jacobian.capabilities import CapabilityError
+from jacobian.contracts.capabilities import (
+    CapabilityAssurance,
+    CapabilityAssuranceLevel,
+    CapabilityDescriptor,
+    CapabilityInstallTier,
+    CapabilityMode,
+    CapabilityProviderAvailability,
+    CapabilityProviderDigestKind,
+    CapabilityProviderRuntime,
+    CapabilityRequest,
+    CapabilityResult,
+)
+from jacobian.contracts.results import Execution, ExecutionStatus
+from jacobian.kernel import JacobianKernel
+from jacobian.provider_measurements import _cold_install_spec
+
+
+class UnavailableAdapter:
+    descriptor = CapabilityDescriptor(
+        capability_id="fixture.unavailable",
+        version="1",
+        title="Unavailable fixture",
+        description="Exercise fail-closed provider registration.",
+        provider="tests.unavailable",
+        provider_runtime=CapabilityProviderRuntime(
+            provider="tests.unavailable",
+            availability=CapabilityProviderAvailability.UNAVAILABLE,
+            platform="linux-x86_64",
+            install_tier=CapabilityInstallTier.T2,
+            license_id="MIT",
+            diagnostic="The fixture executable is not installed.",
+        ),
+        modes=(CapabilityMode.EXPLORE,),
+        input_schema={"type": "object"},
+        output_schema={"type": "object"},
+    )
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        raise AssertionError(f"unavailable adapter invoked: {request.capability_id}")
+
+
+def test_catalog_exposes_exact_runtime_identity_for_every_adapter(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    descriptors = {
+        item.capability_id: item for item in kernel.capabilities.catalog().capabilities
+    }
+
+    assert descriptors
+    assert all(
+        item.provider_runtime.availability is CapabilityProviderAvailability.AVAILABLE
+        for item in descriptors.values()
+    )
+    assert all(
+        item.provider_runtime.digest is not None for item in descriptors.values()
+    )
+    assert descriptors["graph.compute.properties"].provider_runtime.provider == (
+        "jacobian.networkx"
+    )
+    assert (
+        descriptors["polynomial.map.compute_jacobian"].provider_runtime.provider
+        == "jacobian.sympy"
+    )
+    assert (
+        descriptors["universal_algebra.search.countermodel"].provider_runtime.provider
+        == "jacobian.z3"
+    )
+
+
+def test_unavailable_adapter_is_rejected_before_catalog_advertisement(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+
+    with pytest.raises(CapabilityError, match="is unavailable"):
+        kernel.register_capability(UnavailableAdapter())
+
+    assert "fixture.unavailable" not in {
+        item.capability_id for item in kernel.capabilities.catalog().capabilities
+    }
+
+
+def test_unhealthy_optional_lean_runtime_is_absent_from_catalog(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    unavailable = CapabilityProviderRuntime(
+        provider="jacobian.lean4",
+        availability=CapabilityProviderAvailability.UNAVAILABLE,
+        platform="linux-x86_64",
+        install_tier=CapabilityInstallTier.T3,
+        license_id="Apache-2.0",
+        diagnostic="The pinned Lean runtime is unavailable.",
+    )
+    monkeypatch.setattr(
+        "jacobian.kernel.lean_provider_runtime",
+        lambda **_kwargs: unavailable,
+    )
+
+    kernel = JacobianKernel(tmp_path, install_references=True)
+
+    assert kernel.lean is None
+    assert "lean.check" not in {
+        item.capability_id for item in kernel.capabilities.catalog().capabilities
+    }
+
+
+def test_invocation_binds_descriptor_runtime_to_result_provenance(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    descriptor = next(
+        item
+        for item in kernel.capabilities.catalog().capabilities
+        if item.capability_id == "polynomial.map.evaluate"
+    )
+    # Invalid input is intentional: provenance must also survive failed execution.
+    result = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id=descriptor.capability_id,
+            mode=CapabilityMode.EXPLORE,
+            input={},
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert descriptor.provider_runtime is not None
+    assert result.provider == descriptor.provider
+    assert result.provider_digest == descriptor.provider_runtime.digest
+
+
+def test_runtime_contract_accepts_a_bound_completed_result() -> None:
+    runtime = CapabilityProviderRuntime(
+        provider="tests.fixture",
+        availability=CapabilityProviderAvailability.AVAILABLE,
+        version="1",
+        digest="sha256:" + "a" * 64,
+        digest_kind=CapabilityProviderDigestKind.SOURCE_TREE,
+        platform="any",
+        install_tier=CapabilityInstallTier.T0,
+        license_id="MIT",
+    )
+    result = CapabilityResult(
+        capability_id="fixture.identity",
+        capability_version="1",
+        mode=CapabilityMode.EXPLORE,
+        execution=Execution(status=ExecutionStatus.COMPLETED),
+        assurance=CapabilityAssurance(
+            level=CapabilityAssuranceLevel.COMPUTED,
+            basis="fixture computation",
+        ),
+        provider=runtime.provider,
+        provider_digest=runtime.digest,
+    )
+
+    assert result.provider == runtime.provider
+    assert result.provider_digest == runtime.digest
+
+
+def test_source_runtime_has_no_implicit_working_directory_install() -> None:
+    runtime = CapabilityProviderRuntime(
+        provider="tests.fixture",
+        availability=CapabilityProviderAvailability.AVAILABLE,
+        version="1",
+        digest="sha256:" + "a" * 64,
+        digest_kind=CapabilityProviderDigestKind.SOURCE_TREE,
+        platform="any",
+        install_tier=CapabilityInstallTier.T1,
+        license_id="MIT",
+    )
+
+    assert _cold_install_spec(runtime) is None


### PR DESCRIPTION
## Problem

Capability descriptors named a provider but did not say whether the exact backend was installed and healthy, which version or digest was running, what install tier and license applied, or which fixed checker identities were available. Lean runtime metadata was also special-cased in the MCP adapter, and missing optional backends could become invocation-time surprises. There was no repeatable command for replacing rough backend-size estimates with local measurements.

## Change

- add a structured provider runtime contract for availability, exact version and digest coverage, platform, install tier, license metadata, features, checker identities, and canonical provider configuration
- require an `AVAILABLE` runtime before capability registration and bind provider plus digest to every known-capability result
- identify built-in source, NetworkX, SymPy, Z3, and pinned Lean/Mathlib runtimes; omit `lean.check` when its separately managed runtime is unhealthy
- remove the Lean-only MCP runtime response and expose its profiles through the generic descriptor contract
- add `provider-measure` for installed bytes, cold start, peak RSS, a provider-specific reproduction, and explicitly requested fresh-cache cold installs
- add fail-closed, provenance-forgery, optional-backend, MCP-budget, CLI, and measurement tests plus public reference documentation

## Impact and compatibility

This adds no top-level MCP tools and does not change mathematical assurance. Availability and measurements remain operational facts; they cannot promote a conclusion to `VERIFIED`.

The descriptor and result payloads gain additive provider fields. Registration now rejects adapters that omit runtime identity, so operator-installed adapter authors must populate `provider_runtime`; `source_provider_runtime` provides the source-backed path. Source-tree and T3 providers without a safe automated installer report a skipped cold-install measurement.

## Validation

- `uv run pytest`: 420 passed; the Mathlib replay failed only under four-worker resource contention with the existing toolchain-unavailable diagnostic
- `uv run pytest -n 0 tests/integration/test_lean.py::test_mathlib_sqrt_two_proof_creates_bound_verification_record -q`: 1 passed
- focused provider, capability service, CLI, and MCP tests: 25 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`
- `git diff --check`
- live NetworkX measurement including a fresh-cache cold install completed successfully; source-backed cold install correctly reported `SKIPPED`