### PR TITLE
feat(matrices): add verified integer Hermite normal forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,14 +140,16 @@ construction and properties, exact rational polynomial maps, finite magma law
 evaluation and countermodel search, reference-domain exploration and
 verification, Lean checking, and local research-memory search.
 
-The optional `flint` extra pins Python-FLINT 0.9.0 and adds
-`linear.rational_solution.find` for one exact finite rational `A x = b`
-candidate. A returned vector remains `COMPUTED`; a not-found outcome makes no
-consistency claim. With bundled references enabled,
-`linear.rational_solution.verify` independently replays every equation using
-standard-library exact rational arithmetic and alone may create a bound
-verification record. See the
-[exact rational solution contract](docs/reference/linear-rational-solutions.md).
+The optional `flint` extra pins Python-FLINT 0.9.0 and adds two exact producer
+slices. `linear.rational_solution.find` returns one finite rational `A x = b`
+candidate, while `matrix.normal_form.hermite` returns integer matrices `H` and
+`U` for the proposed relation `H = U A`. Both remain `COMPUTED`. With bundled
+references enabled, separate standard-library checkers can verify every
+rational equation or the full HNF relation, unimodularity, and row-normal-form
+conditions. See the
+[exact rational solution contract](docs/reference/linear-rational-solutions.md)
+and the
+[integer matrix HNF contract](docs/reference/matrix-hermite-normal-form.md).
 
 The base kernel also registers canonical CNF, total assignment, and raw DRAT
 proof artifact contracts. When exact CaDiCaL 3.0.1 is present, optional

--- a/benchmarks/ab_cases/hnf-report.schema.json
+++ b/benchmarks/ab_cases/hnf-report.schema.json
@@ -1,0 +1,125 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "case_id": {
+      "type": "string"
+    },
+    "status": {
+      "enum": [
+        "NORMAL_FORM_PRODUCED"
+      ]
+    },
+    "conclusion": {
+      "enum": [
+        "TRUE"
+      ]
+    },
+    "normal_form": {
+      "$ref": "#/$defs/integer_matrix"
+    },
+    "transformation": {
+      "$ref": "#/$defs/integer_matrix"
+    },
+    "assurance": {
+      "enum": [
+        "SELF_CHECKED",
+        "COMPUTED",
+        "VERIFIED"
+      ]
+    },
+    "final_verification": {
+      "enum": [
+        "UNVERIFIED",
+        "VERIFIED"
+      ]
+    },
+    "matrix_uri": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^artifact://sha256/[0-9a-f]{64}$"
+    },
+    "normal_form_uri": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^artifact://sha256/[0-9a-f]{64}$"
+    },
+    "verification_record_uri": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^artifact://sha256/[0-9a-f]{64}$"
+    },
+    "limitations": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "feedback": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "reasoning_focus": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "infrastructure_work": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tooling_gaps": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "reasoning_focus",
+        "infrastructure_work",
+        "tooling_gaps"
+      ]
+    }
+  },
+  "$defs": {
+    "integer_matrix": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 32,
+      "items": {
+        "type": "array",
+        "minItems": 1,
+        "maxItems": 32,
+        "items": {
+          "type": "string",
+          "pattern": "^-?(0|[1-9][0-9]*)$"
+        }
+      }
+    }
+  },
+  "required": [
+    "case_id",
+    "status",
+    "conclusion",
+    "normal_form",
+    "transformation",
+    "assurance",
+    "final_verification",
+    "matrix_uri",
+    "normal_form_uri",
+    "verification_record_uri",
+    "limitations",
+    "feedback"
+  ]
+}

--- a/benchmarks/agent_ab.py
+++ b/benchmarks/agent_ab.py
@@ -36,6 +36,7 @@ from jacobian.artifacts import ArtifactService
 from jacobian.contracts.capabilities import CapabilityMode, CapabilityRequest
 from jacobian.contracts.exact import CanonicalRational
 from jacobian.contracts.linear import LinearRationalSystem
+from jacobian.contracts.matrices import ExactIntegerMatrix
 from jacobian.contracts.sat import (
     CanonicalCnf,
     SatAssignmentArtifact,
@@ -65,6 +66,7 @@ PARTITION_REPORT_SCHEMA = CASES_ROOT / "partition-report.schema.json"
 SAT_REPORT_SCHEMA = CASES_ROOT / "sat-report.schema.json"
 SMT_REPORT_SCHEMA = CASES_ROOT / "smt-report.schema.json"
 LINEAR_REPORT_SCHEMA = CASES_ROOT / "linear-report.schema.json"
+HNF_REPORT_SCHEMA = CASES_ROOT / "hnf-report.schema.json"
 LEAN_DECLARATION_REPORT_SCHEMA = CASES_ROOT / "lean-report.schema.json"
 LEAN_PROOF_REPORT_SCHEMA = CASES_ROOT / "lean-proof-report.schema.json"
 DEFAULT_RESULTS_ROOT = Path(__file__).with_name("results") / "ab"
@@ -93,6 +95,12 @@ LINEAR_CAPABILITY_IDS = frozenset(
     {
         "linear.rational_solution.find",
         "linear.rational_solution.verify",
+    }
+)
+HNF_CAPABILITY_IDS = frozenset(
+    {
+        "matrix.normal_form.hermite",
+        "matrix.normal_form.hermite.verify",
     }
 )
 LEAN_PROOF_CONDITIONS = ("baseline", "tactic", "retrieval", "combined")
@@ -220,6 +228,25 @@ verification. Report VERIFIED only when the verifier returns
 VERIFIED_SOLUTION and copy the exact system, solution, and
 verification-record URIs. Copy the producer's ordered solution values in the
 declared variable order.
+"""
+
+HNF_CONTROL_INSTRUCTIONS = """\
+Jacobian and all MCP servers are unavailable. You may write and run local code
+in the empty workspace. Return exact integer matrices H and U such that H is
+the row Hermite normal form of the supplied A and H = U A with det(U) = +/-1.
+Report SELF_CHECKED and UNVERIFIED, with null durable artifact and
+verification-record URIs.
+"""
+
+HNF_TREATMENT_INSTRUCTIONS = """\
+Use only jacobian_local for mathematical work. Do not use shell commands or
+create programs. Describe the exact capability IDs matrix.normal_form.hermite
+and matrix.normal_form.hermite.verify directly. Invoke the producer on the
+supplied exact integer matrix, then pass its normal_form_uri to the verifier in
+VERIFY mode. Provider output alone is not verification. Report VERIFIED only
+when the verifier returns VERIFIED_HERMITE_NORMAL_FORM. Copy the producer's
+exact H and U entries and the exact matrix, normal-form, and verification-record
+URIs.
 """
 
 LEAN_DECLARATION_INSTRUCTIONS = """\
@@ -561,6 +588,287 @@ def _score_linear_report(
             "independent checker replay",
         ],
     }
+
+
+def _hnf_case_matrix(case: Mapping[str, Any]) -> ExactIntegerMatrix:
+    matrix = case.get("matrix")
+    if not isinstance(matrix, Mapping):
+        raise BenchmarkError("HNF case must contain an exact integer matrix")
+    try:
+        return ExactIntegerMatrix.model_validate(matrix)
+    except ValueError as exc:
+        raise BenchmarkError("HNF case contains an invalid integer matrix") from exc
+
+
+def _reported_hnf_matrix(
+    report: Mapping[str, Any],
+    field: str,
+) -> ExactIntegerMatrix:
+    entries = report.get(field)
+    if not isinstance(entries, list):
+        raise BenchmarkError(f"HNF report omitted {field}")
+    try:
+        return ExactIntegerMatrix(entries=entries)
+    except ValueError as exc:
+        raise BenchmarkError(f"HNF report contains an invalid {field}") from exc
+
+
+def _integer_entries(matrix: ExactIntegerMatrix) -> list[list[int]]:
+    return [[int(value) for value in row] for row in matrix.entries]
+
+
+def _multiply_integer_matrices(
+    left: list[list[int]],
+    right: list[list[int]],
+) -> list[list[int]]:
+    return [
+        [
+            sum(
+                left_value * right[row][column]
+                for row, left_value in enumerate(left_row)
+            )
+            for column in range(len(right[0]))
+        ]
+        for left_row in left
+    ]
+
+
+def _integer_determinant_bareiss(matrix: list[list[int]]) -> int:
+    size = len(matrix)
+    if any(len(row) != size for row in matrix):
+        raise BenchmarkError("HNF transformation must be square")
+    if size == 1:
+        return matrix[0][0]
+    work = [row[:] for row in matrix]
+    sign = 1
+    previous_pivot = 1
+    for column in range(size - 1):
+        pivot_row = next(
+            (row for row in range(column, size) if work[row][column] != 0),
+            None,
+        )
+        if pivot_row is None:
+            return 0
+        if pivot_row != column:
+            work[column], work[pivot_row] = work[pivot_row], work[column]
+            sign = -sign
+        pivot = work[column][column]
+        for row in range(column + 1, size):
+            for target_column in range(column + 1, size):
+                numerator = (
+                    work[row][target_column] * pivot
+                    - work[row][column] * work[column][target_column]
+                )
+                quotient, remainder = divmod(numerator, previous_pivot)
+                if remainder:
+                    raise BenchmarkError("HNF determinant oracle division failed")
+                work[row][target_column] = quotient
+            work[row][column] = 0
+        previous_pivot = pivot
+    return sign * work[-1][-1]
+
+
+def _is_row_hnf_oracle(matrix: list[list[int]]) -> bool:
+    last_nonzero_row = -1
+    for row, values in enumerate(matrix):
+        if any(value != 0 for value in values):
+            last_nonzero_row = row
+    previous_pivot_column = -1
+    for row in range(last_nonzero_row + 1):
+        pivot_column = next(
+            (column for column, value in enumerate(matrix[row]) if value != 0),
+            None,
+        )
+        if pivot_column is None or pivot_column <= previous_pivot_column:
+            return False
+        pivot = matrix[row][pivot_column]
+        if pivot < 0 or any(
+            matrix[above][pivot_column] < 0 or matrix[above][pivot_column] >= pivot
+            for above in range(row)
+        ):
+            return False
+        previous_pivot_column = pivot_column
+    return all(
+        all(value == 0 for value in matrix[row])
+        for row in range(last_nonzero_row + 1, len(matrix))
+    )
+
+
+def _score_hnf_report(
+    case: Mapping[str, Any],
+    report: Mapping[str, Any],
+    *,
+    condition: str,
+    state_dir: Path,
+    mcp_calls: Sequence[str],
+    shell_calls: Sequence[str],
+    capability_invocations: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    source = _hnf_case_matrix(case)
+    normal_form = _reported_hnf_matrix(report, "normal_form")
+    transformation = _reported_hnf_matrix(report, "transformation")
+    source_entries = _integer_entries(source)
+    normal_entries = _integer_entries(normal_form)
+    transform_entries = _integer_entries(transformation)
+    if (
+        len(normal_entries) != len(source_entries)
+        or len(normal_entries[0]) != len(source_entries[0])
+        or len(transform_entries) != len(source_entries)
+        or len(transform_entries[0]) != len(source_entries)
+        or _multiply_integer_matrices(transform_entries, source_entries)
+        != normal_entries
+        or abs(_integer_determinant_bareiss(transform_entries)) != 1
+        or not _is_row_hnf_oracle(normal_entries)
+    ):
+        raise BenchmarkError("HNF report fails the independent exact oracle")
+    if (
+        report.get("case_id") != case.get("case_id")
+        or report.get("status") != "NORMAL_FORM_PRODUCED"
+        or report.get("conclusion") != "TRUE"
+    ):
+        raise BenchmarkError("HNF report has the wrong case, status, or conclusion")
+    _validate_feedback(report.get("feedback"))
+
+    if condition == "control":
+        if mcp_calls:
+            raise BenchmarkError("HNF control used an MCP tool")
+        if (
+            report.get("assurance") != "SELF_CHECKED"
+            or report.get("final_verification") != "UNVERIFIED"
+            or report.get("matrix_uri") is not None
+            or report.get("normal_form_uri") is not None
+            or report.get("verification_record_uri") is not None
+        ):
+            raise BenchmarkError(
+                "HNF control must remain self-checked without durable evidence"
+            )
+        return {
+            "passed": True,
+            "false_certification": False,
+            "replay_success": False,
+            "checks": [
+                "independent exact HNF oracle",
+                "no-Jacobian control isolation",
+            ],
+        }
+    if condition != "treatment":
+        raise BenchmarkError(f"unknown condition: {condition}")
+    if shell_calls:
+        raise BenchmarkError("HNF treatment used a shell command")
+    if "capability.invoke" not in mcp_calls:
+        raise BenchmarkError("HNF treatment did not invoke a Jacobian capability")
+    if (
+        report.get("assurance") != "VERIFIED"
+        or report.get("final_verification") != "VERIFIED"
+    ):
+        raise BenchmarkError("HNF treatment did not report verified assurance")
+    matrix_uri = report.get("matrix_uri")
+    normal_form_uri = report.get("normal_form_uri")
+    record_uri = report.get("verification_record_uri")
+    if not all(
+        isinstance(uri, str) for uri in (matrix_uri, normal_form_uri, record_uri)
+    ):
+        raise BenchmarkError("HNF treatment omitted durable artifact URIs")
+    assert isinstance(matrix_uri, str)
+    assert isinstance(normal_form_uri, str)
+    assert isinstance(record_uri, str)
+
+    kernel = JacobianKernel(state_dir, install_references=True)
+    try:
+        resolved = kernel.matrix_normal_forms.resolve_hermite_normal_form(
+            normal_form_uri
+        )
+        record_artifact = kernel.store.get(record_uri)
+        record = VerificationRecord.model_validate(record_artifact.payload)
+        semantics = kernel.store.get(
+            kernel.matrix_normal_forms.installation.semantics_uri
+        )
+    except (StoreError, ValueError) as exc:
+        raise BenchmarkError("HNF treatment artifacts are unavailable") from exc
+    if (
+        resolved.matrix != source
+        or resolved.candidate.normal_form != normal_form
+        or resolved.candidate.transformation != transformation
+        or resolved.matrix_artifact.artifact_uri != matrix_uri
+        or matrix_uri not in resolved.artifact.manifest.parents
+        or record.conclusion.value != "TRUE"
+        or record.bindings.claim_digest
+        != resolved.matrix_artifact.manifest.object_digest
+        or record.bindings.semantics_digest != semantics.manifest.object_digest
+        or record.bindings.candidate_digest != resolved.artifact.manifest.object_digest
+        or not {matrix_uri, normal_form_uri, record.evidence_uri}.issubset(
+            record_artifact.manifest.parents
+        )
+    ):
+        raise BenchmarkError("HNF verification record is not exactly bound")
+
+    produced_index: int | None = None
+    verified_trace = False
+    for index, invocation in enumerate(capability_invocations):
+        invocation_input = invocation.get("input")
+        invocation_output = invocation.get("output")
+        if (
+            invocation.get("capability_id") == "matrix.normal_form.hermite"
+            and isinstance(invocation_input, Mapping)
+            and _matches_integer_matrix(invocation_input.get("matrix"), source)
+            and isinstance(invocation_output, Mapping)
+            and invocation_output.get("matrix_uri") == matrix_uri
+            and invocation_output.get("normal_form_uri") == normal_form_uri
+            and normal_form_uri in (invocation.get("artifact_uris") or [])
+        ):
+            produced_index = index
+        if (
+            produced_index is not None
+            and index > produced_index
+            and invocation.get("capability_id") == "matrix.normal_form.hermite.verify"
+            and invocation_input == {"normal_form_uri": normal_form_uri}
+            and isinstance(invocation_output, Mapping)
+            and invocation_output.get("verification_record_uri") == record_uri
+            and isinstance(invocation.get("assurance"), Mapping)
+            and invocation["assurance"].get("level") == "VERIFIED"
+            and record_uri in (invocation.get("artifact_uris") or [])
+        ):
+            verified_trace = True
+            break
+    if not verified_trace:
+        raise BenchmarkError("HNF treatment lacks an ordered compute-to-verify trace")
+
+    replay = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="matrix.normal_form.hermite.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"normal_form_uri": normal_form_uri},
+        )
+    )
+    if (
+        replay.assurance.level.value != "VERIFIED"
+        or replay.assurance.verification_record_uri != record_uri
+        or replay.output.get("conclusion") != "TRUE"
+        or replay.output.get("matrix_uri") != matrix_uri
+        or replay.output.get("normal_form_uri") != normal_form_uri
+    ):
+        raise BenchmarkError("HNF treatment evidence does not replay independently")
+    return {
+        "passed": True,
+        "false_certification": False,
+        "replay_success": True,
+        "checks": [
+            "independent exact HNF oracle",
+            "durable source and candidate binding",
+            "ordered compute-to-verify trace",
+            "independent checker replay",
+        ],
+    }
+
+
+def _matches_integer_matrix(
+    value: object,
+    expected: ExactIntegerMatrix,
+) -> bool:
+    try:
+        return ExactIntegerMatrix.model_validate(value) == expected
+    except ValueError:
+        return False
 
 
 def _score_sat_report(
@@ -951,6 +1259,16 @@ def score_report(
     capability_attempt_ids: Sequence[str] = (),
     capability_invocations: Sequence[Mapping[str, Any]] = (),
 ) -> dict[str, Any]:
+    if case.get("task_type") == "matrix_hermite_normal_form":
+        return _score_hnf_report(
+            case,
+            report,
+            condition=condition,
+            state_dir=state_dir,
+            mcp_calls=mcp_calls,
+            shell_calls=shell_calls,
+            capability_invocations=capability_invocations,
+        )
     if case.get("task_type") == "linear_rational_solution":
         return _score_linear_report(
             case,
@@ -1855,6 +2173,12 @@ def _codex_command(
 
 
 def _condition_instructions(task_type: object, condition: str) -> str:
+    if task_type == "matrix_hermite_normal_form":
+        return (
+            HNF_CONTROL_INSTRUCTIONS
+            if condition == "control"
+            else HNF_TREATMENT_INSTRUCTIONS
+        )
     if task_type == "linear_rational_solution":
         return (
             LINEAR_CONTROL_INSTRUCTIONS
@@ -1917,6 +2241,7 @@ def _run_condition(
     is_sat = case.get("task_type") == "sat_decision"
     is_smt = case.get("task_type") == "smt_unsat_proof"
     is_linear = case.get("task_type") == "linear_rational_solution"
+    is_hnf = case.get("task_type") == "matrix_hermite_normal_form"
     is_lean_declaration = case.get("task_type") == "lean_declaration"
     is_lean_proof = case.get("task_type") == "lean_proof"
     sat_context = ""
@@ -1934,6 +2259,14 @@ def _run_condition(
             + json.dumps(system.model_dump(mode="json"), sort_keys=True)
             + "\n"
         )
+    hnf_context = ""
+    if is_hnf:
+        matrix = _hnf_case_matrix(case)
+        hnf_context = (
+            "\nThe exact integer matrix A for this case is:\n"
+            + json.dumps(matrix.model_dump(mode="json"), sort_keys=True)
+            + "\n"
+        )
     condition_instructions = _condition_instructions(
         case.get("task_type"),
         condition,
@@ -1942,6 +2275,7 @@ def _run_condition(
         condition_instructions
         + sat_context
         + linear_context
+        + hnf_context
         + "\n"
         + COMMON_PROMPT.format(**case)
     )
@@ -1969,6 +2303,8 @@ def _run_condition(
             if is_smt
             else LINEAR_REPORT_SCHEMA
             if is_linear
+            else HNF_REPORT_SCHEMA
+            if is_hnf
             else PARTITION_REPORT_SCHEMA
             if is_partition
             else REPORT_SCHEMA
@@ -2088,6 +2424,12 @@ def _run_condition(
                 and report.get("final_verification") == "VERIFIED"
                 and not score.get("passed")
             )
+            or (
+                is_hnf
+                and isinstance(report, dict)
+                and report.get("final_verification") == "VERIFIED"
+                and not score.get("passed")
+            )
         ),
         "intervention_attempted": bool(
             (
@@ -2108,6 +2450,10 @@ def _run_condition(
                     telemetry["capability_attempt_ids"]
                 )
             )
+            or (
+                is_hnf
+                and HNF_CAPABILITY_IDS.intersection(telemetry["capability_attempt_ids"])
+            )
         ),
         "intervention_used": bool(
             (
@@ -2120,6 +2466,7 @@ def _run_condition(
                 is_linear
                 and LINEAR_CAPABILITY_IDS.intersection(telemetry["capability_ids"])
             )
+            or (is_hnf and HNF_CAPABILITY_IDS.intersection(telemetry["capability_ids"]))
         ),
         "operational_failure": bool(score.get("operational_failure")),
         "score": score,

--- a/docs/contributing/atomic-capability-portfolio.md
+++ b/docs/contributing/atomic-capability-portfolio.md
@@ -473,9 +473,10 @@ proof-support claim. See
 
 ### Python-FLINT first
 
-The first rational-solution slice is implemented; see the
+The rational-solution and integer row-HNF slices are implemented; see the
 [exact rational solution contract](../reference/linear-rational-solutions.md)
-and the
+and [integer matrix HNF contract](../reference/matrix-hermite-normal-form.md).
+The rational-solution usability evidence is recorded in the
 [Python-FLINT rational-solution pilot](../reference/capability-workflow-evaluations.md#python-flint-rational-solution-pilot).
 The remaining sequence stays demand-gated.
 
@@ -486,8 +487,9 @@ Implement one vertical slice at a time:
    `A x = b`. Failure to find a vector says nothing about consistency.
 2. Add an inconsistent-system outcome only with a separately checkable
    left-nullspace or equivalent certificate.
-3. Add `matrix.normal_form.hermite` only when the pinned binding returns enough
-   transformation data to check the exact relation and normal-form conditions.
+3. `matrix.normal_form.hermite` is implemented with the binding's complete
+   left transformation. Independent replay checks `H = U A`, unimodularity,
+   and every FLINT row-HNF condition.
 4. Add `polynomial.factor` with a product relation. Checking that the factors
    multiply to the input does not by itself certify irreducibility or
    completeness; keep those as open obligations until separately checked.
@@ -574,8 +576,10 @@ backlog.
     [exact rational solution contract](../reference/linear-rational-solutions.md)
     and the
     [Python-FLINT rational-solution pilot](../reference/capability-workflow-evaluations.md#python-flint-rational-solution-pilot).
-12. Python-FLINT polynomial or integer-matrix slice chosen from transcript
-    demand.
+12. Python-FLINT integer-matrix row-HNF slice. Implemented; see the
+    [integer matrix HNF contract](../reference/matrix-hermite-normal-form.md)
+    and the
+    [Python-FLINT HNF pilot](../reference/capability-workflow-evaluations.md#python-flint-hermite-normal-form-pilot).
 13. Typed expression AST and one SymPy polynomial-normalization slice.
 14. Re-rank E/Vampire, Metamath, nauty, Singular, PARI, Normaliz, GAP, fplll,
     and HiGHS from accumulated workflow evidence.

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,6 +61,7 @@ expectations.
 - [SAT artifact contracts](reference/sat-artifacts.md)
 - [SMT Alethe artifact contracts](reference/smt-artifacts.md)
 - [Exact rational solution artifacts](reference/linear-rational-solutions.md)
+- [Integer matrix Hermite normal form](reference/matrix-hermite-normal-form.md)
 - [v0.2 specification](reference/specifications/v0.2.md)
 - [v0.2 conformance specification](reference/conformance-v0.2.md)
 - [Plugin conformance contract](reference/plugin-conformance.md)

--- a/docs/reference/capability-workflow-evaluations.md
+++ b/docs/reference/capability-workflow-evaluations.md
@@ -478,6 +478,39 @@ discovery and lower-overhead MCP composition remain follow-up work. Because
 this was a prescribed-capability pilot, it measures contract use and assurance
 discipline rather than autonomous portfolio discovery.
 
+### Python-FLINT Hermite-normal-form pilot
+
+The frozen 2026-07-26 HNF pilot used `gpt-5.6-terra`, high reasoning effort, a
+420-second per-run limit, and one repetition of two private exact integer
+matrices. One was a three-by-four matrix and one was a singular four-by-three
+matrix with a zero row. Their case digests were
+`sha256:947a2f92b36cc8003b6d990dc9522f3b6a1cc2819085dded794947699b71320d`
+and
+`sha256:671188addd5934fb2a6b9d95ced1d0aaad819eaa354c16128e0d0af68ecaab38`.
+
+Control computed `H` and `U` directly and could report only
+`SELF_CHECKED/UNVERIFIED`. Treatment was prescribed
+`matrix.normal_form.hermite` and
+`matrix.normal_form.hermite.verify`. It had to pass the producer's
+`normal_form_uri` into the verifier and copy the exact matrices and durable
+URIs. The hidden scorer independently checked `H = U A`, `det(U) = ±1`, every
+FLINT row-HNF condition, artifact bindings, the ordered invocation trace, and
+clean-kernel replay.
+
+| Condition | Passed | False certifications | Clean replays | Median seconds | Median input tokens | Median calls | Tool errors |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| control | 2 / 2 | 0 | 0 / 2 | 73.804 | 40,787.5 | 1.5 | 0 |
+| Python-FLINT producer + verifier | 2 / 2 | 0 | 2 / 2 | 41.524 | 104,488.5 | 4 | 0 |
+
+Both treatments used the intended capabilities without parameter errors,
+capability rejection, or operational failure. Both verification records
+replayed independently. The treatment was faster on these cases but consumed
+more cumulative input tokens, so the small pilot does not establish a general
+runtime advantage. It supports retaining the complete `H, U` output, the
+producer/verifier split, and direct URI handoff without another contract
+revision. As a prescribed-capability pilot, it measures usability and
+assurance discipline rather than autonomous portfolio selection.
+
 ## Source policy
 
 Use the supplied research collection according to evidence strength:

--- a/docs/reference/matrix-hermite-normal-form.md
+++ b/docs/reference/matrix-hermite-normal-form.md
@@ -1,0 +1,86 @@
+# Integer matrix Hermite normal form
+
+`matrix.normal_form.hermite` computes one exact row Hermite normal form for a
+finite integer matrix. `matrix.normal_form.hermite.verify` independently
+checks the stored result. Computation and verification are separate trust
+boundaries.
+
+## Input contract
+
+The producer accepts one nonempty rectangular matrix over `ZZ`:
+
+- 1 to 32 rows and 1 to 32 columns;
+- canonical decimal integer strings such as `"0"`, `"-3"`, and `"42"`; and
+- at most 256 decimal digits per entry.
+
+The request includes a wall-clock budget from 1 to 60 seconds. The default is
+10 seconds.
+
+## Computed evidence
+
+The optional `flint` extra pins Python-FLINT 0.9.0 and its linked FLINT 3.6.0
+library for this profile. Its HNF operation calls
+`fmpz_mat.hnf(transform=True)` in an isolated process and returns two exact
+integer matrices:
+
+- `H`, the proposed row Hermite normal form; and
+- `U`, the proposed left transformation satisfying `H = U A`.
+
+The [Python-FLINT matrix documentation][python-flint-hnf] exposes this exact
+transformation relation. Jacobian records the Python distribution digest,
+operation profile, resource budget, source identity, `H`, and `U`. A successful
+provider call has `COMPUTED` assurance and `conclusion: UNKNOWN`; it does not
+verify its own output.
+
+Timeout, process failure, an invalid worker response, excessive output, or a
+runtime identity change produces no normal-form artifact and no mathematical
+conclusion.
+
+## Row-HNF convention
+
+The candidate uses FLINT's row convention:
+
+1. every zero row follows every nonzero row;
+2. the first nonzero entry of each nonzero row is positive;
+3. pivot columns increase strictly down the rows; and
+4. every entry above a pivot lies in the half-open interval `[0, pivot)`.
+
+These conditions match FLINT 3.6.0's
+[`fmpz_mat_is_in_hnf` implementation][flint-is-in-hnf]. Entries to the left of
+a pivot are zero because the pivot is the row's first nonzero entry.
+
+## Independent verification
+
+With bundled references enabled, `matrix.normal_form.hermite.verify` runs an
+operator-authorized standard-library checker in a clean process. The checker
+accepts only when all of the following hold:
+
+1. artifact schemas, semantics, payload digests, exact source bindings, and
+   parent lineage agree;
+2. `H` and `U` have the dimensions bound to `A`;
+3. exact integer multiplication gives `H = U A`;
+4. an independent fraction-free Bareiss determinant gives `det(U) = 1` or
+   `det(U) = -1`; and
+5. every row-HNF convention condition above holds.
+
+Only acceptance creates a verification record and returns `VERIFIED`.
+Rejection, timeout, cancellation, malformed evidence, or checker failure
+returns `UNKNOWN`. Rejection does not prove any opposite normal-form claim.
+
+## Artifact bindings
+
+The source matrix and HNF candidate are immutable artifacts under one
+versioned integer-matrix semantics descriptor. The candidate binds:
+
+- the source artifact URI, object digest, and payload digest;
+- the exact source dimensions;
+- the complete `H` and `U` matrices;
+- the pinned producer runtime identity and operation profile; and
+- the enforced resource budget.
+
+The verification witness separately binds the exact source, candidate,
+semantics, and checker identity. Replacing any source entry, transformation,
+normal-form entry, digest, binding, or lineage edge invalidates replay.
+
+[python-flint-hnf]: https://python-flint.readthedocs.io/en/latest/fmpz_mat.html#flint.fmpz_mat.hnf
+[flint-is-in-hnf]: https://github.com/flintlib/flint/blob/v3.6.0/src/fmpz_mat/is_in_hnf.c

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -170,10 +170,12 @@ provider identity is available:
 | `sat.unsat_proof.find` | With CaDiCaL 3.0.1, preserve raw DRAT evidence without certifying UNSAT. |
 | `smt.unsat_proof.find` | With the `smt` extra and cvc5 1.3.4, preserve raw Alethe for one pinned-profile QF query, expose holes, and retain `UNKNOWN`. |
 | `linear.rational_solution.find` | With the `flint` extra and Python-FLINT 0.9.0, produce one exact rational vector for a declared `A x = b` system; not-found remains a non-conclusion. |
+| `matrix.normal_form.hermite` | With the `flint` extra and Python-FLINT 0.9.0, produce exact `H` and `U` for the proposed row-HNF relation `H = U A`; the provider does not verify the relation or form. |
 
 See the [SAT artifact contracts](sat-artifacts.md) and
 [SMT Alethe artifact contracts](smt-artifacts.md), and
-[exact rational solution artifacts](linear-rational-solutions.md) for exact
+[exact rational solution artifacts](linear-rational-solutions.md) and
+[integer matrix Hermite normal form](matrix-hermite-normal-form.md) for exact
 input profiles, resource bounds, artifact bindings, and independent
 verification boundaries.
 
@@ -187,6 +189,7 @@ When the operator enables bundled references, the catalog also includes:
 | `lean.proof_state.apply_tactic` | Apply one tactic through the pinned Lean REPL and materialize the resulting goals and replay source. |
 | `lean.retrieve.premises` | Ask pinned Mathlib `exact?` for bounded candidate tactics and declaration references for one proof state. |
 | `linear.rational_solution.verify` | Independently replay every equation for one exact stored vector; rejection does not prove inconsistency. |
+| `matrix.normal_form.hermite.verify` | Independently check `H = U A`, `det(U) = ±1`, and every FLINT row-HNF condition for one exact stored candidate. |
 
 The two exploratory Lean capabilities use the maintained
 `leanprover-community/repl` JSON protocol pinned in the Lake manifest. Their

--- a/src/jacobian/contracts/matrices.py
+++ b/src/jacobian/contracts/matrices.py
@@ -4,11 +4,28 @@ from __future__ import annotations
 
 from typing import Literal, Self
 
-from pydantic import Field, model_validator
+from pydantic import Field, StrictInt, model_validator
 
-from jacobian.contracts.common import ArtifactUri
-from jacobian.contracts.exact import CanonicalRational
+from jacobian.contracts.capabilities import (
+    CapabilityProviderAvailability,
+    CapabilityProviderRuntime,
+)
+from jacobian.contracts.common import ArtifactUri, CheckerUri, Sha256Digest
+from jacobian.contracts.exact import CanonicalInteger, CanonicalRational
 from jacobian.contracts.results import ContractModel
+
+MAX_MATRIX_DIMENSION = 32
+MAX_INTEGER_DIGITS = 256
+PYTHON_FLINT_HNF_CONFIGURATION = {
+    "distribution": "python-flint",
+    "domain": "ZZ",
+    "operation": "fmpz_mat.hnf(transform=True)",
+    "flint_library_version": "3.6.0",
+    "maximum_rows": 32,
+    "maximum_columns": 32,
+    "normal_form_convention": "FLINT_ROW_HNF",
+    "relation": "H=U*A",
+}
 
 
 class ExactRationalMatrix(ContractModel):
@@ -26,6 +43,32 @@ class ExactRationalMatrix(ContractModel):
             raise ValueError("matrix rows must contain between 1 and 32 entries")
         if any(len(row) != column_count for row in self.entries):
             raise ValueError("matrix rows must all have the same length")
+        return self
+
+
+class ExactIntegerMatrix(ContractModel):
+    """One nonempty rectangular matrix over exact canonical integers."""
+
+    matrix_schema_version: Literal["1"] = "1"
+    domain: Literal["ZZ"] = "ZZ"
+    entries: tuple[tuple[CanonicalInteger, ...], ...] = Field(
+        min_length=1,
+        max_length=MAX_MATRIX_DIMENSION,
+    )
+
+    @model_validator(mode="after")
+    def require_bounded_rectangular_nonempty_rows(self) -> Self:
+        column_count = len(self.entries[0])
+        if column_count == 0 or column_count > MAX_MATRIX_DIMENSION:
+            raise ValueError("matrix rows must contain between 1 and 32 entries")
+        if any(len(row) != column_count for row in self.entries):
+            raise ValueError("matrix rows must all have the same length")
+        if any(
+            len(value.lstrip("-")) > MAX_INTEGER_DIGITS
+            for row in self.entries
+            for value in row
+        ):
+            raise ValueError("integer matrix entries are limited to 256 decimal digits")
         return self
 
 
@@ -87,3 +130,150 @@ class MatrixRankOutput(ContractModel):
     method: Literal["EXACT_RATIONAL_ROW_REDUCTION"] = "EXACT_RATIONAL_ROW_REDUCTION"
     backend: Literal["sympy"] = "sympy"
     backend_version: str
+
+
+class MatrixHermiteResourceBudget(ContractModel):
+    """Wall-clock bound for one isolated Python-FLINT HNF attempt."""
+
+    budget_version: Literal["1"] = "1"
+    wall_seconds: StrictInt = Field(default=10, ge=1, le=60)
+
+
+class MatrixBinding(ContractModel):
+    """Exact stored identity and dimensions of one integer matrix."""
+
+    binding_version: Literal["1"] = "1"
+    matrix_artifact_uri: ArtifactUri
+    matrix_object_digest: Sha256Digest
+    matrix_payload_digest: Sha256Digest
+    row_count: StrictInt = Field(ge=1, le=MAX_MATRIX_DIMENSION)
+    column_count: StrictInt = Field(ge=1, le=MAX_MATRIX_DIMENSION)
+
+
+class MatrixHermiteNormalFormArtifact(ContractModel):
+    """One HNF candidate plus its proposed left transformation."""
+
+    normal_form_schema_version: Literal["1"] = "1"
+    source: MatrixBinding
+    declared_scope: Literal["FULL_MATRIX"] = "FULL_MATRIX"
+    normal_form: ExactIntegerMatrix
+    transformation: ExactIntegerMatrix
+    producer: CapabilityProviderRuntime
+    resource_budget: MatrixHermiteResourceBudget
+    method: Literal["ROW_HNF_LEFT_UNIMODULAR_TRANSFORM"] = (
+        "ROW_HNF_LEFT_UNIMODULAR_TRANSFORM"
+    )
+
+    @model_validator(mode="after")
+    def require_bound_shapes_and_pinned_producer(self) -> Self:
+        normal_rows = len(self.normal_form.entries)
+        normal_columns = len(self.normal_form.entries[0])
+        transform_rows = len(self.transformation.entries)
+        transform_columns = len(self.transformation.entries[0])
+        if (normal_rows, normal_columns) != (
+            self.source.row_count,
+            self.source.column_count,
+        ):
+            raise ValueError("normal form dimensions must match the source matrix")
+        if (transform_rows, transform_columns) != (
+            self.source.row_count,
+            self.source.row_count,
+        ):
+            raise ValueError("left transformation must be square by source row count")
+        if (
+            self.producer.provider != "python-flint"
+            or self.producer.availability
+            is not CapabilityProviderAvailability.AVAILABLE
+            or self.producer.version != "0.9.0"
+            or self.producer.configuration != PYTHON_FLINT_HNF_CONFIGURATION
+        ):
+            raise ValueError(
+                "normal-form producer must be the pinned Python-FLINT HNF profile"
+            )
+        return self
+
+
+class MatrixHermiteNormalFormRequest(ContractModel):
+    matrix: ExactIntegerMatrix
+    resource_budget: MatrixHermiteResourceBudget = Field(
+        default_factory=MatrixHermiteResourceBudget
+    )
+
+
+class MatrixHermiteNormalFormOutput(ContractModel):
+    """Unverified outcome of one bounded row-HNF computation."""
+
+    status: Literal["NORMAL_FORM_PRODUCED", "NO_NORMAL_FORM_PRODUCED"]
+    conclusion: Literal["UNKNOWN"] = "UNKNOWN"
+    matrix_uri: ArtifactUri
+    normal_form_uri: ArtifactUri | None = None
+    normal_form: ExactIntegerMatrix | None = None
+    transformation: ExactIntegerMatrix | None = None
+    exactness: Literal["EXACT_INTEGER"] = "EXACT_INTEGER"
+    determinism: Literal["DETERMINISTIC"] = "DETERMINISTIC"
+    verification: Literal["UNVERIFIED"] = "UNVERIFIED"
+    certificate_available: bool
+    method: Literal["ROW_HNF_LEFT_UNIMODULAR_TRANSFORM"] = (
+        "ROW_HNF_LEFT_UNIMODULAR_TRANSFORM"
+    )
+    backend: Literal["python-flint"] = "python-flint"
+    backend_version: Literal["0.9.0"] = "0.9.0"
+    flint_library_version: Literal["3.6.0"] = "3.6.0"
+    detail: str = Field(min_length=1, max_length=1024)
+
+    @model_validator(mode="after")
+    def bind_candidate_projection(self) -> Self:
+        produced = self.status == "NORMAL_FORM_PRODUCED"
+        if produced != (
+            self.normal_form_uri is not None
+            and self.normal_form is not None
+            and self.transformation is not None
+            and self.certificate_available
+        ):
+            raise ValueError(
+                "produced output requires one durable normal form and transformation"
+            )
+        if not produced and (
+            self.normal_form_uri is not None
+            or self.normal_form is not None
+            or self.transformation is not None
+            or self.certificate_available
+        ):
+            raise ValueError("failed output cannot carry normal-form evidence")
+        return self
+
+
+class MatrixHermiteNormalFormVerificationRequest(ContractModel):
+    normal_form_uri: ArtifactUri
+
+
+class MatrixHermiteNormalFormVerificationOutput(ContractModel):
+    """Projection of independent HNF and row-equivalence replay."""
+
+    status: Literal[
+        "VERIFIED_HERMITE_NORMAL_FORM",
+        "REJECTED",
+        "TIMEOUT",
+        "CANCELLED",
+        "ERROR",
+    ]
+    conclusion: Literal["TRUE", "UNKNOWN"]
+    matrix_uri: ArtifactUri
+    normal_form_uri: ArtifactUri
+    witness_uri: ArtifactUri
+    checker_id: CheckerUri
+    verification_record_uri: ArtifactUri | None = None
+    detail: str = Field(min_length=1, max_length=1024)
+
+    @model_validator(mode="after")
+    def bind_verified_projection(self) -> Self:
+        if self.status == "VERIFIED_HERMITE_NORMAL_FORM":
+            if self.conclusion != "TRUE" or self.verification_record_uri is None:
+                raise ValueError(
+                    "verified HNF output requires TRUE and a verification record"
+                )
+        elif self.conclusion != "UNKNOWN" or self.verification_record_uri is not None:
+            raise ValueError(
+                "non-verified HNF output cannot carry a conclusion or record"
+            )
+        return self

--- a/src/jacobian/flint_hnf.py
+++ b/src/jacobian/flint_hnf.py
@@ -1,0 +1,407 @@
+"""Bounded Python-FLINT row Hermite-normal-form producer."""
+
+from __future__ import annotations
+
+import sys
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic import ValidationError
+
+from jacobian.bounded_process import BoundedProcessResult, run_bounded_process
+from jacobian.canonical import canonicalize_json, loads_strict_json
+from jacobian.capabilities import CapabilityAdapter, CapabilityInvocationError
+from jacobian.contracts.capabilities import (
+    CapabilityAssurance,
+    CapabilityAssuranceLevel,
+    CapabilityCompleteness,
+    CapabilityCompletenessStatus,
+    CapabilityDescriptor,
+    CapabilityDiagnostic,
+    CapabilityMode,
+    CapabilityProviderAvailability,
+    CapabilityProviderRuntime,
+    CapabilityRelationship,
+    CapabilityRequest,
+    CapabilityResult,
+    CapabilityScope,
+)
+from jacobian.contracts.matrices import (
+    PYTHON_FLINT_HNF_CONFIGURATION,
+    ExactIntegerMatrix,
+    MatrixHermiteNormalFormOutput,
+    MatrixHermiteNormalFormRequest,
+)
+from jacobian.contracts.results import Execution, ExecutionStatus
+from jacobian.flint_hnf_worker import FLINT_HNF_WORKER_PROTOCOL
+from jacobian.matrix_normal_forms import MatrixNormalFormArtifactService
+from jacobian.provider_runtime import (
+    PYTHON_FLINT_VERSION,
+    python_flint_hnf_provider_runtime,
+)
+from jacobian.schema_registry import model_schema
+
+FLINT_HNF_STDOUT_LIMIT = 1_000_000
+FLINT_HNF_STDERR_LIMIT = 64_000
+
+
+@dataclass(frozen=True, slots=True)
+class _FlintHnfRun:
+    execution_status: ExecutionStatus
+    runtime_ms: int
+    normal_form: ExactIntegerMatrix | None = None
+    transformation: ExactIntegerMatrix | None = None
+    detail: str | None = None
+
+
+def install_python_flint_hnf_capability(
+    matrices: MatrixNormalFormArtifactService,
+    runtime: CapabilityProviderRuntime,
+) -> CapabilityAdapter:
+    """Install the producer only for the exact supported HNF profile."""
+
+    if (
+        runtime.availability is not CapabilityProviderAvailability.AVAILABLE
+        or runtime.provider != "python-flint"
+        or runtime.version != PYTHON_FLINT_VERSION
+        or runtime.configuration != PYTHON_FLINT_HNF_CONFIGURATION
+    ):
+        raise ValueError("the pinned Python-FLINT HNF runtime is not available")
+    return PythonFlintHermiteNormalFormAdapter(
+        matrices=matrices,
+        runtime=runtime,
+    )
+
+
+class _PythonFlintHnfBackend:
+    def __init__(self, runtime: CapabilityProviderRuntime) -> None:
+        self.runtime = runtime
+
+    def run(self, request: MatrixHermiteNormalFormRequest) -> _FlintHnfRun:
+        started = time.monotonic()
+        if python_flint_hnf_provider_runtime(refresh=True) != self.runtime:
+            return _failure(
+                started,
+                ExecutionStatus.ERROR,
+                (
+                    "The installed Python-FLINT HNF runtime no longer matches the "
+                    "capability descriptor; no normal-form evidence was retained."
+                ),
+            )
+        command = [sys.executable, "-I", "-m", "jacobian.flint_hnf_worker"]
+        worker_request = {
+            "protocol": FLINT_HNF_WORKER_PROTOCOL,
+            "matrix": request.matrix.model_dump(mode="json"),
+        }
+        try:
+            completed = run_bounded_process(
+                command,
+                input_bytes=canonicalize_json(worker_request),
+                timeout_seconds=float(request.resource_budget.wall_seconds),
+                environment={
+                    "LANG": "C",
+                    "LC_ALL": "C",
+                    "TZ": "UTC",
+                    "PYTHONHASHSEED": "0",
+                },
+                stdout_limit=FLINT_HNF_STDOUT_LIMIT,
+                stderr_limit=FLINT_HNF_STDERR_LIMIT,
+            )
+        except OSError:
+            return _failure(
+                started,
+                ExecutionStatus.ERROR,
+                "The isolated Python-FLINT HNF worker could not be started.",
+            )
+        operational = _operational_failure(started, completed)
+        if operational is not None:
+            return operational
+        try:
+            normal_form, transformation = _parse_worker_output(
+                completed.stdout,
+                rows=len(request.matrix.entries),
+                columns=len(request.matrix.entries[0]),
+            )
+        except (UnicodeDecodeError, ValueError, ValidationError):
+            return _failure(
+                started,
+                ExecutionStatus.ERROR,
+                (
+                    "The Python-FLINT HNF worker returned output outside its exact "
+                    "bounded protocol; no normal-form evidence was retained."
+                ),
+            )
+        if python_flint_hnf_provider_runtime(refresh=True) != self.runtime:
+            return _failure(
+                started,
+                ExecutionStatus.ERROR,
+                (
+                    "The installed Python-FLINT HNF runtime changed during execution; "
+                    "no normal-form evidence was retained."
+                ),
+            )
+        return _FlintHnfRun(
+            execution_status=ExecutionStatus.COMPLETED,
+            runtime_ms=_runtime_ms(started),
+            normal_form=normal_form,
+            transformation=transformation,
+        )
+
+
+class PythonFlintHermiteNormalFormAdapter:
+    """Produce one row-HNF candidate and left transformation."""
+
+    def __init__(
+        self,
+        *,
+        matrices: MatrixNormalFormArtifactService,
+        runtime: CapabilityProviderRuntime,
+    ) -> None:
+        self.matrices = matrices
+        self.backend = _PythonFlintHnfBackend(runtime)
+        self._descriptor = CapabilityDescriptor(
+            capability_id="matrix.normal_form.hermite",
+            version="1",
+            title="Compute an exact row Hermite normal form",
+            description=(
+                "Use pinned Python-FLINT to return H and U for one integer matrix, "
+                "with the proposed relation H = U A. Verify row-HNF conditions and "
+                "unimodularity separately."
+            ),
+            provider="python-flint",
+            provider_runtime=runtime,
+            modes=(CapabilityMode.EXPLORE,),
+            input_schema=model_schema(MatrixHermiteNormalFormRequest),
+            output_schema=model_schema(MatrixHermiteNormalFormOutput),
+            tags=(
+                "linear-algebra",
+                "integer",
+                "matrix",
+                "hermite-normal-form",
+                "exact",
+                "python-flint",
+            ),
+        )
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        return self._descriptor
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        try:
+            validated = MatrixHermiteNormalFormRequest.model_validate(request.input)
+            matrix_uri = self.matrices.put_matrix(validated.matrix).artifact_uri
+            resolved = self.matrices.resolve_matrix(matrix_uri)
+        except (ValidationError, ValueError) as exc:
+            raise CapabilityInvocationError(
+                CapabilityDiagnostic(
+                    code="INVALID_EXACT_INTEGER_MATRIX",
+                    stage="input_validation",
+                    message=str(exc),
+                    path="matrix",
+                    schema_uri=self.matrices.installation.matrix_schema_uri,
+                    expected=(
+                        "one nonempty 1..32 by 1..32 exact integer matrix with "
+                        "canonical strings of at most 256 decimal digits"
+                    ),
+                    hint=(
+                        "Encode every entry as a canonical integer string such as "
+                        '"0", "-3", or "42".'
+                    ),
+                )
+            ) from exc
+
+        run = self.backend.run(validated)
+        normal_form_uri: str | None = None
+        if (
+            run.execution_status is ExecutionStatus.COMPLETED
+            and run.normal_form is not None
+            and run.transformation is not None
+        ):
+            normal_form_uri = self.matrices.put_hermite_normal_form(
+                matrix_uri=matrix_uri,
+                normal_form=run.normal_form.entries,
+                transformation=run.transformation.entries,
+                producer=self.backend.runtime,
+                resource_budget=validated.resource_budget,
+            ).artifact_uri
+        output = MatrixHermiteNormalFormOutput(
+            status=(
+                "NORMAL_FORM_PRODUCED"
+                if normal_form_uri is not None
+                else "NO_NORMAL_FORM_PRODUCED"
+            ),
+            matrix_uri=matrix_uri,
+            normal_form_uri=normal_form_uri,
+            normal_form=run.normal_form if normal_form_uri is not None else None,
+            transformation=(
+                run.transformation if normal_form_uri is not None else None
+            ),
+            certificate_available=normal_form_uri is not None,
+            detail=(
+                "Python-FLINT produced exact H and U with the proposed relation "
+                "H = U A; row-HNF conditions and unimodularity remain unverified."
+                if normal_form_uri is not None
+                else (
+                    run.detail
+                    or "No normal-form evidence was produced; no conclusion follows."
+                )
+            ),
+        )
+        artifact_uris = (
+            (matrix_uri, normal_form_uri)
+            if normal_form_uri is not None
+            else (matrix_uri,)
+        )
+        relationships = (
+            (
+                CapabilityRelationship(
+                    relation_id="matrix.relation.row-hermite-normal-form-of",
+                    source_artifact_uris=(normal_form_uri,),
+                    target_artifact_uris=(matrix_uri,),
+                ),
+            )
+            if normal_form_uri is not None
+            else ()
+        )
+        return CapabilityResult(
+            capability_id=self.descriptor.capability_id,
+            capability_version=self.descriptor.version,
+            mode=request.mode,
+            execution=Execution(
+                status=run.execution_status,
+                runtime_ms=run.runtime_ms,
+                detail=run.detail,
+            ),
+            output=output.model_dump(mode="json"),
+            scope=CapabilityScope(
+                description="the full declared exact integer matrix",
+                parameters={
+                    "declared_scope": "FULL_MATRIX",
+                    "row_count": resolved.binding.row_count,
+                    "column_count": resolved.binding.column_count,
+                    "normal_form_convention": "FLINT_ROW_HNF",
+                    "relation": "H=U*A",
+                    "wall_seconds": validated.resource_budget.wall_seconds,
+                },
+                artifact_uri=matrix_uri,
+            ),
+            completeness=CapabilityCompleteness(
+                status=(
+                    CapabilityCompletenessStatus.COMPLETE
+                    if normal_form_uri is not None
+                    else CapabilityCompletenessStatus.UNKNOWN
+                ),
+                basis=(
+                    "one full-size H and U were produced; completeness of the "
+                    "provider computation is not independent verification"
+                    if normal_form_uri is not None
+                    else "the bounded provider attempt produced no normal-form "
+                    "evidence; no mathematical conclusion follows"
+                ),
+                assurance_level=(
+                    CapabilityAssuranceLevel.COMPUTED
+                    if run.execution_status is ExecutionStatus.COMPLETED
+                    else CapabilityAssuranceLevel.HEURISTIC
+                ),
+            ),
+            assurance=CapabilityAssurance(
+                level=(
+                    CapabilityAssuranceLevel.COMPUTED
+                    if run.execution_status is ExecutionStatus.COMPLETED
+                    else CapabilityAssuranceLevel.HEURISTIC
+                ),
+                basis=(
+                    "the pinned exact-arithmetic provider produced bound H and U, "
+                    "but provider success does not verify row equivalence or HNF"
+                    if normal_form_uri is not None
+                    else "provider execution did not complete; no mathematical "
+                    "conclusion follows"
+                ),
+            ),
+            artifact_uris=artifact_uris,
+            relationships=relationships,
+        )
+
+
+def _parse_worker_output(
+    stdout: bytes,
+    *,
+    rows: int,
+    columns: int,
+) -> tuple[ExactIntegerMatrix, ExactIntegerMatrix]:
+    if not stdout.endswith(b"\n") or stdout.count(b"\n") != 1:
+        raise ValueError("worker output is not exactly one line")
+    payload: Any = loads_strict_json(stdout[:-1])
+    if (
+        not isinstance(payload, dict)
+        or payload.get("protocol") != FLINT_HNF_WORKER_PROTOCOL
+        or payload.get("status") != "NORMAL_FORM_PRODUCED"
+        or payload.get("backend_version") != PYTHON_FLINT_VERSION
+        or set(payload)
+        != {
+            "protocol",
+            "status",
+            "backend_version",
+            "flint_library_version",
+            "normal_form",
+            "transformation",
+        }
+        or payload.get("flint_library_version") != "3.6.0"
+    ):
+        raise ValueError("worker protocol is invalid")
+    normal_form = ExactIntegerMatrix(entries=payload["normal_form"])
+    transformation = ExactIntegerMatrix(entries=payload["transformation"])
+    if (
+        len(normal_form.entries),
+        len(normal_form.entries[0]),
+    ) != (rows, columns):
+        raise ValueError("worker normal-form shape is invalid")
+    if (
+        len(transformation.entries),
+        len(transformation.entries[0]),
+    ) != (rows, rows):
+        raise ValueError("worker transformation shape is invalid")
+    return normal_form, transformation
+
+
+def _operational_failure(
+    started: float,
+    completed: BoundedProcessResult,
+) -> _FlintHnfRun | None:
+    if completed.timed_out:
+        return _failure(
+            started,
+            ExecutionStatus.TIMEOUT,
+            "The bounded Python-FLINT HNF attempt timed out; no conclusion follows.",
+        )
+    if completed.stdout_exceeded or completed.stderr_exceeded:
+        return _failure(
+            started,
+            ExecutionStatus.ERROR,
+            "The Python-FLINT HNF worker exceeded its output limit.",
+        )
+    if completed.returncode != 0 or completed.stderr or not completed.stdout:
+        return _failure(
+            started,
+            ExecutionStatus.ERROR,
+            "The Python-FLINT HNF worker failed; no evidence was retained.",
+        )
+    return None
+
+
+def _failure(
+    started: float,
+    status: ExecutionStatus,
+    detail: str,
+) -> _FlintHnfRun:
+    return _FlintHnfRun(
+        execution_status=status,
+        runtime_ms=_runtime_ms(started),
+        detail=detail,
+    )
+
+
+def _runtime_ms(started: float) -> int:
+    return max(0, round((time.monotonic() - started) * 1000))

--- a/src/jacobian/flint_hnf_worker.py
+++ b/src/jacobian/flint_hnf_worker.py
@@ -1,0 +1,155 @@
+"""Isolated Python-FLINT worker for integer row Hermite normal form."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import re
+import sys
+from typing import Any
+
+FLINT_HNF_WORKER_PROTOCOL = "jacobian.flint-hnf-worker/v1"
+FLINT_HNF_INPUT_LIMIT = 1_000_000
+MAX_MATRIX_DIMENSION = 32
+MAX_INTEGER_DIGITS = 256
+_INTEGER = re.compile(r"^-?(?:0|[1-9][0-9]*)$")
+
+
+class FlintHnfWorkerError(RuntimeError):
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+def _emit(payload: dict[str, object]) -> None:
+    sys.stdout.write(
+        json.dumps(
+            {"protocol": FLINT_HNF_WORKER_PROTOCOL, **payload},
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        + "\n"
+    )
+    sys.stdout.flush()
+
+
+def _strict_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError("duplicate JSON key")
+        result[key] = value
+    return result
+
+
+def _read_request() -> dict[str, Any]:
+    encoded = sys.stdin.buffer.read(FLINT_HNF_INPUT_LIMIT + 1)
+    if len(encoded) > FLINT_HNF_INPUT_LIMIT:
+        raise FlintHnfWorkerError("FLINT_HNF_INPUT_LIMIT_EXCEEDED")
+    try:
+        payload = json.loads(encoded, object_pairs_hook=_strict_object)
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+        raise FlintHnfWorkerError("FLINT_HNF_INPUT_INVALID") from exc
+    if not isinstance(payload, dict):
+        raise FlintHnfWorkerError("FLINT_HNF_INPUT_INVALID")
+    return payload
+
+
+def _integer(value: object) -> int:
+    if (
+        not isinstance(value, str)
+        or _INTEGER.fullmatch(value) is None
+        or len(value.lstrip("-")) > MAX_INTEGER_DIGITS
+    ):
+        raise FlintHnfWorkerError("FLINT_HNF_MATRIX_INVALID")
+    result = int(value)
+    if str(result) != value:
+        raise FlintHnfWorkerError("FLINT_HNF_MATRIX_INVALID")
+    return result
+
+
+def _validate_matrix(request: dict[str, Any]) -> list[list[int]]:
+    if (
+        set(request) != {"protocol", "matrix"}
+        or request.get("protocol") != FLINT_HNF_WORKER_PROTOCOL
+    ):
+        raise FlintHnfWorkerError("FLINT_HNF_INPUT_INVALID")
+    matrix = request["matrix"]
+    if not isinstance(matrix, dict) or set(matrix) != {
+        "matrix_schema_version",
+        "domain",
+        "entries",
+    }:
+        raise FlintHnfWorkerError("FLINT_HNF_MATRIX_INVALID")
+    if matrix["matrix_schema_version"] != "1" or matrix["domain"] != "ZZ":
+        raise FlintHnfWorkerError("FLINT_HNF_MATRIX_INVALID")
+    entries = matrix["entries"]
+    if (
+        not isinstance(entries, list)
+        or not 1 <= len(entries) <= MAX_MATRIX_DIMENSION
+        or not isinstance(entries[0], list)
+        or not 1 <= len(entries[0]) <= MAX_MATRIX_DIMENSION
+        or any(
+            not isinstance(row, list) or len(row) != len(entries[0]) for row in entries
+        )
+    ):
+        raise FlintHnfWorkerError("FLINT_HNF_MATRIX_INVALID")
+    return [[_integer(value) for value in row] for row in entries]
+
+
+def _wire_matrix(matrix: Any) -> list[list[str]]:
+    entries = [
+        [str(matrix[row, column]) for column in range(matrix.ncols())]
+        for row in range(matrix.nrows())
+    ]
+    if any(
+        _INTEGER.fullmatch(value) is None or len(value.lstrip("-")) > MAX_INTEGER_DIGITS
+        for row in entries
+        for value in row
+    ):
+        raise FlintHnfWorkerError("FLINT_HNF_OUTPUT_LIMIT_EXCEEDED")
+    return entries
+
+
+def _run(request: dict[str, Any]) -> dict[str, object]:
+    entries = _validate_matrix(request)
+    try:
+        flint: Any = importlib.import_module("flint")
+        if getattr(flint, "__version__", None) != "0.9.0":
+            raise FlintHnfWorkerError("FLINT_HNF_VERSION_MISMATCH")
+        if getattr(flint, "__FLINT_VERSION__", None) != "3.6.0":
+            raise FlintHnfWorkerError("FLINT_HNF_LIBRARY_VERSION_MISMATCH")
+        matrix = flint.fmpz_mat(entries)
+        normal_form, transformation = matrix.hnf(transform=True)
+    except FlintHnfWorkerError:
+        raise
+    except (
+        AttributeError,
+        ImportError,
+        OSError,
+        RuntimeError,
+        TypeError,
+        ValueError,
+    ) as exc:
+        raise FlintHnfWorkerError("FLINT_HNF_EXECUTION_FAILED") from exc
+    return {
+        "status": "NORMAL_FORM_PRODUCED",
+        "backend_version": "0.9.0",
+        "flint_library_version": "3.6.0",
+        "normal_form": _wire_matrix(normal_form),
+        "transformation": _wire_matrix(transformation),
+    }
+
+
+def main() -> int:
+    try:
+        result = _run(_read_request())
+    except FlintHnfWorkerError as exc:
+        _emit({"error_code": exc.code})
+        return 2
+    _emit(result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jacobian/kernel.py
+++ b/src/jacobian/kernel.py
@@ -34,6 +34,7 @@ from jacobian.finite_partition import (
     FinitePartitionInstallation,
     install_finite_partition,
 )
+from jacobian.flint_hnf import install_python_flint_hnf_capability
 from jacobian.flint_linear import install_python_flint_linear_capability
 from jacobian.graph_capabilities import GraphInstallation, install_graph_capabilities
 from jacobian.graph_isomorphism import (
@@ -58,6 +59,14 @@ from jacobian.matrix_capabilities import (
     MatrixInstallation,
     install_matrix_capabilities,
 )
+from jacobian.matrix_normal_form_capabilities import (
+    MatrixNormalFormCheckerInstallation,
+    install_matrix_normal_form_checker,
+)
+from jacobian.matrix_normal_forms import (
+    MatrixNormalFormArtifactService,
+    install_matrix_normal_form_artifacts,
+)
 from jacobian.memory import ResearchMemory
 from jacobian.plugin_execution import PluginExecutor
 from jacobian.plugins.registry import PluginRegistry
@@ -76,6 +85,7 @@ from jacobian.provider_runtime import (
     cvc5_provider_runtime,
     drat_trim_provider_runtime,
     lean_provider_runtime,
+    python_flint_hnf_provider_runtime,
     python_flint_provider_runtime,
 )
 from jacobian.references import (
@@ -145,6 +155,13 @@ class JacobianKernel:
             self.store,
             self.schemas,
             self.artifacts,
+        )
+        self.matrix_normal_forms: MatrixNormalFormArtifactService = (
+            install_matrix_normal_form_artifacts(
+                self.store,
+                self.schemas,
+                self.artifacts,
+            )
         )
         self.memory = ResearchMemory(self.store, self.schemas)
         self.workspaces = WorkspaceService(self.store, self.schemas)
@@ -318,6 +335,9 @@ class JacobianKernel:
                 )
             else:
                 self.register_capability(linear_find_adapter)
+        self._install_matrix_normal_form_capabilities(
+            authorize_checker=install_references
+        )
         self.cadical_runtime: CapabilityProviderRuntime = cadical_provider_runtime()
         if (
             self.cadical_runtime.availability
@@ -506,6 +526,47 @@ class JacobianKernel:
                 )
         for entrypoint in capability_adapter_entrypoints:
             self.register_capability(load_capability_adapter(entrypoint, self))
+
+    def _install_matrix_normal_form_capabilities(
+        self,
+        *,
+        authorize_checker: bool,
+    ) -> None:
+        self.matrix_normal_form_checker: MatrixNormalFormCheckerInstallation
+        verification_adapter, self.matrix_normal_form_checker = (
+            install_matrix_normal_form_checker(
+                self.store,
+                self.schemas,
+                self.artifacts,
+                self.matrix_normal_forms,
+                self.verification,
+                self.checkers,
+                authorize_checker=authorize_checker,
+            )
+        )
+        if verification_adapter is not None:
+            self.register_capability(verification_adapter)
+
+        self.python_flint_hnf_runtime: CapabilityProviderRuntime = (
+            python_flint_hnf_provider_runtime()
+        )
+        if (
+            self.python_flint_hnf_runtime.availability
+            is not CapabilityProviderAvailability.AVAILABLE
+        ):
+            return
+        try:
+            adapter = install_python_flint_hnf_capability(
+                self.matrix_normal_forms,
+                self.python_flint_hnf_runtime,
+            )
+        except (OSError, ValueError) as exc:
+            _LOGGER.warning(
+                "Python-FLINT Hermite normal form is not installed: %s",
+                exc,
+            )
+        else:
+            self.register_capability(adapter)
 
     def register_capability(self, adapter: CapabilityAdapter) -> None:
         """Install an operator-owned adapter without changing the kernel or MCP."""

--- a/src/jacobian/matrix_normal_form_capabilities.py
+++ b/src/jacobian/matrix_normal_form_capabilities.py
@@ -1,0 +1,326 @@
+"""Independent verification capability for integer row Hermite normal forms."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from jacobian.artifacts import ArtifactService
+from jacobian.capabilities import CapabilityAdapter, CapabilityInvocationError
+from jacobian.contracts.capabilities import (
+    CapabilityAssurance,
+    CapabilityAssuranceLevel,
+    CapabilityCompleteness,
+    CapabilityCompletenessStatus,
+    CapabilityDescriptor,
+    CapabilityDiagnostic,
+    CapabilityMode,
+    CapabilityRequest,
+    CapabilityResult,
+    CapabilityScope,
+)
+from jacobian.contracts.evidence import (
+    EvidenceBindings,
+    WitnessEnvelope,
+    WitnessRole,
+)
+from jacobian.contracts.matrices import (
+    MatrixHermiteNormalFormVerificationOutput,
+    MatrixHermiteNormalFormVerificationRequest,
+)
+from jacobian.contracts.results import Conclusion, ExecutionStatus, Verification
+from jacobian.matrix_normal_forms import (
+    MatrixNormalFormArtifactError,
+    MatrixNormalFormArtifactService,
+)
+from jacobian.provider_runtime import known_provider_runtime
+from jacobian.registry import CheckerRegistry
+from jacobian.schema_registry import SchemaRegistry, model_schema
+from jacobian.store import ArtifactStore, StoreError
+from jacobian.verification import VerificationService
+
+
+@dataclass(frozen=True, slots=True)
+class MatrixNormalFormCheckerInstallation:
+    witness_schema_uri: str
+    checker_id: str | None
+
+
+def install_matrix_normal_form_checker(
+    store: ArtifactStore,
+    schemas: SchemaRegistry,
+    artifacts: ArtifactService,
+    matrices: MatrixNormalFormArtifactService,
+    verification: VerificationService,
+    checkers: CheckerRegistry,
+    *,
+    authorize_checker: bool,
+) -> tuple[CapabilityAdapter | None, MatrixNormalFormCheckerInstallation]:
+    """Install the witness schema and optionally authorize exact replay."""
+
+    witness_schema_uri = schemas.register_model(
+        name="jacobian.witness-envelope",
+        version="1",
+        model=WitnessEnvelope,
+    )
+    checker_id = None
+    if authorize_checker:
+        checker_id = checkers.authorize(
+            name="integer row Hermite-normal-form replay checker",
+            entrypoint=(
+                "jacobian_checkers.matrix_normal_forms:check_hermite_normal_form"
+            ),
+            evidence_kind="WITNESS",
+            format_id="matrix.normal_form.hermite",
+            format_version="1",
+            claim_schema_uris=(matrices.installation.matrix_schema_uri,),
+            semantics_uris=(matrices.installation.semantics_uri,),
+            candidate_schema_uris=(matrices.installation.normal_form_schema_uri,),
+            reason=(
+                "bundled independent exact H=U*A, unimodularity, and row-HNF checker"
+            ),
+        ).checker_id
+    installation = MatrixNormalFormCheckerInstallation(
+        witness_schema_uri=witness_schema_uri,
+        checker_id=checker_id,
+    )
+    adapter: CapabilityAdapter | None = None
+    if checker_id is not None:
+        adapter = MatrixHermiteNormalFormVerificationAdapter(
+            store=store,
+            artifacts=artifacts,
+            matrices=matrices,
+            verification=verification,
+            installation=installation,
+        )
+    return adapter, installation
+
+
+class MatrixHermiteNormalFormVerificationAdapter:
+    """Verify exact row equivalence and the full FLINT row-HNF convention."""
+
+    def __init__(
+        self,
+        *,
+        store: ArtifactStore,
+        artifacts: ArtifactService,
+        matrices: MatrixNormalFormArtifactService,
+        verification: VerificationService,
+        installation: MatrixNormalFormCheckerInstallation,
+    ) -> None:
+        checker_id = installation.checker_id
+        if checker_id is None:
+            raise ValueError("matrix normal-form checker is not authorized")
+        self.store = store
+        self.artifacts = artifacts
+        self.matrices = matrices
+        self.verification = verification
+        self.installation = installation
+        self._descriptor = CapabilityDescriptor(
+            capability_id="matrix.normal_form.hermite.verify",
+            version="1",
+            title="Verify an exact row Hermite normal form",
+            description=(
+                "Independently check H = U A over ZZ, det(U) = +/-1, and every "
+                "FLINT row-HNF condition for one bound stored candidate."
+            ),
+            provider="jacobian.integer-matrix",
+            provider_runtime=known_provider_runtime(
+                "jacobian.integer-matrix",
+                features=(
+                    "exact-integer-replay",
+                    "unimodular-left-transformation",
+                    "row-hermite-normal-form",
+                    "clean-process-checker",
+                ),
+                checker_ids=(checker_id,),
+            ),
+            modes=(CapabilityMode.VERIFY,),
+            input_schema=model_schema(MatrixHermiteNormalFormVerificationRequest),
+            output_schema=model_schema(MatrixHermiteNormalFormVerificationOutput),
+            tags=(
+                "linear-algebra",
+                "integer",
+                "matrix",
+                "hermite-normal-form",
+                "verification",
+            ),
+        )
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        return self._descriptor
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        validated = MatrixHermiteNormalFormVerificationRequest.model_validate(
+            request.input
+        )
+        try:
+            resolved = self.matrices.resolve_hermite_normal_form(
+                validated.normal_form_uri
+            )
+            semantics = self.store.get(self.matrices.installation.semantics_uri)
+        except (MatrixNormalFormArtifactError, StoreError) as exc:
+            raise CapabilityInvocationError(
+                CapabilityDiagnostic(
+                    code="INVALID_HERMITE_NORMAL_FORM",
+                    stage="artifact_resolution",
+                    message=str(exc),
+                    path="normal_form_uri",
+                    schema_uri=self.matrices.installation.normal_form_schema_uri,
+                    expected=(
+                        "a valid H and U bound by payload and lineage to one exact "
+                        "integer matrix"
+                    ),
+                    hint=(
+                        "Use matrix.normal_form.hermite or materialize a candidate "
+                        "with the registered normal-form schema."
+                    ),
+                )
+            ) from exc
+
+        checker_id = self.installation.checker_id
+        assert checker_id is not None
+        bindings = EvidenceBindings(
+            claim_digest=resolved.matrix_artifact.manifest.object_digest,
+            semantics_digest=semantics.manifest.object_digest,
+            candidate_digest=resolved.artifact.manifest.object_digest,
+        )
+        witness = WitnessEnvelope(
+            witness_format="matrix.normal_form.hermite",
+            format_version="1",
+            role=WitnessRole.SUPPORTS_CLAIM,
+            bindings=bindings,
+            payload={
+                "matrix_uri": resolved.matrix_artifact.artifact_uri,
+                "normal_form_uri": resolved.artifact.artifact_uri,
+            },
+        )
+        witness_artifact = self.artifacts.put(
+            schema_uri=self.installation.witness_schema_uri,
+            semantics_uri=self.matrices.installation.semantics_uri,
+            payload=witness.model_dump(mode="json"),
+            parents=(
+                resolved.matrix_artifact.artifact_uri,
+                resolved.artifact.artifact_uri,
+            ),
+            summary="integer row-HNF verification witness",
+        )
+        checked = self.verification.verify_witness(
+            claim_uri=resolved.matrix_artifact.artifact_uri,
+            candidate_uri=resolved.artifact.artifact_uri,
+            witness_uri=witness_artifact.artifact_uri,
+            checker_id=checker_id,
+            include_artifact_metadata=True,
+        )
+        verified = (
+            checked.execution.status is ExecutionStatus.COMPLETED
+            and checked.conclusion is Conclusion.TRUE
+            and checked.assurance.verification is Verification.VERIFIED
+            and checked.verification_record_uri is not None
+        )
+        status: Literal[
+            "VERIFIED_HERMITE_NORMAL_FORM",
+            "REJECTED",
+            "TIMEOUT",
+            "CANCELLED",
+            "ERROR",
+        ]
+        if verified:
+            status = "VERIFIED_HERMITE_NORMAL_FORM"
+        elif checked.execution.status is ExecutionStatus.COMPLETED:
+            status = "REJECTED"
+        elif checked.execution.status is ExecutionStatus.TIMEOUT:
+            status = "TIMEOUT"
+        elif checked.execution.status is ExecutionStatus.CANCELLED:
+            status = "CANCELLED"
+        else:
+            status = "ERROR"
+        detail = checked.execution.detail
+        if detail is None and checked.input.errors:
+            detail = checked.input.errors[0]
+        if detail is None:
+            detail = (
+                "the authorized checker accepted the exact row-HNF relation"
+                if verified
+                else "the candidate was not independently accepted"
+            )
+        output = MatrixHermiteNormalFormVerificationOutput(
+            status=status,
+            conclusion="TRUE" if verified else "UNKNOWN",
+            matrix_uri=resolved.matrix_artifact.artifact_uri,
+            normal_form_uri=resolved.artifact.artifact_uri,
+            witness_uri=witness_artifact.artifact_uri,
+            checker_id=checker_id,
+            verification_record_uri=(
+                checked.verification_record_uri if verified else None
+            ),
+            detail=detail,
+        )
+        record_uri = checked.verification_record_uri if verified else None
+        artifact_uris = [
+            resolved.matrix_artifact.artifact_uri,
+            resolved.artifact.artifact_uri,
+            witness_artifact.artifact_uri,
+        ]
+        if record_uri is not None:
+            artifact_uris.append(record_uri)
+        assurance_level = (
+            CapabilityAssuranceLevel.VERIFIED
+            if verified
+            else (
+                CapabilityAssuranceLevel.COMPUTED
+                if checked.execution.status is ExecutionStatus.COMPLETED
+                else CapabilityAssuranceLevel.HEURISTIC
+            )
+        )
+        return CapabilityResult(
+            capability_id=self.descriptor.capability_id,
+            capability_version=self.descriptor.version,
+            mode=request.mode,
+            execution=checked.execution,
+            output=output.model_dump(mode="json"),
+            scope=CapabilityScope(
+                description=(
+                    "the full exact source matrix, proposed H, and left transform U"
+                ),
+                parameters={
+                    "declared_scope": "FULL_MATRIX",
+                    "row_count": len(resolved.matrix.entries),
+                    "column_count": len(resolved.matrix.entries[0]),
+                    "normal_form_convention": "FLINT_ROW_HNF",
+                    "checked_relation": "H=U*A",
+                    "checked_unimodularity": True,
+                },
+                artifact_uri=resolved.matrix_artifact.artifact_uri,
+            ),
+            completeness=CapabilityCompleteness(
+                status=CapabilityCompletenessStatus.NOT_APPLICABLE,
+                basis=(
+                    "direct exact replay checks the full finite relation and form; "
+                    "no search or enumeration claim is made"
+                ),
+                assurance_level=(
+                    CapabilityAssuranceLevel.COMPUTED
+                    if checked.execution.status is ExecutionStatus.COMPLETED
+                    else CapabilityAssuranceLevel.HEURISTIC
+                ),
+            ),
+            assurance=CapabilityAssurance(
+                level=assurance_level,
+                basis=(
+                    "accepted in a clean process by the operator-authorized "
+                    "independent exact integer row-HNF checker"
+                    if verified
+                    else (
+                        "checker replay completed without accepting the candidate; "
+                        "no opposite conclusion follows"
+                        if checked.execution.status is ExecutionStatus.COMPLETED
+                        else "checker execution did not complete; no mathematical "
+                        "conclusion follows"
+                    )
+                ),
+                verification_record_uri=record_uri,
+            ),
+            artifact_uris=tuple(artifact_uris),
+        )

--- a/src/jacobian/matrix_normal_forms.py
+++ b/src/jacobian/matrix_normal_forms.py
@@ -1,0 +1,240 @@
+"""Durable integer matrices and Hermite-normal-form candidates."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic import ValidationError
+
+from jacobian.artifacts import ArtifactService
+from jacobian.contracts.artifacts import ArtifactPutResult
+from jacobian.contracts.capabilities import CapabilityProviderRuntime
+from jacobian.contracts.matrices import (
+    ExactIntegerMatrix,
+    MatrixBinding,
+    MatrixHermiteNormalFormArtifact,
+    MatrixHermiteResourceBudget,
+)
+from jacobian.schema_registry import SchemaRegistry, SchemaRegistryError
+from jacobian.store import ArtifactStore, StoredArtifact, StoreError
+
+
+class MatrixNormalFormArtifactError(ValueError):
+    """Stored data does not satisfy the integer-matrix HNF contract."""
+
+
+@dataclass(frozen=True, slots=True)
+class MatrixNormalFormInstallation:
+    semantics_uri: str
+    matrix_schema_uri: str
+    normal_form_schema_uri: str
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedIntegerMatrix:
+    artifact: StoredArtifact
+    matrix: ExactIntegerMatrix
+    binding: MatrixBinding
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedHermiteNormalForm:
+    artifact: StoredArtifact
+    candidate: MatrixHermiteNormalFormArtifact
+    matrix_artifact: StoredArtifact
+    matrix: ExactIntegerMatrix
+
+
+class MatrixNormalFormArtifactService:
+    """Materialize exact matrices and unverified HNF transformation evidence."""
+
+    def __init__(
+        self,
+        store: ArtifactStore,
+        schemas: SchemaRegistry,
+        artifacts: ArtifactService,
+        installation: MatrixNormalFormInstallation,
+    ) -> None:
+        self.store = store
+        self.schemas = schemas
+        self.artifacts = artifacts
+        self.installation = installation
+
+    def put_matrix(
+        self,
+        matrix: ExactIntegerMatrix | dict[str, Any],
+    ) -> ArtifactPutResult:
+        validated = ExactIntegerMatrix.model_validate(matrix)
+        return self.artifacts.put(
+            schema_uri=self.installation.matrix_schema_uri,
+            semantics_uri=self.installation.semantics_uri,
+            payload=validated.model_dump(mode="json"),
+            summary=(
+                "exact integer matrix: "
+                f"{len(validated.entries)} by {len(validated.entries[0])}"
+            ),
+        )
+
+    def resolve_matrix(self, matrix_uri: str) -> ResolvedIntegerMatrix:
+        try:
+            artifact = self.store.get(matrix_uri)
+        except StoreError as exc:
+            raise MatrixNormalFormArtifactError(
+                "source is not an available exact integer-matrix artifact"
+            ) from exc
+        if (
+            artifact.manifest.schema_uri != self.installation.matrix_schema_uri
+            or artifact.manifest.semantics_uri != self.installation.semantics_uri
+        ):
+            raise MatrixNormalFormArtifactError(
+                "source is not an exact integer-matrix artifact"
+            )
+        try:
+            normalized = self.schemas.validate(
+                self.installation.matrix_schema_uri,
+                artifact.payload,
+            )
+            matrix = ExactIntegerMatrix.model_validate(normalized)
+        except (SchemaRegistryError, ValueError, ValidationError) as exc:
+            raise MatrixNormalFormArtifactError(
+                "source is not a valid exact integer-matrix artifact"
+            ) from exc
+        binding = MatrixBinding(
+            matrix_artifact_uri=artifact.artifact_uri,
+            matrix_object_digest=artifact.manifest.object_digest,
+            matrix_payload_digest=artifact.manifest.payload_digest,
+            row_count=len(matrix.entries),
+            column_count=len(matrix.entries[0]),
+        )
+        return ResolvedIntegerMatrix(
+            artifact=artifact,
+            matrix=matrix,
+            binding=binding,
+        )
+
+    def put_hermite_normal_form(
+        self,
+        *,
+        matrix_uri: str,
+        normal_form: Sequence[Sequence[Any]],
+        transformation: Sequence[Sequence[Any]],
+        producer: CapabilityProviderRuntime,
+        resource_budget: MatrixHermiteResourceBudget | dict[str, Any],
+    ) -> ArtifactPutResult:
+        resolved = self.resolve_matrix(matrix_uri)
+        candidate = MatrixHermiteNormalFormArtifact(
+            source=resolved.binding,
+            normal_form=ExactIntegerMatrix(
+                entries=tuple(tuple(value for value in row) for row in normal_form)
+            ),
+            transformation=ExactIntegerMatrix(
+                entries=tuple(tuple(value for value in row) for row in transformation)
+            ),
+            producer=producer,
+            resource_budget=MatrixHermiteResourceBudget.model_validate(resource_budget),
+        )
+        return self.artifacts.put(
+            schema_uri=self.installation.normal_form_schema_uri,
+            semantics_uri=self.installation.semantics_uri,
+            payload=candidate.model_dump(mode="json"),
+            parents=(resolved.artifact.artifact_uri,),
+            summary="unverified row Hermite normal form with left transformation",
+        )
+
+    def resolve_hermite_normal_form(
+        self,
+        normal_form_uri: str,
+    ) -> ResolvedHermiteNormalForm:
+        try:
+            artifact = self.store.get(normal_form_uri)
+        except StoreError as exc:
+            raise MatrixNormalFormArtifactError(
+                "source is not an available Hermite-normal-form artifact"
+            ) from exc
+        if (
+            artifact.manifest.schema_uri != self.installation.normal_form_schema_uri
+            or artifact.manifest.semantics_uri != self.installation.semantics_uri
+        ):
+            raise MatrixNormalFormArtifactError(
+                "source is not a Hermite-normal-form artifact"
+            )
+        try:
+            normalized = self.schemas.validate(
+                self.installation.normal_form_schema_uri,
+                artifact.payload,
+            )
+            candidate = MatrixHermiteNormalFormArtifact.model_validate(normalized)
+        except (SchemaRegistryError, ValueError, ValidationError) as exc:
+            raise MatrixNormalFormArtifactError(
+                "source is not a valid Hermite-normal-form artifact"
+            ) from exc
+        resolved_matrix = self.resolve_matrix(candidate.source.matrix_artifact_uri)
+        if candidate.source != resolved_matrix.binding:
+            raise MatrixNormalFormArtifactError(
+                "normal-form binding does not match its exact source matrix"
+            )
+        if resolved_matrix.artifact.artifact_uri not in artifact.manifest.parents:
+            raise MatrixNormalFormArtifactError(
+                "normal form is missing its exact source-matrix parent"
+            )
+        return ResolvedHermiteNormalForm(
+            artifact=artifact,
+            candidate=candidate,
+            matrix_artifact=resolved_matrix.artifact,
+            matrix=resolved_matrix.matrix,
+        )
+
+
+def install_matrix_normal_form_artifacts(
+    store: ArtifactStore,
+    schemas: SchemaRegistry,
+    artifacts: ArtifactService,
+) -> MatrixNormalFormArtifactService:
+    """Register the exact integer row-HNF semantics and artifact contracts."""
+
+    semantics_uri = store.register_descriptor(
+        kind="semantics",
+        name="jacobian.integer-matrix-row-hermite-normal-form",
+        version="1",
+        definition={
+            "domain": "nonempty rectangular matrices over the integers ZZ",
+            "normal_form": (
+                "FLINT row Hermite convention: zero rows last; positive pivots "
+                "move strictly right; entries above each pivot are in [0, pivot)"
+            ),
+            "relation": (
+                "a candidate H is equivalent to A only when H = U A and U is "
+                "unimodular over ZZ"
+            ),
+            "candidate": (
+                "producer output is computed evidence; only an authorized "
+                "independent checker may verify the bound relation and form"
+            ),
+            "limits": {
+                "maximum_rows": 32,
+                "maximum_columns": 32,
+                "maximum_decimal_digits_per_entry": 256,
+            },
+        },
+    )
+    installation = MatrixNormalFormInstallation(
+        semantics_uri=semantics_uri,
+        matrix_schema_uri=schemas.register_model(
+            name="jacobian.exact-integer-matrix",
+            version="1",
+            model=ExactIntegerMatrix,
+        ),
+        normal_form_schema_uri=schemas.register_model(
+            name="jacobian.matrix-row-hermite-normal-form",
+            version="1",
+            model=MatrixHermiteNormalFormArtifact,
+        ),
+    )
+    return MatrixNormalFormArtifactService(
+        store,
+        schemas,
+        artifacts,
+        installation,
+    )

--- a/src/jacobian/provider_runtime.py
+++ b/src/jacobian/provider_runtime.py
@@ -32,6 +32,7 @@ DRAT_TRIM_RELEASE_TAG = "v05.22.2023"
 DRAT_TRIM_SOURCE_COMMIT = "2e5e29cb0019d5cfd547d4208dca1b3ec290349f"
 DRAT_TRIM_SOURCE_REPOSITORY = "https://github.com/marijnheule/drat-trim"
 PYTHON_FLINT_VERSION = "0.9.0"
+PYTHON_FLINT_HNF_FLINT_VERSION = "3.6.0"
 
 
 class ProviderRuntimeError(RuntimeError):
@@ -705,6 +706,73 @@ def python_flint_provider_runtime(
                 f"{PYTHON_FLINT_VERSION} compatibility profile."
             ),
         )
+    return runtime
+
+
+def python_flint_hnf_provider_runtime(
+    *,
+    refresh: bool = False,
+) -> CapabilityProviderRuntime:
+    """Identify the pinned Python-FLINT integer row-HNF profile."""
+
+    runtime = python_distribution_provider_runtime(
+        "python-flint",
+        distribution_name="python-flint",
+        import_name="flint",
+        required_attributes=("fmpz", "fmpz_mat"),
+        install_tier=CapabilityInstallTier.T1,
+        license_id="MIT AND LGPL-3.0-or-later",
+        features=(
+            "exact-integer",
+            "dense-matrix",
+            "row-hermite-normal-form",
+            "left-transformation",
+        ),
+        configuration={
+            "domain": "ZZ",
+            "operation": "fmpz_mat.hnf(transform=True)",
+            "flint_library_version": PYTHON_FLINT_HNF_FLINT_VERSION,
+            "maximum_rows": 32,
+            "maximum_columns": 32,
+            "normal_form_convention": "FLINT_ROW_HNF",
+            "relation": "H=U*A",
+        },
+        refresh=refresh,
+    )
+    if (
+        runtime.availability is CapabilityProviderAvailability.AVAILABLE
+        and runtime.version != PYTHON_FLINT_VERSION
+    ):
+        return _unavailable_runtime(
+            provider="python-flint",
+            install_tier=CapabilityInstallTier.T1,
+            license_id="MIT AND LGPL-3.0-or-later",
+            diagnostic=(
+                "Python-FLINT is installed but does not match the pinned "
+                f"{PYTHON_FLINT_VERSION} HNF compatibility profile."
+            ),
+        )
+    if runtime.availability is CapabilityProviderAvailability.AVAILABLE:
+        try:
+            flint = importlib.import_module("flint")
+        except (ImportError, OSError):
+            return _unavailable_runtime(
+                provider="python-flint",
+                install_tier=CapabilityInstallTier.T1,
+                license_id="MIT AND LGPL-3.0-or-later",
+                diagnostic="The pinned Python-FLINT HNF runtime cannot be imported.",
+            )
+        if getattr(flint, "__FLINT_VERSION__", None) != PYTHON_FLINT_HNF_FLINT_VERSION:
+            return _unavailable_runtime(
+                provider="python-flint",
+                install_tier=CapabilityInstallTier.T1,
+                license_id="MIT AND LGPL-3.0-or-later",
+                diagnostic=(
+                    "Python-FLINT is installed but its linked FLINT library does "
+                    "not match the pinned "
+                    f"{PYTHON_FLINT_HNF_FLINT_VERSION} HNF profile."
+                ),
+            )
     return runtime
 
 

--- a/src/jacobian_checkers/matrix_normal_forms.py
+++ b/src/jacobian_checkers/matrix_normal_forms.py
@@ -1,0 +1,422 @@
+"""Independent exact replay for integer row Hermite normal forms.
+
+This checker intentionally uses only the Python standard library. It does not
+import Jacobian contracts, Python-FLINT, SymPy, or producer code.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Any
+
+_ARTIFACT_URI = re.compile(r"^artifact://sha256/[0-9a-f]{64}$")
+_DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
+_INTEGER = re.compile(r"^-?(?:0|[1-9][0-9]*)$")
+_ARTIFACT_KEYS = {
+    "artifact_uri",
+    "object_digest",
+    "payload_digest",
+    "schema_uri",
+    "semantics_uri",
+    "parents",
+    "payload",
+}
+_BINDING_KEYS = {
+    "claim_digest",
+    "semantics_digest",
+    "candidate_digest",
+    "scope_digest",
+    "encoding_digest",
+}
+_MATRIX_BINDING_KEYS = {
+    "binding_version",
+    "matrix_artifact_uri",
+    "matrix_object_digest",
+    "matrix_payload_digest",
+    "row_count",
+    "column_count",
+}
+_PROVIDER_KEYS = {
+    "runtime_version",
+    "provider",
+    "availability",
+    "version",
+    "digest",
+    "digest_kind",
+    "platform",
+    "install_tier",
+    "license_id",
+    "license_files",
+    "features",
+    "checker_ids",
+    "configuration",
+    "diagnostic",
+}
+MAX_MATRIX_DIMENSION = 32
+MAX_INTEGER_DIGITS = 256
+_HNF_CONFIGURATION = {
+    "distribution": "python-flint",
+    "domain": "ZZ",
+    "operation": "fmpz_mat.hnf(transform=True)",
+    "flint_library_version": "3.6.0",
+    "maximum_rows": 32,
+    "maximum_columns": 32,
+    "normal_form_convention": "FLINT_ROW_HNF",
+    "relation": "H=U*A",
+}
+
+
+def _reject(detail: str) -> dict[str, Any]:
+    return {
+        "accepted": False,
+        "conclusion": "UNKNOWN",
+        "arithmetic": "EXACT_INTEGER",
+        "method": "DIRECT_WITNESS",
+        "coverage": "NOT_APPLICABLE",
+        "detail": detail,
+    }
+
+
+def _sha256(value: bytes) -> str:
+    return "sha256:" + hashlib.sha256(value).hexdigest()
+
+
+def _canonical_json(value: object) -> bytes:
+    return json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _valid_artifact(value: object) -> bool:
+    if not isinstance(value, dict) or set(value) != _ARTIFACT_KEYS:
+        return False
+    if (
+        not isinstance(value["artifact_uri"], str)
+        or _ARTIFACT_URI.fullmatch(value["artifact_uri"]) is None
+        or not isinstance(value["object_digest"], str)
+        or _DIGEST.fullmatch(value["object_digest"]) is None
+        or not isinstance(value["payload_digest"], str)
+        or _DIGEST.fullmatch(value["payload_digest"]) is None
+        or not isinstance(value["schema_uri"], str)
+        or _ARTIFACT_URI.fullmatch(value["schema_uri"]) is None
+        or not isinstance(value["semantics_uri"], str)
+        or _ARTIFACT_URI.fullmatch(value["semantics_uri"]) is None
+    ):
+        return False
+    parents = value["parents"]
+    return (
+        isinstance(parents, list)
+        and len(parents) == len(set(parents))
+        and all(
+            isinstance(parent, str) and _ARTIFACT_URI.fullmatch(parent) is not None
+            for parent in parents
+        )
+    )
+
+
+def _valid_bindings(value: object) -> bool:
+    if not isinstance(value, dict) or set(value) != _BINDING_KEYS:
+        return False
+    if value["scope_digest"] is not None or value["encoding_digest"] is not None:
+        return False
+    return all(
+        isinstance(value[key], str) and _DIGEST.fullmatch(value[key]) is not None
+        for key in ("claim_digest", "semantics_digest", "candidate_digest")
+    )
+
+
+def _integer(value: object) -> int:
+    if (
+        not isinstance(value, str)
+        or _INTEGER.fullmatch(value) is None
+        or len(value.lstrip("-")) > MAX_INTEGER_DIGITS
+    ):
+        raise ValueError("matrix entry is not a bounded canonical integer")
+    result = int(value)
+    if str(result) != value:
+        raise ValueError("matrix entry is not canonical")
+    return result
+
+
+def _matrix(payload: object) -> list[list[int]]:
+    if not isinstance(payload, dict) or set(payload) != {
+        "matrix_schema_version",
+        "domain",
+        "entries",
+    }:
+        raise ValueError("integer matrix has an invalid shape")
+    if payload["matrix_schema_version"] != "1" or payload["domain"] != "ZZ":
+        raise ValueError("integer matrix uses unsupported semantics")
+    entries = payload["entries"]
+    if (
+        not isinstance(entries, list)
+        or not 1 <= len(entries) <= MAX_MATRIX_DIMENSION
+        or not isinstance(entries[0], list)
+        or not 1 <= len(entries[0]) <= MAX_MATRIX_DIMENSION
+        or any(
+            not isinstance(row, list) or len(row) != len(entries[0]) for row in entries
+        )
+    ):
+        raise ValueError("integer matrix dimensions are malformed")
+    return [[_integer(value) for value in row] for row in entries]
+
+
+def _validate_candidate(
+    payload: object,
+    *,
+    claim: dict[str, Any],
+    candidate: dict[str, Any],
+    rows: int,
+    columns: int,
+) -> tuple[list[list[int]], list[list[int]]]:
+    if not isinstance(payload, dict) or set(payload) != {
+        "normal_form_schema_version",
+        "source",
+        "declared_scope",
+        "normal_form",
+        "transformation",
+        "producer",
+        "resource_budget",
+        "method",
+    }:
+        raise ValueError("HNF candidate has an invalid shape")
+    if (
+        payload["normal_form_schema_version"] != "1"
+        or payload["declared_scope"] != "FULL_MATRIX"
+        or payload["method"] != "ROW_HNF_LEFT_UNIMODULAR_TRANSFORM"
+    ):
+        raise ValueError("HNF candidate uses unsupported semantics")
+    binding = payload["source"]
+    if not isinstance(binding, dict) or set(binding) != _MATRIX_BINDING_KEYS:
+        raise ValueError("HNF source binding is malformed")
+    if binding != {
+        "binding_version": "1",
+        "matrix_artifact_uri": claim["artifact_uri"],
+        "matrix_object_digest": claim["object_digest"],
+        "matrix_payload_digest": claim["payload_digest"],
+        "row_count": rows,
+        "column_count": columns,
+    }:
+        raise ValueError("HNF candidate is not exactly bound to the source matrix")
+    if claim["artifact_uri"] not in candidate["parents"]:
+        raise ValueError("HNF candidate is missing source-matrix lineage")
+    normal_form = _matrix(payload["normal_form"])
+    transformation = _matrix(payload["transformation"])
+    if (
+        len(normal_form) != rows
+        or len(normal_form[0]) != columns
+        or len(transformation) != rows
+        or len(transformation[0]) != rows
+    ):
+        raise ValueError("HNF candidate dimensions do not match the source")
+    provider = payload["producer"]
+    if (
+        not isinstance(provider, dict)
+        or set(provider) != _PROVIDER_KEYS
+        or provider["runtime_version"] != "1"
+        or provider["provider"] != "python-flint"
+        or provider["availability"] != "AVAILABLE"
+        or provider["version"] != "0.9.0"
+        or not isinstance(provider["digest"], str)
+        or _DIGEST.fullmatch(provider["digest"]) is None
+        or provider["digest_kind"] != "PYTHON_DISTRIBUTION_RECORD"
+        or provider["install_tier"] != "T1"
+        or provider["configuration"] != _HNF_CONFIGURATION
+    ):
+        raise ValueError("HNF producer identity is malformed")
+    budget = payload["resource_budget"]
+    if (
+        not isinstance(budget, dict)
+        or set(budget) != {"budget_version", "wall_seconds"}
+        or budget["budget_version"] != "1"
+        or type(budget["wall_seconds"]) is not int
+        or not 1 <= budget["wall_seconds"] <= 60
+    ):
+        raise ValueError("HNF resource budget is malformed")
+    return normal_form, transformation
+
+
+def _multiply(
+    left: list[list[int]],
+    right: list[list[int]],
+) -> list[list[int]]:
+    return [
+        [
+            sum(
+                left_value * right[row][column]
+                for row, left_value in enumerate(left_row)
+            )
+            for column in range(len(right[0]))
+        ]
+        for left_row in left
+    ]
+
+
+def _determinant_bareiss(matrix: list[list[int]]) -> int:
+    size = len(matrix)
+    if any(len(row) != size for row in matrix):
+        raise ValueError("determinant requires a square matrix")
+    if size == 1:
+        return matrix[0][0]
+    work = [row[:] for row in matrix]
+    sign = 1
+    previous_pivot = 1
+    for column in range(size - 1):
+        pivot_row = next(
+            (row for row in range(column, size) if work[row][column] != 0),
+            None,
+        )
+        if pivot_row is None:
+            return 0
+        if pivot_row != column:
+            work[column], work[pivot_row] = work[pivot_row], work[column]
+            sign = -sign
+        pivot = work[column][column]
+        for row in range(column + 1, size):
+            for target_column in range(column + 1, size):
+                numerator = (
+                    work[row][target_column] * pivot
+                    - work[row][column] * work[column][target_column]
+                )
+                quotient, remainder = divmod(numerator, previous_pivot)
+                if remainder != 0:
+                    raise ValueError("fraction-free determinant division failed")
+                work[row][target_column] = quotient
+            work[row][column] = 0
+        previous_pivot = pivot
+    return sign * work[-1][-1]
+
+
+def _is_row_hnf(matrix: list[list[int]]) -> bool:
+    last_nonzero_row = -1
+    for row, values in enumerate(matrix):
+        if any(value != 0 for value in values):
+            last_nonzero_row = row
+    previous_pivot_column = -1
+    for row in range(last_nonzero_row + 1):
+        pivot_column = next(
+            (column for column, value in enumerate(matrix[row]) if value != 0),
+            None,
+        )
+        if pivot_column is None or pivot_column <= previous_pivot_column:
+            return False
+        pivot = matrix[row][pivot_column]
+        if pivot < 0:
+            return False
+        if any(
+            matrix[above][pivot_column] < 0 or matrix[above][pivot_column] >= pivot
+            for above in range(row)
+        ):
+            return False
+        previous_pivot_column = pivot_column
+    return all(
+        all(value == 0 for value in matrix[row])
+        for row in range(last_nonzero_row + 1, len(matrix))
+    )
+
+
+def check_hermite_normal_form(request: dict[str, Any]) -> dict[str, Any]:
+    """Accept only exact row-HNF evidence with a unimodular left transform."""
+
+    try:
+        if not isinstance(request, dict) or set(request) != {
+            "request_version",
+            "claim",
+            "candidate",
+            "scope",
+            "witness",
+            "expected_bindings",
+        }:
+            return _reject("malformed checker request")
+        if request["request_version"] != "1" or request["scope"] is not None:
+            return _reject("unsupported checker request")
+        claim = request["claim"]
+        candidate = request["candidate"]
+        witness = request["witness"]
+        if not all(_valid_artifact(item) for item in (claim, candidate, witness)):
+            return _reject("checker artifact metadata is malformed")
+        expected_bindings = request["expected_bindings"]
+        if not _valid_bindings(expected_bindings):
+            return _reject("expected evidence bindings are malformed")
+        if (
+            claim["semantics_uri"] != candidate["semantics_uri"]
+            or claim["semantics_uri"] != witness["semantics_uri"]
+        ):
+            return _reject("checker artifacts use different semantics")
+        for artifact, label in (
+            (claim, "source matrix"),
+            (candidate, "HNF candidate"),
+            (witness, "HNF witness"),
+        ):
+            if artifact["payload_digest"] != _sha256(
+                _canonical_json(artifact["payload"])
+            ):
+                return _reject(f"{label} payload digest does not match")
+
+        source = _matrix(claim["payload"])
+        normal_form, transformation = _validate_candidate(
+            candidate["payload"],
+            claim=claim,
+            candidate=candidate,
+            rows=len(source),
+            columns=len(source[0]),
+        )
+        if (
+            expected_bindings["claim_digest"] != claim["object_digest"]
+            or expected_bindings["candidate_digest"] != candidate["object_digest"]
+        ):
+            return _reject("expected evidence bindings do not match artifacts")
+        envelope = witness["payload"]
+        if not isinstance(envelope, dict) or set(envelope) != {
+            "evidence_schema_version",
+            "witness_format",
+            "format_version",
+            "role",
+            "bindings",
+            "payload",
+        }:
+            return _reject("HNF witness envelope is malformed")
+        if (
+            envelope["evidence_schema_version"] != "1"
+            or envelope["witness_format"] != "matrix.normal_form.hermite"
+            or envelope["format_version"] != "1"
+            or envelope["role"] != "SUPPORTS_CLAIM"
+            or envelope["bindings"] != expected_bindings
+        ):
+            return _reject("HNF witness envelope is not exactly bound")
+        if envelope["payload"] != {
+            "matrix_uri": claim["artifact_uri"],
+            "normal_form_uri": candidate["artifact_uri"],
+        }:
+            return _reject("HNF witness points at different artifacts")
+        if not {
+            claim["artifact_uri"],
+            candidate["artifact_uri"],
+        }.issubset(set(witness["parents"])):
+            return _reject("HNF witness is missing required lineage")
+
+        if _multiply(transformation, source) != normal_form:
+            return _reject("the proposed exact relation H = U A does not hold")
+        if abs(_determinant_bareiss(transformation)) != 1:
+            return _reject("the proposed left transformation is not unimodular")
+        if not _is_row_hnf(normal_form):
+            return _reject("the candidate does not satisfy FLINT row-HNF conditions")
+        return {
+            "accepted": True,
+            "conclusion": "TRUE",
+            "arithmetic": "EXACT_INTEGER",
+            "method": "DIRECT_WITNESS",
+            "coverage": "NOT_APPLICABLE",
+            "detail": (
+                f"checked H = U A, det(U) = +/-1, and row-HNF conditions for "
+                f"the full {len(source)} by {len(source[0])} integer matrix"
+            ),
+        }
+    except (KeyError, TypeError, ValueError, OverflowError):
+        return _reject("malformed checker request")

--- a/tests/checkers/test_matrix_normal_form_checker.py
+++ b/tests/checkers/test_matrix_normal_form_checker.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from typing import Any
+
+import pytest
+
+from jacobian_checkers.matrix_normal_forms import check_hermite_normal_form
+
+
+def _uri(character: str) -> str:
+    return "artifact://sha256/" + character * 64
+
+
+def _digest(value: object) -> str:
+    encoded = json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _matrix(entries: list[list[int | str]]) -> dict[str, Any]:
+    return {
+        "matrix_schema_version": "1",
+        "domain": "ZZ",
+        "entries": [[str(value) for value in row] for row in entries],
+    }
+
+
+def _artifact(
+    *,
+    uri_character: str,
+    object_character: str,
+    schema_character: str,
+    semantics_uri: str,
+    payload: dict[str, Any],
+    parents: list[str],
+) -> dict[str, Any]:
+    return {
+        "artifact_uri": _uri(uri_character),
+        "object_digest": "sha256:" + object_character * 64,
+        "payload_digest": _digest(payload),
+        "schema_uri": _uri(schema_character),
+        "semantics_uri": semantics_uri,
+        "parents": parents,
+        "payload": payload,
+    }
+
+
+def _request(
+    *,
+    source: list[list[int | str]] | None = None,
+    normal_form: list[list[int | str]] | None = None,
+    transformation: list[list[int | str]] | None = None,
+) -> dict[str, Any]:
+    source = source or [[2, 4], [6, 8]]
+    normal_form = normal_form or [[2, 0], [0, 4]]
+    transformation = transformation or [[-2, 1], [3, -1]]
+    semantics_uri = _uri("e")
+    source_payload = _matrix(source)
+    claim = _artifact(
+        uri_character="a",
+        object_character="1",
+        schema_character="b",
+        semantics_uri=semantics_uri,
+        payload=source_payload,
+        parents=[],
+    )
+    candidate_payload = {
+        "normal_form_schema_version": "1",
+        "source": {
+            "binding_version": "1",
+            "matrix_artifact_uri": claim["artifact_uri"],
+            "matrix_object_digest": claim["object_digest"],
+            "matrix_payload_digest": claim["payload_digest"],
+            "row_count": len(source),
+            "column_count": len(source[0]),
+        },
+        "declared_scope": "FULL_MATRIX",
+        "normal_form": _matrix(normal_form),
+        "transformation": _matrix(transformation),
+        "producer": {
+            "runtime_version": "1",
+            "provider": "python-flint",
+            "availability": "AVAILABLE",
+            "version": "0.9.0",
+            "digest": "sha256:" + "9" * 64,
+            "digest_kind": "PYTHON_DISTRIBUTION_RECORD",
+            "platform": "linux-x86_64",
+            "install_tier": "T1",
+            "license_id": "MIT AND LGPL-3.0-or-later",
+            "license_files": ["python_flint-0.9.0.dist-info/licenses/LICENSE"],
+            "features": [
+                "exact-integer",
+                "dense-matrix",
+                "row-hermite-normal-form",
+                "left-transformation",
+            ],
+            "checker_ids": [],
+            "configuration": {
+                "distribution": "python-flint",
+                "domain": "ZZ",
+                "operation": "fmpz_mat.hnf(transform=True)",
+                "flint_library_version": "3.6.0",
+                "maximum_rows": 32,
+                "maximum_columns": 32,
+                "normal_form_convention": "FLINT_ROW_HNF",
+                "relation": "H=U*A",
+            },
+            "diagnostic": "",
+        },
+        "resource_budget": {"budget_version": "1", "wall_seconds": 5},
+        "method": "ROW_HNF_LEFT_UNIMODULAR_TRANSFORM",
+    }
+    candidate = _artifact(
+        uri_character="c",
+        object_character="2",
+        schema_character="d",
+        semantics_uri=semantics_uri,
+        payload=candidate_payload,
+        parents=[claim["artifact_uri"]],
+    )
+    bindings = {
+        "claim_digest": claim["object_digest"],
+        "semantics_digest": "sha256:" + "3" * 64,
+        "candidate_digest": candidate["object_digest"],
+        "scope_digest": None,
+        "encoding_digest": None,
+    }
+    witness_payload = {
+        "evidence_schema_version": "1",
+        "witness_format": "matrix.normal_form.hermite",
+        "format_version": "1",
+        "role": "SUPPORTS_CLAIM",
+        "bindings": bindings,
+        "payload": {
+            "matrix_uri": claim["artifact_uri"],
+            "normal_form_uri": candidate["artifact_uri"],
+        },
+    }
+    witness = _artifact(
+        uri_character="f",
+        object_character="4",
+        schema_character="5",
+        semantics_uri=semantics_uri,
+        payload=witness_payload,
+        parents=[claim["artifact_uri"], candidate["artifact_uri"]],
+    )
+    return {
+        "request_version": "1",
+        "claim": claim,
+        "candidate": candidate,
+        "scope": None,
+        "witness": witness,
+        "expected_bindings": bindings,
+    }
+
+
+def _refresh_payload_digest(artifact: dict[str, Any]) -> None:
+    artifact["payload_digest"] = _digest(artifact["payload"])
+
+
+def test_checker_accepts_exact_hnf_transformation_evidence() -> None:
+    decision = check_hermite_normal_form(_request())
+
+    assert decision["accepted"] is True
+    assert decision["conclusion"] == "TRUE"
+    assert decision["arithmetic"] == "EXACT_INTEGER"
+
+
+@pytest.mark.parametrize(
+    "matrix",
+    [
+        [[0, 0], [1, 0]],
+        [[0, 1], [1, 0]],
+        [[-1, 0], [0, 1]],
+        [[1, 2], [0, 2]],
+    ],
+    ids=(
+        "zero_row_not_last",
+        "pivot_columns_not_increasing",
+        "negative_pivot",
+        "unreduced_above_pivot",
+    ),
+)
+def test_checker_rejects_each_row_hnf_structure_violation(
+    matrix: list[list[int]],
+) -> None:
+    decision = check_hermite_normal_form(
+        _request(
+            source=matrix,
+            normal_form=matrix,
+            transformation=[[1, 0], [0, 1]],
+        )
+    )
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+def test_checker_rejects_mutation_even_with_refreshed_payload_digest() -> None:
+    request = _request()
+    request["candidate"]["payload"]["normal_form"]["entries"][0][1] = "1"
+    _refresh_payload_digest(request["candidate"])
+
+    decision = check_hermite_normal_form(request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+def test_checker_rejects_rebound_source_identity() -> None:
+    request = _request()
+    request["candidate"]["payload"]["source"]["matrix_object_digest"] = (
+        "sha256:" + "8" * 64
+    )
+    _refresh_payload_digest(request["candidate"])
+
+    decision = check_hermite_normal_form(request)
+
+    assert decision["accepted"] is False
+
+
+def test_checker_rejects_malformed_or_noncanonical_payloads() -> None:
+    requests = []
+
+    extra_field = _request()
+    extra_field["candidate"]["payload"]["unexpected"] = True
+    _refresh_payload_digest(extra_field["candidate"])
+    requests.append(extra_field)
+
+    leading_zero = _request()
+    leading_zero["candidate"]["payload"]["normal_form"]["entries"][0][0] = "02"
+    _refresh_payload_digest(leading_zero["candidate"])
+    requests.append(leading_zero)
+
+    wrong_witness = _request()
+    wrong_witness["witness"]["payload"]["payload"]["normal_form_uri"] = _uri("7")
+    _refresh_payload_digest(wrong_witness["witness"])
+    requests.append(wrong_witness)
+
+    wrong_profile = _request()
+    wrong_profile["candidate"]["payload"]["producer"]["configuration"]["relation"] = (
+        "H=A*U"
+    )
+    _refresh_payload_digest(wrong_profile["candidate"])
+    requests.append(wrong_profile)
+
+    duplicate_parent = _request()
+    duplicate_parent["witness"]["parents"].append(
+        duplicate_parent["claim"]["artifact_uri"]
+    )
+    requests.append(duplicate_parent)
+
+    for request in requests:
+        decision = check_hermite_normal_form(copy.deepcopy(request))
+        assert decision["accepted"] is False
+        assert decision["conclusion"] == "UNKNOWN"

--- a/tests/integration/test_agent_ab_benchmark.py
+++ b/tests/integration/test_agent_ab_benchmark.py
@@ -220,6 +220,49 @@ def _linear_report(
     }
 
 
+def _hnf_case() -> dict[str, Any]:
+    return {
+        "case_id": "HNF-PRIVATE-TEST-001",
+        "version": "1",
+        "task_type": "matrix_hermite_normal_form",
+        "prompt": "Compute the exact row Hermite normal form.",
+        "matrix": {
+            "entries": [
+                ["0", "2", "4"],
+                ["0", "6", "8"],
+            ]
+        },
+    }
+
+
+def _hnf_report(
+    *,
+    matrix_uri: str | None,
+    normal_form_uri: str | None,
+    record_uri: str | None,
+    assurance: str,
+    final_verification: str,
+) -> dict[str, Any]:
+    return {
+        "case_id": "HNF-PRIVATE-TEST-001",
+        "status": "NORMAL_FORM_PRODUCED",
+        "conclusion": "TRUE",
+        "normal_form": [["0", "2", "0"], ["0", "0", "4"]],
+        "transformation": [["-2", "1"], ["3", "-1"]],
+        "assurance": assurance,
+        "final_verification": final_verification,
+        "matrix_uri": matrix_uri,
+        "normal_form_uri": normal_form_uri,
+        "verification_record_uri": record_uri,
+        "limitations": ["the exact supplied integer matrix only"],
+        "feedback": {
+            "reasoning_focus": ["preserve row-HNF and transform conventions"],
+            "infrastructure_work": [],
+            "tooling_gaps": [],
+        },
+    }
+
+
 def test_ab_sat_report_contract_identifies_the_producer_evidence_uri() -> None:
     schema_path = PROJECT_ROOT / "benchmarks" / "ab_cases" / "sat-report.schema.json"
     schema = json.loads(schema_path.read_text(encoding="utf-8"))
@@ -1585,6 +1628,101 @@ def test_ab_linear_scorer_requires_ordered_checker_bound_solution(
     with pytest.raises(
         cast(type[Exception], BENCHMARK["BenchmarkError"]),
         match="does not satisfy",
+    ):
+        score_report(
+            case,
+            wrong,
+            condition="control",
+            state_dir=state_dir,
+            mcp_calls=[],
+        )
+
+
+def test_ab_hnf_scorer_requires_bound_independently_replayed_evidence(
+    tmp_path: Path,
+) -> None:
+    score_report = cast(Any, BENCHMARK["score_report"])
+    case = _hnf_case()
+    state_dir = tmp_path / "state"
+    kernel = JacobianKernel(state_dir, install_references=True)
+    computed = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="matrix.normal_form.hermite",
+            mode=CapabilityMode.EXPLORE,
+            input={"matrix": case["matrix"]},
+        )
+    )
+    normal_form_uri = cast(str, computed.output["normal_form_uri"])
+    matrix_uri = cast(str, computed.output["matrix_uri"])
+    verified = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="matrix.normal_form.hermite.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"normal_form_uri": normal_form_uri},
+        )
+    )
+    record_uri = verified.assurance.verification_record_uri
+    assert record_uri is not None
+
+    control = score_report(
+        case,
+        _hnf_report(
+            matrix_uri=None,
+            normal_form_uri=None,
+            record_uri=None,
+            assurance="SELF_CHECKED",
+            final_verification="UNVERIFIED",
+        ),
+        condition="control",
+        state_dir=state_dir,
+        mcp_calls=[],
+    )
+    assert control["passed"] is True
+
+    treatment = score_report(
+        case,
+        _hnf_report(
+            matrix_uri=matrix_uri,
+            normal_form_uri=normal_form_uri,
+            record_uri=record_uri,
+            assurance="VERIFIED",
+            final_verification="VERIFIED",
+        ),
+        condition="treatment",
+        state_dir=state_dir,
+        mcp_calls=["capability.invoke"],
+        capability_invocations=[
+            {
+                "capability_id": "matrix.normal_form.hermite",
+                "input": {"matrix": case["matrix"]},
+                "output": computed.output,
+                "artifact_uris": computed.artifact_uris,
+            },
+            {
+                "capability_id": "matrix.normal_form.hermite.verify",
+                "input": {"normal_form_uri": normal_form_uri},
+                "output": verified.output,
+                "artifact_uris": verified.artifact_uris,
+                "assurance": verified.assurance.model_dump(mode="json"),
+            },
+        ],
+    )
+
+    assert treatment["passed"] is True
+    assert treatment["false_certification"] is False
+    assert treatment["replay_success"] is True
+
+    wrong = _hnf_report(
+        matrix_uri=None,
+        normal_form_uri=None,
+        record_uri=None,
+        assurance="SELF_CHECKED",
+        final_verification="UNVERIFIED",
+    )
+    wrong["transformation"][0][0] = "0"
+    with pytest.raises(
+        cast(type[Exception], BENCHMARK["BenchmarkError"]),
+        match="independent exact oracle",
     ):
         score_report(
             case,

--- a/tests/integration/test_matrix_hermite_normal_form.py
+++ b/tests/integration/test_matrix_hermite_normal_form.py
@@ -1,0 +1,446 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+import jacobian.provider_runtime as provider_runtime
+from jacobian.bounded_process import BoundedProcessResult
+from jacobian.canonical import canonicalize_json
+from jacobian.contracts.capabilities import (
+    CapabilityAssuranceLevel,
+    CapabilityInstallTier,
+    CapabilityMode,
+    CapabilityProviderAvailability,
+    CapabilityRequest,
+    CapabilityResult,
+)
+from jacobian.contracts.results import ExecutionStatus
+from jacobian.kernel import JacobianKernel
+from jacobian.matrix_normal_form_capabilities import (
+    install_matrix_normal_form_checker,
+)
+
+pytestmark = pytest.mark.usefixtures("initialized_kernel_store")
+
+
+def _matrix(entries: list[list[int | str]]) -> dict[str, Any]:
+    return {"entries": [[str(value) for value in row] for row in entries]}
+
+
+def _invoke(
+    kernel: JacobianKernel,
+    capability_id: str,
+    payload: dict[str, Any],
+    *,
+    mode: CapabilityMode,
+) -> CapabilityResult:
+    return kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id=capability_id,
+            mode=mode,
+            input=payload,
+        )
+    )
+
+
+def _kernel_with_checker(root: Path) -> JacobianKernel:
+    kernel = JacobianKernel(root)
+    adapter, _installation = install_matrix_normal_form_checker(
+        kernel.store,
+        kernel.schemas,
+        kernel.artifacts,
+        kernel.matrix_normal_forms,
+        kernel.verification,
+        kernel.checkers,
+        authorize_checker=True,
+    )
+    assert adapter is not None
+    kernel.register_capability(adapter)
+    return kernel
+
+
+def test_python_flint_produces_bound_rectangular_row_hnf(tmp_path: Path) -> None:
+    kernel = JacobianKernel(tmp_path)
+    result = _invoke(
+        kernel,
+        "matrix.normal_form.hermite",
+        {
+            "matrix": _matrix([[0, 2, 4], [0, 6, 8]]),
+            "resource_budget": {"wall_seconds": 5},
+        },
+        mode=CapabilityMode.EXPLORE,
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output["status"] == "NORMAL_FORM_PRODUCED"
+    assert result.output["conclusion"] == "UNKNOWN"
+    assert result.output["verification"] == "UNVERIFIED"
+    assert result.output["flint_library_version"] == "3.6.0"
+    assert result.output["normal_form"]["entries"] == [
+        ["0", "2", "0"],
+        ["0", "0", "4"],
+    ]
+    assert result.output["transformation"]["entries"] == [
+        ["-2", "1"],
+        ["3", "-1"],
+    ]
+    assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert (
+        result.relationships[0].relation_id
+        == "matrix.relation.row-hermite-normal-form-of"
+    )
+
+    resolved = kernel.matrix_normal_forms.resolve_hermite_normal_form(
+        result.output["normal_form_uri"]
+    )
+    assert resolved.candidate.source.matrix_artifact_uri == result.output["matrix_uri"]
+    assert result.output["matrix_uri"] in resolved.artifact.manifest.parents
+
+
+def test_hnf_runtime_has_a_distinct_exact_operation_profile(tmp_path: Path) -> None:
+    runtime = JacobianKernel(tmp_path).python_flint_hnf_runtime
+
+    assert runtime.availability is CapabilityProviderAvailability.AVAILABLE
+    assert runtime.version == "0.9.0"
+    assert runtime.install_tier is CapabilityInstallTier.T1
+    assert runtime.digest is not None and runtime.digest.startswith("sha256:")
+    assert runtime.configuration == {
+        "distribution": "python-flint",
+        "domain": "ZZ",
+        "operation": "fmpz_mat.hnf(transform=True)",
+        "flint_library_version": "3.6.0",
+        "maximum_rows": 32,
+        "maximum_columns": 32,
+        "normal_form_convention": "FLINT_ROW_HNF",
+        "relation": "H=U*A",
+    }
+
+
+def test_hnf_runtime_rejects_a_different_linked_flint_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    available = provider_runtime.python_flint_hnf_provider_runtime()
+    assert available.availability is CapabilityProviderAvailability.AVAILABLE
+    monkeypatch.setattr(
+        provider_runtime,
+        "python_distribution_provider_runtime",
+        lambda *_args, **_kwargs: available,
+    )
+    monkeypatch.setattr(
+        provider_runtime.importlib,
+        "import_module",
+        lambda _name: SimpleNamespace(__FLINT_VERSION__="3.5.0"),
+    )
+
+    rejected = provider_runtime.python_flint_hnf_provider_runtime(refresh=True)
+
+    assert rejected.availability is CapabilityProviderAvailability.UNAVAILABLE
+    assert rejected.version is None
+    assert rejected.digest is None
+    assert "linked FLINT library" in rejected.diagnostic
+
+
+@pytest.mark.parametrize(
+    "entries",
+    [
+        [["01"]],
+        [["1"], ["2", "3"]],
+        [["9" * 257]],
+    ],
+    ids=("noncanonical_integer", "ragged_rows", "digit_limit"),
+)
+def test_hnf_rejects_inputs_outside_the_exact_matrix_contract(
+    tmp_path: Path,
+    entries: list[list[str]],
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+
+    result = _invoke(
+        kernel,
+        "matrix.normal_form.hermite",
+        {"matrix": {"entries": entries}},
+        mode=CapabilityMode.EXPLORE,
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.output["error"]["stage"] in {
+        "capability_input_validation",
+        "input_validation",
+    }
+
+
+def test_independent_checker_verifies_full_hnf_relation(tmp_path: Path) -> None:
+    kernel = _kernel_with_checker(tmp_path)
+    computed = _invoke(
+        kernel,
+        "matrix.normal_form.hermite",
+        {"matrix": _matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])},
+        mode=CapabilityMode.EXPLORE,
+    )
+    verified = _invoke(
+        kernel,
+        "matrix.normal_form.hermite.verify",
+        {"normal_form_uri": computed.output["normal_form_uri"]},
+        mode=CapabilityMode.VERIFY,
+    )
+
+    assert verified.execution.status is ExecutionStatus.COMPLETED
+    assert verified.output["status"] == "VERIFIED_HERMITE_NORMAL_FORM"
+    assert verified.output["conclusion"] == "TRUE"
+    assert verified.output["verification_record_uri"].startswith("artifact://sha256/")
+    assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED
+
+
+@pytest.mark.parametrize(
+    ("source", "normal_form", "transformation"),
+    [
+        (
+            [[2, 4], [6, 8]],
+            [[2, 1], [0, 4]],
+            [[-2, 1], [3, -1]],
+        ),
+        (
+            [[0, 0], [0, 0]],
+            [[0, 0], [0, 0]],
+            [[2, 0], [0, 2]],
+        ),
+        (
+            [[0, 1], [1, 0]],
+            [[0, 1], [1, 0]],
+            [[1, 0], [0, 1]],
+        ),
+    ],
+    ids=("broken_relation", "nonunimodular_transform", "not_row_hnf"),
+)
+def test_checker_rejects_each_independent_hnf_obligation(
+    tmp_path: Path,
+    source: list[list[int]],
+    normal_form: list[list[int]],
+    transformation: list[list[int]],
+) -> None:
+    kernel = _kernel_with_checker(tmp_path)
+    matrix_uri = kernel.matrix_normal_forms.put_matrix(_matrix(source)).artifact_uri
+    candidate = kernel.matrix_normal_forms.put_hermite_normal_form(
+        matrix_uri=matrix_uri,
+        normal_form=[[str(value) for value in row] for row in normal_form],
+        transformation=[[str(value) for value in row] for row in transformation],
+        producer=kernel.python_flint_hnf_runtime,
+        resource_budget={"wall_seconds": 5},
+    )
+
+    rejected = _invoke(
+        kernel,
+        "matrix.normal_form.hermite.verify",
+        {"normal_form_uri": candidate.artifact_uri},
+        mode=CapabilityMode.VERIFY,
+    )
+
+    assert rejected.execution.status is ExecutionStatus.COMPLETED
+    assert rejected.output["status"] == "REJECTED"
+    assert rejected.output["conclusion"] == "UNKNOWN"
+    assert rejected.output["verification_record_uri"] is None
+    assert rejected.assurance.level is not CapabilityAssuranceLevel.VERIFIED
+
+
+def test_python_flint_hnf_timeout_is_operational(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    monkeypatch.setattr(
+        "jacobian.flint_hnf.run_bounded_process",
+        lambda *_args, **_kwargs: BoundedProcessResult(
+            returncode=None,
+            stdout=b"",
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=True,
+        ),
+    )
+
+    result = _invoke(
+        kernel,
+        "matrix.normal_form.hermite",
+        {"matrix": _matrix([[1]])},
+        mode=CapabilityMode.EXPLORE,
+    )
+
+    assert result.execution.status is ExecutionStatus.TIMEOUT
+    assert result.output["status"] == "NO_NORMAL_FORM_PRODUCED"
+    assert result.output["conclusion"] == "UNKNOWN"
+    assert result.output["normal_form_uri"] is None
+    assert result.assurance.level is not CapabilityAssuranceLevel.VERIFIED
+
+
+def test_hnf_worker_gets_only_fixed_environment_and_budget(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JACOBIAN_HNF_SECRET", "must-not-propagate")
+    observed: dict[str, Any] = {}
+
+    def fake_worker(*_args: Any, **kwargs: Any) -> BoundedProcessResult:
+        observed.update(kwargs)
+        stdout = (
+            canonicalize_json(
+                {
+                    "protocol": "jacobian.flint-hnf-worker/v1",
+                    "status": "NORMAL_FORM_PRODUCED",
+                    "backend_version": "0.9.0",
+                    "flint_library_version": "3.6.0",
+                    "normal_form": [["1"]],
+                    "transformation": [["1"]],
+                }
+            )
+            + b"\n"
+        )
+        return BoundedProcessResult(
+            returncode=0,
+            stdout=stdout,
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=False,
+        )
+
+    kernel = JacobianKernel(tmp_path)
+    monkeypatch.setattr("jacobian.flint_hnf.run_bounded_process", fake_worker)
+    result = _invoke(
+        kernel,
+        "matrix.normal_form.hermite",
+        {
+            "matrix": _matrix([[1]]),
+            "resource_budget": {"wall_seconds": 7},
+        },
+        mode=CapabilityMode.EXPLORE,
+    )
+
+    assert result.output["status"] == "NORMAL_FORM_PRODUCED"
+    assert observed["timeout_seconds"] == 7.0
+    assert observed["environment"] == {
+        "LANG": "C",
+        "LC_ALL": "C",
+        "TZ": "UTC",
+        "PYTHONHASHSEED": "0",
+    }
+    assert "JACOBIAN_HNF_SECRET" in os.environ
+    assert "JACOBIAN_HNF_SECRET" not in observed["environment"]
+
+
+def test_hnf_output_is_discarded_if_runtime_identity_changes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    original = kernel.python_flint_hnf_runtime
+    changed = original.model_copy(update={"digest": "sha256:" + "f" * 64})
+    observations = iter((original, changed))
+    monkeypatch.setattr(
+        "jacobian.flint_hnf.python_flint_hnf_provider_runtime",
+        lambda **_kwargs: next(observations),
+    )
+    monkeypatch.setattr(
+        "jacobian.flint_hnf.run_bounded_process",
+        lambda *_args, **_kwargs: BoundedProcessResult(
+            returncode=0,
+            stdout=canonicalize_json(
+                {
+                    "protocol": "jacobian.flint-hnf-worker/v1",
+                    "status": "NORMAL_FORM_PRODUCED",
+                    "backend_version": "0.9.0",
+                    "flint_library_version": "3.6.0",
+                    "normal_form": [["1"]],
+                    "transformation": [["1"]],
+                }
+            )
+            + b"\n",
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=False,
+        ),
+    )
+
+    result = _invoke(
+        kernel,
+        "matrix.normal_form.hermite",
+        {"matrix": _matrix([[1]])},
+        mode=CapabilityMode.EXPLORE,
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.output["status"] == "NO_NORMAL_FORM_PRODUCED"
+    assert result.output["normal_form_uri"] is None
+    assert "changed during execution" in result.output["detail"]
+
+
+def test_invalid_worker_protocol_retains_no_hnf_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    monkeypatch.setattr(
+        "jacobian.flint_hnf.run_bounded_process",
+        lambda *_args, **_kwargs: BoundedProcessResult(
+            returncode=0,
+            stdout=b'{"status":"NORMAL_FORM_PRODUCED"}\n',
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=False,
+        ),
+    )
+
+    result = _invoke(
+        kernel,
+        "matrix.normal_form.hermite",
+        {"matrix": _matrix([[1]])},
+        mode=CapabilityMode.EXPLORE,
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.output["status"] == "NO_NORMAL_FORM_PRODUCED"
+    assert result.output["normal_form_uri"] is None
+    assert result.output["conclusion"] == "UNKNOWN"
+
+
+def test_hnf_checker_timeout_is_operational(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = _kernel_with_checker(tmp_path)
+    computed = _invoke(
+        kernel,
+        "matrix.normal_form.hermite",
+        {"matrix": _matrix([[1]])},
+        mode=CapabilityMode.EXPLORE,
+    )
+    monkeypatch.setattr(
+        "jacobian.verification.run_bounded_process",
+        lambda *_args, **_kwargs: BoundedProcessResult(
+            returncode=None,
+            stdout=b"",
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=True,
+        ),
+    )
+
+    result = _invoke(
+        kernel,
+        "matrix.normal_form.hermite.verify",
+        {"normal_form_uri": computed.output["normal_form_uri"]},
+        mode=CapabilityMode.VERIFY,
+    )
+
+    assert result.execution.status is ExecutionStatus.TIMEOUT
+    assert result.output["status"] == "TIMEOUT"
+    assert result.output["conclusion"] == "UNKNOWN"
+    assert result.output["verification_record_uri"] is None
+    assert result.assurance.level is not CapabilityAssuranceLevel.VERIFIED


### PR DESCRIPTION
## Problem

The Python-FLINT portfolio had exact rational solution evidence but no integer-matrix normal-form slice. Exposing HNF safely requires retaining the full transformation and keeping provider computation separate from independent verification.

## Result

- Add `matrix.normal_form.hermite`, backed by pinned Python-FLINT 0.9.0 with linked FLINT 3.6.0, in a bounded isolated worker.
- Materialize exact integer source, row-HNF candidate `H`, left transformation `U`, runtime identity, budget, digests, and lineage while retaining `COMPUTED/UNKNOWN`.
- Add operator-authorized `matrix.normal_form.hermite.verify`, whose standard-library checker independently checks exact bindings, `H = U A`, `det(U) = ±1`, and every FLINT row-HNF condition before creating a `VERIFIED` record.
- Add fail-closed mutation, timeout, protocol, runtime-identity, and clean-process replay tests.
- Extend the held-out A/B harness and record the two-case Terra pilot: control 2/2, treatment 2/2, clean replay 2/2, zero false certifications or tool/parameter errors.
- Update the atomic portfolio, catalog, README, and reference contract.

## Compatibility and normative impact

This adds two pre-stable capability IDs and version-1 integer-matrix/HNF artifact contracts. Existing capability contracts are unchanged. The optional producer is unavailable unless both the pinned Python package and linked FLINT library match its exact profile; verifier authorization remains independent of provider availability.

## Validation

- `make check` — 316 passed, 4 deselected by marker
- `make check-static` — Ruff, format, deptry, vulture, mypy, sdist and wheel build passed
- `uv run pytest -q -n 0 tests/checkers/test_matrix_normal_form_checker.py tests/integration/test_matrix_hermite_normal_form.py tests/integration/test_agent_ab_benchmark.py -k 'hnf' -m 'not lean_runtime'` — 21 passed, 31 deselected
- randomized development cross-check — 7,000 Bareiss determinants and 18,000 row-HNF predicates matched FLINT
- held-out `gpt-5.6-terra` high A/B — 2 valid pairs; both conditions 2/2, treatment clean replay 2/2, zero false certifications

An additional broad integration run produced 46 passes and one unrelated `lean_runtime` failure because the local Lean check returned no verification record; the HNF, benchmark, and MCP cases in that run passed.