### PR TITLE
feat(sat): verify DRAT proofs independently

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ proof artifact contracts. When exact CaDiCaL 3.0.1 is present, optional
 `sat.model.find` and `sat.unsat_proof.find` capabilities can materialize bound
 model or text-DRAT evidence. Solver status and produced bytes remain
 unverified; assignment and proof checking are separate capability boundaries.
+With bundled references and an operator-provenanced pinned DRAT-trim runtime,
+`sat.unsat_proof.verify` can independently replay the exact CNF-bound proof and
+create a verification record. Runtime failure or proof rejection remains
+`UNKNOWN`.
 
 Three direct operational tools—`workspace.open`, `workspace.write`, and
 `workspace.query`—provide durable, revisioned paper-like working state outside

--- a/docs/contributing/atomic-capability-portfolio.md
+++ b/docs/contributing/atomic-capability-portfolio.md
@@ -388,6 +388,19 @@ Solver status, failure to produce the requested evidence, timeout, malformed
 output, and stored proof bytes remain unverified and carry `UNKNOWN`. See
 [SAT artifact contracts](../reference/sat-artifacts.md#cadical-exploration).
 
+The DRAT-trim checker checkpoint was implemented on 2026-07-26.
+`sat.unsat_proof.verify` is installed only with bundled references and an
+operator-provenanced DRAT-trim `v05.22.2023` executable. The runtime digest and
+exact upstream source commit are bound into checker authorization, rechecked
+at selection and around clean-process replay, and included in the verification
+environment. The independent checker reconstructs canonical DIMACS and
+validates certificate, payload, binding, lineage, and admitted text-proof
+syntax before bounded DRAT replay. Only exit zero with exactly one
+`s VERIFIED` creates a `VerificationRecord`; mutation, concatenation,
+cross-CNF replay, warnings, excessive output, timeout, and runtime replacement
+fail closed as `UNKNOWN`. See
+[UNSAT proof verification](../reference/sat-artifacts.md#unsat-proof-verification).
+
 CaDiCaL has a small source build and a command line that accepts DIMACS plus a
 proof path. DRAT-trim independently validates a DRAT proof against the input
 formula. Later, evaluate whether a compatible emission or conversion path to
@@ -516,6 +529,8 @@ backlog.
 6. CaDiCaL model and proof-producing exploration adapters. Implemented; see
    [SAT artifact contracts](../reference/sat-artifacts.md#cadical-exploration).
 7. DRAT-trim clean-process checker, authorization fixture, and attack tests.
+   Implemented; see
+   [UNSAT proof verification](../reference/sat-artifacts.md#unsat-proof-verification).
 8. SAT public reproductions and held-out portfolio ablation.
 9. cvc5 Alethe proof-production spike for quantifier-free EUF and linear
    arithmetic.

--- a/docs/explanation/threat-model.md
+++ b/docs/explanation/threat-model.md
@@ -191,9 +191,20 @@ Controls:
   canonical CNF, payload, variable-map and DIMACS digests, assignment,
   evidence bindings, and lineage before evaluating every clause;
 - SAT assignment checker requests expose exact artifact payload digests and
-  parent lineage in addition to object, schema, and semantics identities; and
+  parent lineage in addition to object, schema, and semantics identities;
+- `sat.unsat_proof.verify` independently reconstructs DIMACS and validates the
+  proof certificate, artifact payloads, evidence bindings, and lineage before
+  invoking DRAT-trim;
+- exact DRAT-trim release, source commit, operator provenance sidecar, and
+  executable digest are bound into the checker identity and verification
+  environment, with digest checks at registry selection and before and after
+  clean-process replay;
+- the admitted text proof profile rejects malformed clauses and steps after an
+  empty clause, while bounded replay accepts only exit zero and exactly one
+  `s VERIFIED` status; and
 - a rejected assignment, malformed input, timeout, or checker failure remains
-  `UNKNOWN` and never establishes UNSAT.
+  `UNKNOWN`; proof rejection or operational failure likewise remains
+  `UNKNOWN` and never establishes SAT.
 
 ### Buggy or compromised checker
 

--- a/docs/reference/provider-runtime.md
+++ b/docs/reference/provider-runtime.md
@@ -74,6 +74,22 @@ runtime = source_provider_runtime(
 The adapter places `runtime` in its descriptor. Registration remains
 fail-closed if the source identity cannot be resolved.
 
+### External checker runtimes
+
+An independently authorized checker may itself depend on an external
+executable. In that case its `CheckerRegistration` carries an available
+`EXECUTABLE` provider runtime. The runtime identity contributes to the checker
+ID, is persisted with the authorization record, and is rehashed when the
+checker is selected and before and after clean-process execution. The
+verification environment digest also includes that runtime identity.
+
+Some executables do not provide a trustworthy machine-readable version. Their
+provider probe may require a strict operator-managed provenance sidecar that
+binds the expected upstream release and source commit to the locally measured
+executable digest. Such a sidecar records the operator's authorization basis;
+it is not mathematical evidence or upstream attestation. A missing, malformed,
+or digest-mismatched sidecar leaves the checker capability unavailable.
+
 ## Repeatable measurement
 
 Measure the provider selected for one installed capability:

--- a/docs/reference/sat-artifacts.md
+++ b/docs/reference/sat-artifacts.md
@@ -4,7 +4,8 @@
 
 - Status: Experimental pre-stable contract
 - Optional operations: `sat.model.find` and `sat.unsat_proof.find` when exact
-  CaDiCaL 3.0.1 is installed
+  CaDiCaL 3.0.1 is installed; `sat.unsat_proof.verify` when the operator
+  installs bundled references and an exactly identified DRAT-trim runtime
 - Installed operations: `sat.model.verify` when the operator installs the
   bundled reference checkers
 - Related plan:
@@ -16,7 +17,8 @@ the pinned CaDiCaL runtime is available, but does not install the solver.
 These artifacts begin as typed, unverified evidence. Storing an assignment does
 not establish SAT, and storing proof bytes does not establish UNSAT. An
 operator may separately authorize the bundled assignment checker and expose
-`sat.model.verify`.
+`sat.model.verify`. Proof verification additionally requires a pinned
+DRAT-trim executable with operator-supplied provenance.
 
 ## Registered descriptors
 
@@ -30,10 +32,12 @@ registered by the current kernel:
 | Schema | `jacobian.sat-assignment@1` | Total assignment candidate bound to one CNF |
 | Schema | `jacobian.sat-proof@1` | Preserved raw DRAT bytes bound to one CNF |
 | Schema | `jacobian.witness-envelope@1` | Exact assignment replay evidence |
+| Schema | `jacobian.certificate-envelope@1` | Exact UNSAT proof replay evidence |
 
 The schema URIs are content addressed. They are not capability IDs. The
 assignment verification capability appears in `capability://catalog` only
-when its checker is operator authorized.
+when its checker is operator authorized. The proof verification capability
+also requires an available authorized DRAT-trim runtime.
 
 The SAT schemas are model backed. JSON Schema checks their closed structural
 shape, and the same registry validation path also applies the domain
@@ -203,14 +207,67 @@ truncated, or adversarial bytes may be retained as unverified evidence for
 later fail-closed replay. The current artifact store has a 10 MiB payload
 limit, and this contract bounds the base64 field to 8,000,000 characters.
 
+## UNSAT proof verification
+
+`sat.unsat_proof.verify` accepts one `proof_uri` in `VERIFY` mode. Its adapter
+resolves the raw proof and exact parent CNF, re-derives every CNF binding field,
+requires the source lineage, and materializes a `sat.unsat-proof@1`
+`CertificateEnvelope`. The certificate binds the CNF claim, proof candidate,
+SAT semantics, exact artifact URIs, payload digests, and parents.
+
+The capability is installed only when bundled references are enabled and the
+operator authorizes an available DRAT-trim runtime. The supported runtime is
+upstream release `v05.22.2023`, source commit
+`2e5e29cb0019d5cfd547d4208dca1b3ec290349f`. DRAT-trim does not expose a
+stable machine-readable version identity, so Jacobian requires a sibling
+`drat-trim.jacobian-runtime.json` file with exactly:
+
+```json
+{
+  "runtime_manifest_version": "1",
+  "provider": "drat-trim",
+  "release_tag": "v05.22.2023",
+  "source_repository": "https://github.com/marijnheule/drat-trim",
+  "source_commit": "2e5e29cb0019d5cfd547d4208dca1b3ec290349f",
+  "executable_sha256": "sha256:<64 lowercase hexadecimal digits>"
+}
+```
+
+The sidecar is an operator assertion about the installed build, not upstream
+attestation. The executable digest and provenance become part of the
+authorized checker identity. The registry rehashes the executable when the
+checker is selected; the clean worker checks it before and after replay and
+binds it into the verification environment digest.
+
+The standard-library-only checker adapter independently validates the closed
+CNF, proof, certificate, evidence bindings, payload digests, and lineage. It
+reconstructs canonical DIMACS and admits a bounded ASCII `drat-text/v1`
+profile. Malformed clauses, duplicate or complementary literals, integer
+overflow, deletion of the empty clause, or proof steps after the empty clause
+are rejected before external dispatch. A fixed benign comment is prepended to
+force DRAT-trim's text parser; it does not alter the stored proof bytes.
+
+DRAT-trim runs against temporary CNF and proof files with `-W`, fixed locale,
+bounded time and output, and the exact authorized executable. Acceptance
+requires exit zero, empty stderr, protocol-only output, and exactly one
+`s VERIFIED` line. Any other status, warning, malformed output, excessive
+output, mutation, cross-CNF replay, runtime replacement, timeout,
+cancellation, or crash yields no mathematical conclusion.
+
+Acceptance creates the ordinary kernel `VerificationRecord`, bound to the
+certificate and all three artifacts, and permits `VERIFIED_UNSAT` with
+conclusion `TRUE`. Rejection reports `UNKNOWN`; it does not establish SAT.
+
 ## Trust boundary
 
-The following are deliberately outside this slice:
+The two producer/checker pairs remain separate:
 
-- no DRAT-trim process or checker authorization;
-- no UNSAT conclusion from assignment rejection; and
-- no verification of raw proof bytes.
+- CaDiCaL output and raw proof storage remain unverified;
+- assignment rejection never establishes UNSAT;
+- DRAT-trim rejection never establishes SAT; and
+- only the operator-authorized checker accepting the exact bound certificate
+  may create a `VERIFIED` record.
 
 CaDiCaL is a producer, not a checker. Its status is retained only as an
-unverified operational report. The next slice adds independent clean-process
-DRAT replay as a separate capability and authorization boundary.
+unverified operational report. DRAT-trim replay is an independent
+clean-process capability and authorization boundary.

--- a/src/jacobian/checker_worker.py
+++ b/src/jacobian/checker_worker.py
@@ -3,12 +3,20 @@
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import importlib
+import os
 import sys
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any, cast
 
 from jacobian.canonical import canonicalize_json, loads_strict_json
+from jacobian.contracts.capabilities import (
+    CapabilityProviderAvailability,
+    CapabilityProviderDigestKind,
+    CapabilityProviderRuntime,
+)
 from jacobian.implementation import (
     install_source_only_importer,
     package_source_digest,
@@ -26,10 +34,42 @@ def _resolve(entrypoint: str) -> Callable[[dict[str, Any]], dict[str, Any]]:
     return cast(Callable[[dict[str, Any]], dict[str, Any]], function)
 
 
+def _measure_runtime(
+    encoded: str | None,
+) -> tuple[CapabilityProviderRuntime | None, str | None]:
+    os.environ.pop("JACOBIAN_CHECKER_EXECUTABLE", None)
+    os.environ.pop("JACOBIAN_CHECKER_RUNTIME_DIGEST", None)
+    if encoded is None:
+        return None, None
+    runtime = CapabilityProviderRuntime.model_validate(loads_strict_json(encoded))
+    executable = runtime.configuration.get("executable")
+    if (
+        runtime.availability is not CapabilityProviderAvailability.AVAILABLE
+        or runtime.digest_kind is not CapabilityProviderDigestKind.EXECUTABLE
+        or runtime.digest is None
+        or not isinstance(executable, str)
+    ):
+        raise ValueError("checker runtime identity is incomplete")
+    path = Path(executable).resolve(strict=True)
+    if str(path) != executable:
+        raise ValueError("checker runtime path is not exact")
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    measured = "sha256:" + digest.hexdigest()
+    if measured != runtime.digest:
+        raise ValueError("checker runtime differs from its authorized digest")
+    os.environ["JACOBIAN_CHECKER_EXECUTABLE"] = str(path)
+    os.environ["JACOBIAN_CHECKER_RUNTIME_DIGEST"] = measured
+    return runtime, measured
+
+
 def main() -> int:
-    if len(sys.argv) != 3:
+    if len(sys.argv) not in {3, 4}:
         print(
-            "usage: python -m jacobian.checker_worker module:function expected-digest",
+            "usage: python -m jacobian.checker_worker "
+            "module:function expected-digest [provider-runtime-json]",
             file=sys.stderr,
         )
         return 2
@@ -40,6 +80,9 @@ def main() -> int:
         if measured_before != sys.argv[2]:
             error_code = "SOURCE_CHANGED"
             raise ValueError("checker source differs from its authorized digest")
+        runtime, runtime_digest_before = _measure_runtime(
+            sys.argv[3] if len(sys.argv) == 4 else None
+        )
         install_source_only_importer(sys.argv[1])
         with contextlib.redirect_stdout(sys.stderr):
             checker = _resolve(sys.argv[1])
@@ -48,11 +91,20 @@ def main() -> int:
         if measured_after != measured_before:
             error_code = "SOURCE_CHANGED"
             raise ValueError("checker source changed during execution")
+        _, runtime_digest_after = _measure_runtime(
+            canonicalize_json(runtime.model_dump(mode="json")).decode("utf-8")
+            if runtime is not None
+            else None
+        )
+        if runtime_digest_after != runtime_digest_before:
+            error_code = "SOURCE_CHANGED"
+            raise ValueError("checker runtime changed during execution")
         sys.stdout.buffer.write(
             canonicalize_json(
                 {
                     "decision": response,
                     "measured_checker_digest": measured_after,
+                    "measured_runtime_digest": runtime_digest_after,
                 }
             )
         )

--- a/src/jacobian/contracts/checkers.py
+++ b/src/jacobian/contracts/checkers.py
@@ -7,7 +7,12 @@ from typing import Literal, Self
 
 from pydantic import model_validator
 
-from jacobian.contracts.capabilities import CapabilityId
+from jacobian.contracts.capabilities import (
+    CapabilityId,
+    CapabilityProviderAvailability,
+    CapabilityProviderDigestKind,
+    CapabilityProviderRuntime,
+)
 from jacobian.contracts.common import ArtifactUri, CheckerUri, Sha256Digest
 from jacobian.contracts.evidence import FormatIdentifier
 from jacobian.contracts.plugins import Entrypoint
@@ -33,6 +38,7 @@ class CheckerRegistration(ContractModel):
     name: str
     entrypoint: Entrypoint
     executable_digest: Sha256Digest
+    provider_runtime: CapabilityProviderRuntime | None = None
     evidence_kind: EvidenceKind
     format_id: FormatIdentifier
     format_version: str
@@ -42,6 +48,26 @@ class CheckerRegistration(ContractModel):
     target_schema_uris: tuple[ArtifactUri, ...] = ()
     target_semantics_uris: tuple[ArtifactUri, ...] = ()
     authorized: bool = True
+
+    @model_validator(mode="after")
+    def require_exact_external_runtime(self) -> Self:
+        runtime = self.provider_runtime
+        if runtime is None:
+            return self
+        if (
+            runtime.availability is not CapabilityProviderAvailability.AVAILABLE
+            or runtime.digest_kind is not CapabilityProviderDigestKind.EXECUTABLE
+            or runtime.digest is None
+            or not isinstance(runtime.configuration.get("executable"), str)
+        ):
+            raise ValueError(
+                "checker provider runtime must identify an available executable"
+            )
+        if runtime.checker_ids:
+            raise ValueError(
+                "checker provider runtime cannot recursively contain checker IDs"
+            )
+        return self
 
 
 class CheckerAuditEvent(ContractModel):

--- a/src/jacobian/contracts/sat.py
+++ b/src/jacobian/contracts/sat.py
@@ -342,6 +342,44 @@ class SatProofArtifact(ContractModel):
         return _decode_base64(self.proof_base64)
 
 
+class SatUnsatProofVerificationRequest(ContractModel):
+    """Verify one stored raw DRAT proof against its exact bound CNF."""
+
+    proof_uri: ArtifactUri
+
+
+class SatUnsatProofVerificationOutput(ContractModel):
+    """Model-facing projection of one independent DRAT replay."""
+
+    status: Literal[
+        "VERIFIED_UNSAT",
+        "REJECTED",
+        "TIMEOUT",
+        "CANCELLED",
+        "ERROR",
+    ]
+    conclusion: Literal["TRUE", "UNKNOWN"]
+    cnf_uri: ArtifactUri
+    proof_uri: ArtifactUri
+    certificate_uri: ArtifactUri
+    checker_id: CheckerUri
+    verification_record_uri: ArtifactUri | None = None
+    detail: str = Field(min_length=1, max_length=1024)
+
+    @model_validator(mode="after")
+    def bind_verified_unsat_projection(self) -> Self:
+        if self.status == "VERIFIED_UNSAT":
+            if self.conclusion != "TRUE" or self.verification_record_uri is None:
+                raise ValueError(
+                    "verified UNSAT output requires TRUE and a verification record"
+                )
+        elif self.conclusion != "UNKNOWN" or self.verification_record_uri is not None:
+            raise ValueError(
+                "non-verified proof output cannot carry a conclusion or record"
+            )
+        return self
+
+
 def canonicalize_cnf(
     *,
     variable_names: Sequence[str],

--- a/src/jacobian/kernel.py
+++ b/src/jacobian/kernel.py
@@ -51,7 +51,11 @@ from jacobian.polynomial_capabilities import (
     install_polynomial_capabilities,
 )
 from jacobian.polytope import PolytopeService
-from jacobian.provider_runtime import cadical_provider_runtime, lean_provider_runtime
+from jacobian.provider_runtime import (
+    cadical_provider_runtime,
+    drat_trim_provider_runtime,
+    lean_provider_runtime,
+)
 from jacobian.references import (
     LeanCheckerInstallation,
     PolytopeCheckerInstallation,
@@ -62,7 +66,9 @@ from jacobian.registry import CheckerRegistry
 from jacobian.sat import SatArtifactService, install_sat_artifacts
 from jacobian.sat_capabilities import (
     SatAssignmentCheckerInstallation,
+    SatUnsatProofCheckerInstallation,
     install_sat_assignment_checker,
+    install_sat_unsat_proof_checker,
 )
 from jacobian.schema_registry import SchemaRegistry
 from jacobian.search import SearchService
@@ -212,6 +218,20 @@ class JacobianKernel:
         )
         if sat_assignment_adapter is not None:
             self.register_capability(sat_assignment_adapter)
+        self.drat_trim_runtime: CapabilityProviderRuntime = drat_trim_provider_runtime()
+        self.sat_unsat_proof_checker: SatUnsatProofCheckerInstallation
+        proof_adapter, self.sat_unsat_proof_checker = install_sat_unsat_proof_checker(
+            self.store,
+            self.schemas,
+            self.artifacts,
+            self.sat,
+            self.verification,
+            self.checkers,
+            self.drat_trim_runtime,
+            authorize_checker=install_references,
+        )
+        if proof_adapter is not None:
+            self.register_capability(proof_adapter)
         self.cadical_runtime: CapabilityProviderRuntime = cadical_provider_runtime()
         if (
             self.cadical_runtime.availability

--- a/src/jacobian/provider_runtime.py
+++ b/src/jacobian/provider_runtime.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any
 
 from jacobian.bounded_process import run_bounded_process
+from jacobian.canonical import loads_strict_json
 from jacobian.contracts.capabilities import (
     CapabilityInstallTier,
     CapabilityProviderAvailability,
@@ -23,6 +24,9 @@ from jacobian.contracts.capabilities import (
 from jacobian.implementation import ImplementationError, package_source_digest
 
 CADICAL_VERSION = "3.0.1"
+DRAT_TRIM_RELEASE_TAG = "v05.22.2023"
+DRAT_TRIM_SOURCE_COMMIT = "2e5e29cb0019d5cfd547d4208dca1b3ec290349f"
+DRAT_TRIM_SOURCE_REPOSITORY = "https://github.com/marijnheule/drat-trim"
 
 
 class ProviderRuntimeError(RuntimeError):
@@ -316,6 +320,102 @@ def cadical_provider_runtime(
             "executable": str(resolved),
             "projection": "jacobian.dimacs.cnf/v1",
             "proof_format": "drat-text/v1",
+        },
+    )
+
+
+def drat_trim_provider_runtime(
+    executable: str | Path = "drat-trim",
+    *,
+    provenance_file: str | Path | None = None,
+) -> CapabilityProviderRuntime:
+    """Inspect an operator-provenanced pinned DRAT-trim runtime."""
+
+    resolved_name = shutil.which(os.fspath(executable))
+    if resolved_name is None:
+        return _unavailable_runtime(
+            provider="drat-trim",
+            install_tier=CapabilityInstallTier.T2,
+            license_id="MIT",
+            diagnostic=(
+                f"The pinned DRAT-trim {DRAT_TRIM_RELEASE_TAG} runtime is unavailable."
+            ),
+        )
+    try:
+        resolved = Path(resolved_name).resolve(strict=True)
+        manifest_path = (
+            Path(provenance_file).resolve(strict=True)
+            if provenance_file is not None
+            else resolved.with_name(resolved.name + ".jacobian-runtime.json").resolve(
+                strict=True
+            )
+        )
+        manifest = loads_strict_json(manifest_path.read_bytes())
+        expected_manifest = {
+            "runtime_manifest_version": "1",
+            "provider": "drat-trim",
+            "release_tag": DRAT_TRIM_RELEASE_TAG,
+            "source_repository": DRAT_TRIM_SOURCE_REPOSITORY,
+            "source_commit": DRAT_TRIM_SOURCE_COMMIT,
+        }
+        if (
+            not isinstance(manifest, dict)
+            or set(manifest) != {*expected_manifest, "executable_sha256"}
+            or any(
+                manifest.get(key) != value for key, value in expected_manifest.items()
+            )
+            or not isinstance(manifest.get("executable_sha256"), str)
+        ):
+            raise ProviderRuntimeError("DRAT-trim provenance is invalid")
+        digest = _sha256_file(resolved)
+        if manifest["executable_sha256"] != digest:
+            raise ProviderRuntimeError("DRAT-trim executable digest changed")
+        completed = run_bounded_process(
+            [str(resolved), "-h"],
+            input_bytes=b"",
+            timeout_seconds=5,
+            environment={
+                **os.environ,
+                "LANG": "C",
+                "LC_ALL": "C",
+                "TZ": "UTC",
+            },
+            stdout_limit=16_000,
+            stderr_limit=16_000,
+        )
+        if (
+            completed.timed_out
+            or completed.stdout_exceeded
+            or completed.stderr_exceeded
+            or completed.returncode != 0
+            or b"usage: drat-trim" not in completed.stdout
+        ):
+            raise ProviderRuntimeError("DRAT-trim health probe failed")
+    except (OSError, ProviderRuntimeError, ValueError):
+        return _unavailable_runtime(
+            provider="drat-trim",
+            install_tier=CapabilityInstallTier.T2,
+            license_id="MIT",
+            diagnostic=(
+                f"The pinned DRAT-trim {DRAT_TRIM_RELEASE_TAG} runtime and "
+                "operator provenance are unavailable."
+            ),
+        )
+    return CapabilityProviderRuntime(
+        provider="drat-trim",
+        availability=CapabilityProviderAvailability.AVAILABLE,
+        version=DRAT_TRIM_RELEASE_TAG,
+        digest=digest,
+        digest_kind=CapabilityProviderDigestKind.EXECUTABLE,
+        platform=_platform_tag(),
+        install_tier=CapabilityInstallTier.T2,
+        license_id="MIT",
+        features=("drat-text/v1", "unsat-proof-replay"),
+        configuration={
+            "executable": str(resolved),
+            "provenance_file": str(manifest_path),
+            "source_repository": DRAT_TRIM_SOURCE_REPOSITORY,
+            "source_commit": DRAT_TRIM_SOURCE_COMMIT,
         },
     )
 

--- a/src/jacobian/registry.py
+++ b/src/jacobian/registry.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import BinaryIO
 
 from jacobian.canonical import canonicalize_json, loads_strict_json
+from jacobian.contracts.capabilities import CapabilityProviderRuntime
 from jacobian.contracts.checkers import (
     CheckerAuditEvent,
     CheckerRegistration,
@@ -55,6 +56,32 @@ def compute_entrypoint_digest(entrypoint: str) -> str:
             "The checker entrypoint could not be loaded. Check that the "
             "module:function entrypoint is installed, then retry."
         ) from exc
+
+
+def _require_runtime_unchanged(runtime: CapabilityProviderRuntime | None) -> None:
+    if runtime is None:
+        return
+    executable = runtime.configuration.get("executable")
+    if not isinstance(executable, str) or runtime.digest is None:
+        raise CheckerExecutableChangedError(
+            "The authorized checker runtime identity is incomplete."
+        )
+    try:
+        resolved = Path(executable).resolve(strict=True)
+        digest = hashlib.sha256()
+        with resolved.open("rb") as stream:
+            for block in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(block)
+    except OSError as exc:
+        raise CheckerExecutableChangedError(
+            "The authorized checker runtime is unavailable."
+        ) from exc
+    measured = "sha256:" + digest.hexdigest()
+    if measured != runtime.digest:
+        raise CheckerExecutableChangedError(
+            "The checker runtime changed after authorization. Authorize the "
+            "current runtime, then retry."
+        )
 
 
 class CheckerRegistry:
@@ -138,6 +165,7 @@ class CheckerRegistry:
         candidate_schema_uris: tuple[str, ...],
         target_schema_uris: tuple[str, ...] = (),
         target_semantics_uris: tuple[str, ...] = (),
+        provider_runtime: CapabilityProviderRuntime | None = None,
         reason: str = "operator authorization",
     ) -> CheckerRegistration:
         """Authorize one measured checker for explicit evidence compatibility."""
@@ -153,12 +181,14 @@ class CheckerRegistry:
         )
         if scope_error is not None:
             raise CheckerRegistryError(scope_error)
+        _require_runtime_unchanged(provider_runtime)
         executable_digest = compute_entrypoint_digest(entrypoint)
         unbound_registration = CheckerRegistration(
             checker_id="checker://sha256/" + "0" * 64,
             name=name,
             entrypoint=entrypoint,
             executable_digest=executable_digest,
+            provider_runtime=provider_runtime,
             evidence_kind=selected_kind,
             format_id=format_id,
             format_version=format_version,
@@ -172,7 +202,9 @@ class CheckerRegistry:
         registration = unbound_registration.model_copy(
             update={"checker_id": _checker_identifier(unbound_registration)}
         )
-        encoded = canonicalize_json(registration.model_dump(mode="json"))
+        encoded = canonicalize_json(
+            registration.model_dump(mode="json", exclude_none=True)
+        )
 
         with self._connect() as connection:
             existing = connection.execute(
@@ -273,6 +305,7 @@ class CheckerRegistry:
                 "The checker changed after authorization. Authorize the current "
                 "checker version, then retry."
             )
+        _require_runtime_unchanged(registration.provider_runtime)
         return registration
 
     def require_compatible(
@@ -447,7 +480,7 @@ class CheckerRegistry:
 
 
 def _checker_identifier(registration: CheckerRegistration) -> str:
-    identity_payload = registration.model_dump(mode="json")
+    identity_payload = registration.model_dump(mode="json", exclude_none=True)
     del identity_payload["checker_id"]
     del identity_payload["authorized"]
     identifier = hashlib.sha256(

--- a/src/jacobian/sat.py
+++ b/src/jacobian/sat.py
@@ -48,6 +48,13 @@ class ResolvedSatAssignment:
     cnf_artifact: StoredArtifact
 
 
+@dataclass(frozen=True, slots=True)
+class ResolvedSatProof:
+    artifact: StoredArtifact
+    proof: SatProofArtifact
+    cnf_artifact: StoredArtifact
+
+
 class SatArtifactService:
     """Materialize SAT instances and unverified evidence with exact bindings."""
 
@@ -211,6 +218,41 @@ class SatArtifactService:
             payload=proof_artifact.model_dump(mode="json"),
             parents=(cnf_uri,),
             summary="unverified raw DRAT proof",
+        )
+
+    def resolve_proof(self, proof_uri: str) -> ResolvedSatProof:
+        """Resolve raw proof bytes whose payload and lineage bind one exact CNF."""
+
+        try:
+            artifact = self.store.get(proof_uri)
+        except StoreError as exc:
+            raise SatArtifactError(
+                "source is not an available SAT proof artifact"
+            ) from exc
+        if (
+            artifact.manifest.schema_uri != self.installation.proof_schema_uri
+            or artifact.manifest.semantics_uri != self.installation.semantics_uri
+        ):
+            raise SatArtifactError("source is not a SAT proof artifact")
+        try:
+            normalized = self.schemas.validate(
+                self.installation.proof_schema_uri,
+                artifact.payload,
+            )
+            proof = SatProofArtifact.model_validate(normalized)
+        except (SchemaRegistryError, ValueError, ValidationError) as exc:
+            raise SatArtifactError("source is not a valid SAT proof artifact") from exc
+        binding = self.bind_cnf(proof.cnf.cnf_artifact_uri)
+        if proof.cnf != binding:
+            raise SatArtifactError(
+                "SAT proof binding does not match its exact canonical CNF"
+            )
+        if binding.cnf_artifact_uri not in artifact.manifest.parents:
+            raise SatArtifactError("SAT proof is missing its canonical CNF parent")
+        return ResolvedSatProof(
+            artifact=artifact,
+            proof=proof,
+            cnf_artifact=self.store.get(binding.cnf_artifact_uri),
         )
 
 

--- a/src/jacobian/sat_capabilities.py
+++ b/src/jacobian/sat_capabilities.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass
 from typing import Literal
 
 from jacobian.artifacts import ArtifactService
+from jacobian.canonical import canonicalize_json
 from jacobian.capabilities import CapabilityAdapter, CapabilityInvocationError
 from jacobian.contracts.capabilities import (
     CapabilityAssurance,
@@ -15,11 +17,14 @@ from jacobian.contracts.capabilities import (
     CapabilityDescriptor,
     CapabilityDiagnostic,
     CapabilityMode,
+    CapabilityProviderAvailability,
+    CapabilityProviderRuntime,
     CapabilityRequest,
     CapabilityResult,
     CapabilityScope,
 )
 from jacobian.contracts.evidence import (
+    CertificateEnvelope,
     EvidenceBindings,
     WitnessEnvelope,
     WitnessRole,
@@ -32,6 +37,8 @@ from jacobian.contracts.results import (
 from jacobian.contracts.sat import (
     SatAssignmentVerificationOutput,
     SatAssignmentVerificationRequest,
+    SatUnsatProofVerificationOutput,
+    SatUnsatProofVerificationRequest,
 )
 from jacobian.provider_runtime import known_provider_runtime
 from jacobian.registry import CheckerRegistry
@@ -44,6 +51,12 @@ from jacobian.verification import VerificationService
 @dataclass(frozen=True, slots=True)
 class SatAssignmentCheckerInstallation:
     witness_schema_uri: str
+    checker_id: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class SatUnsatProofCheckerInstallation:
+    certificate_schema_uri: str
     checker_id: str | None
 
 
@@ -89,6 +102,58 @@ def install_sat_assignment_checker(
             sat=sat,
             verification=verification,
             installation=installation,
+        )
+    return adapter, installation
+
+
+def install_sat_unsat_proof_checker(
+    store: ArtifactStore,
+    schemas: SchemaRegistry,
+    artifacts: ArtifactService,
+    sat: SatArtifactService,
+    verification: VerificationService,
+    checkers: CheckerRegistry,
+    runtime: CapabilityProviderRuntime,
+    *,
+    authorize_checker: bool,
+) -> tuple[CapabilityAdapter | None, SatUnsatProofCheckerInstallation]:
+    """Install the proof certificate schema and optionally authorize DRAT replay."""
+
+    certificate_schema_uri = schemas.register_model(
+        name="jacobian.certificate-envelope",
+        version="1",
+        model=CertificateEnvelope,
+    )
+    checker_id = None
+    if (
+        authorize_checker
+        and runtime.availability is CapabilityProviderAvailability.AVAILABLE
+    ):
+        checker_id = checkers.authorize(
+            name="pinned DRAT-trim exact SAT UNSAT proof checker",
+            entrypoint="jacobian_checkers.sat:check_unsat_proof",
+            evidence_kind="CERTIFICATE",
+            format_id="sat.unsat-proof",
+            format_version="1",
+            claim_schema_uris=(sat.installation.cnf_schema_uri,),
+            semantics_uris=(sat.installation.semantics_uri,),
+            candidate_schema_uris=(sat.installation.proof_schema_uri,),
+            provider_runtime=runtime,
+            reason="operator-authorized pinned DRAT-trim proof replay",
+        ).checker_id
+    installation = SatUnsatProofCheckerInstallation(
+        certificate_schema_uri=certificate_schema_uri,
+        checker_id=checker_id,
+    )
+    adapter: CapabilityAdapter | None = None
+    if checker_id is not None:
+        adapter = SatUnsatProofVerificationAdapter(
+            store=store,
+            artifacts=artifacts,
+            sat=sat,
+            verification=verification,
+            installation=installation,
+            runtime=runtime,
         )
     return adapter, installation
 
@@ -291,6 +356,217 @@ class SatAssignmentVerificationAdapter:
                     if verified
                     else (
                         "checker replay completed without accepting the assignment; "
+                        "no opposite conclusion follows"
+                        if checked.execution.status is ExecutionStatus.COMPLETED
+                        else "checker execution did not complete; no mathematical "
+                        "conclusion follows"
+                    )
+                ),
+                verification_record_uri=record_uri,
+            ),
+            artifact_uris=tuple(artifact_uris),
+        )
+
+
+class SatUnsatProofVerificationAdapter:
+    """Verify one raw proof; rejection never establishes satisfiability."""
+
+    def __init__(
+        self,
+        *,
+        store: ArtifactStore,
+        artifacts: ArtifactService,
+        sat: SatArtifactService,
+        verification: VerificationService,
+        installation: SatUnsatProofCheckerInstallation,
+        runtime: CapabilityProviderRuntime,
+    ) -> None:
+        checker_id = installation.checker_id
+        if checker_id is None:
+            raise ValueError("SAT UNSAT proof checker is not authorized")
+        self.store = store
+        self.artifacts = artifacts
+        self.sat = sat
+        self.verification = verification
+        self.installation = installation
+        descriptor_runtime = runtime.model_copy(update={"checker_ids": (checker_id,)})
+        self._descriptor = CapabilityDescriptor(
+            capability_id="sat.unsat_proof.verify",
+            version="1",
+            title="Verify a SAT UNSAT proof",
+            description=(
+                "Replay exact raw text DRAT against its bound canonical CNF in "
+                "operator-authorized pinned DRAT-trim."
+            ),
+            provider="drat-trim",
+            provider_runtime=descriptor_runtime,
+            modes=(CapabilityMode.VERIFY,),
+            input_schema=model_schema(SatUnsatProofVerificationRequest),
+            output_schema=model_schema(SatUnsatProofVerificationOutput),
+            tags=("sat", "cnf", "unsat", "proof", "verification", "drat"),
+        )
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        return self._descriptor
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        validated = SatUnsatProofVerificationRequest.model_validate(request.input)
+        try:
+            resolved = self.sat.resolve_proof(validated.proof_uri)
+            semantics = self.store.get(self.sat.installation.semantics_uri)
+        except (SatArtifactError, StoreError) as exc:
+            raise CapabilityInvocationError(
+                CapabilityDiagnostic(
+                    code="INVALID_SAT_UNSAT_PROOF",
+                    stage="artifact_resolution",
+                    message=str(exc),
+                    path="proof_uri",
+                    schema_uri=self.sat.installation.proof_schema_uri,
+                    expected=(
+                        "a valid raw DRAT proof artifact bound by payload and "
+                        "lineage to one canonical CNF"
+                    ),
+                    hint=(
+                        "Create the proof with SatArtifactService.put_proof against "
+                        "the intended canonical CNF."
+                    ),
+                )
+            ) from exc
+
+        checker_id = self.installation.checker_id
+        assert checker_id is not None
+        bindings = EvidenceBindings(
+            claim_digest=resolved.cnf_artifact.manifest.object_digest,
+            semantics_digest=semantics.manifest.object_digest,
+            candidate_digest=resolved.artifact.manifest.object_digest,
+        )
+        payload = {
+            "cnf_uri": resolved.cnf_artifact.artifact_uri,
+            "proof_uri": resolved.artifact.artifact_uri,
+        }
+        certificate = CertificateEnvelope(
+            certificate_type="sat.unsat-proof",
+            format_version="1",
+            bindings=bindings,
+            payload_digest=(
+                "sha256:" + hashlib.sha256(canonicalize_json(payload)).hexdigest()
+            ),
+            payload=payload,
+        )
+        certificate_artifact = self.artifacts.put(
+            schema_uri=self.installation.certificate_schema_uri,
+            semantics_uri=self.sat.installation.semantics_uri,
+            payload=certificate.model_dump(mode="json"),
+            parents=(
+                resolved.cnf_artifact.artifact_uri,
+                resolved.artifact.artifact_uri,
+            ),
+            summary="SAT UNSAT proof verification certificate",
+        )
+        checked = self.verification.verify_certificate(
+            certificate_uri=certificate_artifact.artifact_uri,
+            checker_id=checker_id,
+            include_artifact_metadata=True,
+        )
+        verified = (
+            checked.execution.status is ExecutionStatus.COMPLETED
+            and checked.conclusion is Conclusion.TRUE
+            and checked.assurance.verification is Verification.VERIFIED
+            and checked.verification_record_uri is not None
+        )
+        status: Literal[
+            "VERIFIED_UNSAT",
+            "REJECTED",
+            "TIMEOUT",
+            "CANCELLED",
+            "ERROR",
+        ]
+        if verified:
+            status = "VERIFIED_UNSAT"
+        elif checked.execution.status is ExecutionStatus.COMPLETED:
+            status = "REJECTED"
+        elif checked.execution.status is ExecutionStatus.TIMEOUT:
+            status = "TIMEOUT"
+        elif checked.execution.status is ExecutionStatus.CANCELLED:
+            status = "CANCELLED"
+        else:
+            status = "ERROR"
+        detail = checked.execution.detail
+        if detail is None and checked.input.errors:
+            detail = checked.input.errors[0]
+        if detail is None:
+            detail = (
+                "the authorized DRAT checker accepted the exact bound proof"
+                if verified
+                else "the proof was not independently accepted"
+            )
+        output = SatUnsatProofVerificationOutput(
+            status=status,
+            conclusion="TRUE" if verified else "UNKNOWN",
+            cnf_uri=resolved.cnf_artifact.artifact_uri,
+            proof_uri=resolved.artifact.artifact_uri,
+            certificate_uri=certificate_artifact.artifact_uri,
+            checker_id=checker_id,
+            verification_record_uri=(
+                checked.verification_record_uri if verified else None
+            ),
+            detail=detail,
+        )
+        record_uri = checked.verification_record_uri if verified else None
+        artifact_uris = [
+            resolved.cnf_artifact.artifact_uri,
+            resolved.artifact.artifact_uri,
+            certificate_artifact.artifact_uri,
+        ]
+        if record_uri is not None:
+            artifact_uris.append(record_uri)
+        assurance_level = (
+            CapabilityAssuranceLevel.VERIFIED
+            if verified
+            else (
+                CapabilityAssuranceLevel.COMPUTED
+                if checked.execution.status is ExecutionStatus.COMPLETED
+                else CapabilityAssuranceLevel.HEURISTIC
+            )
+        )
+        return CapabilityResult(
+            capability_id=self.descriptor.capability_id,
+            capability_version=self.descriptor.version,
+            mode=request.mode,
+            execution=checked.execution,
+            output=output.model_dump(mode="json"),
+            scope=CapabilityScope(
+                description="the full exact canonical CNF bound by the raw proof",
+                parameters={
+                    "declared_scope": "FULL_CNF",
+                    "variable_count": resolved.proof.cnf.variable_count,
+                    "clause_count": resolved.proof.cnf.clause_count,
+                    "proof_format": resolved.proof.proof_format,
+                    "proof_format_version": resolved.proof.proof_format_version,
+                },
+                artifact_uri=resolved.cnf_artifact.artifact_uri,
+            ),
+            completeness=CapabilityCompleteness(
+                status=CapabilityCompletenessStatus.NOT_APPLICABLE,
+                basis=(
+                    "certificate replay checks one exact proof and makes no "
+                    "enumeration-completeness claim"
+                ),
+                assurance_level=(
+                    CapabilityAssuranceLevel.COMPUTED
+                    if checked.execution.status is ExecutionStatus.COMPLETED
+                    else CapabilityAssuranceLevel.HEURISTIC
+                ),
+            ),
+            assurance=CapabilityAssurance(
+                level=assurance_level,
+                basis=(
+                    "accepted by the operator-authorized external DRAT-trim "
+                    "runtime bound into the checker registration"
+                    if verified
+                    else (
+                        "checker replay completed without accepting the proof; "
                         "no opposite conclusion follows"
                         if checked.execution.status is ExecutionStatus.COMPLETED
                         else "checker execution did not complete; no mathematical "

--- a/src/jacobian/verification.py
+++ b/src/jacobian/verification.py
@@ -16,6 +16,7 @@ from pydantic import ValidationError
 from jacobian.bounded_process import run_bounded_process
 from jacobian.canonical import canonicalize_json, loads_strict_json
 from jacobian.contracts.artifacts import ArtifactPutResult
+from jacobian.contracts.capabilities import CapabilityProviderRuntime
 from jacobian.contracts.checkers import CheckerDecision, EvidenceKind
 from jacobian.contracts.evidence import (
     CertificateEnvelope,
@@ -97,18 +98,20 @@ def _digest_bytes(data: bytes) -> str:
     return "sha256:" + hashlib.sha256(data).hexdigest()
 
 
-def _environment_digest(checker_digest: str) -> str:
-    return _digest_bytes(
-        canonicalize_json(
-            {
-                "environment_version": "1",
-                "python": platform.python_version(),
-                "implementation": platform.python_implementation(),
-                "platform": platform.platform(),
-                "checker_digest": checker_digest,
-            }
-        )
-    )
+def _environment_digest(
+    checker_digest: str,
+    provider_runtime: CapabilityProviderRuntime | None = None,
+) -> str:
+    identity: dict[str, Any] = {
+        "environment_version": "1",
+        "python": platform.python_version(),
+        "implementation": platform.python_implementation(),
+        "platform": platform.platform(),
+        "checker_digest": checker_digest,
+    }
+    if provider_runtime is not None:
+        identity["provider_runtime"] = provider_runtime.model_dump(mode="json")
+    return _digest_bytes(canonicalize_json(identity))
 
 
 def _checker_failure_detail(response: Any) -> str:
@@ -202,6 +205,7 @@ class VerificationService:
         entrypoint: str,
         expected_digest: str,
         request: dict[str, Any],
+        provider_runtime: CapabilityProviderRuntime | None = None,
         timeout_seconds: float | None = None,
     ) -> CheckerDecision:
         environment = dict(os.environ)
@@ -210,14 +214,21 @@ class VerificationService:
             30 if timeout_seconds is None else timeout_seconds,
             self.checker_timeout_seconds,
         )
+        command = [
+            sys.executable,
+            "-m",
+            "jacobian.checker_worker",
+            entrypoint,
+            expected_digest,
+        ]
+        if provider_runtime is not None:
+            command.append(
+                canonicalize_json(provider_runtime.model_dump(mode="json")).decode(
+                    "utf-8"
+                )
+            )
         completed = run_bounded_process(
-            [
-                sys.executable,
-                "-m",
-                "jacobian.checker_worker",
-                entrypoint,
-                expected_digest,
-            ],
+            command,
             input_bytes=canonicalize_json(request),
             timeout_seconds=effective_timeout,
             environment=environment,
@@ -249,6 +260,15 @@ class VerificationService:
         if response.get("measured_checker_digest") != expected_digest:
             _LOGGER.warning(
                 "checker worker measured an unexpected implementation: %r",
+                response,
+            )
+            raise CheckerExecutionError(_CHECKER_CHANGED)
+        expected_runtime_digest = (
+            provider_runtime.digest if provider_runtime is not None else None
+        )
+        if response.get("measured_runtime_digest") != expected_runtime_digest:
+            _LOGGER.warning(
+                "checker worker measured an unexpected external runtime: %r",
                 response,
             )
             raise CheckerExecutionError(_CHECKER_CHANGED)
@@ -370,6 +390,7 @@ class VerificationService:
                 entrypoint=checker.entrypoint,
                 expected_digest=checker.executable_digest,
                 request=request,
+                provider_runtime=checker.provider_runtime,
                 timeout_seconds=timeout_seconds,
             )
             runtime_ms = int((time.monotonic() - started) * 1000)
@@ -415,7 +436,10 @@ class VerificationService:
                 method=decision.method,
                 coverage=decision.coverage,
                 request_digest=request_digest,
-                environment_digest=_environment_digest(checker.executable_digest),
+                environment_digest=_environment_digest(
+                    checker.executable_digest,
+                    checker.provider_runtime,
+                ),
             )
             parent_uris = [claim_uri, candidate_uri, witness_uri]
             if scope is not None:
@@ -492,6 +516,7 @@ class VerificationService:
         certificate_uri: str,
         checker_id: str | None = None,
         timeout_seconds: float | None = None,
+        include_artifact_metadata: bool = False,
     ) -> ResultEnvelope:
         """Run a specified compatible checker or uniquely select one."""
 
@@ -573,11 +598,27 @@ class VerificationService:
                 )
             request = {
                 "request_version": "1",
-                "claim": self._checker_artifact(claim),
-                "candidate": self._checker_artifact(candidate),
-                "scope": self._checker_artifact(scope) if scope is not None else None,
+                "claim": self._checker_artifact(
+                    claim,
+                    include_storage_metadata=include_artifact_metadata,
+                ),
+                "candidate": self._checker_artifact(
+                    candidate,
+                    include_storage_metadata=include_artifact_metadata,
+                ),
+                "scope": (
+                    self._checker_artifact(
+                        scope,
+                        include_storage_metadata=include_artifact_metadata,
+                    )
+                    if scope is not None
+                    else None
+                ),
                 "certificate": {
-                    **self._checker_artifact(certificate_artifact),
+                    **self._checker_artifact(
+                        certificate_artifact,
+                        include_storage_metadata=include_artifact_metadata,
+                    ),
                     "payload": certificate.model_dump(mode="json"),
                 },
                 "expected_bindings": certificate.bindings.model_dump(mode="json"),
@@ -587,6 +628,7 @@ class VerificationService:
                 entrypoint=checker.entrypoint,
                 expected_digest=checker.executable_digest,
                 request=request,
+                provider_runtime=checker.provider_runtime,
                 timeout_seconds=timeout_seconds,
             )
             runtime_ms = int((time.monotonic() - started) * 1000)
@@ -632,7 +674,10 @@ class VerificationService:
                 method=decision.method,
                 coverage=decision.coverage,
                 request_digest=request_digest,
-                environment_digest=_environment_digest(checker.executable_digest),
+                environment_digest=_environment_digest(
+                    checker.executable_digest,
+                    checker.provider_runtime,
+                ),
                 relation_id=decision.relation_id,
                 obligation_uri=decision.obligation_uri,
             )
@@ -786,6 +831,7 @@ class VerificationService:
                 entrypoint=checker.entrypoint,
                 expected_digest=checker.executable_digest,
                 request=request,
+                provider_runtime=checker.provider_runtime,
             )
             runtime_ms = int((time.monotonic() - started) * 1000)
             if not decision.accepted:
@@ -830,7 +876,10 @@ class VerificationService:
                 method=decision.method,
                 coverage=decision.coverage,
                 request_digest=request_digest,
-                environment_digest=_environment_digest(checker.executable_digest),
+                environment_digest=_environment_digest(
+                    checker.executable_digest,
+                    checker.provider_runtime,
+                ),
             )
             record_artifact = self._commit_verification_record(
                 checker_id=checker.checker_id,
@@ -981,6 +1030,7 @@ class VerificationService:
                 entrypoint=checker.entrypoint,
                 expected_digest=checker.executable_digest,
                 request=request,
+                provider_runtime=checker.provider_runtime,
             )
             runtime_ms = int((time.monotonic() - started) * 1000)
             if not decision.accepted:
@@ -1024,7 +1074,10 @@ class VerificationService:
                 method=decision.method,
                 coverage=decision.coverage,
                 request_digest=request_digest,
-                environment_digest=_environment_digest(checker.executable_digest),
+                environment_digest=_environment_digest(
+                    checker.executable_digest,
+                    checker.provider_runtime,
+                ),
             )
             record_artifact = self._commit_verification_record(
                 checker_id=checker.checker_id,

--- a/src/jacobian_checkers/sat.py
+++ b/src/jacobian_checkers/sat.py
@@ -6,15 +6,24 @@ import Jacobian's SAT contracts or any solver implementation.
 
 from __future__ import annotations
 
+import base64
+import binascii
 import hashlib
 import json
+import os
 import re
+import subprocess
+import tempfile
+import threading
+import time
 import unicodedata
-from typing import Any
+from pathlib import Path
+from typing import Any, BinaryIO
 
 _ARTIFACT_URI = re.compile(r"^artifact://sha256/[0-9a-f]{64}$")
 _DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
 _VARIABLE_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_.:-]{0,127}$")
+_DRAT_INTEGER = re.compile(r"^(?:0|-?[1-9][0-9]*)$")
 _ARTIFACT_KEYS = {
     "artifact_uri",
     "object_digest",
@@ -31,6 +40,9 @@ _BINDING_KEYS = {
     "scope_digest",
     "encoding_digest",
 }
+DRAT_TRIM_OUTPUT_LIMIT = 1024 * 1024
+DRAT_TRIM_TIMEOUT_SECONDS = 120
+_DRAT_ASCII_PREFIX = b"c jacobian drat-text/v1 force-ascii 0123456789\n"
 
 
 def _reject(detail: str) -> dict[str, Any]:
@@ -39,6 +51,17 @@ def _reject(detail: str) -> dict[str, Any]:
         "conclusion": "UNKNOWN",
         "arithmetic": "EXACT_INTEGER",
         "method": "DIRECT_WITNESS",
+        "coverage": "NOT_APPLICABLE",
+        "detail": detail,
+    }
+
+
+def _reject_proof(detail: str) -> dict[str, Any]:
+    return {
+        "accepted": False,
+        "conclusion": "UNKNOWN",
+        "arithmetic": "EXACT_INTEGER",
+        "method": "CHECKED_CERTIFICATE",
         "coverage": "NOT_APPLICABLE",
         "detail": detail,
     }
@@ -265,6 +288,383 @@ def _validate_assignment(
     ):
         raise ValueError("SAT assignment is not total and Boolean")
     return values
+
+
+def _dimacs_bytes(clauses: list[list[int]], variable_count: int) -> bytes:
+    rows = [f"p cnf {variable_count} {len(clauses)}\n"]
+    for literals in clauses:
+        prefix = " ".join(str(literal) for literal in literals)
+        rows.append(f"{prefix} 0\n" if prefix else "0\n")
+    return "".join(rows).encode("ascii")
+
+
+def _validate_proof(
+    payload: object,
+    *,
+    claim: dict[str, Any],
+    variable_count: int,
+    clause_count: int,
+    variable_map_digest: str,
+    dimacs_digest: str,
+) -> bytes:
+    if not isinstance(payload, dict) or set(payload) != {
+        "proof_schema_version",
+        "cnf",
+        "declared_scope",
+        "proof_format",
+        "proof_format_version",
+        "proof_encoding",
+        "proof_base64",
+        "proof_digest",
+        "producer",
+        "resource_budget",
+    }:
+        raise ValueError("SAT proof has an invalid shape")
+    if (
+        payload["proof_schema_version"] != "1"
+        or payload["declared_scope"] != "FULL_CNF"
+        or payload["proof_format"] != "DRAT"
+        or payload["proof_format_version"] != "drat-text/v1"
+        or payload["proof_encoding"] != "BASE64"
+        or not isinstance(payload["producer"], dict)
+        or not isinstance(payload["resource_budget"], dict)
+        or not isinstance(payload["proof_base64"], str)
+        or len(payload["proof_base64"]) > 8_000_000
+        or not isinstance(payload["proof_digest"], str)
+        or _DIGEST.fullmatch(payload["proof_digest"]) is None
+    ):
+        raise ValueError("SAT proof metadata is malformed")
+    try:
+        raw = base64.b64decode(
+            payload["proof_base64"].encode("ascii"),
+            validate=True,
+        )
+    except (UnicodeEncodeError, binascii.Error) as exc:
+        raise ValueError("SAT proof base64 is malformed") from exc
+    if (
+        base64.b64encode(raw).decode("ascii") != payload["proof_base64"]
+        or _sha256(raw) != payload["proof_digest"]
+    ):
+        raise ValueError("SAT proof bytes do not match their exact digest")
+    binding = payload["cnf"]
+    expected_binding = {
+        "binding_version": "1",
+        "cnf_artifact_uri": claim["artifact_uri"],
+        "cnf_object_digest": claim["object_digest"],
+        "cnf_payload_digest": claim["payload_digest"],
+        "variable_map_digest": variable_map_digest,
+        "dimacs_digest": dimacs_digest,
+        "projection_format": "DIMACS-CNF",
+        "projection_version": "jacobian.dimacs.cnf/v1",
+        "variable_count": variable_count,
+        "clause_count": clause_count,
+    }
+    if binding != expected_binding:
+        raise ValueError("SAT proof is not bound to the exact canonical CNF")
+    return raw
+
+
+def _validate_certificate(
+    certificate: dict[str, Any],
+    *,
+    claim: dict[str, Any],
+    candidate: dict[str, Any],
+    expected_bindings: dict[str, Any],
+) -> None:
+    envelope = certificate["payload"]
+    if not isinstance(envelope, dict) or set(envelope) != {
+        "evidence_schema_version",
+        "certificate_type",
+        "format_version",
+        "bindings",
+        "payload_digest",
+        "payload",
+    }:
+        raise ValueError("SAT proof certificate has an invalid shape")
+    payload = {
+        "cnf_uri": claim["artifact_uri"],
+        "proof_uri": candidate["artifact_uri"],
+    }
+    if (
+        envelope["evidence_schema_version"] != "1"
+        or envelope["certificate_type"] != "sat.unsat-proof"
+        or envelope["format_version"] != "1"
+        or envelope["bindings"] != expected_bindings
+        or envelope["payload"] != payload
+        or envelope["payload_digest"] != _sha256(_canonical_json(payload))
+    ):
+        raise ValueError("SAT proof certificate is not exactly bound")
+
+
+def _validate_drat_text_profile(proof: bytes) -> None:
+    try:
+        text = proof.decode("ascii")
+    except UnicodeDecodeError as exc:
+        raise ValueError("DRAT text proof is not ASCII") from exc
+    empty_clause_seen = False
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line == "c" or line.startswith("c "):
+            continue
+        tokens = line.split()
+        deletion = tokens[0] == "d"
+        if deletion:
+            tokens = tokens[1:]
+        if (
+            not tokens
+            or any(_DRAT_INTEGER.fullmatch(token) is None for token in tokens)
+            or tokens[-1] != "0"
+            or "0" in tokens[:-1]
+        ):
+            raise ValueError("DRAT text proof has malformed clause syntax")
+        literals = [int(token) for token in tokens[:-1]]
+        if (
+            any(abs(literal) > (1 << 31) - 1 for literal in literals)
+            or len(literals) != len(set(literals))
+            or any(-literal in literals for literal in literals)
+        ):
+            raise ValueError("DRAT text proof has a malformed clause")
+        if empty_clause_seen:
+            raise ValueError("DRAT text proof has steps after the empty clause")
+        if not literals:
+            if deletion:
+                raise ValueError("DRAT text proof deletes the empty clause")
+            empty_clause_seen = True
+
+
+def _authorized_runtime() -> tuple[Path, str]:
+    executable = os.environ.get("JACOBIAN_CHECKER_EXECUTABLE")
+    expected_digest = os.environ.get("JACOBIAN_CHECKER_RUNTIME_DIGEST")
+    if (
+        executable is None
+        or expected_digest is None
+        or _DIGEST.fullmatch(expected_digest) is None
+    ):
+        raise ValueError("DRAT-trim runtime is not operator authorized")
+    path = Path(executable).resolve(strict=True)
+    if str(path) != executable or not path.is_file() or path.is_symlink():
+        raise ValueError("DRAT-trim runtime path is not exact")
+    if _sha256(path.read_bytes()) != expected_digest:
+        raise ValueError("DRAT-trim runtime digest changed")
+    return path, expected_digest
+
+
+def _capture_checker_stream(
+    stream: BinaryIO,
+    *,
+    limit: int,
+    process: subprocess.Popen[bytes],
+    captured: bytearray,
+    exceeded: threading.Event,
+) -> None:
+    total = 0
+    read_chunk = getattr(stream, "read1", stream.read)
+    try:
+        while chunk := read_chunk(64 * 1024):
+            total += len(chunk)
+            remaining = max(0, limit - len(captured))
+            captured.extend(chunk[:remaining])
+            if total > limit:
+                exceeded.set()
+                process.kill()
+                return
+    except (OSError, ValueError):
+        return
+
+
+def _bounded_drat_trim(
+    executable: Path,
+    *,
+    cnf: bytes,
+    proof: bytes,
+    expected_runtime_digest: str,
+) -> bool:
+    with tempfile.TemporaryDirectory(prefix="jacobian-drat-trim-") as directory:
+        root = Path(directory)
+        cnf_path = root / "input.cnf"
+        proof_path = root / "proof.drat"
+        cnf_path.write_bytes(cnf)
+        proof_path.write_bytes(_DRAT_ASCII_PREFIX + proof)
+        stdout = bytearray()
+        stderr = bytearray()
+        stdout_exceeded = threading.Event()
+        stderr_exceeded = threading.Event()
+        timed_out = False
+        process = subprocess.Popen(
+            [str(executable), str(cnf_path), str(proof_path), "-W"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env={
+                **os.environ,
+                "LANG": "C",
+                "LC_ALL": "C",
+                "TZ": "UTC",
+            },
+        )
+        assert process.stdout is not None
+        assert process.stderr is not None
+        readers = (
+            threading.Thread(
+                target=_capture_checker_stream,
+                kwargs={
+                    "stream": process.stdout,
+                    "limit": DRAT_TRIM_OUTPUT_LIMIT,
+                    "process": process,
+                    "captured": stdout,
+                    "exceeded": stdout_exceeded,
+                },
+                daemon=True,
+            ),
+            threading.Thread(
+                target=_capture_checker_stream,
+                kwargs={
+                    "stream": process.stderr,
+                    "limit": DRAT_TRIM_OUTPUT_LIMIT,
+                    "process": process,
+                    "captured": stderr,
+                    "exceeded": stderr_exceeded,
+                },
+                daemon=True,
+            ),
+        )
+        for reader in readers:
+            reader.start()
+        deadline = time.monotonic() + DRAT_TRIM_TIMEOUT_SECONDS
+        try:
+            process.wait(timeout=max(0.0, deadline - time.monotonic()))
+        except subprocess.TimeoutExpired:
+            timed_out = True
+            process.kill()
+            process.wait()
+        finally:
+            for reader in readers:
+                reader.join(timeout=max(0.0, deadline - time.monotonic()))
+            if any(reader.is_alive() for reader in readers):
+                timed_out = True
+            if process.poll() is None:
+                process.kill()
+                process.wait()
+            process.stdout.close()
+            process.stderr.close()
+            for reader in readers:
+                reader.join(timeout=0.1)
+        if timed_out:
+            raise subprocess.TimeoutExpired(
+                cmd=[str(executable), str(cnf_path), str(proof_path), "-W"],
+                timeout=DRAT_TRIM_TIMEOUT_SECONDS,
+            )
+        if stdout_exceeded.is_set() or stderr_exceeded.is_set():
+            return False
+        if _sha256(executable.read_bytes()) != expected_runtime_digest:
+            raise ValueError("DRAT-trim runtime changed during replay")
+        try:
+            lines = [
+                line.strip()
+                for line in bytes(stdout)
+                .decode("ascii")
+                .replace("\r", "\n")
+                .splitlines()
+                if line.strip()
+            ]
+            bytes(stderr).decode("ascii")
+        except UnicodeDecodeError:
+            return False
+        statuses = [line for line in lines if line.startswith("s ")]
+        protocol_lines = all(
+            line == "c" or line.startswith(("c ", "s ")) for line in lines
+        )
+        return (
+            process.returncode == 0
+            and statuses == ["s VERIFIED"]
+            and protocol_lines
+            and not stderr
+        )
+
+
+def check_unsat_proof(request: dict[str, Any]) -> dict[str, Any]:
+    """Accept only exact text DRAT replayed by an authorized external checker."""
+
+    try:
+        if not isinstance(request, dict) or set(request) != {
+            "request_version",
+            "claim",
+            "candidate",
+            "scope",
+            "certificate",
+            "expected_bindings",
+        }:
+            return _reject_proof("malformed checker request")
+        if request["request_version"] != "1" or request["scope"] is not None:
+            return _reject_proof("unsupported checker request")
+        claim = request["claim"]
+        candidate = request["candidate"]
+        certificate = request["certificate"]
+        if not all(_valid_artifact(item) for item in (claim, candidate, certificate)):
+            return _reject_proof("checker artifact metadata is malformed")
+        expected_bindings = request["expected_bindings"]
+        if not _valid_bindings(expected_bindings):
+            return _reject_proof("expected evidence bindings are malformed")
+        if (
+            claim["semantics_uri"] != candidate["semantics_uri"]
+            or claim["semantics_uri"] != certificate["semantics_uri"]
+            or claim["payload_digest"] != _sha256(_canonical_json(claim["payload"]))
+            or candidate["payload_digest"]
+            != _sha256(_canonical_json(candidate["payload"]))
+            or certificate["payload_digest"]
+            != _sha256(_canonical_json(certificate["payload"]))
+        ):
+            return _reject_proof("checker artifacts are not exactly bound")
+        clauses, variable_count, variable_map_digest, dimacs_digest = _validate_cnf(
+            claim["payload"]
+        )
+        raw_proof = _validate_proof(
+            candidate["payload"],
+            claim=claim,
+            variable_count=variable_count,
+            clause_count=len(clauses),
+            variable_map_digest=variable_map_digest,
+            dimacs_digest=dimacs_digest,
+        )
+        _validate_drat_text_profile(raw_proof)
+        if claim["artifact_uri"] not in candidate["parents"] or not {
+            claim["artifact_uri"],
+            candidate["artifact_uri"],
+        }.issubset(set(certificate["parents"])):
+            return _reject_proof("SAT proof evidence is missing required lineage")
+        if (
+            expected_bindings["claim_digest"] != claim["object_digest"]
+            or expected_bindings["candidate_digest"] != candidate["object_digest"]
+        ):
+            return _reject_proof("expected evidence bindings do not match artifacts")
+        _validate_certificate(
+            certificate,
+            claim=claim,
+            candidate=candidate,
+            expected_bindings=expected_bindings,
+        )
+        executable, runtime_digest = _authorized_runtime()
+        accepted = _bounded_drat_trim(
+            executable,
+            cnf=_dimacs_bytes(clauses, variable_count),
+            proof=raw_proof,
+            expected_runtime_digest=runtime_digest,
+        )
+        if not accepted:
+            return _reject_proof("DRAT-trim did not accept the exact bound proof")
+        return {
+            "accepted": True,
+            "conclusion": "TRUE",
+            "arithmetic": "EXACT_INTEGER",
+            "method": "CHECKED_CERTIFICATE",
+            "coverage": "NOT_APPLICABLE",
+            "detail": (
+                f"DRAT-trim accepted {len(raw_proof)} exact proof bytes against "
+                f"{len(clauses)} canonical clauses"
+            ),
+        }
+    except (KeyError, OSError, TypeError, ValueError, OverflowError):
+        return _reject_proof("malformed or unauthorized SAT proof checker request")
 
 
 def check_assignment(request: dict[str, Any]) -> dict[str, Any]:

--- a/tests/checkers/test_sat_unsat_proof_checker.py
+++ b/tests/checkers/test_sat_unsat_proof_checker.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+import hashlib
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from jacobian.canonical import canonicalize_json
+from jacobian.contracts.capabilities import (
+    CapabilityInstallTier,
+    CapabilityProviderAvailability,
+    CapabilityProviderDigestKind,
+    CapabilityProviderRuntime,
+)
+from jacobian.contracts.evidence import CertificateEnvelope, EvidenceBindings
+from jacobian.contracts.sat import SatResourceBudget
+from jacobian.kernel import JacobianKernel
+from jacobian_checkers.sat import check_unsat_proof
+
+
+def _sha256_file(path: Path) -> str:
+    return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _producer() -> CapabilityProviderRuntime:
+    return CapabilityProviderRuntime(
+        provider="cadical",
+        availability=CapabilityProviderAvailability.AVAILABLE,
+        version="3.0.1",
+        digest="sha256:" + "d" * 64,
+        digest_kind=CapabilityProviderDigestKind.EXECUTABLE,
+        platform="linux-x86_64",
+        install_tier=CapabilityInstallTier.T2,
+        license_id="MIT",
+    )
+
+
+def _checker_artifact(artifact) -> dict[str, object]:
+    return {
+        "artifact_uri": artifact.artifact_uri,
+        "object_digest": artifact.manifest.object_digest,
+        "payload_digest": artifact.manifest.payload_digest,
+        "schema_uri": artifact.manifest.schema_uri,
+        "semantics_uri": artifact.manifest.semantics_uri,
+        "parents": list(artifact.manifest.parents),
+        "payload": artifact.payload,
+    }
+
+
+def _request(
+    tmp_path: Path,
+    *,
+    proof_bytes: bytes = b"-1 0\n0\n",
+) -> dict[str, object]:
+    kernel = JacobianKernel(tmp_path / "store")
+    cnf_result = kernel.sat.put_cnf(
+        variable_names=("x", "y"),
+        clauses=((1, 2), (-1, 2), (1, -2), (-1, -2)),
+    )
+    proof_result = kernel.sat.put_proof(
+        cnf_uri=cnf_result.artifact_uri,
+        proof=proof_bytes,
+        producer=_producer(),
+        resource_budget=SatResourceBudget(wall_seconds=5),
+    )
+    cnf = kernel.store.get(cnf_result.artifact_uri)
+    proof = kernel.store.get(proof_result.artifact_uri)
+    semantics = kernel.store.get(kernel.sat.installation.semantics_uri)
+    bindings = EvidenceBindings(
+        claim_digest=cnf.manifest.object_digest,
+        semantics_digest=semantics.manifest.object_digest,
+        candidate_digest=proof.manifest.object_digest,
+    )
+    payload = {
+        "cnf_uri": cnf.artifact_uri,
+        "proof_uri": proof.artifact_uri,
+    }
+    certificate = CertificateEnvelope(
+        certificate_type="sat.unsat-proof",
+        format_version="1",
+        bindings=bindings,
+        payload_digest=(
+            "sha256:" + hashlib.sha256(canonicalize_json(payload)).hexdigest()
+        ),
+        payload=payload,
+    )
+    certificate_schema_uri = kernel.schemas.register_model(
+        name="jacobian.certificate-envelope",
+        version="1",
+        model=CertificateEnvelope,
+    )
+    certificate_artifact = kernel.artifacts.put(
+        schema_uri=certificate_schema_uri,
+        semantics_uri=kernel.sat.installation.semantics_uri,
+        payload=certificate.model_dump(mode="json"),
+        parents=(cnf.artifact_uri, proof.artifact_uri),
+        summary="SAT UNSAT proof certificate",
+    )
+    stored_certificate = kernel.store.get(certificate_artifact.artifact_uri)
+    return {
+        "request_version": "1",
+        "claim": _checker_artifact(cnf),
+        "candidate": _checker_artifact(proof),
+        "scope": None,
+        "certificate": _checker_artifact(stored_certificate),
+        "expected_bindings": bindings.model_dump(mode="json"),
+    }
+
+
+def _fake_checker(tmp_path: Path, body: str) -> tuple[Path, Path]:
+    marker = tmp_path / "called"
+    executable = tmp_path / "drat-trim"
+    executable.write_text(
+        (
+            "#!/usr/bin/python3\n"
+            "import pathlib\n"
+            "import sys\n"
+            f"marker = pathlib.Path({str(marker)!r})\n"
+            "marker.write_text('called', encoding='utf-8')\n"
+            f"{body}\n"
+        ),
+        encoding="utf-8",
+    )
+    executable.chmod(0o755)
+    return executable, marker
+
+
+def _install_runtime_environment(
+    monkeypatch: pytest.MonkeyPatch,
+    executable: Path,
+) -> None:
+    monkeypatch.setenv("JACOBIAN_CHECKER_EXECUTABLE", str(executable))
+    monkeypatch.setenv(
+        "JACOBIAN_CHECKER_RUNTIME_DIGEST",
+        _sha256_file(executable),
+    )
+
+
+def test_checker_reconstructs_exact_dimacs_and_forces_ascii_drat(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable, marker = _fake_checker(
+        tmp_path,
+        "cnf = pathlib.Path(sys.argv[1]).read_bytes()\n"
+        "proof = pathlib.Path(sys.argv[2]).read_bytes()\n"
+        "assert cnf == b'p cnf 2 4\\n-1 -2 0\\n-1 2 0\\n1 -2 0\\n1 2 0\\n'\n"
+        "assert proof.startswith(b'c jacobian drat-text/v1 force-ascii ')\n"
+        "assert proof.endswith(b'-1 0\\n0\\n')\n"
+        "print('s VERIFIED')\n"
+        "raise SystemExit(0)",
+    )
+    _install_runtime_environment(monkeypatch, executable)
+
+    decision = check_unsat_proof(_request(tmp_path))
+
+    assert marker.read_text(encoding="utf-8") == "called"
+    assert decision["accepted"] is True
+    assert decision["conclusion"] == "TRUE"
+    assert decision["method"] == "CHECKED_CERTIFICATE"
+    assert decision["coverage"] == "NOT_APPLICABLE"
+
+
+def test_binding_and_lineage_attacks_are_rejected_before_drat_trim(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable, marker = _fake_checker(
+        tmp_path,
+        "raise AssertionError('must not run')",
+    )
+    _install_runtime_environment(monkeypatch, executable)
+    original = _request(tmp_path)
+    mutations: list[dict[str, object]] = []
+
+    changed = deepcopy(original)
+    changed["claim"]["payload"]["clauses"] = list(
+        reversed(changed["claim"]["payload"]["clauses"])
+    )
+    mutations.append(changed)
+
+    changed = deepcopy(original)
+    changed["candidate"]["payload"]["cnf"]["dimacs_digest"] = "sha256:" + "a" * 64
+    mutations.append(changed)
+
+    changed = deepcopy(original)
+    changed["candidate"]["parents"] = []
+    mutations.append(changed)
+
+    changed = deepcopy(original)
+    changed["certificate"]["payload"]["payload"]["proof_uri"] = (
+        "artifact://sha256/" + "a" * 64
+    )
+    mutations.append(changed)
+
+    changed = deepcopy(original)
+    changed["expected_bindings"]["candidate_digest"] = "sha256:" + "a" * 64
+    mutations.append(changed)
+
+    for request in mutations:
+        decision = check_unsat_proof(request)
+        assert decision["accepted"] is False
+        assert decision["conclusion"] == "UNKNOWN"
+    assert not marker.exists()
+
+
+@pytest.mark.parametrize(
+    "proof_bytes",
+    [
+        b"-1 0\n0\n1 0\n",
+        b"1 -1 0\n0\n",
+        b"1 1 0\n0\n",
+        b"1 0 2\n",
+        b"\xff 0\n",
+    ],
+)
+def test_malformed_or_concatenated_proof_is_rejected_before_drat_trim(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    proof_bytes: bytes,
+) -> None:
+    executable, marker = _fake_checker(
+        tmp_path,
+        "raise AssertionError('must not run')",
+    )
+    _install_runtime_environment(monkeypatch, executable)
+
+    decision = check_unsat_proof(_request(tmp_path, proof_bytes=proof_bytes))
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+    assert not marker.exists()
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "print('s NOT VERIFIED')\nraise SystemExit(0)",
+        "print('s VERIFIED')\nraise SystemExit(1)",
+        "print('s VERIFIED')\nprint('s VERIFIED')\nraise SystemExit(0)",
+    ],
+)
+def test_only_one_verified_status_with_zero_exit_is_accepted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    body: str,
+) -> None:
+    executable, _marker = _fake_checker(tmp_path, body)
+    _install_runtime_environment(monkeypatch, executable)
+
+    decision = check_unsat_proof(_request(tmp_path))
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+def test_excessive_checker_output_is_rejected_without_reading_it_into_memory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable, _marker = _fake_checker(
+        tmp_path,
+        "print('x' * 4096)\nraise SystemExit(0)",
+    )
+    _install_runtime_environment(monkeypatch, executable)
+    monkeypatch.setattr("jacobian_checkers.sat.DRAT_TRIM_OUTPUT_LIMIT", 128)
+
+    decision = check_unsat_proof(_request(tmp_path))
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+def test_runtime_digest_mismatch_is_rejected_before_execution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable, marker = _fake_checker(
+        tmp_path,
+        "print('s VERIFIED')\nraise SystemExit(0)",
+    )
+    _install_runtime_environment(monkeypatch, executable)
+    monkeypatch.setenv(
+        "JACOBIAN_CHECKER_RUNTIME_DIGEST",
+        "sha256:" + "a" * 64,
+    )
+
+    decision = check_unsat_proof(_request(tmp_path))
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+    assert not marker.exists()
+
+
+def test_missing_runtime_authorization_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("JACOBIAN_CHECKER_EXECUTABLE", raising=False)
+    monkeypatch.delenv("JACOBIAN_CHECKER_RUNTIME_DIGEST", raising=False)
+
+    decision = check_unsat_proof(_request(tmp_path))
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"

--- a/tests/integration/test_checker_registry.py
+++ b/tests/integration/test_checker_registry.py
@@ -1,14 +1,22 @@
 from __future__ import annotations
 
+import hashlib
 import sqlite3
 from pathlib import Path
 
 import pytest
 
 from jacobian.canonical import canonicalize_json
+from jacobian.contracts.capabilities import (
+    CapabilityInstallTier,
+    CapabilityProviderAvailability,
+    CapabilityProviderDigestKind,
+    CapabilityProviderRuntime,
+)
 from jacobian.contracts.checkers import EvidenceKind
 from jacobian.registry import (
     CheckerCompatibilityError,
+    CheckerExecutableChangedError,
     CheckerNotFoundError,
     CheckerRegistry,
     CheckerRegistryError,
@@ -174,3 +182,44 @@ def test_checker_authorization_requires_explicit_compatibility_scope(
             target_schema_uris=targets,
             target_semantics_uris=targets,
         )
+
+
+@pytest.mark.integration
+@pytest.mark.conformance
+def test_checker_registry_binds_external_runtime_identity(tmp_path: Path) -> None:
+    executable = tmp_path / "external-checker"
+    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    executable.chmod(0o755)
+    runtime = CapabilityProviderRuntime(
+        provider="external-checker",
+        availability=CapabilityProviderAvailability.AVAILABLE,
+        version="1",
+        digest="sha256:" + hashlib.sha256(executable.read_bytes()).hexdigest(),
+        digest_kind=CapabilityProviderDigestKind.EXECUTABLE,
+        platform="linux-x86_64",
+        install_tier=CapabilityInstallTier.T2,
+        license_id="MIT",
+        configuration={"executable": str(executable.resolve())},
+    )
+    registry = CheckerRegistry(ArtifactStore(tmp_path / "store").db_path)
+    checker = registry.authorize(
+        name="externally-backed-v1",
+        entrypoint="jacobian_checkers.reject:check",
+        evidence_kind="WITNESS",
+        format_id="example.witness",
+        format_version="1",
+        claim_schema_uris=(CLAIM_SCHEMA_A,),
+        semantics_uris=(CLAIM_SCHEMA_A,),
+        candidate_schema_uris=(CLAIM_SCHEMA_A,),
+        provider_runtime=runtime,
+    )
+
+    assert registry.require_active(checker.checker_id).provider_runtime == runtime
+
+    executable.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+    executable.chmod(0o755)
+    with pytest.raises(
+        CheckerExecutableChangedError,
+        match="changed after authorization",
+    ):
+        registry.require_active(checker.checker_id)

--- a/tests/integration/test_sat_unsat_proof_external_backend.py
+++ b/tests/integration/test_sat_unsat_proof_external_backend.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from jacobian.contracts.capabilities import (
+    CapabilityAssuranceLevel,
+    CapabilityMode,
+    CapabilityRequest,
+)
+from jacobian.contracts.results import ExecutionStatus
+from jacobian.contracts.sat import SatProofArtifact
+from jacobian.kernel import JacobianKernel
+from jacobian.provider_runtime import (
+    CADICAL_VERSION,
+    DRAT_TRIM_RELEASE_TAG,
+    cadical_provider_runtime,
+    drat_trim_provider_runtime,
+)
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.external_backend,
+    pytest.mark.skipif(
+        shutil.which("cadical") is None or shutil.which("drat-trim") is None,
+        reason="pinned CaDiCaL and DRAT-trim runtimes are not installed",
+    ),
+]
+
+
+def _invoke(
+    kernel: JacobianKernel,
+    capability_id: str,
+    payload: dict[str, object],
+    *,
+    mode: CapabilityMode,
+):
+    return kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id=capability_id,
+            mode=mode,
+            input=payload,
+        )
+    )
+
+
+def test_cadical_text_proof_replays_in_pinned_drat_trim(
+    tmp_path: Path,
+) -> None:
+    cadical = cadical_provider_runtime()
+    drat_trim = drat_trim_provider_runtime()
+    if cadical.version != CADICAL_VERSION:
+        pytest.skip(f"requires pinned CaDiCaL {CADICAL_VERSION}")
+    if drat_trim.version != DRAT_TRIM_RELEASE_TAG:
+        pytest.skip(f"requires pinned DRAT-trim {DRAT_TRIM_RELEASE_TAG}")
+    kernel = JacobianKernel(tmp_path, install_references=True)
+    cnf = kernel.sat.put_cnf(
+        variable_names=(
+            "p1h1",
+            "p1h2",
+            "p2h1",
+            "p2h2",
+            "p3h1",
+            "p3h2",
+        ),
+        clauses=(
+            (1, 2),
+            (3, 4),
+            (5, 6),
+            (-1, -3),
+            (-1, -5),
+            (-3, -5),
+            (-2, -4),
+            (-2, -6),
+            (-4, -6),
+        ),
+    )
+
+    produced = _invoke(
+        kernel,
+        "sat.unsat_proof.find",
+        {
+            "cnf_uri": cnf.artifact_uri,
+            "resource_budget": {"wall_seconds": 5},
+        },
+        mode=CapabilityMode.EXPLORE,
+    )
+    assert produced.execution.status is ExecutionStatus.COMPLETED
+    assert produced.output["status"] == "PROOF_PRODUCED"
+    proof_uri = produced.output["proof_uri"]
+
+    verified = _invoke(
+        kernel,
+        "sat.unsat_proof.verify",
+        {"proof_uri": proof_uri},
+        mode=CapabilityMode.VERIFY,
+    )
+    assert verified.execution.status is ExecutionStatus.COMPLETED
+    assert verified.output["status"] == "VERIFIED_UNSAT"
+    assert verified.output["conclusion"] == "TRUE"
+    assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED
+
+    stored_proof = SatProofArtifact.model_validate(kernel.store.get(proof_uri).payload)
+    empty_proof = kernel.sat.put_proof(
+        cnf_uri=cnf.artifact_uri,
+        proof=b"",
+        producer=stored_proof.producer,
+        resource_budget=stored_proof.resource_budget,
+    )
+    rejected = _invoke(
+        kernel,
+        "sat.unsat_proof.verify",
+        {"proof_uri": empty_proof.artifact_uri},
+        mode=CapabilityMode.VERIFY,
+    )
+    assert rejected.output["status"] == "REJECTED"
+    assert rejected.output["conclusion"] == "UNKNOWN"
+    assert rejected.assurance.verification_record_uri is None
+
+    raw_proof = stored_proof.raw_bytes()
+    assert raw_proof.endswith(b"0\n")
+    unsupported_contradiction = kernel.sat.put_proof(
+        cnf_uri=cnf.artifact_uri,
+        proof=b"0\n",
+        producer=stored_proof.producer,
+        resource_budget=stored_proof.resource_budget,
+    )
+    unsupported_replay = _invoke(
+        kernel,
+        "sat.unsat_proof.verify",
+        {"proof_uri": unsupported_contradiction.artifact_uri},
+        mode=CapabilityMode.VERIFY,
+    )
+    assert unsupported_replay.output["status"] == "REJECTED"
+    assert unsupported_replay.output["conclusion"] == "UNKNOWN"
+    assert unsupported_replay.assurance.verification_record_uri is None
+
+    concatenated_proof = kernel.sat.put_proof(
+        cnf_uri=cnf.artifact_uri,
+        proof=raw_proof + b"1 0\n",
+        producer=stored_proof.producer,
+        resource_budget=stored_proof.resource_budget,
+    )
+    concatenated_replay = _invoke(
+        kernel,
+        "sat.unsat_proof.verify",
+        {"proof_uri": concatenated_proof.artifact_uri},
+        mode=CapabilityMode.VERIFY,
+    )
+    assert concatenated_replay.output["status"] == "REJECTED"
+    assert concatenated_replay.output["conclusion"] == "UNKNOWN"
+    assert concatenated_replay.assurance.verification_record_uri is None
+
+    satisfiable = kernel.sat.put_cnf(
+        variable_names=("x",),
+        clauses=((1,),),
+    )
+    cross_bound = kernel.sat.put_proof(
+        cnf_uri=satisfiable.artifact_uri,
+        proof=stored_proof.raw_bytes(),
+        producer=stored_proof.producer,
+        resource_budget=stored_proof.resource_budget,
+    )
+    cross_replay = _invoke(
+        kernel,
+        "sat.unsat_proof.verify",
+        {"proof_uri": cross_bound.artifact_uri},
+        mode=CapabilityMode.VERIFY,
+    )
+    assert cross_replay.output["status"] == "REJECTED"
+    assert cross_replay.output["conclusion"] == "UNKNOWN"
+    assert cross_replay.assurance.verification_record_uri is None

--- a/tests/integration/test_sat_unsat_proof_verification.py
+++ b/tests/integration/test_sat_unsat_proof_verification.py
@@ -1,0 +1,334 @@
+from __future__ import annotations
+
+import hashlib
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import jacobian_checkers.sat
+from jacobian.contracts.capabilities import (
+    CapabilityAssuranceLevel,
+    CapabilityInstallTier,
+    CapabilityMode,
+    CapabilityProviderAvailability,
+    CapabilityProviderDigestKind,
+    CapabilityProviderRuntime,
+    CapabilityRequest,
+)
+from jacobian.contracts.evidence import CertificateEnvelope
+from jacobian.contracts.results import ExecutionStatus
+from jacobian.contracts.sat import SatResourceBudget
+from jacobian.contracts.verification import VerificationRecord
+from jacobian.kernel import JacobianKernel
+from jacobian.provider_runtime import drat_trim_provider_runtime
+from jacobian.verification import CheckerExecutionError, _environment_digest
+
+pytestmark = pytest.mark.integration
+
+
+def _sha256_file(path: Path) -> str:
+    return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _fake_drat_trim(tmp_path: Path, body: str) -> Path:
+    executable = tmp_path / "drat-trim"
+    executable.write_text(
+        (
+            "#!/usr/bin/python3\n"
+            "import sys\n"
+            "if '-h' in sys.argv:\n"
+            "    print('usage: drat-trim [INPUT] [<PROOF>] [<option> ...]')\n"
+            "    raise SystemExit(0)\n"
+            f"{body}\n"
+        ),
+        encoding="utf-8",
+    )
+    executable.chmod(0o755)
+    manifest = executable.with_name(executable.name + ".jacobian-runtime.json")
+    manifest.write_text(
+        (
+            "{\n"
+            '  "runtime_manifest_version": "1",\n'
+            '  "provider": "drat-trim",\n'
+            '  "release_tag": "v05.22.2023",\n'
+            '  "source_repository": '
+            '"https://github.com/marijnheule/drat-trim",\n'
+            '  "source_commit": '
+            '"2e5e29cb0019d5cfd547d4208dca1b3ec290349f",\n'
+            f'  "executable_sha256": "{_sha256_file(executable)}"\n'
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+    return executable
+
+
+def _producer() -> CapabilityProviderRuntime:
+    return CapabilityProviderRuntime(
+        provider="cadical",
+        availability=CapabilityProviderAvailability.AVAILABLE,
+        version="3.0.1",
+        digest="sha256:" + "d" * 64,
+        digest_kind=CapabilityProviderDigestKind.EXECUTABLE,
+        platform="linux-x86_64",
+        install_tier=CapabilityInstallTier.T2,
+        license_id="MIT",
+    )
+
+
+def _kernel_with_runtime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    executable: Path,
+    *,
+    install_references: bool = True,
+) -> JacobianKernel:
+    runtime = drat_trim_provider_runtime(executable)
+    assert runtime.availability is CapabilityProviderAvailability.AVAILABLE
+    monkeypatch.setattr(
+        "jacobian.kernel.drat_trim_provider_runtime",
+        lambda *_args, **_kwargs: runtime,
+    )
+    return JacobianKernel(
+        tmp_path / "store",
+        install_references=install_references,
+    )
+
+
+@pytest.mark.parametrize(
+    "attack",
+    ["missing_provenance", "wrong_release", "digest_mismatch"],
+)
+def test_drat_trim_runtime_requires_exact_operator_provenance(
+    tmp_path: Path,
+    attack: str,
+) -> None:
+    executable = _fake_drat_trim(
+        tmp_path,
+        "print('s VERIFIED')\nraise SystemExit(0)",
+    )
+    manifest = executable.with_name(executable.name + ".jacobian-runtime.json")
+    if attack == "missing_provenance":
+        manifest.unlink()
+    elif attack == "wrong_release":
+        manifest.write_text(
+            manifest.read_text(encoding="utf-8").replace(
+                '"release_tag": "v05.22.2023"',
+                '"release_tag": "untrusted"',
+            ),
+            encoding="utf-8",
+        )
+    else:
+        executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        executable.chmod(0o755)
+
+    runtime = drat_trim_provider_runtime(executable)
+
+    assert runtime.availability is CapabilityProviderAvailability.UNAVAILABLE
+    assert runtime.version is None
+    assert runtime.digest is None
+    assert runtime.diagnostic is not None
+
+
+def _proof(kernel: JacobianKernel) -> tuple[str, str]:
+    cnf = kernel.sat.put_cnf(
+        variable_names=("x", "y"),
+        clauses=((1, 2), (-1, 2), (1, -2), (-1, -2)),
+    )
+    proof = kernel.sat.put_proof(
+        cnf_uri=cnf.artifact_uri,
+        proof=b"-1 0\n0\n",
+        producer=_producer(),
+        resource_budget=SatResourceBudget(wall_seconds=5),
+    )
+    return cnf.artifact_uri, proof.artifact_uri
+
+
+def _verify(kernel: JacobianKernel, proof_uri: str):
+    return kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="sat.unsat_proof.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"proof_uri": proof_uri},
+        )
+    )
+
+
+@pytest.mark.subprocess
+def test_unsat_proof_is_verified_by_authorized_external_runtime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable = _fake_drat_trim(
+        tmp_path,
+        "print('s VERIFIED')\nraise SystemExit(0)",
+    )
+    kernel = _kernel_with_runtime(tmp_path, monkeypatch, executable)
+    cnf_uri, proof_uri = _proof(kernel)
+    monkeypatch.setattr(
+        jacobian_checkers.sat,
+        "check_unsat_proof",
+        lambda _request: {
+            "accepted": False,
+            "conclusion": "UNKNOWN",
+            "arithmetic": "EXACT_INTEGER",
+            "method": "CHECKED_CERTIFICATE",
+            "coverage": "NOT_APPLICABLE",
+            "detail": "parent-process monkeypatch",
+        },
+    )
+
+    result = _verify(kernel, proof_uri)
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.assurance.level is CapabilityAssuranceLevel.VERIFIED
+    assert result.output["status"] == "VERIFIED_UNSAT"
+    assert result.output["conclusion"] == "TRUE"
+    assert result.output["cnf_uri"] == cnf_uri
+    assert result.output["proof_uri"] == proof_uri
+    certificate_uri = result.output["certificate_uri"]
+    certificate = CertificateEnvelope.model_validate(
+        kernel.store.get(certificate_uri).payload
+    )
+    assert certificate.certificate_type == "sat.unsat-proof"
+    assert certificate.payload == {
+        "cnf_uri": cnf_uri,
+        "proof_uri": proof_uri,
+    }
+    record_uri = result.output["verification_record_uri"]
+    assert record_uri is not None
+    record_artifact = kernel.store.get(record_uri)
+    record = VerificationRecord.model_validate(record_artifact.payload)
+    assert record.checker_id == kernel.sat_unsat_proof_checker.checker_id
+    assert record.evidence_uri == certificate_uri
+    checker = kernel.checkers.require_active(record.checker_id)
+    assert checker.provider_runtime == kernel.drat_trim_runtime
+    assert record.environment_digest == _environment_digest(
+        checker.executable_digest,
+        checker.provider_runtime,
+    )
+    assert set(record_artifact.manifest.parents) == {
+        cnf_uri,
+        proof_uri,
+        certificate_uri,
+    }
+
+
+def test_rejected_proof_never_establishes_sat_or_unsat(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable = _fake_drat_trim(
+        tmp_path,
+        "print('s NOT VERIFIED')\nraise SystemExit(1)",
+    )
+    kernel = _kernel_with_runtime(tmp_path, monkeypatch, executable)
+    _cnf_uri, proof_uri = _proof(kernel)
+
+    result = _verify(kernel, proof_uri)
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert result.output["status"] == "REJECTED"
+    assert result.output["conclusion"] == "UNKNOWN"
+    assert result.output["verification_record_uri"] is None
+    assert result.assurance.verification_record_uri is None
+
+
+def test_proof_verify_requires_runtime_and_operator_authorization(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable = _fake_drat_trim(
+        tmp_path,
+        "print('s VERIFIED')\nraise SystemExit(0)",
+    )
+    without_references = _kernel_with_runtime(
+        tmp_path / "without-references",
+        monkeypatch,
+        executable,
+        install_references=False,
+    )
+    unavailable = drat_trim_provider_runtime(tmp_path / "missing")
+    monkeypatch.setattr(
+        "jacobian.kernel.drat_trim_provider_runtime",
+        lambda *_args, **_kwargs: unavailable,
+    )
+    without_runtime = JacobianKernel(
+        tmp_path / "without-runtime",
+        install_references=True,
+    )
+
+    assert without_references.sat_unsat_proof_checker.checker_id is None
+    assert without_runtime.sat_unsat_proof_checker.checker_id is None
+    for kernel in (without_references, without_runtime):
+        assert "sat.unsat_proof.verify" not in {
+            descriptor.capability_id
+            for descriptor in kernel.capabilities.catalog().capabilities
+        }
+
+
+@pytest.mark.parametrize(
+    ("exception", "expected_status", "expected_output_status"),
+    [
+        (
+            subprocess.TimeoutExpired(cmd=("drat-trim",), timeout=1),
+            ExecutionStatus.TIMEOUT,
+            "TIMEOUT",
+        ),
+        (
+            CheckerExecutionError("deliberate checker crash"),
+            ExecutionStatus.ERROR,
+            "ERROR",
+        ),
+    ],
+)
+def test_checker_operational_failure_never_creates_a_conclusion(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    exception: Exception,
+    expected_status: ExecutionStatus,
+    expected_output_status: str,
+) -> None:
+    executable = _fake_drat_trim(
+        tmp_path,
+        "print('s VERIFIED')\nraise SystemExit(0)",
+    )
+    kernel = _kernel_with_runtime(tmp_path, monkeypatch, executable)
+    _cnf_uri, proof_uri = _proof(kernel)
+
+    def fail(**_kwargs: Any):
+        raise exception
+
+    monkeypatch.setattr(kernel.verification, "_run_checker", fail)
+    result = _verify(kernel, proof_uri)
+
+    assert result.execution.status is expected_status
+    assert result.assurance.level is not CapabilityAssuranceLevel.VERIFIED
+    assert result.output["status"] == expected_output_status
+    assert result.output["conclusion"] == "UNKNOWN"
+    assert result.output["verification_record_uri"] is None
+
+
+def test_runtime_replacement_after_authorization_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable = _fake_drat_trim(
+        tmp_path,
+        "print('s VERIFIED')\nraise SystemExit(0)",
+    )
+    kernel = _kernel_with_runtime(tmp_path, monkeypatch, executable)
+    _cnf_uri, proof_uri = _proof(kernel)
+    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    executable.chmod(0o755)
+
+    result = _verify(kernel, proof_uri)
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.assurance.level is not CapabilityAssuranceLevel.VERIFIED
+    assert result.output["status"] == "ERROR"
+    assert result.output["conclusion"] == "UNKNOWN"
+    assert result.output["verification_record_uri"] is None


### PR DESCRIPTION
## Problem

CaDiCaL can produce CNF-bound text DRAT evidence, but raw proof bytes and solver status cannot establish UNSAT. Jacobian needs an independently authorized replay boundary that fails closed under proof, binding, runtime, and operational attacks.

## Change

- add optional `sat.unsat_proof.verify` backed by pinned DRAT-trim `v05.22.2023` / source commit `2e5e29cb0019d5cfd547d4208dca1b3ec290349f`
- require a strict operator provenance sidecar binding the local executable digest to that source identity
- bind the external runtime into checker registration, worker measurement, and verification environment identity
- reconstruct canonical DIMACS and validate proof/certificate payloads, bindings, and lineage in the independent checker adapter
- enforce a bounded ASCII DRAT profile and bounded clean-process replay; accept only exit zero with exactly one `s VERIFIED`
- add direct, integration, and real CaDiCaL→DRAT-trim attacks for malformed/concatenated proof data, cross-CNF replay, excessive output, runtime replacement, and missing or incorrect provenance
- document the runtime, trust boundary, and completed roadmap checkpoint

## Compatibility and normative impact

This is an experimental pre-stable capability. It is absent unless bundled references are enabled and the exact operator-provenanced runtime is available. Existing checker registrations without an external runtime retain their prior serialized identity shape. Proof rejection and every operational failure remain `UNKNOWN`; only an accepted certificate creates `VERIFIED_UNSAT` and a verification record.

## Validation

- `uv sync --dev`
- `uv run pytest` — 546 passed in 372.48s
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv run deptry .`
- `uv build`
- `git diff --check`
- `git diff -- AGENTS.md README.md docs/`