### PR TITLE
feat(sat): define canonical SAT artifact contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ Release contracts and engineering evidence are:
 - [Tool surface](docs/reference/tools.md)
 - [Provider runtime contract](docs/reference/provider-runtime.md) for
   availability, exact backend identity, install tiers, and local measurement.
+- [SAT artifact contracts](docs/reference/sat-artifacts.md) for canonical CNF,
+  total assignment, and raw proof identity before solver or checker
+  installation.
 - [v0.2 specification](docs/reference/specifications/v0.2.md) and
   [conformance gate](docs/reference/conformance-v0.2.md)
 - [Testing strategy](docs/reference/testing-strategy.md),
@@ -137,6 +140,10 @@ adapter registry and trust-labeled artifacts. Bundled capabilities cover graph
 construction and properties, exact rational polynomial maps, finite magma law
 evaluation and countermodel search, reference-domain exploration and
 verification, Lean checking, and local research-memory search.
+
+The base kernel also registers canonical CNF, total assignment, and raw DRAT
+proof artifact contracts. They do not add SAT capabilities or mathematical
+assurance; solver and independent-checker slices remain separate.
 
 Three direct operational tools—`workspace.open`, `workspace.write`, and
 `workspace.query`—provide durable, revisioned paper-like working state outside

--- a/docs/contributing/atomic-capability-portfolio.md
+++ b/docs/contributing/atomic-capability-portfolio.md
@@ -359,6 +359,17 @@ variable map, projection version, declared scope, provider version, and
 resource budget. Preserve the raw proof as a durable artifact but keep bounded
 inline summaries small.
 
+The artifact-contract checkpoint was implemented on 2026-07-26. The base
+kernel now registers model-backed schemas for canonical CNF, total assignment,
+and raw DRAT proof artifacts without installing a solver, checker, or SAT
+capability. Canonicalization deterministically renumbers the sorted variable
+map, removes duplicate literals and clauses, omits tautologies, orders the
+remaining clauses, and binds the resulting DIMACS bytes. Assignment and proof
+artifacts bind the exact CNF URI, object and payload digests, variable map,
+projection, full scope, producer runtime, and resource budget. Raw proof
+storage and assignment payloads remain unverified. See
+[SAT artifact contracts](../reference/sat-artifacts.md).
+
 CaDiCaL has a small source build and a command line that accepts DIMACS plus a
 proof path. DRAT-trim independently validates a DRAT proof against the input
 formula. A valid SAT assignment can be checked with a deliberately small
@@ -481,7 +492,8 @@ backlog.
    reproduction.
 3. Paired Lean discovery evaluation; decide expose, revise, consolidate into
    examples, or stop.
-4. Canonical CNF, assignment, and proof artifact schemas.
+4. Canonical CNF, assignment, and proof artifact schemas. Implemented; see
+   [SAT artifact contracts](../reference/sat-artifacts.md).
 5. Pure independent SAT-assignment checker with attack tests.
 6. CaDiCaL model and proof-producing exploration adapters.
 7. DRAT-trim clean-process checker, authorization fixture, and attack tests.

--- a/docs/explanation/threat-model.md
+++ b/docs/explanation/threat-model.md
@@ -132,7 +132,9 @@ Controls:
 
 - constrained versioned canonical encoding;
 - domain-separated object identity;
-- validation before persistence;
+- validation before persistence, including registered model-backed cross-field
+  invariants when ordering or derived digests cannot be expressed in JSON
+  Schema alone;
 - size, depth, and dependency limits;
 - digest verification on read.
 
@@ -157,6 +159,24 @@ Controls:
   artifact URIs in the verification record's parents; equal object digests in
   different artifact carriers are insufficient;
 - no caller-controlled checker executable.
+
+### SAT source or projection substitution
+
+An assignment or proof may name another CNF, reuse a variable map with changed
+clauses, change literal numbering, or relabel proof bytes under another format
+version.
+
+Controls:
+
+- canonical CNF artifacts bind the ordered variable map and deterministic
+  DIMACS projection by digest;
+- assignment and raw proof artifacts bind the exact CNF artifact URI, object
+  and payload digests, variable-map and DIMACS digests, projection version,
+  full scope, producer runtime, and resource budget;
+- evidence artifacts retain the exact CNF as a parent;
+- assignment and raw proof storage remains unverified; and
+- future independent checkers must validate every binding before mathematical
+  replay and fail closed on any mismatch.
 
 ### Buggy or compromised checker
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,6 +59,7 @@ expectations.
 - [Tool surface](reference/tools.md)
 - [Provider runtime contract](reference/provider-runtime.md)
 - [Lean declaration discovery](reference/lean-declaration-discovery.md)
+- [SAT artifact contracts](reference/sat-artifacts.md)
 - [v0.2 specification](reference/specifications/v0.2.md)
 - [v0.2 conformance specification](reference/conformance-v0.2.md)
 - [Plugin conformance contract](reference/plugin-conformance.md)

--- a/docs/reference/sat-artifacts.md
+++ b/docs/reference/sat-artifacts.md
@@ -1,0 +1,134 @@
+# SAT artifact contracts
+
+[Documentation home](../index.md)
+
+- Status: Experimental pre-stable contract
+- Installed operations: none
+- Related plan:
+  [Atomic capability portfolio](../contributing/atomic-capability-portfolio.md#wave-2-sat-certificate-vertical-slice)
+
+Jacobian installs canonical CNF, total assignment, and raw DRAT proof artifact
+contracts before installing any SAT solver or checker. These artifacts are
+typed inputs and unverified evidence. Storing an assignment does not establish
+SAT, and storing proof bytes does not establish UNSAT.
+
+## Registered descriptors
+
+`JacobianKernel.sat.installation` exposes the content-addressed descriptor URIs
+registered by the current kernel:
+
+| Descriptor | Registered name and version | Purpose |
+| --- | --- | --- |
+| Semantics | `jacobian.sat@1` | Shared propositional-CNF meaning and evidence boundary |
+| Schema | `jacobian.canonical-cnf@1` | Canonical named-variable CNF and DIMACS binding |
+| Schema | `jacobian.sat-assignment@1` | Total assignment candidate bound to one CNF |
+| Schema | `jacobian.sat-proof@1` | Preserved raw DRAT bytes bound to one CNF |
+
+The schema URIs are content addressed. They are not capability IDs and do not
+add tools to `capability://catalog`.
+
+The SAT schemas are model backed. JSON Schema checks their closed structural
+shape, and the same registry validation path also applies the domain
+cross-field invariants before `artifact.put` commits a payload. Kernel
+construction re-registers those model contracts after restart.
+
+## Canonical CNF
+
+`canonicalize_cnf` accepts variable names plus signed integer clauses. Literal
+IDs refer to the caller's variable-name order. It then:
+
+1. validates the bounded ASCII variable names;
+2. sorts names and assigns contiguous DIMACS IDs starting at one;
+3. renumbers every literal through that map;
+4. removes duplicate literals and clauses;
+5. omits tautological clauses;
+6. sorts literals by variable ID and polarity and sorts the resulting clauses;
+   and
+7. computes the variable-map and deterministic-DIMACS digests.
+
+An empty clause is retained because it is mathematically material. An empty
+formula and unused declared variables are also representable. A literal that
+is zero or refers outside the declared variable map is rejected.
+
+The deterministic projection is:
+
+```text
+p cnf <variable-count> <clause-count>
+<signed literals> 0
+```
+
+It uses ASCII, one LF-terminated row per clause, and projection version
+`jacobian.dimacs.cnf/v1`. The payload records:
+
+- `variable_map_digest`, over the exact ordered symbolic-name map; and
+- `dimacs_digest`, over the exact projected bytes.
+
+Consequently, reordering equivalent source input before canonicalization gives
+one artifact identity. Presenting a stored payload with reordered canonical
+clauses is invalid rather than a second representation.
+
+## Exact CNF binding
+
+Every assignment and proof contains a `SatCnfBinding` with:
+
+| Field | Bound material |
+| --- | --- |
+| `cnf_artifact_uri` | Exact stored manifest and lineage identity |
+| `cnf_object_digest` | Schema-, semantics-, canonicalizer-, and payload-bound object |
+| `cnf_payload_digest` | Canonical CNF payload bytes |
+| `variable_map_digest` | Ordered symbolic-name to DIMACS-ID map |
+| `dimacs_digest` | Exact solver-facing projection |
+| `projection_format`, `projection_version` | DIMACS interpretation |
+| `variable_count`, `clause_count` | Declared full-instance scope |
+
+`SatArtifactService` derives this record from a stored canonical CNF. It does
+not accept a caller-supplied replacement binding, and it records the CNF
+artifact as the evidence artifact's parent.
+
+## Assignment artifacts
+
+An assignment is a strict Boolean vector in variable-map order. Its length must
+equal `variable_count`; partial assignments are not part of version 1. It also
+records:
+
+- declared scope `FULL_CNF`;
+- an available `CapabilityProviderRuntime`, including provider version and
+  exact runtime digest; and
+- the search resource budget, with a required wall-clock bound and optional
+  memory and conflict bounds.
+
+The assignment schema has no conclusion, verification status, checker ID, or
+certificate claim. A later `sat.model.verify` capability must load the bound
+CNF and independently evaluate every clause.
+
+## Raw proof artifacts
+
+A proof artifact preserves the exact raw bytes as canonical base64 and records
+their SHA-256 digest. Version 1 binds:
+
+- format `DRAT`;
+- format version `drat-text/v1`;
+- encoding `BASE64`;
+- declared scope `FULL_CNF`;
+- the complete CNF binding;
+- the exact producer runtime; and
+- the producing search budget.
+
+The artifact layer does not parse the proof or infer UNSAT. Malformed,
+truncated, or adversarial bytes may be retained as unverified evidence for
+later fail-closed replay. The current artifact store has a 10 MiB payload
+limit, and this contract bounds the base64 field to 8,000,000 characters.
+
+## Trust boundary
+
+The following are deliberately outside this slice:
+
+- no assignment evaluator;
+- no CaDiCaL invocation or solver-status interpretation;
+- no DRAT-trim process or checker authorization;
+- no SAT or UNSAT conclusion; and
+- no `VERIFIED` result.
+
+The next slice adds the deliberately small independent assignment checker.
+Proof production and independent clean-process proof replay remain later,
+separate changes.

--- a/src/jacobian/contracts/sat.py
+++ b/src/jacobian/contracts/sat.py
@@ -1,0 +1,353 @@
+"""Canonical SAT instance and unverified evidence artifact contracts."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import unicodedata
+from collections.abc import Iterable, Sequence
+from typing import Annotated, Literal, Self
+
+from pydantic import (
+    Field,
+    StrictBool,
+    StrictInt,
+    StringConstraints,
+    field_validator,
+    model_validator,
+)
+
+from jacobian.canonical import canonicalize_json
+from jacobian.contracts.capabilities import (
+    CapabilityProviderAvailability,
+    CapabilityProviderRuntime,
+)
+from jacobian.contracts.common import ArtifactUri, Sha256Digest
+from jacobian.contracts.results import ContractModel
+
+SatVariableName = Annotated[
+    str,
+    StringConstraints(
+        pattern=r"^[A-Za-z_][A-Za-z0-9_.:-]{0,127}$",
+        strict=True,
+    ),
+]
+CanonicalBase64 = Annotated[
+    str,
+    StringConstraints(
+        pattern=r"^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+        max_length=8_000_000,
+        strict=True,
+    ),
+]
+
+_PROJECTION_FORMAT: Literal["DIMACS-CNF"] = "DIMACS-CNF"
+_PROJECTION_VERSION: Literal["jacobian.dimacs.cnf/v1"] = "jacobian.dimacs.cnf/v1"
+_PROOF_FORMAT: Literal["DRAT"] = "DRAT"
+_PROOF_FORMAT_VERSION: Literal["drat-text/v1"] = "drat-text/v1"
+
+
+def _sha256(value: bytes) -> str:
+    return f"sha256:{hashlib.sha256(value).hexdigest()}"
+
+
+class SatVariableBinding(ContractModel):
+    """One deterministic symbolic-name to DIMACS-ID binding."""
+
+    id: StrictInt = Field(ge=1, le=1_000_000)
+    name: SatVariableName
+
+    @field_validator("name", mode="before")
+    @classmethod
+    def normalize_name(cls, value: object) -> object:
+        if isinstance(value, str):
+            return unicodedata.normalize("NFC", value)
+        return value
+
+
+class SatClause(ContractModel):
+    """One canonical disjunction of signed DIMACS literals."""
+
+    literals: tuple[StrictInt, ...] = Field(max_length=1_000_000)
+
+    @model_validator(mode="after")
+    def require_canonical_literals(self) -> Self:
+        if any(literal == 0 for literal in self.literals):
+            raise ValueError("clause literals must be nonzero")
+        if len(set(self.literals)) != len(self.literals):
+            raise ValueError("clause literals must be unique and canonically ordered")
+        if any(-literal in self.literals for literal in self.literals):
+            raise ValueError("tautological clauses must be omitted")
+        if self.literals != tuple(sorted(self.literals, key=_literal_sort_key)):
+            raise ValueError("clause literals must be unique and canonically ordered")
+        return self
+
+
+class CanonicalCnf(ContractModel):
+    """Canonical named-variable CNF with a deterministic DIMACS projection."""
+
+    cnf_schema_version: Literal["1"] = "1"
+    variables: tuple[SatVariableBinding, ...] = Field(max_length=1_000_000)
+    clauses: tuple[SatClause, ...] = Field(max_length=1_000_000)
+    projection_format: Literal["DIMACS-CNF"] = _PROJECTION_FORMAT
+    projection_version: Literal["jacobian.dimacs.cnf/v1"] = _PROJECTION_VERSION
+    variable_map_digest: Sha256Digest
+    dimacs_digest: Sha256Digest
+
+    @model_validator(mode="after")
+    def require_canonical_instance(self) -> Self:
+        expected_variables = tuple(
+            (index, variable.name)
+            for index, variable in enumerate(
+                sorted(self.variables, key=lambda variable: variable.name),
+                start=1,
+            )
+        )
+        actual_variables = tuple(
+            (variable.id, variable.name) for variable in self.variables
+        )
+        if actual_variables != expected_variables:
+            raise ValueError("variables must use contiguous IDs and ascending names")
+        variable_count = len(self.variables)
+        if any(
+            abs(literal) > variable_count
+            for clause in self.clauses
+            for literal in clause.literals
+        ):
+            raise ValueError("literal references an undeclared variable")
+        if len(set(self.clauses)) != len(self.clauses) or self.clauses != tuple(
+            sorted(self.clauses, key=_clause_sort_key)
+        ):
+            raise ValueError("clauses must be unique and canonically ordered")
+        if self.variable_map_digest != sat_variable_map_digest(self.variables):
+            raise ValueError("variable-map digest does not match the canonical map")
+        if self.dimacs_digest != _sha256(self.to_dimacs_bytes()):
+            raise ValueError(
+                "DIMACS digest does not match the deterministic projection"
+            )
+        return self
+
+    def to_dimacs_bytes(self) -> bytes:
+        """Project this exact canonical instance to deterministic DIMACS bytes."""
+
+        return _dimacs_bytes(len(self.variables), self.clauses)
+
+
+class SatCnfBinding(ContractModel):
+    """Identity needed to replay evidence against one exact CNF projection."""
+
+    binding_version: Literal["1"] = "1"
+    cnf_artifact_uri: ArtifactUri
+    cnf_object_digest: Sha256Digest
+    cnf_payload_digest: Sha256Digest
+    variable_map_digest: Sha256Digest
+    dimacs_digest: Sha256Digest
+    projection_format: Literal["DIMACS-CNF"]
+    projection_version: Literal["jacobian.dimacs.cnf/v1"]
+    variable_count: StrictInt = Field(ge=0, le=1_000_000)
+    clause_count: StrictInt = Field(ge=0, le=1_000_000)
+
+
+class SatResourceBudget(ContractModel):
+    """Declared search budget that produced an unverified evidence artifact."""
+
+    budget_version: Literal["1"] = "1"
+    wall_seconds: StrictInt = Field(ge=1, le=86_400)
+    memory_bytes: StrictInt | None = Field(
+        default=None,
+        ge=1,
+        le=1 << 50,
+    )
+    conflicts: StrictInt | None = Field(
+        default=None,
+        ge=1,
+        le=(1 << 53) - 1,
+    )
+
+
+class SatAssignmentArtifact(ContractModel):
+    """One total, exact, but not self-verifying assignment candidate."""
+
+    assignment_schema_version: Literal["1"] = "1"
+    cnf: SatCnfBinding
+    declared_scope: Literal["FULL_CNF"] = "FULL_CNF"
+    values: tuple[StrictBool, ...] = Field(max_length=1_000_000)
+    producer: CapabilityProviderRuntime
+    resource_budget: SatResourceBudget
+
+    @model_validator(mode="after")
+    def require_total_bound_assignment(self) -> Self:
+        if len(self.values) != self.cnf.variable_count:
+            raise ValueError(
+                "assignment must contain one value for every bound variable"
+            )
+        _require_available_producer(self.producer)
+        return self
+
+
+class SatProofArtifact(ContractModel):
+    """Raw proof bytes bound to one exact CNF without claiming validity."""
+
+    proof_schema_version: Literal["1"] = "1"
+    cnf: SatCnfBinding
+    declared_scope: Literal["FULL_CNF"] = "FULL_CNF"
+    proof_format: Literal["DRAT"] = _PROOF_FORMAT
+    proof_format_version: Literal["drat-text/v1"] = _PROOF_FORMAT_VERSION
+    proof_encoding: Literal["BASE64"] = "BASE64"
+    proof_base64: CanonicalBase64
+    proof_digest: Sha256Digest
+    producer: CapabilityProviderRuntime
+    resource_budget: SatResourceBudget
+
+    @model_validator(mode="after")
+    def require_exact_raw_proof(self) -> Self:
+        raw = _decode_base64(self.proof_base64)
+        if self.proof_base64 != base64.b64encode(raw).decode("ascii"):
+            raise ValueError("proof bytes must use canonical base64")
+        if self.proof_digest != _sha256(raw):
+            raise ValueError("raw proof digest does not match the preserved bytes")
+        _require_available_producer(self.producer)
+        return self
+
+    @classmethod
+    def from_bytes(
+        cls,
+        *,
+        cnf: SatCnfBinding,
+        proof: bytes,
+        producer: CapabilityProviderRuntime,
+        resource_budget: SatResourceBudget,
+    ) -> SatProofArtifact:
+        """Encode exact raw proof bytes without interpreting solver output."""
+
+        return cls(
+            cnf=cnf,
+            proof_base64=base64.b64encode(proof).decode("ascii"),
+            proof_digest=_sha256(proof),
+            producer=producer,
+            resource_budget=resource_budget,
+        )
+
+    def raw_bytes(self) -> bytes:
+        """Recover the exact proof bytes preserved by this artifact."""
+
+        return _decode_base64(self.proof_base64)
+
+
+def canonicalize_cnf(
+    *,
+    variable_names: Sequence[str],
+    clauses: Iterable[Iterable[int]],
+) -> CanonicalCnf:
+    """Normalize one named CNF and return its unique artifact payload.
+
+    Input literal IDs refer to the supplied variable-name order. Names are NFC
+    normalized and sorted; literals are renumbered with that map. Duplicate
+    literals and clauses are removed, and tautological clauses are omitted.
+    """
+
+    normalized_names: list[str] = []
+    for name in variable_names:
+        if not isinstance(name, str):
+            raise ValueError("variable names must be strings")
+        normalized_names.append(unicodedata.normalize("NFC", name))
+    if len(set(normalized_names)) != len(normalized_names):
+        raise ValueError("variable names must be unique after NFC normalization")
+
+    indexed_names = tuple(enumerate(normalized_names, start=1))
+    sorted_names = tuple(sorted(indexed_names, key=lambda item: item[1]))
+    old_to_new = {
+        old_id: new_id for new_id, (old_id, _name) in enumerate(sorted_names, start=1)
+    }
+    variables = tuple(
+        SatVariableBinding(id=new_id, name=name)
+        for new_id, (_old_id, name) in enumerate(sorted_names, start=1)
+    )
+
+    canonical_clauses: set[tuple[int, ...]] = set()
+    for raw_clause in clauses:
+        remapped: set[int] = set()
+        tautological = False
+        for literal in raw_clause:
+            if (
+                isinstance(literal, bool)
+                or not isinstance(literal, int)
+                or literal == 0
+            ):
+                raise ValueError("clause literals must be nonzero integers")
+            old_id = abs(literal)
+            try:
+                new_id = old_to_new[old_id]
+            except KeyError as exc:
+                raise ValueError(
+                    "clause literal references an undeclared variable"
+                ) from exc
+            mapped = new_id if literal > 0 else -new_id
+            if -mapped in remapped:
+                tautological = True
+            remapped.add(mapped)
+        if not tautological:
+            canonical_clauses.add(tuple(sorted(remapped, key=_literal_sort_key)))
+
+    clause_models = tuple(
+        SatClause(literals=literals)
+        for literals in sorted(canonical_clauses, key=_literal_tuple_sort_key)
+    )
+    return CanonicalCnf(
+        variables=variables,
+        clauses=clause_models,
+        variable_map_digest=sat_variable_map_digest(variables),
+        dimacs_digest=_sha256(_dimacs_bytes(len(variables), clause_models)),
+    )
+
+
+def sat_variable_map_digest(
+    variables: Sequence[SatVariableBinding],
+) -> str:
+    """Digest one exact variable map under a domain-separated wire format."""
+
+    payload = {
+        "variable_map_format": "jacobian.sat.variable-map/v1",
+        "variables": [variable.model_dump(mode="json") for variable in variables],
+    }
+    return _sha256(canonicalize_json(payload))
+
+
+def _literal_sort_key(literal: int) -> tuple[int, bool]:
+    return abs(literal), literal > 0
+
+
+def _literal_tuple_sort_key(
+    literals: tuple[int, ...],
+) -> tuple[tuple[int, bool], ...]:
+    return tuple(_literal_sort_key(literal) for literal in literals)
+
+
+def _clause_sort_key(
+    clause: SatClause,
+) -> tuple[tuple[int, bool], ...]:
+    return _literal_tuple_sort_key(clause.literals)
+
+
+def _dimacs_bytes(
+    variable_count: int,
+    clauses: Sequence[SatClause],
+) -> bytes:
+    rows = [f"p cnf {variable_count} {len(clauses)}\n"]
+    for clause in clauses:
+        prefix = " ".join(str(literal) for literal in clause.literals)
+        rows.append(f"{prefix} 0\n" if prefix else "0\n")
+    return "".join(rows).encode("ascii")
+
+
+def _decode_base64(value: str) -> bytes:
+    try:
+        return base64.b64decode(value.encode("ascii"), validate=True)
+    except (UnicodeEncodeError, ValueError, binascii.Error) as exc:
+        raise ValueError("proof bytes must use canonical base64") from exc
+
+
+def _require_available_producer(producer: CapabilityProviderRuntime) -> None:
+    if producer.availability is not CapabilityProviderAvailability.AVAILABLE:
+        raise ValueError("SAT evidence requires an available producer runtime")

--- a/src/jacobian/kernel.py
+++ b/src/jacobian/kernel.py
@@ -51,6 +51,7 @@ from jacobian.references import (
     ReferenceInstaller,
 )
 from jacobian.registry import CheckerRegistry
+from jacobian.sat import SatArtifactService, install_sat_artifacts
 from jacobian.schema_registry import SchemaRegistry
 from jacobian.search import SearchService
 from jacobian.shrinking import ShrinkService
@@ -85,6 +86,11 @@ class JacobianKernel:
         self.store = ArtifactStore(root)
         self.schemas = SchemaRegistry(self.store)
         self.artifacts = ArtifactService(self.store, self.schemas)
+        self.sat: SatArtifactService = install_sat_artifacts(
+            self.store,
+            self.schemas,
+            self.artifacts,
+        )
         self.memory = ResearchMemory(self.store, self.schemas)
         self.workspaces = WorkspaceService(self.store, self.schemas)
         self.plugins = PluginRegistry(self.store)

--- a/src/jacobian/sat.py
+++ b/src/jacobian/sat.py
@@ -1,0 +1,206 @@
+"""Registration and materialization for canonical SAT artifacts."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+
+from pydantic import ValidationError
+
+from jacobian.artifacts import ArtifactService
+from jacobian.contracts.artifacts import ArtifactPutResult
+from jacobian.contracts.capabilities import CapabilityProviderRuntime
+from jacobian.contracts.sat import (
+    CanonicalCnf,
+    SatAssignmentArtifact,
+    SatCnfBinding,
+    SatProofArtifact,
+    SatResourceBudget,
+    canonicalize_cnf,
+)
+from jacobian.schema_registry import SchemaRegistry, SchemaRegistryError
+from jacobian.store import ArtifactStore, StoreError
+
+
+class SatArtifactError(ValueError):
+    """A SAT artifact cannot be created against the requested source."""
+
+
+@dataclass(frozen=True, slots=True)
+class SatArtifactInstallation:
+    semantics_uri: str
+    cnf_schema_uri: str
+    assignment_schema_uri: str
+    proof_schema_uri: str
+
+
+class SatArtifactService:
+    """Materialize SAT instances and unverified evidence with exact bindings."""
+
+    def __init__(
+        self,
+        store: ArtifactStore,
+        schemas: SchemaRegistry,
+        artifacts: ArtifactService,
+        installation: SatArtifactInstallation,
+    ) -> None:
+        self.store = store
+        self.schemas = schemas
+        self.artifacts = artifacts
+        self.installation = installation
+
+    def put_cnf(
+        self,
+        *,
+        variable_names: Sequence[str],
+        clauses: Iterable[Iterable[int]],
+    ) -> ArtifactPutResult:
+        """Canonicalize and materialize one named CNF instance."""
+
+        cnf = canonicalize_cnf(variable_names=variable_names, clauses=clauses)
+        return self.artifacts.put(
+            schema_uri=self.installation.cnf_schema_uri,
+            semantics_uri=self.installation.semantics_uri,
+            payload=cnf.model_dump(mode="json"),
+            summary=(
+                f"canonical CNF: {len(cnf.variables)} variables, "
+                f"{len(cnf.clauses)} clauses"
+            ),
+        )
+
+    def bind_cnf(self, cnf_uri: str) -> SatCnfBinding:
+        """Resolve one canonical CNF and bind its exact stored identity."""
+
+        try:
+            artifact = self.store.get(cnf_uri)
+        except StoreError as exc:
+            raise SatArtifactError(
+                "source is not an available canonical CNF artifact"
+            ) from exc
+        if (
+            artifact.manifest.schema_uri != self.installation.cnf_schema_uri
+            or artifact.manifest.semantics_uri != self.installation.semantics_uri
+        ):
+            raise SatArtifactError("source is not a canonical CNF artifact")
+        try:
+            normalized = self.schemas.validate(
+                self.installation.cnf_schema_uri,
+                artifact.payload,
+            )
+            cnf = CanonicalCnf.model_validate(normalized)
+        except (SchemaRegistryError, ValueError, ValidationError) as exc:
+            raise SatArtifactError(
+                "source is not a valid canonical CNF artifact"
+            ) from exc
+        return SatCnfBinding(
+            cnf_artifact_uri=artifact.artifact_uri,
+            cnf_object_digest=artifact.manifest.object_digest,
+            cnf_payload_digest=artifact.manifest.payload_digest,
+            variable_map_digest=cnf.variable_map_digest,
+            dimacs_digest=cnf.dimacs_digest,
+            projection_format=cnf.projection_format,
+            projection_version=cnf.projection_version,
+            variable_count=len(cnf.variables),
+            clause_count=len(cnf.clauses),
+        )
+
+    def put_assignment(
+        self,
+        *,
+        cnf_uri: str,
+        values: Sequence[bool],
+        producer: CapabilityProviderRuntime,
+        resource_budget: SatResourceBudget,
+    ) -> ArtifactPutResult:
+        """Materialize one total assignment candidate without verifying it."""
+
+        assignment = SatAssignmentArtifact(
+            cnf=self.bind_cnf(cnf_uri),
+            values=tuple(values),
+            producer=producer,
+            resource_budget=resource_budget,
+        )
+        return self.artifacts.put(
+            schema_uri=self.installation.assignment_schema_uri,
+            semantics_uri=self.installation.semantics_uri,
+            payload=assignment.model_dump(mode="json"),
+            parents=(cnf_uri,),
+            summary="unverified SAT assignment candidate",
+        )
+
+    def put_proof(
+        self,
+        *,
+        cnf_uri: str,
+        proof: bytes,
+        producer: CapabilityProviderRuntime,
+        resource_budget: SatResourceBudget,
+    ) -> ArtifactPutResult:
+        """Preserve raw DRAT bytes without interpreting or verifying them."""
+
+        proof_artifact = SatProofArtifact.from_bytes(
+            cnf=self.bind_cnf(cnf_uri),
+            proof=proof,
+            producer=producer,
+            resource_budget=resource_budget,
+        )
+        return self.artifacts.put(
+            schema_uri=self.installation.proof_schema_uri,
+            semantics_uri=self.installation.semantics_uri,
+            payload=proof_artifact.model_dump(mode="json"),
+            parents=(cnf_uri,),
+            summary="unverified raw DRAT proof",
+        )
+
+
+def install_sat_artifacts(
+    store: ArtifactStore,
+    schemas: SchemaRegistry,
+    artifacts: ArtifactService,
+) -> SatArtifactService:
+    """Register the SAT artifact boundary without installing a solver or checker."""
+
+    semantics_uri = store.register_descriptor(
+        kind="semantics",
+        name="jacobian.sat",
+        version="1",
+        definition={
+            "domain": "propositional Boolean satisfiability in conjunctive normal form",
+            "cnf": (
+                "variables use contiguous DIMACS IDs ordered by NFC-normalized names; "
+                "literals and clauses are unique and canonically ordered; duplicate "
+                "literals and clauses are removed; tautological clauses are omitted"
+            ),
+            "projection": (
+                "DIMACS-CNF bytes use jacobian.dimacs.cnf/v1 and are bound by digest"
+            ),
+            "assignment": (
+                "a total unverified candidate bound to the exact CNF artifact, "
+                "variable map, projection, producer runtime, scope, and resource budget"
+            ),
+            "proof": (
+                "raw DRAT bytes preserved as canonical base64 and bound to the exact "
+                "CNF artifact, projection, format version, producer runtime, scope, "
+                "and resource budget; storage alone does not establish UNSAT"
+            ),
+        },
+    )
+    installation = SatArtifactInstallation(
+        semantics_uri=semantics_uri,
+        cnf_schema_uri=schemas.register_model(
+            name="jacobian.canonical-cnf",
+            version="1",
+            model=CanonicalCnf,
+        ),
+        assignment_schema_uri=schemas.register_model(
+            name="jacobian.sat-assignment",
+            version="1",
+            model=SatAssignmentArtifact,
+        ),
+        proof_schema_uri=schemas.register_model(
+            name="jacobian.sat-proof",
+            version="1",
+            model=SatProofArtifact,
+        ),
+    )
+    return SatArtifactService(store, schemas, artifacts, installation)

--- a/src/jacobian/schema_registry.py
+++ b/src/jacobian/schema_registry.py
@@ -6,8 +6,10 @@ from functools import lru_cache
 from typing import Any, cast
 
 from jsonschema import Draft202012Validator, FormatChecker
-from jsonschema.exceptions import SchemaError, ValidationError
+from jsonschema.exceptions import SchemaError
+from jsonschema.exceptions import ValidationError as JsonSchemaValidationError
 from pydantic import BaseModel
+from pydantic import ValidationError as PydanticValidationError
 
 from jacobian.canonical import canonicalize_json, loads_strict_json
 from jacobian.store import ArtifactStore, StoreError
@@ -84,6 +86,7 @@ class SchemaRegistry:
 
     def __init__(self, store: ArtifactStore) -> None:
         self.store = store
+        self._model_contracts: dict[str, type[BaseModel]] = {}
 
     def register(self, *, name: str, version: str, schema: dict[str, Any]) -> str:
         """Register a schema after rejecting unsupported external references."""
@@ -97,6 +100,34 @@ class SchemaRegistry:
             version=version,
             definition=normalized,
         )
+
+    def register_model(
+        self,
+        *,
+        name: str,
+        version: str,
+        model: type[BaseModel],
+    ) -> str:
+        """Register JSON shape plus the model's cross-field contract.
+
+        JSON Schema carries the durable structural contract. The operator-owned
+        model adds invariants JSON Schema cannot express, such as canonical
+        ordering and digests derived from multiple fields. Kernel construction
+        repeats this registration after every restart before accepting writes.
+        """
+
+        schema_uri = self.register(
+            name=name,
+            version=version,
+            schema=model_schema(model),
+        )
+        registered = self._model_contracts.get(schema_uri)
+        if registered is not None and registered is not model:
+            raise SchemaRegistryError(
+                "one schema URI cannot use multiple model-backed contracts"
+            )
+        self._model_contracts[schema_uri] = model
+        return schema_uri
 
     def resolve(self, schema_uri: str) -> dict[str, Any]:
         """Load a previously registered schema definition."""
@@ -125,7 +156,7 @@ class SchemaRegistry:
             key=lambda error: tuple(str(part) for part in error.absolute_path),
         )
         if errors:
-            first: ValidationError = errors[0]
+            first: JsonSchemaValidationError = errors[0]
             location = "/".join(str(part) for part in first.absolute_path) or "$"
             required_field = None
             if (
@@ -146,4 +177,21 @@ class SchemaRegistry:
                 path=location,
                 required_field=required_field,
             )
+        model = self._model_contracts.get(schema_uri)
+        if model is not None:
+            try:
+                normalized = model.model_validate(normalized).model_dump(mode="json")
+            except PydanticValidationError as exc:
+                first_error = exc.errors(include_url=False, include_context=False)[0]
+                raw_location = first_error.get("loc", ())
+                location = "/".join(str(part) for part in raw_location) or "$"
+                required_field = None
+                if first_error.get("type") == "missing" and raw_location:
+                    required_field = str(raw_location[-1])
+                raise SchemaValidationError(
+                    f"{location}: {first_error['msg']}",
+                    path=location,
+                    required_field=required_field,
+                ) from exc
+            normalized = loads_strict_json(canonicalize_json(normalized))
         return normalized

--- a/tests/contract/test_sat_contracts.py
+++ b/tests/contract/test_sat_contracts.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.contracts.capabilities import (
+    CapabilityInstallTier,
+    CapabilityProviderAvailability,
+    CapabilityProviderDigestKind,
+    CapabilityProviderRuntime,
+)
+from jacobian.contracts.sat import (
+    CanonicalCnf,
+    SatAssignmentArtifact,
+    SatCnfBinding,
+    SatProofArtifact,
+    SatResourceBudget,
+    canonicalize_cnf,
+)
+
+_DIGEST_A = "sha256:" + "a" * 64
+_DIGEST_B = "sha256:" + "b" * 64
+_DIGEST_C = "sha256:" + "c" * 64
+_DIGEST_D = "sha256:" + "d" * 64
+_ARTIFACT_A = "artifact://sha256/" + "a" * 64
+
+
+def _producer() -> CapabilityProviderRuntime:
+    return CapabilityProviderRuntime(
+        provider="cadical",
+        availability=CapabilityProviderAvailability.AVAILABLE,
+        version="2.1.3",
+        digest=_DIGEST_D,
+        digest_kind=CapabilityProviderDigestKind.EXECUTABLE,
+        platform="linux-x86_64",
+        install_tier=CapabilityInstallTier.T2,
+        license_id="MIT",
+    )
+
+
+def _binding(*, variable_count: int = 2) -> SatCnfBinding:
+    return SatCnfBinding(
+        cnf_artifact_uri=_ARTIFACT_A,
+        cnf_object_digest=_DIGEST_A,
+        cnf_payload_digest=_DIGEST_B,
+        variable_map_digest=_DIGEST_C,
+        dimacs_digest=_DIGEST_D,
+        projection_format="DIMACS-CNF",
+        projection_version="jacobian.dimacs.cnf/v1",
+        variable_count=variable_count,
+        clause_count=2,
+    )
+
+
+@pytest.mark.contract
+def test_cnf_canonicalization_normalizes_map_literals_clauses_and_tautologies() -> None:
+    first = canonicalize_cnf(
+        variable_names=("b", "a"),
+        clauses=((1, -2, 1), (2,), (1, -1)),
+    )
+    second = canonicalize_cnf(
+        variable_names=("a", "b"),
+        clauses=((1,), (-1, 2), (-1, 2)),
+    )
+
+    assert first == second
+    assert tuple((variable.id, variable.name) for variable in first.variables) == (
+        (1, "a"),
+        (2, "b"),
+    )
+    assert tuple(clause.literals for clause in first.clauses) == ((-1, 2), (1,))
+    assert first.to_dimacs_bytes() == b"p cnf 2 2\n-1 2 0\n1 0\n"
+    assert first.variable_map_digest.startswith("sha256:")
+    assert first.dimacs_digest.startswith("sha256:")
+
+
+@pytest.mark.contract
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    (
+        ("variables", "variables must use contiguous IDs and ascending names"),
+        ("literal_order", "clause literals must be unique and canonically ordered"),
+        ("clause_order", "clauses must be unique and canonically ordered"),
+        ("literal_range", "literal references an undeclared variable"),
+        ("variable_map_digest", "variable-map digest"),
+        ("dimacs_digest", "DIMACS digest"),
+    ),
+)
+def test_canonical_cnf_rejects_noncanonical_or_misbound_payloads(
+    mutation: str,
+    message: str,
+) -> None:
+    payload = canonicalize_cnf(
+        variable_names=("a", "b"),
+        clauses=((-1, 2), (1,)),
+    ).model_dump(mode="json")
+    if mutation == "variables":
+        payload["variables"] = list(reversed(payload["variables"]))
+    elif mutation == "literal_order":
+        payload["clauses"][0]["literals"] = [2, -1]
+    elif mutation == "clause_order":
+        payload["clauses"] = list(reversed(payload["clauses"]))
+    elif mutation == "literal_range":
+        payload["clauses"][0]["literals"] = [-1, 3]
+    elif mutation == "variable_map_digest":
+        payload["variable_map_digest"] = _DIGEST_A
+    else:
+        payload["dimacs_digest"] = _DIGEST_A
+
+    with pytest.raises(ValidationError, match=message):
+        CanonicalCnf.model_validate(payload)
+
+
+@pytest.mark.contract
+def test_cnf_canonicalization_rejects_invalid_variable_maps_and_literals() -> None:
+    with pytest.raises(ValueError, match="variable names must be unique"):
+        canonicalize_cnf(variable_names=("x", "x"), clauses=((1,),))
+    with pytest.raises(ValueError, match="nonzero integers"):
+        canonicalize_cnf(variable_names=("x",), clauses=((True,),))
+    with pytest.raises(ValueError, match="undeclared variable"):
+        canonicalize_cnf(variable_names=("x",), clauses=((2,),))
+
+
+@pytest.mark.contract
+def test_assignment_is_total_strict_and_cannot_claim_verification() -> None:
+    assignment = SatAssignmentArtifact(
+        cnf=_binding(),
+        values=(True, False),
+        producer=_producer(),
+        resource_budget=SatResourceBudget(wall_seconds=30),
+    )
+    assert assignment.declared_scope == "FULL_CNF"
+
+    payload = assignment.model_dump(mode="json")
+    payload["values"] = [True]
+    with pytest.raises(ValidationError, match="one value for every bound variable"):
+        SatAssignmentArtifact.model_validate(payload)
+
+    payload = assignment.model_dump(mode="json")
+    payload["values"] = [1, 0]
+    with pytest.raises(ValidationError):
+        SatAssignmentArtifact.model_validate(payload)
+
+    payload = assignment.model_dump(mode="json")
+    payload["verification"] = "VERIFIED"
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        SatAssignmentArtifact.model_validate(payload)
+
+
+@pytest.mark.contract
+def test_assignment_and_proof_require_an_available_exact_producer() -> None:
+    unavailable = _producer().model_copy(
+        update={
+            "availability": CapabilityProviderAvailability.UNAVAILABLE,
+            "version": None,
+            "digest": None,
+            "digest_kind": None,
+            "diagnostic": "not installed",
+        }
+    )
+    assignment = {
+        "cnf": _binding().model_dump(mode="json"),
+        "values": [True, False],
+        "producer": unavailable.model_dump(mode="json"),
+        "resource_budget": {"wall_seconds": 30},
+    }
+    with pytest.raises(ValidationError, match="available producer runtime"):
+        SatAssignmentArtifact.model_validate(assignment)
+
+    proof = {
+        "cnf": _binding().model_dump(mode="json"),
+        "proof_base64": "",
+        "proof_digest": "sha256:" + "e3b0c44298fc1c149afbf4c8996fb924"
+        "27ae41e4649b934ca495991b7852b855",
+        "producer": unavailable.model_dump(mode="json"),
+        "resource_budget": {"wall_seconds": 30},
+    }
+    with pytest.raises(ValidationError, match="available producer runtime"):
+        SatProofArtifact.model_validate(proof)
+
+
+@pytest.mark.contract
+def test_proof_preserves_exact_bytes_and_rejects_digest_or_encoding_mutation() -> None:
+    proof = SatProofArtifact.from_bytes(
+        cnf=_binding(),
+        proof=b"d -1 2 0\n0\n",
+        producer=_producer(),
+        resource_budget=SatResourceBudget(wall_seconds=30, conflicts=1000),
+    )
+
+    assert proof.raw_bytes() == b"d -1 2 0\n0\n"
+    assert proof.proof_format == "DRAT"
+    assert proof.proof_format_version == "drat-text/v1"
+
+    payload = proof.model_dump(mode="json")
+    payload["proof_digest"] = _DIGEST_A
+    with pytest.raises(ValidationError, match="raw proof digest"):
+        SatProofArtifact.model_validate(payload)
+
+    payload = proof.model_dump(mode="json")
+    payload["proof_base64"] = payload["proof_base64"] + "\n"
+    with pytest.raises(ValidationError):
+        SatProofArtifact.model_validate(payload)
+
+
+@pytest.mark.contract
+def test_binding_and_budget_fields_are_required_and_fail_closed() -> None:
+    assignment = SatAssignmentArtifact(
+        cnf=_binding(),
+        values=(True, False),
+        producer=_producer(),
+        resource_budget=SatResourceBudget(wall_seconds=30),
+    ).model_dump(mode="json")
+
+    for required in (
+        "cnf_artifact_uri",
+        "cnf_object_digest",
+        "cnf_payload_digest",
+        "variable_map_digest",
+        "dimacs_digest",
+        "projection_version",
+    ):
+        mutated = deepcopy(assignment)
+        mutated["cnf"].pop(required)
+        with pytest.raises(ValidationError):
+            SatAssignmentArtifact.model_validate(mutated)
+
+    assignment["resource_budget"] = {"wall_seconds": 0}
+    with pytest.raises(ValidationError):
+        SatAssignmentArtifact.model_validate(assignment)

--- a/tests/contract/test_schema_registry.py
+++ b/tests/contract/test_schema_registry.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Self
 
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 
 from jacobian.schema_registry import (
     SchemaRegistry,
@@ -16,6 +17,17 @@ from jacobian.store import ArtifactStore
 
 class _CachedSchemaModel(BaseModel):
     value: int
+
+
+class _OrderedPair(BaseModel):
+    first: int
+    second: int
+
+    @model_validator(mode="after")
+    def require_order(self) -> Self:
+        if self.first >= self.second:
+            raise ValueError("pair must be ordered")
+        return self
 
 
 @pytest.mark.contract
@@ -69,3 +81,22 @@ def test_schema_validator_cache_is_bound_to_canonical_schema(
     registry.validate(integer_schema, {"value": 1})
     with pytest.raises(SchemaValidationError):
         registry.validate(string_schema, {"value": 1})
+
+
+@pytest.mark.contract
+def test_model_backed_schema_applies_cross_field_contracts(
+    tmp_path: Path,
+) -> None:
+    registry = SchemaRegistry(ArtifactStore(tmp_path))
+    schema_uri = registry.register_model(
+        name="ordered-pair",
+        version="1",
+        model=_OrderedPair,
+    )
+
+    assert registry.validate(schema_uri, {"first": 1, "second": 2}) == {
+        "first": 1,
+        "second": 2,
+    }
+    with pytest.raises(SchemaValidationError, match="pair must be ordered"):
+        registry.validate(schema_uri, {"first": 2, "second": 1})

--- a/tests/integration/test_sat_artifacts.py
+++ b/tests/integration/test_sat_artifacts.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from jacobian.artifacts import ArtifactValidationError
+from jacobian.contracts.capabilities import (
+    CapabilityInstallTier,
+    CapabilityProviderAvailability,
+    CapabilityProviderDigestKind,
+    CapabilityProviderRuntime,
+)
+from jacobian.contracts.sat import (
+    CanonicalCnf,
+    SatAssignmentArtifact,
+    SatProofArtifact,
+    SatResourceBudget,
+)
+from jacobian.kernel import JacobianKernel
+from jacobian.sat import SatArtifactError
+
+
+def _producer() -> CapabilityProviderRuntime:
+    return CapabilityProviderRuntime(
+        provider="cadical",
+        availability=CapabilityProviderAvailability.AVAILABLE,
+        version="2.1.3",
+        digest="sha256:" + "d" * 64,
+        digest_kind=CapabilityProviderDigestKind.EXECUTABLE,
+        platform="linux-x86_64",
+        install_tier=CapabilityInstallTier.T2,
+        license_id="MIT",
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.contract
+def test_sat_service_materializes_one_identity_for_equivalent_cnf_input(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+
+    first = kernel.sat.put_cnf(
+        variable_names=("b", "a"),
+        clauses=((1, -2, 1), (2,), (1, -1)),
+    )
+    second = kernel.sat.put_cnf(
+        variable_names=("a", "b"),
+        clauses=((1,), (-1, 2), (-1, 2)),
+    )
+
+    assert first == second
+    stored = kernel.store.get(first.artifact_uri)
+    cnf = CanonicalCnf.model_validate(stored.payload)
+    assert cnf.to_dimacs_bytes() == b"p cnf 2 2\n-1 2 0\n1 0\n"
+    assert stored.manifest.schema_uri == kernel.sat.installation.cnf_schema_uri
+    assert stored.manifest.semantics_uri == kernel.sat.installation.semantics_uri
+
+
+@pytest.mark.integration
+@pytest.mark.contract
+def test_model_backed_schema_rejects_noncanonical_generic_artifact_put(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    cnf_result = kernel.sat.put_cnf(
+        variable_names=("a", "b"),
+        clauses=((-1, 2), (1,)),
+    )
+    payload = kernel.store.get(cnf_result.artifact_uri).payload
+    payload["clauses"] = list(reversed(payload["clauses"]))
+
+    with pytest.raises(ArtifactValidationError):
+        kernel.artifacts.put(
+            schema_uri=kernel.sat.installation.cnf_schema_uri,
+            semantics_uri=kernel.sat.installation.semantics_uri,
+            payload=payload,
+        )
+
+    restarted = JacobianKernel(tmp_path)
+    with pytest.raises(ArtifactValidationError):
+        restarted.artifacts.put(
+            schema_uri=restarted.sat.installation.cnf_schema_uri,
+            semantics_uri=restarted.sat.installation.semantics_uri,
+            payload=payload,
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.contract
+def test_assignment_and_raw_proof_bind_exact_cnf_identity_and_lineage(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    cnf_result = kernel.sat.put_cnf(
+        variable_names=("a", "b"),
+        clauses=((-1, 2), (1,)),
+    )
+    budget = SatResourceBudget(
+        wall_seconds=30,
+        memory_bytes=256 * 1024 * 1024,
+        conflicts=10_000,
+    )
+    assignment_result = kernel.sat.put_assignment(
+        cnf_uri=cnf_result.artifact_uri,
+        values=(True, False),
+        producer=_producer(),
+        resource_budget=budget,
+    )
+    proof_result = kernel.sat.put_proof(
+        cnf_uri=cnf_result.artifact_uri,
+        proof=b"d -1 2 0\n0\n",
+        producer=_producer(),
+        resource_budget=budget,
+    )
+
+    cnf_artifact = kernel.store.get(cnf_result.artifact_uri)
+    assignment_artifact = kernel.store.get(assignment_result.artifact_uri)
+    proof_artifact = kernel.store.get(proof_result.artifact_uri)
+    assignment = SatAssignmentArtifact.model_validate(assignment_artifact.payload)
+    proof = SatProofArtifact.model_validate(proof_artifact.payload)
+
+    for binding in (assignment.cnf, proof.cnf):
+        assert binding.cnf_artifact_uri == cnf_result.artifact_uri
+        assert binding.cnf_object_digest == cnf_artifact.manifest.object_digest
+        assert binding.cnf_payload_digest == cnf_artifact.manifest.payload_digest
+        assert (
+            binding.variable_map_digest == cnf_artifact.payload["variable_map_digest"]
+        )
+        assert binding.dimacs_digest == cnf_artifact.payload["dimacs_digest"]
+    assert assignment_artifact.manifest.parents == (cnf_result.artifact_uri,)
+    assert proof_artifact.manifest.parents == (cnf_result.artifact_uri,)
+    assert proof.raw_bytes() == b"d -1 2 0\n0\n"
+
+
+@pytest.mark.integration
+@pytest.mark.contract
+def test_sat_service_rejects_a_non_cnf_source_before_writing_evidence(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    cnf_result = kernel.sat.put_cnf(variable_names=("x",), clauses=((1,),))
+    assignment_result = kernel.sat.put_assignment(
+        cnf_uri=cnf_result.artifact_uri,
+        values=(True,),
+        producer=_producer(),
+        resource_budget=SatResourceBudget(wall_seconds=30),
+    )
+
+    with pytest.raises(SatArtifactError, match="canonical CNF artifact"):
+        kernel.sat.put_proof(
+            cnf_uri=assignment_result.artifact_uri,
+            proof=b"0\n",
+            producer=_producer(),
+            resource_budget=SatResourceBudget(wall_seconds=30),
+        )


### PR DESCRIPTION
## Problem

The SAT vertical slice had no domain-owned identity for CNF instances, assignments, or raw UNSAT proofs. A JSON Schema alone also cannot enforce canonical ordering or derived digest invariants before generic artifact writes.

## Change

- add canonical named-variable CNF normalization with deterministic DIMACS projection and exact map/projection digests;
- add total assignment and raw DRAT proof artifacts bound to the exact CNF URI, object and payload digests, variable map, projection version, full scope, producer runtime, and resource budget;
- preserve raw proof bytes as bounded canonical base64 without parsing or claiming UNSAT;
- add model-backed schema registration so cross-field invariants run through the normal artifact validation path and after kernel restart;
- install the schemas in the base kernel without adding a SAT solver, checker, capability, or assurance promotion;
- document the contracts, roadmap checkpoint, and threat boundary.

## Compatibility and normative impact

The artifact formats are new and pre-stable. `SchemaRegistry.register_model` is additive. No existing capability ID or MCP tool changes, and no evidence in this slice can become `VERIFIED`.

## Validation

- `uv sync --dev`
- `uv run pytest -n 1` — 463 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv build`
- `git diff --check`
- wheel and source-distribution content inspection
