### PR TITLE
perf: reuse Lean declaration catalog

### DIFF
--- a/docs/contributing/atomic-capability-portfolio.md
+++ b/docs/contributing/atomic-capability-portfolio.md
@@ -324,6 +324,22 @@ See [Lean declaration-discovery pilot](../reference/capability-workflow-evaluati
 for scorer invariants, per-run measurements, and the excluded operationally
 invalid pair.
 
+The indexed follow-up is implemented. It derives a compact catalog from the
+pinned environment's imported module metadata, binds it to the exact
+environment digest, rechecks its byte identity before and after reuse, and
+keeps final candidate and type matching inside Lean. A fresh held-out
+`List.revzip` search completed in 28.886 seconds instead of timing out; catalog
+reuse completed in 9.568 seconds and direct exact inspection in 9.146 seconds.
+Fresh and reused outputs agreed on declarations, stop reason, and exact scan
+count.
+
+The frozen autonomous rerun passed in both conditions with no tool errors, but
+neither treatment selected discovery. That run therefore does not measure
+intervention lift. Search and inspection remain experimental and
+non-recommended. Before changing recommendation status or exposing interactive
+goal tools, add harder held-out statements where direct automation does not
+already solve the proposition.
+
 ## Wave 2: SAT certificate vertical slice
 
 Use four outcomes rather than one ambiguous solver call:

--- a/docs/reference/capability-workflow-evaluations.md
+++ b/docs/reference/capability-workflow-evaluations.md
@@ -275,6 +275,45 @@ environment identity, and make catalog discovery compact. Then rerun these
 same held-out cases and add cases where direct automation does not already
 solve the proposition.
 
+#### Indexed follow-up
+
+The follow-up implementation uses Mathlib's imported module metadata to build
+an atomically materialized, environment-bound catalog. Catalog candidates keep
+their exact deterministic scan positions; Lean resolves them again and checks
+the elaborated type. Exact inspection uses direct environment lookup. The
+backend checks the catalog byte digest before and after reuse and rejects
+identity changes, partial writes, response-ID mismatches, and tampering.
+
+On the same host, a fresh `List.revzip` search that previously exhausted the
+75-second budget completed in 28.886 seconds. Reusing the catalog for the same
+three-result query completed in 9.568 seconds, and exact inspection completed
+in 9.146 seconds. Fresh and reused searches returned the same three
+declarations, `RESULT_LIMIT`, and `scanned_declarations = 145293`. These are
+development measurements, not latency guarantees.
+
+One frozen pair per case was then rerun with the same model, effort, oracle,
+condition isolation, and 600-second condition budget:
+
+| Case | Condition | Correct | Discovery used | Seconds | Input tokens | Calls | Tool errors | Rejected proofs |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `List.revzip` | control | yes | no | 166.788 | 252,870 | 6 | 0 | 3 |
+| `List.revzip` | treatment | yes | no | 170.406 | 299,191 | 6 | 0 | 3 |
+| set image/preimage | control | yes | no | 57.268 | 140,354 | 3 | 0 | 0 |
+| set image/preimage | treatment | yes | no | 64.866 | 131,915 | 3 | 0 | 0 |
+
+All four runs produced checker-bound exact results with no false
+certification, parameter error, tool error, shell use, or operational failure.
+The treatment agents did not invoke declaration discovery, so the elapsed and
+token deltas are not intervention effects. This rerun shows that merely making
+the experimental capabilities available did not add calls or failures; it does
+not establish autonomous outcome lift.
+
+The performance revision is accepted at the capability layer. Recommendation
+status remains experimental: keep search and inspection separate, do not add
+goal-stepping tools, and evaluate harder held-out statements where direct
+automation does not already solve the proposition before recommending
+discovery by default.
+
 ## Source policy
 
 Use the supplied research collection according to evidence strength:

--- a/docs/reference/lean-declaration-discovery.md
+++ b/docs/reference/lean-declaration-discovery.md
@@ -30,6 +30,13 @@ in deterministic `Name.lt` order. Each result carries its elaborated
 pretty-printed type, declaration kind, namespace when present, optional source
 module and range, and explicit match reasons.
 
+The first name search in one backend session atomically materializes a compact
+catalog of imported public declaration names, source modules, and kinds. Later
+name searches use that catalog to select ordered candidates and their exact scan
+positions. Lean resolves every candidate again in the pinned environment,
+reapplies the filters, and checks elaborated type constants. Broad queries that
+would exceed the bounded candidate handoff use the full Lean scan instead.
+
 `stop_reason` separates the two possible coverage outcomes:
 
 - `RESULT_LIMIT` means the result budget stopped the scan and completeness is
@@ -45,7 +52,8 @@ is not a mathematical nonexistence conclusion.
 `lean.declaration.inspect` accepts an environment and one exact
 `declaration_name`. It returns the declaration's elaborated type, kind,
 namespace, documentation and source metadata when available. A missing exact
-name is an execution error, not an empty successful result.
+name is an execution error, not an empty successful result. Exact inspection
+uses Lean's environment lookup directly; it does not linearly scan the catalog.
 
 ## Environment identity and execution bounds
 
@@ -62,9 +70,17 @@ metaprogramming modules to implement the query. Provider-local helper
 declarations are never searchable. `MATHLIB` exposes declarations imported by
 the pinned `Mathlib` module.
 
-The subprocess is fail-closed, uses `--trust=0`, one worker, a 40-second `CORE`
-or 75-second `MATHLIB` timeout, and a two-MiB structured-output limit.
-Timeouts, unavailable profiles, malformed output, and Lean errors remain
+The catalog is backend-local optimization state, not mathematical evidence. Its
+header binds the exact `environment_digest`; Jacobian records its byte digest,
+checks it before and after reuse, and discards the session if either identity
+changes. Catalog creation uses an atomic rename, and candidate responses carry a
+fresh request identity. A mismatch, partial index, stale response, or tampering
+fails closed rather than falling back within the same operation.
+
+Each bounded query still runs in a separate subprocess with `--trust=0` and one
+worker. The per-query budget is 40 seconds for `CORE` and 105 seconds for
+`MATHLIB`, with a two-MiB structured-output limit and a 128-KiB diagnostic
+limit. Timeouts, unavailable profiles, malformed output, and Lean errors remain
 execution failures without a mathematical conclusion.
 
 See [Retrieve a Lean theorem and check a proof](../tutorials/lean-declaration-discovery.md)

--- a/src/jacobian/_lean_declaration_query.lean
+++ b/src/jacobian/_lean_declaration_query.lean
@@ -6,6 +6,7 @@ import Lean.Elab.Command
 open Lean
 
 structure DeclarationQuery where
+  request_id : String
   operation : String
   declaration_name : Option String
   name_contains : Option String
@@ -14,7 +15,15 @@ structure DeclarationQuery where
   target_module_prefixes : Array String
   kinds : Array String
   limit : Nat
+  candidate_names : Array String
+  candidate_scan_positions : Array Nat
+  scanned_declarations_total : Option Nat
   deriving FromJson
+
+structure DeclarationIndexEntry where
+  name : Name
+  module_name : String
+  kind : String
 
 def declarationKind : ConstantInfo → String
   | .axiomInfo _ => "AXIOM"
@@ -59,6 +68,10 @@ def namespaceMatches (query : DeclarationQuery) (name : Name) : Bool :=
     query.namespace_prefixes.any fun nsPrefix =>
       name.toString == nsPrefix || name.toString.startsWith (nsPrefix ++ ".")
 
+def stringPrefixMatches (prefixes : Array String) (value : String) : Bool :=
+  prefixes.isEmpty || prefixes.any fun itemPrefix =>
+    value == itemPrefix || value.startsWith (itemPrefix ++ ".")
+
 def kindMatches (query : DeclarationQuery) (info : ConstantInfo) : Bool :=
   query.kinds.isEmpty || query.kinds.contains (declarationKind info)
 
@@ -92,68 +105,234 @@ def declarationJson (env : Environment) (name : Name) (info : ConstantInfo)
     ("match_reasons", toJson matchReasons)
   ]
 
+def parseQuery (contents : String) : Except String DeclarationQuery := do
+  let json ← match Json.parse contents with
+    | .ok json => pure json
+    | .error detail => throw s!"invalid query JSON: {detail}"
+  match fromJson? json with
+  | .ok query => pure query
+  | .error detail => throw s!"invalid query contract: {detail}"
+
+def resultEnvelope (query : DeclarationQuery) (payload : Json) : Json :=
+  Json.mkObj [
+    ("request_id", toJson query.request_id),
+    ("payload", payload)
+  ]
+
+def errorEnvelope (requestId code message : String) : Json :=
+  Json.mkObj [
+    ("request_id", toJson requestId),
+    ("code", toJson code),
+    ("message", toJson message)
+  ]
+
+def emit (marker : String) (payload : Json) : IO Unit := do
+  let stdout ← IO.getStdout
+  stdout.putStrLn s!"{marker} {payload.compress}"
+  stdout.flush
+
+def executeQuery (env : Environment) (names : Array Name)
+    (query : DeclarationQuery) :
+    Elab.Command.CommandElabM (Except (String × String) Json) := do
+  if query.limit == 0 || query.limit > 50 then
+    return .error ("LEAN_QUERY_FAILED", "limit must be between 1 and 50")
+  if query.operation == "inspect" then
+      let some rawName := query.declaration_name
+        | return .error ("LEAN_QUERY_FAILED", "declaration_name is required")
+      let name := rawName.toName
+      let some info := env.find? name
+        | return .error (
+            "LEAN_DECLARATION_NOT_FOUND",
+            s!"declaration not found: {rawName}"
+          )
+      if name.toString != rawName || !targetModuleMatches query env name then
+        return .error (
+          "LEAN_DECLARATION_NOT_FOUND",
+          s!"declaration not found: {rawName}"
+        )
+      let type ← renderedType info
+      let declaration ← declarationJson env name info type #[] true
+      return .ok <| Json.mkObj [
+        ("operation", "inspect"),
+        ("declaration", declaration)
+      ]
+  else if query.operation == "search" then
+      if query.name_contains.isNone && query.type_constants.isEmpty then
+        return .error (
+          "LEAN_QUERY_FAILED",
+          "name_contains or type_constants is required"
+        )
+      match query.scanned_declarations_total with
+      | some scannedTotal =>
+        if query.candidate_names.size != query.candidate_scan_positions.size then
+          return .error ("LEAN_QUERY_FAILED", "candidate catalog is inconsistent")
+        let mut results : Array Json := #[]
+        let mut scanned := 0
+        let mut stopReason := "EXHAUSTED"
+        let mut previousPosition := 0
+        for index in [:query.candidate_names.size] do
+          let position := query.candidate_scan_positions[index]!
+          if position == 0 || position <= previousPosition || position > scannedTotal then
+            return .error ("LEAN_QUERY_FAILED", "candidate positions are invalid")
+          previousPosition := position
+          scanned := position
+          let rawName := query.candidate_names[index]!
+          let name := rawName.toName
+          if name.toString != rawName then continue
+          let some info := env.find? name | continue
+          if isPrivateName name || !targetModuleMatches query env name then continue
+          if !namespaceMatches query name || !kindMatches query info then continue
+          let nameMatched :=
+            query.name_contains.map (name.toString.contains ·) |>.getD true
+          if !nameMatched || !typeMatches query info then continue
+          let type ← renderedType info
+          let mut reasons : Array String := #[]
+          if query.name_contains.isSome then
+            reasons := reasons.push "NAME_SUBSTRING"
+          if !query.type_constants.isEmpty then
+            reasons := reasons.push "TYPE_CONSTANTS"
+          results := results.push (
+            ← declarationJson env name info type reasons false
+          )
+          if results.size == query.limit then
+            if position < scannedTotal then
+              stopReason := "RESULT_LIMIT"
+            break
+        if results.size < query.limit then
+          scanned := scannedTotal
+        return .ok <| Json.mkObj [
+          ("operation", "search"),
+          ("declarations", toJson results),
+          ("scanned_declarations", scanned),
+          ("stop_reason", stopReason)
+        ]
+      | none =>
+        let mut results : Array Json := #[]
+        let mut scanned := 0
+        let mut stopReason := "EXHAUSTED"
+        for name in names do
+          if results.size == query.limit then
+            stopReason := "RESULT_LIMIT"
+            break
+          if isPrivateName name || !targetModuleMatches query env name then continue
+          scanned := scanned + 1
+          let some info := env.find? name | continue
+          if !namespaceMatches query name || !kindMatches query info then continue
+          let nameMatched :=
+            query.name_contains.map (name.toString.contains ·) |>.getD true
+          if !nameMatched || !typeMatches query info then continue
+          let type ← renderedType info
+          let mut reasons : Array String := #[]
+          if query.name_contains.isSome then
+            reasons := reasons.push "NAME_SUBSTRING"
+          if !query.type_constants.isEmpty then
+            reasons := reasons.push "TYPE_CONSTANTS"
+          results := results.push (
+            ← declarationJson env name info type reasons false
+          )
+        return .ok <| Json.mkObj [
+          ("operation", "search"),
+          ("declarations", toJson results),
+          ("scanned_declarations", scanned),
+          ("stop_reason", stopReason)
+        ]
+  else
+    return .error ("LEAN_QUERY_FAILED", "operation must be search or inspect")
+
 def readQuery : IO DeclarationQuery := do
   let some path ← IO.getEnv "JACOBIAN_LEAN_QUERY_FILE"
     | throw <| IO.userError "JACOBIAN_LEAN_QUERY_FILE is required"
   let contents ← IO.FS.readFile path
-  let json ← match Json.parse contents with
-    | .ok json => pure json
-    | .error detail => throw <| IO.userError s!"invalid query JSON: {detail}"
-  match fromJson? json with
+  match parseQuery contents with
   | .ok query => pure query
-  | .error detail => throw <| IO.userError s!"invalid query contract: {detail}"
+  | .error detail => throw <| IO.userError detail
+
+def importedIndexEntries (env : Environment) : Array DeclarationIndexEntry :=
+  Id.run do
+    let mut metadata : NameMap (String × String) := {}
+    let moduleNames := env.header.moduleNames
+    for h : index in [:env.header.moduleData.size] do
+      let data := env.header.moduleData[index]
+      let some moduleName := moduleNames[index]?
+        | continue
+      for name in data.constNames ++ data.extraConstNames do
+        if isPrivateName name || metadata.contains name then continue
+        let some info := env.find? name | continue
+        metadata := metadata.insert name (
+          moduleName.toString,
+          declarationKind info
+        )
+    let names := env.constants.toList.toArray.map (·.1) |>.qsort Name.lt
+    let mut entries : Array DeclarationIndexEntry := #[]
+    for name in names do
+      if isPrivateName name then continue
+      let some (moduleName, kind) := metadata.find? name | continue
+      entries := entries.push { name, module_name := moduleName, kind }
+    return entries
+
+def catalogQuery? (query : DeclarationQuery)
+    (entries : Array DeclarationIndexEntry) : Option DeclarationQuery :=
+  Id.run do
+    let some nameContains := query.name_contains | return none
+    let mut candidates : Array String := #[]
+    let mut positions : Array Nat := #[]
+    let mut scanned := 0
+    for entry in entries do
+      if !stringPrefixMatches query.target_module_prefixes entry.module_name then
+        continue
+      scanned := scanned + 1
+      if !namespaceMatches query entry.name ||
+          (!query.kinds.isEmpty && !query.kinds.contains entry.kind) ||
+          !entry.name.toString.contains nameContains then
+        continue
+      if !query.type_constants.isEmpty || candidates.size < query.limit then
+        candidates := candidates.push entry.name.toString
+        positions := positions.push scanned
+        if candidates.size > 10000 then return none
+    return some {
+      query with
+      candidate_names := candidates
+      candidate_scan_positions := positions
+      scanned_declarations_total := some scanned
+    }
+
+def readOrBuildEntries (env : Environment) :
+    IO (Array DeclarationIndexEntry) := do
+  let some rawIndexPath ← IO.getEnv "JACOBIAN_LEAN_INDEX_FILE"
+    | throw <| IO.userError "JACOBIAN_LEAN_INDEX_FILE is required"
+  let some environmentDigest ← IO.getEnv "JACOBIAN_LEAN_ENVIRONMENT_DIGEST"
+    | throw <| IO.userError "JACOBIAN_LEAN_ENVIRONMENT_DIGEST is required"
+  let indexPath := System.FilePath.mk rawIndexPath
+  let entries := importedIndexEntries env
+  if ← indexPath.pathExists then
+    return entries
+  let rows := entries.toList.map fun entry =>
+    s!"{entry.name}\t{entry.module_name}\t{entry.kind}"
+  let serialized := String.intercalate "\n" (environmentDigest :: rows) ++ "\n"
+  let temporaryPath := System.FilePath.mk (rawIndexPath ++ ".tmp")
+  if ← temporaryPath.pathExists then
+    IO.FS.removeFile temporaryPath
+  IO.FS.writeFile temporaryPath serialized
+  IO.FS.rename temporaryPath indexPath
+  return entries
 
 run_cmd do
-  let query ← readQuery
+  let mut query ← readQuery
   let env ← getEnv
-  if query.limit == 0 || query.limit > 50 then
-    throwError "limit must be between 1 and 50"
-  let output ←
-    if query.operation == "inspect" then
-      let some rawName := query.declaration_name
-        | throwError "declaration_name is required"
-      let some (name, info) := env.constants.toList.find? fun (name, _) =>
-          name.toString == rawName
-        | throwError s!"declaration not found: {rawName}"
-      if !targetModuleMatches query env name then
-        throwError s!"declaration not found: {rawName}"
-      let type ← renderedType info
-      let declaration ← declarationJson env name info type #[] true
-      pure <| Json.mkObj [
-        ("operation", "inspect"),
-        ("declaration", declaration)
-      ]
-    else if query.operation == "search" then
-      if query.name_contains.isNone && query.type_constants.isEmpty then
-        throwError "name_contains or type_constants is required"
-      let names := env.constants.toList.toArray.map (·.1) |>.qsort Name.lt
-      let mut results : Array Json := #[]
-      let mut scanned := 0
-      let mut stopReason := "EXHAUSTED"
-      for name in names do
-        if results.size == query.limit then
-          stopReason := "RESULT_LIMIT"
-          break
-        if isPrivateName name || !targetModuleMatches query env name then continue
-        scanned := scanned + 1
-        let some info := env.find? name | continue
-        if !namespaceMatches query name || !kindMatches query info then continue
-        let nameMatched :=
-          query.name_contains.map (name.toString.contains ·) |>.getD true
-        if !nameMatched || !typeMatches query info then continue
-        let type ← renderedType info
-        let mut reasons : Array String := #[]
-        if query.name_contains.isSome then
-          reasons := reasons.push "NAME_SUBSTRING"
-        if !query.type_constants.isEmpty then
-          reasons := reasons.push "TYPE_CONSTANTS"
-        results := results.push (← declarationJson env name info type reasons false)
-      pure <| Json.mkObj [
-        ("operation", "search"),
-        ("declarations", toJson results),
-        ("scanned_declarations", scanned),
-        ("stop_reason", stopReason)
-      ]
-    else
-      throwError "operation must be search or inspect"
-  IO.println s!"JACOBIAN_DECLARATION_RESULT {output.compress}"
+  let mut names : Array Name := #[]
+  if query.operation == "search" &&
+      query.scanned_declarations_total.isNone then
+    let entries ← readOrBuildEntries env
+    match catalogQuery? query entries with
+    | some catalogQuery => query := catalogQuery
+    | none => names := entries.map (·.name)
+  try
+    match ← executeQuery env names query with
+    | .ok output =>
+      emit "JACOBIAN_DECLARATION_RESULT" <| resultEnvelope query output
+    | .error (code, message) =>
+      emit "JACOBIAN_DECLARATION_ERROR" <|
+        errorEnvelope query.request_id code message
+  catch _ =>
+    emit "JACOBIAN_DECLARATION_ERROR" <|
+      errorEnvelope query.request_id "LEAN_QUERY_FAILED" "query execution failed"

--- a/src/jacobian/lean_declarations.py
+++ b/src/jacobian/lean_declarations.py
@@ -7,6 +7,9 @@ import logging
 import os
 import subprocess
 import tempfile
+import threading
+import uuid
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol
 
@@ -26,8 +29,11 @@ from jacobian.contracts.lean import (
 
 _LOGGER = logging.getLogger(__name__)
 _RESULT_PREFIX = "JACOBIAN_DECLARATION_RESULT "
+_ERROR_PREFIX = "JACOBIAN_DECLARATION_ERROR "
 _MAX_STDOUT_BYTES = 2 * 1024 * 1024
 _MAX_STDERR_BYTES = 128 * 1024
+_MAX_CATALOG_CANDIDATES = 10_000
+_MAX_CATALOG_NAME_BYTES = 2 * 1024 * 1024
 _QUERY_SOURCE = Path(__file__).with_name("_lean_declaration_query.lean")
 _IMPORT_TOKEN = "{{JACOBIAN_IMPORT}}"
 
@@ -53,8 +59,222 @@ class LeanDeclarationBackendError(RuntimeError):
         self.message = message
 
 
+class _DeclarationQuerySession(Protocol):
+    def request(
+        self,
+        payload: dict[str, Any],
+        *,
+        timeout_seconds: int,
+    ) -> dict[str, Any]: ...
+
+    def close(self) -> None: ...
+
+
+class _ReusableLeanQuerySession:
+    """Run bounded queries while reusing one environment-bound name index."""
+
+    def __init__(
+        self,
+        *,
+        command: list[str],
+        cwd: Path,
+        process_environment: dict[str, str],
+        source: str,
+        memory_mb: str,
+        isolated_home: bool,
+        environment_digest: str,
+    ) -> None:
+        self._closed = False
+        self._temporary_directory = tempfile.TemporaryDirectory(
+            prefix="jacobian-lean-declarations-"
+        )
+        temporary_root = Path(self._temporary_directory.name)
+        self._source_path = temporary_root / "declaration_query.lean"
+        self._source_path.write_text(source, encoding="utf-8")
+        self._request_path = temporary_root / "query.json"
+        self._index_path = temporary_root / "declarations.index"
+        self._index_digest: str | None = None
+        self._environment_digest = environment_digest
+        self._command = command
+        self._cwd = cwd
+        self._memory_mb = memory_mb
+        self._process_environment = dict(process_environment)
+        self._process_environment.update(
+            {
+                "JACOBIAN_LEAN_ENVIRONMENT_DIGEST": environment_digest,
+                "JACOBIAN_LEAN_INDEX_FILE": str(self._index_path),
+                "JACOBIAN_LEAN_QUERY_FILE": str(self._request_path),
+            }
+        )
+        if isolated_home:
+            self._process_environment["HOME"] = str(temporary_root)
+
+    def request(
+        self,
+        payload: dict[str, Any],
+        *,
+        timeout_seconds: int,
+    ) -> dict[str, Any]:
+        if self._closed:
+            raise _query_failed()
+        self._check_index_identity()
+        request_id = uuid.uuid4().hex
+        wire_payload = {
+            **payload,
+            **self._catalog_fields(payload),
+            "request_id": request_id,
+        }
+        try:
+            self._request_path.write_bytes(canonicalize_json(wire_payload))
+            completed = subprocess.run(
+                [
+                    *self._command,
+                    str(self._source_path),
+                    "-t",
+                    "0",
+                    "-T",
+                    "1000000000",
+                    "-M",
+                    self._memory_mb,
+                    "-j",
+                    "1",
+                    "--trust=0",
+                ],
+                cwd=self._cwd,
+                env=self._process_environment,
+                check=False,
+                capture_output=True,
+                timeout=timeout_seconds,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise LeanDeclarationBackendError(
+                "LEAN_QUERY_TIMEOUT",
+                (
+                    "Lean declaration discovery exceeded the "
+                    f"{timeout_seconds}-second per-query budget."
+                ),
+            ) from exc
+        except OSError as exc:
+            raise _query_failed() from exc
+        if len(completed.stdout) > _MAX_STDOUT_BYTES:
+            raise _structured_output_limit()
+        if len(completed.stderr) > _MAX_STDERR_BYTES:
+            raise _diagnostic_output_limit()
+        if completed.returncode != 0:
+            _LOGGER.warning(
+                "Lean declaration query failed: %s",
+                (completed.stdout + completed.stderr)
+                .decode("utf-8", errors="replace")
+                .strip(),
+            )
+            raise _query_failed()
+        output = _parse_process_response(
+            completed.stdout,
+            expected_request_id=request_id,
+        )
+        self._record_or_check_index(payload)
+        return output
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._temporary_directory.cleanup()
+
+    def _check_index_identity(self) -> None:
+        if self._index_digest is None:
+            return
+        try:
+            current_digest = _sha256_file(self._index_path)
+        except OSError as exc:
+            raise _index_changed() from exc
+        if current_digest != self._index_digest:
+            raise _index_changed()
+
+    def _record_or_check_index(self, payload: dict[str, Any]) -> None:
+        if payload.get("operation") != "search":
+            return
+        try:
+            current_digest = _sha256_file(self._index_path)
+            self._validate_index_header()
+        except OSError as exc:
+            raise _protocol_error() from exc
+        if self._index_digest is None:
+            self._index_digest = current_digest
+        elif current_digest != self._index_digest:
+            raise _index_changed()
+
+    def _catalog_fields(self, payload: dict[str, Any]) -> dict[str, Any]:
+        if (
+            payload.get("operation") != "search"
+            or self._index_digest is None
+            or payload.get("name_contains") is None
+        ):
+            return {
+                "candidate_names": [],
+                "candidate_scan_positions": [],
+                "scanned_declarations_total": None,
+            }
+        target_modules = tuple(payload.get("target_module_prefixes", ()))
+        namespaces = tuple(payload.get("namespace_prefixes", ()))
+        kinds = set(payload.get("kinds", ()))
+        name_contains = str(payload["name_contains"])
+        type_constants = tuple(payload.get("type_constants", ()))
+        limit = int(payload["limit"])
+        candidates: list[str] = []
+        positions: list[int] = []
+        candidate_bytes = 0
+        scanned = 0
+        try:
+            with self._index_path.open(encoding="utf-8") as stream:
+                if next(stream).rstrip("\n") != self._environment_digest:
+                    raise ValueError("declaration index environment mismatch")
+                for line in stream:
+                    name, module, kind = line.rstrip("\n").split("\t")
+                    if not _prefix_matches(module, target_modules):
+                        continue
+                    scanned += 1
+                    if (
+                        not _prefix_matches(name, namespaces)
+                        or (kinds and kind not in kinds)
+                        or name_contains not in name
+                    ):
+                        continue
+                    if type_constants or len(candidates) < limit:
+                        candidates.append(name)
+                        positions.append(scanned)
+                        candidate_bytes += len(name.encode("utf-8"))
+                        if (
+                            len(candidates) > _MAX_CATALOG_CANDIDATES
+                            or candidate_bytes > _MAX_CATALOG_NAME_BYTES
+                        ):
+                            return {
+                                "candidate_names": [],
+                                "candidate_scan_positions": [],
+                                "scanned_declarations_total": None,
+                            }
+        except (OSError, StopIteration, ValueError) as exc:
+            raise _index_changed() from exc
+        return {
+            "candidate_names": candidates,
+            "candidate_scan_positions": positions,
+            "scanned_declarations_total": scanned,
+        }
+
+    def _validate_index_header(self) -> None:
+        with self._index_path.open(encoding="utf-8") as stream:
+            if stream.readline().rstrip("\n") != self._environment_digest:
+                raise OSError("declaration index environment mismatch")
+
+
+@dataclass(frozen=True, slots=True)
+class _SessionEntry:
+    environment_digest: str
+    session: _DeclarationQuerySession
+
+
 class LeanSubprocessDeclarationBackend:
-    """Execute one generated read-only query in a validated Lean installation."""
+    """Reuse one catalog across bounded processes for each validated environment."""
 
     def __init__(
         self,
@@ -71,6 +291,10 @@ class LeanSubprocessDeclarationBackend:
             raise RuntimeError(
                 "Lean declaration query source has an invalid import token"
             )
+        self._sessions: dict[LeanEnvironment, _SessionEntry] = {}
+        self._session_locks = {
+            environment: threading.Lock() for environment in LeanEnvironment
+        }
 
     def environment_digest(self, environment: LeanEnvironment) -> str:
         try:
@@ -91,91 +315,125 @@ class LeanSubprocessDeclarationBackend:
         environment: LeanEnvironment,
         payload: dict[str, Any],
     ) -> dict[str, Any]:
-        environment_digest = self.environment_digest(environment)
+        with self._session_locks[environment]:
+            environment_digest = self.environment_digest(environment)
+            entry = self._sessions.get(environment)
+            if entry is not None and entry.environment_digest != environment_digest:
+                self._discard_session(environment)
+                raise LeanDeclarationBackendError(
+                    "LEAN_ENVIRONMENT_CHANGED",
+                    (
+                        "The pinned Lean environment changed while an indexed "
+                        "declaration session was active."
+                    ),
+                )
+            if entry is None:
+                session = self._start_session(environment, environment_digest)
+                entry = _SessionEntry(
+                    environment_digest=environment_digest,
+                    session=session,
+                )
+                self._sessions[environment] = entry
+                try:
+                    unchanged_after_start = (
+                        self.environment_digest(environment) == environment_digest
+                    )
+                except LeanDeclarationBackendError:
+                    self._discard_session(environment)
+                    raise
+                if not unchanged_after_start:
+                    self._discard_session(environment)
+                    raise LeanDeclarationBackendError(
+                        "LEAN_ENVIRONMENT_CHANGED",
+                        (
+                            "The pinned Lean environment changed while the "
+                            "declaration index was starting."
+                        ),
+                    )
+            try:
+                output = entry.session.request(
+                    payload,
+                    timeout_seconds=self._query_timeout_seconds(environment),
+                )
+            except LeanDeclarationBackendError as exc:
+                if exc.code == "LEAN_DECLARATION_NOT_FOUND":
+                    try:
+                        unchanged = (
+                            self.environment_digest(environment) == environment_digest
+                        )
+                    except LeanDeclarationBackendError:
+                        unchanged = False
+                    if unchanged:
+                        raise
+                self._discard_session(environment)
+                if exc.code == "LEAN_DECLARATION_NOT_FOUND":
+                    raise LeanDeclarationBackendError(
+                        "LEAN_ENVIRONMENT_CHANGED",
+                        (
+                            "The pinned Lean environment changed during "
+                            "declaration inspection."
+                        ),
+                    ) from exc
+                raise
+            try:
+                unchanged_after_query = (
+                    self.environment_digest(environment) == environment_digest
+                )
+            except LeanDeclarationBackendError:
+                self._discard_session(environment)
+                raise
+            if not unchanged_after_query:
+                self._discard_session(environment)
+                raise LeanDeclarationBackendError(
+                    "LEAN_ENVIRONMENT_CHANGED",
+                    "The pinned Lean environment changed during declaration discovery.",
+                )
+            output["_environment_digest"] = environment_digest
+            return output
+
+    def close(self) -> None:
+        """Terminate all active query sessions."""
+
+        for environment, lock in self._session_locks.items():
+            with lock:
+                self._discard_session(environment)
+
+    def _start_session(
+        self,
+        environment: LeanEnvironment,
+        environment_digest: str,
+    ) -> _DeclarationQuerySession:
         import_name = (
             "Init.Prelude" if environment is LeanEnvironment.CORE else "Mathlib"
         )
         source = self._source_template.replace(_IMPORT_TOKEN, import_name)
-        with tempfile.TemporaryDirectory(prefix="jacobian-lean-query-") as directory:
-            temporary_root = Path(directory)
-            query_path = temporary_root / "query.json"
-            query_path.write_bytes(canonicalize_json(payload))
-            command, cwd, memory_mb, timeout_seconds = self._command(
-                environment,
-                temporary_root,
-            )
-            process_environment = self._process_environment(
-                environment,
-                temporary_root,
-                query_path,
-            )
-            try:
-                completed = subprocess.run(
-                    [
-                        *command,
-                        "--stdin",
-                        "-t",
-                        "0",
-                        "-T",
-                        "1000000000",
-                        "-M",
-                        memory_mb,
-                        "-j",
-                        "1",
-                        "--trust=0",
-                    ],
-                    cwd=cwd,
-                    env=process_environment,
-                    input=source,
-                    check=False,
-                    capture_output=True,
-                    text=True,
-                    timeout=timeout_seconds,
-                )
-            except subprocess.TimeoutExpired as exc:
-                raise LeanDeclarationBackendError(
-                    "LEAN_QUERY_TIMEOUT",
-                    (
-                        f"Lean declaration discovery exceeded the "
-                        f"{timeout_seconds}-second {environment.value} budget."
-                    ),
-                ) from exc
-        if len(completed.stdout.encode("utf-8")) > _MAX_STDOUT_BYTES:
-            raise LeanDeclarationBackendError(
-                "LEAN_QUERY_OUTPUT_LIMIT",
-                "Lean declaration discovery exceeded its structured output budget.",
-            )
-        if len(completed.stderr.encode("utf-8")) > _MAX_STDERR_BYTES:
-            raise LeanDeclarationBackendError(
-                "LEAN_QUERY_OUTPUT_LIMIT",
-                "Lean declaration discovery exceeded its diagnostic output budget.",
-            )
-        if completed.returncode != 0:
-            _LOGGER.warning(
-                "Lean declaration query failed: %s",
-                (completed.stdout + completed.stderr).strip(),
-            )
-            if "declaration not found:" in completed.stderr:
-                name = str(payload.get("declaration_name", "the requested name"))
-                raise LeanDeclarationBackendError(
-                    "LEAN_DECLARATION_NOT_FOUND",
-                    f"Lean did not find the exact declaration {name!r}.",
-                )
-            raise LeanDeclarationBackendError(
-                "LEAN_QUERY_FAILED",
-                (
-                    f"Lean could not complete declaration discovery in the "
-                    f"{environment.value} environment."
-                ),
-            )
-        output = _parse_query_output(completed.stdout)
-        if self.environment_digest(environment) != environment_digest:
-            raise LeanDeclarationBackendError(
-                "LEAN_ENVIRONMENT_CHANGED",
-                "The pinned Lean environment changed during declaration discovery.",
-            )
-        output["_environment_digest"] = environment_digest
-        return output
+        temporary_root = Path(tempfile.gettempdir())
+        command, cwd, memory_mb, _ = self._command(
+            environment,
+            temporary_root,
+        )
+        process_environment = self._process_environment(
+            environment,
+            temporary_root,
+        )
+        return _ReusableLeanQuerySession(
+            command=command,
+            cwd=cwd,
+            process_environment=process_environment,
+            source=source,
+            memory_mb=memory_mb,
+            isolated_home=environment is LeanEnvironment.CORE,
+            environment_digest=environment_digest,
+        )
+
+    def _discard_session(self, environment: LeanEnvironment) -> None:
+        entry = self._sessions.pop(environment, None)
+        if entry is not None:
+            entry.session.close()
+
+    @staticmethod
+    def _query_timeout_seconds(environment: LeanEnvironment) -> int:
+        return 40 if environment is LeanEnvironment.CORE else 105
 
     def _command(
         self,
@@ -197,13 +455,12 @@ class LeanSubprocessDeclarationBackend:
                 "LEAN_ENVIRONMENT_UNAVAILABLE",
                 "The pinned Lake executable for MATHLIB discovery is unavailable.",
             )
-        return [str(lake), "env", "lean"], self.mathlib_runtime, "8192", 75
+        return [str(lake), "env", "lean"], self.mathlib_runtime, "8192", 105
 
     def _process_environment(
         self,
         environment: LeanEnvironment,
         temporary_root: Path,
-        query_path: Path,
     ) -> dict[str, str]:
         lean_bin = str(self.lean_executable.parent)
         existing_path = os.environ.get("PATH")
@@ -219,7 +476,6 @@ class LeanSubprocessDeclarationBackend:
         )
         return {
             "HOME": runtime_home,
-            "JACOBIAN_LEAN_QUERY_FILE": str(query_path),
             "LANG": "C.UTF-8",
             "LC_ALL": "C.UTF-8",
             "PATH": path,
@@ -359,21 +615,68 @@ def installed_lean_declaration_service(
     )
 
 
-def _parse_query_output(stdout: str) -> dict[str, Any]:
-    payloads = [
-        line.removeprefix(_RESULT_PREFIX)
-        for line in stdout.splitlines()
-        if line.startswith(_RESULT_PREFIX)
+def _parse_process_response(
+    stdout: bytes,
+    *,
+    expected_request_id: str,
+) -> dict[str, Any]:
+    try:
+        lines = stdout.decode("utf-8").splitlines()
+    except UnicodeDecodeError as exc:
+        raise _protocol_error() from exc
+    responses = [
+        line for line in lines if line.startswith((_RESULT_PREFIX, _ERROR_PREFIX))
     ]
-    if len(payloads) != 1:
+    if len(responses) != 1:
+        raise _protocol_error()
+    return _parse_session_response(
+        responses[0],
+        expected_request_id=expected_request_id,
+    )
+
+
+def _parse_session_response(
+    line: str,
+    *,
+    expected_request_id: str,
+) -> dict[str, Any]:
+    if line.startswith(_RESULT_PREFIX):
+        response_kind = "result"
+        serialized = line.removeprefix(_RESULT_PREFIX)
+    elif line.startswith(_ERROR_PREFIX):
+        response_kind = "error"
+        serialized = line.removeprefix(_ERROR_PREFIX)
+    else:
         raise _protocol_error()
     try:
-        payload = loads_strict_json(payloads[0])
+        envelope = loads_strict_json(serialized)
     except ValueError as exc:
         raise _protocol_error() from exc
-    if not isinstance(payload, dict):
+    if not isinstance(envelope, dict) or envelope.get("request_id") != (
+        expected_request_id
+    ):
         raise _protocol_error()
-    return payload
+    if response_kind == "result":
+        if set(envelope) != {"request_id", "payload"} or not isinstance(
+            envelope["payload"], dict
+        ):
+            raise _protocol_error()
+        return envelope["payload"]
+    if (
+        set(envelope) != {"request_id", "code", "message"}
+        or not isinstance(envelope["code"], str)
+        or not isinstance(envelope["message"], str)
+    ):
+        raise _protocol_error()
+    if envelope["code"] == "LEAN_DECLARATION_NOT_FOUND":
+        raise LeanDeclarationBackendError(
+            "LEAN_DECLARATION_NOT_FOUND",
+            "Lean did not find the exact requested declaration.",
+        )
+    raise LeanDeclarationBackendError(
+        "LEAN_QUERY_FAILED",
+        "Lean could not complete declaration discovery in the selected environment.",
+    )
 
 
 def _require_operation(payload: dict[str, Any], expected: str) -> None:
@@ -385,6 +688,41 @@ def _protocol_error() -> LeanDeclarationBackendError:
     return LeanDeclarationBackendError(
         "LEAN_QUERY_PROTOCOL_ERROR",
         "Lean declaration discovery returned malformed structured output.",
+    )
+
+
+def _structured_output_limit() -> LeanDeclarationBackendError:
+    return LeanDeclarationBackendError(
+        "LEAN_QUERY_OUTPUT_LIMIT",
+        "Lean declaration discovery exceeded its structured output budget.",
+    )
+
+
+def _diagnostic_output_limit() -> LeanDeclarationBackendError:
+    return LeanDeclarationBackendError(
+        "LEAN_QUERY_OUTPUT_LIMIT",
+        "Lean declaration discovery exceeded its diagnostic output budget.",
+    )
+
+
+def _query_failed() -> LeanDeclarationBackendError:
+    return LeanDeclarationBackendError(
+        "LEAN_QUERY_FAILED",
+        "Lean could not complete declaration discovery in the selected environment.",
+    )
+
+
+def _index_changed() -> LeanDeclarationBackendError:
+    return LeanDeclarationBackendError(
+        "LEAN_QUERY_INDEX_CHANGED",
+        "The reusable Lean declaration index changed between bounded queries.",
+    )
+
+
+def _prefix_matches(value: str, prefixes: tuple[Any, ...]) -> bool:
+    return not prefixes or any(
+        isinstance(prefix, str) and (value == prefix or value.startswith(f"{prefix}."))
+        for prefix in prefixes
     )
 
 

--- a/tests/integration/test_lean.py
+++ b/tests/integration/test_lean.py
@@ -5,6 +5,7 @@ import json
 import shutil
 import threading
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
 
@@ -15,7 +16,10 @@ from jacobian.contracts.capabilities import (
     CapabilityRequest,
 )
 from jacobian.contracts.checkers import CheckerDecision
-from jacobian.contracts.lean import LeanEnvironment
+from jacobian.contracts.lean import (
+    LeanDeclarationSearchRequest,
+    LeanEnvironment,
+)
 from jacobian.contracts.results import (
     Arithmetic,
     Conclusion,
@@ -25,6 +29,10 @@ from jacobian.contracts.results import (
     Verification,
 )
 from jacobian.kernel import JacobianKernel
+from jacobian.lean_declarations import (
+    LeanDeclarationBackendError,
+    LeanSubprocessDeclarationBackend,
+)
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 MATHLIB_OLEAN = (
@@ -45,6 +53,52 @@ pytestmark = [
     pytest.mark.external_backend,
     pytest.mark.skipif(shutil.which("lean") is None, reason="Lean is not installed"),
 ]
+
+
+def test_core_declaration_catalog_matches_a_fresh_scan_and_detects_tampering(
+    tmp_path: Path,
+) -> None:
+    indexed_kernel = JacobianKernel(tmp_path / "indexed", install_references=True)
+    fresh_kernel = JacobianKernel(tmp_path / "fresh", install_references=True)
+    indexed = indexed_kernel.lean_declarations
+    fresh = fresh_kernel.lean_declarations
+    assert indexed is not None
+    assert fresh is not None
+    indexed_backend = indexed.backend
+    fresh_backend = fresh.backend
+    assert isinstance(indexed_backend, LeanSubprocessDeclarationBackend)
+    assert isinstance(fresh_backend, LeanSubprocessDeclarationBackend)
+    seed = LeanDeclarationSearchRequest(
+        environment=LeanEnvironment.CORE,
+        name_contains="Nat.add",
+        result_limit=2,
+    )
+    target = LeanDeclarationSearchRequest(
+        environment=LeanEnvironment.CORE,
+        name_contains="Nat.mul",
+        result_limit=2,
+    )
+    try:
+        indexed.search(seed)
+        reused = indexed.search(target)
+        baseline = fresh.search(target)
+
+        assert reused.declarations == baseline.declarations
+        assert reused.scanned_declarations == baseline.scanned_declarations
+        assert reused.stop_reason is baseline.stop_reason
+
+        entry = indexed_backend._sessions[LeanEnvironment.CORE]
+        index_path = cast(Any, entry.session)._index_path
+        index_path.write_text("tampered\n", encoding="utf-8")
+
+        with pytest.raises(LeanDeclarationBackendError) as raised:
+            indexed.search(target)
+
+        assert raised.value.code == "LEAN_QUERY_INDEX_CHANGED"
+        assert LeanEnvironment.CORE not in indexed_backend._sessions
+    finally:
+        indexed_backend.close()
+        fresh_backend.close()
 
 
 @pytest.mark.skipif(

--- a/tests/unit/test_lean_declarations.py
+++ b/tests/unit/test_lean_declarations.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import hashlib
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -28,6 +31,7 @@ from jacobian.lean_declarations import (
     LeanDeclarationBackendError,
     LeanDeclarationService,
     LeanSubprocessDeclarationBackend,
+    _parse_session_response,
 )
 
 _DIGEST = "sha256:" + "a" * 64
@@ -74,6 +78,90 @@ class MissingDeclarationBackend:
             "LEAN_DECLARATION_NOT_FOUND",
             "Lean did not find the exact declaration 'Missing.name'.",
         )
+
+
+@dataclass
+class RecordingSession:
+    responses: list[dict[str, Any] | LeanDeclarationBackendError]
+    requests: list[dict[str, Any]] = field(default_factory=list)
+    closed: bool = False
+    active: int = 0
+    max_active: int = 0
+    request_delay: float = 0.0
+    after_request: Any = None
+    activity_lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def request(
+        self,
+        payload: dict[str, Any],
+        *,
+        timeout_seconds: int,
+    ) -> dict[str, Any]:
+        del timeout_seconds
+        with self.activity_lock:
+            self.active += 1
+            self.max_active = max(self.max_active, self.active)
+        try:
+            self.requests.append(payload)
+            if self.request_delay:
+                time.sleep(self.request_delay)
+            response = self.responses.pop(0)
+            if isinstance(response, LeanDeclarationBackendError):
+                raise response
+            return response
+        finally:
+            if self.after_request is not None:
+                self.after_request()
+            with self.activity_lock:
+                self.active -= 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class RecordingSubprocessBackend(LeanSubprocessDeclarationBackend):
+    def __init__(
+        self,
+        *,
+        lean_executable: Path,
+        provider_runtime: CapabilityProviderRuntime,
+        sessions: list[RecordingSession],
+    ) -> None:
+        super().__init__(
+            lean_executable=lean_executable,
+            mathlib_runtime=None,
+            provider_runtime=provider_runtime,
+        )
+        self.pending_sessions = sessions
+        self.started_sessions: list[RecordingSession] = []
+
+    def _start_session(
+        self,
+        environment: LeanEnvironment,
+        environment_digest: str,
+    ) -> RecordingSession:
+        del environment, environment_digest
+        session = self.pending_sessions.pop(0)
+        self.started_sessions.append(session)
+        return session
+
+
+def _recording_backend(
+    tmp_path: Path,
+    sessions: list[RecordingSession],
+) -> tuple[RecordingSubprocessBackend, Path]:
+    executable = tmp_path / "lean"
+    executable.write_bytes(b"pinned lean executable")
+    digest = "sha256:" + hashlib.sha256(executable.read_bytes()).hexdigest()
+    runtime = _RUNTIME.model_copy(update={"digest": digest, "features": ("CORE",)})
+    return (
+        RecordingSubprocessBackend(
+            lean_executable=executable,
+            provider_runtime=runtime,
+            sessions=sessions,
+        ),
+        executable,
+    )
 
 
 def test_search_adapter_exposes_bounded_computed_retrieval() -> None:
@@ -248,3 +336,127 @@ def test_environment_identity_fails_closed_if_the_lean_executable_changes(
         backend.environment_digest(LeanEnvironment.CORE)
 
     assert raised.value.code == "LEAN_ENVIRONMENT_CHANGED"
+
+
+def test_subprocess_backend_reuses_one_pinned_session_per_environment(
+    tmp_path: Path,
+) -> None:
+    session = RecordingSession(
+        responses=[
+            {"operation": "search", "declarations": []},
+            {"operation": "inspect", "declaration": {"name": "Nat.add"}},
+        ]
+    )
+    backend, _ = _recording_backend(tmp_path, [session])
+
+    searched = backend.query(
+        LeanEnvironment.CORE,
+        {"operation": "search"},
+    )
+    inspected = backend.query(
+        LeanEnvironment.CORE,
+        {"operation": "inspect"},
+    )
+
+    assert len(backend.started_sessions) == 1
+    assert [request["operation"] for request in session.requests] == [
+        "search",
+        "inspect",
+    ]
+    assert searched["_environment_digest"] == inspected["_environment_digest"]
+    backend.close()
+    assert session.closed
+
+
+def test_subprocess_backend_serializes_concurrent_session_requests(
+    tmp_path: Path,
+) -> None:
+    session = RecordingSession(
+        responses=[
+            {"operation": "search", "declarations": []},
+            {"operation": "search", "declarations": []},
+        ],
+        request_delay=0.05,
+    )
+    backend, _ = _recording_backend(tmp_path, [session])
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(
+            executor.map(
+                lambda _: backend.query(
+                    LeanEnvironment.CORE,
+                    {"operation": "search"},
+                ),
+                range(2),
+            )
+        )
+
+    assert len(results) == 2
+    assert len(backend.started_sessions) == 1
+    assert session.max_active == 1
+    backend.close()
+
+
+def test_subprocess_backend_rejects_result_if_environment_changes_during_query(
+    tmp_path: Path,
+) -> None:
+    session = RecordingSession(responses=[{"operation": "search"}])
+    backend, executable = _recording_backend(tmp_path, [session])
+    session.after_request = lambda: executable.write_bytes(b"changed executable")
+
+    with pytest.raises(LeanDeclarationBackendError) as raised:
+        backend.query(LeanEnvironment.CORE, {"operation": "search"})
+
+    assert raised.value.code == "LEAN_ENVIRONMENT_CHANGED"
+    assert session.closed
+
+
+def test_subprocess_backend_discards_timed_out_session_before_retry(
+    tmp_path: Path,
+) -> None:
+    timed_out = RecordingSession(
+        responses=[
+            LeanDeclarationBackendError(
+                "LEAN_QUERY_TIMEOUT",
+                "Lean declaration discovery timed out.",
+            )
+        ]
+    )
+    replacement = RecordingSession(responses=[{"operation": "search"}])
+    backend, _ = _recording_backend(tmp_path, [timed_out, replacement])
+
+    with pytest.raises(LeanDeclarationBackendError) as raised:
+        backend.query(LeanEnvironment.CORE, {"operation": "search"})
+    result = backend.query(LeanEnvironment.CORE, {"operation": "search"})
+
+    assert raised.value.code == "LEAN_QUERY_TIMEOUT"
+    assert timed_out.closed
+    assert len(backend.started_sessions) == 2
+    assert result["operation"] == "search"
+    backend.close()
+
+
+def test_session_protocol_rejects_mismatched_request_identity() -> None:
+    line = (
+        'JACOBIAN_DECLARATION_RESULT {"request_id":"stale",'
+        '"payload":{"operation":"search"}}'
+    )
+
+    with pytest.raises(LeanDeclarationBackendError) as raised:
+        _parse_session_response(line, expected_request_id="current")
+
+    assert raised.value.code == "LEAN_QUERY_PROTOCOL_ERROR"
+
+
+def test_session_protocol_preserves_exact_missing_declaration_failure() -> None:
+    line = (
+        'JACOBIAN_DECLARATION_ERROR {"request_id":"current",'
+        '"code":"LEAN_DECLARATION_NOT_FOUND",'
+        '"message":"declaration not found: Missing.name"}'
+    )
+
+    with pytest.raises(LeanDeclarationBackendError) as raised:
+        _parse_session_response(line, expected_request_id="current")
+
+    assert raised.value.code == "LEAN_DECLARATION_NOT_FOUND"
+    assert raised.value.message == "Lean did not find the exact requested declaration."


### PR DESCRIPTION
## Problem

Lean declaration discovery repeatedly imported Mathlib, sorted and scanned the full environment, and exact inspection linearly searched all constants. In the held-out pilot this caused repeated 75-second tool failures and large agent overhead.

## Change

- Build an atomic, backend-local declaration catalog from pinned Lean module metadata.
- Bind the catalog to the exact environment digest and byte digest; reject identity changes, partial writes, stale response IDs, and tampering.
- Use exact catalog scan positions to preselect bounded candidates, then resolve and recheck every candidate and elaborated type inside Lean.
- Use direct environment lookup for exact inspection.
- Serialize concurrent calls per environment and discard failed or timed-out sessions before retry.
- Document the capability-layer measurements and frozen held-out rerun.

## Compatibility and trust

The public search and inspect request/output contracts are unchanged. Search completeness, exact scan counts, `COMPUTED` assurance, and the independent `lean.check` verification boundary are preserved. The Mathlib per-query operational budget changes from 75 to 105 seconds; this does not promote any result or turn timeout/failure into a conclusion.

## Evidence

On the development host, fresh `List.revzip` search completed in 28.886s, catalog reuse in 9.568s, and exact inspection in 9.146s. Fresh and reused searches agreed on the three declarations, `RESULT_LIMIT`, and `scanned_declarations = 145293`.

The frozen model-in-the-loop follow-up passed all four conditions with no false certification, parameter/tool/shell errors, or operational failure. Neither treatment selected discovery, so the PR does not claim autonomous outcome lift; recommendation status remains experimental.

## Validation

- `uv run pytest` — 446 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`
- `git diff --check`
- `git diff -- AGENTS.md README.md docs/`
- verified the built wheel contains `jacobian/_lean_declaration_query.lean`
