### PR TITLE
ci: reduce test feedback latency without reducing coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,16 +33,14 @@ jobs:
       - run: uv run --frozen deptry .
 
   test:
-    name: Tests (Python ${{ matrix.python-version }})
+    name: Tests (Python ${{ matrix.python-version }}, shard ${{ matrix.shard }}/2)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
+      fail-fast: false
       matrix:
-        include:
-          - python-version: "3.12"
-            coverage: true
-          - python-version: "3.13"
-            coverage: false
+        python-version: ["3.12", "3.13"]
+        shard: [1, 2]
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
@@ -55,14 +53,56 @@ jobs:
             pyproject.toml
             uv.lock
       - run: uv sync --frozen --dev
-      - if: matrix.coverage
-        run: uv run --frozen pytest --cov --cov-report=xml --cov-report=term --durations=10
-      - if: ${{ !matrix.coverage }}
-        run: uv run --frozen pytest --durations=10
+      - if: matrix.python-version == '3.12'
+        run: >-
+          uv run --frozen pytest
+          --splits 2 --group ${{ matrix.shard }}
+          --splitting-algorithm least_duration
+          --cov --cov-report= --cov-fail-under=0
+          --durations=10
+      - if: matrix.python-version != '3.12'
+        run: >-
+          uv run --frozen pytest
+          --splits 2 --group ${{ matrix.shard }}
+          --splitting-algorithm least_duration
+          --durations=10
+      - if: matrix.python-version == '3.12'
+        run: mv .coverage .coverage.shard-${{ matrix.shard }}
       - uses: actions/upload-artifact@v4
-        if: ${{ always() && matrix.coverage }}
+        if: ${{ always() && matrix.python-version == '3.12' }}
         with:
-          name: coverage-${{ matrix.python-version }}
+          name: coverage-data-${{ matrix.shard }}
+          path: .coverage.shard-${{ matrix.shard }}
+          include-hidden-files: true
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: test
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+      - run: uv sync --frozen --dev
+      - uses: actions/download-artifact@v5
+        with:
+          pattern: coverage-data-*
+          path: coverage-data
+          merge-multiple: true
+      - run: uv run --frozen coverage combine coverage-data
+      - run: uv run --frozen coverage report
+      - run: uv run --frozen coverage xml
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage-3.12
           path: coverage.xml
 
   duplicate-code:
@@ -163,7 +203,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: github.ref == 'refs/heads/main'
-    needs: [lint, test, duplicate-code, npm-package, build]
+    needs: [lint, test, coverage, duplicate-code, npm-package, build]
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,17 @@ source-build failure from `uv sync --dev`.
 Use focused tests while implementing. Run the complete applicable validation
 before handing off the final tree, and report only checks that actually ran.
 
+For a quick local feedback loop, skip the integration and end-to-end layers:
+
+```sh
+uv run pytest -m "not integration and not end_to_end"
+```
+
+Pytest assigns these layer markers from the test directories, so new
+integration tests join the right loop without repeated file-level boilerplate.
+Use `uv run pytest --lf` after a failure, `uv run pytest -n 0` while debugging,
+and unfiltered `uv run pytest` before handoff.
+
 ## Verification rules
 
 - Do not turn a timeout, cancellation, error, incomplete enumeration, or

--- a/docs/reference/testing-strategy.md
+++ b/docs/reference/testing-strategy.md
@@ -52,10 +52,15 @@ when investigating regressions. A 120-second per-test backstop prevents local
 deadlocks from hanging indefinitely and is disabled automatically by
 `pytest-timeout` while debugging. Parallel workers retain separate `tmp_path`
 roots; tests that add shared external state must coordinate it explicitly.
-CI collects coverage once on Python 3.12 and runs the full compatibility suite
-without duplicate instrumentation on Python 3.13. Coverage.py's subprocess
-patch includes plugin and checker workers so clean-process execution is not
-misreported as uncovered.
+Tests under `tests/integration/` and `tests/end_to_end/` receive their layer
+marker during collection, preventing a missing module decorator from silently
+expanding the fast loop.
+CI splits each supported Python run into two disjoint groups and retains xdist
+parallelism inside each group. Python 3.12 shards write raw coverage data; a
+dependent job combines both files before enforcing the repository threshold
+and producing the XML report. Python 3.13 runs the same two groups without
+duplicate instrumentation. Coverage.py's subprocess patch includes plugin and
+checker workers so clean-process execution is not misreported as uncovered.
 
 ## Criticality classes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dev = [
     "pyperf>=2.9,<3",
     "pytest>=8.3,<10",
     "pytest-cov>=6,<8",
+    "pytest-split>=0.11,<1",
     "pytest-timeout>=2.4,<3",
     "pytest-xdist>=3.6,<4",
     "ruff>=0.11,<1",

--- a/src/jacobian/atomic_capabilities.py
+++ b/src/jacobian/atomic_capabilities.py
@@ -39,6 +39,7 @@ from jacobian.contracts.results import (
 from jacobian.contracts.shrinking import ShrinkResult
 from jacobian.contracts.witness_search import WitnessFindResult
 from jacobian.provider_runtime import known_provider_runtime
+from jacobian.schema_registry import model_schema
 from jacobian.store import ArtifactStore, StoreError
 
 if TYPE_CHECKING:
@@ -188,7 +189,7 @@ def install_atomic_capabilities(
                 },
                 required=("schema_uri", "semantics_uri", "payload"),
             ),
-            output_schema=ArtifactPutResult.model_json_schema(),
+            output_schema=model_schema(ArtifactPutResult),
             invoke=lambda p: kernel.artifacts.put(
                 schema_uri=p["schema_uri"],
                 semantics_uri=p["semantics_uri"],
@@ -207,7 +208,7 @@ def install_atomic_capabilities(
                 {"claim_uri": _ARTIFACT_URI, "plugin_id": _ARTIFACT_URI},
                 required=("claim_uri", "plugin_id"),
             ),
-            output_schema=ClaimValidationResult.model_json_schema(),
+            output_schema=model_schema(ClaimValidationResult),
             invoke=lambda p: kernel.claims.validate(**p),
             read_only=True,
             tags=("claim", "validation"),
@@ -244,7 +245,7 @@ def install_atomic_capabilities(
                     "wall_seconds",
                 ),
             ),
-            output_schema=EvaluationBatchResult.model_json_schema(),
+            output_schema=model_schema(EvaluationBatchResult),
             invoke=lambda p: kernel.evaluation.evaluate_batch(
                 **{
                     **p,
@@ -288,7 +289,7 @@ def install_atomic_capabilities(
                     "wall_seconds",
                 ),
             ),
-            output_schema=WitnessFindResult.model_json_schema(),
+            output_schema=model_schema(WitnessFindResult),
             invoke=lambda p: kernel.witnesses.find(
                 **{**p, "witness_role": WitnessRole(p["witness_role"])}
             ),
@@ -310,7 +311,7 @@ def install_atomic_capabilities(
                 },
                 required=("claim_uri", "candidate_uri", "witness_uri", "checker_id"),
             ),
-            output_schema=ResultEnvelope.model_json_schema(),
+            output_schema=model_schema(ResultEnvelope),
             invoke=lambda p: kernel.verification.verify_witness(**p),
             unverified_assurance_level=CapabilityAssuranceLevel.HEURISTIC,
             unverified_basis="the checker did not accept the supplied witness",
@@ -325,7 +326,7 @@ def install_atomic_capabilities(
                 {"certificate_uri": _ARTIFACT_URI, "checker_id": _CHECKER_URI},
                 required=("certificate_uri",),
             ),
-            output_schema=ResultEnvelope.model_json_schema(),
+            output_schema=model_schema(ResultEnvelope),
             invoke=lambda p: kernel.verification.verify_certificate(**p),
             unverified_assurance_level=CapabilityAssuranceLevel.HEURISTIC,
             unverified_basis="the checker did not accept the supplied certificate",
@@ -371,7 +372,7 @@ def install_atomic_capabilities(
                     "evaluation_budget",
                 ),
             ),
-            output_schema=ShrinkResult.model_json_schema(),
+            output_schema=model_schema(ShrinkResult),
             invoke=lambda p: kernel.shrinking.run(
                 **{
                     **p,

--- a/src/jacobian/atomic_domain_capabilities.py
+++ b/src/jacobian/atomic_domain_capabilities.py
@@ -16,6 +16,7 @@ from jacobian.contracts.transformations import (
     TransformationApplyResult,
     TransformationRelation,
 )
+from jacobian.schema_registry import model_schema
 
 if TYPE_CHECKING:
     from jacobian.atomic_capabilities import AtomicServiceAdapter
@@ -69,7 +70,7 @@ def build_domain_adapters(
                     "wall_seconds",
                 ),
             ),
-            output_schema=TransformationApplyResult.model_json_schema(),
+            output_schema=model_schema(TransformationApplyResult),
             invoke=lambda p: kernel.transformations.apply(
                 **{
                     **p,
@@ -96,7 +97,7 @@ def build_domain_adapters(
                 {"transformation_uri": artifact_uri},
                 required=("transformation_uri",),
             ),
-            output_schema=ResultEnvelope.model_json_schema(),
+            output_schema=model_schema(ResultEnvelope),
             invoke=lambda p: kernel.verification.verify_transformation(**p),
             unverified_assurance_level=CapabilityAssuranceLevel.HEURISTIC,
             unverified_basis=("the checker did not accept the transformation relation"),
@@ -128,7 +129,7 @@ def build_domain_adapters(
                 },
                 required=("point_uri", "generator_set_uri"),
             ),
-            output_schema=PolytopeSeparateResult.model_json_schema(),
+            output_schema=model_schema(PolytopeSeparateResult),
             invoke=lambda p: kernel.polytope.separate(PolytopeSeparateRequest(**p)),
             tags=("polytope", "exact"),
             provider="jacobian.z3",
@@ -148,7 +149,7 @@ def build_domain_adapters(
                 },
                 required=("subject_uri", "verification_record_uri"),
             ),
-            output_schema=ParameterRegion.model_json_schema(),
+            output_schema=model_schema(ParameterRegion),
             invoke=lambda p: kernel.conjectures.promote_parameter_region(**p),
             read_only=True,
             tags=("parameter", "verification"),

--- a/src/jacobian/atomic_experiment_capabilities.py
+++ b/src/jacobian/atomic_experiment_capabilities.py
@@ -22,6 +22,7 @@ from jacobian.contracts.search import (
     ExperimentControlResult,
     SearchExperimentSnapshot,
 )
+from jacobian.schema_registry import model_schema
 
 if TYPE_CHECKING:
     from jacobian.atomic_capabilities import AtomicServiceAdapter
@@ -60,7 +61,7 @@ def build_experiment_adapters(
                 },
                 required=("structure_uri", "plugin_id", "wall_seconds"),
             ),
-            output_schema=StructureCanonicalizationResult.model_json_schema(),
+            output_schema=model_schema(StructureCanonicalizationResult),
             invoke=lambda p: kernel.structures.canonicalize(**p),
             unverified_assurance_level=CapabilityAssuranceLevel.HEURISTIC,
             unverified_basis="plugin canonicalization is not independently verified",
@@ -86,7 +87,7 @@ def build_experiment_adapters(
                 },
                 required=("claim_uri", "plugin_id", "bounds", "budget"),
             ),
-            output_schema=ExperimentHandle.model_json_schema(),
+            output_schema=model_schema(ExperimentHandle),
             invoke=lambda p: kernel.experiments.start_enumeration(p),
             unverified_assurance_level=CapabilityAssuranceLevel.HEURISTIC,
             unverified_basis=(

--- a/src/jacobian/builtin_capabilities.py
+++ b/src/jacobian/builtin_capabilities.py
@@ -38,6 +38,7 @@ from jacobian.lean_declarations import (
 )
 from jacobian.memory import ResearchMemory
 from jacobian.provider_runtime import known_provider_runtime
+from jacobian.schema_registry import model_schema
 
 _OBJECT_SCHEMA: dict[str, Any] = {"type": "object"}
 
@@ -210,8 +211,8 @@ class LeanDeclarationSearchAdapter:
             provider="jacobian.lean4",
             provider_runtime=provider_runtime,
             modes=(CapabilityMode.EXPLORE,),
-            input_schema=LeanDeclarationSearchRequest.model_json_schema(),
-            output_schema=LeanDeclarationSearchOutput.model_json_schema(),
+            input_schema=model_schema(LeanDeclarationSearchRequest),
+            output_schema=model_schema(LeanDeclarationSearchOutput),
             read_only=True,
             tags=("lean", "declaration", "retrieval", "premise-discovery"),
         )
@@ -289,8 +290,8 @@ class LeanDeclarationInspectAdapter:
             provider="jacobian.lean4",
             provider_runtime=provider_runtime,
             modes=(CapabilityMode.EXPLORE,),
-            input_schema=LeanDeclarationInspectRequest.model_json_schema(),
-            output_schema=LeanDeclarationInspectOutput.model_json_schema(),
+            input_schema=model_schema(LeanDeclarationInspectRequest),
+            output_schema=model_schema(LeanDeclarationInspectOutput),
             read_only=True,
             tags=("lean", "declaration", "retrieval", "inspection"),
         )

--- a/src/jacobian/conjectures.py
+++ b/src/jacobian/conjectures.py
@@ -43,7 +43,7 @@ from jacobian.plugins.registry import (
     PluginRegistryError,
     ResolvedCapability,
 )
-from jacobian.schema_registry import SchemaRegistry, SchemaRegistryError
+from jacobian.schema_registry import SchemaRegistry, SchemaRegistryError, model_schema
 from jacobian.search import SearchError, SearchService
 from jacobian.store import ArtifactStore, StoredArtifact, StoreError
 from jacobian.verification import VerificationService
@@ -91,12 +91,12 @@ class ConjectureService:
         self.transformation_schema_uri = schemas.register(
             name="jacobian.hypothesis-transformation",
             version="1",
-            schema=HypothesisTransformationRecord.model_json_schema(),
+            schema=model_schema(HypothesisTransformationRecord),
         )
         self.parameter_region_subject_schema_uri = schemas.register(
             name="jacobian.parameter-region-subject",
             version="1",
-            schema=ParameterRegionSubject.model_json_schema(),
+            schema=model_schema(ParameterRegionSubject),
         )
 
     def run(

--- a/src/jacobian/experiments.py
+++ b/src/jacobian/experiments.py
@@ -43,7 +43,7 @@ from jacobian.evaluation import (
 from jacobian.experiment_runtime import new_experiment_uri, open_experiment_database
 from jacobian.plugin_execution import PluginExecutor
 from jacobian.plugins.registry import PluginRegistry, PluginRegistryError
-from jacobian.schema_registry import SchemaRegistry, SchemaRegistryError
+from jacobian.schema_registry import SchemaRegistry, SchemaRegistryError, model_schema
 from jacobian.store import ArtifactStore, StoreError
 from jacobian.structures import StructureService
 
@@ -110,17 +110,17 @@ class ExperimentService:
         self.archive_page_schema_uri = schemas.register(
             name="jacobian.enumeration-archive-page",
             version="1",
-            schema=EnumerationArchive.model_json_schema(),
+            schema=model_schema(EnumerationArchive),
         )
         self.archive_manifest_schema_uri = schemas.register(
             name="jacobian.enumeration-archive",
             version="1",
-            schema=EnumerationArchiveManifest.model_json_schema(),
+            schema=model_schema(EnumerationArchiveManifest),
         )
         self.evaluation_schema_uri = schemas.register(
             name="jacobian.evaluation-batch-result",
             version="1",
-            schema=EvaluationBatchResult.model_json_schema(),
+            schema=model_schema(EvaluationBatchResult),
         )
 
     def _put_internal_artifact(

--- a/src/jacobian/finite_partition.py
+++ b/src/jacobian/finite_partition.py
@@ -34,7 +34,7 @@ from jacobian.contracts.results import (
 )
 from jacobian.provider_runtime import known_provider_runtime
 from jacobian.registry import CheckerRegistry
-from jacobian.schema_registry import SchemaRegistry
+from jacobian.schema_registry import SchemaRegistry, model_schema
 from jacobian.store import ArtifactStore
 from jacobian.verification import VerificationService
 
@@ -136,7 +136,7 @@ def install_finite_partition(
     certificate_schema_uri = schemas.register(
         name="jacobian.certificate-envelope",
         version="1",
-        schema=CertificateEnvelope.model_json_schema(),
+        schema=model_schema(CertificateEnvelope),
     )
     checker_id = None
     if authorize_checker:

--- a/src/jacobian/graph_capabilities.py
+++ b/src/jacobian/graph_capabilities.py
@@ -40,7 +40,7 @@ from jacobian.contracts.graph_invariants import (
 from jacobian.contracts.results import Execution, ExecutionStatus
 from jacobian.provider_runtime import known_provider_runtime
 from jacobian.registry import CheckerRegistry
-from jacobian.schema_registry import SchemaRegistry
+from jacobian.schema_registry import SchemaRegistry, model_schema
 from jacobian.store import ArtifactStore, StoreError
 
 _ARTIFACT_URI_PATTERN = r"^artifact://sha256/[0-9a-f]{64}$"
@@ -206,17 +206,17 @@ def install_graph_capabilities(
     neighborhood_schema_uri = schemas.register(
         name="jacobian.graph-neighborhood-independence",
         version="1",
-        schema=GraphNeighborhoodIndependenceArtifact.model_json_schema(),
+        schema=model_schema(GraphNeighborhoodIndependenceArtifact),
     )
     neighborhood_claim_schema_uri = schemas.register(
         name="jacobian.graph-neighborhood-independence-claim",
         version="1",
-        schema=GraphNeighborhoodIndependenceClaim.model_json_schema(),
+        schema=model_schema(GraphNeighborhoodIndependenceClaim),
     )
     certificate_schema_uri = schemas.register(
         name="jacobian.certificate-envelope",
         version="1",
-        schema=CertificateEnvelope.model_json_schema(),
+        schema=model_schema(CertificateEnvelope),
     )
     neighborhood_checker_id = None
     if authorize_checker:
@@ -604,8 +604,8 @@ class GraphNeighborhoodIndependenceAdapter:
                 ),
             ),
             modes=(CapabilityMode.EXPLORE,),
-            input_schema=GraphNeighborhoodIndependenceRequest.model_json_schema(),
-            output_schema=GraphNeighborhoodIndependenceOutput.model_json_schema(),
+            input_schema=model_schema(GraphNeighborhoodIndependenceRequest),
+            output_schema=model_schema(GraphNeighborhoodIndependenceOutput),
             tags=(
                 "graph",
                 "neighborhood",

--- a/src/jacobian/memory.py
+++ b/src/jacobian/memory.py
@@ -12,7 +12,7 @@ from jacobian.contracts.capabilities import (
     CapabilityMode,
 )
 from jacobian.contracts.memory import MemoryHit, MemorySearchResult, ResearchEpisode
-from jacobian.schema_registry import SchemaRegistry
+from jacobian.schema_registry import SchemaRegistry, model_schema
 from jacobian.store import ArtifactStore
 
 
@@ -25,7 +25,7 @@ class ResearchMemory:
         self.episode_schema_uri = schemas.register(
             name="jacobian.research-episode",
             version="1",
-            schema=ResearchEpisode.model_json_schema(),
+            schema=model_schema(ResearchEpisode),
         )
         self.episode_semantics_uri = store.register_descriptor(
             kind="semantics",

--- a/src/jacobian/plugins/registry.py
+++ b/src/jacobian/plugins/registry.py
@@ -22,7 +22,7 @@ from jacobian.implementation import (
     ImplementationError,
     package_source_digest,
 )
-from jacobian.schema_registry import SchemaRegistry
+from jacobian.schema_registry import SchemaRegistry, model_schema
 from jacobian.store import ArtifactStore, StoreError
 
 _LOGGER = logging.getLogger(__name__)
@@ -59,7 +59,7 @@ class PluginRegistry:
         self.snapshot_schema_uri = self.schemas.register(
             name="jacobian.plugin-registry-snapshot",
             version="1",
-            schema=PluginRegistrySnapshot.model_json_schema(),
+            schema=model_schema(PluginRegistrySnapshot),
         )
         self.snapshot_semantics_uri = store.register_descriptor(
             kind="semantics",

--- a/src/jacobian/polynomial_capabilities.py
+++ b/src/jacobian/polynomial_capabilities.py
@@ -56,7 +56,7 @@ from jacobian.contracts.polynomials import (
 from jacobian.contracts.results import ContractModel, Execution, ExecutionStatus
 from jacobian.provider_runtime import known_provider_runtime
 from jacobian.registry import CheckerRegistry
-from jacobian.schema_registry import SchemaRegistry
+from jacobian.schema_registry import SchemaRegistry, model_schema
 from jacobian.store import ArtifactStore, StoredArtifact, StoreError
 
 
@@ -119,37 +119,37 @@ def install_polynomial_capabilities(
     map_schema_uri = schemas.register(
         name="jacobian.rational-polynomial-map",
         version="1",
-        schema=RationalPolynomialMap.model_json_schema(),
+        schema=model_schema(RationalPolynomialMap),
     )
     evaluation_schema_uri = schemas.register(
         name="jacobian.polynomial-map-evaluation",
         version="1",
-        schema=PolynomialMapEvaluation.model_json_schema(),
+        schema=model_schema(PolynomialMapEvaluation),
     )
     jacobian_schema_uri = schemas.register(
         name="jacobian.polynomial-jacobian",
         version="1",
-        schema=PolynomialJacobian.model_json_schema(),
+        schema=model_schema(PolynomialJacobian),
     )
     claim_schema_uri = schemas.register(
         name="jacobian.polynomial-map-injectivity-claim",
         version="1",
-        schema=PolynomialInjectivityClaim.model_json_schema(),
+        schema=model_schema(PolynomialInjectivityClaim),
     )
     jacobian_claim_schema_uri = schemas.register(
         name="jacobian.polynomial-jacobian-claim",
         version="1",
-        schema=PolynomialJacobianClaim.model_json_schema(),
+        schema=model_schema(PolynomialJacobianClaim),
     )
     witness_schema_uri = schemas.register(
         name="jacobian.witness-envelope",
         version="1",
-        schema=WitnessEnvelope.model_json_schema(),
+        schema=model_schema(WitnessEnvelope),
     )
     certificate_schema_uri = schemas.register(
         name="jacobian.certificate-envelope",
         version="1",
-        schema=CertificateEnvelope.model_json_schema(),
+        schema=model_schema(CertificateEnvelope),
     )
     collision_checker_id = None
     jacobian_checker_id = None
@@ -222,8 +222,8 @@ class PolynomialMapEvaluationAdapter:
                 features=("rational-polynomial-evaluation",),
             ),
             modes=(CapabilityMode.EXPLORE,),
-            input_schema=PolynomialEvaluationRequest.model_json_schema(),
-            output_schema=PolynomialEvaluationOutput.model_json_schema(),
+            input_schema=model_schema(PolynomialEvaluationRequest),
+            output_schema=model_schema(PolynomialEvaluationOutput),
             tags=("polynomial", "map", "evaluation", "exact-computation"),
         )
 
@@ -305,8 +305,8 @@ class PolynomialJacobianAdapter:
                 ),
             ),
             modes=(CapabilityMode.EXPLORE,),
-            input_schema=PolynomialJacobianRequest.model_json_schema(),
-            output_schema=PolynomialJacobianOutput.model_json_schema(),
+            input_schema=model_schema(PolynomialJacobianRequest),
+            output_schema=model_schema(PolynomialJacobianOutput),
             tags=("polynomial", "jacobian", "determinant", "exact-computation"),
         )
 
@@ -469,8 +469,8 @@ class PolynomialCollisionAdapter:
                 ),
             ),
             modes=(CapabilityMode.EXPLORE,),
-            input_schema=PolynomialCollisionRequest.model_json_schema(),
-            output_schema=PolynomialCollisionOutput.model_json_schema(),
+            input_schema=model_schema(PolynomialCollisionRequest),
+            output_schema=model_schema(PolynomialCollisionOutput),
             tags=("polynomial", "map", "collision", "witness", "artifact-composition"),
         )
 

--- a/src/jacobian/polytope.py
+++ b/src/jacobian/polytope.py
@@ -43,7 +43,7 @@ from jacobian.contracts.results import (
     ResultEnvelope,
     Verification,
 )
-from jacobian.schema_registry import SchemaRegistry, SchemaRegistryError
+from jacobian.schema_registry import SchemaRegistry, SchemaRegistryError, model_schema
 from jacobian.store import ArtifactStore, StoredArtifact, StoreError
 
 _LOGGER = logging.getLogger(__name__)
@@ -117,7 +117,7 @@ class PolytopeService:
             name="jacobian.rational-point",
             version="1",
             schema=_require_schema_version(
-                RationalPoint.model_json_schema(),
+                model_schema(RationalPoint),
                 "point_schema_version",
             ),
         )
@@ -125,24 +125,24 @@ class PolytopeService:
             name="jacobian.finite-generator-set",
             version="1",
             schema=_require_schema_version(
-                FiniteGeneratorSet.model_json_schema(),
+                model_schema(FiniteGeneratorSet),
                 "generator_set_schema_version",
             ),
         )
         self.claim_schema_uri = schemas.register(
             name="jacobian.polytope-claim",
             version="1",
-            schema=PolytopeClaim.model_json_schema(),
+            schema=model_schema(PolytopeClaim),
         )
         self.witness_schema_uri = schemas.register(
             name="jacobian.witness-envelope",
             version="1",
-            schema=WitnessEnvelope.model_json_schema(),
+            schema=model_schema(WitnessEnvelope),
         )
         self.certificate_schema_uri = schemas.register(
             name="jacobian.certificate-envelope",
             version="1",
-            schema=CertificateEnvelope.model_json_schema(),
+            schema=model_schema(CertificateEnvelope),
         )
 
     def separate(

--- a/src/jacobian/references.py
+++ b/src/jacobian/references.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any
 
@@ -16,7 +15,7 @@ from jacobian.contracts.lean import LeanCandidate, LeanClaim, LeanEnvironment
 from jacobian.contracts.plugins import PluginManifest
 from jacobian.plugins.registry import PluginRegistry
 from jacobian.registry import CheckerRegistry
-from jacobian.schema_registry import SchemaRegistry
+from jacobian.schema_registry import SchemaRegistry, model_schema
 from jacobian.store import ArtifactStore
 
 
@@ -82,17 +81,17 @@ class ReferenceInstaller:
         self.manifest_schema_uri = schemas.register(
             name="jacobian.plugin-manifest",
             version="1",
-            schema=PluginManifest.model_json_schema(),
+            schema=model_schema(PluginManifest),
         )
         self.witness_schema_uri = schemas.register(
             name="jacobian.witness-envelope",
             version="1",
-            schema=WitnessEnvelope.model_json_schema(),
+            schema=model_schema(WitnessEnvelope),
         )
         self.certificate_schema_uri = schemas.register(
             name="jacobian.certificate-envelope",
             version="1",
-            schema=CertificateEnvelope.model_json_schema(),
+            schema=model_schema(CertificateEnvelope),
         )
         self.manifest_semantics_uri = store.register_descriptor(
             kind="semantics",
@@ -154,12 +153,12 @@ class ReferenceInstaller:
         claim_schema_uri = self.schemas.register(
             name="jacobian.lean4.claim",
             version="1",
-            schema=LeanClaim.model_json_schema(),
+            schema=model_schema(LeanClaim),
         )
         candidate_schema_uri = self.schemas.register(
             name="jacobian.lean4.candidate",
             version="1",
-            schema=LeanCandidate.model_json_schema(),
+            schema=model_schema(LeanCandidate),
         )
         configurations: dict[
             LeanEnvironment,
@@ -819,7 +818,7 @@ def _claim_schema(
     *,
     predicate_parameters: dict[str, dict[str, Any]],
 ) -> dict[str, Any]:
-    schema = deepcopy(ClaimSpec.model_json_schema())
+    schema = model_schema(ClaimSpec)
     predicate = schema["$defs"]["PredicateSpec"]
     predicate["properties"]["name"]["enum"] = list(predicate_parameters)
     schema["allOf"] = [

--- a/src/jacobian/schema_registry.py
+++ b/src/jacobian/schema_registry.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from functools import lru_cache
-from typing import Any
+from typing import Any, cast
 
 from jsonschema import Draft202012Validator, FormatChecker
 from jsonschema.exceptions import SchemaError, ValidationError
+from pydantic import BaseModel
 
 from jacobian.canonical import canonicalize_json, loads_strict_json
 from jacobian.store import ArtifactStore, StoreError
@@ -29,6 +30,19 @@ class SchemaValidationError(SchemaRegistryError):
         super().__init__(message)
         self.path = path
         self.required_field = required_field
+
+
+@lru_cache(maxsize=128)
+def _model_schema_bytes(model: type[BaseModel]) -> bytes:
+    """Generate one canonical JSON Schema per Pydantic model and process."""
+
+    return canonicalize_json(model.model_json_schema())
+
+
+def model_schema(model: type[BaseModel]) -> dict[str, Any]:
+    """Return a fresh copy of a cached Pydantic model JSON Schema."""
+
+    return cast(dict[str, Any], loads_strict_json(_model_schema_bytes(model)))
 
 
 def _reject_external_references(value: Any) -> None:

--- a/src/jacobian/search.py
+++ b/src/jacobian/search.py
@@ -57,7 +57,7 @@ from jacobian.plugins.registry import (
     PluginRegistryError,
     ResolvedCapability,
 )
-from jacobian.schema_registry import SchemaRegistry, SchemaRegistryError
+from jacobian.schema_registry import SchemaRegistry, SchemaRegistryError, model_schema
 from jacobian.store import ArtifactStore, StoreError
 from jacobian.verification import VerificationService
 from jacobian.witnesses import WitnessSearchService
@@ -139,22 +139,22 @@ class SearchService:
         self.checkpoint_schema_uri = schemas.register(
             name="jacobian.search-checkpoint",
             version="1",
-            schema=SearchCheckpoint.model_json_schema(),
+            schema=model_schema(SearchCheckpoint),
         )
         self.archive_page_schema_uri = schemas.register(
             name="jacobian.search-archive-page",
             version="1",
-            schema=SearchArchivePage.model_json_schema(),
+            schema=model_schema(SearchArchivePage),
         )
         self.archive_manifest_schema_uri = schemas.register(
             name="jacobian.search-archive",
             version="1",
-            schema=SearchArchiveManifest.model_json_schema(),
+            schema=model_schema(SearchArchiveManifest),
         )
         self.evaluation_schema_uri = schemas.register(
             name="jacobian.evaluation-batch-result",
             version="1",
-            schema=EvaluationBatchResult.model_json_schema(),
+            schema=model_schema(EvaluationBatchResult),
         )
         self._initialize_database()
 

--- a/src/jacobian/transformations.py
+++ b/src/jacobian/transformations.py
@@ -33,7 +33,7 @@ from jacobian.contracts.transformations import (
 )
 from jacobian.plugin_execution import PluginExecutor
 from jacobian.plugins.registry import PluginRegistry, PluginRegistryError
-from jacobian.schema_registry import SchemaRegistry, SchemaRegistryError
+from jacobian.schema_registry import SchemaRegistry, SchemaRegistryError, model_schema
 from jacobian.store import ArtifactStore, StoreError
 
 _LOGGER = logging.getLogger(__name__)
@@ -66,12 +66,12 @@ class TransformationService:
         self.claim_schema_uri = schemas.register(
             name="jacobian.transformation-claim",
             version="1",
-            schema=TransformationClaim.model_json_schema(),
+            schema=model_schema(TransformationClaim),
         )
         self.envelope_schema_uri = schemas.register(
             name="jacobian.transformation-envelope",
             version="1",
-            schema=TransformationEnvelope.model_json_schema(),
+            schema=model_schema(TransformationEnvelope),
         )
 
     def apply(

--- a/src/jacobian/universal_algebra_capabilities.py
+++ b/src/jacobian/universal_algebra_capabilities.py
@@ -50,7 +50,7 @@ from jacobian.contracts.universal_algebra import (
 )
 from jacobian.provider_runtime import known_provider_runtime
 from jacobian.registry import CheckerRegistry
-from jacobian.schema_registry import SchemaRegistry
+from jacobian.schema_registry import SchemaRegistry, model_schema
 from jacobian.store import ArtifactStore
 
 _COUNTERMODEL_TIMEOUT_MS = 10_000
@@ -110,27 +110,27 @@ def install_universal_algebra_capabilities(
     problem_schema_uri = schemas.register(
         name="jacobian.finite-magma-law-problem",
         version="1",
-        schema=FiniteMagmaLawProblem.model_json_schema(),
+        schema=model_schema(FiniteMagmaLawProblem),
     )
     evaluation_schema_uri = schemas.register(
         name="jacobian.finite-magma-law-evaluation",
         version="1",
-        schema=FiniteMagmaLawEvaluationArtifact.model_json_schema(),
+        schema=model_schema(FiniteMagmaLawEvaluationArtifact),
     )
     countermodel_schema_uri = schemas.register(
         name="jacobian.finite-magma-countermodel-search",
         version="1",
-        schema=FiniteMagmaCountermodelArtifact.model_json_schema(),
+        schema=model_schema(FiniteMagmaCountermodelArtifact),
     )
     claim_schema_uri = schemas.register(
         name="jacobian.finite-magma-law-evaluation-claim",
         version="1",
-        schema=FiniteMagmaLawEvaluationClaim.model_json_schema(),
+        schema=model_schema(FiniteMagmaLawEvaluationClaim),
     )
     certificate_schema_uri = schemas.register(
         name="jacobian.certificate-envelope",
         version="1",
-        schema=CertificateEnvelope.model_json_schema(),
+        schema=model_schema(CertificateEnvelope),
     )
     evaluation_checker_id = None
     if authorize_checker:
@@ -190,8 +190,8 @@ class UniversalAlgebraEvaluateLawsAdapter:
                 ),
             ),
             modes=(CapabilityMode.EXPLORE,),
-            input_schema=UniversalAlgebraEvaluationRequest.model_json_schema(),
-            output_schema=UniversalAlgebraEvaluationOutput.model_json_schema(),
+            input_schema=model_schema(UniversalAlgebraEvaluationRequest),
+            output_schema=model_schema(UniversalAlgebraEvaluationOutput),
             tags=(
                 "universal-algebra",
                 "finite-model",
@@ -358,8 +358,8 @@ class UniversalAlgebraSearchCountermodelAdapter:
                 features=("finite-magma-countermodel-search",),
             ),
             modes=(CapabilityMode.EXPLORE,),
-            input_schema=UniversalAlgebraCountermodelSearchRequest.model_json_schema(),
-            output_schema=UniversalAlgebraCountermodelSearchOutput.model_json_schema(),
+            input_schema=model_schema(UniversalAlgebraCountermodelSearchRequest),
+            output_schema=model_schema(UniversalAlgebraCountermodelSearchOutput),
             tags=(
                 "universal-algebra",
                 "finite-model",

--- a/src/jacobian/verification.py
+++ b/src/jacobian/verification.py
@@ -47,7 +47,7 @@ from jacobian.registry import (
     CheckerRegistry,
     CheckerRegistryError,
 )
-from jacobian.schema_registry import SchemaRegistry, SchemaRegistryError
+from jacobian.schema_registry import SchemaRegistry, SchemaRegistryError, model_schema
 from jacobian.store import (
     ArtifactIntegrityError,
     ArtifactNotFoundError,
@@ -166,7 +166,7 @@ class VerificationService:
             kind="schema",
             name="jacobian.verification-record",
             version="1",
-            definition=VerificationRecord.model_json_schema(),
+            definition=model_schema(VerificationRecord),
         )
         self.record_semantics_uri = store.register_descriptor(
             kind="semantics",
@@ -180,13 +180,13 @@ class VerificationService:
             kind="schema",
             name="jacobian.preservation-envelope",
             version="1",
-            definition=PreservationEnvelope.model_json_schema(),
+            definition=model_schema(PreservationEnvelope),
         )
         self.transformation_record_schema_uri = store.register_descriptor(
             kind="schema",
             name="jacobian.transformation-verification-record",
             version="1",
-            definition=TransformationVerificationRecord.model_json_schema(),
+            definition=model_schema(TransformationVerificationRecord),
         )
 
     def _semantics_digest(self, artifact: StoredArtifact) -> str:

--- a/src/jacobian/witnesses.py
+++ b/src/jacobian/witnesses.py
@@ -33,7 +33,7 @@ from jacobian.contracts.witness_search import (
 )
 from jacobian.plugin_execution import PluginExecutor
 from jacobian.plugins.registry import PluginRegistry, PluginRegistryError
-from jacobian.schema_registry import SchemaRegistry, SchemaRegistryError
+from jacobian.schema_registry import SchemaRegistry, SchemaRegistryError, model_schema
 from jacobian.store import ArtifactStore, StoreError
 from jacobian.verification import VerificationService
 
@@ -69,7 +69,7 @@ class WitnessSearchService:
         self.witness_schema_uri = schemas.register(
             name="jacobian.witness-envelope",
             version="1",
-            schema=WitnessEnvelope.model_json_schema(),
+            schema=model_schema(WitnessEnvelope),
         )
 
     def find(

--- a/src/jacobian/workspaces.py
+++ b/src/jacobian/workspaces.py
@@ -40,7 +40,7 @@ from jacobian.contracts.workspaces import (
     WorkspaceWriteRequest,
     WorkspaceWriteResult,
 )
-from jacobian.schema_registry import SchemaRegistry
+from jacobian.schema_registry import SchemaRegistry, model_schema
 from jacobian.store import ArtifactStore, StoreError
 
 
@@ -97,7 +97,7 @@ class WorkspaceService:
         self.revision_schema_uri = schemas.register(
             name="jacobian.workspace-revision",
             version="1",
-            schema=WorkspaceRevision.model_json_schema(),
+            schema=model_schema(WorkspaceRevision),
         )
         self.revision_semantics_uri = store.register_descriptor(
             kind="semantics",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+"""Suite-wide pytest conventions."""
+
+from pathlib import Path
+
+import pytest
+
+_LAYER_MARKERS = {
+    "integration": pytest.mark.integration,
+    "end_to_end": pytest.mark.end_to_end,
+}
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Keep layer markers aligned with the suite's directory structure."""
+
+    tests_root = Path(__file__).parent
+    for item in items:
+        try:
+            layer = Path(item.path).relative_to(tests_root).parts[0]
+        except (ValueError, IndexError):
+            continue
+        marker = _LAYER_MARKERS.get(layer)
+        if marker is not None:
+            item.add_marker(marker)

--- a/tests/contract/test_schema_registry.py
+++ b/tests/contract/test_schema_registry.py
@@ -3,13 +3,39 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from pydantic import BaseModel
 
 from jacobian.schema_registry import (
     SchemaRegistry,
     SchemaRegistryError,
     SchemaValidationError,
+    model_schema,
 )
 from jacobian.store import ArtifactStore
+
+
+class _CachedSchemaModel(BaseModel):
+    value: int
+
+
+@pytest.mark.contract
+def test_cached_model_schema_returns_independent_copies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first = model_schema(_CachedSchemaModel)
+    first["title"] = "mutated"
+
+    def unexpected_regeneration() -> dict[str, object]:
+        pytest.fail("cached schema was regenerated")
+
+    monkeypatch.setattr(
+        _CachedSchemaModel,
+        "model_json_schema",
+        unexpected_regeneration,
+    )
+    second = model_schema(_CachedSchemaModel)
+
+    assert second["title"] == "_CachedSchemaModel"
 
 
 @pytest.mark.contract

--- a/tests/integration/test_capability_service.py
+++ b/tests/integration/test_capability_service.py
@@ -472,6 +472,10 @@ def test_lean_capability_returns_bound_verified_result(tmp_path: Path) -> None:
 
 
 @pytest.mark.integration
+@pytest.mark.skipif(
+    shutil.which("lean") is None,
+    reason="Lean is not installed",
+)
 def test_lean_capability_projects_repairable_checker_diagnostics(
     tmp_path: Path,
 ) -> None:

--- a/tests/integration/test_mcp_adapter.py
+++ b/tests/integration/test_mcp_adapter.py
@@ -520,7 +520,7 @@ def test_mcp_entrypoint_has_nonstarting_help() -> None:
         check=False,
         capture_output=True,
         text=True,
-        timeout=5,
+        timeout=20,
     )
 
     assert completed.returncode == 0

--- a/uv.lock
+++ b/uv.lock
@@ -360,6 +360,7 @@ dev = [
     { name = "pyperf" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-split" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "ruff" },
@@ -390,6 +391,7 @@ dev = [
     { name = "pyperf", specifier = ">=2.9,<3" },
     { name = "pytest", specifier = ">=8.3,<10" },
     { name = "pytest-cov", specifier = ">=6,<8" },
+    { name = "pytest-split", specifier = ">=0.11,<1" },
     { name = "pytest-timeout", specifier = ">=2.4,<3" },
     { name = "pytest-xdist", specifier = ">=3.6,<4" },
     { name = "ruff", specifier = ">=0.11,<1" },
@@ -846,6 +848,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-split"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/16/8af4c5f2ceb3640bb1f78dfdf5c184556b10dfe9369feaaad7ff1c13f329/pytest_split-0.11.0.tar.gz", hash = "sha256:8ebdb29cc72cc962e8eb1ec07db1eeb98ab25e215ed8e3216f6b9fc7ce0ec2b5", size = 13421, upload-time = "2026-02-03T09:14:31.469Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/a1/d4423657caaa8be9b31e491592b49cebdcfd434d3e74512ce71f6ec39905/pytest_split-0.11.0-py3-none-any.whl", hash = "sha256:899d7c0f5730da91e2daf283860eb73b503259cb416851a65599368849c7f382", size = 11911, upload-time = "2026-02-03T09:14:33.708Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

The test suite paid two avoidable latency costs:

- each `JacobianKernel` regenerated the same Pydantic JSON Schemas, even though
  schema validation was already cached by canonical content; and
- the documented fast loop depended on manually repeated markers, so
  unmarked files under `tests/integration/` silently joined it.

CI also ran each Python-version suite in one job. Xdist used the cores within
that runner, but could not distribute the suite across runners.

## Change

- cache canonical Pydantic schema bytes per model and return a fresh decoded
  schema to every caller, preserving isolation from mutation
- route built-in schema registration and capability descriptors through that
  cache, including Lean declaration discovery
- derive `integration` and `end_to_end` markers from their directory layers
- raise the MCP help-process watchdog from 5 to 20 seconds so coverage
  instrumentation and runner contention do not turn a non-performance test
  into a timing assertion
- split both supported Python suites into two disjoint pytest groups while
  retaining xdist work stealing inside each shard
- collect raw Python 3.12 coverage from both shards, combine it in a dependent
  job, and enforce the existing threshold only against the complete union
- document the fast loop, debugger/failure-recovery commands, marker ownership,
  and CI coverage flow

## Performance and coverage evidence

On the same 4-vCPU Linux checkout with pytest 9.1.1:

- the documented fast loop fell from 33.16 seconds and 201 selected tests to
  9.80 seconds and 175 correctly classified non-integration tests
- a representative two-test kernel workload fell from 27.60 to 13.50 seconds
- the unsharded coverage run reported 82.08% total coverage

Against the final rebased tree, pytest-split collects 216 of 432 tests in each
group. Local partition checks found no overlap, and the raw coverage artifact
flow was exercised through `coverage combine`.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv run deptry .`
- `uv build`
- `uv run pytest -q tests/contract/test_schema_registry.py` — 3 passed
- both `pytest --collect-only --splits 2` groups — 216/432 tests each
- `git diff --check`
- CI: all four Python/shard jobs passed
- CI: combined coverage report passed

## Compatibility

No public capability, artifact, assurance, or verification contract changes.
`pytest-split` is a development-only dependency. The coverage threshold and
subprocess coverage instrumentation remain unchanged.

## Suggested review order

1. `schema_registry.py` and its fresh-copy regression test
2. suite-layer marker ownership and the fast-loop documentation
3. sharded CI execution and raw coverage aggregation
