### PR TITLE
chore: limit automatic code owner reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,8 @@
-* @morluto @N0zoM1z0
+# Request review only for publishing and repository-governance changes.
+/.github/CODEOWNERS @morluto @N0zoM1z0
+/.github/workflows/ci.yml @morluto @N0zoM1z0
+/.github/workflows/release.yml @morluto @N0zoM1z0
+/.release-please-manifest.json @morluto @N0zoM1z0
+/release-please-config.json @morluto @N0zoM1z0
+/pyproject.toml @morluto @N0zoM1z0
+/npm/package.json @morluto @N0zoM1z0


### PR DESCRIPTION
## Problem

The repository-wide CODEOWNERS wildcard automatically requests both owners on every ready pull request, even though code-owner approval is optional. That adds review noise to ordinary source, test, and documentation changes.

## Solution

Limit ownership to publishing and repository-governance surfaces: CODEOWNERS, CI and release workflows, Release Please configuration, and the Python and npm package manifests. Other paths no longer trigger automatic review requests.

## Testing

- `git diff --check`
- Manually verified that every pattern names an existing repository path

## Trust & Compatibility Impact

No verification-kernel, checker-registry, artifact-format, or public-API impact. Required approvals remain at zero; this only narrows automatic review requests.

## Checklist

- [ ] Python validation passes locally (`make validate`)
- [x] Relevant documentation updated or not applicable