### PR TITLE
build: publish the Python distribution as jacobian

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -7,7 +7,7 @@ mathematically atomic, agent-visible outcomes to AI agents investigating
 conjectures and other mathematical problems.
 
 This package does not implement the kernel itself. It bootstraps the Python
-distribution (`jacobian-research-kernel`) and provides commands to register
+distribution (`jacobian`) and provides commands to register
 Jacobian with MCP clients, verify the handshake, and forward to the full CLI.
 Agents compose capabilities into their own workflows; this launcher only
 installs, registers, and forwards.
@@ -44,7 +44,7 @@ Supported clients: `claude`, `cursor`, `opencode`, `codex`, `gemini`.
 ## Environment
 
 - `JACOBIAN_STATE_DIR` — state directory (default: `./.jacobian`)
-- `JACOBIAN_PACKAGE` — Python package spec (default: `jacobian-research-kernel`)
+- `JACOBIAN_PACKAGE` — Python package spec (default: `jacobian`)
 
 ## Verification model
 

--- a/npm/bin/jacobian.cjs
+++ b/npm/bin/jacobian.cjs
@@ -35,7 +35,7 @@ Clients:
 
 Environment:
   JACOBIAN_STATE_DIR    State directory (default: ./.jacobian)
-  JACOBIAN_PACKAGE      Python package spec (default: jacobian-research-kernel)
+  JACOBIAN_PACKAGE      Python package spec (default: jacobian)
 `;
 
 function main() {

--- a/npm/bin/launcher.cjs
+++ b/npm/bin/launcher.cjs
@@ -9,14 +9,14 @@ const { join } = require("node:path");
  * Jacobian npm launcher.
  *
  * Detects a usable Python runtime (preferring uv), ensures the
- * `jacobian-research-kernel` package is installed in a shared virtual
+ * `jacobian` package is installed in a shared virtual
  * environment, and spawns the requested Jacobian entry point.
  *
  * The launcher never runs npm lifecycle scripts.  It is a thin Node wrapper
  * that delegates all heavy work to the Python package on PyPI or git.
  */
 
-const PACKAGE_NAME = "jacobian-research-kernel";
+const PACKAGE_NAME = "jacobian";
 const PACKAGE_SPEC = process.env.JACOBIAN_PACKAGE || PACKAGE_NAME;
 const VENV_NAME = "jacobian-venv";
 const STATE_DIR_ENV = "JACOBIAN_STATE_DIR";

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling>=1.27"]
 build-backend = "hatchling.build"
 
 [project]
-name = "jacobian-research-kernel"
+name = "jacobian"
 version = "0.2.0a0"
 description = "A capability-first MCP workbench for executable mathematics"
 readme = "README.md"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,7 @@
   "packages": {
     ".": {
       "release-type": "python",
-      "package-name": "jacobian-research-kernel",
+      "package-name": "jacobian",
       "extra-files": [
         "npm/package.json"
       ]

--- a/src/jacobian/provider_runtime.py
+++ b/src/jacobian/provider_runtime.py
@@ -74,7 +74,7 @@ def _license_files(
 @cache
 def _jacobian_identity() -> tuple[str, str, tuple[str, ...]]:
     try:
-        distribution = importlib.metadata.distribution("jacobian-research-kernel")
+        distribution = importlib.metadata.distribution("jacobian")
         digest = package_source_digest("jacobian.capabilities:CapabilityService")
     except (importlib.metadata.PackageNotFoundError, ImplementationError) as exc:
         raise ProviderRuntimeError(

--- a/uv.lock
+++ b/uv.lock
@@ -335,7 +335,7 @@ wheels = [
 ]
 
 [[package]]
-name = "jacobian-research-kernel"
+name = "jacobian"
 version = "0.2.0a0"
 source = { editable = "." }
 dependencies = [


### PR DESCRIPTION
## Problem

The repository publishes under the internal distribution name `jacobian-research-kernel`, while the canonical `jacobian` name is now available and has been claimed on PyPI. The npm launcher, provider identity lookup, lockfile, and release metadata must agree with that public name.

## Solution

- rename the Python distribution to `jacobian`;
- update the lockfile and Release Please package name;
- make provider runtime identity resolve the renamed installed distribution;
- update the npm launcher default and documentation.

The import package and CLI remain `jacobian`. Existing Python capability and artifact contracts are unchanged.

## Validation

- `uv lock`
- `uv build`
- `twine check` on the clean source distribution and wheel
- `uv run --frozen pytest -n 0 tests/contract/test_provider_runtime.py` — 6 passed
- `npm test` — 13 passed
- clean install from PyPI with `uvx --prerelease allow --from jacobian==0.2.0a0 jacobian --help`
- PyPI JSON metadata reports `jacobian 0.2.0a0` with both artifacts

## Release impact

`jacobian 0.2.0a0` is live on PyPI. The existing GitHub Actions OIDC publisher must be added to that PyPI project before the next automated release.