### PR TITLE
feat: add bounded cvc5 Alethe producer

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ Release contracts and engineering evidence are:
   availability, exact backend identity, install tiers, and local measurement.
 - [SAT artifact contracts](docs/reference/sat-artifacts.md) for canonical CNF,
   raw model and proof identity, and independently checked total assignments.
+- [SMT Alethe artifact contracts](docs/reference/smt-artifacts.md) for the
+  pinned quantifier-free cvc5 producer and its unverified proof boundary.
 - [v0.2 specification](docs/reference/specifications/v0.2.md) and
   [conformance gate](docs/reference/conformance-v0.2.md)
 - [Testing strategy](docs/reference/testing-strategy.md),

--- a/docs/contributing/atomic-capability-portfolio.md
+++ b/docs/contributing/atomic-capability-portfolio.md
@@ -458,6 +458,17 @@ the first slice.
 Keep Z3 as an existing exploration and differential provider. Its broad tactic
 surface has uneven proof support, so a Z3 result must not verify itself.
 
+The cvc5 producer checkpoint was implemented on 2026-07-26. The optional
+`cvc5==1.3.4` wheel now exposes `smt.unsat_proof.find` for exact single-query
+`QF_UF`, `QF_LIA`, and `QF_LRA` inputs. It runs in a bounded isolated worker,
+materializes the exact SMT-LIB source and bound raw Alethe bytes, reports
+lexical holes, and always returns `conclusion: UNKNOWN`. Public reproductions
+found a zero-hole equality contradiction in `QF_UF` and explicit holes in
+small linear integer and rational contradictions. This is useful producer
+evidence and a concrete compatibility target for item 10, not a broad
+proof-support claim. See
+[SMT Alethe artifact contracts](../reference/smt-artifacts.md).
+
 ## Wave 4: shared exact mathematics
 
 ### Python-FLINT first
@@ -546,7 +557,8 @@ backlog.
 8. SAT public reproductions and held-out portfolio ablation. Implemented; see
    [SAT certificate portfolio pilot](../reference/capability-workflow-evaluations.md#sat-certificate-portfolio-pilot).
 9. cvc5 Alethe proof-production spike for quantifier-free EUF and linear
-   arithmetic.
+   arithmetic. Implemented; see
+   [SMT Alethe artifact contracts](../reference/smt-artifacts.md).
 10. Carcara compatibility matrix, checker adapter, mutations, and paired
     evaluation.
 11. Python-FLINT rational-solution find and verify slice.

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,6 +59,7 @@ expectations.
 - [Provider runtime contract](reference/provider-runtime.md)
 - [Lean declaration discovery](reference/lean-declaration-discovery.md)
 - [SAT artifact contracts](reference/sat-artifacts.md)
+- [SMT Alethe artifact contracts](reference/smt-artifacts.md)
 - [v0.2 specification](reference/specifications/v0.2.md)
 - [v0.2 conformance specification](reference/conformance-v0.2.md)
 - [Plugin conformance contract](reference/plugin-conformance.md)

--- a/docs/reference/provider-runtime.md
+++ b/docs/reference/provider-runtime.md
@@ -53,6 +53,11 @@ starts, `lean.check` is absent from `capability://catalog`, and no invocation is
 attempted. Explicit operator-installed adapters fail registration instead of
 silently falling back to another provider.
 
+The optional cvc5 Alethe producer follows the same rule. The exact 1.3.4 wheel
+must expose the required SMT-LIB parser and proof APIs and have a hashed RECORD
+manifest. Otherwise `smt.unsat_proof.find` is absent while the base kernel and
+SMT artifact schemas remain available.
+
 Source-backed adapters can construct metadata without importing their
 implementation:
 

--- a/docs/reference/smt-artifacts.md
+++ b/docs/reference/smt-artifacts.md
@@ -1,0 +1,168 @@
+# SMT Alethe artifact contracts
+
+[Documentation home](../index.md)
+
+- Status: Experimental pre-stable producer contract
+- Optional operation: `smt.unsat_proof.find` when the exact cvc5 1.3.4
+  Python distribution is installed
+- Verification operation: not yet installed; a compatible independent
+  Carcara adapter is the next portfolio checkpoint
+- Related plan:
+  [Atomic capability portfolio](../contributing/atomic-capability-portfolio.md#wave-3-theory-bounded-smt-proof-slice)
+
+Jacobian's first SMT slice preserves one exact quantifier-free SMT-LIB query
+and the raw Alethe bytes emitted by cvc5. It does not expose a broad
+`smt.solve` workflow. A cvc5 `unsat` report, stored proof bytes, or the absence
+of lexical `hole` markers is computed evidence, not independent verification.
+Every producer result therefore carries `conclusion: UNKNOWN`.
+
+Install the optional wheel-backed provider with:
+
+```sh
+uv sync --extra smt
+```
+
+The locked development environment also includes the exact provider so the
+producer contract and public reproduction cases run in CI.
+
+## Registered descriptors
+
+`JacobianKernel.smt.installation` exposes the content-addressed descriptor URIs
+registered by the current kernel:
+
+| Descriptor | Registered name and version | Purpose |
+| --- | --- | --- |
+| Semantics | `jacobian.smt.qf-unsat@1` | Quantifier-free single-query meaning and evidence boundary |
+| Schema | `jacobian.smt-problem@1` | Exact bounded SMT-LIB 2.6 input |
+| Schema | `jacobian.smt-alethe-proof@1` | Raw cvc5 Alethe bytes bound to one exact input |
+
+The schemas are model backed. Their closed structural and cross-field
+invariants also apply when a payload is submitted through `artifact.put`.
+Kernel construction registers the artifact boundary even when cvc5 is absent;
+only the producer capability is conditional.
+
+## Pinned SMT-LIB profile
+
+Profile `jacobian.smtlib2.qf-unsat/v1` admits exactly one query in one of:
+
+- `QF_UF`;
+- `QF_LIA`; or
+- `QF_LRA`.
+
+The source is at most 1,000,000 ASCII bytes, uses LF line endings, ends in LF,
+and has a maximum parenthesis nesting depth of 512. Its top-level commands are
+limited to:
+
+- one leading `set-logic` equal to the separately declared logic;
+- `declare-sort`, `declare-fun`, or `declare-const`;
+- zero or more `assert` commands; and
+- one final argument-free `check-sat`.
+
+Incremental commands, solver-option changes, definitions, assumptions,
+result-retrieval commands, reset, include, multiple queries, quantifiers, and
+theories outside the selected logic are not part of version 1. The contract
+scanner handles comments, strings, and quoted symbols when identifying
+top-level command boundaries. The isolated cvc5 parser then independently
+rejects source that is not valid in the declared logic.
+
+The problem artifact preserves the exact text and SHA-256 digest. It does not
+claim that equivalent presentations have one canonical identity.
+
+## Provider identity and isolation
+
+The catalog entry requires the exact `cvc5==1.3.4` distribution with the
+expected parser, solver, proof-component, and proof-format APIs. Its runtime
+record uses:
+
+- install tier `T1`;
+- license identifier `BSD-3-Clause`;
+- digest kind `PYTHON_DISTRIBUTION_RECORD`;
+- feature flags `smt-lib-2.6` and `alethe-proof-production`; and
+- profile and proof-format configuration.
+
+The digest identifies the installed wheel RECORD manifest; it does not claim
+to rehash every package byte. Provider identity and successful execution
+remain separate from mathematical assurance.
+
+The adapter does not call the native solver in the MCP server process. It
+starts an isolated Python worker in its own bounded process group, fixes locale
+and timezone, and applies the declared wall-time both as cvc5's
+`tlimit-per` and as a parent process deadline. Worker stdout is a closed JSON
+protocol capped at 4 KiB, stderr is capped at 64 KiB, and raw proof capture is
+capped at 6,000,000 bytes. Timeout or stream overflow terminates descendants.
+
+## Alethe proof production
+
+`smt.unsat_proof.find` accepts:
+
+```json
+{
+  "logic": "QF_UF",
+  "smtlib_text": "(set-logic QF_UF)\n(assert false)\n(check-sat)\n",
+  "resource_budget": {
+    "wall_seconds": 5
+  }
+}
+```
+
+The adapter first materializes the exact input problem, then invokes cvc5 with
+proof production enabled and serializes the full proof as Alethe. An
+`UNSATISFIABLE` solver report is usable only when the worker also creates one
+bounded regular proof file and its reported lexical hole count matches the
+captured bytes.
+
+The proof artifact binds:
+
+- the problem artifact URI, object digest, payload digest, logic, profile,
+  language, and exact SMT-LIB digest;
+- format `ALETHE` and version `cvc5.alethe/1.3.4`;
+- exact proof bytes as canonical base64 plus their SHA-256 digest;
+- the exact cvc5 provider runtime;
+- the enforced wall-time budget; and
+- `alethe_hole_count` plus `contains_holes`.
+
+Hole metadata is an inspectable routing signal, not proof checking. It counts
+the exact byte marker `:rule hole`; it does not establish that every other rule
+is supported or valid.
+
+The result reports `PROOF_PRODUCED`, the problem and proof URIs, solver status,
+and hole metadata at assurance level `COMPUTED`. `SATISFIABLE` or `UNKNOWN`
+returns `NO_PROOF_PRODUCED`; it does not produce a model, prove SAT, or imply
+anything from failure to find a proof.
+
+## Reproduction cases
+
+The pinned public spike exercises three small cases:
+
+| Logic | Query shape | Observed producer behavior |
+| --- | --- | --- |
+| `QF_UF` | `a = b` and `not (a = b)` | Alethe produced with zero lexical holes |
+| `QF_LIA` | integer `x >= 1` and `x <= 0` | Alethe produced with at least one explicit hole |
+| `QF_LRA` | real `x > 1` and `x < 0` | Alethe produced with explicit holes |
+
+These observations are version-bound regression cases, not a compatibility
+claim for all inputs in a logic. cvc5's own
+[Alethe output documentation](https://cvc5.github.io/docs/latest/proofs/output_alethe.html)
+also shows that proof output may contain untranslated rewrites represented as
+holes.
+
+## Fail-closed boundary
+
+No proof artifact is retained when:
+
+- source validation or the cvc5 parser rejects the query;
+- the worker times out, crashes, or exceeds an output limit;
+- its JSON protocol, status, proof-presence flag, or hole count is malformed;
+- a non-UNSAT status carries proof material;
+- an UNSAT status lacks one bounded regular proof file; or
+- the proof bytes disagree with the worker's hole metadata.
+
+Operational failure returns `ERROR` or `TIMEOUT`, heuristic assurance, and no
+mathematical conclusion. The already materialized exact problem may remain as
+the operation's sole artifact.
+
+The next slice will pin a separately installed compatible
+[Carcara](https://github.com/ufmg-smite/carcara) revision, define its supported
+rule and theory intersection, replay adversarial mutations, and expose
+`smt.unsat_proof.verify` only through operator-authorized checker identity.
+Until then there is no SMT path to `VERIFIED`.

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -148,6 +148,19 @@ exposes any resulting candidate witness for independent replay. It does not
 recompute or certify either evaluation. This keeps evaluation and witness
 construction separate while making their composition explicit to the agent.
 
+Optional exact runtimes add narrowly scoped operations only when their pinned
+provider identity is available:
+
+| Capability ID | Availability and outcome |
+| --- | --- |
+| `sat.model.find` | With CaDiCaL 3.0.1, preserve one total assignment candidate without certifying SAT. |
+| `sat.unsat_proof.find` | With CaDiCaL 3.0.1, preserve raw DRAT evidence without certifying UNSAT. |
+| `smt.unsat_proof.find` | With the `smt` extra and cvc5 1.3.4, preserve raw Alethe for one pinned-profile QF query, expose holes, and retain `UNKNOWN`. |
+
+See the [SAT artifact contracts](sat-artifacts.md) and
+[SMT Alethe artifact contracts](smt-artifacts.md) for exact input profiles,
+resource bounds, artifact bindings, and independent verification boundaries.
+
 When the operator enables bundled references, the catalog also includes:
 
 | Capability ID | Outcome |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,12 +23,18 @@ dependencies = [
     "z3-solver>=4.15.4,<5",
 ]
 
+[project.optional-dependencies]
+smt = [
+    "cvc5==1.3.4",
+]
+
 [project.scripts]
 jacobian = "jacobian.cli:app"
 jacobian-mcp = "jacobian.adapters.mcp.server:main"
 
 [dependency-groups]
 dev = [
+    "cvc5==1.3.4",
     "deptry>=0.21,<1",
     "hypothesis>=6.130,<7",
     "mypy>=1.15,<3",
@@ -109,7 +115,7 @@ ignore_missing_imports = true
 [tool.deptry]
 extend_exclude = ["benchmarks"]
 known_first_party = ["jacobian", "jacobian_checkers"]
-per_rule_ignores = { "DEP002" = ["mcp-types"] }
+per_rule_ignores = { "DEP002" = ["cvc5", "mcp-types"] }
 
 [tool.coverage.run]
 branch = true

--- a/src/jacobian/contracts/smt.py
+++ b/src/jacobian/contracts/smt.py
@@ -1,0 +1,366 @@
+"""Pinned quantifier-free SMT-LIB and unverified Alethe evidence contracts."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+from typing import Annotated, Literal, Self
+
+from pydantic import (
+    Field,
+    StrictBool,
+    StrictInt,
+    StringConstraints,
+    model_validator,
+)
+
+from jacobian.contracts.capabilities import (
+    CapabilityInstallTier,
+    CapabilityProviderAvailability,
+    CapabilityProviderDigestKind,
+    CapabilityProviderRuntime,
+)
+from jacobian.contracts.common import ArtifactUri, Sha256Digest
+from jacobian.contracts.results import ContractModel
+
+SmtLogic = Literal["QF_UF", "QF_LIA", "QF_LRA"]
+SmtLibText = Annotated[
+    str,
+    StringConstraints(min_length=1, max_length=1_000_000, strict=True),
+]
+CanonicalBase64 = Annotated[
+    str,
+    StringConstraints(
+        pattern=r"^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+        max_length=8_000_000,
+        strict=True,
+    ),
+]
+
+_PROFILE: Literal["jacobian.smtlib2.qf-unsat/v1"] = "jacobian.smtlib2.qf-unsat/v1"
+_INPUT_LANGUAGE: Literal["SMT-LIB-2.6"] = "SMT-LIB-2.6"
+_PROOF_FORMAT_VERSION: Literal["cvc5.alethe/1.3.4"] = "cvc5.alethe/1.3.4"
+_ALLOWED_COMMANDS = frozenset(
+    {
+        "set-logic",
+        "declare-sort",
+        "declare-fun",
+        "declare-const",
+        "assert",
+        "check-sat",
+    }
+)
+_ALETHE_HOLE_MARKER = b":rule hole"
+
+
+def _sha256(value: bytes) -> str:
+    return f"sha256:{hashlib.sha256(value).hexdigest()}"
+
+
+def _decode_base64(value: str) -> bytes:
+    try:
+        return base64.b64decode(value, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise ValueError("proof bytes must use valid canonical base64") from exc
+
+
+def _smtlib_tokens(text: str) -> tuple[str, ...]:
+    tokens: list[str] = []
+    index = 0
+    length = len(text)
+    while index < length:
+        character = text[index]
+        if character.isspace():
+            index += 1
+            continue
+        if character == ";":
+            newline = text.find("\n", index)
+            index = length if newline < 0 else newline + 1
+            continue
+        if character in "()":
+            tokens.append(character)
+            index += 1
+            continue
+        if character == '"':
+            start = index
+            index += 1
+            while index < length:
+                if text[index] != '"':
+                    index += 1
+                    continue
+                if index + 1 < length and text[index + 1] == '"':
+                    index += 2
+                    continue
+                index += 1
+                tokens.append(text[start:index])
+                break
+            else:
+                raise ValueError("SMT-LIB input contains an unterminated string")
+            continue
+        if character == "|":
+            start = index
+            index += 1
+            while index < length and text[index] != "|":
+                if text[index] == "\\":
+                    raise ValueError(
+                        "SMT-LIB quoted symbols in this profile cannot contain backslash"
+                    )
+                index += 1
+            if index >= length:
+                raise ValueError("SMT-LIB input contains an unterminated quoted symbol")
+            index += 1
+            tokens.append(text[start:index])
+            continue
+        start = index
+        while index < length and not text[index].isspace() and text[index] not in "();":
+            if text[index] in '"|':
+                raise ValueError("SMT-LIB token contains an unexpected quote")
+            index += 1
+        if start == index:
+            raise ValueError("SMT-LIB input contains an invalid token")
+        tokens.append(text[start:index])
+    return tuple(tokens)
+
+
+def _top_level_commands(text: str) -> tuple[tuple[str, ...], ...]:
+    commands: list[tuple[str, ...]] = []
+    direct_atoms: list[str] | None = None
+    depth = 0
+    for token in _smtlib_tokens(text):
+        if token == "(":
+            if depth == 0:
+                direct_atoms = []
+            depth += 1
+            if depth > 512:
+                raise ValueError("SMT-LIB input exceeds the profile nesting limit")
+            continue
+        if token == ")":
+            if depth == 0:
+                raise ValueError(
+                    "SMT-LIB input contains an unmatched closing parenthesis"
+                )
+            if depth == 1:
+                assert direct_atoms is not None
+                if not direct_atoms:
+                    raise ValueError("SMT-LIB top-level command cannot be empty")
+                commands.append(tuple(direct_atoms))
+                direct_atoms = None
+            depth -= 1
+            continue
+        if depth == 0:
+            raise ValueError("SMT-LIB input must contain only top-level commands")
+        if depth == 1:
+            assert direct_atoms is not None
+            direct_atoms.append(token)
+    if depth:
+        raise ValueError("SMT-LIB input contains an unmatched opening parenthesis")
+    return tuple(commands)
+
+
+def _validate_single_query_profile(text: str, logic: SmtLogic) -> None:
+    try:
+        raw = text.encode("ascii")
+    except UnicodeEncodeError as exc:
+        raise ValueError("SMT-LIB profile requires ASCII input") from exc
+    if not text.endswith("\n") or "\r" in text:
+        raise ValueError("SMT-LIB profile requires LF endings and a final LF")
+    if any(byte < 32 and byte not in {9, 10} for byte in raw):
+        raise ValueError("SMT-LIB profile contains a disallowed control byte")
+    commands = _top_level_commands(text)
+    if not commands:
+        raise ValueError("SMT-LIB input must contain one query")
+    heads = tuple(command[0] for command in commands)
+    unsupported = tuple(head for head in heads if head not in _ALLOWED_COMMANDS)
+    if unsupported:
+        raise ValueError(f"SMT-LIB profile does not allow command {unsupported[0]!r}")
+    if commands[0] != ("set-logic", logic):
+        raise ValueError("SMT-LIB query must begin with its exact declared set-logic")
+    if heads.count("set-logic") != 1:
+        raise ValueError("SMT-LIB query must contain exactly one set-logic command")
+    if commands[-1] != ("check-sat",) or heads.count("check-sat") != 1:
+        raise ValueError(
+            "SMT-LIB query must end with exactly one argument-free check-sat"
+        )
+
+
+class SmtResourceBudget(ContractModel):
+    """Declared wall-time budget that produced unverified SMT evidence."""
+
+    budget_version: Literal["1"] = "1"
+    wall_seconds: StrictInt = Field(ge=1, le=300)
+
+
+class SmtExplorationBudget(ContractModel):
+    """cvc5 limits enforced by both its solver and the worker process."""
+
+    budget_version: Literal["1"] = "1"
+    wall_seconds: StrictInt = Field(ge=1, le=300)
+
+    def artifact_budget(self) -> SmtResourceBudget:
+        return SmtResourceBudget(wall_seconds=self.wall_seconds)
+
+
+class SmtUnsatProofFindRequest(ContractModel):
+    """Run one bounded Alethe producer on one pinned-profile query."""
+
+    logic: SmtLogic
+    smtlib_text: SmtLibText
+    resource_budget: SmtExplorationBudget
+
+    @model_validator(mode="after")
+    def validate_profile(self) -> Self:
+        _validate_single_query_profile(self.smtlib_text, self.logic)
+        return self
+
+
+class SmtProblemArtifact(ContractModel):
+    """Exact single-query SMT-LIB input framed by the pinned profile."""
+
+    problem_schema_version: Literal["1"] = "1"
+    profile: Literal["jacobian.smtlib2.qf-unsat/v1"] = _PROFILE
+    input_language: Literal["SMT-LIB-2.6"] = _INPUT_LANGUAGE
+    logic: SmtLogic
+    query_scope: Literal["SINGLE_CHECK_SAT"] = "SINGLE_CHECK_SAT"
+    smtlib_text: SmtLibText
+    smtlib_digest: Sha256Digest
+
+    @model_validator(mode="after")
+    def require_exact_profile_input(self) -> Self:
+        _validate_single_query_profile(self.smtlib_text, self.logic)
+        if self.smtlib_digest != _sha256(self.smtlib_text.encode("ascii")):
+            raise ValueError("SMT-LIB digest does not match the exact input bytes")
+        return self
+
+    @classmethod
+    def from_text(
+        cls,
+        *,
+        logic: SmtLogic,
+        smtlib_text: str,
+    ) -> SmtProblemArtifact:
+        return cls(
+            logic=logic,
+            smtlib_text=smtlib_text,
+            smtlib_digest=_sha256(smtlib_text.encode("ascii")),
+        )
+
+    def raw_bytes(self) -> bytes:
+        return self.smtlib_text.encode("ascii")
+
+
+class SmtProblemBinding(ContractModel):
+    """Identity needed to replay a proof against one exact SMT-LIB query."""
+
+    binding_version: Literal["1"] = "1"
+    problem_artifact_uri: ArtifactUri
+    problem_object_digest: Sha256Digest
+    problem_payload_digest: Sha256Digest
+    logic: SmtLogic
+    profile: Literal["jacobian.smtlib2.qf-unsat/v1"]
+    input_language: Literal["SMT-LIB-2.6"]
+    smtlib_digest: Sha256Digest
+
+
+class SmtAletheProofArtifact(ContractModel):
+    """Raw Alethe bytes bound to one query without claiming proof validity."""
+
+    proof_schema_version: Literal["1"] = "1"
+    problem: SmtProblemBinding
+    declared_scope: Literal["FULL_QUERY"] = "FULL_QUERY"
+    proof_format: Literal["ALETHE"] = "ALETHE"
+    proof_format_version: Literal["cvc5.alethe/1.3.4"] = _PROOF_FORMAT_VERSION
+    proof_encoding: Literal["BASE64"] = "BASE64"
+    proof_base64: CanonicalBase64
+    proof_digest: Sha256Digest
+    alethe_hole_count: StrictInt = Field(ge=0, le=1_000_000)
+    contains_holes: StrictBool
+    producer: CapabilityProviderRuntime
+    resource_budget: SmtResourceBudget
+
+    @model_validator(mode="after")
+    def require_exact_raw_proof(self) -> Self:
+        proof = _decode_base64(self.proof_base64)
+        if self.proof_base64 != base64.b64encode(proof).decode("ascii"):
+            raise ValueError("proof bytes must use canonical base64")
+        if self.proof_digest != _sha256(proof):
+            raise ValueError("Alethe proof digest does not match the preserved bytes")
+        holes = proof.count(_ALETHE_HOLE_MARKER)
+        if self.alethe_hole_count != holes or self.contains_holes != (holes > 0):
+            raise ValueError("Alethe hole metadata does not match the proof bytes")
+        if (
+            self.producer.provider != "cvc5"
+            or self.producer.version != "1.3.4"
+            or self.producer.availability
+            is not CapabilityProviderAvailability.AVAILABLE
+            or self.producer.digest is None
+            or self.producer.digest_kind
+            is not CapabilityProviderDigestKind.PYTHON_DISTRIBUTION_RECORD
+            or self.producer.install_tier is not CapabilityInstallTier.T1
+            or "alethe-proof-production" not in self.producer.features
+            or self.producer.configuration.get("profile") != _PROFILE
+            or self.producer.configuration.get("proof_format") != _PROOF_FORMAT_VERSION
+        ):
+            raise ValueError("proof producer must be an available pinned cvc5 runtime")
+        return self
+
+    @classmethod
+    def from_bytes(
+        cls,
+        *,
+        problem: SmtProblemBinding,
+        proof: bytes,
+        producer: CapabilityProviderRuntime,
+        resource_budget: SmtResourceBudget,
+    ) -> SmtAletheProofArtifact:
+        holes = proof.count(_ALETHE_HOLE_MARKER)
+        return cls(
+            problem=problem,
+            proof_base64=base64.b64encode(proof).decode("ascii"),
+            proof_digest=_sha256(proof),
+            alethe_hole_count=holes,
+            contains_holes=holes > 0,
+            producer=producer,
+            resource_budget=resource_budget,
+        )
+
+    def raw_bytes(self) -> bytes:
+        return _decode_base64(self.proof_base64)
+
+
+class SmtUnsatProofFindOutput(ContractModel):
+    """Unverified result of one bounded cvc5 Alethe-production attempt."""
+
+    status: Literal["PROOF_PRODUCED", "NO_PROOF_PRODUCED"]
+    solver_status: Literal["SATISFIABLE", "UNSATISFIABLE", "UNKNOWN"]
+    conclusion: Literal["UNKNOWN"] = "UNKNOWN"
+    problem_uri: ArtifactUri
+    proof_uri: ArtifactUri | None = None
+    contains_holes: StrictBool | None = None
+    alethe_hole_count: StrictInt | None = Field(default=None, ge=0, le=1_000_000)
+    detail: str = Field(min_length=1, max_length=1024)
+
+    @model_validator(mode="after")
+    def bind_proof_to_status(self) -> Self:
+        produced = self.status == "PROOF_PRODUCED"
+        has_proof_fields = (
+            self.proof_uri is not None
+            and self.contains_holes is not None
+            and self.alethe_hole_count is not None
+        )
+        if produced != has_proof_fields:
+            raise ValueError("only a proof-produced result may carry Alethe evidence")
+        if not produced and any(
+            value is not None
+            for value in (
+                self.proof_uri,
+                self.contains_holes,
+                self.alethe_hole_count,
+            )
+        ):
+            raise ValueError("a no-proof result cannot carry Alethe evidence")
+        if produced and self.solver_status != "UNSATISFIABLE":
+            raise ValueError("a proof requires an UNSATISFIABLE solver report")
+        if produced and self.contains_holes != (self.alethe_hole_count > 0):  # type: ignore[operator]
+            raise ValueError("Alethe hole fields are inconsistent")
+        return self

--- a/src/jacobian/cvc5.py
+++ b/src/jacobian/cvc5.py
@@ -1,0 +1,524 @@
+"""Bounded cvc5 adapter for unverified quantifier-free Alethe production."""
+
+from __future__ import annotations
+
+import os
+import stat
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from pydantic import ValidationError
+
+from jacobian.bounded_process import BoundedProcessResult, run_bounded_process
+from jacobian.canonical import loads_strict_json
+from jacobian.capabilities import CapabilityAdapter, CapabilityInvocationError
+from jacobian.contracts.capabilities import (
+    CapabilityAssurance,
+    CapabilityAssuranceLevel,
+    CapabilityCompleteness,
+    CapabilityCompletenessStatus,
+    CapabilityDescriptor,
+    CapabilityDiagnostic,
+    CapabilityMode,
+    CapabilityProviderAvailability,
+    CapabilityProviderDigestKind,
+    CapabilityProviderRuntime,
+    CapabilityRequest,
+    CapabilityResult,
+    CapabilityScope,
+)
+from jacobian.contracts.results import Execution, ExecutionStatus
+from jacobian.contracts.smt import (
+    SmtUnsatProofFindOutput,
+    SmtUnsatProofFindRequest,
+)
+from jacobian.cvc5_worker import (
+    CVC5_PROOF_LIMIT,
+    CVC5_WORKER_PROTOCOL,
+)
+from jacobian.provider_runtime import CVC5_VERSION
+from jacobian.schema_registry import model_schema
+from jacobian.smt import ResolvedSmtProblem, SmtArtifactService
+
+CVC5_STDOUT_LIMIT = 4_096
+CVC5_STDERR_LIMIT = 64_000
+_SolverStatus = Literal["SATISFIABLE", "UNSATISFIABLE", "UNKNOWN"]
+
+
+@dataclass(frozen=True, slots=True)
+class _Cvc5Run:
+    execution_status: ExecutionStatus
+    runtime_ms: int
+    solver_status: _SolverStatus | None = None
+    proof: bytes | None = None
+    alethe_hole_count: int | None = None
+    diagnostic: CapabilityDiagnostic | None = None
+
+
+def install_cvc5_capability(
+    smt: SmtArtifactService,
+    runtime: CapabilityProviderRuntime,
+) -> CapabilityAdapter:
+    """Install the Alethe producer for one exact available cvc5 runtime."""
+
+    if (
+        runtime.provider != "cvc5"
+        or runtime.availability is not CapabilityProviderAvailability.AVAILABLE
+        or runtime.version != CVC5_VERSION
+        or runtime.digest is None
+        or runtime.digest_kind
+        is not CapabilityProviderDigestKind.PYTHON_DISTRIBUTION_RECORD
+    ):
+        raise ValueError("cvc5 capability requires the pinned available runtime")
+    return Cvc5UnsatProofFindAdapter(
+        smt=smt,
+        backend=_Cvc5Backend(runtime=runtime),
+    )
+
+
+class _Cvc5Backend:
+    def __init__(self, *, runtime: CapabilityProviderRuntime) -> None:
+        self.runtime = runtime
+
+    def run(
+        self,
+        resolved: ResolvedSmtProblem,
+        request: SmtUnsatProofFindRequest,
+    ) -> _Cvc5Run:
+        started = time.monotonic()
+        with tempfile.TemporaryDirectory(prefix="jacobian-cvc5-") as directory:
+            root = Path(directory)
+            input_path = root / "input.smt2"
+            proof_path = root / "proof.alethe"
+            input_path.write_bytes(resolved.problem.raw_bytes())
+            command = [
+                sys.executable,
+                "-I",
+                "-m",
+                "jacobian.cvc5_worker",
+                str(input_path),
+                str(proof_path),
+                request.logic,
+                str(request.resource_budget.wall_seconds * 1000),
+            ]
+            try:
+                completed = run_bounded_process(
+                    command,
+                    input_bytes=b"",
+                    timeout_seconds=float(request.resource_budget.wall_seconds),
+                    environment={
+                        **os.environ,
+                        "LANG": "C",
+                        "LC_ALL": "C",
+                        "TZ": "UTC",
+                    },
+                    stdout_limit=CVC5_STDOUT_LIMIT,
+                    stderr_limit=CVC5_STDERR_LIMIT,
+                )
+            except OSError:
+                return _run_failure(
+                    started,
+                    code="CVC5_EXECUTION_FAILED",
+                    stage="solver_execution",
+                    message="The isolated pinned cvc5 worker could not be started.",
+                )
+            operational = _operational_failure(started, completed)
+            if operational is not None:
+                return operational
+            try:
+                solver_status, proof_written, reported_holes = _parse_worker_output(
+                    completed.stdout,
+                )
+            except ValueError:
+                return _run_failure(
+                    started,
+                    code="INVALID_CVC5_WORKER_OUTPUT",
+                    stage="solver_output",
+                    message=(
+                        "The cvc5 worker returned output outside its exact bounded "
+                        "protocol; no solver evidence was retained."
+                    ),
+                )
+            if solver_status == "UNSATISFIABLE":
+                if not proof_written or reported_holes is None:
+                    return _run_failure(
+                        started,
+                        code="CVC5_PROOF_MISSING",
+                        stage="proof_capture",
+                        message=(
+                            "cvc5 reported UNSATISFIABLE without bound Alethe proof "
+                            "metadata; no evidence was retained."
+                        ),
+                    )
+                try:
+                    proof = _read_proof_file(proof_path)
+                except (FileNotFoundError, OSError, OverflowError):
+                    return _run_failure(
+                        started,
+                        code="INVALID_CVC5_PROOF_FILE",
+                        stage="proof_capture",
+                        message=(
+                            "The cvc5 Alethe output was missing, unsafe, or exceeded "
+                            "the durable artifact limit."
+                        ),
+                    )
+                if proof.count(b":rule hole") != reported_holes:
+                    return _run_failure(
+                        started,
+                        code="CVC5_PROOF_METADATA_MISMATCH",
+                        stage="proof_capture",
+                        message=(
+                            "The cvc5 worker proof bytes disagreed with its hole "
+                            "metadata; no evidence was retained."
+                        ),
+                    )
+                return _Cvc5Run(
+                    execution_status=ExecutionStatus.COMPLETED,
+                    runtime_ms=_runtime_ms(started),
+                    solver_status=solver_status,
+                    proof=proof,
+                    alethe_hole_count=reported_holes,
+                )
+            if proof_written or reported_holes is not None or proof_path.exists():
+                return _run_failure(
+                    started,
+                    code="UNEXPECTED_CVC5_PROOF",
+                    stage="proof_capture",
+                    message=(
+                        "The cvc5 worker attached proof material to a non-UNSAT "
+                        "report; no evidence was retained."
+                    ),
+                )
+            return _Cvc5Run(
+                execution_status=ExecutionStatus.COMPLETED,
+                runtime_ms=_runtime_ms(started),
+                solver_status=solver_status,
+            )
+
+
+class Cvc5UnsatProofFindAdapter:
+    """Preserve raw cvc5 Alethe evidence without validating it."""
+
+    def __init__(
+        self,
+        *,
+        smt: SmtArtifactService,
+        backend: _Cvc5Backend,
+    ) -> None:
+        self.smt = smt
+        self.backend = backend
+        self._descriptor = CapabilityDescriptor(
+            capability_id="smt.unsat_proof.find",
+            version="1",
+            title="Find a quantifier-free SMT UNSAT proof",
+            description=(
+                "Ask pinned cvc5 to emit raw Alethe for one QF_UF, QF_LIA, or "
+                "QF_LRA query; preserving bytes or observing no holes does not "
+                "establish UNSAT."
+            ),
+            provider="cvc5",
+            provider_runtime=backend.runtime,
+            modes=(CapabilityMode.EXPLORE,),
+            input_schema=model_schema(SmtUnsatProofFindRequest),
+            output_schema=model_schema(SmtUnsatProofFindOutput),
+            tags=(
+                "smt",
+                "unsat",
+                "proof",
+                "alethe",
+                "exploration",
+                "cvc5",
+                "qf-uf",
+                "qf-lia",
+                "qf-lra",
+            ),
+        )
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        return self._descriptor
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        try:
+            validated = SmtUnsatProofFindRequest.model_validate(request.input)
+            problem_uri = self.smt.put_problem(
+                logic=validated.logic,
+                smtlib_text=validated.smtlib_text,
+            ).artifact_uri
+            resolved = self.smt.resolve_problem(problem_uri)
+        except (ValidationError, ValueError) as exc:
+            raise CapabilityInvocationError(
+                CapabilityDiagnostic(
+                    code="INVALID_SMT_UNSAT_PROOF_REQUEST",
+                    stage="input_validation",
+                    message=str(exc),
+                    path="smtlib_text",
+                    schema_uri=self.smt.installation.problem_schema_uri,
+                    expected=(
+                        "one exact QF_UF, QF_LIA, or QF_LRA SMT-LIB 2.6 query "
+                        "within an enforceable wall-time budget"
+                    ),
+                    hint=(
+                        "Use one set-logic, declarations and assertions, then one "
+                        "final check-sat; incremental and result commands are excluded."
+                    ),
+                )
+            ) from exc
+        run = self.backend.run(resolved, validated)
+        if run.execution_status is not ExecutionStatus.COMPLETED:
+            return _failed_result(self.descriptor, request, resolved, run)
+        assert run.solver_status is not None
+        proof_uri: str | None = None
+        holes: int | None = None
+        if run.solver_status == "UNSATISFIABLE":
+            assert run.proof is not None
+            proof_uri = self.smt.put_proof(
+                problem_uri=problem_uri,
+                proof=run.proof,
+                producer=self.backend.runtime,
+                resource_budget=validated.resource_budget.artifact_budget(),
+            ).artifact_uri
+            holes = run.alethe_hole_count
+            assert holes is not None
+        output = SmtUnsatProofFindOutput(
+            status="PROOF_PRODUCED" if proof_uri is not None else "NO_PROOF_PRODUCED",
+            solver_status=run.solver_status,
+            problem_uri=problem_uri,
+            proof_uri=proof_uri,
+            contains_holes=(holes > 0) if holes is not None else None,
+            alethe_hole_count=holes,
+            detail=(
+                (
+                    f"cvc5 produced raw Alethe with {holes} lexical hole marker(s); "
+                    "the proof remains unverified until a separate compatible "
+                    "checker accepts it."
+                )
+                if proof_uri is not None
+                else (
+                    f"cvc5 reported {run.solver_status} without producing an "
+                    "UNSAT proof; no SAT or UNSAT conclusion follows."
+                )
+            ),
+        )
+        artifacts = [problem_uri]
+        if proof_uri is not None:
+            artifacts.append(proof_uri)
+        return _completed_result(
+            self.descriptor,
+            request,
+            resolved,
+            run,
+            output.model_dump(mode="json"),
+            tuple(artifacts),
+            basis=(
+                "the pinned solver produced bound raw Alethe bytes, but neither "
+                "its UNSAT status, lexical hole count, nor stored proof is an "
+                "independent verification"
+                if proof_uri is not None
+                else "the bounded solver attempt completed without proof evidence; "
+                "no opposite mathematical conclusion follows"
+            ),
+        )
+
+
+def _completed_result(
+    descriptor: CapabilityDescriptor,
+    request: CapabilityRequest,
+    resolved: ResolvedSmtProblem,
+    run: _Cvc5Run,
+    output: dict[str, object],
+    artifact_uris: tuple[str, ...],
+    *,
+    basis: str,
+) -> CapabilityResult:
+    return CapabilityResult(
+        capability_id=descriptor.capability_id,
+        capability_version=descriptor.version,
+        mode=request.mode,
+        execution=Execution(
+            status=ExecutionStatus.COMPLETED,
+            runtime_ms=run.runtime_ms,
+        ),
+        output=output,
+        scope=_scope(resolved),
+        completeness=CapabilityCompleteness(
+            status=CapabilityCompletenessStatus.UNKNOWN,
+            basis=(
+                "this bounded producer makes no proof-validity, exhaustive-search, "
+                "or mathematical completeness claim"
+            ),
+            assurance_level=CapabilityAssuranceLevel.COMPUTED,
+        ),
+        assurance=CapabilityAssurance(
+            level=CapabilityAssuranceLevel.COMPUTED,
+            basis=basis,
+        ),
+        artifact_uris=artifact_uris,
+    )
+
+
+def _failed_result(
+    descriptor: CapabilityDescriptor,
+    request: CapabilityRequest,
+    resolved: ResolvedSmtProblem,
+    run: _Cvc5Run,
+) -> CapabilityResult:
+    assert run.diagnostic is not None
+    return CapabilityResult(
+        capability_id=descriptor.capability_id,
+        capability_version=descriptor.version,
+        mode=request.mode,
+        execution=Execution(
+            status=run.execution_status,
+            runtime_ms=run.runtime_ms,
+            detail=run.diagnostic.message,
+        ),
+        scope=_scope(resolved),
+        completeness=CapabilityCompleteness(
+            status=CapabilityCompletenessStatus.UNKNOWN,
+            basis=(
+                "the producer did not complete with usable proof evidence; no "
+                "coverage or mathematical conclusion follows"
+            ),
+            assurance_level=CapabilityAssuranceLevel.HEURISTIC,
+        ),
+        diagnostics=(run.diagnostic,),
+        assurance=CapabilityAssurance(
+            level=CapabilityAssuranceLevel.HEURISTIC,
+            basis=(
+                "the producer did not complete with usable bound evidence; no "
+                "mathematical conclusion follows"
+            ),
+        ),
+        artifact_uris=(resolved.artifact.artifact_uri,),
+    )
+
+
+def _scope(resolved: ResolvedSmtProblem) -> CapabilityScope:
+    return CapabilityScope(
+        description="the full exact single-query SMT-LIB input supplied to cvc5",
+        parameters={
+            "declared_scope": "FULL_QUERY",
+            "logic": resolved.problem.logic,
+            "profile": resolved.problem.profile,
+            "input_language": resolved.problem.input_language,
+            "smtlib_digest": resolved.problem.smtlib_digest,
+        },
+        artifact_uri=resolved.artifact.artifact_uri,
+    )
+
+
+def _operational_failure(
+    started: float,
+    completed: BoundedProcessResult,
+) -> _Cvc5Run | None:
+    if completed.stdout_exceeded or completed.stderr_exceeded:
+        return _run_failure(
+            started,
+            code="CVC5_OUTPUT_LIMIT_EXCEEDED",
+            stage="solver_output",
+            message=(
+                "The cvc5 worker exceeded a bounded output stream limit; no "
+                "solver evidence was retained."
+            ),
+        )
+    if completed.timed_out:
+        return _run_failure(
+            started,
+            status=ExecutionStatus.TIMEOUT,
+            code="CVC5_TIMEOUT",
+            stage="solver_execution",
+            message=(
+                "cvc5 exceeded the declared wall-time budget; no mathematical "
+                "conclusion follows."
+            ),
+        )
+    if completed.returncode != 0 or completed.stderr:
+        return _run_failure(
+            started,
+            code="CVC5_EXECUTION_FAILED",
+            stage="solver_execution",
+            message=(
+                "The isolated cvc5 worker failed or emitted an unexpected "
+                "diagnostic stream; no solver evidence was retained."
+            ),
+        )
+    return None
+
+
+def _parse_worker_output(
+    stdout: bytes,
+) -> tuple[_SolverStatus, bool, int | None]:
+    payload = loads_strict_json(stdout)
+    if not isinstance(payload, dict) or payload.get("protocol") != CVC5_WORKER_PROTOCOL:
+        raise ValueError("invalid worker protocol")
+    if set(payload) != {
+        "protocol",
+        "solver_status",
+        "proof_written",
+        "alethe_hole_count",
+    }:
+        raise ValueError("unexpected worker fields")
+    status = payload["solver_status"]
+    proof_written = payload["proof_written"]
+    hole_count = payload["alethe_hole_count"]
+    if status not in {"SATISFIABLE", "UNSATISFIABLE", "UNKNOWN"}:
+        raise ValueError("invalid worker status")
+    if not isinstance(proof_written, bool):
+        raise ValueError("invalid proof-written flag")
+    if hole_count is not None and (
+        not isinstance(hole_count, int)
+        or isinstance(hole_count, bool)
+        or hole_count < 0
+        or hole_count > 1_000_000
+    ):
+        raise ValueError("invalid Alethe hole count")
+    return status, proof_written, hole_count
+
+
+def _read_proof_file(path: Path) -> bytes:
+    path_metadata = path.stat(follow_symlinks=False)
+    if not stat.S_ISREG(path_metadata.st_mode):
+        raise OSError("proof output is not a regular file")
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags)
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise OSError("proof output is not a regular file")
+        if metadata.st_size > CVC5_PROOF_LIMIT:
+            raise OverflowError("proof output exceeds its durable artifact limit")
+        with os.fdopen(descriptor, "rb", closefd=False) as stream:
+            proof = stream.read(CVC5_PROOF_LIMIT + 1)
+        if len(proof) > CVC5_PROOF_LIMIT:
+            raise OverflowError("proof output grew beyond its durable artifact limit")
+        return proof
+    finally:
+        os.close(descriptor)
+
+
+def _run_failure(
+    started: float,
+    *,
+    code: str,
+    stage: str,
+    message: str,
+    status: ExecutionStatus = ExecutionStatus.ERROR,
+) -> _Cvc5Run:
+    return _Cvc5Run(
+        execution_status=status,
+        runtime_ms=_runtime_ms(started),
+        diagnostic=CapabilityDiagnostic(
+            code=code,
+            stage=stage,
+            message=message,
+        ),
+    )
+
+
+def _runtime_ms(started: float) -> int:
+    return max(0, int((time.monotonic() - started) * 1000))

--- a/src/jacobian/cvc5_worker.py
+++ b/src/jacobian/cvc5_worker.py
@@ -1,0 +1,174 @@
+"""Isolated cvc5 process used by the bounded Alethe producer adapter."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+CVC5_WORKER_PROTOCOL = "jacobian.cvc5-worker/v1"
+CVC5_INPUT_LIMIT = 1_000_000
+CVC5_PROOF_LIMIT = 6_000_000
+_ALLOWED_PARSED_COMMANDS = frozenset(
+    {"set-logic", "declare-sort", "declare-fun", "assert", "check-sat"}
+)
+_STATUS_MAP = {
+    "sat": "SATISFIABLE",
+    "unsat": "UNSATISFIABLE",
+    "unknown": "UNKNOWN",
+}
+
+
+class Cvc5WorkerError(RuntimeError):
+    """One worker request could not produce usable solver evidence."""
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+def _emit(payload: dict[str, object]) -> None:
+    encoded = json.dumps(
+        {"protocol": CVC5_WORKER_PROTOCOL, **payload},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    sys.stdout.write(encoded + "\n")
+    sys.stdout.flush()
+
+
+def _read_bounded(path: Path) -> bytes:
+    with path.open("rb") as stream:
+        value = stream.read(CVC5_INPUT_LIMIT + 1)
+    if len(value) > CVC5_INPUT_LIMIT:
+        raise Cvc5WorkerError("CVC5_INPUT_LIMIT_EXCEEDED")
+    return value
+
+
+def _run(
+    *,
+    input_path: Path,
+    proof_path: Path,
+    expected_logic: str,
+    wall_milliseconds: int,
+) -> dict[str, object]:
+    try:
+        raw_input = _read_bounded(input_path)
+        smtlib_text = raw_input.decode("ascii")
+    except UnicodeDecodeError as exc:
+        raise Cvc5WorkerError("CVC5_INPUT_NOT_ASCII") from exc
+    try:
+        cvc5: Any = importlib.import_module("cvc5")
+        solver = cvc5.Solver()
+        solver.setOption("produce-proofs", "true")
+        solver.setOption("proof-format-mode", "alethe")
+        solver.setOption("tlimit-per", str(wall_milliseconds))
+        parser = cvc5.InputParser(solver)
+        parser.setStringInput(
+            cvc5.InputLanguage.SMT_LIB_2_6,
+            smtlib_text,
+            "jacobian-input.smt2",
+        )
+        command_names: list[str] = []
+        status_text: str | None = None
+        while True:
+            command = parser.nextCommand()
+            if command.isNull():
+                break
+            name = str(command.getCommandName())
+            if name not in _ALLOWED_PARSED_COMMANDS:
+                raise Cvc5WorkerError("CVC5_COMMAND_OUTSIDE_PROFILE")
+            if status_text is not None:
+                raise Cvc5WorkerError("CVC5_COMMAND_AFTER_CHECK_SAT")
+            result = str(command.invoke(solver, parser.getSymbolManager()))
+            command_names.append(name)
+            if name == "set-logic" and str(solver.getLogic()) != expected_logic:
+                raise Cvc5WorkerError("CVC5_LOGIC_MISMATCH")
+            if name == "check-sat":
+                status_text = result.strip()
+    except Cvc5WorkerError:
+        raise
+    except (AttributeError, ImportError, OSError, RuntimeError, TypeError) as exc:
+        raise Cvc5WorkerError("CVC5_REJECTED_INPUT_OR_FAILED") from exc
+    if (
+        not command_names
+        or command_names[0] != "set-logic"
+        or command_names.count("set-logic") != 1
+        or command_names[-1] != "check-sat"
+        or command_names.count("check-sat") != 1
+        or status_text not in _STATUS_MAP
+    ):
+        raise Cvc5WorkerError("CVC5_QUERY_OUTSIDE_PROFILE")
+    solver_status = _STATUS_MAP[status_text]
+    if solver_status != "UNSATISFIABLE":
+        return {
+            "solver_status": solver_status,
+            "proof_written": False,
+            "alethe_hole_count": None,
+        }
+    try:
+        proofs = solver.getProof(cvc5.ProofComponent.FULL)
+        if len(proofs) != 1:
+            raise Cvc5WorkerError("CVC5_PROOF_COUNT_INVALID")
+        proof = solver.proofToString(proofs[0], cvc5.ProofFormat.ALETHE)
+        if not isinstance(proof, bytes):
+            raise Cvc5WorkerError("CVC5_PROOF_NOT_BYTES")
+        if len(proof) > CVC5_PROOF_LIMIT:
+            raise Cvc5WorkerError("CVC5_PROOF_LIMIT_EXCEEDED")
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_BINARY", 0)
+        descriptor = os.open(proof_path, flags, 0o600)
+        try:
+            with os.fdopen(descriptor, "wb", closefd=False) as stream:
+                stream.write(proof)
+        finally:
+            os.close(descriptor)
+    except Cvc5WorkerError:
+        raise
+    except (OSError, RuntimeError, TypeError) as exc:
+        raise Cvc5WorkerError("CVC5_PROOF_CAPTURE_FAILED") from exc
+    return {
+        "solver_status": solver_status,
+        "proof_written": True,
+        "alethe_hole_count": proof.count(b":rule hole"),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    arguments = sys.argv[1:] if argv is None else argv
+    if len(arguments) != 4:
+        _emit({"error_code": "CVC5_WORKER_ARGUMENTS_INVALID"})
+        return 2
+    input_path = Path(arguments[0])
+    proof_path = Path(arguments[1])
+    expected_logic = arguments[2]
+    try:
+        wall_milliseconds = int(arguments[3])
+    except ValueError:
+        _emit({"error_code": "CVC5_WORKER_ARGUMENTS_INVALID"})
+        return 2
+    if (
+        expected_logic not in {"QF_UF", "QF_LIA", "QF_LRA"}
+        or wall_milliseconds < 1
+        or wall_milliseconds > 300_000
+    ):
+        _emit({"error_code": "CVC5_WORKER_ARGUMENTS_INVALID"})
+        return 2
+    try:
+        result = _run(
+            input_path=input_path,
+            proof_path=proof_path,
+            expected_logic=expected_logic,
+            wall_milliseconds=wall_milliseconds,
+        )
+    except Cvc5WorkerError as exc:
+        _emit({"error_code": exc.code})
+        return 2
+    _emit(result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jacobian/kernel.py
+++ b/src/jacobian/kernel.py
@@ -26,6 +26,7 @@ from jacobian.contracts.capabilities import (
     CapabilityProviderRuntime,
 )
 from jacobian.contracts.lean import LeanEnvironment
+from jacobian.cvc5 import install_cvc5_capability
 from jacobian.evaluation import EvaluationService
 from jacobian.experiment_router import ExperimentRouter
 from jacobian.experiments import ExperimentService
@@ -53,6 +54,7 @@ from jacobian.polynomial_capabilities import (
 from jacobian.polytope import PolytopeService
 from jacobian.provider_runtime import (
     cadical_provider_runtime,
+    cvc5_provider_runtime,
     drat_trim_provider_runtime,
     lean_provider_runtime,
 )
@@ -73,6 +75,7 @@ from jacobian.sat_capabilities import (
 from jacobian.schema_registry import SchemaRegistry
 from jacobian.search import SearchService
 from jacobian.shrinking import ShrinkService
+from jacobian.smt import SmtArtifactService, install_smt_artifacts
 from jacobian.store import ArtifactStore
 from jacobian.structures import StructureService
 from jacobian.transformations import TransformationService
@@ -105,6 +108,11 @@ class JacobianKernel:
         self.schemas = SchemaRegistry(self.store)
         self.artifacts = ArtifactService(self.store, self.schemas)
         self.sat: SatArtifactService = install_sat_artifacts(
+            self.store,
+            self.schemas,
+            self.artifacts,
+        )
+        self.smt: SmtArtifactService = install_smt_artifacts(
             self.store,
             self.schemas,
             self.artifacts,
@@ -250,6 +258,20 @@ class JacobianKernel:
             else:
                 for cadical_adapter in cadical_adapters:
                     self.register_capability(cadical_adapter)
+        self.cvc5_runtime: CapabilityProviderRuntime = cvc5_provider_runtime()
+        if self.cvc5_runtime.availability is CapabilityProviderAvailability.AVAILABLE:
+            try:
+                cvc5_adapter = install_cvc5_capability(
+                    self.smt,
+                    self.cvc5_runtime,
+                )
+            except (OSError, ValueError) as exc:
+                _LOGGER.warning(
+                    "cvc5 SMT proof exploration is not installed: %s",
+                    exc,
+                )
+            else:
+                self.register_capability(cvc5_adapter)
         for atomic_adapter in install_atomic_capabilities(self):
             self.register_capability(atomic_adapter)
         self.register_capability(KnowledgeSearchAdapter(self.memory))

--- a/src/jacobian/provider_measurements.py
+++ b/src/jacobian/provider_measurements.py
@@ -51,6 +51,34 @@ elif provider == "jacobian.z3":
         solver = backend.Solver()
         solver.add(x == 1)
         assert solver.check() == backend.sat
+elif provider == "cvc5":
+    import cvc5 as backend
+    if operation == "reproduction":
+        solver = backend.Solver()
+        solver.setOption("produce-proofs", "true")
+        solver.setOption("proof-format-mode", "alethe")
+        parser = backend.InputParser(solver)
+        parser.setStringInput(
+            backend.InputLanguage.SMT_LIB_2_6,
+            "(set-logic QF_UF)\n"
+            "(declare-fun p () Bool)\n"
+            "(assert p)\n"
+            "(assert (not p))\n"
+            "(check-sat)\n",
+            "provider-measure.smt2",
+        )
+        result = None
+        while True:
+            command = parser.nextCommand()
+            if command.isNull():
+                break
+            output = command.invoke(solver, parser.getSymbolManager())
+            if command.getCommandName() == "check-sat":
+                result = output.strip()
+        assert result == "unsat"
+        proofs = solver.getProof(backend.ProofComponent.FULL)
+        assert len(proofs) == 1
+        assert solver.proofToString(proofs[0], backend.ProofFormat.ALETHE)
 else:
     import jacobian.canonical as backend
     if operation == "reproduction":

--- a/src/jacobian/provider_runtime.py
+++ b/src/jacobian/provider_runtime.py
@@ -24,6 +24,7 @@ from jacobian.contracts.capabilities import (
 from jacobian.implementation import ImplementationError, package_source_digest
 
 CADICAL_VERSION = "3.0.1"
+CVC5_VERSION = "1.3.4"
 DRAT_TRIM_RELEASE_TAG = "v05.22.2023"
 DRAT_TRIM_SOURCE_COMMIT = "2e5e29cb0019d5cfd547d4208dca1b3ec290349f"
 DRAT_TRIM_SOURCE_REPOSITORY = "https://github.com/marijnheule/drat-trim"
@@ -322,6 +323,42 @@ def cadical_provider_runtime(
             "proof_format": "drat-text/v1",
         },
     )
+
+
+def cvc5_provider_runtime() -> CapabilityProviderRuntime:
+    """Inspect the exact optional cvc5 Python distribution used for Alethe."""
+
+    runtime = python_distribution_provider_runtime(
+        "cvc5",
+        distribution_name="cvc5",
+        import_name="cvc5",
+        required_attributes=(
+            "InputParser",
+            "ProofComponent",
+            "ProofFormat",
+            "Solver",
+        ),
+        install_tier=CapabilityInstallTier.T1,
+        license_id="BSD-3-Clause",
+        features=("smt-lib-2.6", "alethe-proof-production"),
+        configuration={
+            "profile": "jacobian.smtlib2.qf-unsat/v1",
+            "proof_format": "cvc5.alethe/1.3.4",
+        },
+    )
+    if (
+        runtime.availability is not CapabilityProviderAvailability.AVAILABLE
+        or runtime.version != CVC5_VERSION
+    ):
+        return _unavailable_runtime(
+            provider="cvc5",
+            install_tier=CapabilityInstallTier.T1,
+            license_id="BSD-3-Clause",
+            diagnostic=(
+                f"The pinned cvc5 {CVC5_VERSION} Python distribution is unavailable."
+            ),
+        )
+    return runtime
 
 
 def drat_trim_provider_runtime(

--- a/src/jacobian/smt.py
+++ b/src/jacobian/smt.py
@@ -1,0 +1,227 @@
+"""Registration and materialization for pinned-profile SMT artifacts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pydantic import ValidationError
+
+from jacobian.artifacts import ArtifactService
+from jacobian.contracts.artifacts import ArtifactPutResult
+from jacobian.contracts.capabilities import CapabilityProviderRuntime
+from jacobian.contracts.smt import (
+    SmtAletheProofArtifact,
+    SmtLogic,
+    SmtProblemArtifact,
+    SmtProblemBinding,
+    SmtResourceBudget,
+)
+from jacobian.schema_registry import SchemaRegistry, SchemaRegistryError
+from jacobian.store import ArtifactStore, StoredArtifact, StoreError
+
+
+class SmtArtifactError(ValueError):
+    """An SMT artifact cannot be created against the requested source."""
+
+
+@dataclass(frozen=True, slots=True)
+class SmtArtifactInstallation:
+    semantics_uri: str
+    problem_schema_uri: str
+    proof_schema_uri: str
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedSmtProblem:
+    artifact: StoredArtifact
+    problem: SmtProblemArtifact
+    binding: SmtProblemBinding
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedSmtProof:
+    artifact: StoredArtifact
+    proof: SmtAletheProofArtifact
+    problem_artifact: StoredArtifact
+
+
+class SmtArtifactService:
+    """Materialize exact SMT-LIB inputs and bound unverified Alethe evidence."""
+
+    def __init__(
+        self,
+        store: ArtifactStore,
+        schemas: SchemaRegistry,
+        artifacts: ArtifactService,
+        installation: SmtArtifactInstallation,
+    ) -> None:
+        self.store = store
+        self.schemas = schemas
+        self.artifacts = artifacts
+        self.installation = installation
+
+    def put_problem(
+        self,
+        *,
+        logic: SmtLogic,
+        smtlib_text: str,
+    ) -> ArtifactPutResult:
+        problem = SmtProblemArtifact.from_text(
+            logic=logic,
+            smtlib_text=smtlib_text,
+        )
+        return self.artifacts.put(
+            schema_uri=self.installation.problem_schema_uri,
+            semantics_uri=self.installation.semantics_uri,
+            payload=problem.model_dump(mode="json"),
+            summary=f"exact {logic} SMT-LIB single query",
+        )
+
+    def resolve_problem(self, problem_uri: str) -> ResolvedSmtProblem:
+        try:
+            artifact = self.store.get(problem_uri)
+        except StoreError as exc:
+            raise SmtArtifactError(
+                "source is not an available SMT problem artifact"
+            ) from exc
+        if (
+            artifact.manifest.schema_uri != self.installation.problem_schema_uri
+            or artifact.manifest.semantics_uri != self.installation.semantics_uri
+        ):
+            raise SmtArtifactError("source is not an SMT problem artifact")
+        try:
+            normalized = self.schemas.validate(
+                self.installation.problem_schema_uri,
+                artifact.payload,
+            )
+            problem = SmtProblemArtifact.model_validate(normalized)
+        except (SchemaRegistryError, ValueError, ValidationError) as exc:
+            raise SmtArtifactError(
+                "source is not a valid SMT problem artifact"
+            ) from exc
+        binding = SmtProblemBinding(
+            problem_artifact_uri=artifact.artifact_uri,
+            problem_object_digest=artifact.manifest.object_digest,
+            problem_payload_digest=artifact.manifest.payload_digest,
+            logic=problem.logic,
+            profile=problem.profile,
+            input_language=problem.input_language,
+            smtlib_digest=problem.smtlib_digest,
+        )
+        return ResolvedSmtProblem(
+            artifact=artifact,
+            problem=problem,
+            binding=binding,
+        )
+
+    def bind_problem(self, problem_uri: str) -> SmtProblemBinding:
+        return self.resolve_problem(problem_uri).binding
+
+    def put_proof(
+        self,
+        *,
+        problem_uri: str,
+        proof: bytes,
+        producer: CapabilityProviderRuntime,
+        resource_budget: SmtResourceBudget,
+    ) -> ArtifactPutResult:
+        proof_artifact = SmtAletheProofArtifact.from_bytes(
+            problem=self.bind_problem(problem_uri),
+            proof=proof,
+            producer=producer,
+            resource_budget=resource_budget,
+        )
+        return self.artifacts.put(
+            schema_uri=self.installation.proof_schema_uri,
+            semantics_uri=self.installation.semantics_uri,
+            payload=proof_artifact.model_dump(mode="json"),
+            parents=(problem_uri,),
+            summary=(
+                "unverified raw cvc5 Alethe proof"
+                + (
+                    f" with {proof_artifact.alethe_hole_count} hole(s)"
+                    if proof_artifact.contains_holes
+                    else " without lexical hole markers"
+                )
+            ),
+        )
+
+    def resolve_proof(self, proof_uri: str) -> ResolvedSmtProof:
+        try:
+            artifact = self.store.get(proof_uri)
+        except StoreError as exc:
+            raise SmtArtifactError(
+                "source is not an available SMT proof artifact"
+            ) from exc
+        if (
+            artifact.manifest.schema_uri != self.installation.proof_schema_uri
+            or artifact.manifest.semantics_uri != self.installation.semantics_uri
+        ):
+            raise SmtArtifactError("source is not an SMT proof artifact")
+        try:
+            normalized = self.schemas.validate(
+                self.installation.proof_schema_uri,
+                artifact.payload,
+            )
+            proof = SmtAletheProofArtifact.model_validate(normalized)
+        except (SchemaRegistryError, ValueError, ValidationError) as exc:
+            raise SmtArtifactError("source is not a valid SMT proof artifact") from exc
+        binding = self.bind_problem(proof.problem.problem_artifact_uri)
+        if proof.problem != binding:
+            raise SmtArtifactError(
+                "SMT proof binding does not match its exact problem artifact"
+            )
+        if binding.problem_artifact_uri not in artifact.manifest.parents:
+            raise SmtArtifactError("SMT proof is missing its problem parent")
+        return ResolvedSmtProof(
+            artifact=artifact,
+            proof=proof,
+            problem_artifact=self.store.get(binding.problem_artifact_uri),
+        )
+
+
+def install_smt_artifacts(
+    store: ArtifactStore,
+    schemas: SchemaRegistry,
+    artifacts: ArtifactService,
+) -> SmtArtifactService:
+    """Register the SMT evidence boundary without installing solver or checker."""
+
+    semantics_uri = store.register_descriptor(
+        kind="semantics",
+        name="jacobian.smt.qf-unsat",
+        version="1",
+        definition={
+            "domain": (
+                "one quantifier-free SMT-LIB 2.6 check-sat query in QF_UF, "
+                "QF_LIA, or QF_LRA"
+            ),
+            "profile": (
+                "jacobian.smtlib2.qf-unsat/v1 permits one set-logic, declarations, "
+                "assertions, and one final check-sat over exact bounded ASCII bytes"
+            ),
+            "proof": (
+                "raw cvc5 1.3.4 Alethe bytes are bound to the exact problem, "
+                "producer runtime, format, and wall-time budget; hole metadata and "
+                "storage do not establish UNSAT"
+            ),
+            "verification": (
+                "only a separately authorized compatible checker may promote a "
+                "bound proof; no checker is installed by this producer slice"
+            ),
+        },
+    )
+    installation = SmtArtifactInstallation(
+        semantics_uri=semantics_uri,
+        problem_schema_uri=schemas.register_model(
+            name="jacobian.smt-problem",
+            version="1",
+            model=SmtProblemArtifact,
+        ),
+        proof_schema_uri=schemas.register_model(
+            name="jacobian.smt-alethe-proof",
+            version="1",
+            model=SmtAletheProofArtifact,
+        ),
+    )
+    return SmtArtifactService(store, schemas, artifacts, installation)

--- a/tests/contract/test_smt_contracts.py
+++ b/tests/contract/test_smt_contracts.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.contracts.capabilities import (
+    CapabilityInstallTier,
+    CapabilityProviderAvailability,
+    CapabilityProviderDigestKind,
+    CapabilityProviderRuntime,
+)
+from jacobian.contracts.smt import (
+    SmtAletheProofArtifact,
+    SmtExplorationBudget,
+    SmtProblemArtifact,
+    SmtProblemBinding,
+    SmtUnsatProofFindOutput,
+)
+
+_PROBLEM_URI = "artifact://sha256/" + "1" * 64
+_PROOF_URI = "artifact://sha256/" + "2" * 64
+_DIGEST = "sha256:" + "3" * 64
+_SMTLIB = (
+    "(set-logic QF_UF)\n"
+    "(declare-sort U 0)\n"
+    "(declare-fun a () U)\n"
+    "(assert (not (= a a)))\n"
+    "(check-sat)\n"
+)
+
+
+def _sha256(value: bytes) -> str:
+    return f"sha256:{hashlib.sha256(value).hexdigest()}"
+
+
+def _runtime() -> CapabilityProviderRuntime:
+    return CapabilityProviderRuntime(
+        provider="cvc5",
+        availability=CapabilityProviderAvailability.AVAILABLE,
+        version="1.3.4",
+        digest=_DIGEST,
+        digest_kind=CapabilityProviderDigestKind.PYTHON_DISTRIBUTION_RECORD,
+        platform="linux-x86_64",
+        install_tier=CapabilityInstallTier.T1,
+        license_id="BSD-3-Clause",
+        license_files=("cvc5.dist-info/licenses/COPYING",),
+        features=("alethe-proof-production",),
+        configuration={
+            "profile": "jacobian.smtlib2.qf-unsat/v1",
+            "proof_format": "cvc5.alethe/1.3.4",
+        },
+    )
+
+
+def _problem() -> SmtProblemArtifact:
+    return SmtProblemArtifact.from_text(logic="QF_UF", smtlib_text=_SMTLIB)
+
+
+def _binding() -> SmtProblemBinding:
+    problem = _problem()
+    return SmtProblemBinding(
+        problem_artifact_uri=_PROBLEM_URI,
+        problem_object_digest=_DIGEST,
+        problem_payload_digest=_DIGEST,
+        logic=problem.logic,
+        profile=problem.profile,
+        input_language=problem.input_language,
+        smtlib_digest=problem.smtlib_digest,
+    )
+
+
+def test_problem_contract_pins_one_exact_quantifier_free_query() -> None:
+    problem = _problem()
+
+    assert problem.logic == "QF_UF"
+    assert problem.smtlib_digest == _sha256(_SMTLIB.encode("ascii"))
+    assert problem.query_scope == "SINGLE_CHECK_SAT"
+
+    for invalid in (
+        _SMTLIB.replace("QF_UF", "ALL"),
+        _SMTLIB.replace("(check-sat)\n", "(check-sat)\n(check-sat)\n"),
+        _SMTLIB.replace("(check-sat)\n", "(push 1)\n(check-sat)\n"),
+        _SMTLIB.replace("(check-sat)\n", "(get-model)\n"),
+        _SMTLIB.replace("(check-sat)\n", "(check-sat)\r\n"),
+    ):
+        with pytest.raises(ValidationError):
+            SmtProblemArtifact.from_text(logic="QF_UF", smtlib_text=invalid)
+
+
+def test_command_scanner_ignores_comments_strings_and_quoted_symbols() -> None:
+    text = (
+        "(set-logic QF_UF)\n"
+        "; (push 1) is only a comment\n"
+        "(declare-fun |semi;paren()| () String)\n"
+        '(assert (= |semi;paren()| "literal (check-sat) ; text"))\n'
+        "(check-sat)\n"
+    )
+
+    problem = SmtProblemArtifact.from_text(logic="QF_UF", smtlib_text=text)
+
+    assert problem.logic == "QF_UF"
+
+
+def test_proof_contract_preserves_bytes_and_marks_holes_without_verifying() -> None:
+    proof = b'(\n(step t0 (cl) :rule hole :args ("untranslated rewrite"))\n)\n'
+
+    artifact = SmtAletheProofArtifact.from_bytes(
+        problem=_binding(),
+        proof=proof,
+        producer=_runtime(),
+        resource_budget=SmtExplorationBudget(wall_seconds=5).artifact_budget(),
+    )
+
+    assert artifact.raw_bytes() == proof
+    assert artifact.proof_digest == _sha256(proof)
+    assert artifact.alethe_hole_count == 1
+    assert artifact.contains_holes is True
+
+    payload = artifact.model_dump(mode="json")
+    payload["alethe_hole_count"] = 0
+    with pytest.raises(ValidationError):
+        SmtAletheProofArtifact.model_validate(payload)
+
+    payload = artifact.model_dump(mode="json")
+    payload["proof_base64"] = base64.b64encode(proof + b" ").decode("ascii")
+    with pytest.raises(ValidationError):
+        SmtAletheProofArtifact.model_validate(payload)
+
+    payload = artifact.model_dump(mode="json")
+    payload["producer"]["digest_kind"] = "SOURCE_TREE"
+    with pytest.raises(ValidationError):
+        SmtAletheProofArtifact.model_validate(payload)
+
+
+def test_producer_output_never_projects_solver_status_or_holes_to_a_conclusion() -> (
+    None
+):
+    output = SmtUnsatProofFindOutput(
+        status="PROOF_PRODUCED",
+        solver_status="UNSATISFIABLE",
+        problem_uri=_PROBLEM_URI,
+        proof_uri=_PROOF_URI,
+        contains_holes=True,
+        alethe_hole_count=2,
+        detail="raw proof evidence only",
+    )
+
+    assert output.conclusion == "UNKNOWN"
+    with pytest.raises(ValidationError):
+        SmtUnsatProofFindOutput(
+            status="NO_PROOF_PRODUCED",
+            solver_status="UNSATISFIABLE",
+            problem_uri=_PROBLEM_URI,
+            proof_uri=_PROOF_URI,
+            contains_holes=False,
+            alethe_hole_count=0,
+            detail="inconsistent",
+        )

--- a/tests/integration/test_cvc5.py
+++ b/tests/integration/test_cvc5.py
@@ -1,0 +1,297 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from jacobian.bounded_process import BoundedProcessResult
+from jacobian.contracts.capabilities import (
+    CapabilityAssuranceLevel,
+    CapabilityInstallTier,
+    CapabilityProviderAvailability,
+    CapabilityProviderRuntime,
+    CapabilityRequest,
+)
+from jacobian.contracts.results import ExecutionStatus
+from jacobian.kernel import JacobianKernel
+from jacobian.provider_measurements import measure_provider
+from jacobian.smt import SmtArtifactError
+
+pytestmark = pytest.mark.external_backend
+
+_QF_UF_UNSAT = (
+    "(set-logic QF_UF)\n"
+    "(declare-sort U 0)\n"
+    "(declare-fun a () U)\n"
+    "(declare-fun b () U)\n"
+    "(assert (= a b))\n"
+    "(assert (not (= a b)))\n"
+    "(check-sat)\n"
+)
+_QF_LIA_UNSAT = (
+    "(set-logic QF_LIA)\n"
+    "(declare-fun x () Int)\n"
+    "(assert (>= x 1))\n"
+    "(assert (<= x 0))\n"
+    "(check-sat)\n"
+)
+_QF_LRA_UNSAT = (
+    "(set-logic QF_LRA)\n"
+    "(declare-fun x () Real)\n"
+    "(assert (> x 1.0))\n"
+    "(assert (< x 0.0))\n"
+    "(check-sat)\n"
+)
+_QF_UF_SAT = "(set-logic QF_UF)\n(declare-fun p () Bool)\n(assert p)\n(check-sat)\n"
+
+
+def _invoke(kernel: JacobianKernel, text: str, *, logic: str = "QF_UF"):
+    return kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="smt.unsat_proof.find",
+            input={
+                "logic": logic,
+                "smtlib_text": text,
+                "resource_budget": {"wall_seconds": 5},
+            },
+        )
+    )
+
+
+@pytest.fixture(scope="module")
+def kernel(tmp_path_factory: pytest.TempPathFactory) -> JacobianKernel:
+    return JacobianKernel(tmp_path_factory.mktemp("cvc5-kernel"))
+
+
+def test_pinned_cvc5_capability_is_discoverable(kernel: JacobianKernel) -> None:
+    assert kernel.cvc5_runtime.availability is CapabilityProviderAvailability.AVAILABLE
+    catalog = kernel.capabilities.catalog().capabilities
+    descriptor = next(
+        descriptor
+        for descriptor in catalog
+        if descriptor.capability_id == "smt.unsat_proof.find"
+    )
+    assert descriptor.provider == "cvc5"
+    assert descriptor.provider_runtime == kernel.cvc5_runtime
+    assert descriptor.provider_runtime.checker_ids == ()
+    assert "smt.unsat_proof.verify" not in {
+        installed.capability_id for installed in catalog
+    }
+    assert kernel.smt.installation.problem_schema_uri.startswith("artifact://sha256/")
+    assert kernel.smt.installation.proof_schema_uri.startswith("artifact://sha256/")
+
+
+def test_pinned_cvc5_measurement_runs_its_proof_reproduction(
+    kernel: JacobianKernel,
+) -> None:
+    measurement = measure_provider(kernel.cvc5_runtime)
+
+    assert measurement.cold_start.status.value == "COMPLETED"
+    assert measurement.reproduction_case.status.value == "COMPLETED"
+    assert measurement.cold_install.status.value == "SKIPPED"
+    assert measurement.installed_bytes > 0
+
+
+def test_qf_uf_proof_is_durable_computed_evidence(kernel: JacobianKernel) -> None:
+    result = _invoke(kernel, _QF_UF_UNSAT)
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert result.output["status"] == "PROOF_PRODUCED"
+    assert result.output["solver_status"] == "UNSATISFIABLE"
+    assert result.output["conclusion"] == "UNKNOWN"
+    assert result.output["contains_holes"] is False
+    assert result.output["alethe_hole_count"] == 0
+    assert result.assurance.verification_record_uri is None
+    assert len(result.artifact_uris) == 2
+
+    resolved = kernel.smt.resolve_proof(result.output["proof_uri"])
+    assert resolved.proof.problem.problem_artifact_uri == result.output["problem_uri"]
+    assert resolved.proof.raw_bytes().startswith(b"(\n")
+    assert resolved.proof.contains_holes is False
+    assert result.output["problem_uri"] in resolved.artifact.manifest.parents
+
+
+@pytest.mark.parametrize(
+    ("logic", "text"),
+    (
+        ("QF_LIA", _QF_LIA_UNSAT),
+        ("QF_LRA", _QF_LRA_UNSAT),
+    ),
+)
+def test_linear_arithmetic_holes_stay_explicit_and_unverified(
+    kernel: JacobianKernel,
+    logic: str,
+    text: str,
+) -> None:
+    result = _invoke(kernel, text, logic=logic)
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output["status"] == "PROOF_PRODUCED"
+    assert result.output["conclusion"] == "UNKNOWN"
+    assert result.output["contains_holes"] is True
+    assert result.output["alethe_hole_count"] >= 1
+    assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert result.assurance.verification_record_uri is None
+
+
+def test_sat_report_produces_no_unsat_artifact_or_conclusion(
+    kernel: JacobianKernel,
+) -> None:
+    result = _invoke(kernel, _QF_UF_SAT)
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output == {
+        "alethe_hole_count": None,
+        "conclusion": "UNKNOWN",
+        "contains_holes": None,
+        "detail": (
+            "cvc5 reported SATISFIABLE without producing an UNSAT proof; "
+            "no SAT or UNSAT conclusion follows."
+        ),
+        "problem_uri": result.output["problem_uri"],
+        "proof_uri": None,
+        "solver_status": "SATISFIABLE",
+        "status": "NO_PROOF_PRODUCED",
+    }
+    assert result.artifact_uris == (result.output["problem_uri"],)
+
+
+def test_incremental_or_mismatched_queries_are_rejected_before_solver_evidence(
+    kernel: JacobianKernel,
+) -> None:
+    for invalid in (
+        _QF_UF_UNSAT.replace("(check-sat)\n", "(push 1)\n(check-sat)\n"),
+        _QF_UF_UNSAT.replace("QF_UF", "QF_LIA"),
+        _QF_UF_UNSAT + "(check-sat)\n",
+    ):
+        result = _invoke(kernel, invalid)
+        assert result.execution.status is ExecutionStatus.ERROR
+        assert result.output["error"]["code"] == "INVALID_SMT_UNSAT_PROOF_REQUEST"
+        assert result.artifact_uris == ()
+        assert result.diagnostics[0].code == "INVALID_SMT_UNSAT_PROOF_REQUEST"
+
+
+def test_theory_outside_declared_logic_fails_in_isolated_parser(
+    kernel: JacobianKernel,
+) -> None:
+    nonlinear_lia = (
+        "(set-logic QF_LIA)\n"
+        "(declare-fun x () Int)\n"
+        "(assert (= (* x x) 2))\n"
+        "(check-sat)\n"
+    )
+
+    result = _invoke(kernel, nonlinear_lia, logic="QF_LIA")
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.output == {}
+    assert result.assurance.level is CapabilityAssuranceLevel.HEURISTIC
+    assert result.diagnostics[0].code == "CVC5_EXECUTION_FAILED"
+    assert len(result.artifact_uris) == 1
+
+
+def test_problem_and_proof_bindings_reject_cross_domain_artifacts(
+    kernel: JacobianKernel,
+) -> None:
+    cnf_uri = kernel.sat.put_cnf(
+        variable_names=("x",),
+        clauses=((1,),),
+    ).artifact_uri
+
+    with pytest.raises(SmtArtifactError):
+        kernel.smt.resolve_problem(cnf_uri)
+    with pytest.raises(SmtArtifactError):
+        kernel.smt.resolve_proof(cnf_uri)
+
+
+def test_worker_proof_metadata_mismatch_fails_closed(
+    kernel: JacobianKernel,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_worker(command: list[str], **_kwargs: Any) -> BoundedProcessResult:
+        Path(command[5]).write_bytes(
+            b'(\n(step t0 (cl) :rule hole :args ("untranslated rewrite"))\n)\n'
+        )
+        stdout = json.dumps(
+            {
+                "protocol": "jacobian.cvc5-worker/v1",
+                "solver_status": "UNSATISFIABLE",
+                "proof_written": True,
+                "alethe_hole_count": 0,
+            },
+            separators=(",", ":"),
+        ).encode()
+        return BoundedProcessResult(
+            returncode=0,
+            stdout=stdout,
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=False,
+        )
+
+    monkeypatch.setattr("jacobian.cvc5.run_bounded_process", fake_worker)
+
+    result = _invoke(kernel, _QF_UF_UNSAT)
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.output == {}
+    assert result.assurance.level is CapabilityAssuranceLevel.HEURISTIC
+    assert result.diagnostics[0].code == "CVC5_PROOF_METADATA_MISMATCH"
+    assert len(result.artifact_uris) == 1
+
+
+def test_worker_timeout_fails_without_solver_conclusion(
+    kernel: JacobianKernel,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "jacobian.cvc5.run_bounded_process",
+        lambda *_args, **_kwargs: BoundedProcessResult(
+            returncode=None,
+            stdout=b"",
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=True,
+        ),
+    )
+
+    result = _invoke(kernel, _QF_UF_UNSAT)
+
+    assert result.execution.status is ExecutionStatus.TIMEOUT
+    assert result.output == {}
+    assert result.assurance.level is CapabilityAssuranceLevel.HEURISTIC
+    assert result.diagnostics[0].code == "CVC5_TIMEOUT"
+    assert len(result.artifact_uris) == 1
+
+
+def test_missing_optional_cvc5_leaves_artifact_boundary_but_no_capability(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    unavailable = CapabilityProviderRuntime(
+        provider="cvc5",
+        availability=CapabilityProviderAvailability.UNAVAILABLE,
+        platform="linux-x86_64",
+        install_tier=CapabilityInstallTier.T1,
+        license_id="BSD-3-Clause",
+        diagnostic="cvc5 is intentionally unavailable for this test.",
+    )
+    monkeypatch.setattr(
+        "jacobian.kernel.cvc5_provider_runtime",
+        lambda: unavailable,
+    )
+
+    without_cvc5 = JacobianKernel(tmp_path)
+
+    assert "smt.unsat_proof.find" not in {
+        descriptor.capability_id
+        for descriptor in without_cvc5.capabilities.catalog().capabilities
+    }
+    assert without_cvc5.smt.installation.problem_schema_uri.startswith(
+        "artifact://sha256/"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -282,6 +282,25 @@ wheels = [
 ]
 
 [[package]]
+name = "cvc5"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/60/dd7697865dfa711efa1ac579bba30eaba20517441b5516ea67a4e3b603f3/cvc5-1.3.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:217e67ed2c4c912a7c417f63d2cde7743c8cae4add4f9b8bab5e00a4fdcf8b56", size = 11508795, upload-time = "2026-05-07T16:56:26.556Z" },
+    { url = "https://files.pythonhosted.org/packages/03/bb/0c501adef14b9f2fca845019ce6687bd3d77c36aeaee7f9e283af9bc009c/cvc5-1.3.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c782cbccedb08a4aadd075f42af0b3a961dc65c9c8c5eeef0ef66e854e378f0c", size = 10107767, upload-time = "2026-05-07T16:22:06.482Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0c/837a0030d3b669b070228aafaef144c4c90036ce8f266466a876c76671cd/cvc5-1.3.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:dc0a0e52b5ff47cf650f056078cb1fead13e2aca8bf32ae6ff3ca46b41bccc15", size = 13070122, upload-time = "2026-05-07T15:52:37.476Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/6f/37102afe027709232ad54993d4c231a0a4614cb74fbffe0bb7bb1062ac96/cvc5-1.3.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:86831656be24ea8232161d5d5ccf4726d09865c888191c366a9c39d450ac0ebe", size = 13700116, upload-time = "2026-05-07T15:53:35.843Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/4f/3ef2a3c930c0a670193432fa14e2fd215fd37b1bd2df7a2ddb173be6a395/cvc5-1.3.4-cp312-cp312-win_amd64.whl", hash = "sha256:72557ccc3d39ca418581043739a7b05d533d3614ffc74e37510cdd421c57793d", size = 11451371, upload-time = "2026-05-07T16:24:13.412Z" },
+    { url = "https://files.pythonhosted.org/packages/59/be/99a9839cf7629a82fd426147a300766b91c27c5f833219bff1d3a613636a/cvc5-1.3.4-cp312-cp312-win_arm64.whl", hash = "sha256:c6abe7be1313655c284bd4a120f7ba7c2a08c3016f0348c4b07170ce5139be33", size = 10621287, upload-time = "2026-05-07T15:50:02.702Z" },
+    { url = "https://files.pythonhosted.org/packages/19/97/2031d96ced7106a8ab6fdfae14185428f195d5a6bbf70a833a30ffce7d99/cvc5-1.3.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f62c87b041ff98a8807e4cc3f28d09dc732242ce6581b62b8db6fc0216b87edc", size = 11508033, upload-time = "2026-05-07T16:56:29.794Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7f/c3d95b7dce19aed58f65f59dfa27718e27a6121dd4ff6e3a6cab17b368c1/cvc5-1.3.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:05493cd167fdddae1eda4f0f142bf6cfd101fac3bc9f35012ea026976a0559ae", size = 10106498, upload-time = "2026-05-07T16:22:09.681Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/82/cbf76057616a2eca2cb8c2f9f10181c2acdf7b61864225d16b9c7b69da95/cvc5-1.3.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:482b77a86e71114a24e7da0e04b8c9725c7329546061c157c101791230dee3d2", size = 13047554, upload-time = "2026-05-07T15:52:40.757Z" },
+    { url = "https://files.pythonhosted.org/packages/03/58/e481927c642196bbf93b80a7d5e85c71fb3afa5e77413f0cd9e4ecd793d5/cvc5-1.3.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35453ffbdd8b351cd7e2009993dd56f49e465e9e9d4ff4b613ae589514430243", size = 13686333, upload-time = "2026-05-07T15:53:39.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/5d/a56b7919bb7bcb1b6ed458713154a6d17e8c8a0165913582d565d508419c/cvc5-1.3.4-cp313-cp313-win_amd64.whl", hash = "sha256:fff8d7944d373e6efa1248c761717037e82215140116bcbd238139d16b5b6006", size = 11454627, upload-time = "2026-05-07T16:24:17.842Z" },
+    { url = "https://files.pythonhosted.org/packages/67/fd/f214d04cb0995631c1fe32fe00b5839ea20c0865c9d6cd7964de55575339/cvc5-1.3.4-cp313-cp313-win_arm64.whl", hash = "sha256:be051c1bbef64ce5a279370c0879c794e96ec470f12d2d23c5708bff660e3db5", size = 10624408, upload-time = "2026-05-07T15:50:06.457Z" },
+]
+
+[[package]]
 name = "cyclonedx-python-lib"
 version = "11.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -476,8 +495,14 @@ dependencies = [
     { name = "z3-solver" },
 ]
 
+[package.optional-dependencies]
+smt = [
+    { name = "cvc5" },
+]
+
 [package.dev-dependencies]
 dev = [
+    { name = "cvc5" },
     { name = "deptry" },
     { name = "hypothesis" },
     { name = "mypy" },
@@ -498,6 +523,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "cvc5", marker = "extra == 'smt'", specifier = "==1.3.4" },
     { name = "jsonschema", specifier = ">=4.23,<5" },
     { name = "mcp", specifier = "==2.0.0b2" },
     { name = "mcp-types", specifier = "==2.0.0b2" },
@@ -509,9 +535,11 @@ requires-dist = [
     { name = "typer", specifier = ">=0.20,<1" },
     { name = "z3-solver", specifier = ">=4.15.4,<5" },
 ]
+provides-extras = ["smt"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "cvc5", specifier = "==1.3.4" },
     { name = "deptry", specifier = ">=0.21,<1" },
     { name = "hypothesis", specifier = ">=6.130,<7" },
     { name = "mypy", specifier = ">=1.15,<3" },


### PR DESCRIPTION
## Problem

The formal-tool roadmap needs a theory-bounded SMT proof producer before an independent Carcara verification slice can be evaluated. A solver status or solver-produced proof must not certify its own UNSAT claim, and native cvc5 execution must not be able to hang the MCP server process.

## Change

- add optional pinned `cvc5==1.3.4` T1 provider identity and measurement support;
- add `smt.unsat_proof.find` for exact single-query `QF_UF`, `QF_LIA`, and `QF_LRA` SMT-LIB 2.6 inputs;
- run cvc5 proof production in a bounded isolated worker with a closed JSON protocol and bounded raw Alethe file capture;
- materialize exact problem and proof artifacts with digest/lineage/runtime/budget bindings and explicit lexical hole metadata;
- keep every producer outcome at `COMPUTED`/`UNKNOWN`; no SMT checker or path to `VERIFIED` is installed;
- document the profile, fail-closed boundary, and public QF_UF/LIA/LRA reproductions, and mark roadmap item 9 implemented.

## Compatibility and normative impact

This adds an experimental pre-stable capability and two artifact schemas. The capability is absent when the optional exact cvc5 wheel is unavailable; the base kernel and SMT artifact boundary still start normally. Existing v0.2 verification semantics are unchanged. Carcara compatibility and independent promotion are explicitly deferred to roadmap item 10.

## Validation

- `make check` — 260 passed, 4 deselected
- focused SMT/cvc5 suite — 16 passed
- `make check-static` — Ruff, deptry, vulture, mypy, sdist, and wheel passed
- `make test` — 556 passed in 221.94s
- `make security-audit` — no known vulnerabilities
- `uv lock --check`
- `git diff --check`

Lean validation was not rerun because this change does not touch Lean code, runtimes, checkers, or fixtures.