### PR TITLE
feat(sat): add CaDiCaL evidence producers

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,8 +141,10 @@ evaluation and countermodel search, reference-domain exploration and
 verification, Lean checking, and local research-memory search.
 
 The base kernel also registers canonical CNF, total assignment, and raw DRAT
-proof artifact contracts. They do not add SAT capabilities or mathematical
-assurance; solver and independent-checker slices remain separate.
+proof artifact contracts. When exact CaDiCaL 3.0.1 is present, optional
+`sat.model.find` and `sat.unsat_proof.find` capabilities can materialize bound
+model or text-DRAT evidence. Solver status and produced bytes remain
+unverified; assignment and proof checking are separate capability boundaries.
 
 Three direct operational tools—`workspace.open`, `workspace.write`, and
 `workspace.query`—provide durable, revisioned paper-like working state outside

--- a/docs/contributing/atomic-capability-portfolio.md
+++ b/docs/contributing/atomic-capability-portfolio.md
@@ -378,6 +378,16 @@ and lineage bindings before evaluating every clause. Acceptance uses the
 kernel's existing `VerificationRecord` path. Rejection, malformed input, and
 operational failure remain `UNKNOWN` and cannot establish UNSAT.
 
+The CaDiCaL producer checkpoint was implemented on 2026-07-26.
+`sat.model.find` and `sat.unsat_proof.find` are installed only when the exact
+pinned CaDiCaL 3.0.1 executable is available. The adapters recheck its
+executable digest, execute the deterministic DIMACS projection under enforced
+wall-time and optional conflict limits, validate the competition status
+protocol, and materialize only a total model or bounded raw text DRAT artifact.
+Solver status, failure to produce the requested evidence, timeout, malformed
+output, and stored proof bytes remain unverified and carry `UNKNOWN`. See
+[SAT artifact contracts](../reference/sat-artifacts.md#cadical-exploration).
+
 CaDiCaL has a small source build and a command line that accepts DIMACS plus a
 proof path. DRAT-trim independently validates a DRAT proof against the input
 formula. Later, evaluate whether a compatible emission or conversion path to
@@ -503,7 +513,8 @@ backlog.
    [SAT artifact contracts](../reference/sat-artifacts.md).
 5. Pure independent SAT-assignment checker with attack tests. Implemented; see
    [SAT artifact contracts](../reference/sat-artifacts.md#assignment-verification).
-6. CaDiCaL model and proof-producing exploration adapters.
+6. CaDiCaL model and proof-producing exploration adapters. Implemented; see
+   [SAT artifact contracts](../reference/sat-artifacts.md#cadical-exploration).
 7. DRAT-trim clean-process checker, authorization fixture, and attack tests.
 8. SAT public reproductions and held-out portfolio ablation.
 9. cvc5 Alethe proof-production spike for quantifier-free EUF and linear

--- a/docs/explanation/threat-model.md
+++ b/docs/explanation/threat-model.md
@@ -175,6 +175,17 @@ Controls:
   full scope, producer runtime, and resource budget;
 - evidence artifacts retain the exact CNF as a parent;
 - assignment and raw proof storage remains unverified;
+- optional CaDiCaL exploration requires exact version 3.0.1, records the
+  executable digest, and rechecks that digest before and after every bounded
+  invocation;
+- model output must be a unique total in-range assignment under a consistent
+  competition status and exit code before materialization;
+- proof output uses explicit text DRAT mode, a bounded non-symlink regular
+  file, and exact raw-byte preservation; timeout, output overflow, malformed
+  protocol, runtime replacement, and unsafe proof output create no solver
+  evidence;
+- every CaDiCaL status remains an unverified producer report with mathematical
+  conclusion `UNKNOWN`;
 - `sat.model.verify` re-derives the assignment binding before dispatch, then a
   standard-library-only clean-process checker independently validates the
   canonical CNF, payload, variable-map and DIMACS digests, assignment,

--- a/docs/reference/sat-artifacts.md
+++ b/docs/reference/sat-artifacts.md
@@ -3,16 +3,20 @@
 [Documentation home](../index.md)
 
 - Status: Experimental pre-stable contract
+- Optional operations: `sat.model.find` and `sat.unsat_proof.find` when exact
+  CaDiCaL 3.0.1 is installed
 - Installed operations: `sat.model.verify` when the operator installs the
   bundled reference checkers
 - Related plan:
   [Atomic capability portfolio](../contributing/atomic-capability-portfolio.md#wave-2-sat-certificate-vertical-slice)
 
-Jacobian installs canonical CNF, total assignment, and raw DRAT proof artifact
-contracts without installing a SAT solver. These artifacts begin as typed,
-unverified evidence. Storing an assignment does not establish SAT, and storing
-proof bytes does not establish UNSAT. An operator may separately authorize the
-bundled assignment checker and expose `sat.model.verify`.
+Jacobian always installs canonical CNF, total assignment, and raw DRAT proof
+artifact contracts. It conditionally exposes two exploration capabilities when
+the pinned CaDiCaL runtime is available, but does not install the solver.
+These artifacts begin as typed, unverified evidence. Storing an assignment does
+not establish SAT, and storing proof bytes does not establish UNSAT. An
+operator may separately authorize the bundled assignment checker and expose
+`sat.model.verify`.
 
 ## Registered descriptors
 
@@ -104,6 +108,56 @@ records:
 The assignment schema has no conclusion, verification status, checker ID, or
 certificate claim.
 
+## CaDiCaL exploration
+
+The base kernel probes `cadical` on `PATH`. It installs `sat.model.find` and
+`sat.unsat_proof.find` only when `cadical --version` reports exactly `3.0.1`.
+The runtime record uses install tier T2, license identifier `MIT`, the resolved
+executable path, platform, supported projection and proof formats, and the
+SHA-256 digest of the executable. Every invocation checks that digest before
+and after execution. A missing executable, another version, or a changed
+executable leaves the capabilities absent or makes the invocation fail without
+evidence.
+
+The implementation is tested against upstream tag `rel-3.0.1`, commit
+`c60730422e758ef1cebe7aeddf2dda31c996bf04`. Jacobian does not download or
+vendor a binary. An operator may build that revision using the upstream
+`./configure && make` path and place the resulting `cadical` executable on
+`PATH`; the locally built executable receives its own recorded digest.
+
+Both operations accept:
+
+- one exact canonical `cnf_uri`; and
+- an enforced wall-time bound plus an optional CaDiCaL conflict bound.
+
+They do not accept a memory bound because this adapter does not yet enforce
+one. The exact canonical DIMACS bytes are written to an isolated temporary
+directory. CaDiCaL runs in a bounded process group with fixed `C` locale,
+bounded stdout and stderr, and descendant termination on timeout or excess
+output.
+
+`sat.model.find` accepts only the documented competition protocol: exit 10
+plus `s SATISFIABLE` and a unique, range-checked, zero-terminated literal for
+every declared variable. It then stores the Boolean vector through
+`SatArtifactService.put_assignment`. The result reports
+`ASSIGNMENT_PRODUCED`, `solver_status: SATISFIABLE`, and
+`conclusion: UNKNOWN`. The candidate becomes mathematically assured only if a
+later `sat.model.verify` invocation independently accepts it.
+
+`sat.unsat_proof.find` invokes CaDiCaL with `--no-binary` and an explicit proof
+path. Exit 20 plus `s UNSATISFIABLE` permits the adapter to read at most
+6,000,000 bytes from a non-symlink regular file and preserve them as
+`drat-text/v1`. Empty proof bytes are allowed because an input containing an
+empty clause can require no added proof step. The result still reports
+`conclusion: UNKNOWN`; no solver status or stored bytes establish UNSAT.
+
+Exit 0 is recorded only as solver status `UNKNOWN`. A SAT report from the
+proof producer, an UNSAT report from the model producer, or any bounded attempt
+without the requested evidence returns `NO_*_PRODUCED` and `UNKNOWN`. Timeout,
+non-protocol exit, inconsistent text status, malformed or partial model,
+oversized output, unsafe proof file, and runtime replacement are operational
+failures. None creates solver evidence or an opposite conclusion.
+
 ## Assignment verification
 
 `sat.model.verify` accepts one `assignment_uri` in `VERIFY` mode. Before
@@ -153,11 +207,10 @@ limit, and this contract bounds the base64 field to 8,000,000 characters.
 
 The following are deliberately outside this slice:
 
-- no CaDiCaL invocation or solver-status interpretation;
 - no DRAT-trim process or checker authorization;
 - no UNSAT conclusion from assignment rejection; and
 - no verification of raw proof bytes.
 
-The next slice adds CaDiCaL model and proof production as unverified
-exploration. Independent clean-process proof replay remains a later, separate
-change.
+CaDiCaL is a producer, not a checker. Its status is retained only as an
+unverified operational report. The next slice adds independent clean-process
+DRAT replay as a separate capability and authorization boundary.

--- a/src/jacobian/cadical.py
+++ b/src/jacobian/cadical.py
@@ -1,0 +1,698 @@
+"""Bounded CaDiCaL exploration adapters for SAT evidence production."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import stat
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from pydantic import ValidationError
+
+from jacobian.bounded_process import BoundedProcessResult, run_bounded_process
+from jacobian.capabilities import CapabilityAdapter, CapabilityInvocationError
+from jacobian.contracts.capabilities import (
+    CapabilityAssurance,
+    CapabilityAssuranceLevel,
+    CapabilityCompleteness,
+    CapabilityCompletenessStatus,
+    CapabilityDescriptor,
+    CapabilityDiagnostic,
+    CapabilityMode,
+    CapabilityProviderAvailability,
+    CapabilityProviderDigestKind,
+    CapabilityProviderRuntime,
+    CapabilityRequest,
+    CapabilityResult,
+    CapabilityScope,
+)
+from jacobian.contracts.results import Execution, ExecutionStatus
+from jacobian.contracts.sat import (
+    CanonicalCnf,
+    SatExplorationBudget,
+    SatExplorationRequest,
+    SatModelFindOutput,
+    SatUnsatProofFindOutput,
+)
+from jacobian.provider_runtime import CADICAL_VERSION
+from jacobian.sat import ResolvedSatCnf, SatArtifactError, SatArtifactService
+from jacobian.schema_registry import model_schema
+
+CADICAL_STDOUT_LIMIT = 16_000_000
+CADICAL_STDERR_LIMIT = 64_000
+CADICAL_PROOF_LIMIT = 6_000_000
+
+_SolverStatus = Literal["SATISFIABLE", "UNSATISFIABLE", "UNKNOWN"]
+
+
+@dataclass(frozen=True, slots=True)
+class _CadicalRun:
+    execution_status: ExecutionStatus
+    runtime_ms: int
+    solver_status: _SolverStatus | None = None
+    model_literals: tuple[int, ...] = ()
+    proof: bytes | None = None
+    diagnostic: CapabilityDiagnostic | None = None
+
+
+def install_cadical_capabilities(
+    sat: SatArtifactService,
+    runtime: CapabilityProviderRuntime,
+    *,
+    executable: str | Path | None = None,
+) -> tuple[CapabilityAdapter, CapabilityAdapter]:
+    """Install model and proof producers for one exact available runtime."""
+
+    if (
+        runtime.provider != "cadical"
+        or runtime.availability is not CapabilityProviderAvailability.AVAILABLE
+        or runtime.version != CADICAL_VERSION
+        or runtime.digest is None
+        or runtime.digest_kind is not CapabilityProviderDigestKind.EXECUTABLE
+    ):
+        raise ValueError("CaDiCaL capabilities require the pinned available runtime")
+    configured = runtime.configuration.get("executable")
+    selected = executable if executable is not None else configured
+    if not isinstance(selected, (str, Path)):
+        raise ValueError("CaDiCaL runtime does not identify its executable")
+    resolved = Path(selected).resolve(strict=True)
+    if (
+        configured is not None
+        and Path(str(configured)).resolve(strict=True) != resolved
+    ):
+        raise ValueError("CaDiCaL executable differs from its runtime identity")
+    backend = _CadicalBackend(runtime=runtime, executable=resolved)
+    return (
+        CadicalModelFindAdapter(sat=sat, backend=backend),
+        CadicalUnsatProofFindAdapter(sat=sat, backend=backend),
+    )
+
+
+class _CadicalBackend:
+    def __init__(
+        self,
+        *,
+        runtime: CapabilityProviderRuntime,
+        executable: Path,
+    ) -> None:
+        self.runtime = runtime
+        self.executable = executable
+
+    def run_model(
+        self,
+        cnf: CanonicalCnf,
+        budget: SatExplorationBudget,
+    ) -> _CadicalRun:
+        return self._run(cnf, budget, produce_proof=False)
+
+    def run_proof(
+        self,
+        cnf: CanonicalCnf,
+        budget: SatExplorationBudget,
+    ) -> _CadicalRun:
+        return self._run(cnf, budget, produce_proof=True)
+
+    def _run(
+        self,
+        cnf: CanonicalCnf,
+        budget: SatExplorationBudget,
+        *,
+        produce_proof: bool,
+    ) -> _CadicalRun:
+        started = time.monotonic()
+        changed = self._runtime_changed()
+        if changed:
+            return _run_failure(
+                started,
+                code="CADICAL_RUNTIME_CHANGED",
+                stage="provider_identity",
+                message=(
+                    "The CaDiCaL executable no longer matches the runtime digest "
+                    "advertised by the capability."
+                ),
+            )
+        with tempfile.TemporaryDirectory(prefix="jacobian-cadical-") as directory:
+            root = Path(directory)
+            cnf_path = root / "input.cnf"
+            proof_path = root / "proof.drat"
+            cnf_path.write_bytes(cnf.to_dimacs_bytes())
+            command = [str(self.executable), "-q"]
+            if produce_proof:
+                command.append("--no-binary")
+            if budget.conflicts is not None:
+                command.extend(("-c", str(budget.conflicts)))
+            command.append(str(cnf_path))
+            if produce_proof:
+                command.append(str(proof_path))
+            try:
+                completed = run_bounded_process(
+                    command,
+                    input_bytes=b"",
+                    timeout_seconds=float(budget.wall_seconds),
+                    environment={
+                        **os.environ,
+                        "LANG": "C",
+                        "LC_ALL": "C",
+                        "TZ": "UTC",
+                    },
+                    stdout_limit=CADICAL_STDOUT_LIMIT,
+                    stderr_limit=CADICAL_STDERR_LIMIT,
+                )
+            except OSError:
+                return _run_failure(
+                    started,
+                    code="CADICAL_EXECUTION_FAILED",
+                    stage="solver_execution",
+                    message="The pinned CaDiCaL process could not be started.",
+                )
+            operational = _operational_failure(started, completed)
+            if operational is not None:
+                return operational
+            if self._runtime_changed():
+                return _run_failure(
+                    started,
+                    code="CADICAL_RUNTIME_CHANGED",
+                    stage="provider_identity",
+                    message=(
+                        "The CaDiCaL executable changed while the operation was "
+                        "running; no solver evidence was retained."
+                    ),
+                )
+            try:
+                solver_status, model_literals = _parse_solver_output(
+                    completed.stdout,
+                    completed.returncode,
+                )
+            except ValueError:
+                return _run_failure(
+                    started,
+                    code="INVALID_CADICAL_OUTPUT",
+                    stage="solver_output",
+                    message=(
+                        "CaDiCaL returned output inconsistent with its documented "
+                        "competition status protocol."
+                    ),
+                )
+            proof: bytes | None = None
+            if produce_proof and solver_status == "UNSATISFIABLE":
+                try:
+                    proof = _read_proof_file(proof_path)
+                except FileNotFoundError:
+                    return _run_failure(
+                        started,
+                        code="CADICAL_PROOF_MISSING",
+                        stage="proof_capture",
+                        message=(
+                            "CaDiCaL reported UNSATISFIABLE without creating the "
+                            "requested DRAT proof file."
+                        ),
+                    )
+                except OverflowError:
+                    return _run_failure(
+                        started,
+                        code="CADICAL_PROOF_LIMIT_EXCEEDED",
+                        stage="proof_capture",
+                        message=(
+                            "The raw CaDiCaL proof exceeded the configured durable "
+                            "artifact limit and was not read or retained."
+                        ),
+                    )
+                except OSError:
+                    return _run_failure(
+                        started,
+                        code="INVALID_CADICAL_PROOF_FILE",
+                        stage="proof_capture",
+                        message=(
+                            "The CaDiCaL proof output was not a safe bounded regular "
+                            "file and was not retained."
+                        ),
+                    )
+            return _CadicalRun(
+                execution_status=ExecutionStatus.COMPLETED,
+                runtime_ms=_runtime_ms(started),
+                solver_status=solver_status,
+                model_literals=model_literals,
+                proof=proof,
+            )
+
+    def _runtime_changed(self) -> bool:
+        try:
+            current = _sha256_file(self.executable)
+        except OSError:
+            return True
+        return current != self.runtime.digest
+
+
+class CadicalModelFindAdapter:
+    """Attempt to produce one total assignment without validating it."""
+
+    def __init__(
+        self,
+        *,
+        sat: SatArtifactService,
+        backend: _CadicalBackend,
+    ) -> None:
+        self.sat = sat
+        self.backend = backend
+        self._descriptor = CapabilityDescriptor(
+            capability_id="sat.model.find",
+            version="1",
+            title="Find a SAT assignment",
+            description=(
+                "Ask pinned CaDiCaL to produce one total assignment for an exact "
+                "canonical CNF; the candidate remains unverified."
+            ),
+            provider="cadical",
+            provider_runtime=backend.runtime,
+            modes=(CapabilityMode.EXPLORE,),
+            input_schema=model_schema(SatExplorationRequest),
+            output_schema=model_schema(SatModelFindOutput),
+            tags=("sat", "cnf", "assignment", "exploration", "cadical"),
+        )
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        return self._descriptor
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        validated, resolved = _resolve_request(self.sat, request)
+        run = self.backend.run_model(resolved.cnf, validated.resource_budget)
+        if run.execution_status is not ExecutionStatus.COMPLETED:
+            return _failed_result(self.descriptor, request, resolved, run)
+        assert run.solver_status is not None
+        assignment_uri: str | None = None
+        if run.solver_status == "SATISFIABLE":
+            try:
+                values = _total_assignment(
+                    run.model_literals,
+                    variable_count=len(resolved.cnf.variables),
+                )
+            except ValueError:
+                return _failed_result(
+                    self.descriptor,
+                    request,
+                    resolved,
+                    _CadicalRun(
+                        execution_status=ExecutionStatus.ERROR,
+                        runtime_ms=run.runtime_ms,
+                        diagnostic=CapabilityDiagnostic(
+                            code="INVALID_CADICAL_MODEL",
+                            stage="model_capture",
+                            message=(
+                                "CaDiCaL reported SATISFIABLE without a unique total "
+                                "assignment for every declared variable."
+                            ),
+                        ),
+                    ),
+                )
+            assignment_uri = self.sat.put_assignment(
+                cnf_uri=resolved.artifact.artifact_uri,
+                values=values,
+                producer=self.backend.runtime,
+                resource_budget=validated.resource_budget.artifact_budget(),
+            ).artifact_uri
+        output = SatModelFindOutput(
+            status=(
+                "ASSIGNMENT_PRODUCED"
+                if assignment_uri is not None
+                else "NO_ASSIGNMENT_PRODUCED"
+            ),
+            solver_status=run.solver_status,
+            cnf_uri=resolved.artifact.artifact_uri,
+            assignment_uri=assignment_uri,
+            detail=(
+                "CaDiCaL produced a total assignment candidate; it remains "
+                "unverified until sat.model.verify accepts it."
+                if assignment_uri is not None
+                else (
+                    f"CaDiCaL reported {run.solver_status} without producing an "
+                    "assignment; no SAT or UNSAT conclusion follows."
+                )
+            ),
+        )
+        artifacts = [resolved.artifact.artifact_uri]
+        if assignment_uri is not None:
+            artifacts.append(assignment_uri)
+        return _completed_result(
+            self.descriptor,
+            request,
+            resolved,
+            run,
+            output.model_dump(mode="json"),
+            tuple(artifacts),
+            basis=(
+                "the pinned solver produced a bound candidate, but only an "
+                "independent assignment checker can verify it"
+                if assignment_uri is not None
+                else "the bounded solver attempt completed without a model; no "
+                "opposite mathematical conclusion follows"
+            ),
+        )
+
+
+class CadicalUnsatProofFindAdapter:
+    """Attempt to preserve raw text DRAT without validating the proof."""
+
+    def __init__(
+        self,
+        *,
+        sat: SatArtifactService,
+        backend: _CadicalBackend,
+    ) -> None:
+        self.sat = sat
+        self.backend = backend
+        self._descriptor = CapabilityDescriptor(
+            capability_id="sat.unsat_proof.find",
+            version="1",
+            title="Find a SAT UNSAT proof",
+            description=(
+                "Ask pinned CaDiCaL to emit raw text DRAT for an exact canonical "
+                "CNF; preserving the proof does not establish UNSAT."
+            ),
+            provider="cadical",
+            provider_runtime=backend.runtime,
+            modes=(CapabilityMode.EXPLORE,),
+            input_schema=model_schema(SatExplorationRequest),
+            output_schema=model_schema(SatUnsatProofFindOutput),
+            tags=("sat", "cnf", "unsat", "proof", "exploration", "cadical"),
+        )
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        return self._descriptor
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        validated, resolved = _resolve_request(self.sat, request)
+        run = self.backend.run_proof(resolved.cnf, validated.resource_budget)
+        if run.execution_status is not ExecutionStatus.COMPLETED:
+            return _failed_result(self.descriptor, request, resolved, run)
+        assert run.solver_status is not None
+        proof_uri: str | None = None
+        if run.solver_status == "UNSATISFIABLE":
+            assert run.proof is not None
+            proof_uri = self.sat.put_proof(
+                cnf_uri=resolved.artifact.artifact_uri,
+                proof=run.proof,
+                producer=self.backend.runtime,
+                resource_budget=validated.resource_budget.artifact_budget(),
+            ).artifact_uri
+        output = SatUnsatProofFindOutput(
+            status="PROOF_PRODUCED" if proof_uri is not None else "NO_PROOF_PRODUCED",
+            solver_status=run.solver_status,
+            cnf_uri=resolved.artifact.artifact_uri,
+            proof_uri=proof_uri,
+            detail=(
+                "CaDiCaL produced raw text DRAT bytes; they remain unverified until "
+                "an independent proof checker accepts them."
+                if proof_uri is not None
+                else (
+                    f"CaDiCaL reported {run.solver_status} without producing an "
+                    "UNSAT proof; no SAT or UNSAT conclusion follows."
+                )
+            ),
+        )
+        artifacts = [resolved.artifact.artifact_uri]
+        if proof_uri is not None:
+            artifacts.append(proof_uri)
+        return _completed_result(
+            self.descriptor,
+            request,
+            resolved,
+            run,
+            output.model_dump(mode="json"),
+            tuple(artifacts),
+            basis=(
+                "the pinned solver produced bound raw proof bytes, but only an "
+                "independent proof checker can establish UNSAT"
+                if proof_uri is not None
+                else "the bounded solver attempt completed without a proof; no "
+                "opposite mathematical conclusion follows"
+            ),
+        )
+
+
+def _resolve_request(
+    sat: SatArtifactService,
+    request: CapabilityRequest,
+) -> tuple[SatExplorationRequest, ResolvedSatCnf]:
+    try:
+        validated = SatExplorationRequest.model_validate(request.input)
+        resolved = sat.resolve_cnf(validated.cnf_uri)
+    except (SatArtifactError, ValidationError) as exc:
+        raise CapabilityInvocationError(
+            CapabilityDiagnostic(
+                code="INVALID_SAT_EXPLORATION_REQUEST",
+                stage="artifact_resolution",
+                message=str(exc),
+                path="cnf_uri",
+                schema_uri=sat.installation.cnf_schema_uri,
+                expected="one valid canonical CNF artifact and enforceable budget",
+                hint=(
+                    "Create the instance with SatArtifactService.put_cnf and use "
+                    "only the advertised wall-time and conflict limits."
+                ),
+            )
+        ) from exc
+    return validated, resolved
+
+
+def _completed_result(
+    descriptor: CapabilityDescriptor,
+    request: CapabilityRequest,
+    resolved: ResolvedSatCnf,
+    run: _CadicalRun,
+    output: dict[str, object],
+    artifact_uris: tuple[str, ...],
+    *,
+    basis: str,
+) -> CapabilityResult:
+    return CapabilityResult(
+        capability_id=descriptor.capability_id,
+        capability_version=descriptor.version,
+        mode=request.mode,
+        execution=Execution(
+            status=ExecutionStatus.COMPLETED,
+            runtime_ms=run.runtime_ms,
+        ),
+        output=output,
+        scope=_scope(resolved),
+        completeness=CapabilityCompleteness(
+            status=CapabilityCompletenessStatus.UNKNOWN,
+            basis=(
+                "this bounded producer makes no exhaustive search or mathematical "
+                "completeness claim"
+            ),
+            assurance_level=CapabilityAssuranceLevel.COMPUTED,
+        ),
+        assurance=CapabilityAssurance(
+            level=CapabilityAssuranceLevel.COMPUTED,
+            basis=basis,
+        ),
+        artifact_uris=artifact_uris,
+    )
+
+
+def _failed_result(
+    descriptor: CapabilityDescriptor,
+    request: CapabilityRequest,
+    resolved: ResolvedSatCnf,
+    run: _CadicalRun,
+) -> CapabilityResult:
+    assert run.diagnostic is not None
+    return CapabilityResult(
+        capability_id=descriptor.capability_id,
+        capability_version=descriptor.version,
+        mode=request.mode,
+        execution=Execution(
+            status=run.execution_status,
+            runtime_ms=run.runtime_ms,
+            detail=run.diagnostic.message,
+        ),
+        scope=_scope(resolved),
+        completeness=CapabilityCompleteness(
+            status=CapabilityCompletenessStatus.UNKNOWN,
+            basis=(
+                "the producer did not complete with usable evidence; no coverage "
+                "or mathematical conclusion follows"
+            ),
+            assurance_level=CapabilityAssuranceLevel.HEURISTIC,
+        ),
+        diagnostics=(run.diagnostic,),
+        assurance=CapabilityAssurance(
+            level=CapabilityAssuranceLevel.HEURISTIC,
+            basis=(
+                "the producer did not complete with usable bound evidence; no "
+                "mathematical conclusion follows"
+            ),
+        ),
+        artifact_uris=(resolved.artifact.artifact_uri,),
+    )
+
+
+def _scope(resolved: ResolvedSatCnf) -> CapabilityScope:
+    return CapabilityScope(
+        description="the full exact canonical CNF supplied to the producer",
+        parameters={
+            "declared_scope": "FULL_CNF",
+            "variable_count": len(resolved.cnf.variables),
+            "clause_count": len(resolved.cnf.clauses),
+            "projection_format": resolved.cnf.projection_format,
+            "projection_version": resolved.cnf.projection_version,
+        },
+        artifact_uri=resolved.artifact.artifact_uri,
+    )
+
+
+def _operational_failure(
+    started: float,
+    completed: BoundedProcessResult,
+) -> _CadicalRun | None:
+    if completed.stdout_exceeded or completed.stderr_exceeded:
+        return _run_failure(
+            started,
+            code="CADICAL_OUTPUT_LIMIT_EXCEEDED",
+            stage="solver_output",
+            message=(
+                "CaDiCaL exceeded a bounded output stream limit; no solver "
+                "evidence was retained."
+            ),
+        )
+    if completed.timed_out:
+        return _run_failure(
+            started,
+            status=ExecutionStatus.TIMEOUT,
+            code="CADICAL_TIMEOUT",
+            stage="solver_execution",
+            message=(
+                "CaDiCaL exceeded the declared wall-time budget; no mathematical "
+                "conclusion follows."
+            ),
+        )
+    if completed.returncode not in {0, 10, 20}:
+        return _run_failure(
+            started,
+            code="CADICAL_EXECUTION_FAILED",
+            stage="solver_execution",
+            message=(
+                "CaDiCaL exited outside the documented UNKNOWN, SAT, and UNSAT "
+                "competition status codes."
+            ),
+        )
+    return None
+
+
+def _run_failure(
+    started: float,
+    *,
+    code: str,
+    stage: str,
+    message: str,
+    status: ExecutionStatus = ExecutionStatus.ERROR,
+) -> _CadicalRun:
+    return _CadicalRun(
+        execution_status=status,
+        runtime_ms=_runtime_ms(started),
+        diagnostic=CapabilityDiagnostic(
+            code=code,
+            stage=stage,
+            message=message,
+        ),
+    )
+
+
+def _parse_solver_output(
+    stdout: bytes,
+    returncode: int | None,
+) -> tuple[_SolverStatus, tuple[int, ...]]:
+    try:
+        text = stdout.decode("ascii")
+    except UnicodeDecodeError as exc:
+        raise ValueError("solver output is not ASCII") from exc
+    declared: list[_SolverStatus] = []
+    model_tokens: list[int] = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line == "c" or line.startswith("c "):
+            continue
+        if line in {"s SATISFIABLE", "s UNSATISFIABLE", "s UNKNOWN"}:
+            declared.append(line.removeprefix("s "))  # type: ignore[arg-type]
+            continue
+        if line.startswith("v "):
+            try:
+                model_tokens.extend(int(token) for token in line[2:].split())
+            except ValueError as exc:
+                raise ValueError("model contains a noninteger token") from exc
+            continue
+        raise ValueError("unexpected solver output line")
+    expected_by_returncode: dict[int, _SolverStatus] = {
+        0: "UNKNOWN",
+        10: "SATISFIABLE",
+        20: "UNSATISFIABLE",
+    }
+    if returncode not in expected_by_returncode:
+        raise ValueError("unexpected solver exit status")
+    expected = expected_by_returncode[returncode]
+    if len(declared) > 1 or (declared and declared[0] != expected):
+        raise ValueError("solver text status and exit status disagree")
+    if not declared and expected != "UNKNOWN":
+        raise ValueError("decisive solver exit omitted its text status")
+    if expected != "SATISFIABLE" and model_tokens:
+        raise ValueError("non-SAT solver output carried model literals")
+    return expected, tuple(model_tokens)
+
+
+def _total_assignment(
+    model_literals: tuple[int, ...],
+    *,
+    variable_count: int,
+) -> tuple[bool, ...]:
+    if not model_literals or model_literals[-1] != 0:
+        raise ValueError("model is not terminated")
+    if 0 in model_literals[:-1]:
+        raise ValueError("model terminates before its final token")
+    values: dict[int, bool] = {}
+    for literal in model_literals[:-1]:
+        variable = abs(literal)
+        if variable < 1 or variable > variable_count or variable in values:
+            raise ValueError("model variable is duplicate or out of range")
+        values[variable] = literal > 0
+    if set(values) != set(range(1, variable_count + 1)):
+        raise ValueError("model is not total")
+    return tuple(values[index] for index in range(1, variable_count + 1))
+
+
+def _read_proof_file(path: Path) -> bytes:
+    path_metadata = path.stat(follow_symlinks=False)
+    if not stat.S_ISREG(path_metadata.st_mode):
+        raise OSError("proof output is not a regular file")
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags)
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise OSError("proof output is not a regular file")
+        if metadata.st_size > CADICAL_PROOF_LIMIT:
+            raise OverflowError("proof output exceeds its durable artifact limit")
+        with os.fdopen(descriptor, "rb", closefd=False) as stream:
+            proof = stream.read(CADICAL_PROOF_LIMIT + 1)
+        if len(proof) > CADICAL_PROOF_LIMIT:
+            raise OverflowError("proof output grew beyond its durable artifact limit")
+        return proof
+    finally:
+        os.close(descriptor)
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def _runtime_ms(started: float) -> int:
+    return max(0, int((time.monotonic() - started) * 1000))

--- a/src/jacobian/contracts/sat.py
+++ b/src/jacobian/contracts/sat.py
@@ -166,6 +166,33 @@ class SatResourceBudget(ContractModel):
     )
 
 
+class SatExplorationBudget(ContractModel):
+    """CaDiCaL limits that the exploration adapter actually enforces."""
+
+    budget_version: Literal["1"] = "1"
+    wall_seconds: StrictInt = Field(ge=1, le=86_400)
+    conflicts: StrictInt | None = Field(
+        default=None,
+        ge=1,
+        le=(1 << 53) - 1,
+    )
+
+    def artifact_budget(self) -> SatResourceBudget:
+        """Project enforced limits into durable SAT evidence provenance."""
+
+        return SatResourceBudget(
+            wall_seconds=self.wall_seconds,
+            conflicts=self.conflicts,
+        )
+
+
+class SatExplorationRequest(ContractModel):
+    """Run one bounded producer against an exact canonical CNF artifact."""
+
+    cnf_uri: ArtifactUri
+    resource_budget: SatExplorationBudget
+
+
 class SatAssignmentArtifact(ContractModel):
     """One total, exact, but not self-verifying assignment candidate."""
 
@@ -221,6 +248,48 @@ class SatAssignmentVerificationOutput(ContractModel):
             raise ValueError(
                 "non-verified assignment output cannot carry a conclusion or record"
             )
+        return self
+
+
+class SatModelFindOutput(ContractModel):
+    """Unverified result of one bounded model-production attempt."""
+
+    status: Literal["ASSIGNMENT_PRODUCED", "NO_ASSIGNMENT_PRODUCED"]
+    solver_status: Literal["SATISFIABLE", "UNSATISFIABLE", "UNKNOWN"]
+    conclusion: Literal["UNKNOWN"] = "UNKNOWN"
+    cnf_uri: ArtifactUri
+    assignment_uri: ArtifactUri | None = None
+    detail: str = Field(min_length=1, max_length=1024)
+
+    @model_validator(mode="after")
+    def bind_assignment_to_status(self) -> Self:
+        produced = self.status == "ASSIGNMENT_PRODUCED"
+        if produced != (self.assignment_uri is not None):
+            raise ValueError(
+                "only an assignment-produced result may carry an assignment URI"
+            )
+        if produced and self.solver_status != "SATISFIABLE":
+            raise ValueError("an assignment requires a SATISFIABLE solver report")
+        return self
+
+
+class SatUnsatProofFindOutput(ContractModel):
+    """Unverified result of one bounded DRAT-production attempt."""
+
+    status: Literal["PROOF_PRODUCED", "NO_PROOF_PRODUCED"]
+    solver_status: Literal["SATISFIABLE", "UNSATISFIABLE", "UNKNOWN"]
+    conclusion: Literal["UNKNOWN"] = "UNKNOWN"
+    cnf_uri: ArtifactUri
+    proof_uri: ArtifactUri | None = None
+    detail: str = Field(min_length=1, max_length=1024)
+
+    @model_validator(mode="after")
+    def bind_proof_to_status(self) -> Self:
+        produced = self.status == "PROOF_PRODUCED"
+        if produced != (self.proof_uri is not None):
+            raise ValueError("only a proof-produced result may carry a proof URI")
+        if produced and self.solver_status != "UNSATISFIABLE":
+            raise ValueError("a proof requires an UNSATISFIABLE solver report")
         return self
 
 

--- a/src/jacobian/kernel.py
+++ b/src/jacobian/kernel.py
@@ -13,6 +13,7 @@ from jacobian.builtin_capabilities import (
     LeanDeclarationInspectAdapter,
     LeanDeclarationSearchAdapter,
 )
+from jacobian.cadical import install_cadical_capabilities
 from jacobian.capabilities import (
     CapabilityAdapter,
     CapabilityService,
@@ -20,7 +21,10 @@ from jacobian.capabilities import (
 )
 from jacobian.claims import ClaimValidationService
 from jacobian.conjectures import ConjectureService
-from jacobian.contracts.capabilities import CapabilityProviderAvailability
+from jacobian.contracts.capabilities import (
+    CapabilityProviderAvailability,
+    CapabilityProviderRuntime,
+)
 from jacobian.contracts.lean import LeanEnvironment
 from jacobian.evaluation import EvaluationService
 from jacobian.experiment_router import ExperimentRouter
@@ -47,7 +51,7 @@ from jacobian.polynomial_capabilities import (
     install_polynomial_capabilities,
 )
 from jacobian.polytope import PolytopeService
-from jacobian.provider_runtime import lean_provider_runtime
+from jacobian.provider_runtime import cadical_provider_runtime, lean_provider_runtime
 from jacobian.references import (
     LeanCheckerInstallation,
     PolytopeCheckerInstallation,
@@ -208,6 +212,24 @@ class JacobianKernel:
         )
         if sat_assignment_adapter is not None:
             self.register_capability(sat_assignment_adapter)
+        self.cadical_runtime: CapabilityProviderRuntime = cadical_provider_runtime()
+        if (
+            self.cadical_runtime.availability
+            is CapabilityProviderAvailability.AVAILABLE
+        ):
+            try:
+                cadical_adapters = install_cadical_capabilities(
+                    self.sat,
+                    self.cadical_runtime,
+                )
+            except (OSError, ValueError) as exc:
+                _LOGGER.warning(
+                    "CaDiCaL SAT exploration is not installed: %s",
+                    exc,
+                )
+            else:
+                for cadical_adapter in cadical_adapters:
+                    self.register_capability(cadical_adapter)
         for atomic_adapter in install_atomic_capabilities(self):
             self.register_capability(atomic_adapter)
         self.register_capability(KnowledgeSearchAdapter(self.memory))

--- a/src/jacobian/provider_runtime.py
+++ b/src/jacobian/provider_runtime.py
@@ -5,12 +5,15 @@ from __future__ import annotations
 import hashlib
 import importlib
 import importlib.metadata
+import os
+import shutil
 import sysconfig
 from collections.abc import Mapping
 from functools import cache
 from pathlib import Path
 from typing import Any
 
+from jacobian.bounded_process import run_bounded_process
 from jacobian.contracts.capabilities import (
     CapabilityInstallTier,
     CapabilityProviderAvailability,
@@ -18,6 +21,8 @@ from jacobian.contracts.capabilities import (
     CapabilityProviderRuntime,
 )
 from jacobian.implementation import ImplementationError, package_source_digest
+
+CADICAL_VERSION = "3.0.1"
 
 
 class ProviderRuntimeError(RuntimeError):
@@ -244,6 +249,73 @@ def python_distribution_provider_runtime(
         configuration={
             "distribution": distribution_name,
             **dict(configuration or {}),
+        },
+    )
+
+
+def cadical_provider_runtime(
+    executable: str | Path = "cadical",
+) -> CapabilityProviderRuntime:
+    """Inspect the exact pinned CaDiCaL competition CLI runtime."""
+
+    resolved_name = shutil.which(os.fspath(executable))
+    if resolved_name is None:
+        return _unavailable_runtime(
+            provider="cadical",
+            install_tier=CapabilityInstallTier.T2,
+            license_id="MIT",
+            diagnostic=(
+                f"The pinned CaDiCaL {CADICAL_VERSION} executable is unavailable."
+            ),
+        )
+    try:
+        resolved = Path(resolved_name).resolve(strict=True)
+        completed = run_bounded_process(
+            [str(resolved), "--version"],
+            input_bytes=b"",
+            timeout_seconds=5,
+            environment={
+                **os.environ,
+                "LANG": "C",
+                "LC_ALL": "C",
+                "TZ": "UTC",
+            },
+            stdout_limit=1024,
+            stderr_limit=4096,
+        )
+        version = completed.stdout.decode("ascii").strip()
+        if (
+            completed.timed_out
+            or completed.stdout_exceeded
+            or completed.stderr_exceeded
+            or completed.returncode != 0
+            or version != CADICAL_VERSION
+        ):
+            raise ProviderRuntimeError("CaDiCaL version probe did not match the pin")
+        digest = _sha256_file(resolved)
+    except (OSError, UnicodeDecodeError, ProviderRuntimeError):
+        return _unavailable_runtime(
+            provider="cadical",
+            install_tier=CapabilityInstallTier.T2,
+            license_id="MIT",
+            diagnostic=(
+                f"The pinned CaDiCaL {CADICAL_VERSION} executable is unavailable."
+            ),
+        )
+    return CapabilityProviderRuntime(
+        provider="cadical",
+        availability=CapabilityProviderAvailability.AVAILABLE,
+        version=CADICAL_VERSION,
+        digest=digest,
+        digest_kind=CapabilityProviderDigestKind.EXECUTABLE,
+        platform=_platform_tag(),
+        install_tier=CapabilityInstallTier.T2,
+        license_id="MIT",
+        features=("competition-cli", "total-model", "drat-text-proof"),
+        configuration={
+            "executable": str(resolved),
+            "projection": "jacobian.dimacs.cnf/v1",
+            "proof_format": "drat-text/v1",
         },
     )
 

--- a/src/jacobian/sat.py
+++ b/src/jacobian/sat.py
@@ -35,6 +35,13 @@ class SatArtifactInstallation:
 
 
 @dataclass(frozen=True, slots=True)
+class ResolvedSatCnf:
+    artifact: StoredArtifact
+    cnf: CanonicalCnf
+    binding: SatCnfBinding
+
+
+@dataclass(frozen=True, slots=True)
 class ResolvedSatAssignment:
     artifact: StoredArtifact
     assignment: SatAssignmentArtifact
@@ -75,8 +82,8 @@ class SatArtifactService:
             ),
         )
 
-    def bind_cnf(self, cnf_uri: str) -> SatCnfBinding:
-        """Resolve one canonical CNF and bind its exact stored identity."""
+    def resolve_cnf(self, cnf_uri: str) -> ResolvedSatCnf:
+        """Resolve one valid canonical CNF and its exact stored identity."""
 
         try:
             artifact = self.store.get(cnf_uri)
@@ -99,7 +106,7 @@ class SatArtifactService:
             raise SatArtifactError(
                 "source is not a valid canonical CNF artifact"
             ) from exc
-        return SatCnfBinding(
+        binding = SatCnfBinding(
             cnf_artifact_uri=artifact.artifact_uri,
             cnf_object_digest=artifact.manifest.object_digest,
             cnf_payload_digest=artifact.manifest.payload_digest,
@@ -110,6 +117,16 @@ class SatArtifactService:
             variable_count=len(cnf.variables),
             clause_count=len(cnf.clauses),
         )
+        return ResolvedSatCnf(
+            artifact=artifact,
+            cnf=cnf,
+            binding=binding,
+        )
+
+    def bind_cnf(self, cnf_uri: str) -> SatCnfBinding:
+        """Resolve one canonical CNF and bind its exact stored identity."""
+
+        return self.resolve_cnf(cnf_uri).binding
 
     def put_assignment(
         self,

--- a/tests/contract/test_sat_contracts.py
+++ b/tests/contract/test_sat_contracts.py
@@ -15,8 +15,11 @@ from jacobian.contracts.sat import (
     CanonicalCnf,
     SatAssignmentArtifact,
     SatCnfBinding,
+    SatExplorationRequest,
+    SatModelFindOutput,
     SatProofArtifact,
     SatResourceBudget,
+    SatUnsatProofFindOutput,
     canonicalize_cnf,
 )
 
@@ -230,3 +233,64 @@ def test_binding_and_budget_fields_are_required_and_fail_closed() -> None:
     assignment["resource_budget"] = {"wall_seconds": 0}
     with pytest.raises(ValidationError):
         SatAssignmentArtifact.model_validate(assignment)
+
+
+@pytest.mark.contract
+def test_exploration_request_exposes_only_enforced_budget_fields() -> None:
+    request = SatExplorationRequest.model_validate(
+        {
+            "cnf_uri": _ARTIFACT_A,
+            "resource_budget": {
+                "wall_seconds": 5,
+                "conflicts": 100,
+            },
+        }
+    )
+
+    assert request.resource_budget.artifact_budget() == SatResourceBudget(
+        wall_seconds=5,
+        conflicts=100,
+    )
+    with pytest.raises(ValidationError):
+        SatExplorationRequest.model_validate(
+            {
+                "cnf_uri": _ARTIFACT_A,
+                "resource_budget": {
+                    "wall_seconds": 5,
+                    "memory_bytes": 1024,
+                },
+            }
+        )
+
+
+@pytest.mark.contract
+def test_exploration_outputs_never_project_a_solver_status_as_a_conclusion() -> None:
+    model = SatModelFindOutput(
+        status="NO_ASSIGNMENT_PRODUCED",
+        solver_status="UNSATISFIABLE",
+        cnf_uri=_ARTIFACT_A,
+        detail="no assignment was produced",
+    )
+    proof = SatUnsatProofFindOutput(
+        status="NO_PROOF_PRODUCED",
+        solver_status="SATISFIABLE",
+        cnf_uri=_ARTIFACT_A,
+        detail="no proof was produced",
+    )
+
+    assert model.conclusion == "UNKNOWN"
+    assert proof.conclusion == "UNKNOWN"
+    with pytest.raises(ValidationError):
+        SatModelFindOutput(
+            status="ASSIGNMENT_PRODUCED",
+            solver_status="SATISFIABLE",
+            cnf_uri=_ARTIFACT_A,
+            detail="missing candidate URI",
+        )
+    with pytest.raises(ValidationError):
+        SatUnsatProofFindOutput(
+            status="PROOF_PRODUCED",
+            solver_status="UNSATISFIABLE",
+            cnf_uri=_ARTIFACT_A,
+            detail="missing proof URI",
+        )

--- a/tests/integration/test_cadical_capabilities.py
+++ b/tests/integration/test_cadical_capabilities.py
@@ -1,0 +1,427 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from jacobian.cadical import install_cadical_capabilities
+from jacobian.contracts.capabilities import (
+    CapabilityAssuranceLevel,
+    CapabilityMode,
+    CapabilityProviderAvailability,
+    CapabilityRequest,
+)
+from jacobian.contracts.results import ExecutionStatus
+from jacobian.contracts.sat import SatAssignmentArtifact, SatProofArtifact
+from jacobian.kernel import JacobianKernel
+from jacobian.provider_runtime import cadical_provider_runtime
+
+pytestmark = pytest.mark.integration
+
+
+def _fake_cadical(tmp_path: Path, body: str) -> Path:
+    executable = tmp_path / "fake-cadical"
+    executable.write_text(
+        (
+            "#!/usr/bin/python3\n"
+            "import pathlib\n"
+            "import sys\n"
+            "import time\n"
+            "if '--version' in sys.argv:\n"
+            "    print('3.0.1')\n"
+            "    raise SystemExit(0)\n"
+            f"{body}\n"
+        ),
+        encoding="utf-8",
+    )
+    executable.chmod(0o755)
+    return executable
+
+
+def _kernel_with_fake(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    executable: Path,
+    *,
+    install_references: bool = False,
+) -> JacobianKernel:
+    unavailable = cadical_provider_runtime(tmp_path / "not-installed")
+    monkeypatch.setattr(
+        "jacobian.kernel.cadical_provider_runtime",
+        lambda *_args, **_kwargs: unavailable,
+    )
+    kernel = JacobianKernel(
+        tmp_path / "store",
+        install_references=install_references,
+    )
+    runtime = cadical_provider_runtime(executable)
+    assert runtime.availability is CapabilityProviderAvailability.AVAILABLE
+    for adapter in install_cadical_capabilities(
+        kernel.sat,
+        runtime,
+        executable=executable,
+    ):
+        kernel.register_capability(adapter)
+    return kernel
+
+
+def _invoke(
+    kernel: JacobianKernel,
+    capability_id: str,
+    cnf_uri: str,
+    *,
+    wall_seconds: int = 2,
+    conflicts: int | None = None,
+):
+    budget: dict[str, int] = {"wall_seconds": wall_seconds}
+    if conflicts is not None:
+        budget["conflicts"] = conflicts
+    return kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id=capability_id,
+            mode=CapabilityMode.EXPLORE,
+            input={
+                "cnf_uri": cnf_uri,
+                "resource_budget": budget,
+            },
+        )
+    )
+
+
+def test_model_find_materializes_only_an_unverified_bound_assignment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable = _fake_cadical(
+        tmp_path,
+        "assert pathlib.Path(sys.argv[-1]).read_bytes() == "
+        "b'p cnf 2 2\\n1 0\\n-2 0\\n'\n"
+        "assert sys.argv[sys.argv.index('-c') + 1] == '50'\n"
+        "print('s SATISFIABLE')\n"
+        "print('v 1 -2 0')\n"
+        "raise SystemExit(10)",
+    )
+    kernel = _kernel_with_fake(
+        tmp_path,
+        monkeypatch,
+        executable,
+        install_references=True,
+    )
+    cnf = kernel.sat.put_cnf(
+        variable_names=("x", "y"),
+        clauses=((1,), (-2,)),
+    )
+
+    result = _invoke(kernel, "sat.model.find", cnf.artifact_uri, conflicts=50)
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output["status"] == "ASSIGNMENT_PRODUCED"
+    assert result.output["solver_status"] == "SATISFIABLE"
+    assert result.output["conclusion"] == "UNKNOWN"
+    assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert result.assurance.verification_record_uri is None
+    assignment_uri = result.output["assignment_uri"]
+    stored = kernel.store.get(assignment_uri)
+    assignment = SatAssignmentArtifact.model_validate(stored.payload)
+    assert assignment.values == (True, False)
+    assert assignment.cnf.cnf_artifact_uri == cnf.artifact_uri
+    assert assignment.resource_budget.wall_seconds == 2
+    assert assignment.resource_budget.conflicts == 50
+    assert assignment.producer.provider == "cadical"
+    assert stored.manifest.parents == (cnf.artifact_uri,)
+
+    verified = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="sat.model.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"assignment_uri": assignment_uri},
+        )
+    )
+    assert verified.output["status"] == "VERIFIED_SATISFYING"
+    assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED
+
+
+def test_proof_find_preserves_raw_text_drat_without_self_verification(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable = _fake_cadical(
+        tmp_path,
+        "assert '--no-binary' in sys.argv\n"
+        "assert pathlib.Path(sys.argv[-2]).read_bytes() == "
+        "b'p cnf 1 2\\n-1 0\\n1 0\\n'\n"
+        "proof = pathlib.Path(sys.argv[-1])\n"
+        "proof.write_bytes(b'0\\nd -1 0\\n')\n"
+        "print('s UNSATISFIABLE')\n"
+        "raise SystemExit(20)",
+    )
+    kernel = _kernel_with_fake(tmp_path, monkeypatch, executable)
+    cnf = kernel.sat.put_cnf(
+        variable_names=("x",),
+        clauses=((1,), (-1,)),
+    )
+
+    result = _invoke(kernel, "sat.unsat_proof.find", cnf.artifact_uri)
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output["status"] == "PROOF_PRODUCED"
+    assert result.output["solver_status"] == "UNSATISFIABLE"
+    assert result.output["conclusion"] == "UNKNOWN"
+    assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert result.assurance.verification_record_uri is None
+    proof_uri = result.output["proof_uri"]
+    stored = kernel.store.get(proof_uri)
+    proof = SatProofArtifact.model_validate(stored.payload)
+    assert proof.raw_bytes() == b"0\nd -1 0\n"
+    assert proof.proof_format == "DRAT"
+    assert proof.proof_format_version == "drat-text/v1"
+    assert stored.manifest.parents == (cnf.artifact_uri,)
+
+
+@pytest.mark.parametrize(
+    ("capability_id", "body", "expected_status", "solver_status"),
+    [
+        (
+            "sat.model.find",
+            "print('s UNSATISFIABLE')\nraise SystemExit(20)",
+            "NO_ASSIGNMENT_PRODUCED",
+            "UNSATISFIABLE",
+        ),
+        (
+            "sat.unsat_proof.find",
+            "print('s SATISFIABLE')\nprint('v 1 0')\nraise SystemExit(10)",
+            "NO_PROOF_PRODUCED",
+            "SATISFIABLE",
+        ),
+        (
+            "sat.model.find",
+            "print('s UNKNOWN')\nraise SystemExit(0)",
+            "NO_ASSIGNMENT_PRODUCED",
+            "UNKNOWN",
+        ),
+    ],
+)
+def test_opposite_or_unknown_solver_status_never_becomes_a_conclusion(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capability_id: str,
+    body: str,
+    expected_status: str,
+    solver_status: str,
+) -> None:
+    executable = _fake_cadical(tmp_path, body)
+    kernel = _kernel_with_fake(tmp_path, monkeypatch, executable)
+    cnf = kernel.sat.put_cnf(variable_names=("x",), clauses=((1,),))
+
+    result = _invoke(kernel, capability_id, cnf.artifact_uri)
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output["status"] == expected_status
+    assert result.output["solver_status"] == solver_status
+    assert result.output["conclusion"] == "UNKNOWN"
+    assert result.artifact_uris == (cnf.artifact_uri,)
+    assert result.assurance.verification_record_uri is None
+
+
+def test_timeout_is_operational_and_materializes_no_solver_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable = _fake_cadical(tmp_path, "time.sleep(5)")
+    kernel = _kernel_with_fake(tmp_path, monkeypatch, executable)
+    cnf = kernel.sat.put_cnf(variable_names=("x",), clauses=((1,),))
+
+    result = _invoke(
+        kernel,
+        "sat.model.find",
+        cnf.artifact_uri,
+        wall_seconds=1,
+    )
+
+    assert result.execution.status is ExecutionStatus.TIMEOUT
+    assert result.output == {}
+    assert result.diagnostics[0].code == "CADICAL_TIMEOUT"
+    assert result.artifact_uris == (cnf.artifact_uri,)
+    assert result.assurance.level is CapabilityAssuranceLevel.HEURISTIC
+
+
+def test_partial_model_fails_closed_without_an_assignment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable = _fake_cadical(
+        tmp_path,
+        "print('s SATISFIABLE')\nprint('v 1 0')\nraise SystemExit(10)",
+    )
+    kernel = _kernel_with_fake(tmp_path, monkeypatch, executable)
+    cnf = kernel.sat.put_cnf(
+        variable_names=("x", "y"),
+        clauses=((1, 2),),
+    )
+
+    result = _invoke(kernel, "sat.model.find", cnf.artifact_uri)
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.output == {}
+    assert result.diagnostics[0].code == "INVALID_CADICAL_MODEL"
+    assert result.artifact_uris == (cnf.artifact_uri,)
+
+
+@pytest.mark.parametrize(
+    ("body", "expected_code"),
+    [
+        (
+            "print('s UNSATISFIABLE')\nraise SystemExit(10)",
+            "INVALID_CADICAL_OUTPUT",
+        ),
+        (
+            "print('solver crashed')\nraise SystemExit(7)",
+            "CADICAL_EXECUTION_FAILED",
+        ),
+    ],
+)
+def test_inconsistent_protocol_or_nondocumented_exit_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    body: str,
+    expected_code: str,
+) -> None:
+    executable = _fake_cadical(tmp_path, body)
+    kernel = _kernel_with_fake(tmp_path, monkeypatch, executable)
+    cnf = kernel.sat.put_cnf(variable_names=("x",), clauses=((1,),))
+
+    result = _invoke(kernel, "sat.model.find", cnf.artifact_uri)
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.diagnostics[0].code == expected_code
+    assert result.artifact_uris == (cnf.artifact_uri,)
+
+
+def test_excessive_stdout_fails_closed_without_an_assignment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable = _fake_cadical(
+        tmp_path,
+        "print('x' * 4096)\nraise SystemExit(10)",
+    )
+    monkeypatch.setattr("jacobian.cadical.CADICAL_STDOUT_LIMIT", 1024)
+    kernel = _kernel_with_fake(tmp_path, monkeypatch, executable)
+    cnf = kernel.sat.put_cnf(variable_names=("x",), clauses=((1,),))
+
+    result = _invoke(kernel, "sat.model.find", cnf.artifact_uri)
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.diagnostics[0].code == "CADICAL_OUTPUT_LIMIT_EXCEEDED"
+    assert result.artifact_uris == (cnf.artifact_uri,)
+
+
+def test_oversized_proof_fails_closed_before_reading_or_materialization(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable = _fake_cadical(
+        tmp_path,
+        "pathlib.Path(sys.argv[-1]).write_bytes(b'x' * 9)\n"
+        "print('s UNSATISFIABLE')\n"
+        "raise SystemExit(20)",
+    )
+    monkeypatch.setattr("jacobian.cadical.CADICAL_PROOF_LIMIT", 8)
+    kernel = _kernel_with_fake(tmp_path, monkeypatch, executable)
+    cnf = kernel.sat.put_cnf(
+        variable_names=("x",),
+        clauses=((1,), (-1,)),
+    )
+
+    result = _invoke(kernel, "sat.unsat_proof.find", cnf.artifact_uri)
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.diagnostics[0].code == "CADICAL_PROOF_LIMIT_EXCEEDED"
+    assert result.artifact_uris == (cnf.artifact_uri,)
+
+
+def test_proof_symlink_is_never_followed_or_materialized(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable = _fake_cadical(
+        tmp_path,
+        "pathlib.Path(sys.argv[-1]).symlink_to('/etc/passwd')\n"
+        "print('s UNSATISFIABLE')\n"
+        "raise SystemExit(20)",
+    )
+    kernel = _kernel_with_fake(tmp_path, monkeypatch, executable)
+    cnf = kernel.sat.put_cnf(
+        variable_names=("x",),
+        clauses=((1,), (-1,)),
+    )
+
+    result = _invoke(kernel, "sat.unsat_proof.find", cnf.artifact_uri)
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.diagnostics[0].code == "INVALID_CADICAL_PROOF_FILE"
+    assert result.artifact_uris == (cnf.artifact_uri,)
+
+
+def test_runtime_tampering_after_probe_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable = _fake_cadical(
+        tmp_path,
+        "print('s SATISFIABLE')\nprint('v 1 0')\nraise SystemExit(10)",
+    )
+    kernel = _kernel_with_fake(tmp_path, monkeypatch, executable)
+    cnf = kernel.sat.put_cnf(variable_names=("x",), clauses=((1,),))
+    executable.write_text("#!/bin/sh\nexit 10\n", encoding="utf-8")
+    executable.chmod(0o755)
+
+    result = _invoke(kernel, "sat.model.find", cnf.artifact_uri)
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.diagnostics[0].code == "CADICAL_RUNTIME_CHANGED"
+    assert result.artifact_uris == (cnf.artifact_uri,)
+
+
+def test_invocation_environment_does_not_require_the_callers_locale(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable = _fake_cadical(
+        tmp_path,
+        "assert os.environ.get('LC_ALL') == 'C'\n"
+        "print('s SATISFIABLE')\n"
+        "print('v 1 0')\n"
+        "raise SystemExit(10)",
+    )
+    text = executable.read_text(encoding="utf-8").replace(
+        "import pathlib\n",
+        "import os\nimport pathlib\n",
+    )
+    executable.write_text(text, encoding="utf-8")
+    executable.chmod(0o755)
+    kernel = _kernel_with_fake(tmp_path, monkeypatch, executable)
+    cnf = kernel.sat.put_cnf(variable_names=("x",), clauses=((1,),))
+
+    result = _invoke(kernel, "sat.model.find", cnf.artifact_uri)
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output["status"] == "ASSIGNMENT_PRODUCED"
+
+
+def test_wrong_cadical_version_is_unavailable(
+    tmp_path: Path,
+) -> None:
+    executable = _fake_cadical(tmp_path, "raise SystemExit(0)")
+    executable.write_text(
+        executable.read_text(encoding="utf-8").replace("3.0.1", "3.0.0"),
+        encoding="utf-8",
+    )
+
+    runtime = cadical_provider_runtime(executable)
+
+    assert runtime.availability is CapabilityProviderAvailability.UNAVAILABLE
+    assert runtime.version is None
+    assert runtime.digest is None
+    assert runtime.diagnostic is not None
+    assert "3.0.1" in runtime.diagnostic

--- a/tests/integration/test_cadical_external_backend.py
+++ b/tests/integration/test_cadical_external_backend.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from jacobian.contracts.capabilities import CapabilityMode, CapabilityRequest
+from jacobian.contracts.results import ExecutionStatus
+from jacobian.kernel import JacobianKernel
+from jacobian.provider_runtime import CADICAL_VERSION, cadical_provider_runtime
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.external_backend,
+    pytest.mark.skipif(
+        shutil.which("cadical") is None,
+        reason="CaDiCaL is not installed",
+    ),
+]
+
+
+def test_pinned_cadical_produces_a_model_and_text_drat_proof(
+    tmp_path: Path,
+) -> None:
+    runtime = cadical_provider_runtime()
+    if runtime.version != CADICAL_VERSION:
+        pytest.skip(f"requires pinned CaDiCaL {CADICAL_VERSION}")
+    kernel = JacobianKernel(tmp_path)
+    capability_ids = {
+        descriptor.capability_id
+        for descriptor in kernel.capabilities.catalog().capabilities
+    }
+    assert {"sat.model.find", "sat.unsat_proof.find"}.issubset(capability_ids)
+
+    satisfiable = kernel.sat.put_cnf(
+        variable_names=("x", "y"),
+        clauses=((1,), (-2,)),
+    )
+    model = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="sat.model.find",
+            mode=CapabilityMode.EXPLORE,
+            input={
+                "cnf_uri": satisfiable.artifact_uri,
+                "resource_budget": {"wall_seconds": 5},
+            },
+        )
+    )
+    assert model.execution.status is ExecutionStatus.COMPLETED
+    assert model.output["status"] == "ASSIGNMENT_PRODUCED"
+    assert model.output["conclusion"] == "UNKNOWN"
+
+    unsatisfiable = kernel.sat.put_cnf(
+        variable_names=("x",),
+        clauses=((1,), (-1,)),
+    )
+    proof = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="sat.unsat_proof.find",
+            mode=CapabilityMode.EXPLORE,
+            input={
+                "cnf_uri": unsatisfiable.artifact_uri,
+                "resource_budget": {"wall_seconds": 5},
+            },
+        )
+    )
+    assert proof.execution.status is ExecutionStatus.COMPLETED
+    assert proof.output["status"] == "PROOF_PRODUCED"
+    assert proof.output["conclusion"] == "UNKNOWN"


### PR DESCRIPTION
## Problem

Jacobian has exact SAT artifact contracts and independent total-assignment replay, but no concrete solver-backed operations that can produce model or UNSAT-proof evidence for agents to compose.

## Change

- probe and record an exact optional CaDiCaL 3.0.1 executable runtime, including its executable SHA-256;
- add `sat.model.find` and `sat.unsat_proof.find` as separate EXPLORE capabilities;
- enforce wall-time and optional conflict budgets through the CaDiCaL CLI;
- validate competition exit/status output and total model shape before materializing an assignment;
- request bounded text DRAT, reject unsafe or oversized proof files, and preserve exact raw bytes;
- recheck runtime identity before and after each invocation;
- document the pin, operational limits, trust boundary, threat controls, and roadmap checkpoint;
- add fake-backend attack tests plus a real pinned CaDiCaL integration reproduction.

## Trust and compatibility

This adds experimental optional capabilities only when exact CaDiCaL 3.0.1 is available. It does not change existing SAT artifact schemas or checker authorization. Solver status, lack of requested evidence, assignments, and raw proof bytes remain `UNKNOWN`/unverified. Only the existing independent `sat.model.verify` path may promote a model; DRAT verification remains the next separate slice.

## Validation

- `uv sync --dev`
- `uv run pytest` — 522 passed, including the installed CaDiCaL 3.0.1 external-backend test
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv run deptry .`
- `uv build`
- `git diff --check`
- `git diff -- AGENTS.md README.md docs/`