### PR TITLE
build: publish npm and PyPI from a dedicated release workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @morluto @N0zoM1z0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,52 +186,26 @@ jobs:
           name: build-timing
           path: build-timing.log
 
-  publish:
-    name: Publish to PyPI
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    if: needs.release-please.outputs.release_created == 'true'
-    needs: [release-please, build]
-    environment: pypi
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/download-artifact@v5
-        with:
-          name: dist
-          path: dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1
-
-  publish-npm:
-    name: Publish to npm
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    if: needs.release-please.outputs.release_created == 'true'
-    needs: [release-please, npm-package]
-    environment: npm
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "24"
-          registry-url: "https://registry.npmjs.org"
-          package-manager-cache: false
-      - run: npm test
-        working-directory: npm
-      - run: npm publish --access public
-        working-directory: npm
-
   release-please:
     name: Release Please
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: github.ref == 'refs/heads/main'
     needs: [lint, test, lean-test, coverage, duplicate-code, npm-package, build]
-    outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
+    permissions:
+      actions: write
+      contents: write
+      issues: write
+      pull-requests: write
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         id: release
+      - name: Dispatch release publishing
+        if: steps.release.outputs.release_created == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag_name }}
+        run: >-
+          gh workflow run release.yml
+          --ref "$RELEASE_TAG"
+          --field tag="$RELEASE_TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,100 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing GitHub release tag to publish
+        required: true
+        type: string
+
+concurrency:
+  group: release-${{ inputs.tag }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build release artifacts
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Verify release ref
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: test "$GITHUB_REF" = "refs/tags/$RELEASE_TAG"
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: ${{ inputs.tag }}
+          persist-credentials: false
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          enable-cache: false
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: "24"
+          package-manager-cache: false
+      - name: Verify immutable release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          test "$(gh release view "$RELEASE_TAG" --json isImmutable --jq .isImmutable)" = "true"
+      - name: Build Python distributions
+        run: uv build --out-dir dist/python
+      - name: Test and pack npm distribution
+        run: |
+          npm test
+          mkdir -p ../dist/npm
+          npm pack --pack-destination ../dist/npm
+        working-directory: npm
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-distributions
+          path: dist/
+          if-no-files-found: error
+          overwrite: true
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        with:
+          name: release-distributions
+          path: artifacts/
+      - uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # release/v1
+        with:
+          packages-dir: artifacts/python/
+
+  publish-npm:
+    name: Publish to npm
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: npm
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        with:
+          name: release-distributions
+          path: artifacts/
+      - run: npm publish artifacts/npm/*.tgz --access public

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,11 +102,31 @@ Verify every relative Markdown link before submitting the change.
 ## Releases
 
 The manifest-driven Release Please configuration keeps the Python and npm
-package versions synchronized. CI tests and packs the npm launcher
-independently, then publishes both distributions after a release is created.
-The `jacobian` package on npm must authorize `.github/workflows/ci.yml` as its
-trusted GitHub Actions publisher, using the `npm` environment; releases use
-OIDC rather than a long-lived npm token.
+package versions synchronized. After the generated release pull request is
+merged, CI validates the exact tree and creates the GitHub release. It then
+dispatches the separate `Release` workflow at that immutable tag. The release
+workflow builds both distributions before its independent PyPI and npm publish
+jobs start.
+
+Both registries use OIDC rather than long-lived tokens. Configure their trusted
+GitHub Actions publishers for repository `morluto/jacobian`, workflow
+`release.yml`, and their matching `pypi` or `npm` environment. Restrict those
+environments to protected release tags and add required reviewers when manual
+approval is desired. Enable GitHub release immutability before the first
+release; publishing fails closed unless GitHub reports that the release tag is
+locked.
+
+The `Release` workflow is normally dispatched automatically. Its manual
+dispatch is a recovery path for an existing GitHub release tag and must run
+from the same tag, for example:
+
+```sh
+gh workflow run release.yml --ref v0.2.0 --field tag=v0.2.0
+```
+
+It does not create or version a release. If one registry publish fails, rerun
+only that failed job so the successful immutable upload is not attempted
+twice.
 
 ## Pull requests
 


### PR DESCRIPTION
## Problem

PyPI and npm publication currently run inside the general CI workflow. That makes `ci.yml` the trusted OIDC identity and couples registry publication to ordinary validation orchestration, even though publishing has a narrower trust boundary and different recovery needs.

## Solution

- keep Release Please behind the existing full CI gate;
- dispatch a dedicated `release.yml` workflow at the created release tag;
- require the workflow ref, checkout SHA, and immutable GitHub release to agree before building;
- build the Python and npm distributions together and hand one overwrite-safe artifact bundle to independent OIDC publishing jobs;
- retain manual dispatch against an existing immutable tag as a recovery path.

The generated Release Please PR remains the explicit version/changelog approval point. Publishing does not introduce a custom release framework or long-lived registry tokens.

## Testing

- `git diff --check origin/main...HEAD`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/ci.yml .github/workflows/release.yml`
- `uv build --out-dir <temporary-directory>/python` — source distribution and wheel built
- `npm test --prefix npm` — 13 passed
- `npm pack` from `npm/` — `jacobian-0.2.0-alpha.0.tgz` built

## Trust & Compatibility Impact

There is no Python, CLI, MCP, checker, artifact-format, or public API change. The trusted publisher identity moves from `ci.yml` to `release.yml`; the PyPI and npm publishers now target that workflow with their respective `pypi` and `npm` environments.

GitHub release immutability must be enabled before the first release using this workflow. The workflow fails closed when GitHub does not report the release tag as immutable. Environment approval and protected-tag rules can be added independently without changing the workflow.

## Checklist

- [x] Relevant workflow and package validation passes locally
- [x] Relevant documentation updated