### PR TITLE
feat(math): add exact rational solution capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,15 @@ construction and properties, exact rational polynomial maps, finite magma law
 evaluation and countermodel search, reference-domain exploration and
 verification, Lean checking, and local research-memory search.
 
+The optional `flint` extra pins Python-FLINT 0.9.0 and adds
+`linear.rational_solution.find` for one exact finite rational `A x = b`
+candidate. A returned vector remains `COMPUTED`; a not-found outcome makes no
+consistency claim. With bundled references enabled,
+`linear.rational_solution.verify` independently replays every equation using
+standard-library exact rational arithmetic and alone may create a bound
+verification record. See the
+[exact rational solution contract](docs/reference/linear-rational-solutions.md).
+
 The base kernel also registers canonical CNF, total assignment, and raw DRAT
 proof artifact contracts. When exact CaDiCaL 3.0.1 is present, optional
 `sat.model.find` and `sat.unsat_proof.find` capabilities can materialize bound

--- a/benchmarks/ab_cases/linear-report.schema.json
+++ b/benchmarks/ab_cases/linear-report.schema.json
@@ -1,0 +1,125 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "case_id": {
+      "type": "string"
+    },
+    "status": {
+      "enum": [
+        "SOLUTION_FOUND"
+      ]
+    },
+    "conclusion": {
+      "enum": [
+        "TRUE"
+      ]
+    },
+    "solution": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "num": {
+            "type": "string",
+            "pattern": "^-?(0|[1-9][0-9]*)$"
+          },
+          "den": {
+            "type": "string",
+            "pattern": "^[1-9][0-9]*$"
+          }
+        },
+        "required": [
+          "num",
+          "den"
+        ]
+      },
+      "minItems": 1,
+      "maxItems": 32
+    },
+    "assurance": {
+      "enum": [
+        "SELF_CHECKED",
+        "COMPUTED",
+        "VERIFIED"
+      ]
+    },
+    "final_verification": {
+      "enum": [
+        "UNVERIFIED",
+        "VERIFIED"
+      ]
+    },
+    "system_uri": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^artifact://sha256/[0-9a-f]{64}$"
+    },
+    "solution_uri": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^artifact://sha256/[0-9a-f]{64}$"
+    },
+    "verification_record_uri": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^artifact://sha256/[0-9a-f]{64}$"
+    },
+    "limitations": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "feedback": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "reasoning_focus": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "infrastructure_work": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tooling_gaps": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "reasoning_focus",
+        "infrastructure_work",
+        "tooling_gaps"
+      ]
+    }
+  },
+  "required": [
+    "case_id",
+    "status",
+    "conclusion",
+    "solution",
+    "assurance",
+    "final_verification",
+    "system_uri",
+    "solution_uri",
+    "verification_record_uri",
+    "limitations",
+    "feedback"
+  ]
+}

--- a/benchmarks/agent_ab.py
+++ b/benchmarks/agent_ab.py
@@ -34,6 +34,8 @@ from typing import Any, cast
 
 from jacobian.artifacts import ArtifactService
 from jacobian.contracts.capabilities import CapabilityMode, CapabilityRequest
+from jacobian.contracts.exact import CanonicalRational
+from jacobian.contracts.linear import LinearRationalSystem
 from jacobian.contracts.sat import (
     CanonicalCnf,
     SatAssignmentArtifact,
@@ -62,6 +64,7 @@ GRAPH_REPORT_SCHEMA = CASES_ROOT / "graph-report.schema.json"
 PARTITION_REPORT_SCHEMA = CASES_ROOT / "partition-report.schema.json"
 SAT_REPORT_SCHEMA = CASES_ROOT / "sat-report.schema.json"
 SMT_REPORT_SCHEMA = CASES_ROOT / "smt-report.schema.json"
+LINEAR_REPORT_SCHEMA = CASES_ROOT / "linear-report.schema.json"
 LEAN_DECLARATION_REPORT_SCHEMA = CASES_ROOT / "lean-report.schema.json"
 LEAN_PROOF_REPORT_SCHEMA = CASES_ROOT / "lean-proof-report.schema.json"
 DEFAULT_RESULTS_ROOT = Path(__file__).with_name("results") / "ab"
@@ -84,6 +87,12 @@ SMT_CAPABILITY_IDS = frozenset(
     {
         "smt.unsat_proof.find",
         "smt.unsat_proof.verify",
+    }
+)
+LINEAR_CAPABILITY_IDS = frozenset(
+    {
+        "linear.rational_solution.find",
+        "linear.rational_solution.verify",
     }
 )
 LEAN_PROOF_CONDITIONS = ("baseline", "tactic", "retrieval", "combined")
@@ -192,6 +201,25 @@ Report VERIFIED only when the verifier returns VERIFIED_UNSAT and a
 verification-record URI. If the verifier rejects the proof, preserve the
 producer's problem_uri and proof_uri but report COMPUTED and UNVERIFIED;
 rejection does not establish SAT.
+"""
+
+LINEAR_CONTROL_INSTRUCTIONS = """\
+Jacobian and all MCP servers are unavailable. You may write and run local code
+in the empty workspace. Return one exact rational vector satisfying every
+supplied equation. Report SELF_CHECKED and UNVERIFIED, with null durable
+artifact and verification-record URIs.
+"""
+
+LINEAR_TREATMENT_INSTRUCTIONS = """\
+Use only jacobian_local for mathematical work. Do not use shell commands or
+create programs. Describe the exact capability IDs
+linear.rational_solution.find and linear.rational_solution.verify directly.
+Invoke the producer on the supplied exact rational system, then pass its
+solution_uri to the verifier in VERIFY mode. A produced vector alone is not
+verification. Report VERIFIED only when the verifier returns
+VERIFIED_SOLUTION and copy the exact system, solution, and
+verification-record URIs. Copy the producer's ordered solution values in the
+declared variable order.
 """
 
 LEAN_DECLARATION_INSTRUCTIONS = """\
@@ -340,6 +368,199 @@ def _reported_sat_assignment(
     if report.get("evidence_kind") != "ASSIGNMENT":
         raise BenchmarkError("SAT report mislabeled its assignment evidence")
     return assignment
+
+
+def _linear_case_system(case: Mapping[str, Any]) -> LinearRationalSystem:
+    system = case.get("system")
+    if not isinstance(system, Mapping):
+        raise BenchmarkError("linear case must contain an exact system object")
+    try:
+        return LinearRationalSystem.model_validate(system)
+    except ValueError as exc:
+        raise BenchmarkError("linear case contains an invalid exact system") from exc
+
+
+def _reported_linear_solution(
+    report: Mapping[str, Any],
+    *,
+    system: LinearRationalSystem,
+) -> tuple[CanonicalRational, ...]:
+    solution = report.get("solution")
+    if not isinstance(solution, list) or len(solution) != len(system.variables):
+        raise BenchmarkError(
+            "linear report must contain one ordered value per declared variable"
+        )
+    try:
+        values = tuple(CanonicalRational.model_validate(value) for value in solution)
+    except ValueError as exc:
+        raise BenchmarkError("linear report contains a noncanonical rational") from exc
+    for row, rhs in zip(system.coefficients.entries, system.rhs, strict=True):
+        actual = sum(
+            (
+                coefficient.as_fraction() * value.as_fraction()
+                for coefficient, value in zip(row, values, strict=True)
+            ),
+            start=0,
+        )
+        if actual != rhs.as_fraction():
+            raise BenchmarkError(
+                "linear report vector does not satisfy every exact equation"
+            )
+    return values
+
+
+def _matches_linear_system(value: object, expected: LinearRationalSystem) -> bool:
+    try:
+        return LinearRationalSystem.model_validate(value) == expected
+    except ValueError:
+        return False
+
+
+def _score_linear_report(
+    case: Mapping[str, Any],
+    report: Mapping[str, Any],
+    *,
+    condition: str,
+    state_dir: Path,
+    mcp_calls: Sequence[str],
+    shell_calls: Sequence[str],
+    capability_invocations: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    system = _linear_case_system(case)
+    values = _reported_linear_solution(report, system=system)
+    if (
+        report.get("case_id") != case.get("case_id")
+        or report.get("status") != "SOLUTION_FOUND"
+        or report.get("conclusion") != "TRUE"
+    ):
+        raise BenchmarkError("linear report has the wrong case, status, or conclusion")
+    _validate_feedback(report.get("feedback"))
+
+    if condition == "control":
+        if mcp_calls:
+            raise BenchmarkError("linear control used an MCP tool")
+        if (
+            report.get("assurance") != "SELF_CHECKED"
+            or report.get("final_verification") != "UNVERIFIED"
+            or report.get("system_uri") is not None
+            or report.get("solution_uri") is not None
+            or report.get("verification_record_uri") is not None
+        ):
+            raise BenchmarkError(
+                "linear control must remain self-checked without durable evidence"
+            )
+        return {
+            "passed": True,
+            "false_certification": False,
+            "replay_success": False,
+            "checks": [
+                "independent exact equation oracle",
+                "no-Jacobian control isolation",
+            ],
+        }
+    if condition != "treatment":
+        raise BenchmarkError(f"unknown condition: {condition}")
+    if shell_calls:
+        raise BenchmarkError("linear treatment used a shell command")
+    if "capability.invoke" not in mcp_calls:
+        raise BenchmarkError("linear treatment did not invoke a Jacobian capability")
+    if (
+        report.get("assurance") != "VERIFIED"
+        or report.get("final_verification") != "VERIFIED"
+    ):
+        raise BenchmarkError("linear treatment did not report verified assurance")
+    system_uri = report.get("system_uri")
+    solution_uri = report.get("solution_uri")
+    record_uri = report.get("verification_record_uri")
+    if not all(isinstance(uri, str) for uri in (system_uri, solution_uri, record_uri)):
+        raise BenchmarkError("linear treatment omitted durable artifact URIs")
+    assert isinstance(system_uri, str)
+    assert isinstance(solution_uri, str)
+    assert isinstance(record_uri, str)
+
+    kernel = JacobianKernel(state_dir, install_references=True)
+    try:
+        resolved = kernel.linear.resolve_solution(solution_uri)
+        record_artifact = kernel.store.get(record_uri)
+        record = VerificationRecord.model_validate(record_artifact.payload)
+        semantics = kernel.store.get(kernel.linear.installation.semantics_uri)
+    except (StoreError, ValueError) as exc:
+        raise BenchmarkError("linear treatment artifacts are unavailable") from exc
+    if (
+        resolved.system != system
+        or resolved.solution.values != values
+        or resolved.system_artifact.artifact_uri != system_uri
+        or system_uri not in resolved.artifact.manifest.parents
+        or record.conclusion.value != "TRUE"
+        or record.bindings.claim_digest
+        != resolved.system_artifact.manifest.object_digest
+        or record.bindings.semantics_digest != semantics.manifest.object_digest
+        or record.bindings.candidate_digest != resolved.artifact.manifest.object_digest
+        or not {system_uri, solution_uri, record.evidence_uri}.issubset(
+            record_artifact.manifest.parents
+        )
+    ):
+        raise BenchmarkError("linear verification record is not exactly bound")
+
+    found_index: int | None = None
+    verified_trace = False
+    for index, invocation in enumerate(capability_invocations):
+        invocation_input = invocation.get("input")
+        invocation_output = invocation.get("output")
+        if (
+            invocation.get("capability_id") == "linear.rational_solution.find"
+            and isinstance(invocation_input, Mapping)
+            and _matches_linear_system(invocation_input.get("system"), system)
+            and isinstance(invocation_output, Mapping)
+            and invocation_output.get("system_uri") == system_uri
+            and invocation_output.get("solution_uri") == solution_uri
+            and solution_uri in (invocation.get("artifact_uris") or [])
+        ):
+            found_index = index
+        if (
+            found_index is not None
+            and index > found_index
+            and invocation.get("capability_id") == "linear.rational_solution.verify"
+            and invocation_input == {"solution_uri": solution_uri}
+            and isinstance(invocation_output, Mapping)
+            and invocation_output.get("verification_record_uri") == record_uri
+            and isinstance(invocation.get("assurance"), Mapping)
+            and invocation["assurance"].get("level") == "VERIFIED"
+            and record_uri in (invocation.get("artifact_uris") or [])
+        ):
+            verified_trace = True
+            break
+    if not verified_trace:
+        raise BenchmarkError(
+            "linear treatment lacks an exact ordered find-to-verify trace"
+        )
+
+    replay = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="linear.rational_solution.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"solution_uri": solution_uri},
+        )
+    )
+    if (
+        replay.assurance.level.value != "VERIFIED"
+        or replay.assurance.verification_record_uri != record_uri
+        or replay.output.get("conclusion") != "TRUE"
+        or replay.output.get("system_uri") != system_uri
+        or replay.output.get("solution_uri") != solution_uri
+    ):
+        raise BenchmarkError("linear treatment evidence does not replay independently")
+    return {
+        "passed": True,
+        "false_certification": False,
+        "replay_success": True,
+        "checks": [
+            "independent exact equation oracle",
+            "durable system and solution binding",
+            "ordered find-to-verify trace",
+            "independent checker replay",
+        ],
+    }
 
 
 def _score_sat_report(
@@ -730,6 +951,16 @@ def score_report(
     capability_attempt_ids: Sequence[str] = (),
     capability_invocations: Sequence[Mapping[str, Any]] = (),
 ) -> dict[str, Any]:
+    if case.get("task_type") == "linear_rational_solution":
+        return _score_linear_report(
+            case,
+            report,
+            condition=condition,
+            state_dir=state_dir,
+            mcp_calls=mcp_calls,
+            shell_calls=shell_calls,
+            capability_invocations=capability_invocations,
+        )
     if case.get("task_type") == "smt_unsat_proof":
         return _score_smt_report(
             case,
@@ -1624,6 +1855,12 @@ def _codex_command(
 
 
 def _condition_instructions(task_type: object, condition: str) -> str:
+    if task_type == "linear_rational_solution":
+        return (
+            LINEAR_CONTROL_INSTRUCTIONS
+            if condition == "control"
+            else LINEAR_TREATMENT_INSTRUCTIONS
+        )
     if task_type == "smt_unsat_proof":
         return (
             SMT_CONTROL_INSTRUCTIONS
@@ -1679,6 +1916,7 @@ def _run_condition(
     is_partition = case.get("task_type") == "finite_partition"
     is_sat = case.get("task_type") == "sat_decision"
     is_smt = case.get("task_type") == "smt_unsat_proof"
+    is_linear = case.get("task_type") == "linear_rational_solution"
     is_lean_declaration = case.get("task_type") == "lean_declaration"
     is_lean_proof = case.get("task_type") == "lean_proof"
     sat_context = ""
@@ -1688,11 +1926,25 @@ def _run_condition(
             "\nThe canonical CNF for this case is available at "
             f"{cnf_uri}. Return this exact URI as cnf_uri.\n"
         )
+    linear_context = ""
+    if is_linear:
+        system = _linear_case_system(case)
+        linear_context = (
+            "\nThe exact rational system for this case is:\n"
+            + json.dumps(system.model_dump(mode="json"), sort_keys=True)
+            + "\n"
+        )
     condition_instructions = _condition_instructions(
         case.get("task_type"),
         condition,
     )
-    prompt = condition_instructions + sat_context + "\n" + COMMON_PROMPT.format(**case)
+    prompt = (
+        condition_instructions
+        + sat_context
+        + linear_context
+        + "\n"
+        + COMMON_PROMPT.format(**case)
+    )
     command = _codex_command(
         codex_command=codex_command,
         condition=condition,
@@ -1715,6 +1967,8 @@ def _run_condition(
             if is_sat
             else SMT_REPORT_SCHEMA
             if is_smt
+            else LINEAR_REPORT_SCHEMA
+            if is_linear
             else PARTITION_REPORT_SCHEMA
             if is_partition
             else REPORT_SCHEMA
@@ -1828,6 +2082,12 @@ def _run_condition(
                 and report.get("final_verification") == "VERIFIED"
                 and not score.get("passed")
             )
+            or (
+                is_linear
+                and isinstance(report, dict)
+                and report.get("final_verification") == "VERIFIED"
+                and not score.get("passed")
+            )
         ),
         "intervention_attempted": bool(
             (
@@ -1842,6 +2102,12 @@ def _run_condition(
                 is_smt
                 and SMT_CAPABILITY_IDS.intersection(telemetry["capability_attempt_ids"])
             )
+            or (
+                is_linear
+                and LINEAR_CAPABILITY_IDS.intersection(
+                    telemetry["capability_attempt_ids"]
+                )
+            )
         ),
         "intervention_used": bool(
             (
@@ -1850,6 +2116,10 @@ def _run_condition(
             )
             or (is_sat and SAT_CAPABILITY_IDS.intersection(telemetry["capability_ids"]))
             or (is_smt and SMT_CAPABILITY_IDS.intersection(telemetry["capability_ids"]))
+            or (
+                is_linear
+                and LINEAR_CAPABILITY_IDS.intersection(telemetry["capability_ids"])
+            )
         ),
         "operational_failure": bool(score.get("operational_failure")),
         "score": score,

--- a/docs/contributing/atomic-capability-portfolio.md
+++ b/docs/contributing/atomic-capability-portfolio.md
@@ -473,6 +473,12 @@ proof-support claim. See
 
 ### Python-FLINT first
 
+The first rational-solution slice is implemented; see the
+[exact rational solution contract](../reference/linear-rational-solutions.md)
+and the
+[Python-FLINT rational-solution pilot](../reference/capability-workflow-evaluations.md#python-flint-rational-solution-pilot).
+The remaining sequence stays demand-gated.
+
 Implement one vertical slice at a time:
 
 1. `linear.rational_solution.find` returns one exact vector for a declared
@@ -564,7 +570,10 @@ backlog.
     [SMT Alethe artifact contracts](../reference/smt-artifacts.md#strict-carcara-verification)
     and the
     [SMT Carcara contract pilot](../reference/capability-workflow-evaluations.md#smt-carcara-contract-pilot).
-11. Python-FLINT rational-solution find and verify slice.
+11. Python-FLINT rational-solution find and verify slice. Implemented; see the
+    [exact rational solution contract](../reference/linear-rational-solutions.md)
+    and the
+    [Python-FLINT rational-solution pilot](../reference/capability-workflow-evaluations.md#python-flint-rational-solution-pilot).
 12. Python-FLINT polynomial or integer-matrix slice chosen from transcript
     demand.
 13. Typed expression AST and one SymPy polynomial-normalization slice.

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,6 +60,7 @@ expectations.
 - [Lean declaration discovery](reference/lean-declaration-discovery.md)
 - [SAT artifact contracts](reference/sat-artifacts.md)
 - [SMT Alethe artifact contracts](reference/smt-artifacts.md)
+- [Exact rational solution artifacts](reference/linear-rational-solutions.md)
 - [v0.2 specification](reference/specifications/v0.2.md)
 - [v0.2 conformance specification](reference/conformance-v0.2.md)
 - [Plugin conformance contract](reference/plugin-conformance.md)

--- a/docs/reference/capability-workflow-evaluations.md
+++ b/docs/reference/capability-workflow-evaluations.md
@@ -438,6 +438,46 @@ compact schema discovery and ranking remain portfolio-level follow-up work.
 Because this was a prescribed-capability pilot, it measures contract use and
 assurance discipline rather than autonomous portfolio discovery.
 
+### Python-FLINT rational-solution pilot
+
+The frozen 2026-07-26 Python-FLINT pilot used `gpt-5.6-terra`, high reasoning
+effort, a 600-second per-run limit, and one repetition of two private exact
+rational systems. One was a square three-variable system and one was an
+overdetermined four-equation, three-variable system. Their case digests were
+`sha256:5bc8e162c74075f5c8e67cb3708ec4bb98a5488b8cd11b6268eca2311a945172`
+and
+`sha256:69ef3f37d3b9a372eb7bd31c2fca42ca2e985443bf0230a5d7d882a2d710b571`.
+
+Control solved each system directly and could report only
+`SELF_CHECKED/UNVERIFIED`. Treatment was prescribed the exact capability IDs
+`linear.rational_solution.find` and
+`linear.rational_solution.verify`. It had to preserve declared variable order,
+pass the producer's `solution_uri` to the verifier, and report `VERIFIED` only
+with the returned verification-record URI. The hidden scorer checked every
+equation with an independent exact oracle, durable system and vector bindings,
+the ordered invocation trace, and clean-kernel replay.
+
+| Condition | Passed | False certifications | Clean replays | Median seconds | Median input tokens | Median calls | Tool errors |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| control | 2 / 2 | 0 | 0 / 2 | 19.488 | 12,754 | 0 | 0 |
+| Python-FLINT producer + verifier | 2 / 2 | 0 | 2 / 2 | 36.692 | 111,162 | 4 | 0 |
+
+Both treatments composed the intended operations without parameter errors or
+capability rejection, and both records replayed independently. Agent feedback
+reported no missing mathematical operation. This supports retaining the
+atomic producer/verifier split and its ordered-vector contract. It does not
+show an accuracy gain over direct work on these small systems; its observed
+value is durable exact evidence and an independent promotion boundary.
+
+One earlier development dispatch is excluded: the response schema represented
+the solution as an open-keyed object, which the model API rejected before any
+tokens or tool calls. The frozen schema uses an ordered array aligned with the
+declared variables. Treatment still used about 111,000 median cumulative input
+tokens and about 17 seconds more wall time than control, so compact descriptor
+discovery and lower-overhead MCP composition remain follow-up work. Because
+this was a prescribed-capability pilot, it measures contract use and assurance
+discipline rather than autonomous portfolio discovery.
+
 ## Source policy
 
 Use the supplied research collection according to evidence strength:

--- a/docs/reference/linear-rational-solutions.md
+++ b/docs/reference/linear-rational-solutions.md
@@ -1,0 +1,156 @@
+# Exact rational solution artifacts
+
+[Documentation home](../index.md)
+
+- Status: Experimental pre-stable contract
+- Provider profile: Python-FLINT 0.9.0, `fmpq_mat.rref`
+- Domain: finite systems `A x = b` over `QQ`
+- Maximum shape: 32 equations by 32 declared variables
+
+## Capability boundary
+
+`linear.rational_solution.find` and
+`linear.rational_solution.verify` are separate mathematical operations:
+
+| Capability | Observable outcome | Assurance |
+| --- | --- | --- |
+| `linear.rational_solution.find` | One exact vector bound to one stored rational system, or no vector | `COMPUTED` when the bounded provider attempt completes; never self-verified |
+| `linear.rational_solution.verify` | Independent replay of every equation for one bound vector | `VERIFIED` only after the operator-authorized checker creates a durable verification record |
+
+The producer runs only when the exact optional Python-FLINT distribution is
+available. Install the pinned wheel with:
+
+```sh
+uv sync --extra flint
+```
+
+The verifier does not import Python-FLINT, SymPy, or the producer. It uses
+standard-library `fractions.Fraction` arithmetic in the existing clean-process
+checker boundary. Bundled checker authorization remains an explicit
+`install_references=True` operator decision.
+
+## Exact system input
+
+A request declares the ordered variable list, coefficient matrix, right-hand
+side, and wall-time budget:
+
+```json
+{
+  "system": {
+    "variables": ["x", "y"],
+    "coefficients": {
+      "entries": [
+        [
+          {"num": "2", "den": "1"},
+          {"num": "1", "den": "1"}
+        ],
+        [
+          {"num": "1", "den": "1"},
+          {"num": "-1", "den": "1"}
+        ]
+      ]
+    },
+    "rhs": [
+      {"num": "5", "den": "1"},
+      {"num": "1", "den": "1"}
+    ]
+  },
+  "resource_budget": {"wall_seconds": 5}
+}
+```
+
+Every rational is a reduced numerator and positive denominator encoded as
+canonical decimal strings. Negative zero, leading zeroes, zero denominators,
+and unreduced values are rejected. Each numerator and denominator is limited
+to 256 decimal digits. The coefficient row count must equal the right-hand
+side length, and the column count must equal the number of unique declared
+variables.
+
+The variable order is semantic. A digest of the ordered list is included in
+the durable system binding so a vector cannot be silently rebound to permuted
+columns.
+
+## Producer behavior
+
+The producer starts an isolated Python process with a fixed locale, timezone,
+and hash seed. Input, output, and wall time are bounded. The worker:
+
+1. constructs the augmented rational matrix `[A | b]`;
+2. calls Python-FLINT 0.9.0 `fmpq_mat.rref`;
+3. rejects a reduced row whose coefficient entries are all zero and whose
+   right-hand side is nonzero;
+4. otherwise sets every free variable to zero and reads one value for each
+   pivot variable; and
+5. returns canonical numerator and denominator strings.
+
+A produced vector is stored with the full system URI, object and payload
+digests, variable-order digest, dimensions, producer distribution digest,
+resource budget, and system-parent lineage. Its relationship to the system is
+still only proposed.
+
+`NO_SOLUTION_PRODUCED` has `UNKNOWN` conclusion and unknown completeness. It
+does not assert that the system is inconsistent. A later inconsistent-system
+capability requires a separately checkable left-nullspace or equivalent
+certificate.
+
+## Independent verification
+
+The authorized `linear.rational_solution.verify` checker accepts only when all
+of these hold:
+
+- the checker request, system, solution, binding, provider record, budget, and
+  witness envelope have their exact closed shapes;
+- artifact URIs, payload digests, object digests, semantics, witness bindings,
+  and parent lineage agree;
+- the solution has one canonical rational for every declared variable; and
+- standard-library exact arithmetic confirms every full equation
+  `sum(A[i][j] * x[j]) == b[i]`.
+
+Wrong values, partial vectors, reordered variables, changed equations,
+noncanonical rationals, provider substitutions, missing lineage, extra fields,
+and artifacts rebound to another system are rejected. Rejection, timeout,
+cancellation, runtime replacement, or malformed checker output remains
+`UNKNOWN` and cannot carry a verification record.
+
+## Runtime identity and measurements
+
+The supported provider identity is:
+
+- distribution: `python-flint==0.9.0`;
+- digest kind: `PYTHON_DISTRIBUTION_RECORD`;
+- license expression: `MIT AND LGPL-3.0-or-later`;
+- install tier: `T1`;
+- required API: `flint.fmpq` and `flint.fmpq_mat`;
+- operation profile: exact `QQ` reduced row-echelon form with free variables
+  fixed to zero.
+
+On the 2026-07-26 Linux x86-64 development host, the repository measurement
+protocol recorded:
+
+| Measurement | Result |
+| --- | ---: |
+| Fresh-cache, no-dependency wheel install | 4.606 s |
+| Installed distribution size | 25,950,757 bytes |
+| Cold import probe | 0.038 s, 42,332,160-byte peak RSS |
+| 2-by-2 exact RREF reproduction | 0.040 s, 42,332,160-byte peak RSS |
+
+These measurements characterize one host and distribution digest; they are
+not performance guarantees.
+
+The paired agent result is recorded in the
+[Python-FLINT rational-solution pilot](capability-workflow-evaluations.md#python-flint-rational-solution-pilot).
+
+## Trust limits
+
+Python-FLINT is a maintained exact-arithmetic provider, not an independent
+verifier of its own output. Provider success, RREF rank, deterministic output,
+and durable storage remain computed evidence. Only the separately registered
+checker may authorize a `VERIFIED` result, and that promotion is bound to the
+exact system, vector, semantics, witness, checker digest, and verification
+request.
+
+Primary provider references are the
+[Python-FLINT repository](https://github.com/flintlib/python-flint),
+[Python-FLINT rational matrix API](https://python-flint.readthedocs.io/en/latest/fmpq_mat.html),
+and the
+[Python-FLINT package release](https://pypi.org/project/python-flint/0.9.0/).

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -164,10 +164,13 @@ provider identity is available:
 | `sat.model.find` | With CaDiCaL 3.0.1, preserve one total assignment candidate without certifying SAT. |
 | `sat.unsat_proof.find` | With CaDiCaL 3.0.1, preserve raw DRAT evidence without certifying UNSAT. |
 | `smt.unsat_proof.find` | With the `smt` extra and cvc5 1.3.4, preserve raw Alethe for one pinned-profile QF query, expose holes, and retain `UNKNOWN`. |
+| `linear.rational_solution.find` | With the `flint` extra and Python-FLINT 0.9.0, produce one exact rational vector for a declared `A x = b` system; not-found remains a non-conclusion. |
 
 See the [SAT artifact contracts](sat-artifacts.md) and
-[SMT Alethe artifact contracts](smt-artifacts.md) for exact input profiles,
-resource bounds, artifact bindings, and independent verification boundaries.
+[SMT Alethe artifact contracts](smt-artifacts.md), and
+[exact rational solution artifacts](linear-rational-solutions.md) for exact
+input profiles, resource bounds, artifact bindings, and independent
+verification boundaries.
 
 When the operator enables bundled references, the catalog also includes:
 
@@ -178,6 +181,7 @@ When the operator enables bundled references, the catalog also includes:
 | `lean.check` | Check a Lean proof in an operator-pinned environment and return its replay evidence. |
 | `lean.proof_state.apply_tactic` | Apply one tactic through the pinned Lean REPL and materialize the resulting goals and replay source. |
 | `lean.retrieve.premises` | Ask pinned Mathlib `exact?` for bounded candidate tactics and declaration references for one proof state. |
+| `linear.rational_solution.verify` | Independently replay every equation for one exact stored vector; rejection does not prove inconsistency. |
 
 The two exploratory Lean capabilities use the maintained
 `leanprover-community/repl` JSON protocol pinned in the Lake manifest. Their

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+flint = [
+    "python-flint==0.9.0",
+]
 smt = [
     "cvc5==1.3.4",
 ]
@@ -39,6 +42,7 @@ dev = [
     "hypothesis>=6.130,<7",
     "mypy>=1.15,<3",
     "pip-audit>=2.9,<3",
+    "python-flint==0.9.0",
     "pre-commit>=4.4,<5",
     "pyperf>=2.9,<3",
     "pytest>=8.3,<10",
@@ -115,7 +119,7 @@ ignore_missing_imports = true
 [tool.deptry]
 extend_exclude = ["benchmarks"]
 known_first_party = ["jacobian", "jacobian_checkers"]
-per_rule_ignores = { "DEP002" = ["cvc5", "mcp-types"] }
+per_rule_ignores = { "DEP002" = ["cvc5", "mcp-types", "python-flint"] }
 
 [tool.coverage.run]
 branch = true

--- a/src/jacobian/contracts/linear.py
+++ b/src/jacobian/contracts/linear.py
@@ -1,0 +1,222 @@
+"""Exact rational linear-system and solution-witness contracts."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Annotated, Literal, Self
+
+from pydantic import Field, StrictInt, StringConstraints, model_validator
+
+from jacobian.canonical import canonicalize_json
+from jacobian.contracts.capabilities import (
+    CapabilityProviderAvailability,
+    CapabilityProviderRuntime,
+)
+from jacobian.contracts.common import ArtifactUri, CheckerUri, Sha256Digest
+from jacobian.contracts.exact import CanonicalRational
+from jacobian.contracts.matrices import ExactRationalMatrix
+from jacobian.contracts.results import ContractModel
+
+MAX_LINEAR_DIMENSION = 32
+MAX_RATIONAL_DIGITS = 256
+
+LinearVariableName = Annotated[
+    str,
+    StringConstraints(
+        pattern=r"^[A-Za-z_][A-Za-z0-9_]{0,63}$",
+        strict=True,
+    ),
+]
+
+
+def _sha256(value: bytes) -> str:
+    return f"sha256:{hashlib.sha256(value).hexdigest()}"
+
+
+def linear_variable_order_digest(variables: tuple[str, ...]) -> str:
+    """Bind the declared column order without inventing a generic object schema."""
+
+    return _sha256(canonicalize_json({"variables": list(variables)}))
+
+
+def _require_bounded_rationals(values: tuple[CanonicalRational, ...]) -> None:
+    for value in values:
+        if (
+            len(value.num.lstrip("-")) > MAX_RATIONAL_DIGITS
+            or len(value.den.lstrip("-")) > MAX_RATIONAL_DIGITS
+        ):
+            raise ValueError(
+                "linear-system rationals are limited to 256 decimal digits "
+                "per numerator and denominator"
+            )
+
+
+class LinearRationalSystem(ContractModel):
+    """One declared finite system ``A x = b`` over exact rationals."""
+
+    system_schema_version: Literal["1"] = "1"
+    domain: Literal["QQ"] = "QQ"
+    relation: Literal["AX_EQUALS_B"] = "AX_EQUALS_B"
+    variables: tuple[LinearVariableName, ...] = Field(
+        min_length=1,
+        max_length=MAX_LINEAR_DIMENSION,
+    )
+    coefficients: ExactRationalMatrix
+    rhs: tuple[CanonicalRational, ...] = Field(
+        min_length=1,
+        max_length=MAX_LINEAR_DIMENSION,
+    )
+
+    @model_validator(mode="after")
+    def require_matching_canonical_dimensions(self) -> Self:
+        if len(set(self.variables)) != len(self.variables):
+            raise ValueError("linear-system variable names must be unique")
+        if len(self.coefficients.entries[0]) != len(self.variables):
+            raise ValueError(
+                "the coefficient column count must equal the declared variable count"
+            )
+        if len(self.coefficients.entries) != len(self.rhs):
+            raise ValueError(
+                "the right-hand side length must equal the coefficient row count"
+            )
+        _require_bounded_rationals(
+            tuple(value for row in self.coefficients.entries for value in row)
+            + self.rhs
+        )
+        return self
+
+
+class LinearSystemBinding(ContractModel):
+    """Exact stored identity and dimensions of one rational system."""
+
+    binding_version: Literal["1"] = "1"
+    system_artifact_uri: ArtifactUri
+    system_object_digest: Sha256Digest
+    system_payload_digest: Sha256Digest
+    variable_order_digest: Sha256Digest
+    row_count: StrictInt = Field(ge=1, le=MAX_LINEAR_DIMENSION)
+    column_count: StrictInt = Field(ge=1, le=MAX_LINEAR_DIMENSION)
+
+
+class LinearRationalResourceBudget(ContractModel):
+    """Wall-clock bound enforced around one isolated Python-FLINT attempt."""
+
+    budget_version: Literal["1"] = "1"
+    wall_seconds: StrictInt = Field(default=10, ge=1, le=60)
+
+
+class LinearRationalSolutionArtifact(ContractModel):
+    """One exact candidate vector, not a self-verifying solver report."""
+
+    solution_schema_version: Literal["1"] = "1"
+    system: LinearSystemBinding
+    declared_scope: Literal["FULL_SYSTEM"] = "FULL_SYSTEM"
+    values: tuple[CanonicalRational, ...] = Field(
+        min_length=1,
+        max_length=MAX_LINEAR_DIMENSION,
+    )
+    producer: CapabilityProviderRuntime
+    resource_budget: LinearRationalResourceBudget
+    method: Literal["RREF_FREE_VARIABLES_ZERO"] = "RREF_FREE_VARIABLES_ZERO"
+
+    @model_validator(mode="after")
+    def require_total_bound_candidate(self) -> Self:
+        if len(self.values) != self.system.column_count:
+            raise ValueError(
+                "solution must contain one exact value for every declared variable"
+            )
+        _require_bounded_rationals(self.values)
+        if (
+            self.producer.provider != "python-flint"
+            or self.producer.availability
+            is not CapabilityProviderAvailability.AVAILABLE
+            or self.producer.version != "0.9.0"
+        ):
+            raise ValueError(
+                "solution producer must be the available pinned Python-FLINT 0.9.0 runtime"
+            )
+        return self
+
+
+class LinearRationalSolutionFindRequest(ContractModel):
+    """Ask the pinned provider for one candidate vector."""
+
+    system: LinearRationalSystem
+    resource_budget: LinearRationalResourceBudget = Field(
+        default_factory=LinearRationalResourceBudget
+    )
+
+
+class LinearRationalSolutionFindOutput(ContractModel):
+    """Unverified outcome of one bounded rational-solution attempt."""
+
+    status: Literal["SOLUTION_PRODUCED", "NO_SOLUTION_PRODUCED"]
+    conclusion: Literal["UNKNOWN"] = "UNKNOWN"
+    system_uri: ArtifactUri
+    solution_uri: ArtifactUri | None = None
+    solution: tuple[CanonicalRational, ...] | None = None
+    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
+    determinism: Literal["DETERMINISTIC"] = "DETERMINISTIC"
+    verification: Literal["UNVERIFIED"] = "UNVERIFIED"
+    certificate_available: bool
+    method: Literal["RREF_FREE_VARIABLES_ZERO"] = "RREF_FREE_VARIABLES_ZERO"
+    backend: Literal["python-flint"] = "python-flint"
+    backend_version: Literal["0.9.0"] = "0.9.0"
+    detail: str = Field(min_length=1, max_length=1024)
+
+    @model_validator(mode="after")
+    def bind_candidate_projection(self) -> Self:
+        produced = self.status == "SOLUTION_PRODUCED"
+        if produced != (
+            self.solution_uri is not None
+            and self.solution is not None
+            and self.certificate_available
+        ):
+            raise ValueError(
+                "produced output requires exactly one durable, directly checkable vector"
+            )
+        if not produced and (
+            self.solution_uri is not None
+            or self.solution is not None
+            or self.certificate_available
+        ):
+            raise ValueError("not-found output cannot carry a solution candidate")
+        return self
+
+
+class LinearRationalSolutionVerificationRequest(ContractModel):
+    """Verify one stored vector against its exact bound system."""
+
+    solution_uri: ArtifactUri
+
+
+class LinearRationalSolutionVerificationOutput(ContractModel):
+    """Model-facing projection of independent ``A x = b`` replay."""
+
+    status: Literal[
+        "VERIFIED_SOLUTION",
+        "REJECTED",
+        "TIMEOUT",
+        "CANCELLED",
+        "ERROR",
+    ]
+    conclusion: Literal["TRUE", "UNKNOWN"]
+    system_uri: ArtifactUri
+    solution_uri: ArtifactUri
+    witness_uri: ArtifactUri
+    checker_id: CheckerUri
+    verification_record_uri: ArtifactUri | None = None
+    detail: str = Field(min_length=1, max_length=1024)
+
+    @model_validator(mode="after")
+    def bind_verified_projection(self) -> Self:
+        if self.status == "VERIFIED_SOLUTION":
+            if self.conclusion != "TRUE" or self.verification_record_uri is None:
+                raise ValueError(
+                    "verified solution output requires TRUE and a verification record"
+                )
+        elif self.conclusion != "UNKNOWN" or self.verification_record_uri is not None:
+            raise ValueError(
+                "non-verified solution output cannot carry a conclusion or record"
+            )
+        return self

--- a/src/jacobian/flint_linear.py
+++ b/src/jacobian/flint_linear.py
@@ -1,0 +1,388 @@
+"""Bounded Python-FLINT rational-solution producer capability."""
+
+from __future__ import annotations
+
+import sys
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic import ValidationError
+
+from jacobian.bounded_process import BoundedProcessResult, run_bounded_process
+from jacobian.canonical import canonicalize_json, loads_strict_json
+from jacobian.capabilities import CapabilityAdapter, CapabilityInvocationError
+from jacobian.contracts.capabilities import (
+    CapabilityAssurance,
+    CapabilityAssuranceLevel,
+    CapabilityCompleteness,
+    CapabilityCompletenessStatus,
+    CapabilityDescriptor,
+    CapabilityDiagnostic,
+    CapabilityMode,
+    CapabilityProviderAvailability,
+    CapabilityProviderRuntime,
+    CapabilityRelationship,
+    CapabilityRequest,
+    CapabilityResult,
+    CapabilityScope,
+)
+from jacobian.contracts.exact import CanonicalRational
+from jacobian.contracts.linear import (
+    LinearRationalSolutionFindOutput,
+    LinearRationalSolutionFindRequest,
+)
+from jacobian.contracts.results import Execution, ExecutionStatus
+from jacobian.flint_linear_worker import FLINT_LINEAR_WORKER_PROTOCOL
+from jacobian.linear import LinearArtifactService
+from jacobian.provider_runtime import (
+    PYTHON_FLINT_VERSION,
+    python_flint_provider_runtime,
+)
+from jacobian.schema_registry import model_schema
+
+FLINT_LINEAR_STDOUT_LIMIT = 64_000
+FLINT_LINEAR_STDERR_LIMIT = 64_000
+
+
+@dataclass(frozen=True, slots=True)
+class _FlintLinearRun:
+    execution_status: ExecutionStatus
+    runtime_ms: int
+    values: tuple[CanonicalRational, ...] | None = None
+    detail: str | None = None
+
+
+def install_python_flint_linear_capability(
+    linear: LinearArtifactService,
+    runtime: CapabilityProviderRuntime,
+) -> CapabilityAdapter:
+    """Install one producer only for the exact supported optional runtime."""
+
+    if (
+        runtime.availability is not CapabilityProviderAvailability.AVAILABLE
+        or runtime.provider != "python-flint"
+        or runtime.version != PYTHON_FLINT_VERSION
+    ):
+        raise ValueError("the pinned Python-FLINT runtime is not available")
+    return PythonFlintRationalSolutionFindAdapter(linear=linear, runtime=runtime)
+
+
+class _PythonFlintBackend:
+    def __init__(self, runtime: CapabilityProviderRuntime) -> None:
+        self.runtime = runtime
+
+    def run(self, request: LinearRationalSolutionFindRequest) -> _FlintLinearRun:
+        started = time.monotonic()
+        if python_flint_provider_runtime(refresh=True) != self.runtime:
+            return _failure(
+                started,
+                ExecutionStatus.ERROR,
+                (
+                    "The installed Python-FLINT runtime no longer matches the "
+                    "capability descriptor; no solution evidence was retained."
+                ),
+            )
+        command = [
+            sys.executable,
+            "-I",
+            "-m",
+            "jacobian.flint_linear_worker",
+        ]
+        worker_request = {
+            "protocol": FLINT_LINEAR_WORKER_PROTOCOL,
+            "system": request.system.model_dump(mode="json"),
+        }
+        try:
+            completed = run_bounded_process(
+                command,
+                input_bytes=canonicalize_json(worker_request),
+                timeout_seconds=float(request.resource_budget.wall_seconds),
+                environment={
+                    "LANG": "C",
+                    "LC_ALL": "C",
+                    "TZ": "UTC",
+                    "PYTHONHASHSEED": "0",
+                },
+                stdout_limit=FLINT_LINEAR_STDOUT_LIMIT,
+                stderr_limit=FLINT_LINEAR_STDERR_LIMIT,
+            )
+        except OSError:
+            return _failure(
+                started,
+                ExecutionStatus.ERROR,
+                "The isolated Python-FLINT worker could not be started.",
+            )
+        operational = _operational_failure(started, completed)
+        if operational is not None:
+            return operational
+        try:
+            values = _parse_worker_output(completed.stdout)
+        except (UnicodeDecodeError, ValueError, ValidationError):
+            return _failure(
+                started,
+                ExecutionStatus.ERROR,
+                (
+                    "The Python-FLINT worker returned output outside its exact "
+                    "bounded protocol; no solution evidence was retained."
+                ),
+            )
+        if python_flint_provider_runtime(refresh=True) != self.runtime:
+            return _failure(
+                started,
+                ExecutionStatus.ERROR,
+                (
+                    "The installed Python-FLINT runtime changed during execution; "
+                    "no solution evidence was retained."
+                ),
+            )
+        return _FlintLinearRun(
+            execution_status=ExecutionStatus.COMPLETED,
+            runtime_ms=_runtime_ms(started),
+            values=values,
+        )
+
+
+class PythonFlintRationalSolutionFindAdapter:
+    """Produce one exact vector candidate without verifying it."""
+
+    def __init__(
+        self,
+        *,
+        linear: LinearArtifactService,
+        runtime: CapabilityProviderRuntime,
+    ) -> None:
+        self.linear = linear
+        self.backend = _PythonFlintBackend(runtime)
+        self._descriptor = CapabilityDescriptor(
+            capability_id="linear.rational_solution.find",
+            version="1",
+            title="Find one exact rational solution",
+            description=(
+                "Use pinned Python-FLINT to return one exact vector for a declared "
+                "finite A x = b system over QQ. A not-found outcome makes no "
+                "consistency conclusion; verify any returned vector separately."
+            ),
+            provider="python-flint",
+            provider_runtime=runtime,
+            modes=(CapabilityMode.EXPLORE,),
+            input_schema=model_schema(LinearRationalSolutionFindRequest),
+            output_schema=model_schema(LinearRationalSolutionFindOutput),
+            tags=(
+                "linear-algebra",
+                "rational",
+                "exact",
+                "solution",
+                "witness",
+                "python-flint",
+            ),
+        )
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        return self._descriptor
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        try:
+            validated = LinearRationalSolutionFindRequest.model_validate(request.input)
+            system_uri = self.linear.put_system(validated.system).artifact_uri
+            resolved = self.linear.resolve_system(system_uri)
+        except (ValidationError, ValueError) as exc:
+            raise CapabilityInvocationError(
+                CapabilityDiagnostic(
+                    code="INVALID_RATIONAL_LINEAR_SYSTEM",
+                    stage="input_validation",
+                    message=str(exc),
+                    path="system",
+                    schema_uri=self.linear.installation.system_schema_uri,
+                    expected=(
+                        "one 1..32 by 1..32 exact rational A x = b system with "
+                        "unique ordered variable names and canonical reduced entries"
+                    ),
+                    hint=(
+                        'Encode each rational as {"num":"integer","den":"positive '
+                        'integer"} and keep coefficient, variable, and RHS dimensions '
+                        "aligned."
+                    ),
+                )
+            ) from exc
+        run = self.backend.run(validated)
+        solution_uri: str | None = None
+        if run.execution_status is ExecutionStatus.COMPLETED and run.values is not None:
+            solution_uri = self.linear.put_solution(
+                system_uri=system_uri,
+                values=run.values,
+                producer=self.backend.runtime,
+                resource_budget=validated.resource_budget,
+            ).artifact_uri
+        output = LinearRationalSolutionFindOutput(
+            status=(
+                "SOLUTION_PRODUCED"
+                if solution_uri is not None
+                else "NO_SOLUTION_PRODUCED"
+            ),
+            system_uri=system_uri,
+            solution_uri=solution_uri,
+            solution=run.values if solution_uri is not None else None,
+            certificate_available=solution_uri is not None,
+            detail=(
+                "Python-FLINT produced one exact vector with all free variables "
+                "set to zero; the relation remains unverified until independent "
+                "replay."
+                if solution_uri is not None
+                else (
+                    run.detail
+                    or "No solution witness was produced; no consistency conclusion "
+                    "follows."
+                )
+            ),
+        )
+        artifact_uris = (
+            (system_uri, solution_uri) if solution_uri is not None else (system_uri,)
+        )
+        relationships = (
+            (
+                CapabilityRelationship(
+                    relation_id="linear.relation.satisfies",
+                    source_artifact_uris=(solution_uri,),
+                    target_artifact_uris=(system_uri,),
+                ),
+            )
+            if solution_uri is not None
+            else ()
+        )
+        return CapabilityResult(
+            capability_id=self.descriptor.capability_id,
+            capability_version=self.descriptor.version,
+            mode=request.mode,
+            execution=Execution(
+                status=run.execution_status,
+                runtime_ms=run.runtime_ms,
+                detail=run.detail,
+            ),
+            output=output.model_dump(mode="json"),
+            scope=CapabilityScope(
+                description="the full declared exact rational A x = b system",
+                parameters={
+                    "declared_scope": "FULL_SYSTEM",
+                    "row_count": resolved.binding.row_count,
+                    "column_count": resolved.binding.column_count,
+                    "variable_order_digest": resolved.binding.variable_order_digest,
+                    "free_variable_policy": "ZERO",
+                    "wall_seconds": validated.resource_budget.wall_seconds,
+                },
+                artifact_uri=system_uri,
+            ),
+            completeness=CapabilityCompleteness(
+                status=(
+                    CapabilityCompletenessStatus.NOT_APPLICABLE
+                    if solution_uri is not None
+                    else CapabilityCompletenessStatus.UNKNOWN
+                ),
+                basis=(
+                    "one directly checkable witness was requested and produced; no "
+                    "enumeration or uniqueness claim is made"
+                    if solution_uri is not None
+                    else "the attempt produced no witness; no consistency or "
+                    "inconsistency conclusion follows"
+                ),
+                assurance_level=(
+                    CapabilityAssuranceLevel.COMPUTED
+                    if run.execution_status is ExecutionStatus.COMPLETED
+                    else CapabilityAssuranceLevel.HEURISTIC
+                ),
+            ),
+            assurance=CapabilityAssurance(
+                level=(
+                    CapabilityAssuranceLevel.COMPUTED
+                    if run.execution_status is ExecutionStatus.COMPLETED
+                    else CapabilityAssuranceLevel.HEURISTIC
+                ),
+                basis=(
+                    "the pinned exact-arithmetic provider produced a bound vector, "
+                    "but provider success does not verify A x = b"
+                    if solution_uri is not None
+                    else (
+                        "the bounded provider attempt completed without witness "
+                        "evidence; no opposite conclusion follows"
+                        if run.execution_status is ExecutionStatus.COMPLETED
+                        else "provider execution did not complete; no mathematical "
+                        "conclusion follows"
+                    )
+                ),
+            ),
+            artifact_uris=artifact_uris,
+            relationships=relationships,
+        )
+
+
+def _parse_worker_output(
+    stdout: bytes,
+) -> tuple[CanonicalRational, ...] | None:
+    if not stdout.endswith(b"\n") or stdout.count(b"\n") != 1:
+        raise ValueError("worker output is not exactly one line")
+    payload: Any = loads_strict_json(stdout[:-1])
+    if (
+        not isinstance(payload, dict)
+        or payload.get("protocol") != FLINT_LINEAR_WORKER_PROTOCOL
+    ):
+        raise ValueError("worker protocol mismatch")
+    status = payload.get("status")
+    if payload.get("backend_version") != PYTHON_FLINT_VERSION:
+        raise ValueError("worker backend version mismatch")
+    if status == "NO_SOLUTION_PRODUCED":
+        if set(payload) != {"protocol", "status", "backend_version"}:
+            raise ValueError("not-found output carries unexpected fields")
+        return None
+    if status != "SOLUTION_PRODUCED" or set(payload) != {
+        "protocol",
+        "status",
+        "backend_version",
+        "values",
+    }:
+        raise ValueError("worker status is invalid")
+    values = payload["values"]
+    if not isinstance(values, list) or not 1 <= len(values) <= 32:
+        raise ValueError("worker solution shape is invalid")
+    return tuple(CanonicalRational.model_validate(value) for value in values)
+
+
+def _operational_failure(
+    started: float,
+    completed: BoundedProcessResult,
+) -> _FlintLinearRun | None:
+    if completed.timed_out:
+        return _failure(
+            started,
+            ExecutionStatus.TIMEOUT,
+            "The bounded Python-FLINT attempt timed out; no conclusion follows.",
+        )
+    if completed.stdout_exceeded or completed.stderr_exceeded:
+        return _failure(
+            started,
+            ExecutionStatus.ERROR,
+            "The Python-FLINT worker exceeded its output limit.",
+        )
+    if completed.returncode != 0 or completed.stderr or not completed.stdout:
+        return _failure(
+            started,
+            ExecutionStatus.ERROR,
+            "The Python-FLINT worker failed; no solution evidence was retained.",
+        )
+    return None
+
+
+def _failure(
+    started: float,
+    status: ExecutionStatus,
+    detail: str,
+) -> _FlintLinearRun:
+    return _FlintLinearRun(
+        execution_status=status,
+        runtime_ms=_runtime_ms(started),
+        detail=detail,
+    )
+
+
+def _runtime_ms(started: float) -> int:
+    return max(0, round((time.monotonic() - started) * 1000))

--- a/src/jacobian/flint_linear_worker.py
+++ b/src/jacobian/flint_linear_worker.py
@@ -1,0 +1,205 @@
+"""Isolated Python-FLINT worker for one exact rational solution candidate."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import re
+import sys
+from fractions import Fraction
+from typing import Any
+
+FLINT_LINEAR_WORKER_PROTOCOL = "jacobian.flint-linear-worker/v1"
+FLINT_LINEAR_INPUT_LIMIT = 1_000_000
+MAX_LINEAR_DIMENSION = 32
+MAX_RATIONAL_DIGITS = 256
+_INTEGER = re.compile(r"^-?(?:0|[1-9][0-9]*)$")
+_VARIABLE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,63}$")
+
+
+class FlintLinearWorkerError(RuntimeError):
+    """One worker request could not produce usable evidence."""
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+def _emit(payload: dict[str, object]) -> None:
+    sys.stdout.write(
+        json.dumps(
+            {"protocol": FLINT_LINEAR_WORKER_PROTOCOL, **payload},
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        + "\n"
+    )
+    sys.stdout.flush()
+
+
+def _strict_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError("duplicate JSON key")
+        result[key] = value
+    return result
+
+
+def _read_request() -> dict[str, Any]:
+    encoded = sys.stdin.buffer.read(FLINT_LINEAR_INPUT_LIMIT + 1)
+    if len(encoded) > FLINT_LINEAR_INPUT_LIMIT:
+        raise FlintLinearWorkerError("FLINT_LINEAR_INPUT_LIMIT_EXCEEDED")
+    try:
+        payload = json.loads(encoded, object_pairs_hook=_strict_object)
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+        raise FlintLinearWorkerError("FLINT_LINEAR_INPUT_INVALID") from exc
+    if not isinstance(payload, dict):
+        raise FlintLinearWorkerError("FLINT_LINEAR_INPUT_INVALID")
+    return payload
+
+
+def _rational(value: Any) -> Fraction:
+    if not isinstance(value, dict) or set(value) != {"num", "den"}:
+        raise FlintLinearWorkerError("FLINT_LINEAR_SYSTEM_INVALID")
+    numerator = value["num"]
+    denominator = value["den"]
+    if (
+        not isinstance(numerator, str)
+        or not isinstance(denominator, str)
+        or _INTEGER.fullmatch(numerator) is None
+        or _INTEGER.fullmatch(denominator) is None
+        or len(numerator.lstrip("-")) > MAX_RATIONAL_DIGITS
+        or len(denominator.lstrip("-")) > MAX_RATIONAL_DIGITS
+    ):
+        raise FlintLinearWorkerError("FLINT_LINEAR_SYSTEM_INVALID")
+    try:
+        result = Fraction(int(numerator), int(denominator))
+    except (ValueError, ZeroDivisionError) as exc:
+        raise FlintLinearWorkerError("FLINT_LINEAR_SYSTEM_INVALID") from exc
+    if str(result.numerator) != numerator or str(result.denominator) != denominator:
+        raise FlintLinearWorkerError("FLINT_LINEAR_SYSTEM_INVALID")
+    return result
+
+
+def _validate_system(
+    request: dict[str, Any],
+) -> tuple[list[list[Fraction]], list[Fraction]]:
+    if (
+        set(request) != {"protocol", "system"}
+        or request.get("protocol") != FLINT_LINEAR_WORKER_PROTOCOL
+    ):
+        raise FlintLinearWorkerError("FLINT_LINEAR_INPUT_INVALID")
+    system = request["system"]
+    if not isinstance(system, dict) or set(system) != {
+        "system_schema_version",
+        "domain",
+        "relation",
+        "variables",
+        "coefficients",
+        "rhs",
+    }:
+        raise FlintLinearWorkerError("FLINT_LINEAR_SYSTEM_INVALID")
+    if (
+        system["system_schema_version"] != "1"
+        or system["domain"] != "QQ"
+        or system["relation"] != "AX_EQUALS_B"
+    ):
+        raise FlintLinearWorkerError("FLINT_LINEAR_SYSTEM_INVALID")
+    variables = system["variables"]
+    if (
+        not isinstance(variables, list)
+        or not 1 <= len(variables) <= MAX_LINEAR_DIMENSION
+        or any(
+            not isinstance(variable, str) or _VARIABLE.fullmatch(variable) is None
+            for variable in variables
+        )
+        or len(set(variables)) != len(variables)
+    ):
+        raise FlintLinearWorkerError("FLINT_LINEAR_SYSTEM_INVALID")
+    matrix = system["coefficients"]
+    if not isinstance(matrix, dict) or set(matrix) != {
+        "matrix_schema_version",
+        "domain",
+        "entries",
+    }:
+        raise FlintLinearWorkerError("FLINT_LINEAR_SYSTEM_INVALID")
+    if matrix["matrix_schema_version"] != "1" or matrix["domain"] != "QQ":
+        raise FlintLinearWorkerError("FLINT_LINEAR_SYSTEM_INVALID")
+    entries = matrix["entries"]
+    rhs = system["rhs"]
+    if (
+        not isinstance(entries, list)
+        or not isinstance(rhs, list)
+        or not 1 <= len(entries) <= MAX_LINEAR_DIMENSION
+        or len(entries) != len(rhs)
+        or any(
+            not isinstance(row, list) or len(row) != len(variables) for row in entries
+        )
+    ):
+        raise FlintLinearWorkerError("FLINT_LINEAR_SYSTEM_INVALID")
+    return (
+        [[_rational(value) for value in row] for row in entries],
+        [_rational(value) for value in rhs],
+    )
+
+
+def _run(request: dict[str, Any]) -> dict[str, object]:
+    coefficients, rhs = _validate_system(request)
+    try:
+        flint: Any = importlib.import_module("flint")
+        if getattr(flint, "__version__", None) != "0.9.0":
+            raise FlintLinearWorkerError("FLINT_LINEAR_VERSION_MISMATCH")
+        augmented = flint.fmpq_mat(
+            [
+                [flint.fmpq(value.numerator, value.denominator) for value in row]
+                + [flint.fmpq(bound.numerator, bound.denominator)]
+                for row, bound in zip(coefficients, rhs, strict=True)
+            ]
+        )
+        reduced, _ = augmented.rref()
+    except (AttributeError, ImportError, OSError, RuntimeError, TypeError) as exc:
+        raise FlintLinearWorkerError("FLINT_LINEAR_EXECUTION_FAILED") from exc
+
+    column_count = len(coefficients[0])
+    values = [flint.fmpq(0) for _ in range(column_count)]
+    for row_index in range(reduced.nrows()):
+        pivot = next(
+            (
+                column
+                for column in range(column_count)
+                if reduced[row_index, column] != 0
+            ),
+            None,
+        )
+        if pivot is None:
+            if reduced[row_index, column_count] != 0:
+                return {
+                    "status": "NO_SOLUTION_PRODUCED",
+                    "backend_version": "0.9.0",
+                }
+            continue
+        values[pivot] = reduced[row_index, column_count]
+
+    return {
+        "status": "SOLUTION_PRODUCED",
+        "backend_version": "0.9.0",
+        "values": [
+            {"num": str(value.numerator), "den": str(value.denominator)}
+            for value in values
+        ],
+    }
+
+
+def main() -> int:
+    try:
+        result = _run(_read_request())
+    except FlintLinearWorkerError as exc:
+        _emit({"error_code": exc.code})
+        return 2
+    _emit(result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jacobian/kernel.py
+++ b/src/jacobian/kernel.py
@@ -34,6 +34,7 @@ from jacobian.finite_partition import (
     FinitePartitionInstallation,
     install_finite_partition,
 )
+from jacobian.flint_linear import install_python_flint_linear_capability
 from jacobian.graph_capabilities import GraphInstallation, install_graph_capabilities
 from jacobian.lean import LeanService
 from jacobian.lean_declarations import (
@@ -43,6 +44,11 @@ from jacobian.lean_declarations import (
 from jacobian.lean_exploration import (
     LeanExplorationInstallation,
     install_lean_exploration_capabilities,
+)
+from jacobian.linear import LinearArtifactService, install_linear_artifacts
+from jacobian.linear_capabilities import (
+    LinearRationalSolutionCheckerInstallation,
+    install_linear_rational_solution_checker,
 )
 from jacobian.matrix_capabilities import (
     MatrixInstallation,
@@ -62,6 +68,7 @@ from jacobian.provider_runtime import (
     cvc5_provider_runtime,
     drat_trim_provider_runtime,
     lean_provider_runtime,
+    python_flint_provider_runtime,
 )
 from jacobian.references import (
     LeanCheckerInstallation,
@@ -122,6 +129,11 @@ class JacobianKernel:
             self.artifacts,
         )
         self.smt: SmtArtifactService = install_smt_artifacts(
+            self.store,
+            self.schemas,
+            self.artifacts,
+        )
+        self.linear: LinearArtifactService = install_linear_artifacts(
             self.store,
             self.schemas,
             self.artifacts,
@@ -265,6 +277,39 @@ class JacobianKernel:
         )
         if smt_proof_adapter is not None:
             self.register_capability(smt_proof_adapter)
+        self.linear_solution_checker: LinearRationalSolutionCheckerInstallation
+        linear_verification_adapter, self.linear_solution_checker = (
+            install_linear_rational_solution_checker(
+                self.store,
+                self.schemas,
+                self.artifacts,
+                self.linear,
+                self.verification,
+                self.checkers,
+                authorize_checker=install_references,
+            )
+        )
+        if linear_verification_adapter is not None:
+            self.register_capability(linear_verification_adapter)
+        self.python_flint_runtime: CapabilityProviderRuntime = (
+            python_flint_provider_runtime()
+        )
+        if (
+            self.python_flint_runtime.availability
+            is CapabilityProviderAvailability.AVAILABLE
+        ):
+            try:
+                linear_find_adapter = install_python_flint_linear_capability(
+                    self.linear,
+                    self.python_flint_runtime,
+                )
+            except (OSError, ValueError) as exc:
+                _LOGGER.warning(
+                    "Python-FLINT rational solution exploration is not installed: %s",
+                    exc,
+                )
+            else:
+                self.register_capability(linear_find_adapter)
         self.cadical_runtime: CapabilityProviderRuntime = cadical_provider_runtime()
         if (
             self.cadical_runtime.availability

--- a/src/jacobian/linear.py
+++ b/src/jacobian/linear.py
@@ -1,0 +1,235 @@
+"""Durable exact-rational linear systems and candidate solutions."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic import ValidationError
+
+from jacobian.artifacts import ArtifactService
+from jacobian.contracts.artifacts import ArtifactPutResult
+from jacobian.contracts.capabilities import CapabilityProviderRuntime
+from jacobian.contracts.linear import (
+    LinearRationalResourceBudget,
+    LinearRationalSolutionArtifact,
+    LinearRationalSystem,
+    LinearSystemBinding,
+    linear_variable_order_digest,
+)
+from jacobian.schema_registry import SchemaRegistry, SchemaRegistryError
+from jacobian.store import ArtifactStore, StoredArtifact, StoreError
+
+
+class LinearArtifactError(ValueError):
+    """A stored value does not satisfy the rational linear-system contract."""
+
+
+@dataclass(frozen=True, slots=True)
+class LinearArtifactInstallation:
+    semantics_uri: str
+    system_schema_uri: str
+    solution_schema_uri: str
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedLinearSystem:
+    artifact: StoredArtifact
+    system: LinearRationalSystem
+    binding: LinearSystemBinding
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedLinearSolution:
+    artifact: StoredArtifact
+    solution: LinearRationalSolutionArtifact
+    system_artifact: StoredArtifact
+    system: LinearRationalSystem
+
+
+class LinearArtifactService:
+    """Materialize exact systems and unverified vectors with strict bindings."""
+
+    def __init__(
+        self,
+        store: ArtifactStore,
+        schemas: SchemaRegistry,
+        artifacts: ArtifactService,
+        installation: LinearArtifactInstallation,
+    ) -> None:
+        self.store = store
+        self.schemas = schemas
+        self.artifacts = artifacts
+        self.installation = installation
+
+    def put_system(
+        self, system: LinearRationalSystem | dict[str, Any]
+    ) -> ArtifactPutResult:
+        """Validate and materialize one canonical rational system."""
+
+        validated = LinearRationalSystem.model_validate(system)
+        return self.artifacts.put(
+            schema_uri=self.installation.system_schema_uri,
+            semantics_uri=self.installation.semantics_uri,
+            payload=validated.model_dump(mode="json"),
+            summary=(
+                "exact rational linear system: "
+                f"{len(validated.coefficients.entries)} equations, "
+                f"{len(validated.variables)} variables"
+            ),
+        )
+
+    def resolve_system(self, system_uri: str) -> ResolvedLinearSystem:
+        """Resolve one valid system and bind its exact stored identity."""
+
+        try:
+            artifact = self.store.get(system_uri)
+        except StoreError as exc:
+            raise LinearArtifactError(
+                "source is not an available rational linear-system artifact"
+            ) from exc
+        if (
+            artifact.manifest.schema_uri != self.installation.system_schema_uri
+            or artifact.manifest.semantics_uri != self.installation.semantics_uri
+        ):
+            raise LinearArtifactError("source is not a rational linear-system artifact")
+        try:
+            normalized = self.schemas.validate(
+                self.installation.system_schema_uri,
+                artifact.payload,
+            )
+            system = LinearRationalSystem.model_validate(normalized)
+        except (SchemaRegistryError, ValueError, ValidationError) as exc:
+            raise LinearArtifactError(
+                "source is not a valid rational linear-system artifact"
+            ) from exc
+        binding = LinearSystemBinding(
+            system_artifact_uri=artifact.artifact_uri,
+            system_object_digest=artifact.manifest.object_digest,
+            system_payload_digest=artifact.manifest.payload_digest,
+            variable_order_digest=linear_variable_order_digest(system.variables),
+            row_count=len(system.coefficients.entries),
+            column_count=len(system.variables),
+        )
+        return ResolvedLinearSystem(
+            artifact=artifact,
+            system=system,
+            binding=binding,
+        )
+
+    def put_solution(
+        self,
+        *,
+        system_uri: str,
+        values: Sequence[Any],
+        producer: CapabilityProviderRuntime,
+        resource_budget: LinearRationalResourceBudget | dict[str, Any],
+    ) -> ArtifactPutResult:
+        """Materialize one total vector candidate without checking the relation."""
+
+        resolved = self.resolve_system(system_uri)
+        solution = LinearRationalSolutionArtifact(
+            system=resolved.binding,
+            values=tuple(values),
+            producer=producer,
+            resource_budget=LinearRationalResourceBudget.model_validate(
+                resource_budget
+            ),
+        )
+        return self.artifacts.put(
+            schema_uri=self.installation.solution_schema_uri,
+            semantics_uri=self.installation.semantics_uri,
+            payload=solution.model_dump(mode="json"),
+            parents=(resolved.artifact.artifact_uri,),
+            summary="unverified exact rational solution candidate",
+        )
+
+    def resolve_solution(self, solution_uri: str) -> ResolvedLinearSolution:
+        """Resolve a vector whose payload and lineage bind one exact system."""
+
+        try:
+            artifact = self.store.get(solution_uri)
+        except StoreError as exc:
+            raise LinearArtifactError(
+                "source is not an available rational solution artifact"
+            ) from exc
+        if (
+            artifact.manifest.schema_uri != self.installation.solution_schema_uri
+            or artifact.manifest.semantics_uri != self.installation.semantics_uri
+        ):
+            raise LinearArtifactError("source is not a rational solution artifact")
+        try:
+            normalized = self.schemas.validate(
+                self.installation.solution_schema_uri,
+                artifact.payload,
+            )
+            solution = LinearRationalSolutionArtifact.model_validate(normalized)
+        except (SchemaRegistryError, ValueError, ValidationError) as exc:
+            raise LinearArtifactError(
+                "source is not a valid rational solution artifact"
+            ) from exc
+        resolved_system = self.resolve_system(solution.system.system_artifact_uri)
+        if solution.system != resolved_system.binding:
+            raise LinearArtifactError(
+                "solution binding does not match its exact rational system"
+            )
+        if resolved_system.artifact.artifact_uri not in artifact.manifest.parents:
+            raise LinearArtifactError(
+                "solution is missing its rational linear-system parent"
+            )
+        return ResolvedLinearSolution(
+            artifact=artifact,
+            solution=solution,
+            system_artifact=resolved_system.artifact,
+            system=resolved_system.system,
+        )
+
+
+def install_linear_artifacts(
+    store: ArtifactStore,
+    schemas: SchemaRegistry,
+    artifacts: ArtifactService,
+) -> LinearArtifactService:
+    """Register exact rational system and candidate-vector contracts."""
+
+    semantics_uri = store.register_descriptor(
+        kind="semantics",
+        name="jacobian.linear-rational-system",
+        version="1",
+        definition={
+            "domain": "finite linear systems over the rational field QQ",
+            "relation": "A candidate x supports the exact claim A x = b",
+            "variable_order": (
+                "coefficient columns and candidate entries follow the declared "
+                "ordered unique variable list"
+            ),
+            "candidate": (
+                "a total exact rational vector bound by payload and lineage to one "
+                "system; producing or storing it does not verify the relation"
+            ),
+            "not_found": (
+                "failure to produce a candidate makes no consistency or "
+                "inconsistency claim"
+            ),
+            "limits": {
+                "maximum_rows": 32,
+                "maximum_columns": 32,
+                "maximum_decimal_digits_per_rational_component": 256,
+            },
+        },
+    )
+    installation = LinearArtifactInstallation(
+        semantics_uri=semantics_uri,
+        system_schema_uri=schemas.register_model(
+            name="jacobian.linear-rational-system",
+            version="1",
+            model=LinearRationalSystem,
+        ),
+        solution_schema_uri=schemas.register_model(
+            name="jacobian.linear-rational-solution",
+            version="1",
+            model=LinearRationalSolutionArtifact,
+        ),
+    )
+    return LinearArtifactService(store, schemas, artifacts, installation)

--- a/src/jacobian/linear_capabilities.py
+++ b/src/jacobian/linear_capabilities.py
@@ -1,0 +1,319 @@
+"""Independent verification capability for exact rational solution vectors."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from jacobian.artifacts import ArtifactService
+from jacobian.capabilities import CapabilityAdapter, CapabilityInvocationError
+from jacobian.contracts.capabilities import (
+    CapabilityAssurance,
+    CapabilityAssuranceLevel,
+    CapabilityCompleteness,
+    CapabilityCompletenessStatus,
+    CapabilityDescriptor,
+    CapabilityDiagnostic,
+    CapabilityMode,
+    CapabilityRequest,
+    CapabilityResult,
+    CapabilityScope,
+)
+from jacobian.contracts.evidence import (
+    EvidenceBindings,
+    WitnessEnvelope,
+    WitnessRole,
+)
+from jacobian.contracts.linear import (
+    LinearRationalSolutionVerificationOutput,
+    LinearRationalSolutionVerificationRequest,
+)
+from jacobian.contracts.results import Conclusion, ExecutionStatus, Verification
+from jacobian.linear import LinearArtifactError, LinearArtifactService
+from jacobian.provider_runtime import known_provider_runtime
+from jacobian.registry import CheckerRegistry
+from jacobian.schema_registry import SchemaRegistry, model_schema
+from jacobian.store import ArtifactStore, StoreError
+from jacobian.verification import VerificationService
+
+
+@dataclass(frozen=True, slots=True)
+class LinearRationalSolutionCheckerInstallation:
+    witness_schema_uri: str
+    checker_id: str | None
+
+
+def install_linear_rational_solution_checker(
+    store: ArtifactStore,
+    schemas: SchemaRegistry,
+    artifacts: ArtifactService,
+    linear: LinearArtifactService,
+    verification: VerificationService,
+    checkers: CheckerRegistry,
+    *,
+    authorize_checker: bool,
+) -> tuple[
+    CapabilityAdapter | None,
+    LinearRationalSolutionCheckerInstallation,
+]:
+    """Install evidence schema and optionally authorize independent replay."""
+
+    witness_schema_uri = schemas.register_model(
+        name="jacobian.witness-envelope",
+        version="1",
+        model=WitnessEnvelope,
+    )
+    checker_id = None
+    if authorize_checker:
+        checker_id = checkers.authorize(
+            name="exact rational linear-solution replay checker",
+            entrypoint="jacobian_checkers.linear:check_rational_solution",
+            evidence_kind="WITNESS",
+            format_id="linear.rational_solution",
+            format_version="1",
+            claim_schema_uris=(linear.installation.system_schema_uri,),
+            semantics_uris=(linear.installation.semantics_uri,),
+            candidate_schema_uris=(linear.installation.solution_schema_uri,),
+            reason="bundled independent exact rational equation checker",
+        ).checker_id
+    installation = LinearRationalSolutionCheckerInstallation(
+        witness_schema_uri=witness_schema_uri,
+        checker_id=checker_id,
+    )
+    adapter: CapabilityAdapter | None = None
+    if checker_id is not None:
+        adapter = LinearRationalSolutionVerificationAdapter(
+            store=store,
+            artifacts=artifacts,
+            linear=linear,
+            verification=verification,
+            installation=installation,
+        )
+    return adapter, installation
+
+
+class LinearRationalSolutionVerificationAdapter:
+    """Verify ``A x = b``; rejection never proves inconsistency."""
+
+    def __init__(
+        self,
+        *,
+        store: ArtifactStore,
+        artifacts: ArtifactService,
+        linear: LinearArtifactService,
+        verification: VerificationService,
+        installation: LinearRationalSolutionCheckerInstallation,
+    ) -> None:
+        checker_id = installation.checker_id
+        if checker_id is None:
+            raise ValueError("rational solution checker is not authorized")
+        self.store = store
+        self.artifacts = artifacts
+        self.linear = linear
+        self.verification = verification
+        self.installation = installation
+        self._descriptor = CapabilityDescriptor(
+            capability_id="linear.rational_solution.verify",
+            version="1",
+            title="Verify one exact rational solution",
+            description=(
+                "Independently replay every equation of one exact stored A x = b "
+                "system against its bound total rational vector. Rejection does not "
+                "establish inconsistency."
+            ),
+            provider="jacobian.linear",
+            provider_runtime=known_provider_runtime(
+                "jacobian.linear",
+                features=(
+                    "exact-rational-equation-replay",
+                    "total-vector",
+                    "clean-process-checker",
+                ),
+                checker_ids=(checker_id,),
+            ),
+            modes=(CapabilityMode.VERIFY,),
+            input_schema=model_schema(LinearRationalSolutionVerificationRequest),
+            output_schema=model_schema(LinearRationalSolutionVerificationOutput),
+            tags=(
+                "linear-algebra",
+                "rational",
+                "solution",
+                "witness",
+                "verification",
+            ),
+        )
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        return self._descriptor
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        validated = LinearRationalSolutionVerificationRequest.model_validate(
+            request.input
+        )
+        try:
+            resolved = self.linear.resolve_solution(validated.solution_uri)
+            semantics = self.store.get(self.linear.installation.semantics_uri)
+        except (LinearArtifactError, StoreError) as exc:
+            raise CapabilityInvocationError(
+                CapabilityDiagnostic(
+                    code="INVALID_RATIONAL_SOLUTION",
+                    stage="artifact_resolution",
+                    message=str(exc),
+                    path="solution_uri",
+                    schema_uri=self.linear.installation.solution_schema_uri,
+                    expected=(
+                        "a valid total exact rational vector bound by payload and "
+                        "lineage to one rational linear-system artifact"
+                    ),
+                    hint=(
+                        "Use linear.rational_solution.find or materialize a candidate "
+                        "with the registered solution schema against the intended "
+                        "system."
+                    ),
+                )
+            ) from exc
+
+        checker_id = self.installation.checker_id
+        assert checker_id is not None
+        bindings = EvidenceBindings(
+            claim_digest=resolved.system_artifact.manifest.object_digest,
+            semantics_digest=semantics.manifest.object_digest,
+            candidate_digest=resolved.artifact.manifest.object_digest,
+        )
+        witness = WitnessEnvelope(
+            witness_format="linear.rational_solution",
+            format_version="1",
+            role=WitnessRole.SUPPORTS_CLAIM,
+            bindings=bindings,
+            payload={
+                "system_uri": resolved.system_artifact.artifact_uri,
+                "solution_uri": resolved.artifact.artifact_uri,
+            },
+        )
+        witness_artifact = self.artifacts.put(
+            schema_uri=self.installation.witness_schema_uri,
+            semantics_uri=self.linear.installation.semantics_uri,
+            payload=witness.model_dump(mode="json"),
+            parents=(
+                resolved.system_artifact.artifact_uri,
+                resolved.artifact.artifact_uri,
+            ),
+            summary="rational linear-solution verification witness",
+        )
+        checked = self.verification.verify_witness(
+            claim_uri=resolved.system_artifact.artifact_uri,
+            candidate_uri=resolved.artifact.artifact_uri,
+            witness_uri=witness_artifact.artifact_uri,
+            checker_id=checker_id,
+            include_artifact_metadata=True,
+        )
+        verified = (
+            checked.execution.status is ExecutionStatus.COMPLETED
+            and checked.conclusion is Conclusion.TRUE
+            and checked.assurance.verification is Verification.VERIFIED
+            and checked.verification_record_uri is not None
+        )
+        status: Literal[
+            "VERIFIED_SOLUTION",
+            "REJECTED",
+            "TIMEOUT",
+            "CANCELLED",
+            "ERROR",
+        ]
+        if verified:
+            status = "VERIFIED_SOLUTION"
+        elif checked.execution.status is ExecutionStatus.COMPLETED:
+            status = "REJECTED"
+        elif checked.execution.status is ExecutionStatus.TIMEOUT:
+            status = "TIMEOUT"
+        elif checked.execution.status is ExecutionStatus.CANCELLED:
+            status = "CANCELLED"
+        else:
+            status = "ERROR"
+        detail = checked.execution.detail
+        if detail is None and checked.input.errors:
+            detail = checked.input.errors[0]
+        if detail is None:
+            detail = (
+                "the authorized checker accepted every exact bound equation"
+                if verified
+                else "the candidate was not independently accepted"
+            )
+        output = LinearRationalSolutionVerificationOutput(
+            status=status,
+            conclusion="TRUE" if verified else "UNKNOWN",
+            system_uri=resolved.system_artifact.artifact_uri,
+            solution_uri=resolved.artifact.artifact_uri,
+            witness_uri=witness_artifact.artifact_uri,
+            checker_id=checker_id,
+            verification_record_uri=(
+                checked.verification_record_uri if verified else None
+            ),
+            detail=detail,
+        )
+        record_uri = checked.verification_record_uri if verified else None
+        artifact_uris = [
+            resolved.system_artifact.artifact_uri,
+            resolved.artifact.artifact_uri,
+            witness_artifact.artifact_uri,
+        ]
+        if record_uri is not None:
+            artifact_uris.append(record_uri)
+        assurance_level = (
+            CapabilityAssuranceLevel.VERIFIED
+            if verified
+            else (
+                CapabilityAssuranceLevel.COMPUTED
+                if checked.execution.status is ExecutionStatus.COMPLETED
+                else CapabilityAssuranceLevel.HEURISTIC
+            )
+        )
+        return CapabilityResult(
+            capability_id=self.descriptor.capability_id,
+            capability_version=self.descriptor.version,
+            mode=request.mode,
+            execution=checked.execution,
+            output=output.model_dump(mode="json"),
+            scope=CapabilityScope(
+                description="the full exact rational A x = b system bound by the vector",
+                parameters={
+                    "declared_scope": "FULL_SYSTEM",
+                    "row_count": len(resolved.system.coefficients.entries),
+                    "column_count": len(resolved.system.variables),
+                    "variable_order_digest": (
+                        resolved.solution.system.variable_order_digest
+                    ),
+                },
+                artifact_uri=resolved.system_artifact.artifact_uri,
+            ),
+            completeness=CapabilityCompleteness(
+                status=CapabilityCompletenessStatus.NOT_APPLICABLE,
+                basis=(
+                    "direct equation replay checks one vector and makes no uniqueness "
+                    "or inconsistency completeness claim"
+                ),
+                assurance_level=(
+                    CapabilityAssuranceLevel.COMPUTED
+                    if checked.execution.status is ExecutionStatus.COMPLETED
+                    else CapabilityAssuranceLevel.HEURISTIC
+                ),
+            ),
+            assurance=CapabilityAssurance(
+                level=assurance_level,
+                basis=(
+                    "accepted in a clean process by the operator-authorized "
+                    "independent exact rational equation checker"
+                    if verified
+                    else (
+                        "checker replay completed without accepting the vector; no "
+                        "opposite conclusion follows"
+                        if checked.execution.status is ExecutionStatus.COMPLETED
+                        else "checker execution did not complete; no mathematical "
+                        "conclusion follows"
+                    )
+                ),
+                verification_record_uri=record_uri,
+            ),
+            artifact_uris=tuple(artifact_uris),
+        )

--- a/src/jacobian/provider_measurements.py
+++ b/src/jacobian/provider_measurements.py
@@ -79,6 +79,13 @@ elif provider == "cvc5":
         proofs = solver.getProof(backend.ProofComponent.FULL)
         assert len(proofs) == 1
         assert solver.proofToString(proofs[0], backend.ProofFormat.ALETHE)
+elif provider == "python-flint":
+    import flint as backend
+    if operation == "reproduction":
+        augmented = backend.fmpq_mat([[2, 1, 5], [1, -1, 1]])
+        reduced, rank = augmented.rref()
+        assert rank == 2
+        assert reduced == backend.fmpq_mat([[1, 0, 2], [0, 1, 1]])
 else:
     import jacobian.canonical as backend
     if operation == "reproduction":

--- a/src/jacobian/provider_runtime.py
+++ b/src/jacobian/provider_runtime.py
@@ -31,6 +31,7 @@ CVC5_VERSION = "1.3.4"
 DRAT_TRIM_RELEASE_TAG = "v05.22.2023"
 DRAT_TRIM_SOURCE_COMMIT = "2e5e29cb0019d5cfd547d4208dca1b3ec290349f"
 DRAT_TRIM_SOURCE_REPOSITORY = "https://github.com/marijnheule/drat-trim"
+PYTHON_FLINT_VERSION = "0.9.0"
 
 
 class ProviderRuntimeError(RuntimeError):
@@ -96,8 +97,7 @@ def _jacobian_identity() -> tuple[str, str, tuple[str, ...]]:
     return distribution.version, digest, _license_files(distribution)
 
 
-@cache
-def _python_distribution_identity(
+def _inspect_python_distribution_identity(
     distribution_name: str,
     import_name: str,
     required_attributes: tuple[str, ...],
@@ -118,6 +118,19 @@ def _python_distribution_identity(
             f"the {distribution_name} provider is not installed and healthy"
         ) from exc
     return distribution.version, digest, _license_files(distribution)
+
+
+@cache
+def _python_distribution_identity(
+    distribution_name: str,
+    import_name: str,
+    required_attributes: tuple[str, ...],
+) -> tuple[str, str, tuple[str, ...]]:
+    return _inspect_python_distribution_identity(
+        distribution_name,
+        import_name,
+        required_attributes,
+    )
 
 
 def _unavailable_runtime(
@@ -224,14 +237,18 @@ def python_distribution_provider_runtime(
     features: tuple[str, ...] = (),
     checker_ids: tuple[str, ...] = (),
     configuration: Mapping[str, Any] | None = None,
+    refresh: bool = False,
 ) -> CapabilityProviderRuntime:
     """Identify one installed Python distribution without trusting an import alone."""
 
     try:
-        version, digest, license_files = _python_distribution_identity(
-            distribution_name,
-            import_name,
-            required_attributes,
+        identity = (
+            _inspect_python_distribution_identity
+            if refresh
+            else _python_distribution_identity
+        )
+        version, digest, license_files = identity(
+            distribution_name, import_name, required_attributes
         )
     except ProviderRuntimeError:
         return _unavailable_runtime(
@@ -646,6 +663,49 @@ def known_provider_runtime(
         checker_ids=checker_ids,
         configuration=configuration,
     )
+
+
+def python_flint_provider_runtime(
+    *,
+    refresh: bool = False,
+) -> CapabilityProviderRuntime:
+    """Identify the exact optional Python-FLINT compatibility profile."""
+
+    runtime = python_distribution_provider_runtime(
+        "python-flint",
+        distribution_name="python-flint",
+        import_name="flint",
+        required_attributes=("fmpq", "fmpq_mat"),
+        install_tier=CapabilityInstallTier.T1,
+        license_id="MIT AND LGPL-3.0-or-later",
+        features=(
+            "exact-rational",
+            "dense-matrix",
+            "reduced-row-echelon-form",
+        ),
+        configuration={
+            "domain": "QQ",
+            "operation": "fmpq_mat.rref",
+            "maximum_rows": 32,
+            "maximum_columns": 32,
+            "free_variable_policy": "ZERO",
+        },
+        refresh=refresh,
+    )
+    if (
+        runtime.availability is CapabilityProviderAvailability.AVAILABLE
+        and runtime.version != PYTHON_FLINT_VERSION
+    ):
+        return _unavailable_runtime(
+            provider="python-flint",
+            install_tier=CapabilityInstallTier.T1,
+            license_id="MIT AND LGPL-3.0-or-later",
+            diagnostic=(
+                "Python-FLINT is installed but does not match the pinned "
+                f"{PYTHON_FLINT_VERSION} compatibility profile."
+            ),
+        )
+    return runtime
 
 
 def lean_provider_runtime(

--- a/src/jacobian_checkers/linear.py
+++ b/src/jacobian_checkers/linear.py
@@ -1,0 +1,381 @@
+"""Independent exact replay for rational linear-solution witnesses.
+
+This module intentionally uses only the Python standard library. It does not
+import Jacobian contracts, Python-FLINT, SymPy, or any producer implementation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from fractions import Fraction
+from typing import Any
+
+_ARTIFACT_URI = re.compile(r"^artifact://sha256/[0-9a-f]{64}$")
+_DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
+_INTEGER = re.compile(r"^-?(?:0|[1-9][0-9]*)$")
+_VARIABLE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,63}$")
+_ARTIFACT_KEYS = {
+    "artifact_uri",
+    "object_digest",
+    "payload_digest",
+    "schema_uri",
+    "semantics_uri",
+    "parents",
+    "payload",
+}
+_BINDING_KEYS = {
+    "claim_digest",
+    "semantics_digest",
+    "candidate_digest",
+    "scope_digest",
+    "encoding_digest",
+}
+_SYSTEM_BINDING_KEYS = {
+    "binding_version",
+    "system_artifact_uri",
+    "system_object_digest",
+    "system_payload_digest",
+    "variable_order_digest",
+    "row_count",
+    "column_count",
+}
+_PROVIDER_KEYS = {
+    "runtime_version",
+    "provider",
+    "availability",
+    "version",
+    "digest",
+    "digest_kind",
+    "platform",
+    "install_tier",
+    "license_id",
+    "license_files",
+    "features",
+    "checker_ids",
+    "configuration",
+    "diagnostic",
+}
+MAX_LINEAR_DIMENSION = 32
+MAX_RATIONAL_DIGITS = 256
+
+
+def _reject(detail: str) -> dict[str, Any]:
+    return {
+        "accepted": False,
+        "conclusion": "UNKNOWN",
+        "arithmetic": "EXACT_RATIONAL",
+        "method": "DIRECT_WITNESS",
+        "coverage": "NOT_APPLICABLE",
+        "detail": detail,
+    }
+
+
+def _sha256(value: bytes) -> str:
+    return "sha256:" + hashlib.sha256(value).hexdigest()
+
+
+def _canonical_json(value: object) -> bytes:
+    # Linear artifacts contain only ASCII strings, lists, and maps. For that
+    # subset this is byte-identical to Jacobian's canonical JSON encoder.
+    return json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _valid_artifact(value: object) -> bool:
+    if not isinstance(value, dict) or set(value) != _ARTIFACT_KEYS:
+        return False
+    if (
+        not isinstance(value["artifact_uri"], str)
+        or _ARTIFACT_URI.fullmatch(value["artifact_uri"]) is None
+        or not isinstance(value["object_digest"], str)
+        or _DIGEST.fullmatch(value["object_digest"]) is None
+        or not isinstance(value["payload_digest"], str)
+        or _DIGEST.fullmatch(value["payload_digest"]) is None
+        or not isinstance(value["schema_uri"], str)
+        or _ARTIFACT_URI.fullmatch(value["schema_uri"]) is None
+        or not isinstance(value["semantics_uri"], str)
+        or _ARTIFACT_URI.fullmatch(value["semantics_uri"]) is None
+    ):
+        return False
+    parents = value["parents"]
+    return (
+        isinstance(parents, list)
+        and len(parents) == len(set(parents))
+        and all(
+            isinstance(parent, str) and _ARTIFACT_URI.fullmatch(parent) is not None
+            for parent in parents
+        )
+    )
+
+
+def _valid_bindings(value: object) -> bool:
+    if not isinstance(value, dict) or set(value) != _BINDING_KEYS:
+        return False
+    if value["scope_digest"] is not None or value["encoding_digest"] is not None:
+        return False
+    return all(
+        isinstance(value[key], str) and _DIGEST.fullmatch(value[key]) is not None
+        for key in ("claim_digest", "semantics_digest", "candidate_digest")
+    )
+
+
+def _rational(value: object) -> Fraction:
+    if not isinstance(value, dict) or set(value) != {"num", "den"}:
+        raise ValueError("rational value has an invalid shape")
+    numerator = value["num"]
+    denominator = value["den"]
+    if (
+        not isinstance(numerator, str)
+        or not isinstance(denominator, str)
+        or _INTEGER.fullmatch(numerator) is None
+        or _INTEGER.fullmatch(denominator) is None
+        or len(numerator.lstrip("-")) > MAX_RATIONAL_DIGITS
+        or len(denominator.lstrip("-")) > MAX_RATIONAL_DIGITS
+    ):
+        raise ValueError("rational value is not bounded canonical integer data")
+    result = Fraction(int(numerator), int(denominator))
+    if str(result.numerator) != numerator or str(result.denominator) != denominator:
+        raise ValueError("rational value is not reduced and canonical")
+    return result
+
+
+def _validate_system(
+    payload: object,
+) -> tuple[list[list[Fraction]], list[Fraction], list[str]]:
+    if not isinstance(payload, dict) or set(payload) != {
+        "system_schema_version",
+        "domain",
+        "relation",
+        "variables",
+        "coefficients",
+        "rhs",
+    }:
+        raise ValueError("rational linear system has an invalid shape")
+    if (
+        payload["system_schema_version"] != "1"
+        or payload["domain"] != "QQ"
+        or payload["relation"] != "AX_EQUALS_B"
+    ):
+        raise ValueError("rational linear system uses unsupported semantics")
+    variables = payload["variables"]
+    if (
+        not isinstance(variables, list)
+        or not 1 <= len(variables) <= MAX_LINEAR_DIMENSION
+        or any(
+            not isinstance(variable, str) or _VARIABLE.fullmatch(variable) is None
+            for variable in variables
+        )
+        or len(variables) != len(set(variables))
+    ):
+        raise ValueError("rational linear-system variables are malformed")
+    matrix = payload["coefficients"]
+    if not isinstance(matrix, dict) or set(matrix) != {
+        "matrix_schema_version",
+        "domain",
+        "entries",
+    }:
+        raise ValueError("rational coefficient matrix has an invalid shape")
+    if matrix["matrix_schema_version"] != "1" or matrix["domain"] != "QQ":
+        raise ValueError("rational coefficient matrix uses unsupported semantics")
+    entries = matrix["entries"]
+    rhs = payload["rhs"]
+    if (
+        not isinstance(entries, list)
+        or not isinstance(rhs, list)
+        or not 1 <= len(entries) <= MAX_LINEAR_DIMENSION
+        or len(entries) != len(rhs)
+        or any(
+            not isinstance(row, list) or len(row) != len(variables) for row in entries
+        )
+    ):
+        raise ValueError("rational linear-system dimensions do not match")
+    return (
+        [[_rational(value) for value in row] for row in entries],
+        [_rational(value) for value in rhs],
+        variables,
+    )
+
+
+def _validate_solution(
+    payload: object,
+    *,
+    claim: dict[str, Any],
+    candidate: dict[str, Any],
+    rows: int,
+    columns: int,
+    variables: list[str],
+) -> list[Fraction]:
+    if not isinstance(payload, dict) or set(payload) != {
+        "solution_schema_version",
+        "system",
+        "declared_scope",
+        "values",
+        "producer",
+        "resource_budget",
+        "method",
+    }:
+        raise ValueError("rational solution has an invalid shape")
+    if (
+        payload["solution_schema_version"] != "1"
+        or payload["declared_scope"] != "FULL_SYSTEM"
+        or payload["method"] != "RREF_FREE_VARIABLES_ZERO"
+    ):
+        raise ValueError("rational solution uses unsupported semantics")
+    binding = payload["system"]
+    if not isinstance(binding, dict) or set(binding) != _SYSTEM_BINDING_KEYS:
+        raise ValueError("rational solution system binding is malformed")
+    expected_variable_digest = _sha256(_canonical_json({"variables": variables}))
+    if binding != {
+        "binding_version": "1",
+        "system_artifact_uri": claim["artifact_uri"],
+        "system_object_digest": claim["object_digest"],
+        "system_payload_digest": claim["payload_digest"],
+        "variable_order_digest": expected_variable_digest,
+        "row_count": rows,
+        "column_count": columns,
+    }:
+        raise ValueError("rational solution is not exactly bound to the system")
+    if claim["artifact_uri"] not in candidate["parents"]:
+        raise ValueError("rational solution is missing system lineage")
+    values = payload["values"]
+    if not isinstance(values, list) or len(values) != columns:
+        raise ValueError("rational solution is not a total vector")
+    provider = payload["producer"]
+    if (
+        not isinstance(provider, dict)
+        or set(provider) != _PROVIDER_KEYS
+        or provider["runtime_version"] != "1"
+        or provider["provider"] != "python-flint"
+        or provider["availability"] != "AVAILABLE"
+        or provider["version"] != "0.9.0"
+        or not isinstance(provider["digest"], str)
+        or _DIGEST.fullmatch(provider["digest"]) is None
+        or provider["digest_kind"] != "PYTHON_DISTRIBUTION_RECORD"
+        or provider["install_tier"] != "T1"
+    ):
+        raise ValueError("rational solution producer identity is malformed")
+    budget = payload["resource_budget"]
+    if (
+        not isinstance(budget, dict)
+        or set(budget) != {"budget_version", "wall_seconds"}
+        or budget["budget_version"] != "1"
+        or type(budget["wall_seconds"]) is not int
+        or not 1 <= budget["wall_seconds"] <= 60
+    ):
+        raise ValueError("rational solution resource budget is malformed")
+    return [_rational(value) for value in values]
+
+
+def check_rational_solution(request: dict[str, Any]) -> dict[str, Any]:
+    """Accept only a total exact vector satisfying every bound equation."""
+
+    try:
+        if not isinstance(request, dict) or set(request) != {
+            "request_version",
+            "claim",
+            "candidate",
+            "scope",
+            "witness",
+            "expected_bindings",
+        }:
+            return _reject("malformed checker request")
+        if request["request_version"] != "1" or request["scope"] is not None:
+            return _reject("unsupported checker request")
+        claim = request["claim"]
+        candidate = request["candidate"]
+        witness = request["witness"]
+        if not all(_valid_artifact(item) for item in (claim, candidate, witness)):
+            return _reject("checker artifact metadata is malformed")
+        if not _valid_bindings(request["expected_bindings"]):
+            return _reject("expected evidence bindings are malformed")
+        if (
+            claim["semantics_uri"] != candidate["semantics_uri"]
+            or claim["semantics_uri"] != witness["semantics_uri"]
+        ):
+            return _reject("checker artifacts use different semantics")
+        if claim["payload_digest"] != _sha256(_canonical_json(claim["payload"])):
+            return _reject("linear-system payload digest does not match")
+        if candidate["payload_digest"] != _sha256(
+            _canonical_json(candidate["payload"])
+        ):
+            return _reject("solution payload digest does not match")
+        if witness["payload_digest"] != _sha256(_canonical_json(witness["payload"])):
+            return _reject("linear witness payload digest does not match")
+
+        coefficients, rhs, variables = _validate_system(claim["payload"])
+        values = _validate_solution(
+            candidate["payload"],
+            claim=claim,
+            candidate=candidate,
+            rows=len(coefficients),
+            columns=len(variables),
+            variables=variables,
+        )
+        expected_bindings = request["expected_bindings"]
+        if (
+            expected_bindings["claim_digest"] != claim["object_digest"]
+            or expected_bindings["candidate_digest"] != candidate["object_digest"]
+        ):
+            return _reject("expected evidence bindings do not match artifacts")
+        envelope = witness["payload"]
+        if not isinstance(envelope, dict) or set(envelope) != {
+            "evidence_schema_version",
+            "witness_format",
+            "format_version",
+            "role",
+            "bindings",
+            "payload",
+        }:
+            return _reject("linear witness envelope is malformed")
+        if (
+            envelope["evidence_schema_version"] != "1"
+            or envelope["witness_format"] != "linear.rational_solution"
+            or envelope["format_version"] != "1"
+            or envelope["role"] != "SUPPORTS_CLAIM"
+            or envelope["bindings"] != expected_bindings
+        ):
+            return _reject("linear witness envelope is not exactly bound")
+        witness_payload = envelope["payload"]
+        if not isinstance(witness_payload, dict) or witness_payload != {
+            "system_uri": claim["artifact_uri"],
+            "solution_uri": candidate["artifact_uri"],
+        }:
+            return _reject("linear witness points at different artifacts")
+        if not {
+            claim["artifact_uri"],
+            candidate["artifact_uri"],
+        }.issubset(set(witness["parents"])):
+            return _reject("linear witness is missing required lineage")
+
+        for row, expected in zip(coefficients, rhs, strict=True):
+            if (
+                sum(
+                    (
+                        coefficient * value
+                        for coefficient, value in zip(row, values, strict=True)
+                    ),
+                    Fraction(0),
+                )
+                != expected
+            ):
+                return _reject("candidate does not satisfy every bound equation")
+        return {
+            "accepted": True,
+            "conclusion": "TRUE",
+            "arithmetic": "EXACT_RATIONAL",
+            "method": "DIRECT_WITNESS",
+            "coverage": "NOT_APPLICABLE",
+            "detail": (
+                f"replayed {len(coefficients)} equations over "
+                f"{len(variables)} exact rational variables"
+            ),
+        }
+    except (KeyError, TypeError, ValueError, ZeroDivisionError, OverflowError):
+        return _reject("malformed checker request")

--- a/tests/checkers/test_linear_solution_checker.py
+++ b/tests/checkers/test_linear_solution_checker.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import hashlib
+from copy import deepcopy
+from typing import Any
+
+import pytest
+
+from jacobian.canonical import canonicalize_json
+from jacobian.contracts.capabilities import (
+    CapabilityInstallTier,
+    CapabilityProviderAvailability,
+    CapabilityProviderDigestKind,
+    CapabilityProviderRuntime,
+)
+from jacobian.contracts.evidence import EvidenceBindings, WitnessEnvelope
+from jacobian.contracts.linear import (
+    LinearRationalResourceBudget,
+    LinearRationalSolutionArtifact,
+    LinearRationalSystem,
+    LinearSystemBinding,
+    linear_variable_order_digest,
+)
+from jacobian_checkers.linear import check_rational_solution
+
+_SYSTEM_URI = "artifact://sha256/" + "1" * 64
+_SOLUTION_URI = "artifact://sha256/" + "2" * 64
+_WITNESS_URI = "artifact://sha256/" + "3" * 64
+_SCHEMA_URI = "artifact://sha256/" + "4" * 64
+_SEMANTICS_URI = "artifact://sha256/" + "5" * 64
+_SYSTEM_OBJECT_DIGEST = "sha256:" + "a" * 64
+_SOLUTION_OBJECT_DIGEST = "sha256:" + "b" * 64
+_SEMANTICS_DIGEST = "sha256:" + "c" * 64
+
+
+def _digest(value: object) -> str:
+    return "sha256:" + hashlib.sha256(canonicalize_json(value)).hexdigest()
+
+
+def _q(num: int, den: int = 1) -> dict[str, str]:
+    return {"num": str(num), "den": str(den)}
+
+
+def _producer() -> CapabilityProviderRuntime:
+    return CapabilityProviderRuntime(
+        provider="python-flint",
+        availability=CapabilityProviderAvailability.AVAILABLE,
+        version="0.9.0",
+        digest="sha256:" + "d" * 64,
+        digest_kind=CapabilityProviderDigestKind.PYTHON_DISTRIBUTION_RECORD,
+        platform="linux-x86_64",
+        install_tier=CapabilityInstallTier.T1,
+        license_id="MIT AND LGPL-3.0-or-later",
+        license_files=("python_flint-0.9.0.dist-info/licenses/LICENSE",),
+        features=("exact-rational", "dense-matrix", "reduced-row-echelon-form"),
+        configuration={
+            "distribution": "python-flint",
+            "domain": "QQ",
+            "operation": "fmpq_mat.rref",
+            "maximum_rows": 32,
+            "maximum_columns": 32,
+            "free_variable_policy": "ZERO",
+        },
+    )
+
+
+def _request() -> dict[str, Any]:
+    system = LinearRationalSystem.model_validate(
+        {
+            "variables": ["x", "y"],
+            "coefficients": {
+                "entries": [
+                    [_q(2), _q(1)],
+                    [_q(1), _q(-1)],
+                ]
+            },
+            "rhs": [_q(5), _q(1)],
+        }
+    )
+    system_payload = system.model_dump(mode="json")
+    system_payload_digest = _digest(system_payload)
+    solution = LinearRationalSolutionArtifact(
+        system=LinearSystemBinding(
+            system_artifact_uri=_SYSTEM_URI,
+            system_object_digest=_SYSTEM_OBJECT_DIGEST,
+            system_payload_digest=system_payload_digest,
+            variable_order_digest=linear_variable_order_digest(system.variables),
+            row_count=2,
+            column_count=2,
+        ),
+        values=(_q(2), _q(1)),
+        producer=_producer(),
+        resource_budget=LinearRationalResourceBudget(wall_seconds=5),
+    )
+    solution_payload = solution.model_dump(mode="json")
+    bindings = EvidenceBindings(
+        claim_digest=_SYSTEM_OBJECT_DIGEST,
+        semantics_digest=_SEMANTICS_DIGEST,
+        candidate_digest=_SOLUTION_OBJECT_DIGEST,
+    )
+    witness = WitnessEnvelope(
+        witness_format="linear.rational_solution",
+        format_version="1",
+        role="SUPPORTS_CLAIM",
+        bindings=bindings,
+        payload={
+            "system_uri": _SYSTEM_URI,
+            "solution_uri": _SOLUTION_URI,
+        },
+    )
+    witness_payload = witness.model_dump(mode="json")
+    return {
+        "request_version": "1",
+        "claim": {
+            "artifact_uri": _SYSTEM_URI,
+            "object_digest": _SYSTEM_OBJECT_DIGEST,
+            "payload_digest": system_payload_digest,
+            "schema_uri": _SCHEMA_URI,
+            "semantics_uri": _SEMANTICS_URI,
+            "parents": [],
+            "payload": system_payload,
+        },
+        "candidate": {
+            "artifact_uri": _SOLUTION_URI,
+            "object_digest": _SOLUTION_OBJECT_DIGEST,
+            "payload_digest": _digest(solution_payload),
+            "schema_uri": _SCHEMA_URI,
+            "semantics_uri": _SEMANTICS_URI,
+            "parents": [_SYSTEM_URI],
+            "payload": solution_payload,
+        },
+        "scope": None,
+        "witness": {
+            "artifact_uri": _WITNESS_URI,
+            "object_digest": "sha256:" + "e" * 64,
+            "payload_digest": _digest(witness_payload),
+            "schema_uri": _SCHEMA_URI,
+            "semantics_uri": _SEMANTICS_URI,
+            "parents": [_SOLUTION_URI, _SYSTEM_URI],
+            "payload": witness_payload,
+        },
+        "expected_bindings": bindings.model_dump(mode="json"),
+    }
+
+
+def test_checker_accepts_vector_satisfying_every_exact_equation() -> None:
+    decision = check_rational_solution(_request())
+
+    assert decision["accepted"] is True
+    assert decision["conclusion"] == "TRUE"
+    assert decision["arithmetic"] == "EXACT_RATIONAL"
+    assert decision["method"] == "DIRECT_WITNESS"
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    (
+        "wrong_value",
+        "omit_equation",
+        "change_rhs",
+        "change_variable_order",
+        "partial_vector",
+        "noncanonical_rational",
+        "change_source_uri",
+        "mismatched_bindings",
+        "missing_candidate_lineage",
+        "missing_witness_lineage",
+        "wrong_provider",
+        "extra_candidate_field",
+    ),
+)
+def test_checker_rejects_mutated_or_misbound_solution_evidence(
+    mutation: str,
+) -> None:
+    request = _request()
+    system = request["claim"]["payload"]
+    solution = request["candidate"]["payload"]
+    if mutation == "wrong_value":
+        solution["values"][0] = _q(3)
+        request["candidate"]["payload_digest"] = _digest(solution)
+    elif mutation == "omit_equation":
+        system["coefficients"]["entries"].pop()
+        system["rhs"].pop()
+        request["claim"]["payload_digest"] = _digest(system)
+    elif mutation == "change_rhs":
+        system["rhs"][0] = _q(6)
+        request["claim"]["payload_digest"] = _digest(system)
+    elif mutation == "change_variable_order":
+        system["variables"] = ["y", "x"]
+        request["claim"]["payload_digest"] = _digest(system)
+    elif mutation == "partial_vector":
+        solution["values"].pop()
+        request["candidate"]["payload_digest"] = _digest(solution)
+    elif mutation == "noncanonical_rational":
+        solution["values"][0] = {"num": "4", "den": "2"}
+        request["candidate"]["payload_digest"] = _digest(solution)
+    elif mutation == "change_source_uri":
+        solution["system"]["system_artifact_uri"] = "artifact://sha256/" + "9" * 64
+        request["candidate"]["payload_digest"] = _digest(solution)
+    elif mutation == "mismatched_bindings":
+        request["witness"]["payload"]["bindings"]["candidate_digest"] = (
+            "sha256:" + "9" * 64
+        )
+        request["witness"]["payload_digest"] = _digest(request["witness"]["payload"])
+    elif mutation == "missing_candidate_lineage":
+        request["candidate"]["parents"] = []
+    elif mutation == "missing_witness_lineage":
+        request["witness"]["parents"] = [_SOLUTION_URI]
+    elif mutation == "wrong_provider":
+        solution["producer"]["provider"] = "sympy"
+        request["candidate"]["payload_digest"] = _digest(solution)
+    else:
+        solution["verification"] = "VERIFIED"
+        request["candidate"]["payload_digest"] = _digest(solution)
+
+    decision = check_rational_solution(request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+def test_checker_rejects_valid_vector_rebound_to_another_system() -> None:
+    request = _request()
+    request["claim"]["payload"]["rhs"] = [_q(4), _q(1)]
+    request["claim"]["payload_digest"] = _digest(request["claim"]["payload"])
+    request["claim"]["object_digest"] = "sha256:" + "8" * 64
+    request["expected_bindings"]["claim_digest"] = request["claim"]["object_digest"]
+    request["witness"]["payload"]["bindings"] = deepcopy(request["expected_bindings"])
+    request["witness"]["payload_digest"] = _digest(request["witness"]["payload"])
+
+    decision = check_rational_solution(request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"

--- a/tests/contract/test_linear_contracts.py
+++ b/tests/contract/test_linear_contracts.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.contracts.linear import (
+    LinearRationalSolutionFindRequest,
+    LinearRationalSolutionVerificationOutput,
+    LinearRationalSystem,
+)
+
+
+def _q(num: int, den: int = 1) -> dict[str, str]:
+    return {"num": str(num), "den": str(den)}
+
+
+def _system() -> dict[str, object]:
+    return {
+        "variables": ["x", "y"],
+        "coefficients": {
+            "entries": [
+                [_q(2), _q(1)],
+                [_q(1), _q(-1)],
+            ]
+        },
+        "rhs": [_q(5), _q(1)],
+    }
+
+
+def test_linear_system_requires_exact_matching_dimensions() -> None:
+    system = LinearRationalSystem.model_validate(_system())
+    assert system.variables == ("x", "y")
+    assert len(system.coefficients.entries) == len(system.rhs) == 2
+
+    malformed = _system()
+    malformed["rhs"] = [_q(5)]
+    with pytest.raises(ValidationError, match="right-hand side"):
+        LinearRationalSystem.model_validate(malformed)
+
+    malformed = _system()
+    malformed["variables"] = ["x"]
+    with pytest.raises(ValidationError, match="variable"):
+        LinearRationalSystem.model_validate(malformed)
+
+
+def test_linear_find_request_rejects_ambiguous_or_oversized_rationals() -> None:
+    noncanonical = _system()
+    noncanonical["rhs"] = [{"num": "2", "den": "2"}, _q(1)]
+    with pytest.raises(ValidationError, match="reduced"):
+        LinearRationalSolutionFindRequest.model_validate(
+            {"system": noncanonical, "resource_budget": {"wall_seconds": 5}}
+        )
+
+    oversized = _system()
+    oversized["rhs"] = [
+        {"num": "1" * 257, "den": "1"},
+        _q(1),
+    ]
+    with pytest.raises(ValidationError, match="256 decimal digits"):
+        LinearRationalSolutionFindRequest.model_validate(
+            {"system": oversized, "resource_budget": {"wall_seconds": 5}}
+        )
+
+
+def test_only_verified_solution_output_can_carry_true_and_record() -> None:
+    common = {
+        "system_uri": "artifact://sha256/" + "1" * 64,
+        "solution_uri": "artifact://sha256/" + "2" * 64,
+        "witness_uri": "artifact://sha256/" + "3" * 64,
+        "checker_id": "checker://sha256/" + "4" * 64,
+        "detail": "checked",
+    }
+    verified = LinearRationalSolutionVerificationOutput.model_validate(
+        {
+            **common,
+            "status": "VERIFIED_SOLUTION",
+            "conclusion": "TRUE",
+            "verification_record_uri": "artifact://sha256/" + "5" * 64,
+        }
+    )
+    assert verified.conclusion == "TRUE"
+
+    with pytest.raises(ValidationError):
+        LinearRationalSolutionVerificationOutput.model_validate(
+            {
+                **common,
+                "status": "REJECTED",
+                "conclusion": "TRUE",
+                "verification_record_uri": "artifact://sha256/" + "5" * 64,
+            }
+        )

--- a/tests/integration/test_agent_ab_benchmark.py
+++ b/tests/integration/test_agent_ab_benchmark.py
@@ -162,6 +162,64 @@ def _sat_report(
     }
 
 
+def _linear_case() -> dict[str, Any]:
+    return {
+        "case_id": "LINEAR-PRIVATE-TEST-001",
+        "version": "1",
+        "task_type": "linear_rational_solution",
+        "prompt": "Find one exact solution of the supplied rational system.",
+        "system": {
+            "variables": ["u", "v"],
+            "coefficients": {
+                "entries": [
+                    [
+                        {"num": "2", "den": "1"},
+                        {"num": "1", "den": "1"},
+                    ],
+                    [
+                        {"num": "1", "den": "1"},
+                        {"num": "-1", "den": "1"},
+                    ],
+                ]
+            },
+            "rhs": [
+                {"num": "5", "den": "1"},
+                {"num": "1", "den": "1"},
+            ],
+        },
+    }
+
+
+def _linear_report(
+    *,
+    system_uri: str | None,
+    solution_uri: str | None,
+    record_uri: str | None,
+    assurance: str,
+    final_verification: str,
+) -> dict[str, Any]:
+    return {
+        "case_id": "LINEAR-PRIVATE-TEST-001",
+        "status": "SOLUTION_FOUND",
+        "conclusion": "TRUE",
+        "solution": [
+            {"num": "2", "den": "1"},
+            {"num": "1", "den": "1"},
+        ],
+        "assurance": assurance,
+        "final_verification": final_verification,
+        "system_uri": system_uri,
+        "solution_uri": solution_uri,
+        "verification_record_uri": record_uri,
+        "limitations": ["one exact vector; no uniqueness claim"],
+        "feedback": {
+            "reasoning_focus": ["preserve exact variable order"],
+            "infrastructure_work": [],
+            "tooling_gaps": [],
+        },
+    }
+
+
 def test_ab_sat_report_contract_identifies_the_producer_evidence_uri() -> None:
     schema_path = PROJECT_ROOT / "benchmarks" / "ab_cases" / "sat-report.schema.json"
     schema = json.loads(schema_path.read_text(encoding="utf-8"))
@@ -1440,6 +1498,101 @@ def test_ab_sat_scorer_requires_ordered_checker_bound_assignment(
     assert treatment["passed"] is True
     assert treatment["false_certification"] is False
     assert treatment["replay_success"] is True
+
+
+def test_ab_linear_scorer_requires_ordered_checker_bound_solution(
+    tmp_path: Path,
+) -> None:
+    score_report = cast(Any, BENCHMARK["score_report"])
+    case = _linear_case()
+    state_dir = tmp_path / "state"
+    kernel = JacobianKernel(state_dir, install_references=True)
+    found = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="linear.rational_solution.find",
+            mode=CapabilityMode.EXPLORE,
+            input={"system": case["system"]},
+        )
+    )
+    solution_uri = cast(str, found.output["solution_uri"])
+    system_uri = cast(str, found.output["system_uri"])
+    verified = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="linear.rational_solution.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"solution_uri": solution_uri},
+        )
+    )
+    record_uri = verified.assurance.verification_record_uri
+    assert record_uri is not None
+
+    control = score_report(
+        case,
+        _linear_report(
+            system_uri=None,
+            solution_uri=None,
+            record_uri=None,
+            assurance="SELF_CHECKED",
+            final_verification="UNVERIFIED",
+        ),
+        condition="control",
+        state_dir=state_dir,
+        mcp_calls=[],
+    )
+    assert control["passed"] is True
+
+    treatment = score_report(
+        case,
+        _linear_report(
+            system_uri=system_uri,
+            solution_uri=solution_uri,
+            record_uri=record_uri,
+            assurance="VERIFIED",
+            final_verification="VERIFIED",
+        ),
+        condition="treatment",
+        state_dir=state_dir,
+        mcp_calls=["capability.invoke"],
+        capability_invocations=[
+            {
+                "capability_id": "linear.rational_solution.find",
+                "input": {"system": case["system"]},
+                "output": found.output,
+                "artifact_uris": found.artifact_uris,
+            },
+            {
+                "capability_id": "linear.rational_solution.verify",
+                "input": {"solution_uri": solution_uri},
+                "output": verified.output,
+                "artifact_uris": verified.artifact_uris,
+                "assurance": verified.assurance.model_dump(mode="json"),
+            },
+        ],
+    )
+
+    assert treatment["passed"] is True
+    assert treatment["false_certification"] is False
+    assert treatment["replay_success"] is True
+
+    wrong = _linear_report(
+        system_uri=None,
+        solution_uri=None,
+        record_uri=None,
+        assurance="SELF_CHECKED",
+        final_verification="UNVERIFIED",
+    )
+    wrong["solution"][0] = {"num": "0", "den": "1"}
+    with pytest.raises(
+        cast(type[Exception], BENCHMARK["BenchmarkError"]),
+        match="does not satisfy",
+    ):
+        score_report(
+            case,
+            wrong,
+            condition="control",
+            state_dir=state_dir,
+            mcp_calls=[],
+        )
 
 
 def test_ab_sat_scorer_rejects_unbound_verified_claim(tmp_path: Path) -> None:

--- a/tests/integration/test_linear_rational_solution.py
+++ b/tests/integration/test_linear_rational_solution.py
@@ -1,0 +1,474 @@
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import jacobian.provider_runtime as provider_runtime
+from jacobian.bounded_process import BoundedProcessResult
+from jacobian.canonical import canonicalize_json
+from jacobian.contracts.capabilities import (
+    CapabilityAssuranceLevel,
+    CapabilityCompletenessStatus,
+    CapabilityInstallTier,
+    CapabilityMode,
+    CapabilityProviderAvailability,
+    CapabilityProviderDigestKind,
+    CapabilityProviderRuntime,
+    CapabilityRequest,
+    CapabilityResult,
+)
+from jacobian.contracts.results import ExecutionStatus
+from jacobian.kernel import JacobianKernel
+from jacobian.linear_capabilities import install_linear_rational_solution_checker
+from jacobian.provider_runtime import PYTHON_FLINT_VERSION
+
+pytestmark = pytest.mark.usefixtures("initialized_kernel_store")
+
+
+def _q(num: int, den: int = 1) -> dict[str, str]:
+    return {"num": str(num), "den": str(den)}
+
+
+def _system(
+    coefficients: list[list[tuple[int, int] | int]],
+    rhs: list[tuple[int, int] | int],
+) -> dict[str, Any]:
+    def wire(value: tuple[int, int] | int) -> dict[str, str]:
+        return _q(*value) if isinstance(value, tuple) else _q(value)
+
+    return {
+        "variables": [f"x{index}" for index in range(len(coefficients[0]))],
+        "coefficients": {
+            "entries": [[wire(value) for value in row] for row in coefficients]
+        },
+        "rhs": [wire(value) for value in rhs],
+    }
+
+
+def _invoke(
+    kernel: JacobianKernel,
+    capability_id: str,
+    payload: dict[str, Any],
+    *,
+    mode: CapabilityMode,
+) -> CapabilityResult:
+    return kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id=capability_id,
+            mode=mode,
+            input=payload,
+        )
+    )
+
+
+def _kernel_with_linear_checker(root: Path) -> JacobianKernel:
+    kernel = JacobianKernel(root)
+    adapter, _installation = install_linear_rational_solution_checker(
+        kernel.store,
+        kernel.schemas,
+        kernel.artifacts,
+        kernel.linear,
+        kernel.verification,
+        kernel.checkers,
+        authorize_checker=True,
+    )
+    assert adapter is not None
+    kernel.register_capability(adapter)
+    return kernel
+
+
+def test_python_flint_find_returns_one_exact_unverified_solution(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    assert (
+        kernel.python_flint_runtime.availability
+        is CapabilityProviderAvailability.AVAILABLE
+    )
+    result = _invoke(
+        kernel,
+        "linear.rational_solution.find",
+        {
+            "system": _system([[2, 1], [1, -1]], [5, 1]),
+            "resource_budget": {"wall_seconds": 5},
+        },
+        mode=CapabilityMode.EXPLORE,
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output["status"] == "SOLUTION_PRODUCED"
+    assert result.output["solution"] == [_q(2), _q(1)]
+    assert result.output["conclusion"] == "UNKNOWN"
+    assert result.output["verification"] == "UNVERIFIED"
+    assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert result.relationships[0].relation_id == "linear.relation.satisfies"
+
+    resolved = kernel.linear.resolve_solution(result.output["solution_uri"])
+    assert resolved.solution.system.system_artifact_uri == result.output["system_uri"]
+    assert result.output["system_uri"] in resolved.artifact.manifest.parents
+
+
+def test_python_flint_runtime_is_exact_optional_distribution_identity(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    runtime = kernel.python_flint_runtime
+
+    assert runtime.version == PYTHON_FLINT_VERSION
+    assert runtime.install_tier is CapabilityInstallTier.T1
+    assert runtime.digest.startswith("sha256:")
+    assert runtime.digest_kind.value == "PYTHON_DISTRIBUTION_RECORD"
+    assert runtime.license_id == "MIT AND LGPL-3.0-or-later"
+    assert runtime.license_files == ("python_flint-0.9.0.dist-info/licenses/LICENSE",)
+    assert runtime.configuration["operation"] == "fmpq_mat.rref"
+
+
+def test_python_flint_runtime_rejects_an_unpinned_binding_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    wrong = CapabilityProviderRuntime(
+        provider="python-flint",
+        availability=CapabilityProviderAvailability.AVAILABLE,
+        version="0.8.0",
+        digest="sha256:" + "d" * 64,
+        digest_kind=CapabilityProviderDigestKind.PYTHON_DISTRIBUTION_RECORD,
+        platform="linux-x86_64",
+        install_tier=CapabilityInstallTier.T1,
+        license_id="MIT AND LGPL-3.0-or-later",
+        license_files=("python_flint-0.8.0.dist-info/licenses/LICENSE",),
+    )
+    monkeypatch.setattr(
+        provider_runtime,
+        "python_distribution_provider_runtime",
+        lambda *_args, **_kwargs: wrong,
+    )
+
+    rejected = provider_runtime.python_flint_provider_runtime()
+
+    assert rejected.availability is CapabilityProviderAvailability.UNAVAILABLE
+    assert rejected.version is None
+    assert rejected.digest is None
+    assert "pinned 0.9.0" in rejected.diagnostic
+
+
+def test_verifier_authorization_is_separate_from_provider_availability(
+    tmp_path: Path,
+    kernel_store_template: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    unavailable = CapabilityProviderRuntime(
+        provider="python-flint",
+        availability=CapabilityProviderAvailability.UNAVAILABLE,
+        platform="linux-x86_64",
+        install_tier=CapabilityInstallTier.T1,
+        license_id="MIT AND LGPL-3.0-or-later",
+        diagnostic="optional provider unavailable for test",
+    )
+    monkeypatch.setattr(
+        "jacobian.kernel.python_flint_provider_runtime",
+        lambda: unavailable,
+    )
+
+    default_root = tmp_path / "default"
+    authorized_root = tmp_path / "authorized"
+    shutil.copytree(kernel_store_template, default_root)
+    shutil.copytree(kernel_store_template, authorized_root)
+    default = JacobianKernel(default_root)
+    default_ids = {
+        descriptor.capability_id
+        for descriptor in default.capabilities.catalog().capabilities
+    }
+    assert "linear.rational_solution.find" not in default_ids
+    assert "linear.rational_solution.verify" not in default_ids
+
+    authorized = JacobianKernel(authorized_root, install_references=True)
+    authorized_ids = {
+        descriptor.capability_id
+        for descriptor in authorized.capabilities.catalog().capabilities
+    }
+    assert "linear.rational_solution.find" not in authorized_ids
+    assert "linear.rational_solution.verify" in authorized_ids
+
+
+def test_python_flint_find_handles_underdetermined_system_deterministically(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    result = _invoke(
+        kernel,
+        "linear.rational_solution.find",
+        {
+            "system": _system([[1, 1, 1], [2, -1, 1]], [3, 2]),
+            "resource_budget": {"wall_seconds": 5},
+        },
+        mode=CapabilityMode.EXPLORE,
+    )
+
+    assert result.output["status"] == "SOLUTION_PRODUCED"
+    assert result.output["solution"] == [_q(5, 3), _q(4, 3), _q(0)]
+
+
+def test_not_found_is_not_an_inconsistency_conclusion(tmp_path: Path) -> None:
+    kernel = JacobianKernel(tmp_path)
+    result = _invoke(
+        kernel,
+        "linear.rational_solution.find",
+        {
+            "system": _system([[1, 1], [1, 1]], [2, 3]),
+            "resource_budget": {"wall_seconds": 5},
+        },
+        mode=CapabilityMode.EXPLORE,
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output["status"] == "NO_SOLUTION_PRODUCED"
+    assert result.output["conclusion"] == "UNKNOWN"
+    assert result.output["solution_uri"] is None
+    assert result.completeness.status is CapabilityCompletenessStatus.UNKNOWN
+    assert "inconsistent" not in result.output["detail"].lower()
+
+
+def test_independent_checker_verifies_and_rejects_bound_solutions(
+    tmp_path: Path,
+) -> None:
+    kernel = _kernel_with_linear_checker(tmp_path)
+    found = _invoke(
+        kernel,
+        "linear.rational_solution.find",
+        {
+            "system": _system([[2, 1], [1, -1]], [5, 1]),
+            "resource_budget": {"wall_seconds": 5},
+        },
+        mode=CapabilityMode.EXPLORE,
+    )
+    accepted = _invoke(
+        kernel,
+        "linear.rational_solution.verify",
+        {"solution_uri": found.output["solution_uri"]},
+        mode=CapabilityMode.VERIFY,
+    )
+    assert accepted.output["status"] == "VERIFIED_SOLUTION"
+    assert accepted.output["conclusion"] == "TRUE"
+    assert accepted.output["verification_record_uri"].startswith("artifact://sha256/")
+    assert accepted.assurance.level is CapabilityAssuranceLevel.VERIFIED
+
+    wrong = kernel.linear.put_solution(
+        system_uri=found.output["system_uri"],
+        values=(_q(0), _q(0)),
+        producer=kernel.python_flint_runtime,
+        resource_budget={"wall_seconds": 5},
+    )
+    rejected = _invoke(
+        kernel,
+        "linear.rational_solution.verify",
+        {"solution_uri": wrong.artifact_uri},
+        mode=CapabilityMode.VERIFY,
+    )
+    assert rejected.output["status"] == "REJECTED"
+    assert rejected.output["conclusion"] == "UNKNOWN"
+    assert rejected.output["verification_record_uri"] is None
+
+
+def test_python_flint_timeout_is_operational_not_mathematical(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    monkeypatch.setattr(
+        "jacobian.flint_linear.run_bounded_process",
+        lambda *_args, **_kwargs: BoundedProcessResult(
+            returncode=None,
+            stdout=b"",
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=True,
+        ),
+    )
+    result = _invoke(
+        kernel,
+        "linear.rational_solution.find",
+        {
+            "system": _system([[1]], [1]),
+            "resource_budget": {"wall_seconds": 1},
+        },
+        mode=CapabilityMode.EXPLORE,
+    )
+
+    assert result.execution.status is ExecutionStatus.TIMEOUT
+    assert result.output["status"] == "NO_SOLUTION_PRODUCED"
+    assert result.output["conclusion"] == "UNKNOWN"
+    assert result.assurance.level is not CapabilityAssuranceLevel.VERIFIED
+
+
+def test_python_flint_worker_gets_only_fixed_environment_and_exact_budget(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JACOBIAN_LINEAR_SECRET", "must-not-propagate")
+    observed: dict[str, Any] = {}
+
+    def fake_worker(*_args: Any, **kwargs: Any) -> BoundedProcessResult:
+        observed.update(kwargs)
+        stdout = (
+            canonicalize_json(
+                {
+                    "protocol": "jacobian.flint-linear-worker/v1",
+                    "status": "SOLUTION_PRODUCED",
+                    "backend_version": "0.9.0",
+                    "values": [_q(1)],
+                }
+            )
+            + b"\n"
+        )
+        return BoundedProcessResult(
+            returncode=0,
+            stdout=stdout,
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=False,
+        )
+
+    kernel = JacobianKernel(tmp_path)
+    monkeypatch.setattr("jacobian.flint_linear.run_bounded_process", fake_worker)
+    result = _invoke(
+        kernel,
+        "linear.rational_solution.find",
+        {
+            "system": _system([[1]], [1]),
+            "resource_budget": {"wall_seconds": 7},
+        },
+        mode=CapabilityMode.EXPLORE,
+    )
+
+    assert result.output["status"] == "SOLUTION_PRODUCED"
+    assert observed["timeout_seconds"] == 7.0
+    assert observed["environment"] == {
+        "LANG": "C",
+        "LC_ALL": "C",
+        "TZ": "UTC",
+        "PYTHONHASHSEED": "0",
+    }
+    assert "JACOBIAN_LINEAR_SECRET" in os.environ
+    assert "JACOBIAN_LINEAR_SECRET" not in observed["environment"]
+
+
+def test_python_flint_discards_output_if_runtime_identity_changes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    original_runtime = kernel.python_flint_runtime
+    changed_runtime = original_runtime.model_copy(
+        update={"digest": "sha256:" + "f" * 64}
+    )
+    observations = iter((original_runtime, changed_runtime))
+    monkeypatch.setattr(
+        "jacobian.flint_linear.python_flint_provider_runtime",
+        lambda **_kwargs: next(observations),
+    )
+    monkeypatch.setattr(
+        "jacobian.flint_linear.run_bounded_process",
+        lambda *_args, **_kwargs: BoundedProcessResult(
+            returncode=0,
+            stdout=(
+                canonicalize_json(
+                    {
+                        "protocol": "jacobian.flint-linear-worker/v1",
+                        "status": "SOLUTION_PRODUCED",
+                        "backend_version": "0.9.0",
+                        "values": [_q(1)],
+                    }
+                )
+                + b"\n"
+            ),
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=False,
+        ),
+    )
+
+    result = _invoke(
+        kernel,
+        "linear.rational_solution.find",
+        {"system": _system([[1]], [1])},
+        mode=CapabilityMode.EXPLORE,
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.output["status"] == "NO_SOLUTION_PRODUCED"
+    assert result.output["solution_uri"] is None
+    assert result.output["conclusion"] == "UNKNOWN"
+    assert "changed during execution" in result.output["detail"]
+
+
+def test_invalid_worker_protocol_fails_without_solution_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    monkeypatch.setattr(
+        "jacobian.flint_linear.run_bounded_process",
+        lambda *_args, **_kwargs: BoundedProcessResult(
+            returncode=0,
+            stdout=b'{"status":"SOLUTION_PRODUCED","values":[]}\n',
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=False,
+        ),
+    )
+    result = _invoke(
+        kernel,
+        "linear.rational_solution.find",
+        {"system": _system([[1]], [1])},
+        mode=CapabilityMode.EXPLORE,
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.output["status"] == "NO_SOLUTION_PRODUCED"
+    assert result.output["solution_uri"] is None
+    assert result.output["conclusion"] == "UNKNOWN"
+
+
+def test_linear_checker_timeout_is_operational_not_mathematical(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = _kernel_with_linear_checker(tmp_path)
+    found = _invoke(
+        kernel,
+        "linear.rational_solution.find",
+        {"system": _system([[1]], [1])},
+        mode=CapabilityMode.EXPLORE,
+    )
+    monkeypatch.setattr(
+        "jacobian.verification.run_bounded_process",
+        lambda *_args, **_kwargs: BoundedProcessResult(
+            returncode=None,
+            stdout=b"",
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=True,
+        ),
+    )
+
+    result = _invoke(
+        kernel,
+        "linear.rational_solution.verify",
+        {"solution_uri": found.output["solution_uri"]},
+        mode=CapabilityMode.VERIFY,
+    )
+
+    assert result.execution.status is ExecutionStatus.TIMEOUT
+    assert result.output["status"] == "TIMEOUT"
+    assert result.output["conclusion"] == "UNKNOWN"
+    assert result.output["verification_record_uri"] is None
+    assert result.assurance.level is not CapabilityAssuranceLevel.VERIFIED

--- a/uv.lock
+++ b/uv.lock
@@ -496,6 +496,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+flint = [
+    { name = "python-flint" },
+]
 smt = [
     { name = "cvc5" },
 ]
@@ -515,6 +518,7 @@ dev = [
     { name = "pytest-split" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
+    { name = "python-flint" },
     { name = "ruff" },
     { name = "types-jsonschema" },
     { name = "types-networkx" },
@@ -530,12 +534,13 @@ requires-dist = [
     { name = "networkx", specifier = ">=3.4,<4" },
     { name = "pydantic", specifier = ">=2.12,<3" },
     { name = "pydantic-core", specifier = ">=2.41,<3" },
+    { name = "python-flint", marker = "extra == 'flint'", specifier = "==0.9.0" },
     { name = "rfc8785", specifier = "==0.1.4" },
     { name = "sympy", specifier = ">=1.14,<2" },
     { name = "typer", specifier = ">=0.20,<1" },
     { name = "z3-solver", specifier = ">=4.15.4,<5" },
 ]
-provides-extras = ["smt"]
+provides-extras = ["flint", "smt"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -552,6 +557,7 @@ dev = [
     { name = "pytest-split", specifier = ">=0.11,<1" },
     { name = "pytest-timeout", specifier = ">=2.4,<3" },
     { name = "pytest-xdist", specifier = ">=3.6,<4" },
+    { name = "python-flint", specifier = "==0.9.0" },
     { name = "ruff", specifier = ">=0.11,<1" },
     { name = "types-jsonschema", specifier = ">=4.23,<5" },
     { name = "types-networkx", specifier = ">=3.4,<4" },
@@ -1207,6 +1213,26 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-flint"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/d3/32226210a7703b0cfbe0f5b2c56e38b7b7177d4c69663247d8813352595c/python_flint-0.9.0.tar.gz", hash = "sha256:686b2907eedaf0c0842caefab29a5775d2e633fd5815b81e13b81ca2c6ad0a36", size = 486670, upload-time = "2026-07-03T23:29:23.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/20/42ec7f09155485314f97071e53e576bbf00c03cdfd52b37b8dced83a2baa/python_flint-0.9.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:be6f010e4c2dbe8994250e2ca218ff1e301ee143c03e712bab812ff9e6b4fc46", size = 8870927, upload-time = "2026-07-03T23:28:23.197Z" },
+    { url = "https://files.pythonhosted.org/packages/41/c3/2323ed921fa08ad2a0935775dddba8502d30bfdc3034920abfdac2138236/python_flint-0.9.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:025fd4e77f2cbbf40f63b9cd7571aad3803deb57aecd72e7c397480fe84921a0", size = 7882651, upload-time = "2026-07-03T23:28:25.477Z" },
+    { url = "https://files.pythonhosted.org/packages/db/3f/5f57004f9f43ac6508f874cc97123f11b27b6811b5bb0d320c43f600f0cb/python_flint-0.9.0-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:376b88cacd30612479e839ffdba887599d3f9c8c0e214852bf80bb2b194e4d76", size = 10125938, upload-time = "2026-07-03T23:28:27.426Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/43/fe3689c62e6e5bd2f511165b3baaa4edfce1db2f2c26d0108a0f753b2c49/python_flint-0.9.0-cp310-abi3-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0e681705564a22367def0e026185af43783fd466839493baf7bc21c9e506bf15", size = 10137028, upload-time = "2026-07-03T23:28:29.717Z" },
+    { url = "https://files.pythonhosted.org/packages/63/dd/4b49e36612e924707090c569cf5c3daa9ba3c3e3050897715e3136d055af/python_flint-0.9.0-cp310-abi3-win_amd64.whl", hash = "sha256:8f1059536b7393e48b1444894c3b54ce1b961e4aa4a356e19217b26690f20db0", size = 9593474, upload-time = "2026-07-03T23:28:31.729Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/0e/bf3ad3be80edf54cb98005e3dd19d9b0a8d3618f841f12b703c819b94282/python_flint-0.9.0-cp310-abi3-win_arm64.whl", hash = "sha256:4d78476bce46d28e3655ac5521c2af29a1928ac320aa7e6ace88ebe46fb136e2", size = 7874815, upload-time = "2026-07-03T23:28:33.696Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/78/39c80424b399677603629d3e6a2e67dbdaf49a33ace98a581be93ed14688/python_flint-0.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:cf1356f6850c8ef11789773005d192a9035e828bc41644be56ec9b35ac41b2fe", size = 9134679, upload-time = "2026-07-03T23:28:35.202Z" },
+    { url = "https://files.pythonhosted.org/packages/47/99/f0b224ca7f85c1368bacc6ad1aac6f13ce9355e25f17a5bcf4e21c4bb639/python_flint-0.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:70e965a6f8096b3f40cd335d16227715a61c59e27a1cf9979e57717cfae4e6da", size = 7962573, upload-time = "2026-07-03T23:28:37.122Z" },
+    { url = "https://files.pythonhosted.org/packages/22/7d/a9c0538fbd4444cd6ef98852e1ded2b65caadd255604963d38917358653b/python_flint-0.9.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2a0d8db1fab69104afdc7a9763a690337a1cecafbf476b310f5bcd8ccc97b29b", size = 10190202, upload-time = "2026-07-03T23:28:39.121Z" },
+    { url = "https://files.pythonhosted.org/packages/24/a1/db9ded0b3938117a55581057ddaa78d997607e3c5c632e8e7f2b6c6ae017/python_flint-0.9.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7d60da4bf413c264215ba396ed87601632ede21dfc8c05661b424942cbbfb98e", size = 10222717, upload-time = "2026-07-03T23:28:41.172Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/3d/8fa26b07514d7c433d14d338df9df4c57ad6875ef7a01fb578d79be8a449/python_flint-0.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:1f3a3672d589e376d47288dcebcb712997dc719880a4dbf1779bf0f2b20d0293", size = 9682364, upload-time = "2026-07-03T23:28:43.326Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/4c/28a9e33bbc323263dc2408e6a253e77099183b5e870f453dfc1efeb75107/python_flint-0.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:e9d5fcfc3eca4254306ba4130914c61f84b5a4e816f97e31070fda620478dd96", size = 7964982, upload-time = "2026-07-03T23:28:45.475Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

Portfolio item 11 needs a shared exact linear-algebra slice without allowing a producer to certify its own result. Jacobian had no provider-backed operation for materializing one rational `A x = b` witness and no independent replay boundary for promoting that exact relation.

## Resulting change

- Pin optional `python-flint==0.9.0` and register `linear.rational_solution.find` only when that exact distribution identity is available.
- Run `fmpq_mat.rref` in a bounded isolated worker, materialize one exact ordered vector, and keep provider success at `COMPUTED`. Free variables are deterministically zero; failure to produce a vector remains `UNKNOWN` and makes no inconsistency claim.
- Add exact system/solution schemas, variable-order and object/payload bindings, parent lineage, resource budgets, and provider provenance.
- Add operator-authorized `linear.rational_solution.verify`, backed by a clean-process, standard-library-only exact rational checker. Only a fully bound replay of every equation may create a verification record.
- Fail closed on malformed protocols, timeouts, runtime identity changes, noncanonical rationals, partial/reordered vectors, provider substitution, binding changes, and missing lineage.
- Extend the held-out agent A/B harness and document the contract, measurements, and frozen two-case `gpt-5.6-terra` pilot.

## Compatibility and normative impact

This adds two experimental namespaced capabilities and new artifact contracts; it does not change an existing capability contract. The producer is optional. The verifier is available only when bundled references/checkers are operator-authorized. No search, timeout, rejection, or solver status is promoted to a mathematical conclusion.

## Validation

- `make check` — 288 passed, 4 deselected
- `make check-static` — Ruff, format, deptry, vulture, mypy, sdist, and wheel passed
- `uv run pytest -q tests/integration/test_linear_rational_solution.py` — 12 passed
- `uv run pytest -q tests/integration/test_agent_ab_benchmark.py::test_ab_linear_scorer_requires_ordered_checker_bound_solution` — 1 passed
- focused checker/contract/integration suite — 31 passed
- `git diff --check`
- provider reproduction: 2-by-2 exact RREF passed; measured 25,950,757 installed bytes, 0.038 s cold import, and 0.040 s reproduction on the documented Linux host
- held-out Terra A/B: 2/2 control and 2/2 treatment passed; both treatment records replayed in a clean kernel, with zero false certifications, parameter errors, or tool errors

The complete non-Lean and Lean suites were not rerun locally; routine handoff checks and focused trust-boundary tests passed, with exhaustive lanes left to CI.