### PR TITLE
ci: make exhaustive Lean validation CI-owned

### DIFF
--- a/.github/actions/setup-lean/action.yml
+++ b/.github/actions/setup-lean/action.yml
@@ -1,0 +1,60 @@
+name: Prepare Lean test environment
+description: Restore pinned Lean and Mathlib, install Python dependencies, and build the Jacobian REPL.
+
+inputs:
+  timing-heading:
+    description: Heading used in the GitHub step summary
+    required: false
+    default: Lean phase timing
+
+runs:
+  using: composite
+  steps:
+    - name: Start Lean setup timing
+      shell: bash
+      run: echo "LEAN_SETUP_STARTED_AT=$(date +%s)" >> "$GITHUB_ENV"
+    - name: Set up Lean and restore Mathlib cache
+      uses: leanprover/lean-action@38fbc41a8c28c4cbaec22d7f7de508ec2e7c0dd9 # v1
+      with:
+        lake-package-directory: lean
+        use-mathlib-cache: true
+        test: false
+        lint: false
+    - name: Record Lean setup timing
+      shell: bash
+      env:
+        TIMING_HEADING: ${{ inputs.timing-heading }}
+      run: |
+        duration=$(($(date +%s) - LEAN_SETUP_STARTED_AT))
+        {
+          echo "## $TIMING_HEADING"
+          echo ""
+          echo "| Phase | Seconds |"
+          echo "| --- | ---: |"
+          echo "| Toolchain and Mathlib cache | $duration |"
+        } >> "$GITHUB_STEP_SUMMARY"
+    - name: Set up Python
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+      with:
+        python-version: "3.12"
+    - name: Set up uv
+      uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+      with:
+        enable-cache: true
+        cache-dependency-glob: |
+          pyproject.toml
+          uv.lock
+    - name: Install Python dependencies
+      shell: bash
+      run: uv sync --frozen --dev
+    - name: Build Lean REPL
+      shell: bash
+      working-directory: lean
+      run: |
+        started=$SECONDS
+        set +e
+        lake build repl
+        status=$?
+        set -e
+        echo "| Build Jacobian Lean REPL | $((SECONDS - started)) |" >> "$GITHUB_STEP_SUMMARY"
+        exit "$status"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,12 +9,13 @@
 
 ```sh
 make setup
-make validate
+make check
 ```
 
 ## Trust & Compatibility Impact
 <!-- Does this change affect the verification kernel, checker registry, artifact format, or public API? -->
 
 ## Checklist
-- [ ] Python validation passes locally (`make validate`)
+- [ ] Routine local validation passes (`make check`)
+- [ ] Relevant focused tests are listed above
 - [ ] Relevant documentation updated

--- a/.github/scripts/classify-ci-paths
+++ b/.github/scripts/classify-ci-paths
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+run_lean=false
+classification=isolated
+
+if (( $# == 0 )); then
+  run_lean=true
+  classification=full
+else
+  for path in "$@"; do
+    case "$path" in
+      docs/*|*.md|.github/ISSUE_TEMPLATE/*|.github/CODEOWNERS|npm/*)
+        ;;
+      *)
+        run_lean=true
+        classification=full
+        break
+        ;;
+    esac
+  done
+fi
+
+printf 'run-lean=%s\nclassification=%s\n' "$run_lean" "$classification"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,46 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  plan:
+    name: Plan CI
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      run-lean: ${{ steps.classify.outputs.run-lean }}
+      classification: ${{ steps.classify.outputs.classification }}
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - id: classify
+        name: Classify changed paths
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            mapfile -d '' changed_paths < <(
+              git diff --name-only -z "$BASE_SHA" "$HEAD_SHA"
+            )
+            plan_output=$(
+              .github/scripts/classify-ci-paths "${changed_paths[@]}"
+            )
+          else
+            plan_output=$'run-lean=true\nclassification=full'
+          fi
+
+          printf '%s\n' "$plan_output" >> "$GITHUB_OUTPUT"
+          run_lean=$(sed -n 's/^run-lean=//p' <<< "$plan_output")
+          classification=$(sed -n 's/^classification=//p' <<< "$plan_output")
+          {
+            echo "## CI plan"
+            echo ""
+            echo "- Classification: \`$classification\`"
+            echo "- Run real Lean validation: \`$run_lean\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   lint:
     name: Lint & Format
     runs-on: ubuntu-latest
@@ -130,6 +170,8 @@ jobs:
 
   lean-test-shards:
     name: Lean Tests (${{ matrix.lane }})
+    needs: plan
+    if: needs.plan.outputs.run-lean == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
@@ -138,25 +180,17 @@ jobs:
         lane: [1, 2]
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
-      - uses: leanprover/lean-action@38fbc41a8c28c4cbaec22d7f7de508ec2e7c0dd9 # v1
-        with:
-          lake-package-directory: lean
-          use-mathlib-cache: true
-          test: false
-          lint: false
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
-        with:
-          python-version: "3.12"
-      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
-        with:
-          enable-cache: true
-          cache-dependency-glob: |
-            pyproject.toml
-            uv.lock
-      - run: uv sync --frozen --dev
-      - run: lake build repl
-        working-directory: lean
-      - run: make test-lean
+      - name: Prepare Lean test environment
+        uses: ./.github/actions/setup-lean
+      - name: Run Lean tests
+        run: |
+          started=$SECONDS
+          set +e
+          make test-lean
+          status=$?
+          set -e
+          echo "| Selected Lean tests | $((SECONDS - started)) |" >> "$GITHUB_STEP_SUMMARY"
+          exit "$status"
         env:
           PYTEST_ARGS: >-
             --splits 2 --group ${{ matrix.lane }}
@@ -167,14 +201,20 @@ jobs:
   lean-test:
     name: Lean Tests
     if: always()
-    needs: lean-test-shards
+    needs: [plan, lean-test-shards]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Require every Lean shard
+      - name: Require planned Lean validation
         env:
+          RUN_LEAN: ${{ needs.plan.outputs.run-lean }}
           SHARD_RESULT: ${{ needs.lean-test-shards.result }}
-        run: test "$SHARD_RESULT" = "success"
+        run: |
+          if [ "$RUN_LEAN" = "true" ]; then
+            test "$SHARD_RESULT" = "success"
+          else
+            test "$SHARD_RESULT" = "skipped"
+          fi
 
   coverage:
     name: Coverage
@@ -297,27 +337,3 @@ jobs:
         with:
           name: build-timing
           path: build-timing.log
-
-  release-please:
-    name: Release Please
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      actions: write
-      contents: write
-      issues: write
-      pull-requests: write
-    if: github.ref == 'refs/heads/main'
-    needs: [lint, validate-agents-md, security-audit, test, lean-test, coverage, duplicate-code, npm-package, build]
-    steps:
-      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
-        id: release
-      - name: Dispatch release publishing
-        if: steps.release.outputs.release_created == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ steps.release.outputs.tag_name }}
-        run: >-
-          gh workflow run release.yml
-          --ref "$RELEASE_TAG"
-          --field tag="$RELEASE_TAG"

--- a/.github/workflows/lean-debug.yml
+++ b/.github/workflows/lean-debug.yml
@@ -1,0 +1,52 @@
+name: Lean Debug
+
+on:
+  workflow_dispatch:
+    inputs:
+      pytest-selector:
+        description: One Lean pytest file or node ID to run
+        required: true
+        default: tests/integration/test_lean.py
+        type: string
+      keyword:
+        description: Optional pytest -k expression
+        required: false
+        type: string
+
+concurrency:
+  group: lean-debug-${{ github.ref }}-${{ inputs.pytest-selector }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  lean-debug:
+    name: Focused Lean reproduction
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+      - name: Prepare Lean test environment
+        uses: ./.github/actions/setup-lean
+        with:
+          timing-heading: Lean debug phase timing
+      - name: Run focused Lean test
+        env:
+          TEST_SELECTOR: ${{ inputs.pytest-selector }}
+          TEST_KEYWORD: ${{ inputs.keyword }}
+        run: |
+          args=(-n 0 -m lean_runtime "$TEST_SELECTOR" --durations=10)
+          if [ -n "$TEST_KEYWORD" ]; then
+            args+=(-k "$TEST_KEYWORD")
+          fi
+
+          started=$SECONDS
+          set +e
+          uv run --frozen pytest "${args[@]}"
+          status=$?
+          set -e
+          echo "| Selected Lean tests | $((SECONDS - started)) |" >> "$GITHUB_STEP_SUMMARY"
+          exit "$status"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,58 @@
+name: Release Please
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: release-please-main
+  cancel-in-progress: false
+
+permissions:
+  actions: write
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    name: Update or create the release
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - id: validated-head
+        name: Require CI for the current main head
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          VALIDATED_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          current=true
+          if [ "$EVENT_NAME" = "workflow_run" ]; then
+            main_sha=$(
+              gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/main" \
+                --jq '.object.sha'
+            )
+            if [ "$VALIDATED_SHA" != "$main_sha" ]; then
+              current=false
+              echo "Skipping stale CI result for \`$VALIDATED_SHA\`; current main is \`$main_sha\`." \
+                >> "$GITHUB_STEP_SUMMARY"
+            fi
+          fi
+          echo "current=$current" >> "$GITHUB_OUTPUT"
+      - if: steps.validated-head.outputs.current == 'true'
+        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
+        id: release
+      - name: Dispatch release publishing
+        if: steps.release.outputs.release_created == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag_name }}
+        run: >-
+          gh workflow run release.yml
+          --ref "$RELEASE_TAG"
+          --field tag="$RELEASE_TAG"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,17 +25,19 @@ make test-fast
 
 `make test-fast` is the short non-integration feedback loop. Run `make check`
 before pushing; it performs lint, formatting, dependency, type, fast tests,
-and package-build checks. CI owns the full Python matrix, integration,
-end-to-end, coverage, and real-Lean validation. `make validate` remains
-available for exhaustive local validation. Run `make help` for focused
-commands. The measured costs and reasoning behind these lanes are recorded in
-the [test-suite cost audit](docs/contributing/test-suite-cost-audit.md).
+and package-build checks. Push after that check and let CI own the full Python
+matrix, integration, end-to-end, coverage, and real-Lean validation.
+`make validate-full` is only for reproducing exhaustive CI validation locally
+when CI is unavailable or an environment-specific failure requires it. Run
+`make help` for focused commands. The measured costs and reasoning behind
+these lanes are recorded in the
+[test-suite cost audit](docs/contributing/test-suite-cost-audit.md).
 Tests can be narrowed without learning another wrapper:
 
 ```sh
 make test TESTS=tests/integration/test_mcp_adapter.py
 make test TESTS=tests/integration/test_mcp_adapter.py PYTEST_ARGS="-k schema -n 0"
-make test-lean
+make test-lean TESTS=tests/integration/test_lean.py PYTEST_ARGS="-k induction"
 make refresh-test-durations
 make refresh-lean-test-durations
 ```
@@ -51,7 +53,8 @@ source-build failure from `uv sync --dev`.
 Use focused tests while implementing. Run `make check` before pushing and wait
 for green CI checks before merge. Run complete local validation only
 when changing CI itself, debugging an environment-specific failure, or when CI
-is unavailable. Report only checks that actually ran.
+is unavailable; use `make validate-full` for that exceptional path. Report only
+checks that actually ran.
 
 For a quick local feedback loop, skip the integration and end-to-end layers:
 
@@ -66,7 +69,9 @@ of the normal xdist pool because Mathlib processes can retain several
 gigabytes. CI installs the pinned Lean toolchain and Mathlib cache in a
 dedicated pair of serial lanes on separate runners.
 Use `uv run pytest --lf` after a failure, `uv run pytest -n 0` while debugging,
-and `make check` before pushing. Use
+and `make check` before pushing. Use `make test-lean TESTS=path/to/test.py` for
+a deliberately focused local Lean reproduction, or dispatch the remote Lean
+debug workflow from GitHub Actions when local Lean is impractical. Use
 `make test-lean PYTEST_ARGS=--lf` to rerun a failed Lean-runtime test.
 Do not use unfiltered `uv run pytest` as the normal complete-suite command
 because it mixes Lean into the general xdist pool.

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PYTEST_ARGS ?=
 TESTS ?=
 EVAL_ARGS ?=
 
-.PHONY: help setup hooks fix lint typecheck test test-fast test-lean test-failed test-durations refresh-test-durations refresh-lean-test-durations build check validate agent-eval
+.PHONY: help setup hooks fix lint typecheck test test-fast test-lean test-failed test-durations refresh-test-durations refresh-lean-test-durations build check validate-full agent-eval
 
 help: ## Show available developer commands.
 	@awk 'BEGIN {FS = ":.*## "; printf "Jacobian developer commands:\n\n"} /^[a-zA-Z_-]+:.*## / {printf "  %-12s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -39,8 +39,8 @@ test-fast: ## Run the sequential non-integration feedback loop.
 	$(UV_RUN) pytest -n 0 -m "not integration and not end_to_end and not lean_runtime" \
 		tests/unit tests/contract tests/checkers tests/reference $(PYTEST_ARGS)
 
-test-lean: ## Run pinned Lean integration tests serially.
-	$(UV_RUN) pytest -n 0 -m lean_runtime $(PYTEST_ARGS)
+test-lean: ## Run pinned Lean tests serially; narrow with TESTS=... and PYTEST_ARGS=....
+	$(UV_RUN) pytest -n 0 -m lean_runtime $(TESTS) $(PYTEST_ARGS)
 
 test-failed: ## Re-run failures from the previous pytest invocation.
 	$(UV_RUN) pytest --lf -m "not lean_runtime" $(PYTEST_ARGS)
@@ -74,7 +74,7 @@ build: ## Build Python source and wheel distributions.
 
 check: lint typecheck test-fast build ## Run the routine local pre-push checks.
 
-validate: lint typecheck test test-lean build ## Run complete local validation.
+validate-full: lint typecheck test test-lean build ## Reproduce exhaustive CI validation locally (slow and exceptional).
 
 agent-eval: ## Plan a local agent eval; execution requires explicit EVAL_ARGS.
 	$(UV_RUN) python benchmarks/agent_ab.py $(EVAL_ARGS)

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ uv run python benchmarks/agent_mcp.py
 Raw transcripts, isolated Jacobian state, reports, structured agent feedback,
 and scores are written to the ignored `benchmarks/results/` directory.
 Model-in-the-loop evaluations are local, optional, and never part of
-`make test-fast`, `make test`, `make validate`, or CI. Preview a selected
+`make test-fast`, `make test`, `make validate-full`, or CI. Preview a selected
 paired evaluation without executing a model:
 
 ```sh

--- a/docs/contributing/test-suite-cost-audit.md
+++ b/docs/contributing/test-suite-cost-audit.md
@@ -59,15 +59,26 @@ make test-fast
 make test TESTS=tests/integration/test_mcp_adapter.py
 make test
 make test-lean
-make validate
+make validate-full
 ```
 
 `make test-fast` is the normal edit loop. Use focused integration tests while
 changing stores, adapters, plugins, subprocesses, or checker execution.
 `make test` runs the complete non-Lean suite, and `make test-lean` keeps the
-memory-heavy backend serial. `make validate` is the final local gate. Do not
-use unfiltered `uv run pytest` as the default handoff command because it mixes
-Lean into the general parallel pool.
+memory-heavy backend serial. Neither is a routine pre-push requirement:
+`make check` is the local handoff gate, and CI owns exhaustive validation.
+`make validate-full` exists only to reproduce that exhaustive validation when
+CI is unavailable or an environment-specific failure requires it. Do not use
+unfiltered `uv run pytest` as the default handoff command because it mixes Lean
+into the general parallel pool.
+
+Recent CI phase timing supports retaining two independent Lean shards. On both
+lanes, Lean toolchain and Mathlib cache setup took about 83 to 85 seconds,
+`lake build repl` took 11 to 12 seconds, and selected tests took 66 to 71
+seconds. Sharing Jacobian's build output would serialize both shards behind a
+new preparation job to avoid only the small build phase, so CI keeps the build
+local to each parallel lane. The workflow records these phases for future
+decisions.
 
 Refresh CI timings after a material suite expansion or when shard runtimes
 diverge:

--- a/docs/reference/agent-evaluations.md
+++ b/docs/reference/agent-evaluations.md
@@ -29,10 +29,10 @@ verified status.
 ## Local execution boundary
 
 Model-in-the-loop evaluation is a separate, optional local activity. It is not
-called by `make test-fast`, `make test`, `make validate`, CI, release jobs, or
-pre-commit hooks. Those paths may test case loading, scoring, replay, telemetry,
-and dispatch guards with deterministic fixtures, but they never launch an
-evaluated model.
+called by `make test-fast`, `make test`, `make validate-full`, CI, release
+jobs, or pre-commit hooks. Those paths may test case loading, scoring, replay,
+telemetry, and dispatch guards with deterministic fixtures, but they never
+launch an evaluated model.
 
 Use the dedicated entry point with explicit cases. Without `--execute`, it
 prints a plan and exits without starting Codex:

--- a/docs/reference/testing-strategy.md
+++ b/docs/reference/testing-strategy.md
@@ -36,20 +36,21 @@ make test-fast
 make test-failed
 make test TESTS=tests/integration/test_mcp_adapter.py
 make test TESTS=tests/integration/test_mcp_adapter.py PYTEST_ARGS="-k schema -n 0"
-make test-lean
+make test-lean TESTS=tests/integration/test_lean.py PYTEST_ARGS="-k induction"
 make refresh-test-durations
 make refresh-lean-test-durations
 make test-durations
 make check
-make validate
+make validate-full
 ```
 
 `make test-fast` collects only unit, contract, checker, and reference
 directories, then excludes integration-marked cases. Avoiding collection of
 integration and end-to-end modules keeps the loop short without dropping
 independent checker tests. `make check` is the routine local pre-push gate;
-CI owns exhaustive validation. `make validate` remains the local full-suite
-escape hatch. The full
+developers should push after it and let CI own exhaustive validation.
+`make validate-full` is the local full-suite escape hatch for CI reproduction,
+not a routine handoff requirement. The full
 suite uses `pytest-xdist` work stealing and
 at most four workers because test durations vary substantially and many tests
 wait on isolated subprocesses. `make test-failed` is the failure-recovery
@@ -83,7 +84,10 @@ collects the full marker-selected suite, so new Lean tests cannot fall outside
 a file allowlist. Refresh `.lean_test_durations` after adding or materially
 changing those tests. Each runner executes its lane serially, avoiding
 concurrent multi-gigabyte Mathlib processes on one machine while shortening
-the CI critical path and preserving real-backend coverage.
+the CI critical path and preserving real-backend coverage. A manually
+dispatched Lean debug workflow accepts one pytest node or file selector and
+provides the same pinned remote environment for focused reproduction when
+local Lean is impractical.
 Python 3.12 shards write raw coverage data; a dependent job combines both
 files before enforcing the repository threshold and producing the XML report.
 Python 3.13 runs the same two groups without duplicate instrumentation.

--- a/tests/unit/test_ci_plan.py
+++ b/tests/unit/test_ci_plan.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+PLANNER = Path(__file__).parents[2] / ".github" / "scripts" / "classify-ci-paths"
+
+
+@pytest.mark.parametrize(
+    ("paths", "expected"),
+    [
+        ((), {"run-lean": "true", "classification": "full"}),
+        (
+            ("README.md", "docs/how-to/contribute.md", ".github/CODEOWNERS"),
+            {"run-lean": "false", "classification": "isolated"},
+        ),
+        (
+            ("npm/package.json", "npm/npm-packaging.test.mjs"),
+            {"run-lean": "false", "classification": "isolated"},
+        ),
+        (
+            ("src/jacobian/kernel.py",),
+            {"run-lean": "true", "classification": "full"},
+        ),
+        (
+            ("docs/index.md", "pyproject.toml"),
+            {"run-lean": "true", "classification": "full"},
+        ),
+        (
+            (".github/workflows/ci.yml",),
+            {"run-lean": "true", "classification": "full"},
+        ),
+    ],
+)
+def test_ci_plan_fails_closed_outside_isolated_paths(
+    paths: tuple[str, ...],
+    expected: dict[str, str],
+) -> None:
+    completed = subprocess.run(
+        [PLANNER, *paths],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert (
+        dict(line.split("=", 1) for line in completed.stdout.splitlines()) == expected
+    )


### PR DESCRIPTION
## Problem

The documented local handoff path still implied that contributors should run
the complete non-Lean and real-Lean suites before pushing, despite CI already
owning those expensive environments. Release Please also ran at the end of the
validation workflow, so a release-automation permission failure made an
otherwise healthy `main` run appear broken.

## Solution

- Make `make check` the routine pre-push gate and rename exhaustive local
  reproduction to `make validate-full`.
- Let focused Lean runs accept `TESTS=...`, and add a manually dispatched Lean
  Debug workflow for one pytest file or node.
- Share pinned Lean, Mathlib, Python, uv, and REPL setup through one composite
  action, with phase timing in each job summary.
- Add a tested, fail-closed CI planner. It skips real Lean only for isolated
  documentation, repository-metadata, and npm-only pull requests; source,
  dependency, workflow, mixed, unknown, and every `main` change still run Lean.
- Move Release Please into a separate workflow after successful CI. Stale CI
  completions are ignored unless their SHA is still the current `main` head.

Recent CI evidence supports retaining two independent Lean shards: Mathlib and
toolchain setup took 83–85 seconds per lane, the Jacobian REPL build took only
11–12 seconds, and selected tests took 66–71 seconds. Sharing the small build
artifact would serialize the parallel lanes for little expected latency gain.

## Testing

- `make check` — 252 fast tests passed; lint, formatting, dependency checks,
  strict mypy, and Python package builds passed.
- `uv run --frozen pytest -n 0 tests/unit/test_ci_plan.py` — 6 planner policy
  cases passed.
- `uv run --frozen pre-commit run check-yaml --all-files`
- `uv run --frozen pre-commit run actionlint --all-files`
- `git diff --check`

The PR CI run owns real Lean validation.

## Trust & Compatibility Impact

No mathematical contract, verification authority, checker behavior, artifact
format, or public API changes. The planner defaults to full Lean validation for
empty or unrecognized path sets. The repository keeps read-only default
`GITHUB_TOKEN` permissions while allowing the dedicated Release Please workflow
to create its pull request.

Suggested review order:

1. `.github/scripts/classify-ci-paths` and `tests/unit/test_ci_plan.py`
2. `.github/workflows/ci.yml`
3. `.github/actions/setup-lean/action.yml` and `lean-debug.yml`
4. `.github/workflows/release-please.yml`
5. Makefile and contributor documentation

## Checklist

- [x] Routine local validation passes (`make check`)
- [x] Relevant focused tests are listed above
- [x] Relevant documentation updated
