### PR TITLE
feat(eval): benchmark Lean declaration discovery

### DIFF
--- a/benchmarks/ab_cases/lean-report.schema.json
+++ b/benchmarks/ab_cases/lean-report.schema.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "case_id",
+    "statement",
+    "proof",
+    "declarations",
+    "conclusion",
+    "assurance",
+    "verification_record_uri",
+    "limitations",
+    "feedback"
+  ],
+  "properties": {
+    "case_id": {
+      "type": "string"
+    },
+    "statement": {
+      "type": "string"
+    },
+    "proof": {
+      "type": "string"
+    },
+    "declarations": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "conclusion": {
+      "enum": [
+        "TRUE",
+        "UNKNOWN"
+      ]
+    },
+    "assurance": {
+      "enum": [
+        "HEURISTIC",
+        "VERIFIED"
+      ]
+    },
+    "verification_record_uri": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "limitations": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "feedback": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "reasoning_focus",
+        "infrastructure_work",
+        "tooling_gaps"
+      ],
+      "properties": {
+        "reasoning_focus": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "infrastructure_work": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tooling_gaps": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/benchmarks/ab_cases/lean_declaration_ab_001.json
+++ b/benchmarks/ab_cases/lean_declaration_ab_001.json
@@ -1,0 +1,19 @@
+{
+  "case_id": "LEAN-DECLARATION-AB-001",
+  "version": "1",
+  "task_type": "lean_declaration",
+  "evaluation_lineage": {
+    "created_at": "2026-07-26",
+    "source": "Maintainer-authored held-out family from the pinned Mathlib snapshot",
+    "public_reproduction_overlap": false,
+    "oracle_kind": "authorized lean.check replay"
+  },
+  "prompt": "Prove exactly this proposition in the pinned MATHLIB environment:\n\n∀ (l : List Nat), (List.revzip l).map Prod.snd = l.reverse\n\nReturn a proof body accepted by lean.check and name each declaration explicitly cited by the proof.",
+  "expected": {
+    "environment": "MATHLIB",
+    "statement": "∀ (l : List Nat), (List.revzip l).map Prod.snd = l.reverse",
+    "conclusion": "TRUE",
+    "oracle_declaration": "List.revzip_map_snd",
+    "oracle_proof": "intro l; exact List.revzip_map_snd l"
+  }
+}

--- a/benchmarks/ab_cases/lean_declaration_ab_002.json
+++ b/benchmarks/ab_cases/lean_declaration_ab_002.json
@@ -1,0 +1,19 @@
+{
+  "case_id": "LEAN-DECLARATION-AB-002",
+  "version": "1",
+  "task_type": "lean_declaration",
+  "evaluation_lineage": {
+    "created_at": "2026-07-26",
+    "source": "Maintainer-authored held-out family from the pinned Mathlib snapshot",
+    "public_reproduction_overlap": false,
+    "oracle_kind": "authorized lean.check replay"
+  },
+  "prompt": "Prove exactly this proposition in the pinned MATHLIB environment:\n\n∀ (f : Nat → Nat) (t : Set Nat), f '' (f ⁻¹' t) = Set.range f ∩ t\n\nReturn a proof body accepted by lean.check and name each declaration explicitly cited by the proof.",
+  "expected": {
+    "environment": "MATHLIB",
+    "statement": "∀ (f : Nat → Nat) (t : Set Nat), f '' (f ⁻¹' t) = Set.range f ∩ t",
+    "conclusion": "TRUE",
+    "oracle_declaration": "Set.image_preimage_eq_range_inter",
+    "oracle_proof": "intro f t; exact Set.image_preimage_eq_range_inter"
+  }
+}

--- a/benchmarks/agent_ab.py
+++ b/benchmarks/agent_ab.py
@@ -1,11 +1,17 @@
-"""Run paired no-tool and Jacobian-capability Codex evaluations.
+"""Run paired Codex portfolio-ablation evaluations.
 
 This benchmark measures whether Jacobian changes agent outcomes. It is
 separate from ``agent_mcp.py``, which validates MCP and checker integration.
 
-Run a three-pair pilot with:
+Run a three-pair baseline pilot with:
 
     uv run python benchmarks/agent_ab.py --case ERDOS-STRAUS-AB-001
+
+Run the held-out Lean declaration-discovery pilot with:
+
+    uv run python benchmarks/agent_ab.py --case LEAN-DECLARATION-AB-001 \
+        --case LEAN-DECLARATION-AB-002 --model gpt-5.6-sol \
+        --reasoning-effort high
 """
 
 from __future__ import annotations
@@ -41,8 +47,15 @@ CASES_ROOT = Path(__file__).with_name("ab_cases")
 REPORT_SCHEMA = CASES_ROOT / "report.schema.json"
 GRAPH_REPORT_SCHEMA = CASES_ROOT / "graph-report.schema.json"
 PARTITION_REPORT_SCHEMA = CASES_ROOT / "partition-report.schema.json"
+LEAN_REPORT_SCHEMA = CASES_ROOT / "lean-report.schema.json"
 DEFAULT_RESULTS_ROOT = Path(__file__).with_name("results") / "ab"
 CONDITIONS = ("control", "treatment")
+LEAN_DISCOVERY_IDS = frozenset(
+    {
+        "lean.declaration.search",
+        "lean.declaration.inspect",
+    }
+)
 
 COMMON_PROMPT = """\
 Complete mathematical evaluation case {case_id}.
@@ -53,7 +66,7 @@ Return only the required JSON report. Record what work concerned mathematical
 strategy in feedback.reasoning_focus, what work concerned constructing or
 operating infrastructure in feedback.infrastructure_work, and missing
 capabilities in feedback.tooling_gaps. Empty lists are valid. Do not claim
-anything beyond the exact finite scope.
+anything beyond the exact declared scope.
 """
 
 CONTROL_INSTRUCTIONS = """\
@@ -102,6 +115,17 @@ use shell commands or create programs. Copy the returned durable URIs. Report
 VERIFIED only when the capability returns VERIFIED assurance.
 """
 
+LEAN_INSTRUCTIONS = """\
+Use only the jacobian_local MCP server for mathematical work. Do not use shell
+commands or create programs. Inspect the installed capability catalog, construct
+a Lean proof body for the exact MATHLIB statement, and independently replay it
+with lean.check in VERIFY mode. The proof field is the body consumed by
+lean.check, without a leading `by`. List declarations explicitly cited by that
+body. Report VERIFIED only when lean.check returns VERIFIED assurance, and copy
+its exact verification_record_uri. Retrieval or inspection alone is not
+verification.
+"""
+
 
 class BenchmarkError(RuntimeError):
     """The A/B runner, report, or known-answer evidence is invalid."""
@@ -138,8 +162,21 @@ def score_report(
     condition: str,
     state_dir: Path,
     mcp_calls: Sequence[str],
+    shell_calls: Sequence[str] = (),
+    capability_attempt_ids: Sequence[str] = (),
     capability_invocations: Sequence[Mapping[str, Any]] = (),
 ) -> dict[str, Any]:
+    if case.get("task_type") == "lean_declaration":
+        return _score_lean_report(
+            case,
+            report,
+            condition=condition,
+            state_dir=state_dir,
+            mcp_calls=mcp_calls,
+            shell_calls=shell_calls,
+            capability_attempt_ids=capability_attempt_ids,
+            capability_invocations=capability_invocations,
+        )
     if case.get("task_type") == "graph":
         return _score_graph_report(
             case,
@@ -203,6 +240,258 @@ def score_report(
     else:
         raise BenchmarkError(f"unknown condition: {condition}")
     return {"passed": True, "checks": checks}
+
+
+def _score_lean_report(
+    case: Mapping[str, Any],
+    report: Mapping[str, Any],
+    *,
+    condition: str,
+    state_dir: Path,
+    mcp_calls: Sequence[str],
+    shell_calls: Sequence[str],
+    capability_attempt_ids: Sequence[str],
+    capability_invocations: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    expected_value = case.get("expected")
+    if not isinstance(expected_value, Mapping):
+        raise BenchmarkError("Lean case expected must be an object")
+    expected = expected_value
+    for field in ("case_id", "statement"):
+        wanted = case.get(field) if field == "case_id" else expected.get(field)
+        if report.get(field) != wanted:
+            raise BenchmarkError(f"Lean report {field} differs from the known answer")
+    proof = report.get("proof")
+    if not isinstance(proof, str) or not proof.strip():
+        raise BenchmarkError("Lean report proof must be non-empty")
+    declarations = report.get("declarations")
+    if (
+        not isinstance(declarations, list)
+        or not all(isinstance(item, str) and item for item in declarations)
+        or len(set(declarations)) != len(declarations)
+    ):
+        raise BenchmarkError("Lean report declarations must be distinct names")
+    if any(declaration not in proof for declaration in declarations):
+        raise BenchmarkError("Lean report names a declaration not cited by its proof")
+    feedback = report.get("feedback")
+    if (
+        not isinstance(feedback, dict)
+        or set(feedback) != {"reasoning_focus", "infrastructure_work", "tooling_gaps"}
+        or not all(
+            isinstance(value, list) and all(isinstance(item, str) for item in value)
+            for value in feedback.values()
+        )
+    ):
+        raise BenchmarkError("Lean report feedback has an invalid structure")
+    if condition not in CONDITIONS:
+        raise BenchmarkError(f"unknown condition: {condition}")
+    if shell_calls:
+        raise BenchmarkError("Lean evaluation condition used a shell command")
+    if "capability.invoke" not in mcp_calls:
+        raise BenchmarkError("Lean evaluation did not invoke a capability")
+    if condition == "control" and LEAN_DISCOVERY_IDS.intersection(
+        capability_attempt_ids
+    ):
+        raise BenchmarkError("Lean control reached an ablated discovery capability")
+    intervention_attempted = bool(
+        LEAN_DISCOVERY_IDS.intersection(capability_attempt_ids)
+    )
+    intervention_used = any(
+        invocation.get("capability_id") in LEAN_DISCOVERY_IDS
+        for invocation in capability_invocations
+    )
+    if report.get("conclusion") != expected.get("conclusion"):
+        operational_error = _lean_operational_failure(
+            report=report,
+            expected=expected,
+            proof=proof,
+            capability_invocations=capability_invocations,
+        )
+        if operational_error is not None:
+            return {
+                "passed": False,
+                "operational_failure": True,
+                "error": operational_error,
+                "intervention_attempted": intervention_attempted,
+                "intervention_used": intervention_used,
+            }
+        raise BenchmarkError("Lean report conclusion differs from the known answer")
+    if report.get("assurance") != "VERIFIED":
+        raise BenchmarkError("Lean report did not claim checker-backed assurance")
+    record_uri = report.get("verification_record_uri")
+    if not isinstance(record_uri, str):
+        raise BenchmarkError("Lean report omitted its verification record")
+    _score_lean_record(
+        state_dir=state_dir,
+        record_uri=record_uri,
+        statement=str(expected["statement"]),
+        proof=proof,
+        environment=str(expected["environment"]),
+    )
+    exact_check = any(
+        invocation.get("capability_id") == "lean.check"
+        and invocation.get("input")
+        == {
+            "environment": expected["environment"],
+            "statement": expected["statement"],
+            "proof": proof,
+        }
+        and isinstance(invocation.get("output"), Mapping)
+        and invocation["output"].get("verification_record_uri") == record_uri
+        and isinstance(invocation.get("assurance"), Mapping)
+        and invocation["assurance"].get("level") == "VERIFIED"
+        for invocation in capability_invocations
+    )
+    if not exact_check:
+        raise BenchmarkError(
+            "Lean report lacks an exact statement and proof checker-bound trace"
+        )
+    return {
+        "passed": True,
+        "checks": [
+            "held-out exact statement",
+            "authorized Lean replay record",
+            "exact checker-bound capability trace",
+            "condition-specific portfolio isolation",
+        ],
+        "intervention_attempted": intervention_attempted,
+        "intervention_used": intervention_used,
+    }
+
+
+def _lean_operational_failure(
+    *,
+    report: Mapping[str, Any],
+    expected: Mapping[str, Any],
+    proof: str,
+    capability_invocations: Sequence[Mapping[str, Any]],
+) -> str | None:
+    if (
+        report.get("conclusion") != "UNKNOWN"
+        or report.get("assurance") != "HEURISTIC"
+        or report.get("verification_record_uri") is not None
+    ):
+        return None
+    expected_input = {
+        "environment": expected["environment"],
+        "statement": expected["statement"],
+        "proof": proof,
+    }
+    markers = (
+        "toolchain is unavailable",
+        "executable could not be resolved",
+        "checker timed out",
+    )
+    for invocation in capability_invocations:
+        output = invocation.get("output")
+        diagnostics = output.get("diagnostics") if isinstance(output, Mapping) else None
+        if (
+            invocation.get("capability_id") != "lean.check"
+            or invocation.get("input") != expected_input
+            or not isinstance(diagnostics, list)
+        ):
+            continue
+        for diagnostic in diagnostics:
+            if isinstance(diagnostic, str) and any(
+                marker in diagnostic.lower() for marker in markers
+            ):
+                return diagnostic
+    return None
+
+
+def _score_lean_record(
+    *,
+    state_dir: Path,
+    record_uri: str,
+    statement: str,
+    proof: str,
+    environment: str,
+) -> None:
+    store = ArtifactStore(state_dir)
+    try:
+        record_artifact = store.get(record_uri)
+        record = VerificationRecord.model_validate(record_artifact.payload)
+        evidence = store.get(record.evidence_uri)
+        parents = [store.get(uri) for uri in record_artifact.manifest.parents]
+    except (StoreError, ValueError) as exc:
+        raise BenchmarkError("Lean verification record is unavailable") from exc
+    if record.conclusion.value != "TRUE":
+        raise BenchmarkError("Lean verification record has the wrong conclusion")
+    if record.evidence_uri not in record_artifact.manifest.parents:
+        raise BenchmarkError("Lean verification record does not parent its certificate")
+    certificate = evidence.payload
+    payload = certificate.get("payload") if isinstance(certificate, dict) else None
+    if (
+        not isinstance(certificate, dict)
+        or certificate.get("certificate_type") != "lean4.kernel"
+        or not isinstance(payload, dict)
+        or payload.get("environment") != environment
+        or payload.get("statement") != statement
+        or payload.get("proof") != proof
+    ):
+        raise BenchmarkError(
+            "Lean certificate does not bind the exact statement and proof"
+        )
+    candidate = next(
+        (
+            artifact
+            for artifact in parents
+            if isinstance(artifact.payload, dict)
+            and artifact.payload.get("proof") == proof
+            and artifact.payload.get("statement") == statement
+        ),
+        None,
+    )
+    claim = next(
+        (
+            artifact
+            for artifact in parents
+            if isinstance(artifact.payload, dict)
+            and "proof" not in artifact.payload
+            and artifact.payload.get("statement") == statement
+        ),
+        None,
+    )
+    if candidate is None or claim is None:
+        raise BenchmarkError(
+            "Lean verification record omits its exact claim or candidate"
+        )
+    if (
+        candidate.payload.get("environment") != environment
+        or claim.payload.get("environment") != environment
+        or record.bindings.candidate_digest != candidate.manifest.object_digest
+        or record.bindings.claim_digest != claim.manifest.object_digest
+    ):
+        raise BenchmarkError("Lean verification bindings do not match exact artifacts")
+
+
+def _lean_false_certification(
+    case: Mapping[str, Any],
+    report: Mapping[str, Any],
+    state_dir: Path,
+) -> bool:
+    if report.get("assurance") != "VERIFIED":
+        return False
+    expected = case.get("expected")
+    record_uri = report.get("verification_record_uri")
+    proof = report.get("proof")
+    if (
+        not isinstance(expected, Mapping)
+        or not isinstance(record_uri, str)
+        or not isinstance(proof, str)
+    ):
+        return True
+    try:
+        _score_lean_record(
+            state_dir=state_dir,
+            record_uri=record_uri,
+            statement=str(expected["statement"]),
+            proof=proof,
+            environment=str(expected["environment"]),
+        )
+    except (BenchmarkError, KeyError):
+        return True
+    return False
 
 
 def _score_partition_report(
@@ -524,6 +813,7 @@ def _codex_command(
     model: str | None,
     reasoning_effort: str,
     report_schema: Path = REPORT_SCHEMA,
+    task_type: str | None = None,
 ) -> list[str]:
     command = [
         codex_command,
@@ -545,18 +835,32 @@ def _codex_command(
         "-c",
         "model_reasoning_effort=" + json.dumps(reasoning_effort),
     ]
-    if condition == "treatment":
+    if condition == "treatment" or task_type == "lean_declaration":
         uv_command = shutil.which("uv")
         if uv_command is None:
             raise BenchmarkError("uv is required for the treatment MCP server")
-        server_args = [
-            "run",
-            "--project",
-            str(PROJECT_ROOT),
-            "jacobian-mcp",
-            "--state-dir",
-            str(state_dir),
-        ]
+        if task_type == "lean_declaration":
+            server_args = [
+                "run",
+                "--project",
+                str(PROJECT_ROOT),
+                "python",
+                str(PROJECT_ROOT / "benchmarks" / "agent_ab_mcp.py"),
+                "--state-dir",
+                str(state_dir),
+            ]
+            if condition == "control":
+                for capability_id in sorted(LEAN_DISCOVERY_IDS):
+                    server_args.extend(["--exclude-capability", capability_id])
+        else:
+            server_args = [
+                "run",
+                "--project",
+                str(PROJECT_ROOT),
+                "jacobian-mcp",
+                "--state-dir",
+                str(state_dir),
+            ]
         command.extend(
             [
                 "-c",
@@ -603,7 +907,10 @@ def _run_condition(
     state_dir.mkdir()
     is_graph = case.get("task_type") == "graph"
     is_partition = case.get("task_type") == "finite_partition"
-    if is_graph:
+    is_lean = case.get("task_type") == "lean_declaration"
+    if is_lean:
+        condition_instructions = LEAN_INSTRUCTIONS
+    elif is_graph:
         condition_instructions = (
             GRAPH_CONTROL_INSTRUCTIONS
             if condition == "control"
@@ -628,8 +935,13 @@ def _run_condition(
         state_dir=state_dir,
         model=model,
         reasoning_effort=reasoning_effort,
+        task_type=(
+            str(case["task_type"]) if isinstance(case.get("task_type"), str) else None
+        ),
         report_schema=(
-            GRAPH_REPORT_SCHEMA
+            LEAN_REPORT_SCHEMA
+            if is_lean
+            else GRAPH_REPORT_SCHEMA
             if is_graph
             else PARTITION_REPORT_SCHEMA
             if is_partition
@@ -676,6 +988,8 @@ def _run_condition(
                 condition=condition,
                 state_dir=state_dir,
                 mcp_calls=telemetry["mcp_calls"],
+                shell_calls=telemetry["shell_calls"],
+                capability_attempt_ids=telemetry["capability_attempt_ids"],
                 capability_invocations=telemetry["capability_invocations"],
             )
         except (BenchmarkError, OSError, json.JSONDecodeError) as exc:
@@ -694,6 +1008,9 @@ def _run_condition(
         "mcp_call_count": len(telemetry["mcp_calls"]),
         "tool_error_count": telemetry["tool_error_count"],
         "parameter_error_count": telemetry["parameter_error_count"],
+        "capability_rejection_count": telemetry["capability_rejection_count"],
+        "capability_attempt_ids": telemetry["capability_attempt_ids"],
+        "capability_ids": telemetry["capability_ids"],
         "shell_calls": telemetry["shell_calls"],
         "shell_call_count": len(telemetry["shell_calls"]),
         "workspace_file_count": sum(
@@ -702,6 +1019,11 @@ def _run_condition(
         "agent_report": report,
         "false_certification": bool(
             (
+                is_lean
+                and isinstance(report, dict)
+                and _lean_false_certification(case, report, state_dir)
+            )
+            or (
                 is_graph
                 and isinstance(report, dict)
                 and (
@@ -716,6 +1038,14 @@ def _run_condition(
                 and report.get("verification_record_uri") is None
             )
         ),
+        "intervention_attempted": bool(
+            is_lean
+            and LEAN_DISCOVERY_IDS.intersection(telemetry["capability_attempt_ids"])
+        ),
+        "intervention_used": bool(
+            is_lean and LEAN_DISCOVERY_IDS.intersection(telemetry["capability_ids"])
+        ),
+        "operational_failure": bool(score.get("operational_failure")),
         "score": score,
     }
     (condition_root / "result.json").write_text(
@@ -740,6 +1070,10 @@ def summarize_pairs(results: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
             {
                 "case_id": case_id,
                 "repetition": repetition,
+                "valid": not bool(
+                    control.get("operational_failure")
+                    or treatment.get("operational_failure")
+                ),
                 "control_passed": bool(control["score"].get("passed")),
                 "treatment_passed": bool(treatment["score"].get("passed")),
                 "elapsed_delta_seconds": round(
@@ -759,6 +1093,14 @@ def summarize_pairs(results: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
                 - int(control.get("tool_error_count", 0)),
                 "parameter_error_delta": int(treatment.get("parameter_error_count", 0))
                 - int(control.get("parameter_error_count", 0)),
+                "capability_rejection_delta": int(
+                    treatment.get("capability_rejection_count", 0)
+                )
+                - int(control.get("capability_rejection_count", 0)),
+                "treatment_intervention_attempted": bool(
+                    treatment.get("intervention_attempted")
+                ),
+                "treatment_intervention_used": bool(treatment.get("intervention_used")),
             }
         )
     condition_summary = {
@@ -769,6 +1111,7 @@ def summarize_pairs(results: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
     }
     return {
         "pair_count": len(pairs),
+        "valid_pair_count": sum(bool(pair["valid"]) for pair in pairs),
         "conditions": condition_summary,
         "pairs": pairs,
     }
@@ -801,8 +1144,20 @@ def _condition_summary(results: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
         "parameter_error_count": sum(
             int(result.get("parameter_error_count", 0)) for result in results
         ),
+        "capability_rejection_count": sum(
+            int(result.get("capability_rejection_count", 0)) for result in results
+        ),
         "false_certification_count": sum(
             bool(result.get("false_certification")) for result in results
+        ),
+        "operational_failure_count": sum(
+            bool(result.get("operational_failure")) for result in results
+        ),
+        "intervention_attempt_count": sum(
+            bool(result.get("intervention_attempted")) for result in results
+        ),
+        "intervention_success_count": sum(
+            bool(result.get("intervention_used")) for result in results
         ),
     }
 

--- a/benchmarks/agent_ab_mcp.py
+++ b/benchmarks/agent_ab_mcp.py
@@ -1,0 +1,25 @@
+"""Start a local Jacobian MCP server with a frozen evaluation ablation."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+from pathlib import Path
+
+from jacobian.adapters.mcp.server import create_server
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--state-dir", type=Path, required=True)
+    parser.add_argument("--exclude-capability", action="append", default=[])
+    args = parser.parse_args(argv)
+    create_server(
+        state_dir=args.state_dir,
+        capability_exclusions=frozenset(args.exclude_capability),
+    ).run("stdio")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/contributing/atomic-capability-portfolio.md
+++ b/docs/contributing/atomic-capability-portfolio.md
@@ -303,8 +303,26 @@ host with warm filesystem caches, direct helper measurements were:
 
 The first two operations return `COMPUTED` retrieval evidence and bind the
 exact pinned environment-manifest digest. The last operation alone returned
-`VERIFIED`. These measurements establish a workable spike, not portfolio lift;
-the held-out paired evaluation remains the next separate queue item.
+`VERIFIED`. These measurements established a workable spike, not portfolio
+lift.
+
+The held-out paired pilot completed on 2026-07-26. Both `List.revzip`
+treatments used discovery and reached independently verified proofs, but the
+controls also passed. Discovery added 226--288 seconds, 208k--365k input
+tokens, and three to six additional tool execution errors in those pairs. A
+second statement family was solved without selecting discovery. The decision
+is to revise rather than stabilize, consolidate, or retire:
+
+- retain search and exact inspection as separate experimental atomic outcomes;
+- do not recommend them or add goal-stepping capabilities yet;
+- replace repeated Mathlib startup and full scans with a reusable pinned index
+  or persistent query service instead of merely raising the timeout;
+- compact catalog discovery; and
+- rerun the frozen held-out evaluation before changing recommendation status.
+
+See [Lean declaration-discovery pilot](../reference/capability-workflow-evaluations.md#lean-declaration-discovery-pilot)
+for scorer invariants, per-run measurements, and the excluded operationally
+invalid pair.
 
 ## Wave 2: SAT certificate vertical slice
 

--- a/docs/reference/capability-workflow-evaluations.md
+++ b/docs/reference/capability-workflow-evaluations.md
@@ -226,6 +226,55 @@ but not enough to recommend `goal.decompose` or premise-retrieval capabilities
 by default. A paired agent evaluation should measure their outcome value;
 completed source must still go through `lean.check`.
 
+### Lean declaration-discovery pilot
+
+The 2026-07-26 pilot compared the same Jacobian portfolio under both
+conditions. The control server omitted only `lean.declaration.search` and
+`lean.declaration.inspect`; both conditions retained `lean.check`. Prompts,
+`gpt-5.6-sol`, high reasoning effort, per-condition timeout, output schema, and
+hidden checker oracle were matched. The two held-out statements used
+`List.revzip` and `Set.image`/`Set.preimage`, not the public square-root
+tutorial. The scorer required the report, successful invocation trace,
+candidate, claim, certificate, and authorized verification record to bind the
+exact statement and proof.
+
+Three valid pairs and one operationally invalid pair were inspected. This is a
+small development pilot, not a powered performance comparison:
+
+| Case/run | Condition | Correct | Discovery used | Seconds | Input tokens | Calls | Tool errors | Rejected proofs |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `List.revzip` A | control | yes | no | 88.292 | 278,161 | 7 | 1 | 1 |
+| `List.revzip` A | treatment | yes | yes | 376.399 | 486,143 | 12 | 4 | 1 |
+| `List.revzip` B | control | yes | no | 214.873 | 250,982 | 6 | 0 | 3 |
+| `List.revzip` B | treatment | yes | yes | 440.582 | 615,722 | 15 | 6 | 1 |
+| set image/preimage | control | yes | no | 88.583 | 140,217 | 3 | 0 | 0 |
+| set image/preimage | treatment | yes | no | 59.424 | 139,035 | 3 | 0 | 0 |
+
+No valid run falsely certified a result, used the shell, or made a parameter
+error. In both `List.revzip` pairs, treatment eventually used successful exact
+inspection or search results and produced a checker-accepted proof. It did not
+improve completion: control also passed. Treatment added 288.107 and 225.709
+seconds, 207,982 and 364,740 input tokens, five and nine MCP calls, and three
+and six additional tool execution errors. Most errors were Mathlib searches
+exhausting the 75-second subprocess budget. The set case did not exercise
+discovery in either treatment run, so its elapsed difference is sampling and
+runtime variance, not intervention lift.
+
+One additional set pair is excluded from comparative interpretation. Its first
+condition passed; the second condition's `lean.check` reported the pinned
+toolchain unavailable after registration and returned `UNKNOWN`. The agent
+correctly reported heuristic assurance with no record. This is an operational
+runtime flake and neither a mathematical failure nor evidence for treatment.
+
+The decision is **revise**. Keep search and exact inspection available as
+separate experimental atomic outcomes, but do not recommend them or expand to
+goal stepping and premise application yet. A longer timeout would only hide
+the dominant cost. First replace repeated full Mathlib process startup and
+scans with a reusable pinned index or persistent query service, keep exact
+environment identity, and make catalog discovery compact. Then rerun these
+same held-out cases and add cases where direct automation does not already
+solve the proposition.
+
 ## Source policy
 
 Use the supplied research collection according to evidence strength:

--- a/src/jacobian/adapters/mcp/server.py
+++ b/src/jacobian/adapters/mcp/server.py
@@ -159,8 +159,12 @@ def create_server(
     token_verifier: Any | None = None,
     auth: Any | None = None,
     capability_adapter_entrypoints: tuple[str, ...] = (),
+    capability_exclusions: frozenset[str] = frozenset(),
 ) -> MCPServer[AppState]:
     """Create a local or tenant-routed adapter over the Jacobian kernel."""
+
+    if tenant_isolation and capability_exclusions:
+        raise ValueError("capability exclusions are supported only by local evaluation")
 
     # Keep ``--help`` and ``--version`` independent of the MCP runtime's
     # heavier imports and shutdown hooks.
@@ -205,6 +209,7 @@ def create_server(
             configured_root,
             install_references=install_references,
             capability_adapter_entrypoints=capability_adapter_entrypoints,
+            capability_exclusions=capability_exclusions,
         )
     )
     tenant_router = (

--- a/src/jacobian/eval_telemetry.py
+++ b/src/jacobian/eval_telemetry.py
@@ -22,7 +22,10 @@ _PARAMETER_ERROR_CODES = frozenset(
 
 def _contains_value(value: object, *, field: str, accepted: set[object]) -> bool:
     if isinstance(value, Mapping):
-        if value.get(field) in accepted:
+        candidate = value.get(field)
+        if isinstance(candidate, str | int | float | bool | type(None)) and (
+            candidate in accepted
+        ):
             return True
         return any(
             _contains_value(item, field=field, accepted=accepted)
@@ -57,12 +60,14 @@ def parse_agent_transcript(path: Path) -> dict[str, Any]:
 
     mcp_calls: list[str] = []
     successful_calls: list[str] = []
+    capability_attempt_ids: list[str] = []
     capability_ids: list[str] = []
     capability_invocations: list[dict[str, Any]] = []
     shell_calls: list[str] = []
     usage: dict[str, Any] | None = None
     tool_error_count = 0
     parameter_error_count = 0
+    capability_rejection_count = 0
     for line in path.read_text(encoding="utf-8").splitlines():
         try:
             event = json.loads(line)
@@ -86,11 +91,23 @@ def parse_agent_transcript(path: Path) -> dict[str, Any]:
         ):
             tool = item["tool"]
             mcp_calls.append(tool)
+            arguments = item.get("arguments")
+            if (
+                tool == "capability.invoke"
+                and isinstance(arguments, Mapping)
+                and isinstance(arguments.get("capability_id"), str)
+            ):
+                capability_attempt_ids.append(arguments["capability_id"])
             result = item.get("result")
+            response = _mcp_text_payload(item)
             failed = bool(
                 item.get("status") in {"error", "failed"}
                 or item.get("error")
                 or (isinstance(result, Mapping) and result.get("isError") is True)
+                or (
+                    isinstance(response, Mapping)
+                    and isinstance(response.get("error"), Mapping)
+                )
                 or _contains_value(
                     item,
                     field="status",
@@ -101,8 +118,16 @@ def parse_agent_transcript(path: Path) -> dict[str, Any]:
                 tool_error_count += 1
             else:
                 successful_calls.append(tool)
-                arguments = item.get("arguments")
-                response = _mcp_text_payload(item)
+                if (
+                    tool == "capability.invoke"
+                    and isinstance(response, Mapping)
+                    and _contains_value(
+                        response.get("output"),
+                        field="status",
+                        accepted={"REJECTED"},
+                    )
+                ):
+                    capability_rejection_count += 1
                 execution = (
                     response.get("execution") if isinstance(response, Mapping) else None
                 )
@@ -142,7 +167,9 @@ def parse_agent_transcript(path: Path) -> dict[str, Any]:
         "usage": usage,
         "tool_error_count": tool_error_count,
         "parameter_error_count": parameter_error_count,
+        "capability_rejection_count": capability_rejection_count,
         "successful_tool_calls": successful_calls,
+        "capability_attempt_ids": capability_attempt_ids,
         "capability_ids": capability_ids,
         "capability_invocations": capability_invocations,
     }

--- a/src/jacobian/kernel.py
+++ b/src/jacobian/kernel.py
@@ -77,7 +77,11 @@ class JacobianKernel:
         *,
         install_references: bool = False,
         capability_adapter_entrypoints: tuple[str, ...] = (),
+        capability_exclusions: frozenset[str] = frozenset(),
     ) -> None:
+        # Construction-time exclusions support controlled portfolio ablations.
+        # They are not a runtime authorization or access-control mechanism.
+        self._capability_exclusions = capability_exclusions
         self.store = ArtifactStore(root)
         self.schemas = SchemaRegistry(self.store)
         self.artifacts = ArtifactService(self.store, self.schemas)
@@ -176,8 +180,8 @@ class JacobianKernel:
         self.lean_declarations: LeanDeclarationService | None = None
         self.capabilities = CapabilityService(self.store, self.memory)
         for atomic_adapter in install_atomic_capabilities(self):
-            self.capabilities.register(atomic_adapter)
-        self.capabilities.register(KnowledgeSearchAdapter(self.memory))
+            self.register_capability(atomic_adapter)
+        self.register_capability(KnowledgeSearchAdapter(self.memory))
         self.finite_partition: FinitePartitionInstallation
         finite_partition, self.finite_partition = install_finite_partition(
             self.store,
@@ -187,7 +191,7 @@ class JacobianKernel:
             self.checkers,
             authorize_checker=install_references,
         )
-        self.capabilities.register(finite_partition)
+        self.register_capability(finite_partition)
         self.graph: GraphInstallation
         graph_adapters, self.graph = install_graph_capabilities(
             self.store,
@@ -197,7 +201,7 @@ class JacobianKernel:
             authorize_checker=install_references,
         )
         for graph_adapter in graph_adapters:
-            self.capabilities.register(graph_adapter)
+            self.register_capability(graph_adapter)
         self.polynomial: PolynomialInstallation
         polynomial_adapters, self.polynomial = install_polynomial_capabilities(
             self.store,
@@ -207,7 +211,7 @@ class JacobianKernel:
             authorize_checker=install_references,
         )
         for polynomial_adapter in polynomial_adapters:
-            self.capabilities.register(polynomial_adapter)
+            self.register_capability(polynomial_adapter)
         self.universal_algebra: UniversalAlgebraInstallation
         universal_algebra_adapters, self.universal_algebra = (
             install_universal_algebra_capabilities(
@@ -219,7 +223,7 @@ class JacobianKernel:
             )
         )
         for universal_algebra_adapter in universal_algebra_adapters:
-            self.capabilities.register(universal_algebra_adapter)
+            self.register_capability(universal_algebra_adapter)
         if install_references:
             self.references = self.reference_installer.install_all()
             self.polytope_checkers = self.reference_installer.install_polytope_checkers(
@@ -260,13 +264,13 @@ class JacobianKernel:
                         exc,
                     )
                 if self.lean_declarations is not None:
-                    self.capabilities.register(
+                    self.register_capability(
                         LeanDeclarationSearchAdapter(
                             self.lean_declarations,
                             runtime,
                         )
                     )
-                    self.capabilities.register(
+                    self.register_capability(
                         LeanDeclarationInspectAdapter(
                             self.lean_declarations,
                             runtime,
@@ -278,16 +282,18 @@ class JacobianKernel:
                     self.verification,
                     self.lean_checkers,
                 )
-                self.capabilities.register(LeanCheckAdapter(self.lean, runtime))
+                self.register_capability(LeanCheckAdapter(self.lean, runtime))
             else:
                 _LOGGER.warning(
                     "lean.check is not installed: %s",
                     runtime.diagnostic,
                 )
         for entrypoint in capability_adapter_entrypoints:
-            self.capabilities.register(load_capability_adapter(entrypoint, self))
+            self.register_capability(load_capability_adapter(entrypoint, self))
 
     def register_capability(self, adapter: CapabilityAdapter) -> None:
         """Install an operator-owned adapter without changing the kernel or MCP."""
 
+        if adapter.descriptor.capability_id in self._capability_exclusions:
+            return
         self.capabilities.register(adapter)

--- a/tests/integration/test_agent_ab_benchmark.py
+++ b/tests/integration/test_agent_ab_benchmark.py
@@ -57,6 +57,7 @@ def test_ab_transcript_parser_separates_mcp_and_shell_calls(tmp_path: Path) -> N
                     "item": {
                         "type": "mcp_tool_call",
                         "tool": "capability.invoke",
+                        "metadata": {"status": {"phase": "done"}},
                     },
                 },
                 {
@@ -77,10 +78,99 @@ def test_ab_transcript_parser_separates_mcp_and_shell_calls(tmp_path: Path) -> N
         "usage": {"input_tokens": 12, "output_tokens": 3},
         "tool_error_count": 0,
         "parameter_error_count": 0,
+        "capability_rejection_count": 0,
         "successful_tool_calls": ["capability.invoke"],
+        "capability_attempt_ids": [],
         "capability_ids": [],
         "capability_invocations": [],
     }
+
+
+def test_ab_transcript_parser_counts_completed_capability_rejections(
+    tmp_path: Path,
+) -> None:
+    parse_transcript = cast(Any, BENCHMARK["parse_transcript"])
+    transcript = tmp_path / "transcript.jsonl"
+    response = {
+        "capability_id": "lean.check",
+        "execution": {"status": "COMPLETED"},
+        "output": {
+            "conclusion": "UNKNOWN",
+            "input": {"status": "REJECTED", "errors": ["unsolved goals"]},
+        },
+        "assurance": {"level": "HEURISTIC"},
+    }
+    transcript.write_text(
+        json.dumps(
+            {
+                "type": "item.completed",
+                "item": {
+                    "type": "mcp_tool_call",
+                    "tool": "capability.invoke",
+                    "arguments": {
+                        "capability_id": "lean.check",
+                        "payload": {
+                            "environment": "MATHLIB",
+                            "statement": "True",
+                            "proof": "exact False.elim",
+                        },
+                    },
+                    "result": {
+                        "content": [{"type": "text", "text": json.dumps(response)}]
+                    },
+                    "status": "completed",
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    telemetry = parse_transcript(transcript)
+
+    assert telemetry["capability_rejection_count"] == 1
+    assert telemetry["tool_error_count"] == 0
+    assert telemetry["capability_ids"] == ["lean.check"]
+
+
+def test_ab_transcript_parser_counts_structured_mcp_errors(tmp_path: Path) -> None:
+    parse_transcript = cast(Any, BENCHMARK["parse_transcript"])
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text(
+        json.dumps(
+            {
+                "type": "item.completed",
+                "item": {
+                    "type": "mcp_tool_call",
+                    "tool": "capability.describe",
+                    "arguments": {"capability_id": "missing.capability"},
+                    "result": {
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": json.dumps(
+                                    {
+                                        "error": {
+                                            "code": "UNKNOWN_CAPABILITY",
+                                            "message": "Unknown capability",
+                                        }
+                                    }
+                                ),
+                            }
+                        ]
+                    },
+                    "status": "completed",
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    telemetry = parse_transcript(transcript)
+
+    assert telemetry["tool_error_count"] == 1
+    assert telemetry["successful_tool_calls"] == []
 
 
 def test_ab_scorer_accepts_control_and_durable_treatment(tmp_path: Path) -> None:
@@ -504,3 +594,278 @@ def test_ab_partition_scorer_rejects_duplicate_case_ids(tmp_path: Path) -> None:
         assert "distinct and non-empty" in str(exc)
     else:
         raise AssertionError("duplicate partition case identifiers were accepted")
+
+
+def test_ab_lean_scorer_requires_exact_checker_bound_trace(tmp_path: Path) -> None:
+    load_cases = cast(Any, BENCHMARK["load_cases"])
+    score_report = cast(Any, BENCHMARK["score_report"])
+    case = load_cases(["LEAN-DECLARATION-AB-001"])[0]
+    expected = cast(dict[str, Any], case["expected"])
+    statement = cast(str, expected["statement"])
+    proof = cast(str, expected["oracle_proof"])
+    state_dir = tmp_path / "state"
+    kernel = JacobianKernel(state_dir, install_references=True)
+    checked = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="lean.check",
+            mode=CapabilityMode.VERIFY,
+            input={
+                "environment": "MATHLIB",
+                "statement": statement,
+                "proof": proof,
+            },
+        )
+    )
+    record_uri = checked.assurance.verification_record_uri
+    assert record_uri is not None
+    report = {
+        "case_id": case["case_id"],
+        "statement": statement,
+        "proof": proof,
+        "declarations": ["List.revzip_map_snd"],
+        "conclusion": "TRUE",
+        "assurance": "VERIFIED",
+        "verification_record_uri": record_uri,
+        "limitations": [],
+        "feedback": {
+            "reasoning_focus": ["matched the exact declaration type"],
+            "infrastructure_work": [],
+            "tooling_gaps": [],
+        },
+    }
+    invocations = [
+        {
+            "capability_id": "lean.declaration.search",
+            "input": {
+                "environment": "MATHLIB",
+                "name_contains": "revzip",
+                "result_limit": 10,
+            },
+            "output": {
+                "declarations": [{"name": "List.revzip_map_snd"}],
+                "environment_digest": "sha256:" + "a" * 64,
+            },
+            "assurance": {"level": "COMPUTED"},
+        },
+        {
+            "capability_id": "lean.check",
+            "input": {
+                "environment": "MATHLIB",
+                "statement": statement,
+                "proof": proof,
+            },
+            "output": checked.output,
+            "artifact_uris": list(checked.artifact_uris),
+            "assurance": checked.assurance.model_dump(mode="json"),
+        },
+    ]
+
+    score = score_report(
+        case,
+        report,
+        condition="treatment",
+        state_dir=state_dir,
+        mcp_calls=["capability.invoke", "capability.invoke"],
+        shell_calls=[],
+        capability_attempt_ids=[
+            "lean.declaration.search",
+            "lean.check",
+        ],
+        capability_invocations=invocations,
+    )
+
+    assert score["passed"] is True
+    assert score["intervention_attempted"] is True
+    assert score["intervention_used"] is True
+
+    report["proof"] = "exact List.revzip_map_snd []"
+    try:
+        score_report(
+            case,
+            report,
+            condition="treatment",
+            state_dir=state_dir,
+            mcp_calls=["capability.invoke", "capability.invoke"],
+            shell_calls=[],
+            capability_attempt_ids=[
+                "lean.declaration.search",
+                "lean.check",
+            ],
+            capability_invocations=invocations,
+        )
+    except BENCHMARK["BenchmarkError"] as exc:
+        assert "exact statement and proof" in str(exc)
+    else:
+        raise AssertionError("mismatched Lean proof was accepted")
+
+    report["proof"] = proof
+    report["declarations"] = ["List.not_cited"]
+    try:
+        score_report(
+            case,
+            report,
+            condition="treatment",
+            state_dir=state_dir,
+            mcp_calls=["capability.invoke", "capability.invoke"],
+            shell_calls=[],
+            capability_attempt_ids=[
+                "lean.declaration.search",
+                "lean.check",
+            ],
+            capability_invocations=invocations,
+        )
+    except BENCHMARK["BenchmarkError"] as exc:
+        assert "not cited" in str(exc)
+    else:
+        raise AssertionError("uncited Lean declaration was accepted")
+
+
+def test_ab_lean_scorer_rejects_false_certification(tmp_path: Path) -> None:
+    load_cases = cast(Any, BENCHMARK["load_cases"])
+    score_report = cast(Any, BENCHMARK["score_report"])
+    case = load_cases(["LEAN-DECLARATION-AB-001"])[0]
+    expected = cast(dict[str, Any], case["expected"])
+    report = {
+        "case_id": case["case_id"],
+        "statement": expected["statement"],
+        "proof": expected["oracle_proof"],
+        "declarations": [],
+        "conclusion": "TRUE",
+        "assurance": "VERIFIED",
+        "verification_record_uri": None,
+        "limitations": [],
+        "feedback": {
+            "reasoning_focus": [],
+            "infrastructure_work": [],
+            "tooling_gaps": [],
+        },
+    }
+
+    try:
+        score_report(
+            case,
+            report,
+            condition="control",
+            state_dir=tmp_path,
+            mcp_calls=["capability.invoke"],
+            shell_calls=[],
+            capability_attempt_ids=["lean.check"],
+            capability_invocations=[],
+        )
+    except BENCHMARK["BenchmarkError"] as exc:
+        assert "verification record" in str(exc)
+    else:
+        raise AssertionError("unrecorded Lean verification was accepted")
+
+
+def test_ab_lean_scorer_separates_checker_runtime_failure(tmp_path: Path) -> None:
+    load_cases = cast(Any, BENCHMARK["load_cases"])
+    score_report = cast(Any, BENCHMARK["score_report"])
+    case = load_cases(["LEAN-DECLARATION-AB-002"])[0]
+    expected = cast(dict[str, Any], case["expected"])
+    proof = cast(str, expected["oracle_proof"])
+    diagnostic = (
+        "The pinned Lean 4.31.0 toolchain is unavailable. Install it, then retry."
+    )
+    report = {
+        "case_id": case["case_id"],
+        "statement": expected["statement"],
+        "proof": proof,
+        "declarations": ["Set.image_preimage_eq_range_inter"],
+        "conclusion": "UNKNOWN",
+        "assurance": "HEURISTIC",
+        "verification_record_uri": None,
+        "limitations": [diagnostic],
+        "feedback": {
+            "reasoning_focus": [],
+            "infrastructure_work": [],
+            "tooling_gaps": [diagnostic],
+        },
+    }
+
+    score = score_report(
+        case,
+        report,
+        condition="control",
+        state_dir=tmp_path,
+        mcp_calls=["capability.invoke"],
+        shell_calls=[],
+        capability_attempt_ids=["lean.check"],
+        capability_invocations=[
+            {
+                "capability_id": "lean.check",
+                "input": {
+                    "environment": "MATHLIB",
+                    "statement": expected["statement"],
+                    "proof": proof,
+                },
+                "output": {
+                    "conclusion": "UNKNOWN",
+                    "diagnostics": [diagnostic],
+                    "verification_record_uri": None,
+                },
+                "assurance": {"level": "HEURISTIC"},
+            }
+        ],
+    )
+
+    assert score["passed"] is False
+    assert score["operational_failure"] is True
+    assert "toolchain is unavailable" in score["error"]
+
+
+def test_ab_lean_control_ablation_keeps_checker_only(tmp_path: Path) -> None:
+    kernel = JacobianKernel(
+        tmp_path,
+        install_references=True,
+        capability_exclusions=frozenset(
+            {
+                "lean.declaration.search",
+                "lean.declaration.inspect",
+            }
+        ),
+    )
+
+    lean_ids = {
+        descriptor.capability_id
+        for descriptor in kernel.capabilities.catalog().capabilities
+        if descriptor.capability_id.startswith("lean.")
+    }
+
+    assert lean_ids == {"lean.check"}
+    excluded = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="lean.declaration.search",
+            mode=CapabilityMode.EXPLORE,
+            input={
+                "environment": "MATHLIB",
+                "name_contains": "revzip",
+                "result_limit": 1,
+            },
+        )
+    )
+    assert excluded.execution.status.value == "ERROR"
+    assert excluded.diagnostics[0].code == "UNKNOWN_CAPABILITY"
+
+
+def test_ab_lean_codex_command_uses_same_mcp_with_control_ablation(
+    tmp_path: Path,
+) -> None:
+    codex_command = cast(Any, BENCHMARK["_codex_command"])
+    common = {
+        "codex_command": "codex",
+        "workspace": tmp_path / "workspace",
+        "report_path": tmp_path / "report.json",
+        "state_dir": tmp_path / "state",
+        "model": "gpt-5.6",
+        "reasoning_effort": "high",
+        "task_type": "lean_declaration",
+    }
+
+    control = codex_command(condition="control", **common)
+    treatment = codex_command(condition="treatment", **common)
+
+    assert "agent_ab_mcp.py" in " ".join(control)
+    assert "agent_ab_mcp.py" in " ".join(treatment)
+    assert " ".join(control).count("--exclude-capability") == 2
+    assert "--exclude-capability" not in " ".join(treatment)


### PR DESCRIPTION
## Problem

The experimental `lean.declaration.search` and `lean.declaration.inspect` capabilities had a public reproduction but no held-out measurement of their marginal value against the same portfolio with `lean.check` only.

## Change

- add two held-out Mathlib declaration families and a strict structured report contract;
- add a local construction-time portfolio ablation so both conditions use the same MCP surface while control omits only declaration search/inspect;
- require exact statement/proof trace, durable claim/candidate/certificate bindings, and an authorized Lean verification record;
- separate attempted/successful discovery, proof rejection, structured MCP error, false certification, and operational checker failure telemetry;
- record the three-valid-pair pilot and the decision to revise rather than recommend, consolidate, or retire the capabilities.

The pilot found no completion lift. On the `List.revzip` case, treatment added 226–288 seconds, 208k–365k input tokens, and 3–6 additional tool errors. The next step is a reusable pinned index or persistent query service plus compact catalog discovery, not a larger timeout or more goal/tactic tools.

## Compatibility and normative impact

No capability contract or assurance rule changes. Construction-time exclusions are local evaluation composition, not runtime authorization. Search and exact inspection remain separate experimental `EXPLORE` outcomes; only `lean.check` may produce the accepted `VERIFIED` result.

## Validation

- `uv sync --dev`
- `uv run pytest` (`438 passed`)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`
- `git diff --check`
- held-out paired Codex pilot with `gpt-5.6-sol`, high reasoning effort, randomized condition order, exact Lean replay oracle