### PR TITLE
feat: verify exact SAT assignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,7 @@ Release contracts and engineering evidence are:
 - [Provider runtime contract](docs/reference/provider-runtime.md) for
   availability, exact backend identity, install tiers, and local measurement.
 - [SAT artifact contracts](docs/reference/sat-artifacts.md) for canonical CNF,
-  total assignment, and raw proof identity before solver or checker
-  installation.
+  raw model and proof identity, and independently checked total assignments.
 - [v0.2 specification](docs/reference/specifications/v0.2.md) and
   [conformance gate](docs/reference/conformance-v0.2.md)
 - [Testing strategy](docs/reference/testing-strategy.md),

--- a/docs/contributing/atomic-capability-portfolio.md
+++ b/docs/contributing/atomic-capability-portfolio.md
@@ -367,16 +367,23 @@ map, removes duplicate literals and clauses, omits tautologies, orders the
 remaining clauses, and binds the resulting DIMACS bytes. Assignment and proof
 artifacts bind the exact CNF URI, object and payload digests, variable map,
 projection, full scope, producer runtime, and resource budget. Raw proof
-storage and assignment payloads remain unverified. See
+storage and assignment payloads remain unverified when created. See
 [SAT artifact contracts](../reference/sat-artifacts.md).
+
+The assignment-checker checkpoint was implemented on 2026-07-26.
+`sat.model.verify` is installed only with an operator-authorized bundled
+checker. Its standard-library-only clean-process implementation independently
+validates the canonical CNF and all source, projection, assignment, evidence,
+and lineage bindings before evaluating every clause. Acceptance uses the
+kernel's existing `VerificationRecord` path. Rejection, malformed input, and
+operational failure remain `UNKNOWN` and cannot establish UNSAT.
 
 CaDiCaL has a small source build and a command line that accepts DIMACS plus a
 proof path. DRAT-trim independently validates a DRAT proof against the input
-formula. A valid SAT assignment can be checked with a deliberately small
-implementation that shares no solver code. Later, evaluate whether a
-compatible emission or conversion path to a verified checker such as CakeLPR
-actually exists. Do not assume format compatibility or block the first
-independent-checker slice on that hardening.
+formula. Later, evaluate whether a compatible emission or conversion path to
+a verified checker such as CakeLPR actually exists. Do not assume format
+compatibility or block the first independent proof-checker slice on that
+hardening.
 
 Write attack tests before authorizing the UNSAT checker:
 
@@ -494,7 +501,8 @@ backlog.
    examples, or stop.
 4. Canonical CNF, assignment, and proof artifact schemas. Implemented; see
    [SAT artifact contracts](../reference/sat-artifacts.md).
-5. Pure independent SAT-assignment checker with attack tests.
+5. Pure independent SAT-assignment checker with attack tests. Implemented; see
+   [SAT artifact contracts](../reference/sat-artifacts.md#assignment-verification).
 6. CaDiCaL model and proof-producing exploration adapters.
 7. DRAT-trim clean-process checker, authorization fixture, and attack tests.
 8. SAT public reproductions and held-out portfolio ablation.

--- a/docs/explanation/threat-model.md
+++ b/docs/explanation/threat-model.md
@@ -174,9 +174,15 @@ Controls:
   and payload digests, variable-map and DIMACS digests, projection version,
   full scope, producer runtime, and resource budget;
 - evidence artifacts retain the exact CNF as a parent;
-- assignment and raw proof storage remains unverified; and
-- future independent checkers must validate every binding before mathematical
-  replay and fail closed on any mismatch.
+- assignment and raw proof storage remains unverified;
+- `sat.model.verify` re-derives the assignment binding before dispatch, then a
+  standard-library-only clean-process checker independently validates the
+  canonical CNF, payload, variable-map and DIMACS digests, assignment,
+  evidence bindings, and lineage before evaluating every clause;
+- SAT assignment checker requests expose exact artifact payload digests and
+  parent lineage in addition to object, schema, and semantics identities; and
+- a rejected assignment, malformed input, timeout, or checker failure remains
+  `UNKNOWN` and never establishes UNSAT.
 
 ### Buggy or compromised checker
 

--- a/docs/reference/sat-artifacts.md
+++ b/docs/reference/sat-artifacts.md
@@ -3,14 +3,16 @@
 [Documentation home](../index.md)
 
 - Status: Experimental pre-stable contract
-- Installed operations: none
+- Installed operations: `sat.model.verify` when the operator installs the
+  bundled reference checkers
 - Related plan:
   [Atomic capability portfolio](../contributing/atomic-capability-portfolio.md#wave-2-sat-certificate-vertical-slice)
 
 Jacobian installs canonical CNF, total assignment, and raw DRAT proof artifact
-contracts before installing any SAT solver or checker. These artifacts are
-typed inputs and unverified evidence. Storing an assignment does not establish
-SAT, and storing proof bytes does not establish UNSAT.
+contracts without installing a SAT solver. These artifacts begin as typed,
+unverified evidence. Storing an assignment does not establish SAT, and storing
+proof bytes does not establish UNSAT. An operator may separately authorize the
+bundled assignment checker and expose `sat.model.verify`.
 
 ## Registered descriptors
 
@@ -23,9 +25,11 @@ registered by the current kernel:
 | Schema | `jacobian.canonical-cnf@1` | Canonical named-variable CNF and DIMACS binding |
 | Schema | `jacobian.sat-assignment@1` | Total assignment candidate bound to one CNF |
 | Schema | `jacobian.sat-proof@1` | Preserved raw DRAT bytes bound to one CNF |
+| Schema | `jacobian.witness-envelope@1` | Exact assignment replay evidence |
 
-The schema URIs are content addressed. They are not capability IDs and do not
-add tools to `capability://catalog`.
+The schema URIs are content addressed. They are not capability IDs. The
+assignment verification capability appears in `capability://catalog` only
+when its checker is operator authorized.
 
 The SAT schemas are model backed. JSON Schema checks their closed structural
 shape, and the same registry validation path also applies the domain
@@ -98,8 +102,34 @@ records:
   memory and conflict bounds.
 
 The assignment schema has no conclusion, verification status, checker ID, or
-certificate claim. A later `sat.model.verify` capability must load the bound
-CNF and independently evaluate every clause.
+certificate claim.
+
+## Assignment verification
+
+`sat.model.verify` accepts one `assignment_uri` in `VERIFY` mode. Before
+starting a checker process, its adapter:
+
+1. validates the stored assignment with the model-backed schema;
+2. resolves the CNF named inside the assignment;
+3. derives the current CNF binding from that stored artifact;
+4. requires every binding field to match and the CNF to be an assignment
+   parent; and
+5. materializes a `sat.assignment@1` witness bound to the exact CNF,
+   assignment, and SAT semantics.
+
+The authorized checker then runs in a clean process. Its implementation uses
+only the Python standard library and no solver code or Jacobian SAT contract
+implementation. It independently validates the closed canonical CNF shape,
+variable ordering, clause ordering, payload, variable-map and DIMACS digests,
+assignment binding, total strict-Boolean vector, evidence bindings, and
+lineage. It returns `TRUE` only after evaluating every clause successfully.
+
+Acceptance creates the ordinary kernel `VerificationRecord` and allows the
+capability result to report `VERIFIED`. Assignment rejection reports
+`UNKNOWN`: it does not establish UNSAT. A malformed or misbound artifact fails
+before checker dispatch. Timeout, checker error, cancellation, and incomplete
+execution likewise remain non-verified and carry no SAT or UNSAT conclusion.
+Direct witness replay makes no enumeration-completeness claim.
 
 ## Raw proof artifacts
 
@@ -123,12 +153,11 @@ limit, and this contract bounds the base64 field to 8,000,000 characters.
 
 The following are deliberately outside this slice:
 
-- no assignment evaluator;
 - no CaDiCaL invocation or solver-status interpretation;
 - no DRAT-trim process or checker authorization;
-- no SAT or UNSAT conclusion; and
-- no `VERIFIED` result.
+- no UNSAT conclusion from assignment rejection; and
+- no verification of raw proof bytes.
 
-The next slice adds the deliberately small independent assignment checker.
-Proof production and independent clean-process proof replay remain later,
-separate changes.
+The next slice adds CaDiCaL model and proof production as unverified
+exploration. Independent clean-process proof replay remains a later, separate
+change.

--- a/src/jacobian/contracts/sat.py
+++ b/src/jacobian/contracts/sat.py
@@ -23,7 +23,7 @@ from jacobian.contracts.capabilities import (
     CapabilityProviderAvailability,
     CapabilityProviderRuntime,
 )
-from jacobian.contracts.common import ArtifactUri, Sha256Digest
+from jacobian.contracts.common import ArtifactUri, CheckerUri, Sha256Digest
 from jacobian.contracts.results import ContractModel
 
 SatVariableName = Annotated[
@@ -183,6 +183,44 @@ class SatAssignmentArtifact(ContractModel):
                 "assignment must contain one value for every bound variable"
             )
         _require_available_producer(self.producer)
+        return self
+
+
+class SatAssignmentVerificationRequest(ContractModel):
+    """Verify one stored total assignment against its exact bound CNF."""
+
+    assignment_uri: ArtifactUri
+
+
+class SatAssignmentVerificationOutput(ContractModel):
+    """Model-facing projection of one independent assignment replay."""
+
+    status: Literal[
+        "VERIFIED_SATISFYING",
+        "REJECTED",
+        "TIMEOUT",
+        "CANCELLED",
+        "ERROR",
+    ]
+    conclusion: Literal["TRUE", "UNKNOWN"]
+    cnf_uri: ArtifactUri
+    assignment_uri: ArtifactUri
+    witness_uri: ArtifactUri
+    checker_id: CheckerUri
+    verification_record_uri: ArtifactUri | None = None
+    detail: str = Field(min_length=1, max_length=1024)
+
+    @model_validator(mode="after")
+    def bind_verified_projection(self) -> Self:
+        if self.status == "VERIFIED_SATISFYING":
+            if self.conclusion != "TRUE" or self.verification_record_uri is None:
+                raise ValueError(
+                    "verified satisfying output requires TRUE and a verification record"
+                )
+        elif self.conclusion != "UNKNOWN" or self.verification_record_uri is not None:
+            raise ValueError(
+                "non-verified assignment output cannot carry a conclusion or record"
+            )
         return self
 
 

--- a/src/jacobian/kernel.py
+++ b/src/jacobian/kernel.py
@@ -56,6 +56,10 @@ from jacobian.references import (
 )
 from jacobian.registry import CheckerRegistry
 from jacobian.sat import SatArtifactService, install_sat_artifacts
+from jacobian.sat_capabilities import (
+    SatAssignmentCheckerInstallation,
+    install_sat_assignment_checker,
+)
 from jacobian.schema_registry import SchemaRegistry
 from jacobian.search import SearchService
 from jacobian.shrinking import ShrinkService
@@ -190,6 +194,20 @@ class JacobianKernel:
         self.lean_declarations: LeanDeclarationService | None = None
         self.lean_exploration: LeanExplorationInstallation | None = None
         self.capabilities = CapabilityService(self.store, self.memory)
+        self.sat_assignment_checker: SatAssignmentCheckerInstallation
+        sat_assignment_adapter, self.sat_assignment_checker = (
+            install_sat_assignment_checker(
+                self.store,
+                self.schemas,
+                self.artifacts,
+                self.sat,
+                self.verification,
+                self.checkers,
+                authorize_checker=install_references,
+            )
+        )
+        if sat_assignment_adapter is not None:
+            self.register_capability(sat_assignment_adapter)
         for atomic_adapter in install_atomic_capabilities(self):
             self.register_capability(atomic_adapter)
         self.register_capability(KnowledgeSearchAdapter(self.memory))

--- a/src/jacobian/sat.py
+++ b/src/jacobian/sat.py
@@ -19,7 +19,7 @@ from jacobian.contracts.sat import (
     canonicalize_cnf,
 )
 from jacobian.schema_registry import SchemaRegistry, SchemaRegistryError
-from jacobian.store import ArtifactStore, StoreError
+from jacobian.store import ArtifactStore, StoredArtifact, StoreError
 
 
 class SatArtifactError(ValueError):
@@ -32,6 +32,13 @@ class SatArtifactInstallation:
     cnf_schema_uri: str
     assignment_schema_uri: str
     proof_schema_uri: str
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedSatAssignment:
+    artifact: StoredArtifact
+    assignment: SatAssignmentArtifact
+    cnf_artifact: StoredArtifact
 
 
 class SatArtifactService:
@@ -126,6 +133,43 @@ class SatArtifactService:
             payload=assignment.model_dump(mode="json"),
             parents=(cnf_uri,),
             summary="unverified SAT assignment candidate",
+        )
+
+    def resolve_assignment(self, assignment_uri: str) -> ResolvedSatAssignment:
+        """Resolve an assignment whose payload and lineage bind one exact CNF."""
+
+        try:
+            artifact = self.store.get(assignment_uri)
+        except StoreError as exc:
+            raise SatArtifactError(
+                "source is not an available SAT assignment artifact"
+            ) from exc
+        if (
+            artifact.manifest.schema_uri != self.installation.assignment_schema_uri
+            or artifact.manifest.semantics_uri != self.installation.semantics_uri
+        ):
+            raise SatArtifactError("source is not a SAT assignment artifact")
+        try:
+            normalized = self.schemas.validate(
+                self.installation.assignment_schema_uri,
+                artifact.payload,
+            )
+            assignment = SatAssignmentArtifact.model_validate(normalized)
+        except (SchemaRegistryError, ValueError, ValidationError) as exc:
+            raise SatArtifactError(
+                "source is not a valid SAT assignment artifact"
+            ) from exc
+        binding = self.bind_cnf(assignment.cnf.cnf_artifact_uri)
+        if assignment.cnf != binding:
+            raise SatArtifactError(
+                "SAT assignment binding does not match its exact canonical CNF"
+            )
+        if binding.cnf_artifact_uri not in artifact.manifest.parents:
+            raise SatArtifactError("SAT assignment is missing its canonical CNF parent")
+        return ResolvedSatAssignment(
+            artifact=artifact,
+            assignment=assignment,
+            cnf_artifact=self.store.get(binding.cnf_artifact_uri),
         )
 
     def put_proof(

--- a/src/jacobian/sat_capabilities.py
+++ b/src/jacobian/sat_capabilities.py
@@ -1,0 +1,303 @@
+"""Model-facing verification for exact SAT assignment artifacts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from jacobian.artifacts import ArtifactService
+from jacobian.capabilities import CapabilityAdapter, CapabilityInvocationError
+from jacobian.contracts.capabilities import (
+    CapabilityAssurance,
+    CapabilityAssuranceLevel,
+    CapabilityCompleteness,
+    CapabilityCompletenessStatus,
+    CapabilityDescriptor,
+    CapabilityDiagnostic,
+    CapabilityMode,
+    CapabilityRequest,
+    CapabilityResult,
+    CapabilityScope,
+)
+from jacobian.contracts.evidence import (
+    EvidenceBindings,
+    WitnessEnvelope,
+    WitnessRole,
+)
+from jacobian.contracts.results import (
+    Conclusion,
+    ExecutionStatus,
+    Verification,
+)
+from jacobian.contracts.sat import (
+    SatAssignmentVerificationOutput,
+    SatAssignmentVerificationRequest,
+)
+from jacobian.provider_runtime import known_provider_runtime
+from jacobian.registry import CheckerRegistry
+from jacobian.sat import SatArtifactError, SatArtifactService
+from jacobian.schema_registry import SchemaRegistry, model_schema
+from jacobian.store import ArtifactStore, StoreError
+from jacobian.verification import VerificationService
+
+
+@dataclass(frozen=True, slots=True)
+class SatAssignmentCheckerInstallation:
+    witness_schema_uri: str
+    checker_id: str | None
+
+
+def install_sat_assignment_checker(
+    store: ArtifactStore,
+    schemas: SchemaRegistry,
+    artifacts: ArtifactService,
+    sat: SatArtifactService,
+    verification: VerificationService,
+    checkers: CheckerRegistry,
+    *,
+    authorize_checker: bool,
+) -> tuple[CapabilityAdapter | None, SatAssignmentCheckerInstallation]:
+    """Install the assignment evidence schema and optionally authorize replay."""
+
+    witness_schema_uri = schemas.register_model(
+        name="jacobian.witness-envelope",
+        version="1",
+        model=WitnessEnvelope,
+    )
+    checker_id = None
+    if authorize_checker:
+        checker_id = checkers.authorize(
+            name="exact total SAT assignment replay checker",
+            entrypoint="jacobian_checkers.sat:check_assignment",
+            evidence_kind="WITNESS",
+            format_id="sat.assignment",
+            format_version="1",
+            claim_schema_uris=(sat.installation.cnf_schema_uri,),
+            semantics_uris=(sat.installation.semantics_uri,),
+            candidate_schema_uris=(sat.installation.assignment_schema_uri,),
+            reason="bundled independent SAT assignment checker",
+        ).checker_id
+    installation = SatAssignmentCheckerInstallation(
+        witness_schema_uri=witness_schema_uri,
+        checker_id=checker_id,
+    )
+    adapter: CapabilityAdapter | None = None
+    if checker_id is not None:
+        adapter = SatAssignmentVerificationAdapter(
+            store=store,
+            artifacts=artifacts,
+            sat=sat,
+            verification=verification,
+            installation=installation,
+        )
+    return adapter, installation
+
+
+class SatAssignmentVerificationAdapter:
+    """Verify one assignment; never infer UNSAT from assignment rejection."""
+
+    def __init__(
+        self,
+        *,
+        store: ArtifactStore,
+        artifacts: ArtifactService,
+        sat: SatArtifactService,
+        verification: VerificationService,
+        installation: SatAssignmentCheckerInstallation,
+    ) -> None:
+        checker_id = installation.checker_id
+        if checker_id is None:
+            raise ValueError("SAT assignment checker is not authorized")
+        self.store = store
+        self.artifacts = artifacts
+        self.sat = sat
+        self.verification = verification
+        self.installation = installation
+        self._descriptor = CapabilityDescriptor(
+            capability_id="sat.model.verify",
+            version="1",
+            title="Verify a SAT assignment",
+            description=(
+                "Independently replay one total assignment against every clause "
+                "of its exact bound canonical CNF."
+            ),
+            provider="jacobian.sat",
+            provider_runtime=known_provider_runtime(
+                "jacobian.sat",
+                features=("total-assignment-replay", "canonical-cnf"),
+                checker_ids=(checker_id,),
+            ),
+            modes=(CapabilityMode.VERIFY,),
+            input_schema=model_schema(SatAssignmentVerificationRequest),
+            output_schema=model_schema(SatAssignmentVerificationOutput),
+            tags=("sat", "cnf", "assignment", "verification"),
+        )
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        return self._descriptor
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        validated = SatAssignmentVerificationRequest.model_validate(request.input)
+        try:
+            resolved = self.sat.resolve_assignment(validated.assignment_uri)
+            semantics = self.store.get(self.sat.installation.semantics_uri)
+        except (SatArtifactError, StoreError) as exc:
+            raise CapabilityInvocationError(
+                CapabilityDiagnostic(
+                    code="INVALID_SAT_ASSIGNMENT",
+                    stage="artifact_resolution",
+                    message=str(exc),
+                    path="assignment_uri",
+                    schema_uri=self.sat.installation.assignment_schema_uri,
+                    expected=(
+                        "a valid SAT assignment artifact bound by payload and lineage "
+                        "to one canonical CNF"
+                    ),
+                    hint=(
+                        "Create the assignment with SatArtifactService.put_assignment "
+                        "against the intended canonical CNF."
+                    ),
+                )
+            ) from exc
+
+        checker_id = self.installation.checker_id
+        assert checker_id is not None
+        bindings = EvidenceBindings(
+            claim_digest=resolved.cnf_artifact.manifest.object_digest,
+            semantics_digest=semantics.manifest.object_digest,
+            candidate_digest=resolved.artifact.manifest.object_digest,
+        )
+        witness = WitnessEnvelope(
+            witness_format="sat.assignment",
+            format_version="1",
+            role=WitnessRole.SUPPORTS_CLAIM,
+            bindings=bindings,
+            payload={
+                "cnf_uri": resolved.cnf_artifact.artifact_uri,
+                "assignment_uri": resolved.artifact.artifact_uri,
+            },
+        )
+        witness_artifact = self.artifacts.put(
+            schema_uri=self.installation.witness_schema_uri,
+            semantics_uri=self.sat.installation.semantics_uri,
+            payload=witness.model_dump(mode="json"),
+            parents=(
+                resolved.cnf_artifact.artifact_uri,
+                resolved.artifact.artifact_uri,
+            ),
+            summary="SAT assignment verification witness",
+        )
+        checked = self.verification.verify_witness(
+            claim_uri=resolved.cnf_artifact.artifact_uri,
+            candidate_uri=resolved.artifact.artifact_uri,
+            witness_uri=witness_artifact.artifact_uri,
+            checker_id=checker_id,
+            include_artifact_metadata=True,
+        )
+        verified = (
+            checked.execution.status is ExecutionStatus.COMPLETED
+            and checked.conclusion is Conclusion.TRUE
+            and checked.assurance.verification is Verification.VERIFIED
+            and checked.verification_record_uri is not None
+        )
+        status: Literal[
+            "VERIFIED_SATISFYING",
+            "REJECTED",
+            "TIMEOUT",
+            "CANCELLED",
+            "ERROR",
+        ]
+        if verified:
+            status = "VERIFIED_SATISFYING"
+        elif checked.execution.status is ExecutionStatus.COMPLETED:
+            status = "REJECTED"
+        elif checked.execution.status is ExecutionStatus.TIMEOUT:
+            status = "TIMEOUT"
+        elif checked.execution.status is ExecutionStatus.CANCELLED:
+            status = "CANCELLED"
+        else:
+            status = "ERROR"
+        detail = checked.execution.detail
+        if detail is None and checked.input.errors:
+            detail = checked.input.errors[0]
+        if detail is None:
+            detail = (
+                "the authorized checker accepted the total assignment"
+                if verified
+                else "the assignment was not independently accepted"
+            )
+        output = SatAssignmentVerificationOutput(
+            status=status,
+            conclusion="TRUE" if verified else "UNKNOWN",
+            cnf_uri=resolved.cnf_artifact.artifact_uri,
+            assignment_uri=resolved.artifact.artifact_uri,
+            witness_uri=witness_artifact.artifact_uri,
+            checker_id=checker_id,
+            verification_record_uri=(
+                checked.verification_record_uri if verified else None
+            ),
+            detail=detail,
+        )
+        record_uri = checked.verification_record_uri if verified else None
+        artifact_uris = [
+            resolved.cnf_artifact.artifact_uri,
+            resolved.artifact.artifact_uri,
+            witness_artifact.artifact_uri,
+        ]
+        if record_uri is not None:
+            artifact_uris.append(record_uri)
+        assurance_level = (
+            CapabilityAssuranceLevel.VERIFIED
+            if verified
+            else (
+                CapabilityAssuranceLevel.COMPUTED
+                if checked.execution.status is ExecutionStatus.COMPLETED
+                else CapabilityAssuranceLevel.HEURISTIC
+            )
+        )
+        return CapabilityResult(
+            capability_id=self.descriptor.capability_id,
+            capability_version=self.descriptor.version,
+            mode=request.mode,
+            execution=checked.execution,
+            output=output.model_dump(mode="json"),
+            scope=CapabilityScope(
+                description="the full exact canonical CNF bound by the assignment",
+                parameters={
+                    "declared_scope": "FULL_CNF",
+                    "variable_count": resolved.assignment.cnf.variable_count,
+                    "clause_count": resolved.assignment.cnf.clause_count,
+                },
+                artifact_uri=resolved.cnf_artifact.artifact_uri,
+            ),
+            completeness=CapabilityCompleteness(
+                status=CapabilityCompletenessStatus.NOT_APPLICABLE,
+                basis=(
+                    "direct assignment replay checks one witness and makes no "
+                    "enumeration or UNSAT completeness claim"
+                ),
+                assurance_level=(
+                    CapabilityAssuranceLevel.COMPUTED
+                    if checked.execution.status is ExecutionStatus.COMPLETED
+                    else CapabilityAssuranceLevel.HEURISTIC
+                ),
+            ),
+            assurance=CapabilityAssurance(
+                level=assurance_level,
+                basis=(
+                    "accepted by the operator-authorized independent SAT "
+                    "assignment checker"
+                    if verified
+                    else (
+                        "checker replay completed without accepting the assignment; "
+                        "no opposite conclusion follows"
+                        if checked.execution.status is ExecutionStatus.COMPLETED
+                        else "checker execution did not complete; no mathematical "
+                        "conclusion follows"
+                    )
+                ),
+                verification_record_uri=record_uri,
+            ),
+            artifact_uris=tuple(artifact_uris),
+        )

--- a/src/jacobian/verification.py
+++ b/src/jacobian/verification.py
@@ -270,6 +270,7 @@ class VerificationService:
         witness_uri: str,
         checker_id: str,
         timeout_seconds: float | None = None,
+        include_artifact_metadata: bool = False,
     ) -> ResultEnvelope:
         """Replay a bound witness with the explicitly selected checker."""
 
@@ -342,28 +343,26 @@ class VerificationService:
             )
             request = {
                 "request_version": "1",
-                "claim": {
-                    "artifact_uri": claim_uri,
-                    "object_digest": claim.manifest.object_digest,
-                    "schema_uri": claim.manifest.schema_uri,
-                    "semantics_uri": claim.manifest.semantics_uri,
-                    "payload": claim.payload,
-                },
-                "candidate": {
-                    "artifact_uri": candidate_uri,
-                    "object_digest": candidate.manifest.object_digest,
-                    "schema_uri": candidate.manifest.schema_uri,
-                    "semantics_uri": candidate.manifest.semantics_uri,
-                    "payload": candidate.payload,
-                },
-                "scope": (self._checker_artifact(scope) if scope is not None else None),
-                "witness": {
-                    "artifact_uri": witness_uri,
-                    "object_digest": witness_artifact.manifest.object_digest,
-                    "schema_uri": witness_artifact.manifest.schema_uri,
-                    "semantics_uri": witness_artifact.manifest.semantics_uri,
-                    "payload": witness.model_dump(mode="json"),
-                },
+                "claim": self._checker_artifact(
+                    claim,
+                    include_storage_metadata=include_artifact_metadata,
+                ),
+                "candidate": self._checker_artifact(
+                    candidate,
+                    include_storage_metadata=include_artifact_metadata,
+                ),
+                "scope": (
+                    self._checker_artifact(
+                        scope,
+                        include_storage_metadata=include_artifact_metadata,
+                    )
+                    if scope is not None
+                    else None
+                ),
+                "witness": self._checker_artifact(
+                    witness_artifact,
+                    include_storage_metadata=include_artifact_metadata,
+                ),
                 "expected_bindings": expected_bindings,
             }
             request_digest = _digest_bytes(canonicalize_json(request))
@@ -1113,19 +1112,27 @@ class VerificationService:
         return self.store.get(sorted(matches)[0])
 
     @staticmethod
-    def _checker_artifact(artifact: StoredArtifact | None) -> dict[str, Any]:
+    def _checker_artifact(
+        artifact: StoredArtifact | None,
+        *,
+        include_storage_metadata: bool = False,
+    ) -> dict[str, Any]:
         if artifact is None:
             raise ValueError(
                 "Verification evidence is incomplete. Recreate it from the exact "
                 "claim and candidate, then retry."
             )
-        return {
+        result = {
             "artifact_uri": artifact.artifact_uri,
             "object_digest": artifact.manifest.object_digest,
             "schema_uri": artifact.manifest.schema_uri,
             "semantics_uri": artifact.manifest.semantics_uri,
             "payload": artifact.payload,
         }
+        if include_storage_metadata:
+            result["payload_digest"] = artifact.manifest.payload_digest
+            result["parents"] = list(artifact.manifest.parents)
+        return result
 
     def _commit_verification_record(
         self,

--- a/src/jacobian_checkers/sat.py
+++ b/src/jacobian_checkers/sat.py
@@ -1,0 +1,368 @@
+"""Independent exact replay for total SAT assignments.
+
+This module intentionally uses only the Python standard library.  It does not
+import Jacobian's SAT contracts or any solver implementation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import unicodedata
+from typing import Any
+
+_ARTIFACT_URI = re.compile(r"^artifact://sha256/[0-9a-f]{64}$")
+_DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
+_VARIABLE_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_.:-]{0,127}$")
+_ARTIFACT_KEYS = {
+    "artifact_uri",
+    "object_digest",
+    "payload_digest",
+    "schema_uri",
+    "semantics_uri",
+    "parents",
+    "payload",
+}
+_BINDING_KEYS = {
+    "claim_digest",
+    "semantics_digest",
+    "candidate_digest",
+    "scope_digest",
+    "encoding_digest",
+}
+
+
+def _reject(detail: str) -> dict[str, Any]:
+    return {
+        "accepted": False,
+        "conclusion": "UNKNOWN",
+        "arithmetic": "EXACT_INTEGER",
+        "method": "DIRECT_WITNESS",
+        "coverage": "NOT_APPLICABLE",
+        "detail": detail,
+    }
+
+
+def _sha256(value: bytes) -> str:
+    return "sha256:" + hashlib.sha256(value).hexdigest()
+
+
+def _canonical_json(value: object) -> bytes:
+    # SAT claim payloads contain only ASCII strings, integers, lists, and maps,
+    # for which this is the same byte representation as Jacobian's canonical
+    # JSON encoder.
+    return json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _literal_key(literal: int) -> tuple[int, bool]:
+    return abs(literal), literal > 0
+
+
+def _valid_artifact(value: object) -> bool:
+    if not isinstance(value, dict) or set(value) != _ARTIFACT_KEYS:
+        return False
+    if (
+        not isinstance(value["artifact_uri"], str)
+        or _ARTIFACT_URI.fullmatch(value["artifact_uri"]) is None
+        or not isinstance(value["object_digest"], str)
+        or _DIGEST.fullmatch(value["object_digest"]) is None
+        or not isinstance(value["payload_digest"], str)
+        or _DIGEST.fullmatch(value["payload_digest"]) is None
+        or not isinstance(value["schema_uri"], str)
+        or _ARTIFACT_URI.fullmatch(value["schema_uri"]) is None
+        or not isinstance(value["semantics_uri"], str)
+        or _ARTIFACT_URI.fullmatch(value["semantics_uri"]) is None
+    ):
+        return False
+    parents = value["parents"]
+    return (
+        isinstance(parents, list)
+        and len(parents) == len(set(parents))
+        and all(
+            isinstance(parent, str) and _ARTIFACT_URI.fullmatch(parent) is not None
+            for parent in parents
+        )
+    )
+
+
+def _valid_bindings(value: object) -> bool:
+    if not isinstance(value, dict) or set(value) != _BINDING_KEYS:
+        return False
+    if value["scope_digest"] is not None or value["encoding_digest"] is not None:
+        return False
+    return all(
+        isinstance(value[key], str) and _DIGEST.fullmatch(value[key]) is not None
+        for key in ("claim_digest", "semantics_digest", "candidate_digest")
+    )
+
+
+def _validate_cnf(payload: object) -> tuple[list[list[int]], int, str, str]:
+    if not isinstance(payload, dict) or set(payload) != {
+        "cnf_schema_version",
+        "variables",
+        "clauses",
+        "projection_format",
+        "projection_version",
+        "variable_map_digest",
+        "dimacs_digest",
+    }:
+        raise ValueError("canonical CNF has an invalid shape")
+    if (
+        payload["cnf_schema_version"] != "1"
+        or payload["projection_format"] != "DIMACS-CNF"
+        or payload["projection_version"] != "jacobian.dimacs.cnf/v1"
+    ):
+        raise ValueError("canonical CNF uses an unsupported format")
+
+    variables = payload["variables"]
+    if not isinstance(variables, list) or len(variables) > 1_000_000:
+        raise ValueError("canonical CNF variable map is malformed")
+    names: list[str] = []
+    for expected_id, variable in enumerate(variables, start=1):
+        if (
+            not isinstance(variable, dict)
+            or set(variable) != {"id", "name"}
+            or type(variable["id"]) is not int
+            or variable["id"] != expected_id
+            or not isinstance(variable["name"], str)
+            or _VARIABLE_NAME.fullmatch(variable["name"]) is None
+            or unicodedata.normalize("NFC", variable["name"]) != variable["name"]
+        ):
+            raise ValueError("canonical CNF variable map is malformed")
+        names.append(variable["name"])
+    if names != sorted(names) or len(names) != len(set(names)):
+        raise ValueError("canonical CNF variable map is not canonical")
+
+    clauses = payload["clauses"]
+    if not isinstance(clauses, list) or len(clauses) > 1_000_000:
+        raise ValueError("canonical CNF clauses are malformed")
+    normalized_clauses: list[list[int]] = []
+    clause_keys: list[tuple[tuple[int, bool], ...]] = []
+    for clause in clauses:
+        if (
+            not isinstance(clause, dict)
+            or set(clause) != {"literals"}
+            or not isinstance(clause["literals"], list)
+            or len(clause["literals"]) > 1_000_000
+        ):
+            raise ValueError("canonical CNF clause is malformed")
+        literals = clause["literals"]
+        if any(
+            type(literal) is not int or literal == 0 or abs(literal) > len(variables)
+            for literal in literals
+        ):
+            raise ValueError("canonical CNF literal is malformed")
+        if (
+            len(literals) != len(set(literals))
+            or any(-literal in literals for literal in literals)
+            or literals != sorted(literals, key=_literal_key)
+        ):
+            raise ValueError("canonical CNF clause is not canonical")
+        normalized_clauses.append(literals)
+        clause_keys.append(tuple(_literal_key(literal) for literal in literals))
+    if clause_keys != sorted(clause_keys) or len(clause_keys) != len(set(clause_keys)):
+        raise ValueError("canonical CNF clauses are not canonical")
+
+    variable_map_payload = {
+        "variable_map_format": "jacobian.sat.variable-map/v1",
+        "variables": variables,
+    }
+    variable_map_digest = _sha256(_canonical_json(variable_map_payload))
+    if payload["variable_map_digest"] != variable_map_digest:
+        raise ValueError("canonical CNF variable-map digest does not match")
+    rows = [f"p cnf {len(variables)} {len(clauses)}\n"]
+    for literals in normalized_clauses:
+        prefix = " ".join(str(literal) for literal in literals)
+        rows.append(f"{prefix} 0\n" if prefix else "0\n")
+    dimacs_digest = _sha256("".join(rows).encode("ascii"))
+    if payload["dimacs_digest"] != dimacs_digest:
+        raise ValueError("canonical CNF DIMACS digest does not match")
+    return normalized_clauses, len(variables), variable_map_digest, dimacs_digest
+
+
+def _validate_assignment(
+    payload: object,
+    *,
+    claim: dict[str, Any],
+    variable_count: int,
+    clause_count: int,
+    variable_map_digest: str,
+    dimacs_digest: str,
+) -> list[bool]:
+    if not isinstance(payload, dict) or set(payload) != {
+        "assignment_schema_version",
+        "cnf",
+        "declared_scope",
+        "values",
+        "producer",
+        "resource_budget",
+    }:
+        raise ValueError("SAT assignment has an invalid shape")
+    if (
+        payload["assignment_schema_version"] != "1"
+        or payload["declared_scope"] != "FULL_CNF"
+        or not isinstance(payload["producer"], dict)
+        or not isinstance(payload["resource_budget"], dict)
+    ):
+        raise ValueError("SAT assignment metadata is malformed")
+    binding = payload["cnf"]
+    if not isinstance(binding, dict) or set(binding) != {
+        "binding_version",
+        "cnf_artifact_uri",
+        "cnf_object_digest",
+        "cnf_payload_digest",
+        "variable_map_digest",
+        "dimacs_digest",
+        "projection_format",
+        "projection_version",
+        "variable_count",
+        "clause_count",
+    }:
+        raise ValueError("SAT assignment CNF binding is malformed")
+    if (
+        binding["binding_version"] != "1"
+        or not isinstance(binding["cnf_artifact_uri"], str)
+        or _ARTIFACT_URI.fullmatch(binding["cnf_artifact_uri"]) is None
+        or any(
+            not isinstance(binding[key], str) or _DIGEST.fullmatch(binding[key]) is None
+            for key in (
+                "cnf_object_digest",
+                "cnf_payload_digest",
+                "variable_map_digest",
+                "dimacs_digest",
+            )
+        )
+        or type(binding["variable_count"]) is not int
+        or type(binding["clause_count"]) is not int
+    ):
+        raise ValueError("SAT assignment CNF binding is malformed")
+    expected_binding = {
+        "binding_version": "1",
+        "cnf_artifact_uri": claim["artifact_uri"],
+        "cnf_object_digest": claim["object_digest"],
+        "cnf_payload_digest": claim["payload_digest"],
+        "variable_map_digest": variable_map_digest,
+        "dimacs_digest": dimacs_digest,
+        "projection_format": "DIMACS-CNF",
+        "projection_version": "jacobian.dimacs.cnf/v1",
+        "variable_count": variable_count,
+        "clause_count": clause_count,
+    }
+    if binding != expected_binding:
+        raise ValueError("SAT assignment is not bound to the exact canonical CNF")
+    values = payload["values"]
+    if (
+        not isinstance(values, list)
+        or len(values) != variable_count
+        or any(type(value) is not bool for value in values)
+    ):
+        raise ValueError("SAT assignment is not total and Boolean")
+    return values
+
+
+def check_assignment(request: dict[str, Any]) -> dict[str, Any]:
+    """Accept only a total assignment satisfying every exact bound clause."""
+
+    try:
+        if not isinstance(request, dict) or set(request) != {
+            "request_version",
+            "claim",
+            "candidate",
+            "scope",
+            "witness",
+            "expected_bindings",
+        }:
+            return _reject("malformed checker request")
+        if request["request_version"] != "1" or request["scope"] is not None:
+            return _reject("unsupported checker request")
+        claim = request["claim"]
+        candidate = request["candidate"]
+        witness = request["witness"]
+        if not all(_valid_artifact(item) for item in (claim, candidate, witness)):
+            return _reject("checker artifact metadata is malformed")
+        if not _valid_bindings(request["expected_bindings"]):
+            return _reject("expected evidence bindings are malformed")
+        if (
+            claim["semantics_uri"] != candidate["semantics_uri"]
+            or claim["semantics_uri"] != witness["semantics_uri"]
+        ):
+            return _reject("checker artifacts use different semantics")
+        if claim["payload_digest"] != _sha256(_canonical_json(claim["payload"])):
+            return _reject("canonical CNF payload digest does not match")
+
+        clauses, variable_count, variable_map_digest, dimacs_digest = _validate_cnf(
+            claim["payload"]
+        )
+        values = _validate_assignment(
+            candidate["payload"],
+            claim=claim,
+            variable_count=variable_count,
+            clause_count=len(clauses),
+            variable_map_digest=variable_map_digest,
+            dimacs_digest=dimacs_digest,
+        )
+        if claim["artifact_uri"] not in candidate["parents"]:
+            return _reject("SAT assignment is missing canonical CNF lineage")
+
+        expected_bindings = request["expected_bindings"]
+        if (
+            expected_bindings["claim_digest"] != claim["object_digest"]
+            or expected_bindings["candidate_digest"] != candidate["object_digest"]
+        ):
+            return _reject("expected evidence bindings do not match artifacts")
+        envelope = witness["payload"]
+        if not isinstance(envelope, dict) or set(envelope) != {
+            "evidence_schema_version",
+            "witness_format",
+            "format_version",
+            "role",
+            "bindings",
+            "payload",
+        }:
+            return _reject("SAT witness envelope is malformed")
+        if (
+            envelope["evidence_schema_version"] != "1"
+            or envelope["witness_format"] != "sat.assignment"
+            or envelope["format_version"] != "1"
+            or envelope["role"] != "SUPPORTS_CLAIM"
+            or envelope["bindings"] != expected_bindings
+        ):
+            return _reject("SAT witness envelope is not exactly bound")
+        witness_payload = envelope["payload"]
+        if not isinstance(witness_payload, dict) or witness_payload != {
+            "cnf_uri": claim["artifact_uri"],
+            "assignment_uri": candidate["artifact_uri"],
+        }:
+            return _reject("SAT witness points at different artifacts")
+        if not {
+            claim["artifact_uri"],
+            candidate["artifact_uri"],
+        }.issubset(set(witness["parents"])):
+            return _reject("SAT witness is missing required lineage")
+
+        for clause in clauses:
+            if not any(
+                values[abs(literal) - 1] if literal > 0 else not values[-literal - 1]
+                for literal in clause
+            ):
+                return _reject("assignment does not satisfy every bound clause")
+        return {
+            "accepted": True,
+            "conclusion": "TRUE",
+            "arithmetic": "EXACT_INTEGER",
+            "method": "DIRECT_WITNESS",
+            "coverage": "NOT_APPLICABLE",
+            "detail": (
+                f"replayed {len(clauses)} clauses under a total "
+                f"{variable_count}-variable assignment"
+            ),
+        }
+    except (KeyError, TypeError, ValueError, OverflowError):
+        return _reject("malformed checker request")

--- a/tests/checkers/test_sat_assignment_checker.py
+++ b/tests/checkers/test_sat_assignment_checker.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import hashlib
+from copy import deepcopy
+from typing import Any
+
+import pytest
+
+from jacobian.canonical import canonicalize_json
+from jacobian.contracts.capabilities import (
+    CapabilityInstallTier,
+    CapabilityProviderAvailability,
+    CapabilityProviderDigestKind,
+    CapabilityProviderRuntime,
+)
+from jacobian.contracts.evidence import EvidenceBindings, WitnessEnvelope
+from jacobian.contracts.sat import (
+    SatAssignmentArtifact,
+    SatCnfBinding,
+    SatResourceBudget,
+    canonicalize_cnf,
+)
+from jacobian_checkers.sat import check_assignment
+
+_CNF_URI = "artifact://sha256/" + "1" * 64
+_ASSIGNMENT_URI = "artifact://sha256/" + "2" * 64
+_WITNESS_URI = "artifact://sha256/" + "3" * 64
+_SCHEMA_URI = "artifact://sha256/" + "4" * 64
+_SEMANTICS_URI = "artifact://sha256/" + "5" * 64
+_CNF_OBJECT_DIGEST = "sha256:" + "a" * 64
+_ASSIGNMENT_OBJECT_DIGEST = "sha256:" + "b" * 64
+_SEMANTICS_DIGEST = "sha256:" + "c" * 64
+
+
+def _digest(value: object) -> str:
+    return "sha256:" + hashlib.sha256(canonicalize_json(value)).hexdigest()
+
+
+def _producer() -> CapabilityProviderRuntime:
+    return CapabilityProviderRuntime(
+        provider="cadical",
+        availability=CapabilityProviderAvailability.AVAILABLE,
+        version="2.1.3",
+        digest="sha256:" + "d" * 64,
+        digest_kind=CapabilityProviderDigestKind.EXECUTABLE,
+        platform="linux-x86_64",
+        install_tier=CapabilityInstallTier.T2,
+        license_id="MIT",
+    )
+
+
+def _request() -> dict[str, Any]:
+    cnf = canonicalize_cnf(
+        variable_names=("a", "b"),
+        clauses=((-1, 2), (1, 2)),
+    )
+    cnf_payload = cnf.model_dump(mode="json")
+    cnf_payload_digest = _digest(cnf_payload)
+    assignment = SatAssignmentArtifact(
+        cnf=SatCnfBinding(
+            cnf_artifact_uri=_CNF_URI,
+            cnf_object_digest=_CNF_OBJECT_DIGEST,
+            cnf_payload_digest=cnf_payload_digest,
+            variable_map_digest=cnf.variable_map_digest,
+            dimacs_digest=cnf.dimacs_digest,
+            projection_format=cnf.projection_format,
+            projection_version=cnf.projection_version,
+            variable_count=2,
+            clause_count=2,
+        ),
+        values=(False, True),
+        producer=_producer(),
+        resource_budget=SatResourceBudget(wall_seconds=30),
+    )
+    assignment_payload = assignment.model_dump(mode="json")
+    bindings = EvidenceBindings(
+        claim_digest=_CNF_OBJECT_DIGEST,
+        semantics_digest=_SEMANTICS_DIGEST,
+        candidate_digest=_ASSIGNMENT_OBJECT_DIGEST,
+    )
+    witness = WitnessEnvelope(
+        witness_format="sat.assignment",
+        format_version="1",
+        role="SUPPORTS_CLAIM",
+        bindings=bindings,
+        payload={
+            "cnf_uri": _CNF_URI,
+            "assignment_uri": _ASSIGNMENT_URI,
+        },
+    )
+    return {
+        "request_version": "1",
+        "claim": {
+            "artifact_uri": _CNF_URI,
+            "object_digest": _CNF_OBJECT_DIGEST,
+            "payload_digest": cnf_payload_digest,
+            "schema_uri": _SCHEMA_URI,
+            "semantics_uri": _SEMANTICS_URI,
+            "parents": [],
+            "payload": cnf_payload,
+        },
+        "candidate": {
+            "artifact_uri": _ASSIGNMENT_URI,
+            "object_digest": _ASSIGNMENT_OBJECT_DIGEST,
+            "payload_digest": _digest(assignment_payload),
+            "schema_uri": _SCHEMA_URI,
+            "semantics_uri": _SEMANTICS_URI,
+            "parents": [_CNF_URI],
+            "payload": assignment_payload,
+        },
+        "scope": None,
+        "witness": {
+            "artifact_uri": _WITNESS_URI,
+            "object_digest": "sha256:" + "e" * 64,
+            "payload_digest": "sha256:" + "f" * 64,
+            "schema_uri": _SCHEMA_URI,
+            "semantics_uri": _SEMANTICS_URI,
+            "parents": [_ASSIGNMENT_URI, _CNF_URI],
+            "payload": witness.model_dump(mode="json"),
+        },
+        "expected_bindings": bindings.model_dump(mode="json"),
+    }
+
+
+def test_checker_accepts_a_total_assignment_satisfying_every_clause() -> None:
+    decision = check_assignment(_request())
+
+    assert decision["accepted"] is True
+    assert decision["conclusion"] == "TRUE"
+    assert decision["method"] == "DIRECT_WITNESS"
+    assert decision["coverage"] == "NOT_APPLICABLE"
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    (
+        "flip_value",
+        "omit_clause",
+        "add_clause",
+        "reorder_clauses",
+        "renumber_literal",
+        "change_variable_map",
+        "change_source_uri",
+        "partial_assignment",
+        "boolean_variable_count",
+        "mismatched_bindings",
+        "missing_lineage",
+        "extra_candidate_field",
+    ),
+)
+def test_checker_rejects_mutated_or_misbound_assignment_evidence(
+    mutation: str,
+) -> None:
+    request = _request()
+    cnf = request["claim"]["payload"]
+    assignment = request["candidate"]["payload"]
+    if mutation == "flip_value":
+        assignment["values"][1] = False
+    elif mutation == "omit_clause":
+        cnf["clauses"].pop()
+    elif mutation == "add_clause":
+        cnf["clauses"].append({"literals": [2]})
+    elif mutation == "reorder_clauses":
+        cnf["clauses"] = list(reversed(cnf["clauses"]))
+    elif mutation == "renumber_literal":
+        cnf["clauses"][0]["literals"][1] = 1
+    elif mutation == "change_variable_map":
+        cnf["variables"][1]["name"] = "c"
+    elif mutation == "change_source_uri":
+        assignment["cnf"]["cnf_artifact_uri"] = "artifact://sha256/" + "9" * 64
+    elif mutation == "partial_assignment":
+        assignment["values"].pop()
+    elif mutation == "boolean_variable_count":
+        assignment["cnf"]["variable_count"] = True
+    elif mutation == "mismatched_bindings":
+        request["witness"]["payload"]["bindings"]["candidate_digest"] = (
+            "sha256:" + "9" * 64
+        )
+    elif mutation == "missing_lineage":
+        request["candidate"]["parents"] = []
+    else:
+        assignment["verification"] = "VERIFIED"
+
+    decision = check_assignment(request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+def test_checker_rejects_a_valid_assignment_rebound_to_another_cnf() -> None:
+    request = _request()
+    other = canonicalize_cnf(variable_names=("a", "b"), clauses=((1,),))
+    request["claim"]["payload"] = other.model_dump(mode="json")
+    request["claim"]["payload_digest"] = _digest(request["claim"]["payload"])
+    request["claim"]["object_digest"] = "sha256:" + "8" * 64
+    request["expected_bindings"]["claim_digest"] = request["claim"]["object_digest"]
+    request["witness"]["payload"]["bindings"] = deepcopy(request["expected_bindings"])
+
+    decision = check_assignment(request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"

--- a/tests/integration/test_sat_assignment_verification.py
+++ b/tests/integration/test_sat_assignment_verification.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import subprocess
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import jacobian_checkers.sat
+from jacobian.contracts.capabilities import (
+    CapabilityAssuranceLevel,
+    CapabilityInstallTier,
+    CapabilityMode,
+    CapabilityProviderAvailability,
+    CapabilityProviderDigestKind,
+    CapabilityProviderRuntime,
+    CapabilityRequest,
+)
+from jacobian.contracts.results import ExecutionStatus
+from jacobian.contracts.sat import SatResourceBudget
+from jacobian.contracts.verification import VerificationRecord
+from jacobian.kernel import JacobianKernel
+from jacobian.verification import CheckerExecutionError
+
+
+def _producer() -> CapabilityProviderRuntime:
+    return CapabilityProviderRuntime(
+        provider="cadical",
+        availability=CapabilityProviderAvailability.AVAILABLE,
+        version="2.1.3",
+        digest="sha256:" + "d" * 64,
+        digest_kind=CapabilityProviderDigestKind.EXECUTABLE,
+        platform="linux-x86_64",
+        install_tier=CapabilityInstallTier.T2,
+        license_id="MIT",
+    )
+
+
+def _assignment(
+    kernel: JacobianKernel,
+    *,
+    values: tuple[bool, bool],
+) -> tuple[str, str]:
+    cnf = kernel.sat.put_cnf(
+        variable_names=("a", "b"),
+        clauses=((-1, 2), (1, 2)),
+    )
+    assignment = kernel.sat.put_assignment(
+        cnf_uri=cnf.artifact_uri,
+        values=values,
+        producer=_producer(),
+        resource_budget=SatResourceBudget(wall_seconds=30),
+    )
+    return cnf.artifact_uri, assignment.artifact_uri
+
+
+def _verify(kernel: JacobianKernel, assignment_uri: str):
+    return kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="sat.model.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"assignment_uri": assignment_uri},
+        )
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.subprocess
+def test_sat_assignment_is_verified_by_an_authorized_clean_process(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+    cnf_uri, assignment_uri = _assignment(kernel, values=(False, True))
+
+    monkeypatch.setattr(
+        jacobian_checkers.sat,
+        "check_assignment",
+        lambda _request: {
+            "accepted": False,
+            "conclusion": "UNKNOWN",
+            "arithmetic": "SYMBOLIC",
+            "method": "DIRECT_WITNESS",
+            "coverage": "NOT_APPLICABLE",
+            "detail": "parent-process monkeypatch",
+        },
+    )
+    result = _verify(kernel, assignment_uri)
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.assurance.level is CapabilityAssuranceLevel.VERIFIED
+    assert result.output["status"] == "VERIFIED_SATISFYING"
+    assert result.output["conclusion"] == "TRUE"
+    assert result.output["cnf_uri"] == cnf_uri
+    assert result.output["assignment_uri"] == assignment_uri
+    record_uri = result.assurance.verification_record_uri
+    assert record_uri is not None
+    record_artifact = kernel.store.get(record_uri)
+    record = VerificationRecord.model_validate(record_artifact.payload)
+    assert record.checker_id == kernel.sat_assignment_checker.checker_id
+    assert record.evidence_uri == result.output["witness_uri"]
+    assert set(record_artifact.manifest.parents) == {
+        cnf_uri,
+        assignment_uri,
+        result.output["witness_uri"],
+    }
+
+
+@pytest.mark.integration
+@pytest.mark.subprocess
+def test_unsatisfying_assignment_is_rejected_without_an_opposite_conclusion(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+    _cnf_uri, assignment_uri = _assignment(kernel, values=(False, False))
+
+    result = _verify(kernel, assignment_uri)
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert result.output["status"] == "REJECTED"
+    assert result.output["conclusion"] == "UNKNOWN"
+    assert result.output["verification_record_uri"] is None
+    assert result.assurance.verification_record_uri is None
+
+
+@pytest.mark.integration
+def test_sat_assignment_verify_requires_operator_authorized_checker(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+
+    assert kernel.sat_assignment_checker.checker_id is None
+    assert "sat.model.verify" not in {
+        descriptor.capability_id
+        for descriptor in kernel.capabilities.catalog().capabilities
+    }
+
+
+@pytest.mark.integration
+def test_misbound_assignment_artifact_fails_before_checker_dispatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+    cnf_uri, assignment_uri = _assignment(kernel, values=(False, True))
+    second = kernel.sat.put_cnf(variable_names=("a", "b"), clauses=((1,),))
+    stored = kernel.store.get(assignment_uri)
+    payload = deepcopy(stored.payload)
+    payload["cnf"]["cnf_artifact_uri"] = second.artifact_uri
+    forged = kernel.store.put(
+        schema_uri=stored.manifest.schema_uri,
+        semantics_uri=stored.manifest.semantics_uri,
+        payload=payload,
+        parents=(cnf_uri,),
+        summary="forged SAT assignment binding",
+    )
+    called = False
+
+    def unexpected_checker(**_kwargs: Any):
+        nonlocal called
+        called = True
+        raise AssertionError("checker must not receive malformed source bindings")
+
+    monkeypatch.setattr(kernel.verification, "_run_checker", unexpected_checker)
+    result = _verify(kernel, forged.artifact_uri)
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.assurance.level is not CapabilityAssuranceLevel.VERIFIED
+    assert called is False
+
+
+@pytest.mark.integration
+def test_checker_timeout_cannot_create_a_sat_conclusion(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+    _cnf_uri, assignment_uri = _assignment(kernel, values=(False, True))
+
+    def timeout(**_kwargs: Any):
+        raise subprocess.TimeoutExpired(cmd=("sat-assignment-checker",), timeout=1)
+
+    monkeypatch.setattr(kernel.verification, "_run_checker", timeout)
+    result = _verify(kernel, assignment_uri)
+
+    assert result.execution.status is ExecutionStatus.TIMEOUT
+    assert result.assurance.level is not CapabilityAssuranceLevel.VERIFIED
+    assert result.output["status"] == "TIMEOUT"
+    assert result.output["conclusion"] == "UNKNOWN"
+    assert result.assurance.verification_record_uri is None
+
+
+@pytest.mark.integration
+def test_checker_error_cannot_create_a_sat_conclusion(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+    _cnf_uri, assignment_uri = _assignment(kernel, values=(False, True))
+
+    def fail(**_kwargs: Any):
+        raise CheckerExecutionError("deliberate checker failure")
+
+    monkeypatch.setattr(kernel.verification, "_run_checker", fail)
+    result = _verify(kernel, assignment_uri)
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.assurance.level is not CapabilityAssuranceLevel.VERIFIED
+    assert result.output["status"] == "ERROR"
+    assert result.output["conclusion"] == "UNKNOWN"
+    assert result.assurance.verification_record_uri is None


### PR DESCRIPTION
## Problem

SAT assignment artifacts are exact and source-bound, but storage alone cannot establish satisfiability. The roadmap needs a small independent checker that can promote only a satisfying total assignment while keeping malformed evidence, rejection, and operational failure mathematically inconclusive.

## Solution

- Add a standard-library-only clean-process SAT assignment checker that independently validates canonical CNF shape/order, payload and projection digests, exact assignment/evidence bindings, lineage, total strict-Boolean values, and every clause.
- Add the operator-authorized `sat.model.verify` capability. It re-derives source bindings before dispatch and uses the existing `VerificationService`/`VerificationRecord` promotion path.
- Keep the capability absent unless bundled reference checkers are explicitly installed.
- Preserve legacy checker request shapes; the additional payload-digest and parent metadata is opt-in only for the new SAT checker.
- Add attack, clean-process, rejection, timeout, crash, and pre-dispatch misbinding tests, plus reference/roadmap/threat-model documentation.

## Testing

```sh
uv sync --dev
uv run pytest                              # 504 passed
uv run ruff check .
uv run ruff format --check .
uv run mypy
uv run deptry .
uv build
git diff --check
git diff -- AGENTS.md README.md docs/
```

The pinned Lean REPL required by the latest main was materialized locally with `lake build repl` before the final full-suite run.

## Trust & Compatibility Impact

This is trust-critical checker and evidence-promotion code. `VERIFIED` is produced only after the measured, authorized checker accepts in a clean process and the kernel commits a binding `VerificationRecord`. An unsatisfying assignment remains `UNKNOWN` and does not establish UNSAT; malformed/misbound inputs fail before dispatch; timeout, cancellation, and checker failure remain non-verified. The threat model and SAT reference contract are updated.

The SAT contracts and capability are experimental pre-stable additions. Existing checker request shapes remain unchanged unless a caller explicitly requests the new storage metadata path.

## Checklist

- [x] Python validation passes locally
- [x] Relevant documentation updated
