### PR TITLE
feat(capabilities): add Lean declaration discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,9 +202,12 @@ lake build
 ```
 
 The operation and trust boundary are documented under
-[`lean.check`](docs/reference/tools.md). This is a trusted local integration,
-not a broker sandbox; the pinned Lake environment still has host-local runtime
-access.
+[`lean.check`](docs/reference/tools.md). Read-only
+[Lean declaration discovery](docs/reference/lean-declaration-discovery.md)
+can retrieve and inspect premises before completed source crosses that checker
+boundary; the [guided reproduction](docs/tutorials/lean-declaration-discovery.md)
+shows the composition. This is a trusted local integration, not a broker
+sandbox; the pinned Lake environment still has host-local runtime access.
 
 ## Distribution
 

--- a/docs/contributing/atomic-capability-portfolio.md
+++ b/docs/contributing/atomic-capability-portfolio.md
@@ -289,6 +289,23 @@ improve task completion or provenance enough to justify their catalog and token
 cost; otherwise improve `lean.check` examples or use an agent-side retrieval
 skill.
 
+The contract spike implemented on 2026-07-26 chose an exact-constant type
+pattern over pretty-printed type text. All named constants must occur in Lean's
+elaborated type expression. This keeps the query structural and makes a full
+no-match Mathlib scan practical without a custom index. On the development
+host with warm filesystem caches, direct helper measurements were:
+
+- 11.1 seconds for a one-result Mathlib name search;
+- 29.8 seconds to exhaust 626,944 public declarations for a no-match type
+  pattern; and
+- 69.0 seconds for the tested public search, inspect, and independent
+  `lean.check` composition.
+
+The first two operations return `COMPUTED` retrieval evidence and bind the
+exact pinned environment-manifest digest. The last operation alone returned
+`VERIFIED`. These measurements establish a workable spike, not portfolio lift;
+the held-out paired evaluation remains the next separate queue item.
+
 ## Wave 2: SAT certificate vertical slice
 
 Use four outcomes rather than one ambiguous solver call:

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,6 +41,8 @@ and build toward a complete result.
 - [Find and verify a counterexample](tutorials/first-verified-result.md) shows
   the boundary between an unverified evaluator result and independently
   verified evidence.
+- [Retrieve a Lean theorem and check a proof](tutorials/lean-declaration-discovery.md)
+  composes computed declaration retrieval with independent Lean replay.
 
 ## How-to guides
 
@@ -56,6 +58,7 @@ expectations.
 
 - [Tool surface](reference/tools.md)
 - [Provider runtime contract](reference/provider-runtime.md)
+- [Lean declaration discovery](reference/lean-declaration-discovery.md)
 - [v0.2 specification](reference/specifications/v0.2.md)
 - [v0.2 conformance specification](reference/conformance-v0.2.md)
 - [Plugin conformance contract](reference/plugin-conformance.md)

--- a/docs/reference/lean-declaration-discovery.md
+++ b/docs/reference/lean-declaration-discovery.md
@@ -1,0 +1,71 @@
+# Lean declaration discovery
+
+Jacobian exposes two read-only `EXPLORE` capabilities over the installed,
+pinned Lean runtime:
+
+- `lean.declaration.search` performs bounded declaration retrieval; and
+- `lean.declaration.inspect` resolves one exact declaration name.
+
+They return computed environment metadata. Finding or inspecting a theorem does
+not verify a new claim. Completed proof source must still pass `lean.check`.
+
+## Search contract
+
+`lean.declaration.search` accepts:
+
+- `environment`: `CORE` or `MATHLIB`;
+- `name_contains`: an optional case-sensitive declaration-name substring;
+- `type_pattern.constants`: an optional list of one to eight exact Lean
+  constant names, all of which must occur in the elaborated declaration type;
+- optional `namespace_prefixes` and declaration `kinds`; and
+- `result_limit`, from 1 through 50.
+
+At least one of `name_contains` or `type_pattern` is required. If both are
+present, both must match. Type patterns inspect constants in Lean's elaborated
+expression. They are not pretty-printed text matching, unification, typeclass
+search, or proof search.
+
+The provider excludes private declarations and visits public declaration names
+in deterministic `Name.lt` order. Each result carries its elaborated
+pretty-printed type, declaration kind, namespace when present, optional source
+module and range, and explicit match reasons.
+
+`stop_reason` separates the two possible coverage outcomes:
+
+- `RESULT_LIMIT` means the result budget stopped the scan and completeness is
+  `PARTIAL`; and
+- `EXHAUSTED` means the deterministic scan exhausted the declared environment
+  and filters, so completeness is `COMPLETE` with `COMPUTED` assurance.
+
+An exhausted empty result is evidence that this exact scan found no match. It
+is not a mathematical nonexistence conclusion.
+
+## Inspect contract
+
+`lean.declaration.inspect` accepts an environment and one exact
+`declaration_name`. It returns the declaration's elaborated type, kind,
+namespace, documentation and source metadata when available. A missing exact
+name is an execution error, not an empty successful result.
+
+## Environment identity and execution bounds
+
+Both outputs carry `environment_digest`. The
+`jacobian.lean.environment-manifest/v1` digest binds the selected import,
+platform, pinned Lean version, and executable provider digest. `MATHLIB` also
+binds the byte digests of `lake-manifest.json` and `lean-toolchain` plus the
+authorized Mathlib commit. This is an exact runtime-manifest identity, not an
+independent proof certificate.
+
+The `CORE` profile exposes only imported `Init.*` declarations compatible with
+the checker profile, even though the provider process also loads Lean
+metaprogramming modules to implement the query. Provider-local helper
+declarations are never searchable. `MATHLIB` exposes declarations imported by
+the pinned `Mathlib` module.
+
+The subprocess is fail-closed, uses `--trust=0`, one worker, a 40-second `CORE`
+or 75-second `MATHLIB` timeout, and a two-MiB structured-output limit.
+Timeouts, unavailable profiles, malformed output, and Lean errors remain
+execution failures without a mathematical conclusion.
+
+See [Retrieve a Lean theorem and check a proof](../tutorials/lean-declaration-discovery.md)
+for the public composition.

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -151,11 +151,15 @@ When the operator enables bundled references, the catalog also includes:
 
 | Capability ID | Outcome |
 | --- | --- |
+| `lean.declaration.search` | Search public declarations by a bounded name and/or elaborated-type constant pattern; retrieval remains computed evidence. |
+| `lean.declaration.inspect` | Resolve one exact declaration with type, kind, docs, source metadata, and pinned environment digest. |
 | `lean.check` | Check a Lean proof in an operator-pinned environment and return its replay evidence. |
 
 Operator-installed adapters appear in the same catalog. Agents should call
 `capability.describe` before invoking an unfamiliar capability instead of
-guessing payload fields.
+guessing payload fields. The
+[Lean declaration discovery contract](lean-declaration-discovery.md) defines
+its matching, coverage, environment identity, and assurance semantics.
 
 ## Mathematical operation portfolio
 

--- a/docs/tutorials/lean-declaration-discovery.md
+++ b/docs/tutorials/lean-declaration-discovery.md
@@ -1,0 +1,105 @@
+# Retrieve a Lean theorem and check a proof
+
+[Documentation home](../index.md)
+
+This tutorial searches pinned Mathlib metadata, inspects the selected theorem,
+then submits a small proof to the independent `lean.check` boundary. Retrieval
+remains `COMPUTED`; only successful kernel replay returns `VERIFIED`.
+
+## Prerequisites
+
+Install the locked Python environment and prepare the pinned Lean runtime as
+described in the [Lean setup](../../README.md#lean-certificates).
+
+## Run the public composition
+
+Save this as `lean_declaration_discovery.py`:
+
+```python
+import asyncio
+import json
+from pathlib import Path
+
+from mcp import Client
+
+from jacobian.adapters.mcp.server import create_server
+
+
+STATE_DIR = Path(".jacobian-lean-tutorial")
+
+
+async def tool(client: Client, name: str, arguments: dict) -> dict:
+    result = await client.call_tool(name, arguments)
+    return json.loads(result.content[0].text)
+
+
+async def main() -> None:
+    server = create_server(STATE_DIR, install_references=True)
+
+    async with Client(server, raise_exceptions=True) as client:
+        searched = await tool(
+            client,
+            "capability.invoke",
+            {
+                "capability_id": "lean.declaration.search",
+                "mode": "EXPLORE",
+                "payload": {
+                    "environment": "MATHLIB",
+                    "name_contains": "irrational_sqrt_two",
+                    "result_limit": 1,
+                },
+            },
+        )
+        declaration_name = searched["output"]["declarations"][0]["name"]
+        assert searched["assurance"]["level"] == "COMPUTED"
+        assert searched["assurance"]["verification_record_uri"] is None
+
+        inspected = await tool(
+            client,
+            "capability.invoke",
+            {
+                "capability_id": "lean.declaration.inspect",
+                "mode": "EXPLORE",
+                "payload": {
+                    "environment": "MATHLIB",
+                    "declaration_name": declaration_name,
+                },
+            },
+        )
+        assert inspected["output"]["declaration"]["type"] == "Irrational √2"
+        assert (
+            inspected["output"]["environment_digest"]
+            == searched["output"]["environment_digest"]
+        )
+
+        checked = await tool(
+            client,
+            "capability.invoke",
+            {
+                "capability_id": "lean.check",
+                "mode": "VERIFY",
+                "payload": {
+                    "environment": "MATHLIB",
+                    "statement": "Irrational (Real.sqrt 2)",
+                    "proof": f"exact {declaration_name}",
+                },
+            },
+        )
+        assert checked["output"]["conclusion"] == "TRUE"
+        assert checked["assurance"]["level"] == "VERIFIED"
+        assert checked["output"]["verification_record_uri"] is not None
+
+
+asyncio.run(main())
+```
+
+Run it from the repository root:
+
+```sh
+uv run python lean_declaration_discovery.py
+```
+
+The first two calls provide premise evidence and exact environment identity.
+They do not inherit the theorem's truth as a verification record. The final
+call binds the proposition and proof source to the authorized Lean checker and
+replays them in the pinned Mathlib environment.

--- a/src/jacobian/_lean_declaration_query.lean
+++ b/src/jacobian/_lean_declaration_query.lean
@@ -1,0 +1,159 @@
+import {{JACOBIAN_IMPORT}}
+import Lean.DeclarationRange
+import Lean.DocString
+import Lean.Elab.Command
+
+open Lean
+
+structure DeclarationQuery where
+  operation : String
+  declaration_name : Option String
+  name_contains : Option String
+  type_constants : Array String
+  namespace_prefixes : Array String
+  target_module_prefixes : Array String
+  kinds : Array String
+  limit : Nat
+  deriving FromJson
+
+def declarationKind : ConstantInfo → String
+  | .axiomInfo _ => "AXIOM"
+  | .defnInfo _ => "DEFINITION"
+  | .thmInfo _ => "THEOREM"
+  | .opaqueInfo _ => "OPAQUE"
+  | .quotInfo _ => "QUOTIENT"
+  | .inductInfo _ => "INDUCTIVE"
+  | .ctorInfo _ => "CONSTRUCTOR"
+  | .recInfo _ => "RECURSOR"
+
+def moduleContaining? (env : Environment) (declName : Name) : Option Name := do
+  let some moduleIdx := env.getModuleIdxFor? declName
+    | none
+  env.allImportedModuleNames[moduleIdx]?
+
+def declarationNamespace (name : Name) : Option String :=
+  let ns := name.getPrefix
+  if ns.isAnonymous then none else some ns.toString
+
+def sourceJson (env : Environment) (name : Name) :
+    Elab.Command.CommandElabM Json := do
+  let ranges ← findDeclarationRanges? name
+  return match ranges with
+    | none => Json.null
+    | some ranges =>
+      Json.mkObj [
+        ("module", toJson ((moduleContaining? env name).map toString)),
+        ("line", toJson ranges.selectionRange.pos.line),
+        ("column", toJson ranges.selectionRange.pos.column),
+        ("end_line", toJson ranges.selectionRange.endPos.line),
+        ("end_column", toJson ranges.selectionRange.endPos.column)
+      ]
+
+def renderedType (info : ConstantInfo) :
+    Elab.Command.CommandElabM String :=
+  Elab.Command.liftTermElabM do
+    return (← Meta.ppExpr info.type).pretty
+
+def namespaceMatches (query : DeclarationQuery) (name : Name) : Bool :=
+  query.namespace_prefixes.isEmpty ||
+    query.namespace_prefixes.any fun nsPrefix =>
+      name.toString == nsPrefix || name.toString.startsWith (nsPrefix ++ ".")
+
+def kindMatches (query : DeclarationQuery) (info : ConstantInfo) : Bool :=
+  query.kinds.isEmpty || query.kinds.contains (declarationKind info)
+
+def targetModuleMatches (query : DeclarationQuery) (env : Environment)
+    (name : Name) : Bool :=
+  match moduleContaining? env name with
+  | none => false
+  | some modName =>
+    query.target_module_prefixes.isEmpty ||
+      query.target_module_prefixes.any fun modulePrefix =>
+        modName.toString == modulePrefix ||
+          modName.toString.startsWith (modulePrefix ++ ".")
+
+def typeMatches (query : DeclarationQuery) (info : ConstantInfo) : Bool :=
+  let used := info.type.getUsedConstantsAsSet
+  query.type_constants.all fun constant => used.contains constant.toName
+
+def declarationJson (env : Environment) (name : Name) (info : ConstantInfo)
+    (type : String) (matchReasons : Array String) (includeDetails : Bool) :
+    Elab.Command.CommandElabM Json := do
+  let source ← sourceJson env name
+  let docString ←
+    if includeDetails then findDocString? env name else pure none
+  return Json.mkObj [
+    ("name", toJson name.toString),
+    ("type", toJson type),
+    ("kind", toJson (declarationKind info)),
+    ("namespace", toJson (declarationNamespace name)),
+    ("docstring", toJson docString),
+    ("source", source),
+    ("match_reasons", toJson matchReasons)
+  ]
+
+def readQuery : IO DeclarationQuery := do
+  let some path ← IO.getEnv "JACOBIAN_LEAN_QUERY_FILE"
+    | throw <| IO.userError "JACOBIAN_LEAN_QUERY_FILE is required"
+  let contents ← IO.FS.readFile path
+  let json ← match Json.parse contents with
+    | .ok json => pure json
+    | .error detail => throw <| IO.userError s!"invalid query JSON: {detail}"
+  match fromJson? json with
+  | .ok query => pure query
+  | .error detail => throw <| IO.userError s!"invalid query contract: {detail}"
+
+run_cmd do
+  let query ← readQuery
+  let env ← getEnv
+  if query.limit == 0 || query.limit > 50 then
+    throwError "limit must be between 1 and 50"
+  let output ←
+    if query.operation == "inspect" then
+      let some rawName := query.declaration_name
+        | throwError "declaration_name is required"
+      let some (name, info) := env.constants.toList.find? fun (name, _) =>
+          name.toString == rawName
+        | throwError s!"declaration not found: {rawName}"
+      if !targetModuleMatches query env name then
+        throwError s!"declaration not found: {rawName}"
+      let type ← renderedType info
+      let declaration ← declarationJson env name info type #[] true
+      pure <| Json.mkObj [
+        ("operation", "inspect"),
+        ("declaration", declaration)
+      ]
+    else if query.operation == "search" then
+      if query.name_contains.isNone && query.type_constants.isEmpty then
+        throwError "name_contains or type_constants is required"
+      let names := env.constants.toList.toArray.map (·.1) |>.qsort Name.lt
+      let mut results : Array Json := #[]
+      let mut scanned := 0
+      let mut stopReason := "EXHAUSTED"
+      for name in names do
+        if results.size == query.limit then
+          stopReason := "RESULT_LIMIT"
+          break
+        if isPrivateName name || !targetModuleMatches query env name then continue
+        scanned := scanned + 1
+        let some info := env.find? name | continue
+        if !namespaceMatches query name || !kindMatches query info then continue
+        let nameMatched :=
+          query.name_contains.map (name.toString.contains ·) |>.getD true
+        if !nameMatched || !typeMatches query info then continue
+        let type ← renderedType info
+        let mut reasons : Array String := #[]
+        if query.name_contains.isSome then
+          reasons := reasons.push "NAME_SUBSTRING"
+        if !query.type_constants.isEmpty then
+          reasons := reasons.push "TYPE_CONSTANTS"
+        results := results.push (← declarationJson env name info type reasons false)
+      pure <| Json.mkObj [
+        ("operation", "search"),
+        ("declarations", toJson results),
+        ("scanned_declarations", scanned),
+        ("stop_reason", stopReason)
+      ]
+    else
+      throwError "operation must be search or inspect"
+  IO.println s!"JACOBIAN_DECLARATION_RESULT {output.compress}"

--- a/src/jacobian/builtin_capabilities.py
+++ b/src/jacobian/builtin_capabilities.py
@@ -4,22 +4,38 @@ from __future__ import annotations
 
 from typing import Any
 
+from jacobian.capabilities import CapabilityInvocationError
 from jacobian.contracts.capabilities import (
     CapabilityAssurance,
     CapabilityAssuranceLevel,
+    CapabilityCompleteness,
+    CapabilityCompletenessStatus,
     CapabilityDescriptor,
+    CapabilityDiagnostic,
     CapabilityMode,
     CapabilityProviderRuntime,
     CapabilityRequest,
     CapabilityResult,
+    CapabilityScope,
 )
-from jacobian.contracts.lean import LeanEnvironment
+from jacobian.contracts.lean import (
+    LeanDeclarationInspectOutput,
+    LeanDeclarationInspectRequest,
+    LeanDeclarationSearchOutput,
+    LeanDeclarationSearchRequest,
+    LeanDeclarationSearchStopReason,
+    LeanEnvironment,
+)
 from jacobian.contracts.results import (
     Execution,
     ExecutionStatus,
     Verification,
 )
 from jacobian.lean import LeanService
+from jacobian.lean_declarations import (
+    LeanDeclarationBackendError,
+    LeanDeclarationService,
+)
 from jacobian.memory import ResearchMemory
 from jacobian.provider_runtime import known_provider_runtime
 
@@ -174,3 +190,161 @@ class LeanCheckAdapter:
                 *((scope_uri,) if scope_uri is not None else ()),
             ),
         )
+
+
+class LeanDeclarationSearchAdapter:
+    def __init__(
+        self,
+        declarations: LeanDeclarationService,
+        provider_runtime: CapabilityProviderRuntime,
+    ) -> None:
+        self.declarations = declarations
+        self._descriptor = CapabilityDescriptor(
+            capability_id="lean.declaration.search",
+            version="1",
+            title="Search Lean declarations",
+            description=(
+                "Search a pinned Lean environment by a case-sensitive name substring "
+                "and/or exact constants occurring in elaborated declaration types."
+            ),
+            provider="jacobian.lean4",
+            provider_runtime=provider_runtime,
+            modes=(CapabilityMode.EXPLORE,),
+            input_schema=LeanDeclarationSearchRequest.model_json_schema(),
+            output_schema=LeanDeclarationSearchOutput.model_json_schema(),
+            read_only=True,
+            tags=("lean", "declaration", "retrieval", "premise-discovery"),
+        )
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        return self._descriptor
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        query = LeanDeclarationSearchRequest.model_validate(request.input)
+        try:
+            searched = self.declarations.search(query)
+        except LeanDeclarationBackendError as exc:
+            raise _declaration_invocation_error(exc) from exc
+        complete = searched.stop_reason is LeanDeclarationSearchStopReason.EXHAUSTED
+        return CapabilityResult(
+            capability_id=self.descriptor.capability_id,
+            capability_version=self.descriptor.version,
+            mode=request.mode,
+            execution=Execution(status=ExecutionStatus.COMPLETED),
+            output=searched.model_dump(mode="json"),
+            scope=CapabilityScope(
+                description="the installed pinned Lean declaration environment",
+                parameters={
+                    "environment": searched.environment.value,
+                    "environment_digest": searched.environment_digest,
+                    "matching": (
+                        "case-sensitive name substring and exact constants occurring "
+                        "in the elaborated type"
+                    ),
+                    "namespace_prefixes": list(query.namespace_prefixes),
+                    "kinds": [kind.value for kind in query.kinds],
+                },
+            ),
+            completeness=CapabilityCompleteness(
+                status=(
+                    CapabilityCompletenessStatus.COMPLETE
+                    if complete
+                    else CapabilityCompletenessStatus.PARTIAL
+                ),
+                basis=(
+                    "the deterministic declaration scan exhausted the declared "
+                    "environment and filters"
+                    if complete
+                    else "the result budget stopped the declaration scan"
+                ),
+                assurance_level=CapabilityAssuranceLevel.COMPUTED,
+            ),
+            assurance=CapabilityAssurance(
+                level=CapabilityAssuranceLevel.COMPUTED,
+                basis=(
+                    "metadata read from the pinned Lean environment; retrieved "
+                    "declarations are evidence and do not verify a theorem"
+                ),
+            ),
+        )
+
+
+class LeanDeclarationInspectAdapter:
+    def __init__(
+        self,
+        declarations: LeanDeclarationService,
+        provider_runtime: CapabilityProviderRuntime,
+    ) -> None:
+        self.declarations = declarations
+        self._descriptor = CapabilityDescriptor(
+            capability_id="lean.declaration.inspect",
+            version="1",
+            title="Inspect a Lean declaration",
+            description=(
+                "Resolve one exact declaration in a pinned Lean environment and "
+                "return its elaborated type, kind, docs, source metadata, and "
+                "environment digest."
+            ),
+            provider="jacobian.lean4",
+            provider_runtime=provider_runtime,
+            modes=(CapabilityMode.EXPLORE,),
+            input_schema=LeanDeclarationInspectRequest.model_json_schema(),
+            output_schema=LeanDeclarationInspectOutput.model_json_schema(),
+            read_only=True,
+            tags=("lean", "declaration", "retrieval", "inspection"),
+        )
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        return self._descriptor
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        query = LeanDeclarationInspectRequest.model_validate(request.input)
+        try:
+            inspected = self.declarations.inspect(query)
+        except LeanDeclarationBackendError as exc:
+            raise _declaration_invocation_error(exc) from exc
+        return CapabilityResult(
+            capability_id=self.descriptor.capability_id,
+            capability_version=self.descriptor.version,
+            mode=request.mode,
+            execution=Execution(status=ExecutionStatus.COMPLETED),
+            output=inspected.model_dump(mode="json"),
+            scope=CapabilityScope(
+                description="one exact declaration in the pinned Lean environment",
+                parameters={
+                    "environment": inspected.environment.value,
+                    "environment_digest": inspected.environment_digest,
+                    "declaration_name": query.declaration_name,
+                },
+            ),
+            completeness=CapabilityCompleteness(
+                status=CapabilityCompletenessStatus.COMPLETE,
+                basis="the exact declaration name resolved in the declared environment",
+                assurance_level=CapabilityAssuranceLevel.COMPUTED,
+            ),
+            assurance=CapabilityAssurance(
+                level=CapabilityAssuranceLevel.COMPUTED,
+                basis=(
+                    "metadata read from the pinned Lean environment; inspecting a "
+                    "declaration does not verify a new theorem"
+                ),
+            ),
+        )
+
+
+def _declaration_invocation_error(
+    error: LeanDeclarationBackendError,
+) -> CapabilityInvocationError:
+    return CapabilityInvocationError(
+        CapabilityDiagnostic(
+            code=error.code,
+            stage="lean_declaration_query",
+            message=error.message,
+            hint=(
+                "Call capability.describe for the exact query contract and verify "
+                "that the requested pinned environment is installed."
+            ),
+        )
+    )

--- a/src/jacobian/contracts/lean.py
+++ b/src/jacobian/contracts/lean.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 from enum import StrEnum
-from typing import Literal
+from typing import Literal, Self
 
-from pydantic import Field
+from pydantic import Field, StrictInt, model_validator
 
-from jacobian.contracts.common import ArtifactUri
+from jacobian.contracts.common import ArtifactUri, Sha256Digest
 from jacobian.contracts.results import ContractModel, ResultEnvelope
 
 
@@ -36,3 +36,140 @@ class LeanVerifyResult(ContractModel):
     certificate_uri: ArtifactUri
     result: ResultEnvelope
     cache_hit: bool = False
+
+
+class LeanDeclarationKind(StrEnum):
+    AXIOM = "AXIOM"
+    DEFINITION = "DEFINITION"
+    THEOREM = "THEOREM"
+    OPAQUE = "OPAQUE"
+    QUOTIENT = "QUOTIENT"
+    INDUCTIVE = "INDUCTIVE"
+    CONSTRUCTOR = "CONSTRUCTOR"
+    RECURSOR = "RECURSOR"
+
+
+class LeanDeclarationMatchReason(StrEnum):
+    NAME_SUBSTRING = "NAME_SUBSTRING"
+    TYPE_CONSTANTS = "TYPE_CONSTANTS"
+
+
+class LeanDeclarationSearchStopReason(StrEnum):
+    RESULT_LIMIT = "RESULT_LIMIT"
+    EXHAUSTED = "EXHAUSTED"
+
+
+class LeanDeclarationSource(ContractModel):
+    module: str | None = Field(default=None, min_length=1, max_length=512)
+    line: StrictInt = Field(ge=1)
+    column: StrictInt = Field(ge=0)
+    end_line: StrictInt = Field(ge=1)
+    end_column: StrictInt = Field(ge=0)
+
+
+class LeanDeclarationRecord(ContractModel):
+    name: str = Field(min_length=1, max_length=512)
+    type: str = Field(min_length=1, max_length=20_000)
+    kind: LeanDeclarationKind
+    namespace: str | None = Field(default=None, min_length=1, max_length=512)
+    docstring: str | None = Field(default=None, max_length=20_000)
+    source: LeanDeclarationSource | None = None
+    match_reasons: tuple[LeanDeclarationMatchReason, ...] = ()
+
+    @model_validator(mode="after")
+    def require_unique_match_reasons(self) -> Self:
+        if len(set(self.match_reasons)) != len(self.match_reasons):
+            raise ValueError("declaration match reasons must be unique")
+        return self
+
+
+class LeanDeclarationTypePattern(ContractModel):
+    """All named constants must occur in the elaborated declaration type."""
+
+    constants: tuple[str, ...] = Field(min_length=1, max_length=8)
+
+    @model_validator(mode="after")
+    def require_distinct_constant_names(self) -> Self:
+        _require_distinct_lean_names(
+            self.constants, field_name="type pattern constants"
+        )
+        return self
+
+
+class LeanDeclarationSearchRequest(ContractModel):
+    environment: LeanEnvironment = LeanEnvironment.CORE
+    name_contains: str | None = Field(default=None, min_length=1, max_length=256)
+    type_pattern: LeanDeclarationTypePattern | None = None
+    namespace_prefixes: tuple[str, ...] = Field(default=(), max_length=16)
+    kinds: tuple[LeanDeclarationKind, ...] = ()
+    result_limit: StrictInt = Field(default=10, ge=1, le=50)
+
+    @model_validator(mode="after")
+    def require_query_and_distinct_filters(self) -> Self:
+        if self.name_contains is None and self.type_pattern is None:
+            raise ValueError("name_contains or type_pattern is required")
+        if self.name_contains is not None:
+            _require_lean_text(self.name_contains, field_name="name_contains")
+        _require_distinct_lean_names(
+            self.namespace_prefixes,
+            field_name="namespace prefixes",
+        )
+        if len(set(self.kinds)) != len(self.kinds):
+            raise ValueError("declaration kinds must be unique")
+        return self
+
+
+class LeanDeclarationSearchOutput(ContractModel):
+    environment: LeanEnvironment
+    environment_digest: Sha256Digest
+    query: LeanDeclarationSearchRequest
+    declarations: tuple[LeanDeclarationRecord, ...]
+    scanned_declarations: StrictInt = Field(ge=0)
+    stop_reason: LeanDeclarationSearchStopReason
+
+    @model_validator(mode="after")
+    def bind_result_budget(self) -> Self:
+        if len(self.declarations) > self.query.result_limit:
+            raise ValueError("declaration results exceed the requested result limit")
+        return self
+
+
+class LeanDeclarationInspectRequest(ContractModel):
+    environment: LeanEnvironment = LeanEnvironment.CORE
+    declaration_name: str = Field(min_length=1, max_length=512)
+
+    @model_validator(mode="after")
+    def require_exact_name_text(self) -> Self:
+        _require_lean_text(self.declaration_name, field_name="declaration_name")
+        return self
+
+
+class LeanDeclarationInspectOutput(ContractModel):
+    environment: LeanEnvironment
+    environment_digest: Sha256Digest
+    query: LeanDeclarationInspectRequest
+    declaration: LeanDeclarationRecord
+
+    @model_validator(mode="after")
+    def bind_exact_name(self) -> Self:
+        if self.declaration.name != self.query.declaration_name:
+            raise ValueError(
+                "inspected declaration differs from the requested exact name"
+            )
+        return self
+
+
+def _require_lean_text(value: str, *, field_name: str) -> None:
+    if not value.strip() or "\x00" in value or any(char in "\r\n" for char in value):
+        raise ValueError(f"{field_name} must be one non-empty Lean name fragment")
+
+
+def _require_distinct_lean_names(
+    values: tuple[str, ...],
+    *,
+    field_name: str,
+) -> None:
+    for value in values:
+        _require_lean_text(value, field_name=field_name)
+    if len(set(values)) != len(values):
+        raise ValueError(f"{field_name} must be unique")

--- a/src/jacobian/kernel.py
+++ b/src/jacobian/kernel.py
@@ -10,6 +10,8 @@ from jacobian.atomic_capabilities import install_atomic_capabilities
 from jacobian.builtin_capabilities import (
     KnowledgeSearchAdapter,
     LeanCheckAdapter,
+    LeanDeclarationInspectAdapter,
+    LeanDeclarationSearchAdapter,
 )
 from jacobian.capabilities import (
     CapabilityAdapter,
@@ -29,6 +31,10 @@ from jacobian.finite_partition import (
 )
 from jacobian.graph_capabilities import GraphInstallation, install_graph_capabilities
 from jacobian.lean import LeanService
+from jacobian.lean_declarations import (
+    LeanDeclarationService,
+    installed_lean_declaration_service,
+)
 from jacobian.memory import ResearchMemory
 from jacobian.plugin_execution import PluginExecutor
 from jacobian.plugins.registry import PluginRegistry
@@ -167,6 +173,7 @@ class JacobianKernel:
         self.polytope_checkers: PolytopeCheckerInstallation | None = None
         self.lean_checkers: dict[LeanEnvironment, LeanCheckerInstallation] = {}
         self.lean: LeanService | None = None
+        self.lean_declarations: LeanDeclarationService | None = None
         self.capabilities = CapabilityService(self.store, self.memory)
         for atomic_adapter in install_atomic_capabilities(self):
             self.capabilities.register(atomic_adapter)
@@ -245,6 +252,26 @@ class JacobianKernel:
                 ),
             )
             if runtime.availability is CapabilityProviderAvailability.AVAILABLE:
+                try:
+                    self.lean_declarations = installed_lean_declaration_service(runtime)
+                except (OSError, RuntimeError) as exc:
+                    _LOGGER.warning(
+                        "Lean declaration discovery is not installed: %s",
+                        exc,
+                    )
+                if self.lean_declarations is not None:
+                    self.capabilities.register(
+                        LeanDeclarationSearchAdapter(
+                            self.lean_declarations,
+                            runtime,
+                        )
+                    )
+                    self.capabilities.register(
+                        LeanDeclarationInspectAdapter(
+                            self.lean_declarations,
+                            runtime,
+                        )
+                    )
                 self.lean = LeanService(
                     self.store,
                     self.artifacts,

--- a/src/jacobian/lean_declarations.py
+++ b/src/jacobian/lean_declarations.py
@@ -1,0 +1,396 @@
+"""Read-only declaration discovery over pinned Lean environments."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any, Protocol
+
+from pydantic import ValidationError
+
+from jacobian.canonical import canonicalize_json, loads_strict_json
+from jacobian.contracts.capabilities import CapabilityProviderRuntime
+from jacobian.contracts.lean import (
+    LeanDeclarationInspectOutput,
+    LeanDeclarationInspectRequest,
+    LeanDeclarationRecord,
+    LeanDeclarationSearchOutput,
+    LeanDeclarationSearchRequest,
+    LeanDeclarationSearchStopReason,
+    LeanEnvironment,
+)
+
+_LOGGER = logging.getLogger(__name__)
+_RESULT_PREFIX = "JACOBIAN_DECLARATION_RESULT "
+_MAX_STDOUT_BYTES = 2 * 1024 * 1024
+_MAX_STDERR_BYTES = 128 * 1024
+_QUERY_SOURCE = Path(__file__).with_name("_lean_declaration_query.lean")
+_IMPORT_TOKEN = "{{JACOBIAN_IMPORT}}"
+
+
+class LeanDeclarationBackend(Protocol):
+    """The process boundary needed by typed declaration discovery."""
+
+    def environment_digest(self, environment: LeanEnvironment) -> str: ...
+
+    def query(
+        self,
+        environment: LeanEnvironment,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]: ...
+
+
+class LeanDeclarationBackendError(RuntimeError):
+    """A bounded backend failure safe for capability diagnostic mapping."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+class LeanSubprocessDeclarationBackend:
+    """Execute one generated read-only query in a validated Lean installation."""
+
+    def __init__(
+        self,
+        *,
+        lean_executable: Path,
+        mathlib_runtime: Path | None,
+        provider_runtime: CapabilityProviderRuntime,
+    ) -> None:
+        self.lean_executable = lean_executable
+        self.mathlib_runtime = mathlib_runtime
+        self.provider_runtime = provider_runtime
+        self._source_template = _QUERY_SOURCE.read_text(encoding="utf-8")
+        if self._source_template.count(_IMPORT_TOKEN) != 1:
+            raise RuntimeError(
+                "Lean declaration query source has an invalid import token"
+            )
+
+    def environment_digest(self, environment: LeanEnvironment) -> str:
+        try:
+            if _sha256_file(self.lean_executable) != self.provider_runtime.digest:
+                raise LeanDeclarationBackendError(
+                    "LEAN_ENVIRONMENT_CHANGED",
+                    "The pinned Lean executable changed after capability registration.",
+                )
+            return self._compute_environment_digest(environment)
+        except OSError as exc:
+            raise LeanDeclarationBackendError(
+                "LEAN_ENVIRONMENT_UNAVAILABLE",
+                f"The pinned Lean {environment.value} environment is not installed.",
+            ) from exc
+
+    def query(
+        self,
+        environment: LeanEnvironment,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        environment_digest = self.environment_digest(environment)
+        import_name = (
+            "Init.Prelude" if environment is LeanEnvironment.CORE else "Mathlib"
+        )
+        source = self._source_template.replace(_IMPORT_TOKEN, import_name)
+        with tempfile.TemporaryDirectory(prefix="jacobian-lean-query-") as directory:
+            temporary_root = Path(directory)
+            query_path = temporary_root / "query.json"
+            query_path.write_bytes(canonicalize_json(payload))
+            command, cwd, memory_mb, timeout_seconds = self._command(
+                environment,
+                temporary_root,
+            )
+            process_environment = self._process_environment(
+                environment,
+                temporary_root,
+                query_path,
+            )
+            try:
+                completed = subprocess.run(
+                    [
+                        *command,
+                        "--stdin",
+                        "-t",
+                        "0",
+                        "-T",
+                        "1000000000",
+                        "-M",
+                        memory_mb,
+                        "-j",
+                        "1",
+                        "--trust=0",
+                    ],
+                    cwd=cwd,
+                    env=process_environment,
+                    input=source,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout_seconds,
+                )
+            except subprocess.TimeoutExpired as exc:
+                raise LeanDeclarationBackendError(
+                    "LEAN_QUERY_TIMEOUT",
+                    (
+                        f"Lean declaration discovery exceeded the "
+                        f"{timeout_seconds}-second {environment.value} budget."
+                    ),
+                ) from exc
+        if len(completed.stdout.encode("utf-8")) > _MAX_STDOUT_BYTES:
+            raise LeanDeclarationBackendError(
+                "LEAN_QUERY_OUTPUT_LIMIT",
+                "Lean declaration discovery exceeded its structured output budget.",
+            )
+        if len(completed.stderr.encode("utf-8")) > _MAX_STDERR_BYTES:
+            raise LeanDeclarationBackendError(
+                "LEAN_QUERY_OUTPUT_LIMIT",
+                "Lean declaration discovery exceeded its diagnostic output budget.",
+            )
+        if completed.returncode != 0:
+            _LOGGER.warning(
+                "Lean declaration query failed: %s",
+                (completed.stdout + completed.stderr).strip(),
+            )
+            if "declaration not found:" in completed.stderr:
+                name = str(payload.get("declaration_name", "the requested name"))
+                raise LeanDeclarationBackendError(
+                    "LEAN_DECLARATION_NOT_FOUND",
+                    f"Lean did not find the exact declaration {name!r}.",
+                )
+            raise LeanDeclarationBackendError(
+                "LEAN_QUERY_FAILED",
+                (
+                    f"Lean could not complete declaration discovery in the "
+                    f"{environment.value} environment."
+                ),
+            )
+        output = _parse_query_output(completed.stdout)
+        if self.environment_digest(environment) != environment_digest:
+            raise LeanDeclarationBackendError(
+                "LEAN_ENVIRONMENT_CHANGED",
+                "The pinned Lean environment changed during declaration discovery.",
+            )
+        output["_environment_digest"] = environment_digest
+        return output
+
+    def _command(
+        self,
+        environment: LeanEnvironment,
+        temporary_root: Path,
+    ) -> tuple[list[str], Path, str, int]:
+        if environment is LeanEnvironment.CORE:
+            return [str(self.lean_executable)], temporary_root, "1024", 40
+        if self.mathlib_runtime is None:
+            raise LeanDeclarationBackendError(
+                "LEAN_ENVIRONMENT_UNAVAILABLE",
+                "The pinned Lean MATHLIB environment is not installed.",
+            )
+        lake = self.lean_executable.with_name(
+            "lake.exe" if self.lean_executable.suffix.lower() == ".exe" else "lake"
+        )
+        if not lake.is_file():
+            raise LeanDeclarationBackendError(
+                "LEAN_ENVIRONMENT_UNAVAILABLE",
+                "The pinned Lake executable for MATHLIB discovery is unavailable.",
+            )
+        return [str(lake), "env", "lean"], self.mathlib_runtime, "8192", 75
+
+    def _process_environment(
+        self,
+        environment: LeanEnvironment,
+        temporary_root: Path,
+        query_path: Path,
+    ) -> dict[str, str]:
+        lean_bin = str(self.lean_executable.parent)
+        existing_path = os.environ.get("PATH")
+        path = (
+            f"{lean_bin}{os.pathsep}{existing_path}"
+            if existing_path is not None
+            else lean_bin
+        )
+        runtime_home = (
+            os.environ.get("HOME", str(temporary_root))
+            if environment is LeanEnvironment.MATHLIB
+            else str(temporary_root)
+        )
+        return {
+            "HOME": runtime_home,
+            "JACOBIAN_LEAN_QUERY_FILE": str(query_path),
+            "LANG": "C.UTF-8",
+            "LC_ALL": "C.UTF-8",
+            "PATH": path,
+        }
+
+    def _compute_environment_digest(self, environment: LeanEnvironment) -> str:
+        identity: dict[str, Any] = {
+            "contract": "jacobian.lean.environment-manifest/v1",
+            "environment": environment.value,
+            "import_name": (
+                "Init.Prelude" if environment is LeanEnvironment.CORE else "Mathlib"
+            ),
+            "lean_version": self.provider_runtime.version,
+            "platform": self.provider_runtime.platform,
+            "provider_digest": self.provider_runtime.digest,
+        }
+        if environment is LeanEnvironment.MATHLIB:
+            if self.mathlib_runtime is None:
+                raise RuntimeError("cannot identify an unavailable Mathlib environment")
+            profile = self.provider_runtime.configuration.get("profiles", {}).get(
+                LeanEnvironment.MATHLIB.value,
+                {},
+            )
+            identity.update(
+                {
+                    "lake_manifest_digest": _sha256_file(
+                        self.mathlib_runtime / "lake-manifest.json"
+                    ),
+                    "lean_toolchain_digest": _sha256_file(
+                        self.mathlib_runtime / "lean-toolchain"
+                    ),
+                    "mathlib_commit": profile.get("mathlib_commit"),
+                }
+            )
+        return "sha256:" + hashlib.sha256(canonicalize_json(identity)).hexdigest()
+
+
+class LeanDeclarationService:
+    """Validate backend JSON into stable typed discovery results."""
+
+    def __init__(self, backend: LeanDeclarationBackend) -> None:
+        self.backend = backend
+
+    def search(
+        self,
+        query: LeanDeclarationSearchRequest,
+    ) -> LeanDeclarationSearchOutput:
+        type_constants = (
+            list(query.type_pattern.constants) if query.type_pattern is not None else []
+        )
+        raw = self.backend.query(
+            query.environment,
+            {
+                "operation": "search",
+                "declaration_name": None,
+                "name_contains": query.name_contains,
+                "type_constants": type_constants,
+                "namespace_prefixes": list(query.namespace_prefixes),
+                "target_module_prefixes": (
+                    ["Init"] if query.environment is LeanEnvironment.CORE else []
+                ),
+                "kinds": [kind.value for kind in query.kinds],
+                "limit": query.result_limit,
+            },
+        )
+        _require_operation(raw, "search")
+        environment_digest = (
+            raw["_environment_digest"]
+            if "_environment_digest" in raw
+            else self.backend.environment_digest(query.environment)
+        )
+        try:
+            return LeanDeclarationSearchOutput(
+                environment=query.environment,
+                environment_digest=environment_digest,
+                query=query,
+                declarations=tuple(
+                    LeanDeclarationRecord.model_validate(item)
+                    for item in raw["declarations"]
+                ),
+                scanned_declarations=raw["scanned_declarations"],
+                stop_reason=LeanDeclarationSearchStopReason(raw["stop_reason"]),
+            )
+        except (KeyError, TypeError, ValueError, ValidationError) as exc:
+            raise _protocol_error() from exc
+
+    def inspect(
+        self,
+        query: LeanDeclarationInspectRequest,
+    ) -> LeanDeclarationInspectOutput:
+        raw = self.backend.query(
+            query.environment,
+            {
+                "operation": "inspect",
+                "declaration_name": query.declaration_name,
+                "name_contains": None,
+                "type_constants": [],
+                "namespace_prefixes": [],
+                "target_module_prefixes": (
+                    ["Init"] if query.environment is LeanEnvironment.CORE else []
+                ),
+                "kinds": [],
+                "limit": 1,
+            },
+        )
+        _require_operation(raw, "inspect")
+        environment_digest = (
+            raw["_environment_digest"]
+            if "_environment_digest" in raw
+            else self.backend.environment_digest(query.environment)
+        )
+        try:
+            return LeanDeclarationInspectOutput(
+                environment=query.environment,
+                environment_digest=environment_digest,
+                query=query,
+                declaration=LeanDeclarationRecord.model_validate(raw["declaration"]),
+            )
+        except (KeyError, TypeError, ValueError, ValidationError) as exc:
+            raise _protocol_error() from exc
+
+
+def installed_lean_declaration_service(
+    provider_runtime: CapabilityProviderRuntime,
+) -> LeanDeclarationService:
+    """Bind discovery to the same separately validated pinned runtime identity."""
+
+    from jacobian_checkers import lean4
+
+    lean_executable, mathlib_runtime = lean4.inspect_runtime(require_mathlib=True)
+    return LeanDeclarationService(
+        LeanSubprocessDeclarationBackend(
+            lean_executable=lean_executable,
+            mathlib_runtime=mathlib_runtime,
+            provider_runtime=provider_runtime,
+        )
+    )
+
+
+def _parse_query_output(stdout: str) -> dict[str, Any]:
+    payloads = [
+        line.removeprefix(_RESULT_PREFIX)
+        for line in stdout.splitlines()
+        if line.startswith(_RESULT_PREFIX)
+    ]
+    if len(payloads) != 1:
+        raise _protocol_error()
+    try:
+        payload = loads_strict_json(payloads[0])
+    except ValueError as exc:
+        raise _protocol_error() from exc
+    if not isinstance(payload, dict):
+        raise _protocol_error()
+    return payload
+
+
+def _require_operation(payload: dict[str, Any], expected: str) -> None:
+    if payload.get("operation") != expected:
+        raise _protocol_error()
+
+
+def _protocol_error() -> LeanDeclarationBackendError:
+    return LeanDeclarationBackendError(
+        "LEAN_QUERY_PROTOCOL_ERROR",
+        "Lean declaration discovery returned malformed structured output.",
+    )
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()

--- a/tests/contract/test_lean_declaration_contracts.py
+++ b/tests/contract/test_lean_declaration_contracts.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.contracts.lean import (
+    LeanDeclarationInspectRequest,
+    LeanDeclarationKind,
+    LeanDeclarationSearchRequest,
+    LeanDeclarationTypePattern,
+    LeanEnvironment,
+)
+
+
+def test_declaration_search_requires_a_name_or_structured_type_pattern() -> None:
+    with pytest.raises(ValidationError, match="name_contains or type_pattern"):
+        LeanDeclarationSearchRequest(environment=LeanEnvironment.MATHLIB)
+
+
+def test_declaration_search_contract_normalizes_no_hidden_query_semantics() -> None:
+    request = LeanDeclarationSearchRequest(
+        environment=LeanEnvironment.MATHLIB,
+        name_contains="irrational_sqrt",
+        type_pattern=LeanDeclarationTypePattern(
+            constants=("Irrational", "Real.sqrt"),
+        ),
+        namespace_prefixes=("Mathlib",),
+        kinds=(LeanDeclarationKind.THEOREM,),
+        result_limit=7,
+    )
+
+    assert request.type_pattern is not None
+    assert request.type_pattern.constants == ("Irrational", "Real.sqrt")
+    assert request.result_limit == 7
+
+
+@pytest.mark.parametrize(
+    "constants",
+    [
+        (),
+        ("Irrational", "Irrational"),
+    ],
+)
+def test_declaration_type_pattern_rejects_empty_or_duplicate_constants(
+    constants: tuple[str, ...],
+) -> None:
+    with pytest.raises(ValidationError):
+        LeanDeclarationTypePattern(constants=constants)
+
+
+def test_declaration_inspect_requires_one_bounded_exact_name() -> None:
+    request = LeanDeclarationInspectRequest(
+        environment=LeanEnvironment.CORE,
+        declaration_name="Nat.add",
+    )
+    assert request.declaration_name == "Nat.add"
+
+    with pytest.raises(ValidationError):
+        LeanDeclarationInspectRequest(
+            environment=LeanEnvironment.CORE,
+            declaration_name="",
+        )

--- a/tests/integration/test_lean.py
+++ b/tests/integration/test_lean.py
@@ -9,6 +9,11 @@ from pathlib import Path
 import pytest
 
 from jacobian.adapters.mcp.server import create_server
+from jacobian.contracts.capabilities import (
+    CapabilityAssuranceLevel,
+    CapabilityMode,
+    CapabilityRequest,
+)
 from jacobian.contracts.checkers import CheckerDecision
 from jacobian.contracts.lean import LeanEnvironment
 from jacobian.contracts.results import (
@@ -46,12 +51,44 @@ pytestmark = [
     not MATHLIB_OLEAN.is_file(),
     reason="the pinned mathlib runtime has not been built",
 )
-def test_mathlib_sqrt_two_proof_creates_bound_verification_record(
+@pytest.mark.timeout(240)
+def test_mathlib_discovery_composes_with_bound_sqrt_two_verification(
     tmp_path: Path,
 ) -> None:
     kernel = JacobianKernel(tmp_path, install_references=True)
     assert kernel.lean is not None
+    assert kernel.lean_declarations is not None
     assert kernel.lean_checkers[LeanEnvironment.MATHLIB].checker_timeout_seconds == 105
+
+    searched = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="lean.declaration.search",
+            mode=CapabilityMode.EXPLORE,
+            input={
+                "environment": "MATHLIB",
+                "name_contains": "irrational_sqrt_two",
+                "result_limit": 1,
+            },
+        )
+    )
+    inspected = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="lean.declaration.inspect",
+            mode=CapabilityMode.EXPLORE,
+            input={
+                "environment": "MATHLIB",
+                "declaration_name": "irrational_sqrt_two",
+            },
+        )
+    )
+
+    assert searched.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert searched.assurance.verification_record_uri is None
+    assert searched.output["declarations"][0]["name"] == "irrational_sqrt_two"
+    assert inspected.output["declaration"]["type"] == "Irrational √2"
+    assert (
+        inspected.output["environment_digest"] == searched.output["environment_digest"]
+    )
 
     verified = kernel.lean.verify(
         environment=LeanEnvironment.MATHLIB,
@@ -78,6 +115,31 @@ def test_core_lean_induction_proof_creates_bound_verification_record(
 ) -> None:
     kernel = JacobianKernel(tmp_path, install_references=True)
     assert kernel.lean is not None
+
+    inspected = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="lean.declaration.inspect",
+            mode=CapabilityMode.EXPLORE,
+            input={
+                "environment": "CORE",
+                "declaration_name": "Nat.add",
+            },
+        )
+    )
+    outside_profile = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="lean.declaration.search",
+            mode=CapabilityMode.EXPLORE,
+            input={
+                "environment": "CORE",
+                "name_contains": "Lean.Meta.ppExpr",
+            },
+        )
+    )
+
+    assert inspected.output["declaration"]["type"] == "Nat → Nat → Nat"
+    assert outside_profile.output["declarations"] == []
+    assert outside_profile.output["stop_reason"] == "EXHAUSTED"
 
     verified = kernel.lean.verify(
         statement="∀ n : Nat, n + 0 = n",

--- a/tests/integration/test_provider_runtime_integration.py
+++ b/tests/integration/test_provider_runtime_integration.py
@@ -108,9 +108,14 @@ def test_unhealthy_optional_lean_runtime_is_absent_from_catalog(
     kernel = JacobianKernel(tmp_path, install_references=True)
 
     assert kernel.lean is None
-    assert "lean.check" not in {
+    capability_ids = {
         item.capability_id for item in kernel.capabilities.catalog().capabilities
     }
+    assert {
+        "lean.check",
+        "lean.declaration.inspect",
+        "lean.declaration.search",
+    }.isdisjoint(capability_ids)
 
 
 def test_invocation_binds_descriptor_runtime_to_result_provenance(

--- a/tests/unit/test_lean_declarations.py
+++ b/tests/unit/test_lean_declarations.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from jacobian.builtin_capabilities import (
+    LeanDeclarationInspectAdapter,
+    LeanDeclarationSearchAdapter,
+)
+from jacobian.capabilities import CapabilityInvocationError
+from jacobian.contracts.capabilities import (
+    CapabilityAssuranceLevel,
+    CapabilityCompletenessStatus,
+    CapabilityInstallTier,
+    CapabilityMode,
+    CapabilityProviderAvailability,
+    CapabilityProviderDigestKind,
+    CapabilityProviderRuntime,
+    CapabilityRequest,
+)
+from jacobian.contracts.lean import LeanEnvironment
+from jacobian.lean_declarations import (
+    LeanDeclarationBackend,
+    LeanDeclarationBackendError,
+    LeanDeclarationService,
+    LeanSubprocessDeclarationBackend,
+)
+
+_DIGEST = "sha256:" + "a" * 64
+_RUNTIME = CapabilityProviderRuntime(
+    provider="jacobian.lean4",
+    availability=CapabilityProviderAvailability.AVAILABLE,
+    version="4.31.0",
+    digest="sha256:" + "b" * 64,
+    digest_kind=CapabilityProviderDigestKind.EXECUTABLE,
+    platform="test",
+    install_tier=CapabilityInstallTier.T3,
+    license_id="Apache-2.0",
+    features=("CORE", "MATHLIB"),
+)
+
+
+@dataclass
+class FakeBackend(LeanDeclarationBackend):
+    response: dict[str, Any]
+    calls: list[tuple[LeanEnvironment, dict[str, Any]]] = field(default_factory=list)
+
+    def environment_digest(self, _environment: LeanEnvironment) -> str:
+        return _DIGEST
+
+    def query(
+        self,
+        environment: LeanEnvironment,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        self.calls.append((environment, payload))
+        return self.response
+
+
+class MissingDeclarationBackend:
+    def environment_digest(self, _environment: LeanEnvironment) -> str:
+        return _DIGEST
+
+    def query(
+        self,
+        _environment: LeanEnvironment,
+        _payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        raise LeanDeclarationBackendError(
+            "LEAN_DECLARATION_NOT_FOUND",
+            "Lean did not find the exact declaration 'Missing.name'.",
+        )
+
+
+def test_search_adapter_exposes_bounded_computed_retrieval() -> None:
+    backend = FakeBackend(
+        {
+            "operation": "search",
+            "declarations": [
+                {
+                    "name": "irrational_sqrt_two",
+                    "type": "Irrational √2",
+                    "kind": "THEOREM",
+                    "namespace": None,
+                    "docstring": None,
+                    "source": {
+                        "module": "Mathlib.NumberTheory.Real.Irrational",
+                        "line": 143,
+                        "column": 8,
+                        "end_line": 143,
+                        "end_column": 27,
+                    },
+                    "match_reasons": ["NAME_SUBSTRING"],
+                }
+            ],
+            "scanned_declarations": 20_001,
+            "stop_reason": "RESULT_LIMIT",
+        }
+    )
+    adapter = LeanDeclarationSearchAdapter(
+        LeanDeclarationService(backend),
+        _RUNTIME,
+    )
+
+    result = adapter.invoke(
+        CapabilityRequest(
+            capability_id="lean.declaration.search",
+            mode=CapabilityMode.EXPLORE,
+            input={
+                "environment": "MATHLIB",
+                "name_contains": "irrational_sqrt_two",
+                "result_limit": 1,
+            },
+        )
+    )
+
+    assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert result.completeness.status is CapabilityCompletenessStatus.PARTIAL
+    assert result.output["environment_digest"] == _DIGEST
+    assert result.output["declarations"][0]["name"] == "irrational_sqrt_two"
+    assert result.scope is not None
+    assert result.scope.parameters["matching"] == (
+        "case-sensitive name substring and exact constants occurring in the "
+        "elaborated type"
+    )
+    assert backend.calls[0][1] == {
+        "operation": "search",
+        "declaration_name": None,
+        "name_contains": "irrational_sqrt_two",
+        "type_constants": [],
+        "namespace_prefixes": [],
+        "target_module_prefixes": [],
+        "kinds": [],
+        "limit": 1,
+    }
+
+
+def test_exhausted_search_reports_computed_complete_coverage() -> None:
+    backend = FakeBackend(
+        {
+            "operation": "search",
+            "declarations": [],
+            "scanned_declarations": 626_944,
+            "stop_reason": "EXHAUSTED",
+        }
+    )
+    adapter = LeanDeclarationSearchAdapter(
+        LeanDeclarationService(backend),
+        _RUNTIME,
+    )
+
+    result = adapter.invoke(
+        CapabilityRequest(
+            capability_id="lean.declaration.search",
+            mode=CapabilityMode.EXPLORE,
+            input={
+                "environment": "MATHLIB",
+                "type_pattern": {"constants": ["Jacobian.DoesNotExist"]},
+            },
+        )
+    )
+
+    assert result.completeness.status is CapabilityCompletenessStatus.COMPLETE
+    assert result.completeness.assurance_level is CapabilityAssuranceLevel.COMPUTED
+    assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
+
+
+def test_inspect_adapter_returns_docs_without_promoting_the_theorem() -> None:
+    backend = FakeBackend(
+        {
+            "operation": "inspect",
+            "declaration": {
+                "name": "Nat.add",
+                "type": "Nat → Nat → Nat",
+                "kind": "DEFINITION",
+                "namespace": "Nat",
+                "docstring": "Addition of natural numbers.",
+                "source": None,
+                "match_reasons": [],
+            },
+        }
+    )
+    adapter = LeanDeclarationInspectAdapter(
+        LeanDeclarationService(backend),
+        _RUNTIME,
+    )
+
+    result = adapter.invoke(
+        CapabilityRequest(
+            capability_id="lean.declaration.inspect",
+            mode=CapabilityMode.EXPLORE,
+            input={
+                "environment": "CORE",
+                "declaration_name": "Nat.add",
+            },
+        )
+    )
+
+    assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert result.assurance.verification_record_uri is None
+    assert result.output["declaration"]["docstring"].startswith("Addition")
+    assert result.output["environment_digest"] == _DIGEST
+
+
+def test_missing_declaration_is_an_explicit_failed_operation() -> None:
+    adapter = LeanDeclarationInspectAdapter(
+        LeanDeclarationService(MissingDeclarationBackend()),
+        _RUNTIME,
+    )
+
+    with pytest.raises(CapabilityInvocationError) as raised:
+        adapter.invoke(
+            CapabilityRequest(
+                capability_id="lean.declaration.inspect",
+                mode=CapabilityMode.EXPLORE,
+                input={
+                    "environment": "CORE",
+                    "declaration_name": "Missing.name",
+                },
+            )
+        )
+
+    assert raised.value.diagnostic.code == "LEAN_DECLARATION_NOT_FOUND"
+
+
+def test_environment_identity_fails_closed_if_the_lean_executable_changes(
+    tmp_path: Path,
+) -> None:
+    executable = tmp_path / "lean"
+    executable.write_bytes(b"pinned lean executable")
+    digest = "sha256:" + hashlib.sha256(executable.read_bytes()).hexdigest()
+    runtime = _RUNTIME.model_copy(update={"digest": digest, "features": ("CORE",)})
+    backend = LeanSubprocessDeclarationBackend(
+        lean_executable=executable,
+        mathlib_runtime=None,
+        provider_runtime=runtime,
+    )
+
+    assert backend.environment_digest(LeanEnvironment.CORE).startswith("sha256:")
+
+    executable.write_bytes(b"changed lean executable")
+
+    with pytest.raises(LeanDeclarationBackendError) as raised:
+        backend.environment_digest(LeanEnvironment.CORE)
+
+    assert raised.value.code == "LEAN_ENVIRONMENT_CHANGED"


### PR DESCRIPTION
## Problem

Agents can replay completed Lean source, but the installed portfolio cannot retrieve or inspect premises from the same pinned Lean and Mathlib environments. That forces models to guess declaration names or hide retrieval outside the capability trust and provenance model.

## Change

- add atomic EXPLORE capabilities `lean.declaration.search` and `lean.declaration.inspect`
- use a bounded read-only Lean helper with deterministic name order and structured elaborated-type constant patterns
- return typed declaration, source, coverage, stop-reason, and exact environment-manifest identity records
- keep CORE aligned with `Init.*`, exclude helper-local/private declarations, and fail closed on runtime mutation, timeout, oversized output, malformed protocol data, or missing names
- add the public Mathlib retrieval, inspection, and `lean.check` composition plus reference documentation and roadmap measurements

## Compatibility and normative impact

This adds two experimental capability IDs only when the optional pinned Lean runtime is healthy. Existing capability inputs, outputs, and verification authority are unchanged. Declaration retrieval is COMPUTED evidence; only the existing authorized `lean.check` path can return VERIFIED.

## Validation

- `uv sync --dev`
- `uv run pytest` (431 passed)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`
- `git diff --check`
- real pinned Mathlib search, inspect, structured type-pattern scan, and independent sqrt-two replay
- built wheel inspected to confirm both the Python adapter and Lean helper are packaged