### PR TITLE
fix(ci): complete required checks for isolated plans

### DIFF
--- a/.github/scripts/validate-ci-plan
+++ b/.github/scripts/validate-ci-plan
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+declare -A plan=()
+expected_keys=(
+  classification
+  run-python
+  run-lean
+  run-npm
+  run-static
+  run-build
+  run-security
+  run-duplicate
+)
+
+while IFS='=' read -r key value; do
+  case "$key" in
+    classification|run-python|run-lean|run-npm|run-static|run-build|run-security|run-duplicate)
+      ;;
+    *)
+      echo "invalid CI plan key: $key" >&2
+      exit 1
+      ;;
+  esac
+  if [[ -v "plan[$key]" ]]; then
+    echo "duplicate CI plan key: $key" >&2
+    exit 1
+  fi
+  plan["$key"]=$value
+done
+
+for key in "${expected_keys[@]}"; do
+  if [[ ! -v "plan[$key]" ]]; then
+    echo "missing CI plan key: $key" >&2
+    exit 1
+  fi
+done
+
+for key in "${expected_keys[@]:1}"; do
+  case "${plan[$key]}" in
+    true|false) ;;
+    *)
+      echo "invalid CI plan value for $key: ${plan[$key]}" >&2
+      exit 1
+      ;;
+  esac
+done
+
+case "${plan[classification]}" in
+  docs)
+    expected_npm=false
+    ;;
+  npm)
+    expected_npm=true
+    ;;
+  full)
+    for key in "${expected_keys[@]:1}"; do
+      if [[ "${plan[$key]}" != true ]]; then
+        echo "full CI plan must enable $key" >&2
+        exit 1
+      fi
+    done
+    exit 0
+    ;;
+  *)
+    echo "invalid CI classification: ${plan[classification]}" >&2
+    exit 1
+    ;;
+esac
+
+for key in run-python run-static run-build run-security run-duplicate; do
+  if [[ "${plan[$key]}" != false ]]; then
+    echo "${plan[classification]} CI plan must disable $key" >&2
+    exit 1
+  fi
+done
+if [[ "${plan[run-npm]}" != "$expected_npm" ]]; then
+  echo "${plan[classification]} CI plan has an invalid run-npm value" >&2
+  exit 1
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
             plan_output=$(.github/scripts/classify-ci-paths --force-full)
           fi
 
+          printf '%s\n' "$plan_output" | .github/scripts/validate-ci-plan
           printf '%s\n' "$plan_output" >> "$GITHUB_OUTPUT"
           classification=$(sed -n 's/^classification=//p' <<< "$plan_output")
           {
@@ -71,24 +72,41 @@ jobs:
   lint:
     name: Lint & Format
     needs: plan
-    if: needs.plan.outputs.run-static == 'true'
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      - name: Require a valid static-analysis plan
+        env:
+          PLAN_RESULT: ${{ needs.plan.result }}
+          RUN_STATIC: ${{ needs.plan.outputs.run-static }}
+        run: |
+          test "$PLAN_RESULT" = "success"
+          case "$RUN_STATIC" in
+            true|false) ;;
+            *) exit 1 ;;
+          esac
+      - if: needs.plan.outputs.run-static == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - if: needs.plan.outputs.run-static == 'true'
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
-      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+      - if: needs.plan.outputs.run-static == 'true'
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
           cache-dependency-glob: |
             pyproject.toml
             uv.lock
-      - run: uv sync --frozen --dev
-      - run: make lint-full
-      - run: make typecheck
+      - if: needs.plan.outputs.run-static == 'true'
+        run: uv sync --frozen --dev
+      - if: needs.plan.outputs.run-static == 'true'
+        run: make lint-full
+      - if: needs.plan.outputs.run-static == 'true'
+        run: make typecheck
       - name: Check TODO comments reference issues
+        if: needs.plan.outputs.run-static == 'true'
         run: |
           violations="$(rg --pcre2 -n 'TODO(?!\(#\d+\))' --type py src/ tests/ || true)"
           if [ -n "$violations" ]; then
@@ -142,7 +160,7 @@ jobs:
   test:
     name: Tests (Python ${{ matrix.python-version }}, shard ${{ matrix.shard }}/2)
     needs: plan
-    if: needs.plan.outputs.run-python == 'true'
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
@@ -151,23 +169,40 @@ jobs:
         python-version: ["3.12", "3.13"]
         shard: [1, 2]
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      - name: Require a valid Python plan
+        env:
+          PLAN_RESULT: ${{ needs.plan.result }}
+          RUN_PYTHON: ${{ needs.plan.outputs.run-python }}
+        run: |
+          test "$PLAN_RESULT" = "success"
+          case "$RUN_PYTHON" in
+            true|false) ;;
+            *) exit 1 ;;
+          esac
+      - if: needs.plan.outputs.run-python == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - if: needs.plan.outputs.run-python == 'true'
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+      - if: needs.plan.outputs.run-python == 'true'
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
           cache-dependency-glob: |
             pyproject.toml
             uv.lock
-      - run: uv sync --frozen --dev
-      - run: >-
+      - if: needs.plan.outputs.run-python == 'true'
+        run: uv sync --frozen --dev
+      - if: needs.plan.outputs.run-python == 'true'
+        run: >-
           uv run --frozen python -c
           "import json, pathlib;
           data = json.loads(pathlib.Path('.test_durations').read_text());
           assert data, '.test_durations must contain measured test timings'"
-      - if: matrix.python-version == '3.12'
+      - if: >-
+          needs.plan.outputs.run-python == 'true' &&
+          matrix.python-version == '3.12'
         run: >-
           uv run --frozen pytest
           -m "not lean_runtime"
@@ -176,7 +211,9 @@ jobs:
           --durations-path .test_durations
           --cov --cov-report= --cov-fail-under=0
           --durations=10
-      - if: matrix.python-version != '3.12'
+      - if: >-
+          needs.plan.outputs.run-python == 'true' &&
+          matrix.python-version != '3.12'
         run: >-
           uv run --frozen pytest
           -m "not lean_runtime"
@@ -184,10 +221,18 @@ jobs:
           --splitting-algorithm least_duration
           --durations-path .test_durations
           --durations=10
-      - if: matrix.python-version == '3.12'
+      - if: >-
+          needs.plan.outputs.run-python == 'true' &&
+          matrix.python-version == '3.12'
         run: mv .coverage .coverage.shard-${{ matrix.shard }}
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: ${{ always() && matrix.python-version == '3.12' }}
+        if: >-
+          ${{
+            !cancelled() &&
+            needs.plan.result == 'success' &&
+            needs.plan.outputs.run-python == 'true' &&
+            matrix.python-version == '3.12'
+          }}
         with:
           name: coverage-data-${{ matrix.shard }}
           path: .coverage.shard-${{ matrix.shard }}
@@ -207,11 +252,11 @@ jobs:
           TEST_RESULT: ${{ needs.test.result }}
         run: |
           test "$PLAN_RESULT" = "success"
-          if [ "$RUN_PYTHON" = "true" ]; then
-            test "$TEST_RESULT" = "success"
-          else
-            test "$TEST_RESULT" = "skipped"
-          fi
+          case "$RUN_PYTHON" in
+            true|false) ;;
+            *) exit 1 ;;
+          esac
+          test "$TEST_RESULT" = "success"
 
   lean-test-shards:
     name: Lean Tests (${{ matrix.lane }})
@@ -257,15 +302,15 @@ jobs:
           SHARD_RESULT: ${{ needs.lean-test-shards.result }}
         run: |
           test "$PLAN_RESULT" = "success"
-          if [ "$RUN_LEAN" = "true" ]; then
-            test "$SHARD_RESULT" = "success"
-          else
-            test "$SHARD_RESULT" = "skipped"
-          fi
+          case "$RUN_LEAN" in
+            true) test "$SHARD_RESULT" = "success" ;;
+            false) test "$SHARD_RESULT" = "skipped" ;;
+            *) exit 1 ;;
+          esac
 
   coverage:
     name: Coverage
-    if: always() && needs.plan.outputs.run-python == 'true' && needs.test.result == 'success'
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [plan, test]
@@ -273,28 +318,49 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      - name: Require successful Python validation
+        env:
+          PLAN_RESULT: ${{ needs.plan.result }}
+          RUN_PYTHON: ${{ needs.plan.outputs.run-python }}
+          TEST_RESULT: ${{ needs.test.result }}
+        run: |
+          test "$PLAN_RESULT" = "success"
+          case "$RUN_PYTHON" in
+            true|false) ;;
+            *) exit 1 ;;
+          esac
+          test "$TEST_RESULT" = "success"
+      - if: needs.plan.outputs.run-python == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - if: needs.plan.outputs.run-python == 'true'
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
-      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+      - if: needs.plan.outputs.run-python == 'true'
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
           cache-dependency-glob: |
             pyproject.toml
             uv.lock
-      - run: uv sync --frozen --dev
+      - if: needs.plan.outputs.run-python == 'true'
+        run: uv sync --frozen --dev
       - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        if: needs.plan.outputs.run-python == 'true'
         with:
           pattern: coverage-data-*
           path: coverage-data
           merge-multiple: true
-      - run: uv run --frozen coverage combine coverage-data
-      - run: uv run --frozen coverage report | tee coverage-report.txt
+      - if: needs.plan.outputs.run-python == 'true'
+        run: uv run --frozen coverage combine coverage-data
+      - if: needs.plan.outputs.run-python == 'true'
+        run: uv run --frozen coverage report | tee coverage-report.txt
         shell: bash -o pipefail {0}
-      - run: uv run --frozen coverage xml
+      - if: needs.plan.outputs.run-python == 'true'
+        run: uv run --frozen coverage xml
       - name: Post coverage summary to PR
         if: >-
+          needs.plan.outputs.run-python == 'true' &&
           github.event_name == 'pull_request' &&
           github.event.pull_request.user.type != 'Bot' &&
           github.event.pull_request.head.repo.full_name == github.repository
@@ -336,6 +402,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: needs.plan.outputs.run-python == 'true'
         with:
           name: coverage-3.12
           path: coverage.xml
@@ -343,56 +410,102 @@ jobs:
   duplicate-code:
     name: Duplicate Code Detection
     needs: plan
-    if: needs.plan.outputs.run-duplicate == 'true'
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      - name: Require a valid duplicate-code plan
+        env:
+          PLAN_RESULT: ${{ needs.plan.result }}
+          RUN_DUPLICATE: ${{ needs.plan.outputs.run-duplicate }}
+        run: |
+          test "$PLAN_RESULT" = "success"
+          case "$RUN_DUPLICATE" in
+            true|false) ;;
+            *) exit 1 ;;
+          esac
+      - if: needs.plan.outputs.run-duplicate == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - if: needs.plan.outputs.run-duplicate == 'true'
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "20"
-      - run: npx --yes jscpd@5.0.12 --config .jscpd.json .
+      - if: needs.plan.outputs.run-duplicate == 'true'
+        run: npx --yes jscpd@5.0.12 --config .jscpd.json .
 
   npm-package:
     name: npm Package
     needs: plan
-    if: needs.plan.outputs.run-npm == 'true'
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      - name: Require a valid npm plan
+        env:
+          PLAN_RESULT: ${{ needs.plan.result }}
+          RUN_NPM: ${{ needs.plan.outputs.run-npm }}
+        run: |
+          test "$PLAN_RESULT" = "success"
+          case "$RUN_NPM" in
+            true|false) ;;
+            *) exit 1 ;;
+          esac
+      - if: needs.plan.outputs.run-npm == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - if: needs.plan.outputs.run-npm == 'true'
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24"
           package-manager-cache: false
-      - run: npm test
+      - if: needs.plan.outputs.run-npm == 'true'
+        run: npm test
         working-directory: npm
-      - run: npm pack --dry-run
+      - if: needs.plan.outputs.run-npm == 'true'
+        run: npm pack --dry-run
         working-directory: npm
 
   build:
     name: Build
     needs: plan
-    if: needs.plan.outputs.run-build == 'true'
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      - name: Require a valid build plan
+        env:
+          PLAN_RESULT: ${{ needs.plan.result }}
+          RUN_BUILD: ${{ needs.plan.outputs.run-build }}
+        run: |
+          test "$PLAN_RESULT" = "success"
+          case "$RUN_BUILD" in
+            true|false) ;;
+            *) exit 1 ;;
+          esac
+      - if: needs.plan.outputs.run-build == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - if: needs.plan.outputs.run-build == 'true'
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
-      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+      - if: needs.plan.outputs.run-build == 'true'
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
           cache-dependency-glob: |
             pyproject.toml
             uv.lock
-      - run: |
+      - if: needs.plan.outputs.run-build == 'true'
+        run: |
           echo "::group::Build timing"
           /usr/bin/time -v make build 2>&1 | tee build-timing.log
           echo "::endgroup::"
       - name: Extract build metrics
-        if: always()
+        if: >-
+          ${{
+            !cancelled() &&
+            needs.plan.result == 'success' &&
+            needs.plan.outputs.run-build == 'true'
+          }}
         run: |
           {
             echo "## Build Performance"
@@ -406,11 +519,17 @@ jobs:
             echo "Build cache: setup-uv (enabled), dependency cache keyed on pyproject.toml + uv.lock"
           } >> "$GITHUB_STEP_SUMMARY"
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: needs.plan.outputs.run-build == 'true'
         with:
           name: dist
           path: dist/
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: always()
+        if: >-
+          ${{
+            !cancelled() &&
+            needs.plan.result == 'success' &&
+            needs.plan.outputs.run-build == 'true'
+          }}
         with:
           name: build-timing
           path: build-timing.log

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,8 @@ Python, npm, Lean, static, package, security, and duplicate-code lanes.
 Documentation plus npm or npm-only changes run npm packaging without the
 Python and Lean lanes. Source, dependency, workflow, mixed, empty, and unknown
 change sets run complete validation, as does every push to `main`.
+Required status contexts still complete after checking the plan when their
+expensive validation is intentionally omitted.
 Maintainers can add the `ci:full` label to force every lane or `ci:lean` to
 add real-Lean validation to an otherwise isolated plan. These overrides only
 add work; labels cannot reduce the fail-closed path classification.

--- a/tests/unit/test_ci_plan.py
+++ b/tests/unit/test_ci_plan.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 PLANNER = Path(__file__).parents[2] / ".github" / "scripts" / "classify-ci-paths"
+VALIDATOR = Path(__file__).parents[2] / ".github" / "scripts" / "validate-ci-plan"
 
 
 @pytest.mark.parametrize(
@@ -152,3 +153,67 @@ def test_lean_override_only_adds_lean_to_an_isolated_plan() -> None:
         "run-security": "false",
         "run-duplicate": "false",
     }
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ("README.md",),
+        ("npm/package.json",),
+        ("src/jacobian/kernel.py",),
+        ("--force-lean", "--", "README.md"),
+        ("--force-lean", "--", "npm/package.json"),
+    ],
+)
+def test_ci_plan_output_is_internally_consistent(args: tuple[str, ...]) -> None:
+    plan = subprocess.run(
+        [PLANNER, *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+    subprocess.run([VALIDATOR], input=plan, check=True, text=True)
+
+
+@pytest.mark.parametrize(
+    "plan",
+    [
+        "",
+        "classification=docs\nrun-python=flase\n",
+        "classification=full\n"
+        "run-python=false\n"
+        "run-lean=false\n"
+        "run-npm=false\n"
+        "run-static=false\n"
+        "run-build=false\n"
+        "run-security=false\n"
+        "run-duplicate=false\n",
+        "classification=docs\n"
+        "classification=docs\n"
+        "run-python=false\n"
+        "run-lean=false\n"
+        "run-npm=false\n"
+        "run-static=false\n"
+        "run-build=false\n"
+        "run-security=false\n"
+        "run-duplicate=false\n",
+        "classification=docs\n"
+        "run-python=false\n"
+        "run-lean=false\n"
+        "run-npm=true\n"
+        "run-static=false\n"
+        "run-build=false\n"
+        "run-security=false\n"
+        "run-duplicate=false\n",
+    ],
+)
+def test_ci_plan_validator_rejects_malformed_or_incoherent_plans(plan: str) -> None:
+    completed = subprocess.run(
+        [VALIDATOR],
+        input=plan,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode != 0


### PR DESCRIPTION
## Problem

Change-aware CI skips expensive lanes for documentation-only and isolated npm changes, but the repository ruleset requires the individual lane contexts. GitHub records a job-level false condition as `skipped`, so those otherwise valid pull requests remain blocked even when the stable aggregate checks pass.

## Solution

Required jobs now always create their existing contexts unless the workflow is cancelled. Each starts with a fail-closed plan gate, then either runs its real validation steps or completes as an intentional no-op when that lane is not planned. Planned failures still fail their original context, and Coverage also fails when planned Python validation fails.

The planner boundary now validates exact keys, Boolean values, and coherent `docs`, `npm`, and `full` tuples before publishing job outputs. Missing, malformed, duplicate, or contradictory output fails the plan instead of allowing expensive validation to be skipped.

This keeps the ruleset's current context names unchanged and does not run dependency setup, test suites, packaging, or builds for intentionally omitted lanes.

## Testing

```sh
uv run --frozen pytest -n 0 tests/unit/test_ci_plan.py  # 19 passed
uv run --frozen pre-commit run check-yaml --files .github/workflows/ci.yml
uv run --frozen pre-commit run actionlint --files .github/workflows/ci.yml
git diff --check origin/main...HEAD
```

The planner tests cover valid docs, npm, full, and forced-Lean plans plus malformed, duplicate, and incoherent output.

## Trust & Compatibility Impact

No verification-kernel, checker-registry, artifact-format, public-API, or required-context name changes. The CI planner now fails closed on invalid output, and superseded workflows remain cancellation-aware.

## Checklist

- [ ] Routine local validation passes (`make check`)
- [x] Relevant focused tests are listed above
- [x] Relevant documentation updated
