### PR TITLE
feat(sat): validate the certificate portfolio

### DIFF
--- a/benchmarks/ab_cases/sat-report.schema.json
+++ b/benchmarks/ab_cases/sat-report.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "case_id": {"type": "string"},
+    "status": {"enum": ["SATISFIABLE", "UNSATISFIABLE", "UNKNOWN"]},
+    "conclusion": {"enum": ["TRUE", "UNKNOWN"]},
+    "assurance": {"enum": ["SELF_CHECKED", "COMPUTED", "VERIFIED"]},
+    "final_verification": {"enum": ["UNVERIFIED", "VERIFIED"]},
+    "evidence_kind": {"enum": ["ASSIGNMENT", "UNSAT_PROOF", "NONE"]},
+    "assignment": {
+      "type": ["object", "null"],
+      "additionalProperties": {"type": "boolean"}
+    },
+    "cnf_uri": {
+      "type": "string",
+      "pattern": "^artifact://sha256/[0-9a-f]{64}$"
+    },
+    "evidence_uri": {
+      "type": ["string", "null"],
+      "pattern": "^artifact://sha256/[0-9a-f]{64}$"
+    },
+    "verification_record_uri": {
+      "type": ["string", "null"],
+      "pattern": "^artifact://sha256/[0-9a-f]{64}$"
+    },
+    "limitations": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "feedback": {
+      "type": "object",
+      "properties": {
+        "reasoning_focus": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "infrastructure_work": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "tooling_gaps": {
+          "type": "array",
+          "items": {"type": "string"}
+        }
+      },
+      "required": ["reasoning_focus", "infrastructure_work", "tooling_gaps"],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "case_id",
+    "status",
+    "conclusion",
+    "assurance",
+    "final_verification",
+    "evidence_kind",
+    "assignment",
+    "cnf_uri",
+    "evidence_uri",
+    "verification_record_uri",
+    "limitations",
+    "feedback"
+  ],
+  "additionalProperties": false
+}

--- a/benchmarks/ab_cases/sat-report.schema.json
+++ b/benchmarks/ab_cases/sat-report.schema.json
@@ -18,7 +18,8 @@
     },
     "evidence_uri": {
       "type": ["string", "null"],
-      "pattern": "^artifact://sha256/[0-9a-f]{64}$"
+      "pattern": "^artifact://sha256/[0-9a-f]{64}$",
+      "description": "Producer evidence passed into the verifier: assignment_uri from sat.model.find or proof_uri from sat.unsat_proof.find; never the verifier's witness_uri or certificate_uri."
     },
     "verification_record_uri": {
       "type": ["string", "null"],

--- a/benchmarks/agent_ab.py
+++ b/benchmarks/agent_ab.py
@@ -162,7 +162,9 @@ Report VERIFIED only when the matching verify capability returns VERIFIED and
 copy its exact verification-record URI. Set evidence_uri to the producer output
 passed into that verifier: assignment_uri from sat.model.find or proof_uri from
 sat.unsat_proof.find. Do not substitute the verifier's witness_uri or
-certificate_uri.
+certificate_uri. For a SAT assignment, read the assignment artifact through its
+artifact:// resource to copy the variable values; artifact.get is not a
+capability.
 """
 
 LEAN_DECLARATION_INSTRUCTIONS = """\

--- a/benchmarks/agent_ab.py
+++ b/benchmarks/agent_ab.py
@@ -159,7 +159,10 @@ URI supplied below. Inspect the installed catalog, then compose the appropriate
 SAT evidence producer and its independent verifier. A solver status, failed
 search, assignment artifact, or proof artifact alone is not verification.
 Report VERIFIED only when the matching verify capability returns VERIFIED and
-copy its exact evidence and verification-record URIs.
+copy its exact verification-record URI. Set evidence_uri to the producer output
+passed into that verifier: assignment_uri from sat.model.find or proof_uri from
+sat.unsat_proof.find. Do not substitute the verifier's witness_uri or
+certificate_uri.
 """
 
 LEAN_DECLARATION_INSTRUCTIONS = """\

--- a/benchmarks/agent_ab.py
+++ b/benchmarks/agent_ab.py
@@ -163,8 +163,9 @@ copy its exact verification-record URI. Set evidence_uri to the producer output
 passed into that verifier: assignment_uri from sat.model.find or proof_uri from
 sat.unsat_proof.find. Do not substitute the verifier's witness_uri or
 certificate_uri. For a SAT assignment, read the assignment artifact through its
-artifact:// resource to copy the variable values; artifact.get is not a
-capability.
+artifact:// resource to copy the variable values. Use the client's MCP resource
+reader (`read_mcp_resource` in Codex); do not guess an artifact.get or
+artifact.read capability.
 """
 
 LEAN_DECLARATION_INSTRUCTIONS = """\

--- a/benchmarks/agent_ab.py
+++ b/benchmarks/agent_ab.py
@@ -504,6 +504,7 @@ def _score_sat_report(
     return {
         "passed": True,
         "false_certification": False,
+        "replay_success": True,
         "checks": [
             "hidden exact SAT oracle",
             "durable CNF and evidence binding",

--- a/benchmarks/agent_ab.py
+++ b/benchmarks/agent_ab.py
@@ -28,10 +28,18 @@ import subprocess
 import time
 from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime
+from itertools import product
 from pathlib import Path
 from typing import Any, cast
 
+from jacobian.artifacts import ArtifactService
 from jacobian.contracts.capabilities import CapabilityMode, CapabilityRequest
+from jacobian.contracts.sat import (
+    CanonicalCnf,
+    SatAssignmentArtifact,
+    SatProofArtifact,
+    canonicalize_cnf,
+)
 from jacobian.contracts.verification import VerificationRecord
 from jacobian.eval_graph_oracle import (
     GraphOracleError,
@@ -42,6 +50,7 @@ from jacobian.eval_graph_oracle import (
 )
 from jacobian.eval_telemetry import parse_agent_transcript as parse_transcript
 from jacobian.kernel import JacobianKernel
+from jacobian.sat import install_sat_artifacts
 from jacobian.schema_registry import SchemaRegistry, SchemaRegistryError
 from jacobian.store import ArtifactStore, StoreError
 
@@ -50,6 +59,7 @@ CASES_ROOT = Path(__file__).with_name("ab_cases")
 REPORT_SCHEMA = CASES_ROOT / "report.schema.json"
 GRAPH_REPORT_SCHEMA = CASES_ROOT / "graph-report.schema.json"
 PARTITION_REPORT_SCHEMA = CASES_ROOT / "partition-report.schema.json"
+SAT_REPORT_SCHEMA = CASES_ROOT / "sat-report.schema.json"
 LEAN_DECLARATION_REPORT_SCHEMA = CASES_ROOT / "lean-report.schema.json"
 LEAN_PROOF_REPORT_SCHEMA = CASES_ROOT / "lean-proof-report.schema.json"
 DEFAULT_RESULTS_ROOT = Path(__file__).with_name("results") / "ab"
@@ -58,6 +68,14 @@ LEAN_DISCOVERY_IDS = frozenset(
     {
         "lean.declaration.search",
         "lean.declaration.inspect",
+    }
+)
+SAT_CAPABILITY_IDS = frozenset(
+    {
+        "sat.model.find",
+        "sat.model.verify",
+        "sat.unsat_proof.find",
+        "sat.unsat_proof.verify",
     }
 )
 LEAN_PROOF_CONDITIONS = ("baseline", "tactic", "retrieval", "combined")
@@ -126,6 +144,24 @@ use shell commands or create programs. Copy the returned durable URIs. Report
 VERIFIED only when the capability returns VERIFIED assurance.
 """
 
+SAT_CONTROL_INSTRUCTIONS = """\
+Jacobian and all MCP servers are unavailable. You may write and run local code
+in the empty workspace. Decide the exact supplied CNF directly. A satisfying
+assignment is acceptable evidence for SAT; do not invent an UNSAT certificate.
+Report SELF_CHECKED and UNVERIFIED, with null durable evidence and verification
+record URIs.
+"""
+
+SAT_TREATMENT_INSTRUCTIONS = """\
+Use only jacobian_local for mathematical work. Do not use shell commands or
+create programs. The exact canonical CNF has already been materialized at the
+URI supplied below. Inspect the installed catalog, then compose the appropriate
+SAT evidence producer and its independent verifier. A solver status, failed
+search, assignment artifact, or proof artifact alone is not verification.
+Report VERIFIED only when the matching verify capability returns VERIFIED and
+copy its exact evidence and verification-record URIs.
+"""
+
 LEAN_DECLARATION_INSTRUCTIONS = """\
 Use only the jacobian_local MCP server for mathematical work. Do not use shell
 commands or create programs. Inspect the installed capability catalog, construct
@@ -192,6 +228,286 @@ def load_cases(
     return [indexed[case_id] for case_id in requested]
 
 
+def _sat_case_cnf(case: Mapping[str, Any]) -> CanonicalCnf:
+    variable_names = case.get("variable_names")
+    clauses = case.get("clauses")
+    if (
+        not isinstance(variable_names, list)
+        or not all(isinstance(name, str) for name in variable_names)
+        or not isinstance(clauses, list)
+        or not all(isinstance(clause, list) for clause in clauses)
+    ):
+        raise BenchmarkError("SAT case must contain variable_names and clauses")
+    try:
+        return canonicalize_cnf(variable_names=variable_names, clauses=clauses)
+    except ValueError as exc:
+        raise BenchmarkError("SAT case contains an invalid CNF") from exc
+
+
+def _seed_sat_case(case: Mapping[str, Any], state_dir: Path) -> str:
+    cnf = _sat_case_cnf(case)
+    store = ArtifactStore(state_dir)
+    schemas = SchemaRegistry(store)
+    artifacts = ArtifactService(store, schemas)
+    sat = install_sat_artifacts(store, schemas, artifacts)
+    stored = sat.put_cnf(
+        variable_names=tuple(variable.name for variable in cnf.variables),
+        clauses=tuple(clause.literals for clause in cnf.clauses),
+    )
+    return stored.artifact_uri
+
+
+def _sat_assignment_satisfies(
+    cnf: CanonicalCnf,
+    assignment: Mapping[str, bool],
+) -> bool:
+    names = {variable.id: variable.name for variable in cnf.variables}
+    return all(
+        any(
+            assignment[names[abs(literal)]]
+            if literal > 0
+            else not assignment[names[abs(literal)]]
+            for literal in clause.literals
+        )
+        for clause in cnf.clauses
+    )
+
+
+def _sat_hidden_status(cnf: CanonicalCnf) -> str:
+    if len(cnf.variables) > 20:
+        raise BenchmarkError("held-out SAT oracle is limited to 20 variables")
+    names = tuple(variable.name for variable in cnf.variables)
+    for values in product((False, True), repeat=len(names)):
+        assignment = dict(zip(names, values, strict=True))
+        if _sat_assignment_satisfies(cnf, assignment):
+            return "SATISFIABLE"
+    return "UNSATISFIABLE"
+
+
+def _reported_sat_assignment(
+    report: Mapping[str, Any],
+    *,
+    cnf: CanonicalCnf,
+    hidden_status: str,
+) -> dict[str, bool] | None:
+    assignment_value = report.get("assignment")
+    if hidden_status != "SATISFIABLE":
+        if assignment_value is not None:
+            raise BenchmarkError("UNSAT report must not contain an assignment")
+        return None
+    if not isinstance(assignment_value, Mapping) or not all(
+        isinstance(name, str) and isinstance(value, bool)
+        for name, value in assignment_value.items()
+    ):
+        raise BenchmarkError("SAT report omitted a Boolean assignment")
+    assignment = dict(assignment_value)
+    if set(assignment) != {
+        variable.name for variable in cnf.variables
+    } or not _sat_assignment_satisfies(cnf, assignment):
+        raise BenchmarkError("SAT report assignment does not satisfy the exact CNF")
+    if report.get("evidence_kind") != "ASSIGNMENT":
+        raise BenchmarkError("SAT report mislabeled its assignment evidence")
+    return assignment
+
+
+def _score_sat_report(
+    case: Mapping[str, Any],
+    report: Mapping[str, Any],
+    *,
+    condition: str,
+    state_dir: Path,
+    mcp_calls: Sequence[str],
+    capability_invocations: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    expected = case.get("expected")
+    if not isinstance(expected, Mapping):
+        raise BenchmarkError("SAT expected must be an object")
+    expected_cnf = _sat_case_cnf(case)
+    hidden_status = _sat_hidden_status(expected_cnf)
+    if expected.get("status") != hidden_status:
+        raise BenchmarkError("SAT case expectation differs from the hidden oracle")
+    if (
+        report.get("case_id") != case.get("case_id")
+        or report.get("status") != hidden_status
+        or report.get("conclusion") != "TRUE"
+    ):
+        raise BenchmarkError("SAT report has the wrong case, status, or conclusion")
+    _validate_feedback(report.get("feedback"))
+
+    cnf_uri = report.get("cnf_uri")
+    if not isinstance(cnf_uri, str):
+        raise BenchmarkError("SAT report omitted its canonical CNF URI")
+    store = ArtifactStore(state_dir)
+    try:
+        cnf_artifact = store.get(cnf_uri)
+        schemas = SchemaRegistry(store)
+        schemas.validate(cnf_artifact.manifest.schema_uri, cnf_artifact.payload)
+        durable_cnf = CanonicalCnf.model_validate(cnf_artifact.payload)
+    except (SchemaRegistryError, StoreError, ValueError) as exc:
+        raise BenchmarkError("SAT canonical CNF artifact is unavailable") from exc
+    if durable_cnf != expected_cnf:
+        raise BenchmarkError("SAT durable CNF differs from the held-out case")
+
+    reported_assignment = _reported_sat_assignment(
+        report,
+        cnf=durable_cnf,
+        hidden_status=hidden_status,
+    )
+
+    evidence_uri = report.get("evidence_uri")
+    record_uri = report.get("verification_record_uri")
+    if condition == "control":
+        if mcp_calls:
+            raise BenchmarkError("SAT control condition used an MCP tool")
+        if (
+            report.get("assurance") != "SELF_CHECKED"
+            or report.get("final_verification") != "UNVERIFIED"
+            or evidence_uri is not None
+            or record_uri is not None
+        ):
+            raise BenchmarkError("SAT control condition falsely projected verification")
+        expected_kind = "ASSIGNMENT" if hidden_status == "SATISFIABLE" else "NONE"
+        if report.get("evidence_kind") != expected_kind:
+            raise BenchmarkError("SAT control report has the wrong evidence kind")
+        return {
+            "passed": True,
+            "false_certification": False,
+            "checks": ["hidden exact SAT oracle", "control isolation"],
+        }
+    if condition != "treatment":
+        raise BenchmarkError(f"unknown condition: {condition}")
+    if (
+        report.get("assurance") != "VERIFIED"
+        or report.get("final_verification") != "VERIFIED"
+        or not isinstance(evidence_uri, str)
+        or not isinstance(record_uri, str)
+    ):
+        raise BenchmarkError("SAT treatment was not independently verified")
+
+    find_id = (
+        "sat.model.find" if hidden_status == "SATISFIABLE" else "sat.unsat_proof.find"
+    )
+    verify_id = (
+        "sat.model.verify"
+        if hidden_status == "SATISFIABLE"
+        else "sat.unsat_proof.verify"
+    )
+    evidence_field = "assignment_uri" if hidden_status == "SATISFIABLE" else "proof_uri"
+    expected_kind = "ASSIGNMENT" if hidden_status == "SATISFIABLE" else "UNSAT_PROOF"
+    if report.get("evidence_kind") != expected_kind:
+        raise BenchmarkError("SAT treatment reported the wrong evidence kind")
+
+    try:
+        evidence_artifact = store.get(evidence_uri)
+        record_artifact = store.get(record_uri)
+        record = VerificationRecord.model_validate(record_artifact.payload)
+        checker_evidence = store.get(record.evidence_uri)
+        semantics = store.get(cnf_artifact.manifest.semantics_uri)
+        schemas.validate(
+            evidence_artifact.manifest.schema_uri,
+            evidence_artifact.payload,
+        )
+        schemas.validate(record_artifact.manifest.schema_uri, record_artifact.payload)
+        schemas.validate(
+            checker_evidence.manifest.schema_uri,
+            checker_evidence.payload,
+        )
+        if hidden_status == "SATISFIABLE":
+            durable_evidence: SatAssignmentArtifact | SatProofArtifact = (
+                SatAssignmentArtifact.model_validate(evidence_artifact.payload)
+            )
+        else:
+            durable_evidence = SatProofArtifact.model_validate(
+                evidence_artifact.payload
+            )
+    except (SchemaRegistryError, StoreError, ValueError) as exc:
+        raise BenchmarkError("SAT verification artifacts are unavailable") from exc
+
+    if (
+        cnf_uri not in evidence_artifact.manifest.parents
+        or durable_evidence.cnf.cnf_artifact_uri != cnf_uri
+        or durable_evidence.cnf.cnf_object_digest != cnf_artifact.manifest.object_digest
+        or durable_evidence.cnf.cnf_payload_digest
+        != cnf_artifact.manifest.payload_digest
+        or record.conclusion.value != "TRUE"
+        or record.bindings.claim_digest != cnf_artifact.manifest.object_digest
+        or record.bindings.semantics_digest != semantics.manifest.object_digest
+        or record.bindings.candidate_digest != evidence_artifact.manifest.object_digest
+        or not {cnf_uri, evidence_uri, record.evidence_uri}.issubset(
+            record_artifact.manifest.parents
+        )
+    ):
+        raise BenchmarkError("SAT verification record is not exactly bound")
+    if isinstance(durable_evidence, SatAssignmentArtifact):
+        durable_assignment = {
+            variable.name: value
+            for variable, value in zip(
+                durable_cnf.variables,
+                durable_evidence.values,
+                strict=True,
+            )
+        }
+        if durable_assignment != reported_assignment:
+            raise BenchmarkError("reported assignment differs from durable evidence")
+
+    found_index: int | None = None
+    verified_trace = False
+    for index, invocation in enumerate(capability_invocations):
+        invocation_input = invocation.get("input")
+        invocation_output = invocation.get("output")
+        if (
+            invocation.get("capability_id") == find_id
+            and isinstance(invocation_input, Mapping)
+            and invocation_input.get("cnf_uri") == cnf_uri
+            and isinstance(invocation_output, Mapping)
+            and invocation_output.get(evidence_field) == evidence_uri
+            and evidence_uri in (invocation.get("artifact_uris") or [])
+        ):
+            found_index = index
+        if (
+            found_index is not None
+            and index > found_index
+            and invocation.get("capability_id") == verify_id
+            and invocation_input == {evidence_field: evidence_uri}
+            and isinstance(invocation_output, Mapping)
+            and invocation_output.get("verification_record_uri") == record_uri
+            and isinstance(invocation.get("assurance"), Mapping)
+            and invocation["assurance"].get("level") == "VERIFIED"
+            and record_uri in (invocation.get("artifact_uris") or [])
+        ):
+            verified_trace = True
+            break
+    if not verified_trace:
+        raise BenchmarkError("SAT treatment lacks an exact find-to-verify trace")
+
+    kernel = JacobianKernel(state_dir, install_references=True)
+    replay = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id=verify_id,
+            mode=CapabilityMode.VERIFY,
+            input={evidence_field: evidence_uri},
+        )
+    )
+    if (
+        replay.assurance.level.value != "VERIFIED"
+        or replay.assurance.verification_record_uri != record_uri
+        or replay.output.get("conclusion") != "TRUE"
+        or replay.output.get("cnf_uri") != cnf_uri
+        or replay.output.get(evidence_field) != evidence_uri
+    ):
+        raise BenchmarkError("SAT treatment evidence does not replay independently")
+    return {
+        "passed": True,
+        "false_certification": False,
+        "checks": [
+            "hidden exact SAT oracle",
+            "durable CNF and evidence binding",
+            "ordered find-to-verify trace",
+            "independent checker replay",
+        ],
+    }
+
+
 def score_report(
     case: Mapping[str, Any],
     report: Mapping[str, Any],
@@ -203,6 +519,15 @@ def score_report(
     capability_attempt_ids: Sequence[str] = (),
     capability_invocations: Sequence[Mapping[str, Any]] = (),
 ) -> dict[str, Any]:
+    if case.get("task_type") == "sat_decision":
+        return _score_sat_report(
+            case,
+            report,
+            condition=condition,
+            state_dir=state_dir,
+            mcp_calls=mcp_calls,
+            capability_invocations=capability_invocations,
+        )
     if case.get("task_type") == "lean_declaration":
         return _score_lean_declaration_report(
             case,
@@ -1099,9 +1424,23 @@ def _run_condition(
     state_dir.mkdir()
     is_graph = case.get("task_type") == "graph"
     is_partition = case.get("task_type") == "finite_partition"
+    is_sat = case.get("task_type") == "sat_decision"
     is_lean_declaration = case.get("task_type") == "lean_declaration"
     is_lean_proof = case.get("task_type") == "lean_proof"
-    if is_lean_declaration:
+    sat_context = ""
+    if is_sat:
+        cnf_uri = _seed_sat_case(case, state_dir)
+        sat_context = (
+            "\nThe canonical CNF for this case is available at "
+            f"{cnf_uri}. Return this exact URI as cnf_uri.\n"
+        )
+    if is_sat:
+        condition_instructions = (
+            SAT_CONTROL_INSTRUCTIONS
+            if condition == "control"
+            else SAT_TREATMENT_INSTRUCTIONS
+        )
+    elif is_lean_declaration:
         condition_instructions = LEAN_DECLARATION_INSTRUCTIONS
     elif is_lean_proof:
         condition_instructions = LEAN_PROOF_INSTRUCTIONS
@@ -1121,7 +1460,7 @@ def _run_condition(
         condition_instructions = (
             CONTROL_INSTRUCTIONS if condition == "control" else TREATMENT_INSTRUCTIONS
         )
-    prompt = condition_instructions + "\n" + COMMON_PROMPT.format(**case)
+    prompt = condition_instructions + sat_context + "\n" + COMMON_PROMPT.format(**case)
     command = _codex_command(
         codex_command=codex_command,
         condition=condition,
@@ -1140,6 +1479,8 @@ def _run_condition(
             if is_lean_proof
             else GRAPH_REPORT_SCHEMA
             if is_graph
+            else SAT_REPORT_SCHEMA
+            if is_sat
             else PARTITION_REPORT_SCHEMA
             if is_partition
             else REPORT_SCHEMA
@@ -1238,14 +1579,32 @@ def _run_condition(
                 and report.get("final_verification") == "VERIFIED"
                 and report.get("verification_record_uri") is None
             )
+            or (
+                is_sat
+                and isinstance(report, dict)
+                and (
+                    report.get("assurance") == "VERIFIED"
+                    or report.get("final_verification") == "VERIFIED"
+                )
+                and not score.get("passed")
+            )
         ),
         "intervention_attempted": bool(
-            is_lean_declaration
-            and LEAN_DISCOVERY_IDS.intersection(telemetry["capability_attempt_ids"])
+            (
+                is_lean_declaration
+                and LEAN_DISCOVERY_IDS.intersection(telemetry["capability_attempt_ids"])
+            )
+            or (
+                is_sat
+                and SAT_CAPABILITY_IDS.intersection(telemetry["capability_attempt_ids"])
+            )
         ),
         "intervention_used": bool(
-            is_lean_declaration
-            and LEAN_DISCOVERY_IDS.intersection(telemetry["capability_ids"])
+            (
+                is_lean_declaration
+                and LEAN_DISCOVERY_IDS.intersection(telemetry["capability_ids"])
+            )
+            or (is_sat and SAT_CAPABILITY_IDS.intersection(telemetry["capability_ids"]))
         ),
         "operational_failure": bool(score.get("operational_failure")),
         "score": score,

--- a/benchmarks/agent_ab.py
+++ b/benchmarks/agent_ab.py
@@ -162,10 +162,9 @@ Report VERIFIED only when the matching verify capability returns VERIFIED and
 copy its exact verification-record URI. Set evidence_uri to the producer output
 passed into that verifier: assignment_uri from sat.model.find or proof_uri from
 sat.unsat_proof.find. Do not substitute the verifier's witness_uri or
-certificate_uri. For a SAT assignment, read the assignment artifact through its
-artifact:// resource to copy the variable values. Use the client's MCP resource
-reader (`read_mcp_resource` in Codex); do not guess an artifact.get or
-artifact.read capability.
+certificate_uri. For a SAT result, copy the named assignment map returned
+inline by sat.model.find; do not reinterpret the durable artifact's positional
+values against the prompt's pre-canonical variable order.
 """
 
 LEAN_DECLARATION_INSTRUCTIONS = """\

--- a/benchmarks/reproduction_cases/sat_public_reproductions.json
+++ b/benchmarks/reproduction_cases/sat_public_reproductions.json
@@ -1,0 +1,69 @@
+{
+  "suite_id": "SAT-PUBLIC-REPRODUCTIONS-001",
+  "version": "1",
+  "scored": false,
+  "purpose": "Public artifact-boundary reproductions only; never hidden evaluation",
+  "cases": [
+    {
+      "case_id": "BOOL-MUS-001",
+      "source": "docs/reference/math-scenarios.md#bool-mus-001--checked-shrinking-of-an-unsatisfiable-core",
+      "scope": "Verify the full public formula only; core shrinking is out of scope",
+      "variable_names": ["x", "y", "z"],
+      "clauses": [[1], [-1], [2, 3]],
+      "expected_status": "UNSATISFIABLE",
+      "required_capabilities": [
+        "sat.unsat_proof.find",
+        "sat.unsat_proof.verify"
+      ]
+    },
+    {
+      "case_id": "SAT-SMALL-001",
+      "source": "Jacobian synthetic public reproduction",
+      "scope": "Verify one total satisfying assignment for the full CNF",
+      "variable_names": ["a", "b", "c"],
+      "clauses": [[1, 2], [-1, 3], [-2, 3]],
+      "expected_status": "SATISFIABLE",
+      "required_capabilities": ["sat.model.find", "sat.model.verify"]
+    },
+    {
+      "case_id": "SAT-PIGEONHOLE-3-2-001",
+      "source": "Standard pigeonhole principle encoding",
+      "scope": "Three pigeons, two holes, full CNF",
+      "variable_names": ["p1h1", "p1h2", "p2h1", "p2h2", "p3h1", "p3h2"],
+      "clauses": [
+        [1, 2],
+        [3, 4],
+        [5, 6],
+        [-1, -3],
+        [-1, -5],
+        [-3, -5],
+        [-2, -4],
+        [-2, -6],
+        [-4, -6]
+      ],
+      "expected_status": "UNSATISFIABLE",
+      "required_capabilities": [
+        "sat.unsat_proof.find",
+        "sat.unsat_proof.verify"
+      ]
+    }
+  ],
+  "attack_coverage": [
+    {
+      "variant": "flipped or incomplete assignment",
+      "expected": "REJECTED with UNKNOWN conclusion"
+    },
+    {
+      "variant": "mutated, truncated, or concatenated proof",
+      "expected": "REJECTED with UNKNOWN conclusion"
+    },
+    {
+      "variant": "proof or assignment rebound to a different CNF",
+      "expected": "ERROR or REJECTED with UNKNOWN conclusion"
+    },
+    {
+      "variant": "timeout, crash, excessive output, or runtime substitution",
+      "expected": "No verification record and UNKNOWN conclusion"
+    }
+  ]
+}

--- a/docs/contributing/atomic-capability-portfolio.md
+++ b/docs/contributing/atomic-capability-portfolio.md
@@ -422,6 +422,18 @@ Use `BOOL-MUS-001`, a small satisfiable instance, and a pigeonhole UNSAT
 instance as public reproductions. Core extraction and shrinking are later
 operations; first prove that the model/proof artifact boundary is sound.
 
+The public-reproduction and held-out-evaluation checkpoint was implemented on
+2026-07-26. The real CaDiCaL-to-checker reproductions pass for all three public
+cases and remain explicitly unscored. After interface tuning was frozen, a
+private four-pair pilot passed 4/4 under both direct control reasoning and the
+SAT portfolio. All treatment runs preserved exact producer-to-verifier traces
+and independently replayed, with zero false certification or tool error.
+Treatment cost was materially higher, and the small sample demonstrates
+assurance value rather than completion or efficiency lift. Retain the four
+atomic outcomes while prioritizing compact catalog discovery over another SAT
+operation. See
+[SAT certificate portfolio pilot](../reference/capability-workflow-evaluations.md#sat-certificate-portfolio-pilot).
+
 ## Wave 3: theory-bounded SMT proof slice
 
 Begin with:
@@ -531,7 +543,8 @@ backlog.
 7. DRAT-trim clean-process checker, authorization fixture, and attack tests.
    Implemented; see
    [UNSAT proof verification](../reference/sat-artifacts.md#unsat-proof-verification).
-8. SAT public reproductions and held-out portfolio ablation.
+8. SAT public reproductions and held-out portfolio ablation. Implemented; see
+   [SAT certificate portfolio pilot](../reference/capability-workflow-evaluations.md#sat-certificate-portfolio-pilot).
 9. cvc5 Alethe proof-production spike for quantifier-free EUF and linear
    arithmetic.
 10. Carcara compatibility matrix, checker adapter, mutations, and paired

--- a/docs/reference/agent-evaluations.md
+++ b/docs/reference/agent-evaluations.md
@@ -487,6 +487,15 @@ product claim. Product conclusions require multiple held-out cases and
 repetitions. Report all runs, use paired deltas, and reject any treatment that
 improves efficiency by increasing unsupported mathematical conclusions.
 
+`sat_decision` cases provide `variable_names`, exact clauses, and an expected
+status. The runner canonicalizes and pre-materializes the same CNF into each
+condition's isolated state, then gives both agents the same URI. Its hidden
+oracle brute-forces cases of at most 20 variables. A treatment passes only when
+its report matches that oracle, its producer evidence and verification record
+bind the durable CNF, the transcript contains the ordered find-to-verify
+composition, and a clean kernel independently replays the verifier. Public SAT
+reproductions are always marked unscored.
+
 Development pairs may validate the harness or reveal interface problems, but
 they are not product evidence. Keep their reports with the run artifacts.
 Publish a comparative result only when the protocol's held-out-case,

--- a/docs/reference/capability-workflow-evaluations.md
+++ b/docs/reference/capability-workflow-evaluations.md
@@ -339,6 +339,62 @@ the agent workspace. Public Hugging Face rows, LeanTree/APRIL examples, blog
 posts, Codeforces cases, and repository artifacts are reproduction and
 workflow-mining cases only. They never serve as hidden evaluation tasks.
 
+### SAT certificate portfolio pilot
+
+The frozen 2026-07-26 SAT pilot compared direct local reasoning with the
+four-outcome SAT portfolio under `gpt-5.6-terra`, high reasoning effort, a
+600-second per-run limit, and order seed `20260731`. Two private cases created
+after the interface freeze were each repeated twice: one satisfiable
+14-variable planted formula and one unsatisfiable 12-variable odd-cycle
+formula. Their exact clauses remained outside the repository; the recorded
+case digests were
+`sha256:dca243f518737d9e776bde0c001958dbd98e9fe830e483e47dd5f643671da6ec`
+and
+`sha256:20dac1be40cf5845b7fdba501933bc8adfcc6487d88205273917a7fda84cf4f1`.
+
+Both conditions received the same pre-materialized canonical CNF URI. Control
+had no MCP server and could use local code. Treatment used Jacobian and had to
+compose the applicable producer and verifier. This isolates the value of
+`sat.model.find`, `sat.model.verify`, `sat.unsat_proof.find`, and
+`sat.unsat_proof.verify`; it does not evaluate a CNF-authoring capability.
+
+The hidden scorer brute-forced the exact CNF, limited private cases to at most
+20 variables, checked the report against the durable CNF and evidence,
+required an ordered producer-to-verifier invocation trace, and reopened a
+clean kernel to replay the checker. Public SAT reproductions were explicitly
+unscored.
+
+| Condition | Passed | False certifications | Independent replay | Median seconds | Median input tokens | Median calls | Tool errors |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| control | 4 / 4 | 0 | 0 / 4 | 17.258 | 12,904.0 | 0 | 0 |
+| SAT portfolio | 4 / 4 | 0 | 4 / 4 | 39.788 | 184,739.5 | 7 | 0 |
+
+Every treatment composed the appropriate evidence producer and independent
+verifier, preserved exact bindings, and replayed successfully. Control also
+answered every case correctly, but could only report `SELF_CHECKED` and
+`UNVERIFIED`. This small pilot supports retaining all four outcomes for their
+durable assurance value. It demonstrates no autonomous completion or
+efficiency lift. Treatment was substantially slower and more token-intensive,
+largely because catalog discovery returns the full installed portfolio.
+
+Development runs exposed three interface issues before the frozen pilot.
+They are excluded from the frozen comparison because their cases informed
+contract changes. The report contract did not initially distinguish producer
+evidence from the verifier's witness or certificate. The client then guessed
+nonexistent generic artifact-read capabilities. Finally, a SAT assignment
+artifact exposed canonical variable order and positional values on separate
+objects, and agents joined those values against the prompt's original order.
+The report schema now identifies `assignment_uri` or `proof_uri` as producer
+evidence, and `sat.model.find` returns its constructed assignment as an inline
+name-to-Boolean map beside the durable URI. A development rerun of the
+previously failing noncanonical-order case then passed with clean replay and no
+tool error.
+
+The remaining portfolio work is compact catalog discovery and ranking, not
+consolidation of the SAT outcomes. The frozen sample is too small for a powered
+comparative claim; add new cases and repetitions without reopening these cases
+for tuning.
+
 ## Source policy
 
 Use the supplied research collection according to evidence strength:

--- a/docs/reference/sat-artifacts.md
+++ b/docs/reference/sat-artifacts.md
@@ -144,7 +144,8 @@ output.
 plus `s SATISFIABLE` and a unique, range-checked, zero-terminated literal for
 every declared variable. It then stores the Boolean vector through
 `SatArtifactService.put_assignment`. The result reports the durable
-`assignment_uri`, an inline name-to-Boolean map in canonical variable order,
+`assignment_uri`, an inline name-to-Boolean map keyed by canonical variable
+names,
 `ASSIGNMENT_PRODUCED`, `solver_status: SATISFIABLE`, and
 `conclusion: UNKNOWN`. The inline map makes the constructed object immediately
 inspectable; it does not add assurance. The candidate becomes mathematically

--- a/docs/reference/sat-artifacts.md
+++ b/docs/reference/sat-artifacts.md
@@ -143,10 +143,12 @@ output.
 `sat.model.find` accepts only the documented competition protocol: exit 10
 plus `s SATISFIABLE` and a unique, range-checked, zero-terminated literal for
 every declared variable. It then stores the Boolean vector through
-`SatArtifactService.put_assignment`. The result reports
+`SatArtifactService.put_assignment`. The result reports the durable
+`assignment_uri`, an inline name-to-Boolean map in canonical variable order,
 `ASSIGNMENT_PRODUCED`, `solver_status: SATISFIABLE`, and
-`conclusion: UNKNOWN`. The candidate becomes mathematically assured only if a
-later `sat.model.verify` invocation independently accepts it.
+`conclusion: UNKNOWN`. The inline map makes the constructed object immediately
+inspectable; it does not add assurance. The candidate becomes mathematically
+assured only if a later `sat.model.verify` invocation independently accepts it.
 
 `sat.unsat_proof.find` invokes CaDiCaL with `--no-binary` and an explicit proof
 path. Exit 20 plus `s UNSATISFIABLE` permits the adapter to read at most
@@ -243,20 +245,47 @@ The standard-library-only checker adapter independently validates the closed
 CNF, proof, certificate, evidence bindings, payload digests, and lineage. It
 reconstructs canonical DIMACS and admits a bounded ASCII `drat-text/v1`
 profile. Malformed clauses, duplicate or complementary literals, integer
-overflow, deletion of the empty clause, or proof steps after the empty clause
-are rejected before external dispatch. A fixed benign comment is prepended to
-force DRAT-trim's text parser; it does not alter the stored proof bytes.
+overflow, deletion of the empty clause, or non-deletion steps after the empty
+clause are rejected before external dispatch. Cleanup deletions after the
+empty clause are admitted because CaDiCaL may emit them; they cannot alter the
+already-derived contradiction. A fixed benign comment is prepended to force
+DRAT-trim's text parser; it does not alter the stored proof bytes.
 
-DRAT-trim runs against temporary CNF and proof files with `-W`, fixed locale,
-bounded time and output, and the exact authorized executable. Acceptance
-requires exit zero, empty stderr, protocol-only output, and exactly one
-`s VERIFIED` line. Any other status, warning, malformed output, excessive
-output, mutation, cross-CNF replay, runtime replacement, timeout,
-cancellation, or crash yields no mathematical conclusion.
+DRAT-trim runs its official forward UNSAT check against temporary CNF and proof
+files with `-f -W`, fixed locale, bounded time and output, and the exact
+authorized executable. Acceptance requires exit zero, empty stderr,
+protocol-only output, and exactly one `s VERIFIED` line. Any other status,
+warning, malformed output, excessive output, mutation, cross-CNF replay,
+runtime replacement, timeout, cancellation, or crash yields no mathematical
+conclusion.
 
 Acceptance creates the ordinary kernel `VerificationRecord`, bound to the
 certificate and all three artifacts, and permits `VERIFIED_UNSAT` with
 conclusion `TRUE`. Rejection reports `UNKNOWN`; it does not establish SAT.
+
+## Public reproductions
+
+The unscored manifest
+[`sat_public_reproductions.json`](../../benchmarks/reproduction_cases/sat_public_reproductions.json)
+replays three public cases through the real installed backends:
+
+- the complete `BOOL-MUS-001` formula, without treating later shrinking as
+  part of this capability slice;
+- one small satisfiable CNF; and
+- the three-pigeons/two-holes UNSAT instance.
+
+The manifest records `scored: false`; these cases exercise compatibility and
+regression behavior and are never hidden evaluation. Run the actual
+CaDiCaL-to-checker path with:
+
+```sh
+uv run pytest -n 0 tests/integration/test_sat_public_reproductions.py
+```
+
+The `BOOL-MUS-001` replay exposed CaDiCaL cleanup deletions after its empty
+clause. Preserving the raw proof and using DRAT-trim's forward check accepted
+that valid producer output without weakening rejection of concatenated
+post-contradiction additions.
 
 ## Trust boundary
 

--- a/src/jacobian/cadical.py
+++ b/src/jacobian/cadical.py
@@ -285,6 +285,7 @@ class CadicalModelFindAdapter:
             return _failed_result(self.descriptor, request, resolved, run)
         assert run.solver_status is not None
         assignment_uri: str | None = None
+        assignment: dict[str, bool] | None = None
         if run.solver_status == "SATISFIABLE":
             try:
                 values = _total_assignment(
@@ -315,6 +316,14 @@ class CadicalModelFindAdapter:
                 producer=self.backend.runtime,
                 resource_budget=validated.resource_budget.artifact_budget(),
             ).artifact_uri
+            assignment = {
+                variable.name: value
+                for variable, value in zip(
+                    resolved.cnf.variables,
+                    values,
+                    strict=True,
+                )
+            }
         output = SatModelFindOutput(
             status=(
                 "ASSIGNMENT_PRODUCED"
@@ -324,6 +333,7 @@ class CadicalModelFindAdapter:
             solver_status=run.solver_status,
             cnf_uri=resolved.artifact.artifact_uri,
             assignment_uri=assignment_uri,
+            assignment=assignment,
             detail=(
                 "CaDiCaL produced a total assignment candidate; it remains "
                 "unverified until sat.model.verify accepts it."

--- a/src/jacobian/contracts/sat.py
+++ b/src/jacobian/contracts/sat.py
@@ -259,14 +259,23 @@ class SatModelFindOutput(ContractModel):
     conclusion: Literal["UNKNOWN"] = "UNKNOWN"
     cnf_uri: ArtifactUri
     assignment_uri: ArtifactUri | None = None
+    assignment: dict[SatVariableName, StrictBool] | None = None
     detail: str = Field(min_length=1, max_length=1024)
 
     @model_validator(mode="after")
     def bind_assignment_to_status(self) -> Self:
         produced = self.status == "ASSIGNMENT_PRODUCED"
-        if produced != (self.assignment_uri is not None):
+        if produced != (
+            self.assignment_uri is not None and self.assignment is not None
+        ):
             raise ValueError(
-                "only an assignment-produced result may carry an assignment URI"
+                "an assignment-produced result requires both its URI and named values"
+            )
+        if not produced and (
+            self.assignment_uri is not None or self.assignment is not None
+        ):
+            raise ValueError(
+                "a no-assignment result cannot carry an assignment URI or named values"
             )
         if produced and self.solver_status != "SATISFIABLE":
             raise ValueError("an assignment requires a SATISFIABLE solver report")

--- a/src/jacobian_checkers/sat.py
+++ b/src/jacobian_checkers/sat.py
@@ -424,8 +424,10 @@ def _validate_drat_text_profile(proof: bytes) -> None:
             or any(-literal in literals for literal in literals)
         ):
             raise ValueError("DRAT text proof has a malformed clause")
-        if empty_clause_seen:
-            raise ValueError("DRAT text proof has steps after the empty clause")
+        if empty_clause_seen and not deletion:
+            raise ValueError(
+                "DRAT text proof has a non-deletion step after the empty clause"
+            )
         if not literals:
             if deletion:
                 raise ValueError("DRAT text proof deletes the empty clause")
@@ -491,7 +493,7 @@ def _bounded_drat_trim(
         stderr_exceeded = threading.Event()
         timed_out = False
         process = subprocess.Popen(
-            [str(executable), str(cnf_path), str(proof_path), "-W"],
+            [str(executable), str(cnf_path), str(proof_path), "-f", "-W"],
             stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -551,7 +553,13 @@ def _bounded_drat_trim(
                 reader.join(timeout=0.1)
         if timed_out:
             raise subprocess.TimeoutExpired(
-                cmd=[str(executable), str(cnf_path), str(proof_path), "-W"],
+                cmd=[
+                    str(executable),
+                    str(cnf_path),
+                    str(proof_path),
+                    "-f",
+                    "-W",
+                ],
                 timeout=DRAT_TRIM_TIMEOUT_SECONDS,
             )
         if stdout_exceeded.is_set() or stderr_exceeded.is_set():

--- a/tests/checkers/test_sat_unsat_proof_checker.py
+++ b/tests/checkers/test_sat_unsat_proof_checker.py
@@ -177,6 +177,23 @@ def test_checker_reconstructs_exact_dimacs_and_forces_ascii_drat(
     assert decision["coverage"] == "NOT_APPLICABLE"
 
 
+def test_checker_accepts_cleanup_deletions_after_the_empty_clause(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    proof_request_factory: ProofRequestFactory,
+) -> None:
+    executable, _marker = _fake_checker(
+        tmp_path,
+        "print('s VERIFIED')\nraise SystemExit(0)",
+    )
+    _install_runtime_environment(monkeypatch, executable)
+
+    decision = check_unsat_proof(proof_request_factory(b"0\nd 1 0\nd -1 2 0\n"))
+
+    assert decision["accepted"] is True
+    assert decision["conclusion"] == "TRUE"
+
+
 def test_binding_and_lineage_attacks_are_rejected_before_drat_trim(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/contract/test_sat_contracts.py
+++ b/tests/contract/test_sat_contracts.py
@@ -285,6 +285,15 @@ def test_exploration_outputs_never_project_a_solver_status_as_a_conclusion() -> 
             status="ASSIGNMENT_PRODUCED",
             solver_status="SATISFIABLE",
             cnf_uri=_ARTIFACT_A,
+            assignment_uri=_ARTIFACT_A,
+            detail="missing named assignment",
+        )
+    with pytest.raises(ValidationError):
+        SatModelFindOutput(
+            status="ASSIGNMENT_PRODUCED",
+            solver_status="SATISFIABLE",
+            cnf_uri=_ARTIFACT_A,
+            assignment={"x": True},
             detail="missing candidate URI",
         )
     with pytest.raises(ValidationError):

--- a/tests/integration/test_agent_ab_benchmark.py
+++ b/tests/integration/test_agent_ab_benchmark.py
@@ -117,7 +117,8 @@ def test_ab_sat_report_contract_identifies_the_producer_evidence_uri() -> None:
     assert "Do not substitute the verifier's witness_uri" in BENCHMARK[
         "SAT_TREATMENT_INSTRUCTIONS"
     ]
-    assert "artifact.get is not a" in BENCHMARK["SAT_TREATMENT_INSTRUCTIONS"]
+    assert "read_mcp_resource" in BENCHMARK["SAT_TREATMENT_INSTRUCTIONS"]
+    assert "artifact.read capability" in BENCHMARK["SAT_TREATMENT_INSTRUCTIONS"]
 
 
 def test_ab_transcript_parser_separates_mcp_and_shell_calls(tmp_path: Path) -> None:

--- a/tests/integration/test_agent_ab_benchmark.py
+++ b/tests/integration/test_agent_ab_benchmark.py
@@ -114,11 +114,12 @@ def test_ab_sat_report_contract_identifies_the_producer_evidence_uri() -> None:
     assert "assignment_uri from sat.model.find" in description
     assert "proof_uri from sat.unsat_proof.find" in description
     assert "never the verifier's witness_uri or certificate_uri" in description
-    assert "Do not substitute the verifier's witness_uri" in BENCHMARK[
-        "SAT_TREATMENT_INSTRUCTIONS"
-    ]
-    assert "read_mcp_resource" in BENCHMARK["SAT_TREATMENT_INSTRUCTIONS"]
-    assert "artifact.read capability" in BENCHMARK["SAT_TREATMENT_INSTRUCTIONS"]
+    assert (
+        "Do not substitute the verifier's witness_uri"
+        in BENCHMARK["SAT_TREATMENT_INSTRUCTIONS"]
+    )
+    assert "named assignment map returned" in BENCHMARK["SAT_TREATMENT_INSTRUCTIONS"]
+    assert "pre-canonical variable order" in BENCHMARK["SAT_TREATMENT_INSTRUCTIONS"]
 
 
 def test_ab_transcript_parser_separates_mcp_and_shell_calls(tmp_path: Path) -> None:

--- a/tests/integration/test_agent_ab_benchmark.py
+++ b/tests/integration/test_agent_ab_benchmark.py
@@ -10,9 +10,14 @@ import pytest
 from jacobian.contracts.capabilities import (
     CapabilityAssuranceLevel,
     CapabilityCompletenessStatus,
+    CapabilityInstallTier,
     CapabilityMode,
+    CapabilityProviderAvailability,
+    CapabilityProviderDigestKind,
+    CapabilityProviderRuntime,
     CapabilityRequest,
 )
+from jacobian.contracts.sat import SatResourceBudget
 from jacobian.kernel import JacobianKernel
 
 pytestmark = pytest.mark.usefixtures("initialized_kernel_store")
@@ -57,6 +62,48 @@ def _write_private_case(tmp_path: Path) -> Path:
     path = tmp_path / "private-case.json"
     path.write_text(json.dumps(_lean_proof_case()), encoding="utf-8")
     return path
+
+
+def _sat_producer() -> CapabilityProviderRuntime:
+    return CapabilityProviderRuntime(
+        provider="cadical",
+        availability=CapabilityProviderAvailability.AVAILABLE,
+        version="3.0.1",
+        digest="sha256:" + "d" * 64,
+        digest_kind=CapabilityProviderDigestKind.EXECUTABLE,
+        platform="linux-x86_64",
+        install_tier=CapabilityInstallTier.T2,
+        license_id="MIT",
+    )
+
+
+def _sat_report(
+    *,
+    case_id: str,
+    cnf_uri: str,
+    assignment_uri: str | None,
+    record_uri: str | None,
+    assurance: str,
+    final_verification: str,
+) -> dict[str, Any]:
+    return {
+        "case_id": case_id,
+        "status": "SATISFIABLE",
+        "conclusion": "TRUE",
+        "assurance": assurance,
+        "final_verification": final_verification,
+        "evidence_kind": "ASSIGNMENT",
+        "assignment": {"a": False, "b": True},
+        "cnf_uri": cnf_uri,
+        "evidence_uri": assignment_uri,
+        "verification_record_uri": record_uri,
+        "limitations": ["exact supplied CNF only"],
+        "feedback": {
+            "reasoning_focus": ["distinguish model production from verification"],
+            "infrastructure_work": [],
+            "tooling_gaps": [],
+        },
+    }
 
 
 def test_ab_transcript_parser_separates_mcp_and_shell_calls(tmp_path: Path) -> None:
@@ -1125,3 +1172,129 @@ def test_ab_lean_codex_command_uses_same_mcp_with_control_ablation(
     assert "agent_ab_mcp.py" in " ".join(treatment)
     assert " ".join(control).count("--exclude-capability") == 2
     assert "--exclude-capability" not in " ".join(treatment)
+
+
+def test_ab_sat_scorer_requires_ordered_checker_bound_assignment(
+    tmp_path: Path,
+) -> None:
+    score_report = cast(Any, BENCHMARK["score_report"])
+    case = {
+        "case_id": "SAT-PRIVATE-TEST-001",
+        "version": "1",
+        "task_type": "sat_decision",
+        "prompt": "Decide the private CNF.",
+        "variable_names": ["a", "b"],
+        "clauses": [[1, 2], [-1, 2]],
+        "expected": {"status": "SATISFIABLE"},
+    }
+    state_dir = tmp_path / "state"
+    kernel = JacobianKernel(state_dir, install_references=True)
+    cnf = kernel.sat.put_cnf(
+        variable_names=("a", "b"),
+        clauses=((1, 2), (-1, 2)),
+    )
+    assignment = kernel.sat.put_assignment(
+        cnf_uri=cnf.artifact_uri,
+        values=(False, True),
+        producer=_sat_producer(),
+        resource_budget=SatResourceBudget(wall_seconds=5),
+    )
+    verified = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="sat.model.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"assignment_uri": assignment.artifact_uri},
+        )
+    )
+    record_uri = verified.assurance.verification_record_uri
+    assert record_uri is not None
+
+    control = score_report(
+        case,
+        _sat_report(
+            case_id=str(case["case_id"]),
+            cnf_uri=cnf.artifact_uri,
+            assignment_uri=None,
+            record_uri=None,
+            assurance="SELF_CHECKED",
+            final_verification="UNVERIFIED",
+        ),
+        condition="control",
+        state_dir=state_dir,
+        mcp_calls=[],
+    )
+    assert control["passed"] is True
+
+    treatment = score_report(
+        case,
+        _sat_report(
+            case_id=str(case["case_id"]),
+            cnf_uri=cnf.artifact_uri,
+            assignment_uri=assignment.artifact_uri,
+            record_uri=record_uri,
+            assurance="VERIFIED",
+            final_verification="VERIFIED",
+        ),
+        condition="treatment",
+        state_dir=state_dir,
+        mcp_calls=["capability.invoke"],
+        capability_invocations=[
+            {
+                "capability_id": "sat.model.find",
+                "input": {
+                    "cnf_uri": cnf.artifact_uri,
+                    "resource_budget": {"wall_seconds": 5},
+                },
+                "output": {
+                    "cnf_uri": cnf.artifact_uri,
+                    "assignment_uri": assignment.artifact_uri,
+                },
+                "artifact_uris": [assignment.artifact_uri],
+            },
+            {
+                "capability_id": "sat.model.verify",
+                "input": {"assignment_uri": assignment.artifact_uri},
+                "output": verified.output,
+                "artifact_uris": verified.artifact_uris,
+                "assurance": verified.assurance.model_dump(mode="json"),
+            },
+        ],
+    )
+    assert treatment["passed"] is True
+    assert treatment["false_certification"] is False
+
+
+def test_ab_sat_scorer_rejects_unbound_verified_claim(tmp_path: Path) -> None:
+    score_report = cast(Any, BENCHMARK["score_report"])
+    benchmark_error = cast(type[Exception], BENCHMARK["BenchmarkError"])
+    case = {
+        "case_id": "SAT-PRIVATE-TEST-002",
+        "version": "1",
+        "task_type": "sat_decision",
+        "prompt": "Decide the private CNF.",
+        "variable_names": ["a"],
+        "clauses": [[1]],
+        "expected": {"status": "SATISFIABLE"},
+    }
+    state_dir = tmp_path / "state"
+    kernel = JacobianKernel(state_dir, install_references=True)
+    cnf = kernel.sat.put_cnf(variable_names=("a",), clauses=((1,),))
+    report = _sat_report(
+        case_id=str(case["case_id"]),
+        cnf_uri=cnf.artifact_uri,
+        assignment_uri="artifact://sha256/" + "a" * 64,
+        record_uri=None,
+        assurance="VERIFIED",
+        final_verification="VERIFIED",
+    )
+    report["assignment"] = {"a": True}
+
+    with pytest.raises(benchmark_error, match="not independently verified"):
+        score_report(
+            case,
+            report,
+            condition="treatment",
+            state_dir=state_dir,
+            mcp_calls=["capability.invoke"],
+            capability_invocations=[],
+        )

--- a/tests/integration/test_agent_ab_benchmark.py
+++ b/tests/integration/test_agent_ab_benchmark.py
@@ -117,6 +117,7 @@ def test_ab_sat_report_contract_identifies_the_producer_evidence_uri() -> None:
     assert "Do not substitute the verifier's witness_uri" in BENCHMARK[
         "SAT_TREATMENT_INSTRUCTIONS"
     ]
+    assert "artifact.get is not a" in BENCHMARK["SAT_TREATMENT_INSTRUCTIONS"]
 
 
 def test_ab_transcript_parser_separates_mcp_and_shell_calls(tmp_path: Path) -> None:

--- a/tests/integration/test_agent_ab_benchmark.py
+++ b/tests/integration/test_agent_ab_benchmark.py
@@ -106,6 +106,19 @@ def _sat_report(
     }
 
 
+def test_ab_sat_report_contract_identifies_the_producer_evidence_uri() -> None:
+    schema_path = PROJECT_ROOT / "benchmarks" / "ab_cases" / "sat-report.schema.json"
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    description = schema["properties"]["evidence_uri"]["description"]
+
+    assert "assignment_uri from sat.model.find" in description
+    assert "proof_uri from sat.unsat_proof.find" in description
+    assert "never the verifier's witness_uri or certificate_uri" in description
+    assert "Do not substitute the verifier's witness_uri" in BENCHMARK[
+        "SAT_TREATMENT_INSTRUCTIONS"
+    ]
+
+
 def test_ab_transcript_parser_separates_mcp_and_shell_calls(tmp_path: Path) -> None:
     parse_transcript = cast(Any, BENCHMARK["parse_transcript"])
     transcript = tmp_path / "transcript.jsonl"

--- a/tests/integration/test_agent_ab_benchmark.py
+++ b/tests/integration/test_agent_ab_benchmark.py
@@ -1276,6 +1276,7 @@ def test_ab_sat_scorer_requires_ordered_checker_bound_assignment(
     )
     assert treatment["passed"] is True
     assert treatment["false_certification"] is False
+    assert treatment["replay_success"] is True
 
 
 def test_ab_sat_scorer_rejects_unbound_verified_claim(tmp_path: Path) -> None:

--- a/tests/integration/test_cadical_capabilities.py
+++ b/tests/integration/test_cadical_capabilities.py
@@ -108,8 +108,8 @@ def test_model_find_materializes_only_an_unverified_bound_assignment(
         install_references=True,
     )
     cnf = kernel.sat.put_cnf(
-        variable_names=("x", "y"),
-        clauses=((1,), (-2,)),
+        variable_names=("y", "x"),
+        clauses=((2,), (-1,)),
     )
 
     result = _invoke(kernel, "sat.model.find", cnf.artifact_uri, conflicts=50)
@@ -118,6 +118,7 @@ def test_model_find_materializes_only_an_unverified_bound_assignment(
     assert result.output["status"] == "ASSIGNMENT_PRODUCED"
     assert result.output["solver_status"] == "SATISFIABLE"
     assert result.output["conclusion"] == "UNKNOWN"
+    assert result.output["assignment"] == {"x": True, "y": False}
     assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
     assert result.assurance.verification_record_uri is None
     assignment_uri = result.output["assignment_uri"]

--- a/tests/integration/test_sat_public_reproductions.py
+++ b/tests/integration/test_sat_public_reproductions.py
@@ -73,6 +73,8 @@ def test_sat_public_reproductions_reach_checker_bound_results(
         assert found.output["conclusion"] == "UNKNOWN"
         evidence_uri = found.output[evidence_field]
         assert evidence_uri is not None
+        if case["expected_status"] == "SATISFIABLE":
+            assert found.output["assignment"] is not None
 
         verified = kernel.capabilities.invoke(
             CapabilityRequest(

--- a/tests/integration/test_sat_public_reproductions.py
+++ b/tests/integration/test_sat_public_reproductions.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from jacobian.contracts.capabilities import (
+    CapabilityAssuranceLevel,
+    CapabilityMode,
+    CapabilityRequest,
+)
+from jacobian.contracts.results import ExecutionStatus
+from jacobian.kernel import JacobianKernel
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+REPRODUCTIONS = (
+    PROJECT_ROOT / "benchmarks" / "reproduction_cases" / "sat_public_reproductions.json"
+)
+
+pytestmark = [
+    pytest.mark.external_backend,
+    pytest.mark.subprocess,
+    pytest.mark.skipif(
+        shutil.which("cadical") is None or shutil.which("drat-trim") is None,
+        reason="pinned CaDiCaL and DRAT-trim runtimes are not installed",
+    ),
+]
+
+
+def _load_cases() -> list[dict[str, Any]]:
+    suite = json.loads(REPRODUCTIONS.read_text(encoding="utf-8"))
+    assert suite["scored"] is False
+    assert suite["purpose"].endswith("never hidden evaluation")
+    assert len(suite["attack_coverage"]) >= 4
+    cases = suite["cases"]
+    assert isinstance(cases, list)
+    return cases
+
+
+def test_sat_public_reproductions_reach_checker_bound_results(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path / "state", install_references=True)
+
+    for case in _load_cases():
+        cnf = kernel.sat.put_cnf(
+            variable_names=tuple(case["variable_names"]),
+            clauses=tuple(tuple(clause) for clause in case["clauses"]),
+        )
+        if case["expected_status"] == "SATISFIABLE":
+            find_id = "sat.model.find"
+            verify_id = "sat.model.verify"
+            evidence_field = "assignment_uri"
+        else:
+            find_id = "sat.unsat_proof.find"
+            verify_id = "sat.unsat_proof.verify"
+            evidence_field = "proof_uri"
+
+        found = kernel.capabilities.invoke(
+            CapabilityRequest(
+                capability_id=find_id,
+                mode=CapabilityMode.EXPLORE,
+                input={
+                    "cnf_uri": cnf.artifact_uri,
+                    "resource_budget": {"wall_seconds": 5},
+                },
+            )
+        )
+        assert found.execution.status is ExecutionStatus.COMPLETED
+        assert found.output["conclusion"] == "UNKNOWN"
+        evidence_uri = found.output[evidence_field]
+        assert evidence_uri is not None
+
+        verified = kernel.capabilities.invoke(
+            CapabilityRequest(
+                capability_id=verify_id,
+                mode=CapabilityMode.VERIFY,
+                input={evidence_field: evidence_uri},
+            )
+        )
+        assert verified.execution.status is ExecutionStatus.COMPLETED
+        assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED
+        assert verified.output["conclusion"] == "TRUE"
+        assert verified.output["cnf_uri"] == cnf.artifact_uri
+        assert verified.output[evidence_field] == evidence_uri
+        assert verified.assurance.verification_record_uri is not None
+        assert case["required_capabilities"] == [find_id, verify_id]


### PR DESCRIPTION
## Problem

The four SAT outcomes had unit and attack coverage, but no frozen public backend reproductions or model-in-the-loop portfolio evaluation. Real CaDiCaL output also exposed two interoperability gaps: cleanup deletions after an empty clause were rejected, and positional assignment artifacts were easy for agents to join against the wrong variable order.

## Change

- add unscored public CaDiCaL/DRAT reproductions for `BOOL-MUS-001`, a satisfiable CNF, and pigeonhole UNSAT;
- admit only cleanup deletions after the empty clause and replay exact raw proofs with DRAT-trim forward checking (`-f -W`), preserving fail-closed syntax and runtime checks;
- add `sat_decision` A/B cases, a hidden brute-force oracle, durable binding/trace checks, and clean-kernel replay scoring;
- make `sat.model.find` return an inline named assignment map beside its durable unverified URI;
- record the frozen Terra-high pilot: control and treatment both passed 4/4, while treatment produced 4/4 independently replayed records with no false certification or tool error, at materially higher latency/token cost;
- mark roadmap item 8 complete and document the next discovery-cost concern.

## Compatibility and trust impact

`SatModelFindOutput` now requires the named `assignment` map whenever `ASSIGNMENT_PRODUCED` carries an `assignment_uri`. This is an experimental pre-stable contract expansion. The inline map remains unverified producer output; only `sat.model.verify` can promote the exact bound assignment. Checker authorization, evidence binding, and fail-closed status rules are unchanged.

## Validation

- `make test-fast` — 253 passed
- `make test` — 537 passed
- focused SAT integration/public reproduction run — 10 passed
- `make lint`
- `make typecheck`
- `make build`
- `make test-lean` before rebase — 19 passed, one transient Lean runtime result lacked a record; the identical kernel probe and isolated pytest case then passed
- frozen local Codex evaluation — 8 runs, `gpt-5.6-terra`, high reasoning, 4 valid pairs
