### PR TITLE
feat(polynomials): add verified typed polynomial normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ availability can depend on local backends.
 | Domain | Agent-visible outcomes |
 | --- | --- |
 | Polynomial maps | Evaluate maps, compute Jacobians, search for collisions, independently verify collisions |
-| Polynomial algebra | Factor univariate polynomials, verify identities, verify exact system solutions |
+| Polynomial algebra | Normalize typed expressions, factor univariate polynomials, verify identities, verify exact system solutions |
 | Exact linear algebra | Compute determinants, rank, kernels, and integer row Hermite normal forms; find and verify rational solutions to `Ax = b` |
 | Graphs | Construct and inspect graphs, enumerate paths, realize degree sequences, test isomorphism, search colorings |
 | SAT and SMT | Find models or proof artifacts; independently replay assignments, DRAT proofs, and Alethe proofs |

--- a/benchmarks/ab_cases/polynomial-normalization-report.schema.json
+++ b/benchmarks/ab_cases/polynomial-normalization-report.schema.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": {
+    "canonical_rational": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "num": {
+          "type": "string",
+          "pattern": "^-?(0|[1-9][0-9]*)$"
+        },
+        "den": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]*$"
+        }
+      },
+      "required": [
+        "num",
+        "den"
+      ]
+    },
+    "polynomial_term": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "coefficient": {
+          "$ref": "#/$defs/canonical_rational"
+        },
+        "exponents": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 4,
+          "items": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 127
+          }
+        }
+      },
+      "required": [
+        "coefficient",
+        "exponents"
+      ]
+    }
+  },
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "case_id": {
+      "type": "string"
+    },
+    "status": {
+      "enum": [
+        "NORMALIZATION_PRODUCED"
+      ]
+    },
+    "conclusion": {
+      "enum": [
+        "TRUE"
+      ]
+    },
+    "variables": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 4,
+      "items": {
+        "type": "string",
+        "pattern": "^[A-Za-z][A-Za-z0-9_]{0,31}$"
+      }
+    },
+    "normalized": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "terms": {
+          "type": "array",
+          "maxItems": 1024,
+          "items": {
+            "$ref": "#/$defs/polynomial_term"
+          }
+        }
+      },
+      "required": [
+        "terms"
+      ]
+    },
+    "assurance": {
+      "enum": [
+        "SELF_CHECKED",
+        "COMPUTED",
+        "VERIFIED"
+      ]
+    },
+    "final_verification": {
+      "enum": [
+        "UNVERIFIED",
+        "VERIFIED"
+      ]
+    },
+    "expression_uri": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^artifact://sha256/[0-9a-f]{64}$"
+    },
+    "normalization_uri": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^artifact://sha256/[0-9a-f]{64}$"
+    },
+    "verification_record_uri": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^artifact://sha256/[0-9a-f]{64}$"
+    },
+    "limitations": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "feedback": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "reasoning_focus": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "infrastructure_work": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tooling_gaps": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "reasoning_focus",
+        "infrastructure_work",
+        "tooling_gaps"
+      ]
+    }
+  },
+  "required": [
+    "case_id",
+    "status",
+    "conclusion",
+    "variables",
+    "normalized",
+    "assurance",
+    "final_verification",
+    "expression_uri",
+    "normalization_uri",
+    "verification_record_uri",
+    "limitations",
+    "feedback"
+  ]
+}

--- a/benchmarks/agent_ab.py
+++ b/benchmarks/agent_ab.py
@@ -37,6 +37,11 @@ from jacobian.contracts.capabilities import CapabilityMode, CapabilityRequest
 from jacobian.contracts.exact import CanonicalRational
 from jacobian.contracts.linear import LinearRationalSystem
 from jacobian.contracts.matrices import ExactIntegerMatrix
+from jacobian.contracts.polynomial_expressions import PolynomialExpressionArtifact
+from jacobian.contracts.polynomials import (
+    RationalPolynomial,
+    SparseRationalPolynomial,
+)
 from jacobian.contracts.sat import (
     CanonicalCnf,
     SatAssignmentArtifact,
@@ -67,6 +72,9 @@ SAT_REPORT_SCHEMA = CASES_ROOT / "sat-report.schema.json"
 SMT_REPORT_SCHEMA = CASES_ROOT / "smt-report.schema.json"
 LINEAR_REPORT_SCHEMA = CASES_ROOT / "linear-report.schema.json"
 HNF_REPORT_SCHEMA = CASES_ROOT / "hnf-report.schema.json"
+POLYNOMIAL_NORMALIZATION_REPORT_SCHEMA = (
+    CASES_ROOT / "polynomial-normalization-report.schema.json"
+)
 LEAN_DECLARATION_REPORT_SCHEMA = CASES_ROOT / "lean-report.schema.json"
 LEAN_PROOF_REPORT_SCHEMA = CASES_ROOT / "lean-proof-report.schema.json"
 DEFAULT_RESULTS_ROOT = Path(__file__).with_name("results") / "ab"
@@ -101,6 +109,12 @@ HNF_CAPABILITY_IDS = frozenset(
     {
         "matrix.normal_form.hermite",
         "matrix.normal_form.hermite.verify",
+    }
+)
+POLYNOMIAL_NORMALIZATION_CAPABILITY_IDS = frozenset(
+    {
+        "polynomial.expression.normalize",
+        "polynomial.expression_normalization.verify",
     }
 )
 LEAN_PROOF_CONDITIONS = ("baseline", "tactic", "retrieval", "combined")
@@ -247,6 +261,23 @@ VERIFY mode. Provider output alone is not verification. Report VERIFIED only
 when the verifier returns VERIFIED_HERMITE_NORMAL_FORM. Copy the producer's
 exact H and U entries and the exact matrix, normal-form, and verification-record
 URIs.
+"""
+POLYNOMIAL_NORMALIZATION_CONTROL_INSTRUCTIONS = """\
+Jacobian and all MCP servers are unavailable. You may write and run local code
+in the empty workspace. Expand the supplied typed rational-polynomial
+expression and return its exact canonical sparse coefficients in descending
+lexicographic exponent order. Report SELF_CHECKED and UNVERIFIED, with null
+durable artifact and verification-record URIs.
+"""
+POLYNOMIAL_NORMALIZATION_TREATMENT_INSTRUCTIONS = """\
+Use only jacobian_local for mathematical work. Do not use shell commands or
+create programs. Describe the exact capability IDs
+polynomial.expression.normalize and
+polynomial.expression_normalization.verify directly. Invoke the producer on
+the supplied typed expression, then pass its normalization_uri to the verifier
+in VERIFY mode. Provider output alone is not verification. Report VERIFIED
+only when the verifier returns VERIFIED_NORMALIZATION. Copy the producer's
+exact canonical coefficients and all durable URIs.
 """
 
 LEAN_DECLARATION_INSTRUCTIONS = """\
@@ -861,6 +892,240 @@ def _score_hnf_report(
     }
 
 
+def _polynomial_expression_case(
+    case: Mapping[str, Any],
+) -> PolynomialExpressionArtifact:
+    try:
+        return PolynomialExpressionArtifact.model_validate(case.get("expression"))
+    except ValueError as exc:
+        raise BenchmarkError(
+            "polynomial normalization case has an invalid typed expression"
+        ) from exc
+
+
+def _expected_polynomial_normalization(
+    case: Mapping[str, Any],
+    source: PolynomialExpressionArtifact,
+) -> SparseRationalPolynomial:
+    try:
+        return RationalPolynomial(
+            variables=source.variables,
+            polynomial=SparseRationalPolynomial.model_validate(
+                case.get("expected_normalized")
+            ),
+        ).polynomial
+    except ValueError as exc:
+        raise BenchmarkError(
+            "polynomial normalization case has an invalid hidden oracle"
+        ) from exc
+
+
+def _reported_polynomial_normalization(
+    report: Mapping[str, Any],
+    source: PolynomialExpressionArtifact,
+) -> SparseRationalPolynomial:
+    try:
+        return RationalPolynomial(
+            variables=source.variables,
+            polynomial=SparseRationalPolynomial.model_validate(
+                report.get("normalized")
+            ),
+        ).polynomial
+    except ValueError as exc:
+        raise BenchmarkError(
+            "polynomial normalization report has invalid canonical coefficients"
+        ) from exc
+
+
+def _matches_polynomial_expression(
+    value: object,
+    expected: PolynomialExpressionArtifact,
+) -> bool:
+    try:
+        return PolynomialExpressionArtifact.model_validate(value) == expected
+    except ValueError:
+        return False
+
+
+def _score_polynomial_normalization_report(
+    case: Mapping[str, Any],
+    report: Mapping[str, Any],
+    *,
+    condition: str,
+    state_dir: Path,
+    mcp_calls: Sequence[str],
+    shell_calls: Sequence[str],
+    capability_invocations: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    source = _polynomial_expression_case(case)
+    expected = _expected_polynomial_normalization(case, source)
+    reported = _reported_polynomial_normalization(report, source)
+    if reported != expected:
+        raise BenchmarkError(
+            "polynomial normalization report differs from the held-out exact oracle"
+        )
+    if (
+        report.get("case_id") != case.get("case_id")
+        or report.get("status") != "NORMALIZATION_PRODUCED"
+        or report.get("conclusion") != "TRUE"
+        or report.get("variables") != list(source.variables)
+    ):
+        raise BenchmarkError(
+            "polynomial normalization report has the wrong case, status, or ring"
+        )
+    _validate_feedback(report.get("feedback"))
+
+    if condition == "control":
+        if mcp_calls:
+            raise BenchmarkError("polynomial normalization control used an MCP tool")
+        if (
+            report.get("assurance") != "SELF_CHECKED"
+            or report.get("final_verification") != "UNVERIFIED"
+            or report.get("expression_uri") is not None
+            or report.get("normalization_uri") is not None
+            or report.get("verification_record_uri") is not None
+        ):
+            raise BenchmarkError(
+                "polynomial normalization control must remain self-checked without "
+                "durable evidence"
+            )
+        return {
+            "passed": True,
+            "false_certification": False,
+            "replay_success": False,
+            "checks": [
+                "held-out exact coefficient oracle",
+                "no-Jacobian control isolation",
+            ],
+        }
+    if condition != "treatment":
+        raise BenchmarkError(f"unknown condition: {condition}")
+    if shell_calls:
+        raise BenchmarkError("polynomial normalization treatment used a shell command")
+    if "capability.invoke" not in mcp_calls:
+        raise BenchmarkError(
+            "polynomial normalization treatment did not invoke Jacobian"
+        )
+    if (
+        report.get("assurance") != "VERIFIED"
+        or report.get("final_verification") != "VERIFIED"
+    ):
+        raise BenchmarkError(
+            "polynomial normalization treatment did not report verified assurance"
+        )
+    expression_uri = report.get("expression_uri")
+    normalization_uri = report.get("normalization_uri")
+    record_uri = report.get("verification_record_uri")
+    if not all(
+        isinstance(uri, str) for uri in (expression_uri, normalization_uri, record_uri)
+    ):
+        raise BenchmarkError(
+            "polynomial normalization treatment omitted durable artifact URIs"
+        )
+    assert isinstance(expression_uri, str)
+    assert isinstance(normalization_uri, str)
+    assert isinstance(record_uri, str)
+
+    kernel = JacobianKernel(state_dir, install_references=True)
+    try:
+        resolved = kernel.polynomial_expressions.resolve_normalization(
+            normalization_uri
+        )
+        record_artifact = kernel.store.get(record_uri)
+        record = VerificationRecord.model_validate(record_artifact.payload)
+        semantics = kernel.store.get(
+            kernel.polynomial_expressions.installation.semantics_uri
+        )
+    except (StoreError, ValueError) as exc:
+        raise BenchmarkError(
+            "polynomial normalization treatment artifacts are unavailable"
+        ) from exc
+    if (
+        resolved.expression != source
+        or resolved.candidate.normalized != expected
+        or resolved.expression_artifact.artifact_uri != expression_uri
+        or expression_uri not in resolved.artifact.manifest.parents
+        or record.conclusion.value != "TRUE"
+        or record.bindings.claim_digest
+        != resolved.expression_artifact.manifest.object_digest
+        or record.bindings.semantics_digest != semantics.manifest.object_digest
+        or record.bindings.candidate_digest != resolved.artifact.manifest.object_digest
+        or not {expression_uri, normalization_uri, record.evidence_uri}.issubset(
+            record_artifact.manifest.parents
+        )
+    ):
+        raise BenchmarkError(
+            "polynomial normalization verification record is not exactly bound"
+        )
+
+    produced_index: int | None = None
+    verified_trace = False
+    for index, invocation in enumerate(capability_invocations):
+        invocation_input = invocation.get("input")
+        invocation_output = invocation.get("output")
+        if (
+            invocation.get("capability_id") == "polynomial.expression.normalize"
+            and isinstance(invocation_input, Mapping)
+            and _matches_polynomial_expression(
+                invocation_input.get("expression"),
+                source,
+            )
+            and isinstance(invocation_output, Mapping)
+            and invocation_output.get("expression_uri") == expression_uri
+            and invocation_output.get("normalization_uri") == normalization_uri
+            and normalization_uri in (invocation.get("artifact_uris") or [])
+        ):
+            produced_index = index
+        if (
+            produced_index is not None
+            and index > produced_index
+            and invocation.get("capability_id")
+            == "polynomial.expression_normalization.verify"
+            and invocation_input == {"normalization_uri": normalization_uri}
+            and isinstance(invocation_output, Mapping)
+            and invocation_output.get("verification_record_uri") == record_uri
+            and isinstance(invocation.get("assurance"), Mapping)
+            and invocation["assurance"].get("level") == "VERIFIED"
+            and record_uri in (invocation.get("artifact_uris") or [])
+        ):
+            verified_trace = True
+            break
+    if not verified_trace:
+        raise BenchmarkError(
+            "polynomial normalization treatment lacks an ordered compute-to-verify "
+            "trace"
+        )
+
+    replay = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="polynomial.expression_normalization.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"normalization_uri": normalization_uri},
+        )
+    )
+    if (
+        replay.assurance.level.value != "VERIFIED"
+        or replay.assurance.verification_record_uri != record_uri
+        or replay.output.get("conclusion") != "TRUE"
+        or replay.output.get("expression_uri") != expression_uri
+        or replay.output.get("normalization_uri") != normalization_uri
+    ):
+        raise BenchmarkError(
+            "polynomial normalization evidence does not replay independently"
+        )
+    return {
+        "passed": True,
+        "false_certification": False,
+        "replay_success": True,
+        "checks": [
+            "held-out exact coefficient oracle",
+            "durable source and candidate binding",
+            "ordered compute-to-verify trace",
+            "independent checker replay",
+        ],
+    }
+
+
 def _matches_integer_matrix(
     value: object,
     expected: ExactIntegerMatrix,
@@ -1259,6 +1524,16 @@ def score_report(
     capability_attempt_ids: Sequence[str] = (),
     capability_invocations: Sequence[Mapping[str, Any]] = (),
 ) -> dict[str, Any]:
+    if case.get("task_type") == "polynomial_expression_normalization":
+        return _score_polynomial_normalization_report(
+            case,
+            report,
+            condition=condition,
+            state_dir=state_dir,
+            mcp_calls=mcp_calls,
+            shell_calls=shell_calls,
+            capability_invocations=capability_invocations,
+        )
     if case.get("task_type") == "matrix_hermite_normal_form":
         return _score_hnf_report(
             case,
@@ -2173,6 +2448,12 @@ def _codex_command(
 
 
 def _condition_instructions(task_type: object, condition: str) -> str:
+    if task_type == "polynomial_expression_normalization":
+        return (
+            POLYNOMIAL_NORMALIZATION_CONTROL_INSTRUCTIONS
+            if condition == "control"
+            else POLYNOMIAL_NORMALIZATION_TREATMENT_INSTRUCTIONS
+        )
     if task_type == "matrix_hermite_normal_form":
         return (
             HNF_CONTROL_INSTRUCTIONS
@@ -2242,6 +2523,9 @@ def _run_condition(
     is_smt = case.get("task_type") == "smt_unsat_proof"
     is_linear = case.get("task_type") == "linear_rational_solution"
     is_hnf = case.get("task_type") == "matrix_hermite_normal_form"
+    is_polynomial_normalization = (
+        case.get("task_type") == "polynomial_expression_normalization"
+    )
     is_lean_declaration = case.get("task_type") == "lean_declaration"
     is_lean_proof = case.get("task_type") == "lean_proof"
     sat_context = ""
@@ -2267,6 +2551,14 @@ def _run_condition(
             + json.dumps(matrix.model_dump(mode="json"), sort_keys=True)
             + "\n"
         )
+    polynomial_normalization_context = ""
+    if is_polynomial_normalization:
+        expression = _polynomial_expression_case(case)
+        polynomial_normalization_context = (
+            "\nThe exact typed rational-polynomial expression for this case is:\n"
+            + json.dumps(expression.model_dump(mode="json"), sort_keys=True)
+            + "\n"
+        )
     condition_instructions = _condition_instructions(
         case.get("task_type"),
         condition,
@@ -2276,6 +2568,7 @@ def _run_condition(
         + sat_context
         + linear_context
         + hnf_context
+        + polynomial_normalization_context
         + "\n"
         + COMMON_PROMPT.format(**case)
     )
@@ -2305,6 +2598,8 @@ def _run_condition(
             if is_linear
             else HNF_REPORT_SCHEMA
             if is_hnf
+            else POLYNOMIAL_NORMALIZATION_REPORT_SCHEMA
+            if is_polynomial_normalization
             else PARTITION_REPORT_SCHEMA
             if is_partition
             else REPORT_SCHEMA
@@ -2430,6 +2725,12 @@ def _run_condition(
                 and report.get("final_verification") == "VERIFIED"
                 and not score.get("passed")
             )
+            or (
+                is_polynomial_normalization
+                and isinstance(report, dict)
+                and report.get("final_verification") == "VERIFIED"
+                and not score.get("passed")
+            )
         ),
         "intervention_attempted": bool(
             (
@@ -2454,6 +2755,12 @@ def _run_condition(
                 is_hnf
                 and HNF_CAPABILITY_IDS.intersection(telemetry["capability_attempt_ids"])
             )
+            or (
+                is_polynomial_normalization
+                and POLYNOMIAL_NORMALIZATION_CAPABILITY_IDS.intersection(
+                    telemetry["capability_attempt_ids"]
+                )
+            )
         ),
         "intervention_used": bool(
             (
@@ -2467,6 +2774,12 @@ def _run_condition(
                 and LINEAR_CAPABILITY_IDS.intersection(telemetry["capability_ids"])
             )
             or (is_hnf and HNF_CAPABILITY_IDS.intersection(telemetry["capability_ids"]))
+            or (
+                is_polynomial_normalization
+                and POLYNOMIAL_NORMALIZATION_CAPABILITY_IDS.intersection(
+                    telemetry["capability_ids"]
+                )
+            )
         ),
         "operational_failure": bool(score.get("operational_failure")),
         "score": score,

--- a/docs/contributing/atomic-capability-portfolio.md
+++ b/docs/contributing/atomic-capability-portfolio.md
@@ -503,18 +503,21 @@ shared exact provider than importing SageMath.
 
 ### SymPy second
 
-Define a small versioned expression AST with explicit symbols, coefficient
-domains, functions, and assumptions. Convert that AST to SymPy internally.
-Never pass unsanitized user strings to `sympify`, `parse_expr`, `lambdify`, or
-Python evaluation; the [SymPy documentation][sympy-parsing] explicitly warns
-that these paths use `eval`.
+The first typed normalization slice is implemented; see the
+[typed polynomial expression normalization contract](../reference/polynomial-expression-normalization.md)
+and the
+[SymPy normalization pilot](../reference/capability-workflow-evaluations.md#sympy-typed-polynomial-normalization-pilot).
+It defines a small versioned polynomial AST with explicit symbols and
+coefficients, then constructs SymPy objects internally. It never passes
+unsanitized user strings to `sympify`, `parse_expr`, `lambdify`, or Python
+evaluation; the [SymPy documentation][sympy-parsing] explicitly warns that
+these paths use `eval`.
 
-Start with polynomial normalization where canonical coefficients provide a
-clear independent relation. Follow with narrowly scoped differentiation or
-simplification only when the output records assumptions, domains, branch
-conditions, and remaining obligations. Symbolic integration should not be an
-early slice: condition sets, branch cuts, and unevaluated results make its
-contract and verification boundary substantially larger.
+Any follow-up differentiation or simplification remains demand-gated and must
+record assumptions, domains, branch conditions, and remaining obligations.
+Symbolic integration should not be an early slice: condition sets, branch
+cuts, and unevaluated results make its contract and verification boundary
+substantially larger.
 
 Avoid duplicate public IDs backed separately by FLINT and SymPy. Choose the
 provider that best fits the declared domain, record it in provenance, and use
@@ -581,6 +584,10 @@ backlog.
     and the
     [Python-FLINT HNF pilot](../reference/capability-workflow-evaluations.md#python-flint-hermite-normal-form-pilot).
 13. Typed expression AST and one SymPy polynomial-normalization slice.
+    Implemented; see the
+    [typed polynomial expression normalization contract](../reference/polynomial-expression-normalization.md)
+    and the
+    [SymPy normalization pilot](../reference/capability-workflow-evaluations.md#sympy-typed-polynomial-normalization-pilot).
 14. Re-rank E/Vampire, Metamath, nauty, Singular, PARI, Normaliz, GAP, fplll,
     and HiGHS from accumulated workflow evidence.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,6 +62,7 @@ expectations.
 - [SMT Alethe artifact contracts](reference/smt-artifacts.md)
 - [Exact rational solution artifacts](reference/linear-rational-solutions.md)
 - [Integer matrix Hermite normal form](reference/matrix-hermite-normal-form.md)
+- [Typed polynomial expression normalization](reference/polynomial-expression-normalization.md)
 - [v0.2 specification](reference/specifications/v0.2.md)
 - [v0.2 conformance specification](reference/conformance-v0.2.md)
 - [Plugin conformance contract](reference/plugin-conformance.md)

--- a/docs/reference/capability-workflow-evaluations.md
+++ b/docs/reference/capability-workflow-evaluations.md
@@ -511,6 +511,41 @@ producer/verifier split, and direct URI handoff without another contract
 revision. As a prescribed-capability pilot, it measures usability and
 assurance discipline rather than autonomous portfolio selection.
 
+### SymPy typed polynomial-normalization pilot
+
+The frozen 2026-07-26 polynomial-normalization pilot used `gpt-5.6-terra`,
+high reasoning effort, a 420-second per-run limit, and one repetition of two
+private typed expressions over `QQ`. One expanded a rational bivariate cubic;
+the other exercised cancellation across three variables. Their case digests
+were
+`sha256:51083df44f4d5b95de6965d84d871be29d5aa38fbf56dcd453adb2da5081f657`
+and
+`sha256:6a331705051832318f6f2f747dabbedfb32229517f41ad22193130f8b39af00a`.
+
+Control normalized the expression directly and could report only
+`SELF_CHECKED/UNVERIFIED`. Treatment was prescribed
+`polynomial.expression.normalize` and
+`polynomial.expression_normalization.verify`. It had to pass the producer's
+`normalization_uri` into the verifier and report the exact sparse rational
+polynomial plus all durable URIs. The hidden scorer independently compared
+every coefficient and exponent to the held-out oracle, checked source and
+candidate bindings, required an ordered compute-to-verify invocation trace,
+and replayed the verification in a clean kernel.
+
+| Condition | Passed | False certifications | Clean replays | Median seconds | Median input tokens | Median calls | Tool errors |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| control | 2 / 2 | 0 | 0 / 2 | 19.130 | 12,862.5 | 0 | 0 |
+| SymPy producer + verifier | 2 / 2 | 0 | 2 / 2 | 56.733 | 117,232 | 4 | 0 |
+
+Both treatments used the intended capabilities without parameter errors,
+capability rejection, or operational failure. Both verification records
+replayed independently. Treatment consumed substantially more time and input
+tokens on these small expressions; this prescribed-capability pilot therefore
+supports the contract and assurance boundary, not a general efficiency or
+autonomous portfolio-value claim. The result supports retaining the typed AST,
+canonical sparse output, producer/verifier split, and direct URI handoff
+without another contract revision.
+
 ## Source policy
 
 Use the supplied research collection according to evidence strength:

--- a/docs/reference/polynomial-expression-normalization.md
+++ b/docs/reference/polynomial-expression-normalization.md
@@ -1,0 +1,93 @@
+# Typed polynomial expression normalization
+
+`polynomial.expression.normalize` converts one bounded typed expression over an
+explicit rational polynomial ring to canonical sparse coefficients.
+`polynomial.expression_normalization.verify` independently checks the stored
+relation. Provider computation and verification are separate trust boundaries.
+
+## Typed input
+
+The source artifact declares `QQ`, one ordered tuple of 1 to 4 distinct
+variables, and a version-1 expression AST. The only node kinds are:
+
+- `rational`, with a reduced canonical numerator and positive denominator;
+- `variable`, whose name must occur in the declared tuple;
+- `add` and `multiply`, each with 2 to 16 operands;
+- `negate`; and
+- `power`, with an integer exponent from 0 to 32.
+
+Power zero denotes the polynomial-ring identity, including for a syntactic zero
+base. The contract excludes formula strings, expression division, functions,
+assumptions, and branch-sensitive operations. Jacobian constructs SymPy
+objects directly from validated nodes and never passes user text to `sympify`
+or `parse_expr`. This boundary matters because the
+[SymPy parsing documentation][sympy-parsing] warns that `parse_expr` uses
+`eval` and must not receive unsanitized input.
+
+The complete tree is limited to 128 nodes and depth 16. Validation also rejects
+an expression when conservative bounds exceed:
+
+- 1,024 expanded nonzero terms;
+- exponent 127 for any declared variable;
+- 256 decimal digits in one rational numerator or denominator; or
+- a 4,096-digit conservative coefficient-arithmetic budget.
+
+The request includes a wall-clock budget from 1 to 60 seconds; the default is
+10 seconds.
+
+## Computed normalization
+
+The base environment pins SymPy 1.14.0 for this profile. An isolated process
+constructs rational literals and symbols from the AST, then calls
+`Poly(expression, *variables, domain=QQ)`. SymPy's
+[polynomial domain documentation][sympy-domains] defines `QQ` as the rational
+field used for exact polynomial coefficients.
+
+The result omits zero coefficients and orders terms by descending
+lexicographic exponent tuple. Jacobian records the source identity, full
+canonical polynomial, SymPy distribution digest, exact operation profile, and
+resource budget. Successful provider output has `COMPUTED` assurance and
+`conclusion: UNKNOWN`; it does not verify its own equivalence claim.
+
+Timeout, process failure, excessive output, a malformed worker response, or a
+runtime identity change produces no normalization artifact and no mathematical
+conclusion.
+
+## Independent verification
+
+With bundled references enabled,
+`polynomial.expression_normalization.verify` runs an operator-authorized
+standard-library checker in a clean process. It imports neither SymPy nor the
+producer. The checker:
+
+1. validates artifact schemas, semantics, payload digests, exact source
+   bindings, provider profile, resource budget, and parent lineage;
+2. independently validates every AST node and all structural and arithmetic
+   bounds;
+3. recursively expands the complete AST with `fractions.Fraction`;
+4. independently validates canonical sparse output, including reduced
+   rationals, exponent dimensions, unique monomials, and term order; and
+5. compares every exact coefficient by exponent tuple.
+
+Only full equality creates a verification record and returns `VERIFIED`.
+Mismatch, malformed evidence, timeout, cancellation, or checker failure returns
+`UNKNOWN`; rejection does not establish an opposite mathematical claim.
+
+## Artifact binding
+
+The source expression and normalization candidate are immutable artifacts
+under one versioned semantics descriptor. The candidate binds:
+
+- the source URI, object digest, and payload digest;
+- the exact ordered variable tuple;
+- independently reproducible node, depth, term, and coefficient bounds;
+- the complete canonical sparse polynomial;
+- the pinned SymPy runtime identity and operation profile; and
+- the enforced wall-clock budget.
+
+The verification witness separately binds the exact source, candidate,
+semantics, and checker identity. Replacing any node, coefficient, exponent,
+digest, binding, runtime profile, or lineage edge invalidates replay.
+
+[sympy-domains]: https://docs.sympy.org/1.14.0/modules/polys/domainsref.html
+[sympy-parsing]: https://docs.sympy.org/1.14.0/modules/parsing.html

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -128,7 +128,8 @@ of catalog membership:
 - [SAT artifact contracts](sat-artifacts.md);
 - [SMT Alethe artifact contracts](smt-artifacts.md);
 - [exact rational solution artifacts](linear-rational-solutions.md);
-- [integer matrix Hermite normal form](matrix-hermite-normal-form.md); and
+- [integer matrix Hermite normal form](matrix-hermite-normal-form.md);
+- [typed polynomial expression normalization](polynomial-expression-normalization.md);
 - [Lean declaration discovery contract](lean-declaration-discovery.md).
 
 ## Mathematical operation portfolio

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "pydantic>=2.12,<3",
     "pydantic-core>=2.41,<3",
     "rfc8785==0.1.4",
-    "sympy>=1.14,<2",
+    "sympy==1.14.0",
     "typer>=0.20,<1",
     "z3-solver>=4.15.4,<5",
 ]

--- a/src/jacobian/contracts/polynomial_expressions.py
+++ b/src/jacobian/contracts/polynomial_expressions.py
@@ -1,0 +1,425 @@
+"""Typed exact rational-polynomial expression contracts."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from math import comb
+from typing import Annotated, Literal, Self
+
+from pydantic import Field, StrictInt, model_validator
+
+from jacobian.contracts.capabilities import (
+    CapabilityProviderAvailability,
+    CapabilityProviderRuntime,
+)
+from jacobian.contracts.common import ArtifactUri, CheckerUri, Sha256Digest
+from jacobian.contracts.exact import CanonicalRational
+from jacobian.contracts.polynomials import (
+    PolynomialVariable,
+    SparseRationalPolynomial,
+)
+from jacobian.contracts.results import ContractModel
+
+MAX_EXPRESSION_VARIABLES = 4
+MAX_EXPRESSION_NODES = 128
+MAX_EXPRESSION_DEPTH = 16
+MAX_EXPRESSION_OPERANDS = 16
+MAX_EXPRESSION_POWER = 32
+MAX_EXPRESSION_TERMS = 1024
+MAX_EXPRESSION_EXPONENT = 127
+MAX_EXPRESSION_INTEGER_DIGITS = 256
+MAX_EXPRESSION_COEFFICIENT_DIGIT_BUDGET = 4096
+SYMPY_POLYNOMIAL_NORMALIZATION_CONFIGURATION = {
+    "distribution": "sympy",
+    "domain": "QQ",
+    "operation": "Poly(expression, *variables, domain=QQ).terms()",
+    "expression_schema_version": "1",
+    "maximum_variables": MAX_EXPRESSION_VARIABLES,
+    "maximum_nodes": MAX_EXPRESSION_NODES,
+    "maximum_depth": MAX_EXPRESSION_DEPTH,
+    "maximum_expanded_terms": MAX_EXPRESSION_TERMS,
+    "maximum_exponent_per_variable": MAX_EXPRESSION_EXPONENT,
+    "maximum_coefficient_digit_budget": MAX_EXPRESSION_COEFFICIENT_DIGIT_BUDGET,
+}
+
+
+class PolynomialRationalExpression(ContractModel):
+    kind: Literal["rational"] = "rational"
+    value: CanonicalRational
+
+
+class PolynomialVariableExpression(ContractModel):
+    kind: Literal["variable"] = "variable"
+    name: PolynomialVariable
+
+
+class PolynomialAddExpression(ContractModel):
+    kind: Literal["add"] = "add"
+    operands: tuple[PolynomialExpressionNode, ...] = Field(
+        min_length=2,
+        max_length=MAX_EXPRESSION_OPERANDS,
+    )
+
+
+class PolynomialMultiplyExpression(ContractModel):
+    kind: Literal["multiply"] = "multiply"
+    operands: tuple[PolynomialExpressionNode, ...] = Field(
+        min_length=2,
+        max_length=MAX_EXPRESSION_OPERANDS,
+    )
+
+
+class PolynomialNegateExpression(ContractModel):
+    kind: Literal["negate"] = "negate"
+    operand: PolynomialExpressionNode
+
+
+class PolynomialPowerExpression(ContractModel):
+    kind: Literal["power"] = "power"
+    base: PolynomialExpressionNode
+    exponent: StrictInt = Field(ge=0, le=MAX_EXPRESSION_POWER)
+
+
+PolynomialExpressionNode = Annotated[
+    PolynomialRationalExpression
+    | PolynomialVariableExpression
+    | PolynomialAddExpression
+    | PolynomialMultiplyExpression
+    | PolynomialNegateExpression
+    | PolynomialPowerExpression,
+    Field(discriminator="kind"),
+]
+
+for _recursive_model in (
+    PolynomialAddExpression,
+    PolynomialMultiplyExpression,
+    PolynomialNegateExpression,
+    PolynomialPowerExpression,
+):
+    _recursive_model.model_rebuild(
+        _types_namespace={"PolynomialExpressionNode": PolynomialExpressionNode}
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class PolynomialExpressionAnalysis:
+    node_count: int
+    depth: int
+    expanded_term_upper_bound: int
+    maximum_exponents: tuple[int, ...]
+    coefficient_digit_budget: int
+
+
+@dataclass(frozen=True, slots=True)
+class _NodeAnalysis:
+    node_count: int
+    depth: int
+    term_upper_bound: int
+    maximum_exponents: tuple[int, ...]
+    coefficient_digit_budget: int
+
+
+def analyze_polynomial_expression(
+    expression: PolynomialExpressionNode,
+    variables: tuple[PolynomialVariable, ...],
+) -> PolynomialExpressionAnalysis:
+    """Validate and conservatively bound one typed polynomial expression."""
+
+    variable_indices = {variable: index for index, variable in enumerate(variables)}
+    if len(variable_indices) != len(variables):
+        raise ValueError("polynomial expression variables must be unique")
+    analysis = _analyze_node(expression, variable_indices)
+    if analysis.node_count > MAX_EXPRESSION_NODES:
+        raise ValueError("polynomial expressions are limited to 128 AST nodes")
+    if analysis.depth > MAX_EXPRESSION_DEPTH:
+        raise ValueError("polynomial expressions are limited to depth 16")
+    if analysis.term_upper_bound > MAX_EXPRESSION_TERMS:
+        raise ValueError("polynomial expression expansion exceeds the 1024-term budget")
+    if any(
+        exponent > MAX_EXPRESSION_EXPONENT for exponent in analysis.maximum_exponents
+    ):
+        raise ValueError(
+            "polynomial expression exponent exceeds 127 for a declared variable"
+        )
+    if analysis.coefficient_digit_budget > MAX_EXPRESSION_COEFFICIENT_DIGIT_BUDGET:
+        raise ValueError(
+            "polynomial expression exceeds the exact coefficient digit budget"
+        )
+    return PolynomialExpressionAnalysis(
+        node_count=analysis.node_count,
+        depth=analysis.depth,
+        expanded_term_upper_bound=analysis.term_upper_bound,
+        maximum_exponents=analysis.maximum_exponents,
+        coefficient_digit_budget=analysis.coefficient_digit_budget,
+    )
+
+
+def _analyze_node(
+    expression: PolynomialExpressionNode,
+    variable_indices: dict[str, int],
+) -> _NodeAnalysis:
+    dimension = len(variable_indices)
+    zero_degrees = (0,) * dimension
+    if isinstance(expression, PolynomialRationalExpression):
+        if (
+            len(expression.value.num.lstrip("-")) > MAX_EXPRESSION_INTEGER_DIGITS
+            or len(expression.value.den) > MAX_EXPRESSION_INTEGER_DIGITS
+        ):
+            raise ValueError(
+                "polynomial rational literals are limited to 256 decimal digits"
+            )
+        return _NodeAnalysis(
+            node_count=1,
+            depth=1,
+            term_upper_bound=int(expression.value.as_fraction() != 0),
+            maximum_exponents=zero_degrees,
+            coefficient_digit_budget=(
+                len(expression.value.num.lstrip("-")) + len(expression.value.den)
+            ),
+        )
+    if isinstance(expression, PolynomialVariableExpression):
+        index = variable_indices.get(expression.name)
+        if index is None:
+            raise ValueError(f"expression variable {expression.name!r} is not declared")
+        variable_degrees = [0] * dimension
+        variable_degrees[index] = 1
+        return _NodeAnalysis(1, 1, 1, tuple(variable_degrees), 1)
+    if isinstance(expression, PolynomialNegateExpression):
+        operand = _analyze_node(expression.operand, variable_indices)
+        return _NodeAnalysis(
+            node_count=1 + operand.node_count,
+            depth=1 + operand.depth,
+            term_upper_bound=operand.term_upper_bound,
+            maximum_exponents=operand.maximum_exponents,
+            coefficient_digit_budget=operand.coefficient_digit_budget,
+        )
+    if isinstance(expression, PolynomialPowerExpression):
+        base = _analyze_node(expression.base, variable_indices)
+        exponent = expression.exponent
+        if exponent == 0:
+            terms = 1
+            power_degrees = zero_degrees
+        elif base.term_upper_bound == 0:
+            terms = 0
+            power_degrees = zero_degrees
+        else:
+            terms = _bounded_combination_count(base.term_upper_bound, exponent)
+            power_degrees = tuple(value * exponent for value in base.maximum_exponents)
+        return _NodeAnalysis(
+            node_count=1 + base.node_count,
+            depth=1 + base.depth,
+            term_upper_bound=terms,
+            maximum_exponents=power_degrees,
+            coefficient_digit_budget=(
+                1 if exponent == 0 else base.coefficient_digit_budget * exponent
+            ),
+        )
+    if isinstance(expression, (PolynomialAddExpression, PolynomialMultiplyExpression)):
+        children = tuple(
+            _analyze_node(operand, variable_indices) for operand in expression.operands
+        )
+        node_count = 1 + sum(child.node_count for child in children)
+        depth = 1 + max(child.depth for child in children)
+        if isinstance(expression, PolynomialAddExpression):
+            terms = _bounded_sum(child.term_upper_bound for child in children)
+            combined_degrees = tuple(
+                max(child.maximum_exponents[index] for child in children)
+                for index in range(dimension)
+            )
+            coefficient_digit_budget = sum(
+                child.coefficient_digit_budget for child in children
+            ) + len(children)
+        else:
+            if any(child.term_upper_bound == 0 for child in children):
+                terms = 0
+                combined_degrees = zero_degrees
+            else:
+                terms = _bounded_product(child.term_upper_bound for child in children)
+                combined_degrees = tuple(
+                    sum(child.maximum_exponents[index] for child in children)
+                    for index in range(dimension)
+                )
+            coefficient_digit_budget = sum(
+                child.coefficient_digit_budget for child in children
+            )
+        return _NodeAnalysis(
+            node_count,
+            depth,
+            terms,
+            combined_degrees,
+            coefficient_digit_budget,
+        )
+    raise TypeError("unsupported polynomial expression node")
+
+
+def _bounded_sum(values: Iterable[int]) -> int:
+    total = 0
+    for value in values:
+        total += value
+        if total > MAX_EXPRESSION_TERMS:
+            return MAX_EXPRESSION_TERMS + 1
+    return total
+
+
+def _bounded_product(values: Iterable[int]) -> int:
+    total = 1
+    for value in values:
+        total *= value
+        if total > MAX_EXPRESSION_TERMS:
+            return MAX_EXPRESSION_TERMS + 1
+    return total
+
+
+def _bounded_combination_count(terms: int, exponent: int) -> int:
+    if terms == 1:
+        return 1
+    result = comb(terms + exponent - 1, exponent)
+    return min(result, MAX_EXPRESSION_TERMS + 1)
+
+
+class PolynomialExpressionArtifact(ContractModel):
+    expression_schema_version: Literal["1"] = "1"
+    domain: Literal["QQ"] = "QQ"
+    variables: tuple[PolynomialVariable, ...] = Field(
+        min_length=1,
+        max_length=MAX_EXPRESSION_VARIABLES,
+    )
+    expression: PolynomialExpressionNode
+
+    @model_validator(mode="after")
+    def require_bounded_declared_polynomial(self) -> Self:
+        analyze_polynomial_expression(self.expression, self.variables)
+        return self
+
+
+class PolynomialExpressionResourceBudget(ContractModel):
+    budget_version: Literal["1"] = "1"
+    wall_seconds: StrictInt = Field(default=10, ge=1, le=60)
+
+
+class PolynomialExpressionBinding(ContractModel):
+    binding_version: Literal["1"] = "1"
+    expression_artifact_uri: ArtifactUri
+    expression_object_digest: Sha256Digest
+    expression_payload_digest: Sha256Digest
+    variables: tuple[PolynomialVariable, ...] = Field(
+        min_length=1,
+        max_length=MAX_EXPRESSION_VARIABLES,
+    )
+    node_count: StrictInt = Field(ge=1, le=MAX_EXPRESSION_NODES)
+    depth: StrictInt = Field(ge=1, le=MAX_EXPRESSION_DEPTH)
+    expanded_term_upper_bound: StrictInt = Field(
+        ge=0,
+        le=MAX_EXPRESSION_TERMS,
+    )
+    coefficient_digit_budget: StrictInt = Field(
+        ge=1,
+        le=MAX_EXPRESSION_COEFFICIENT_DIGIT_BUDGET,
+    )
+
+
+class PolynomialExpressionNormalizationArtifact(ContractModel):
+    normalization_schema_version: Literal["1"] = "1"
+    source: PolynomialExpressionBinding
+    declared_scope: Literal["FULL_EXPRESSION"] = "FULL_EXPRESSION"
+    normalized: SparseRationalPolynomial
+    producer: CapabilityProviderRuntime
+    resource_budget: PolynomialExpressionResourceBudget
+    method: Literal["SYMPY_POLY_QQ_CANONICAL_TERMS"] = "SYMPY_POLY_QQ_CANONICAL_TERMS"
+
+    @model_validator(mode="after")
+    def require_matching_ring_and_pinned_producer(self) -> Self:
+        dimension = len(self.source.variables)
+        if any(len(term.exponents) != dimension for term in self.normalized.terms):
+            raise ValueError(
+                "normalized monomials must match the declared variable order"
+            )
+        if (
+            self.producer.provider != "jacobian.sympy"
+            or self.producer.availability
+            is not CapabilityProviderAvailability.AVAILABLE
+            or self.producer.version != "1.14.0"
+            or self.producer.configuration
+            != SYMPY_POLYNOMIAL_NORMALIZATION_CONFIGURATION
+        ):
+            raise ValueError(
+                "normalization producer must be the pinned SymPy polynomial profile"
+            )
+        return self
+
+
+class PolynomialExpressionNormalizeRequest(ContractModel):
+    expression: PolynomialExpressionArtifact
+    resource_budget: PolynomialExpressionResourceBudget = Field(
+        default_factory=PolynomialExpressionResourceBudget
+    )
+
+
+class PolynomialExpressionNormalizeOutput(ContractModel):
+    status: Literal["NORMALIZATION_PRODUCED", "NO_NORMALIZATION_PRODUCED"]
+    conclusion: Literal["UNKNOWN"] = "UNKNOWN"
+    expression_uri: ArtifactUri
+    normalization_uri: ArtifactUri | None = None
+    normalized: SparseRationalPolynomial | None = None
+    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
+    determinism: Literal["DETERMINISTIC"] = "DETERMINISTIC"
+    verification: Literal["UNVERIFIED"] = "UNVERIFIED"
+    verification_candidate_available: bool
+    method: Literal["SYMPY_POLY_QQ_CANONICAL_TERMS"] = "SYMPY_POLY_QQ_CANONICAL_TERMS"
+    backend: Literal["sympy"] = "sympy"
+    backend_version: Literal["1.14.0"] = "1.14.0"
+    detail: str = Field(min_length=1, max_length=1024)
+
+    @model_validator(mode="after")
+    def bind_candidate_projection(self) -> Self:
+        produced = self.status == "NORMALIZATION_PRODUCED"
+        if produced != (
+            self.normalization_uri is not None
+            and self.normalized is not None
+            and self.verification_candidate_available
+        ):
+            raise ValueError(
+                "produced output requires one durable normalization candidate"
+            )
+        if not produced and (
+            self.normalization_uri is not None
+            or self.normalized is not None
+            or self.verification_candidate_available
+        ):
+            raise ValueError("failed output cannot carry normalization evidence")
+        return self
+
+
+class PolynomialExpressionNormalizationVerificationRequest(ContractModel):
+    normalization_uri: ArtifactUri
+
+
+class PolynomialExpressionNormalizationVerificationOutput(ContractModel):
+    status: Literal[
+        "VERIFIED_NORMALIZATION",
+        "REJECTED",
+        "TIMEOUT",
+        "CANCELLED",
+        "ERROR",
+    ]
+    conclusion: Literal["TRUE", "UNKNOWN"]
+    expression_uri: ArtifactUri
+    normalization_uri: ArtifactUri
+    witness_uri: ArtifactUri
+    checker_id: CheckerUri
+    verification_record_uri: ArtifactUri | None = None
+    detail: str = Field(min_length=1, max_length=1024)
+
+    @model_validator(mode="after")
+    def bind_verified_projection(self) -> Self:
+        if self.status == "VERIFIED_NORMALIZATION":
+            if self.conclusion != "TRUE" or self.verification_record_uri is None:
+                raise ValueError(
+                    "verified normalization requires TRUE and a verification record"
+                )
+        elif self.conclusion != "UNKNOWN" or self.verification_record_uri is not None:
+            raise ValueError(
+                "non-verified normalization cannot carry a conclusion or record"
+            )
+        return self

--- a/src/jacobian/kernel.py
+++ b/src/jacobian/kernel.py
@@ -74,6 +74,14 @@ from jacobian.polynomial_capabilities import (
     PolynomialInstallation,
     install_polynomial_capabilities,
 )
+from jacobian.polynomial_expression_capabilities import (
+    PolynomialExpressionCheckerInstallation,
+    install_polynomial_expression_checker,
+)
+from jacobian.polynomial_expressions import (
+    PolynomialExpressionArtifactService,
+    install_polynomial_expression_artifacts,
+)
 from jacobian.polynomial_system_capabilities import (
     PolynomialSystemInstallation,
     install_polynomial_system_capabilities,
@@ -87,6 +95,7 @@ from jacobian.provider_runtime import (
     lean_provider_runtime,
     python_flint_hnf_provider_runtime,
     python_flint_provider_runtime,
+    sympy_polynomial_normalization_provider_runtime,
 )
 from jacobian.references import (
     LeanCheckerInstallation,
@@ -112,6 +121,9 @@ from jacobian.smt_capabilities import (
 )
 from jacobian.store import ArtifactStore
 from jacobian.structures import StructureService
+from jacobian.sympy_polynomial_normalization import (
+    install_sympy_polynomial_normalization_capability,
+)
 from jacobian.transformations import TransformationService
 from jacobian.universal_algebra_capabilities import (
     UniversalAlgebraInstallation,
@@ -158,6 +170,13 @@ class JacobianKernel:
         )
         self.matrix_normal_forms: MatrixNormalFormArtifactService = (
             install_matrix_normal_form_artifacts(
+                self.store,
+                self.schemas,
+                self.artifacts,
+            )
+        )
+        self.polynomial_expressions: PolynomialExpressionArtifactService = (
+            install_polynomial_expression_artifacts(
                 self.store,
                 self.schemas,
                 self.artifacts,
@@ -336,6 +355,9 @@ class JacobianKernel:
             else:
                 self.register_capability(linear_find_adapter)
         self._install_matrix_normal_form_capabilities(
+            authorize_checker=install_references
+        )
+        self._install_polynomial_expression_capabilities(
             authorize_checker=install_references
         )
         self.cadical_runtime: CapabilityProviderRuntime = cadical_provider_runtime()
@@ -563,6 +585,47 @@ class JacobianKernel:
         except (OSError, ValueError) as exc:
             _LOGGER.warning(
                 "Python-FLINT Hermite normal form is not installed: %s",
+                exc,
+            )
+        else:
+            self.register_capability(adapter)
+
+    def _install_polynomial_expression_capabilities(
+        self,
+        *,
+        authorize_checker: bool,
+    ) -> None:
+        self.polynomial_expression_checker: PolynomialExpressionCheckerInstallation
+        verification_adapter, self.polynomial_expression_checker = (
+            install_polynomial_expression_checker(
+                self.store,
+                self.schemas,
+                self.artifacts,
+                self.polynomial_expressions,
+                self.verification,
+                self.checkers,
+                authorize_checker=authorize_checker,
+            )
+        )
+        if verification_adapter is not None:
+            self.register_capability(verification_adapter)
+
+        self.sympy_polynomial_normalization_runtime: CapabilityProviderRuntime = (
+            sympy_polynomial_normalization_provider_runtime()
+        )
+        if (
+            self.sympy_polynomial_normalization_runtime.availability
+            is not CapabilityProviderAvailability.AVAILABLE
+        ):
+            return
+        try:
+            adapter = install_sympy_polynomial_normalization_capability(
+                self.polynomial_expressions,
+                self.sympy_polynomial_normalization_runtime,
+            )
+        except (OSError, ValueError) as exc:
+            _LOGGER.warning(
+                "SymPy typed polynomial normalization is not installed: %s",
                 exc,
             )
         else:

--- a/src/jacobian/polynomial_expression_capabilities.py
+++ b/src/jacobian/polynomial_expression_capabilities.py
@@ -1,0 +1,348 @@
+"""Independent verification for typed polynomial-expression normalization."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from jacobian.artifacts import ArtifactService
+from jacobian.capabilities import CapabilityAdapter, CapabilityInvocationError
+from jacobian.contracts.capabilities import (
+    CapabilityAssurance,
+    CapabilityAssuranceLevel,
+    CapabilityCompleteness,
+    CapabilityCompletenessStatus,
+    CapabilityDescriptor,
+    CapabilityDiagnostic,
+    CapabilityMode,
+    CapabilityRelationship,
+    CapabilityRelationshipStatus,
+    CapabilityRequest,
+    CapabilityResult,
+    CapabilityScope,
+)
+from jacobian.contracts.evidence import (
+    EvidenceBindings,
+    WitnessEnvelope,
+    WitnessRole,
+)
+from jacobian.contracts.polynomial_expressions import (
+    PolynomialExpressionNormalizationVerificationOutput,
+    PolynomialExpressionNormalizationVerificationRequest,
+)
+from jacobian.contracts.results import Conclusion, ExecutionStatus, Verification
+from jacobian.polynomial_expressions import (
+    PolynomialExpressionArtifactError,
+    PolynomialExpressionArtifactService,
+)
+from jacobian.provider_runtime import known_provider_runtime
+from jacobian.registry import CheckerRegistry
+from jacobian.schema_registry import SchemaRegistry, model_schema
+from jacobian.store import ArtifactStore, StoreError
+from jacobian.verification import VerificationService
+
+
+@dataclass(frozen=True, slots=True)
+class PolynomialExpressionCheckerInstallation:
+    witness_schema_uri: str
+    checker_id: str | None
+
+
+def install_polynomial_expression_checker(
+    store: ArtifactStore,
+    schemas: SchemaRegistry,
+    artifacts: ArtifactService,
+    expressions: PolynomialExpressionArtifactService,
+    verification: VerificationService,
+    checkers: CheckerRegistry,
+    *,
+    authorize_checker: bool,
+) -> tuple[CapabilityAdapter | None, PolynomialExpressionCheckerInstallation]:
+    """Install the witness schema and optionally authorize exact AST replay."""
+
+    witness_schema_uri = schemas.register_model(
+        name="jacobian.witness-envelope",
+        version="1",
+        model=WitnessEnvelope,
+    )
+    checker_id = None
+    if authorize_checker:
+        checker_id = checkers.authorize(
+            name="typed rational polynomial normalization replay checker",
+            entrypoint=(
+                "jacobian_checkers.polynomial_expressions:"
+                "check_polynomial_expression_normalization"
+            ),
+            evidence_kind="WITNESS",
+            format_id="polynomial.expression_normalization",
+            format_version="1",
+            claim_schema_uris=(expressions.installation.expression_schema_uri,),
+            semantics_uris=(expressions.installation.semantics_uri,),
+            candidate_schema_uris=(expressions.installation.normalization_schema_uri,),
+            reason=(
+                "bundled independent exact typed-AST expansion and coefficient checker"
+            ),
+        ).checker_id
+    installation = PolynomialExpressionCheckerInstallation(
+        witness_schema_uri=witness_schema_uri,
+        checker_id=checker_id,
+    )
+    adapter: CapabilityAdapter | None = None
+    if checker_id is not None:
+        adapter = PolynomialExpressionNormalizationVerificationAdapter(
+            store=store,
+            artifacts=artifacts,
+            expressions=expressions,
+            verification=verification,
+            installation=installation,
+        )
+    return adapter, installation
+
+
+class PolynomialExpressionNormalizationVerificationAdapter:
+    """Verify canonical coefficients against every node of one bound AST."""
+
+    def __init__(
+        self,
+        *,
+        store: ArtifactStore,
+        artifacts: ArtifactService,
+        expressions: PolynomialExpressionArtifactService,
+        verification: VerificationService,
+        installation: PolynomialExpressionCheckerInstallation,
+    ) -> None:
+        checker_id = installation.checker_id
+        if checker_id is None:
+            raise ValueError("polynomial expression checker is not authorized")
+        self.store = store
+        self.artifacts = artifacts
+        self.expressions = expressions
+        self.verification = verification
+        self.installation = installation
+        self._descriptor = CapabilityDescriptor(
+            capability_id="polynomial.expression_normalization.verify",
+            version="1",
+            title="Verify a typed polynomial normalization",
+            description=(
+                "Independently expand the complete typed QQ-polynomial AST using "
+                "exact standard-library rational arithmetic and compare every "
+                "canonical sparse coefficient."
+            ),
+            provider="jacobian.polynomial-expression",
+            provider_runtime=known_provider_runtime(
+                "jacobian.polynomial-expression",
+                features=(
+                    "typed-ast-replay",
+                    "exact-rational",
+                    "canonical-sparse-polynomial",
+                    "clean-process-checker",
+                ),
+                checker_ids=(checker_id,),
+            ),
+            modes=(CapabilityMode.VERIFY,),
+            input_schema=model_schema(
+                PolynomialExpressionNormalizationVerificationRequest
+            ),
+            output_schema=model_schema(
+                PolynomialExpressionNormalizationVerificationOutput
+            ),
+            tags=(
+                "polynomial",
+                "symbolic",
+                "normalization",
+                "typed-expression",
+                "exact-rational",
+                "verification",
+            ),
+        )
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        return self._descriptor
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        validated = PolynomialExpressionNormalizationVerificationRequest.model_validate(
+            request.input
+        )
+        try:
+            resolved = self.expressions.resolve_normalization(
+                validated.normalization_uri
+            )
+            semantics = self.store.get(self.expressions.installation.semantics_uri)
+        except (PolynomialExpressionArtifactError, StoreError) as exc:
+            raise CapabilityInvocationError(
+                CapabilityDiagnostic(
+                    code="INVALID_POLYNOMIAL_EXPRESSION_NORMALIZATION",
+                    stage="artifact_resolution",
+                    message=str(exc),
+                    path="normalization_uri",
+                    schema_uri=(self.expressions.installation.normalization_schema_uri),
+                    expected=(
+                        "one canonical sparse polynomial candidate bound by payload "
+                        "and lineage to a valid typed QQ-polynomial expression"
+                    ),
+                    hint=(
+                        "Use polynomial.expression.normalize or materialize a candidate "
+                        "with the registered normalization schema."
+                    ),
+                )
+            ) from exc
+
+        checker_id = self.installation.checker_id
+        assert checker_id is not None
+        bindings = EvidenceBindings(
+            claim_digest=resolved.expression_artifact.manifest.object_digest,
+            semantics_digest=semantics.manifest.object_digest,
+            candidate_digest=resolved.artifact.manifest.object_digest,
+        )
+        witness = WitnessEnvelope(
+            witness_format="polynomial.expression_normalization",
+            format_version="1",
+            role=WitnessRole.SUPPORTS_CLAIM,
+            bindings=bindings,
+            payload={
+                "expression_uri": resolved.expression_artifact.artifact_uri,
+                "normalization_uri": resolved.artifact.artifact_uri,
+            },
+        )
+        witness_artifact = self.artifacts.put(
+            schema_uri=self.installation.witness_schema_uri,
+            semantics_uri=self.expressions.installation.semantics_uri,
+            payload=witness.model_dump(mode="json"),
+            parents=(
+                resolved.expression_artifact.artifact_uri,
+                resolved.artifact.artifact_uri,
+            ),
+            summary="typed polynomial normalization verification witness",
+        )
+        checked = self.verification.verify_witness(
+            claim_uri=resolved.expression_artifact.artifact_uri,
+            candidate_uri=resolved.artifact.artifact_uri,
+            witness_uri=witness_artifact.artifact_uri,
+            checker_id=checker_id,
+            include_artifact_metadata=True,
+        )
+        verified = (
+            checked.execution.status is ExecutionStatus.COMPLETED
+            and checked.conclusion is Conclusion.TRUE
+            and checked.assurance.verification is Verification.VERIFIED
+            and checked.verification_record_uri is not None
+        )
+        status: Literal[
+            "VERIFIED_NORMALIZATION",
+            "REJECTED",
+            "TIMEOUT",
+            "CANCELLED",
+            "ERROR",
+        ]
+        if verified:
+            status = "VERIFIED_NORMALIZATION"
+        elif checked.execution.status is ExecutionStatus.COMPLETED:
+            status = "REJECTED"
+        elif checked.execution.status is ExecutionStatus.TIMEOUT:
+            status = "TIMEOUT"
+        elif checked.execution.status is ExecutionStatus.CANCELLED:
+            status = "CANCELLED"
+        else:
+            status = "ERROR"
+        detail = checked.execution.detail
+        if detail is None and checked.input.errors:
+            detail = checked.input.errors[0]
+        if detail is None:
+            detail = (
+                "the authorized checker accepted the exact AST normalization"
+                if verified
+                else "the candidate was not independently accepted"
+            )
+        output = PolynomialExpressionNormalizationVerificationOutput(
+            status=status,
+            conclusion="TRUE" if verified else "UNKNOWN",
+            expression_uri=resolved.expression_artifact.artifact_uri,
+            normalization_uri=resolved.artifact.artifact_uri,
+            witness_uri=witness_artifact.artifact_uri,
+            checker_id=checker_id,
+            verification_record_uri=(
+                checked.verification_record_uri if verified else None
+            ),
+            detail=detail,
+        )
+        record_uri = checked.verification_record_uri if verified else None
+        artifact_uris = [
+            resolved.expression_artifact.artifact_uri,
+            resolved.artifact.artifact_uri,
+            witness_artifact.artifact_uri,
+        ]
+        if record_uri is not None:
+            artifact_uris.append(record_uri)
+        return CapabilityResult(
+            capability_id=self.descriptor.capability_id,
+            capability_version=self.descriptor.version,
+            mode=request.mode,
+            execution=checked.execution,
+            output=output.model_dump(mode="json"),
+            scope=CapabilityScope(
+                description=(
+                    "the full typed source expression and every proposed canonical "
+                    "sparse coefficient"
+                ),
+                parameters={
+                    "declared_scope": "FULL_EXPRESSION",
+                    "variables": list(resolved.expression.variables),
+                    "node_count": resolved.candidate.source.node_count,
+                    "normalized_term_count": len(resolved.candidate.normalized.terms),
+                },
+                artifact_uri=resolved.expression_artifact.artifact_uri,
+            ),
+            completeness=CapabilityCompleteness(
+                status=CapabilityCompletenessStatus.NOT_APPLICABLE,
+                basis=(
+                    "direct exact replay covers the full finite AST relation; no "
+                    "search or enumeration claim is made"
+                ),
+                assurance_level=(
+                    CapabilityAssuranceLevel.COMPUTED
+                    if checked.execution.status is ExecutionStatus.COMPLETED
+                    else CapabilityAssuranceLevel.HEURISTIC
+                ),
+            ),
+            assurance=CapabilityAssurance(
+                level=(
+                    CapabilityAssuranceLevel.VERIFIED
+                    if verified
+                    else (
+                        CapabilityAssuranceLevel.COMPUTED
+                        if checked.execution.status is ExecutionStatus.COMPLETED
+                        else CapabilityAssuranceLevel.HEURISTIC
+                    )
+                ),
+                basis=(
+                    "accepted in a clean process by the operator-authorized "
+                    "independent exact typed-polynomial checker"
+                    if verified
+                    else (
+                        "checker replay completed without accepting the candidate; "
+                        "no mathematical conclusion follows"
+                        if checked.execution.status is ExecutionStatus.COMPLETED
+                        else "checker execution did not complete; no mathematical "
+                        "conclusion follows"
+                    )
+                ),
+                verification_record_uri=record_uri,
+            ),
+            relationships=(
+                (
+                    CapabilityRelationship(
+                        relation_id=("polynomial.relation.expression-normalization-of"),
+                        source_artifact_uris=(resolved.artifact.artifact_uri,),
+                        target_artifact_uris=(
+                            resolved.expression_artifact.artifact_uri,
+                        ),
+                        status=CapabilityRelationshipStatus.VERIFIED,
+                        verification_record_uri=record_uri,
+                    ),
+                )
+                if verified
+                else ()
+            ),
+            artifact_uris=tuple(artifact_uris),
+        )

--- a/src/jacobian/polynomial_expressions.py
+++ b/src/jacobian/polynomial_expressions.py
@@ -1,0 +1,277 @@
+"""Durable typed polynomial expressions and normalization candidates."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic import ValidationError
+
+from jacobian.artifacts import ArtifactService
+from jacobian.contracts.artifacts import ArtifactPutResult
+from jacobian.contracts.capabilities import CapabilityProviderRuntime
+from jacobian.contracts.polynomial_expressions import (
+    PolynomialExpressionArtifact,
+    PolynomialExpressionBinding,
+    PolynomialExpressionNormalizationArtifact,
+    PolynomialExpressionResourceBudget,
+    analyze_polynomial_expression,
+)
+from jacobian.contracts.polynomials import SparseRationalPolynomial
+from jacobian.schema_registry import SchemaRegistry, SchemaRegistryError
+from jacobian.store import ArtifactStore, StoredArtifact, StoreError
+
+
+class PolynomialExpressionArtifactError(ValueError):
+    """Stored data does not satisfy the typed polynomial-expression contract."""
+
+
+@dataclass(frozen=True, slots=True)
+class PolynomialExpressionInstallation:
+    semantics_uri: str
+    expression_schema_uri: str
+    normalization_schema_uri: str
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedPolynomialExpression:
+    artifact: StoredArtifact
+    expression: PolynomialExpressionArtifact
+    binding: PolynomialExpressionBinding
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedPolynomialNormalization:
+    artifact: StoredArtifact
+    candidate: PolynomialExpressionNormalizationArtifact
+    expression_artifact: StoredArtifact
+    expression: PolynomialExpressionArtifact
+
+
+class PolynomialExpressionArtifactService:
+    """Materialize typed expressions and unverified canonicalization evidence."""
+
+    def __init__(
+        self,
+        store: ArtifactStore,
+        schemas: SchemaRegistry,
+        artifacts: ArtifactService,
+        installation: PolynomialExpressionInstallation,
+    ) -> None:
+        self.store = store
+        self.schemas = schemas
+        self.artifacts = artifacts
+        self.installation = installation
+
+    def put_expression(
+        self,
+        expression: PolynomialExpressionArtifact | dict[str, Any],
+    ) -> ArtifactPutResult:
+        validated = PolynomialExpressionArtifact.model_validate(expression)
+        analysis = analyze_polynomial_expression(
+            validated.expression,
+            validated.variables,
+        )
+        return self.artifacts.put(
+            schema_uri=self.installation.expression_schema_uri,
+            semantics_uri=self.installation.semantics_uri,
+            payload=validated.model_dump(mode="json"),
+            summary=(
+                "typed rational polynomial expression: "
+                f"{len(validated.variables)} variables, "
+                f"{analysis.node_count} AST nodes"
+            ),
+        )
+
+    def resolve_expression(self, expression_uri: str) -> ResolvedPolynomialExpression:
+        try:
+            artifact = self.store.get(expression_uri)
+        except StoreError as exc:
+            raise PolynomialExpressionArtifactError(
+                "source is not an available typed polynomial-expression artifact"
+            ) from exc
+        if (
+            artifact.manifest.schema_uri != self.installation.expression_schema_uri
+            or artifact.manifest.semantics_uri != self.installation.semantics_uri
+        ):
+            raise PolynomialExpressionArtifactError(
+                "source is not a typed polynomial-expression artifact"
+            )
+        try:
+            normalized = self.schemas.validate(
+                self.installation.expression_schema_uri,
+                artifact.payload,
+            )
+            expression = PolynomialExpressionArtifact.model_validate(normalized)
+            analysis = analyze_polynomial_expression(
+                expression.expression,
+                expression.variables,
+            )
+        except (SchemaRegistryError, ValueError, ValidationError) as exc:
+            raise PolynomialExpressionArtifactError(
+                "source is not a valid typed polynomial-expression artifact"
+            ) from exc
+        binding = PolynomialExpressionBinding(
+            expression_artifact_uri=artifact.artifact_uri,
+            expression_object_digest=artifact.manifest.object_digest,
+            expression_payload_digest=artifact.manifest.payload_digest,
+            variables=expression.variables,
+            node_count=analysis.node_count,
+            depth=analysis.depth,
+            expanded_term_upper_bound=analysis.expanded_term_upper_bound,
+            coefficient_digit_budget=analysis.coefficient_digit_budget,
+        )
+        return ResolvedPolynomialExpression(
+            artifact=artifact,
+            expression=expression,
+            binding=binding,
+        )
+
+    def put_normalization(
+        self,
+        *,
+        expression_uri: str,
+        normalized: SparseRationalPolynomial | dict[str, Any],
+        producer: CapabilityProviderRuntime,
+        resource_budget: PolynomialExpressionResourceBudget | dict[str, Any],
+    ) -> ArtifactPutResult:
+        resolved = self.resolve_expression(expression_uri)
+        candidate = PolynomialExpressionNormalizationArtifact(
+            source=resolved.binding,
+            normalized=SparseRationalPolynomial.model_validate(normalized),
+            producer=producer,
+            resource_budget=PolynomialExpressionResourceBudget.model_validate(
+                resource_budget
+            ),
+        )
+        return self.artifacts.put(
+            schema_uri=self.installation.normalization_schema_uri,
+            semantics_uri=self.installation.semantics_uri,
+            payload=candidate.model_dump(mode="json"),
+            parents=(resolved.artifact.artifact_uri,),
+            summary="unverified canonical sparse polynomial normalization",
+        )
+
+    def resolve_normalization(
+        self,
+        normalization_uri: str,
+    ) -> ResolvedPolynomialNormalization:
+        try:
+            artifact = self.store.get(normalization_uri)
+        except StoreError as exc:
+            raise PolynomialExpressionArtifactError(
+                "source is not an available polynomial-normalization artifact"
+            ) from exc
+        if (
+            artifact.manifest.schema_uri != self.installation.normalization_schema_uri
+            or artifact.manifest.semantics_uri != self.installation.semantics_uri
+        ):
+            raise PolynomialExpressionArtifactError(
+                "source is not a polynomial-normalization artifact"
+            )
+        try:
+            normalized = self.schemas.validate(
+                self.installation.normalization_schema_uri,
+                artifact.payload,
+            )
+            candidate = PolynomialExpressionNormalizationArtifact.model_validate(
+                normalized
+            )
+        except (SchemaRegistryError, ValueError, ValidationError) as exc:
+            raise PolynomialExpressionArtifactError(
+                "source is not a valid polynomial-normalization artifact"
+            ) from exc
+        resolved_expression = self.resolve_expression(
+            candidate.source.expression_artifact_uri
+        )
+        if candidate.source != resolved_expression.binding:
+            raise PolynomialExpressionArtifactError(
+                "normalization binding does not match its exact source expression"
+            )
+        if resolved_expression.artifact.artifact_uri not in artifact.manifest.parents:
+            raise PolynomialExpressionArtifactError(
+                "normalization is missing its exact source-expression parent"
+            )
+        return ResolvedPolynomialNormalization(
+            artifact=artifact,
+            candidate=candidate,
+            expression_artifact=resolved_expression.artifact,
+            expression=resolved_expression.expression,
+        )
+
+
+def install_polynomial_expression_artifacts(
+    store: ArtifactStore,
+    schemas: SchemaRegistry,
+    artifacts: ArtifactService,
+) -> PolynomialExpressionArtifactService:
+    """Register one bounded typed QQ-expression and normalization contract."""
+
+    semantics_uri = store.register_descriptor(
+        kind="semantics",
+        name="jacobian.typed-rational-polynomial-expression-normalization",
+        version="1",
+        definition={
+            "domain": (
+                "commutative polynomial rings QQ[x_1,...,x_n] with one explicit "
+                "ordered variable tuple"
+            ),
+            "expression_ast": {
+                "version": "1",
+                "nodes": [
+                    "rational",
+                    "variable",
+                    "add",
+                    "multiply",
+                    "negate",
+                    "power",
+                ],
+                "power_exponents": "nonnegative integers; every base to power zero is one",
+                "excluded": [
+                    "string parsing",
+                    "expression division",
+                    "functions",
+                    "assumptions",
+                    "branch-sensitive operations",
+                ],
+            },
+            "normalization": (
+                "combine exact rational coefficients by exponent tuple and emit "
+                "nonzero terms in descending lexicographic exponent order"
+            ),
+            "candidate": (
+                "SymPy output is computed evidence; only an operator-authorized "
+                "independent checker may verify equality with the bound AST"
+            ),
+            "limits": {
+                "maximum_variables": 4,
+                "maximum_nodes": 128,
+                "maximum_depth": 16,
+                "maximum_operands_per_node": 16,
+                "maximum_power": 32,
+                "maximum_expanded_terms": 1024,
+                "maximum_exponent_per_variable": 127,
+                "maximum_decimal_digits_per_rational_component": 256,
+                "maximum_coefficient_digit_budget": 4096,
+            },
+        },
+    )
+    installation = PolynomialExpressionInstallation(
+        semantics_uri=semantics_uri,
+        expression_schema_uri=schemas.register_model(
+            name="jacobian.typed-rational-polynomial-expression",
+            version="1",
+            model=PolynomialExpressionArtifact,
+        ),
+        normalization_schema_uri=schemas.register_model(
+            name="jacobian.polynomial-expression-normalization",
+            version="1",
+            model=PolynomialExpressionNormalizationArtifact,
+        ),
+    )
+    return PolynomialExpressionArtifactService(
+        store,
+        schemas,
+        artifacts,
+        installation,
+    )

--- a/src/jacobian/provider_runtime.py
+++ b/src/jacobian/provider_runtime.py
@@ -21,6 +21,9 @@ from jacobian.contracts.capabilities import (
     CapabilityProviderDigestKind,
     CapabilityProviderRuntime,
 )
+from jacobian.contracts.polynomial_expressions import (
+    SYMPY_POLYNOMIAL_NORMALIZATION_CONFIGURATION,
+)
 from jacobian.implementation import ImplementationError, package_source_digest
 
 CADICAL_VERSION = "3.0.1"
@@ -33,6 +36,7 @@ DRAT_TRIM_SOURCE_COMMIT = "2e5e29cb0019d5cfd547d4208dca1b3ec290349f"
 DRAT_TRIM_SOURCE_REPOSITORY = "https://github.com/marijnheule/drat-trim"
 PYTHON_FLINT_VERSION = "0.9.0"
 PYTHON_FLINT_HNF_FLINT_VERSION = "3.6.0"
+SYMPY_VERSION = "1.14.0"
 
 
 class ProviderRuntimeError(RuntimeError):
@@ -664,6 +668,43 @@ def known_provider_runtime(
         checker_ids=checker_ids,
         configuration=configuration,
     )
+
+
+def sympy_polynomial_normalization_provider_runtime(
+    *,
+    refresh: bool = False,
+) -> CapabilityProviderRuntime:
+    """Identify the pinned typed polynomial-normalization profile."""
+
+    runtime = python_distribution_provider_runtime(
+        "jacobian.sympy",
+        distribution_name="sympy",
+        import_name="sympy",
+        required_attributes=("Add", "Mul", "Poly", "Pow", "QQ", "Rational", "Symbol"),
+        install_tier=CapabilityInstallTier.T0,
+        license_id="BSD-3-Clause",
+        features=(
+            "typed-polynomial-expression",
+            "exact-rational",
+            "canonical-sparse-normalization",
+        ),
+        configuration=SYMPY_POLYNOMIAL_NORMALIZATION_CONFIGURATION,
+        refresh=refresh,
+    )
+    if (
+        runtime.availability is CapabilityProviderAvailability.AVAILABLE
+        and runtime.version != SYMPY_VERSION
+    ):
+        return _unavailable_runtime(
+            provider="jacobian.sympy",
+            install_tier=CapabilityInstallTier.T0,
+            license_id="BSD-3-Clause",
+            diagnostic=(
+                "SymPy is installed but does not match the pinned "
+                f"{SYMPY_VERSION} polynomial-normalization profile."
+            ),
+        )
+    return runtime
 
 
 def python_flint_provider_runtime(

--- a/src/jacobian/sympy_polynomial_normalization.py
+++ b/src/jacobian/sympy_polynomial_normalization.py
@@ -1,0 +1,413 @@
+"""Bounded SymPy producer for typed polynomial-expression normalization."""
+
+from __future__ import annotations
+
+import sys
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic import ValidationError
+
+from jacobian.bounded_process import BoundedProcessResult, run_bounded_process
+from jacobian.canonical import canonicalize_json, loads_strict_json
+from jacobian.capabilities import CapabilityAdapter, CapabilityInvocationError
+from jacobian.contracts.capabilities import (
+    CapabilityAssurance,
+    CapabilityAssuranceLevel,
+    CapabilityCompleteness,
+    CapabilityCompletenessStatus,
+    CapabilityDescriptor,
+    CapabilityDiagnostic,
+    CapabilityMode,
+    CapabilityProviderAvailability,
+    CapabilityProviderRuntime,
+    CapabilityRelationship,
+    CapabilityRequest,
+    CapabilityResult,
+    CapabilityScope,
+)
+from jacobian.contracts.polynomial_expressions import (
+    SYMPY_POLYNOMIAL_NORMALIZATION_CONFIGURATION,
+    PolynomialExpressionNormalizeOutput,
+    PolynomialExpressionNormalizeRequest,
+)
+from jacobian.contracts.polynomials import (
+    RationalPolynomial,
+    SparseRationalPolynomial,
+)
+from jacobian.contracts.results import Execution, ExecutionStatus
+from jacobian.polynomial_expressions import PolynomialExpressionArtifactService
+from jacobian.provider_runtime import (
+    SYMPY_VERSION,
+    sympy_polynomial_normalization_provider_runtime,
+)
+from jacobian.schema_registry import model_schema
+from jacobian.sympy_polynomial_worker import SYMPY_POLYNOMIAL_WORKER_PROTOCOL
+
+SYMPY_NORMALIZATION_STDOUT_LIMIT = 2_000_000
+SYMPY_NORMALIZATION_STDERR_LIMIT = 64_000
+
+
+@dataclass(frozen=True, slots=True)
+class _SympyNormalizationRun:
+    execution_status: ExecutionStatus
+    runtime_ms: int
+    normalized: SparseRationalPolynomial | None = None
+    detail: str | None = None
+
+
+def install_sympy_polynomial_normalization_capability(
+    expressions: PolynomialExpressionArtifactService,
+    runtime: CapabilityProviderRuntime,
+) -> CapabilityAdapter:
+    """Install the producer only for the exact supported SymPy profile."""
+
+    if (
+        runtime.availability is not CapabilityProviderAvailability.AVAILABLE
+        or runtime.provider != "jacobian.sympy"
+        or runtime.version != SYMPY_VERSION
+        or runtime.configuration != SYMPY_POLYNOMIAL_NORMALIZATION_CONFIGURATION
+    ):
+        raise ValueError("the pinned SymPy polynomial-normalization runtime is absent")
+    return SympyPolynomialExpressionNormalizeAdapter(
+        expressions=expressions,
+        runtime=runtime,
+    )
+
+
+class _SympyPolynomialNormalizationBackend:
+    def __init__(self, runtime: CapabilityProviderRuntime) -> None:
+        self.runtime = runtime
+
+    def run(
+        self,
+        request: PolynomialExpressionNormalizeRequest,
+    ) -> _SympyNormalizationRun:
+        started = time.monotonic()
+        if (
+            sympy_polynomial_normalization_provider_runtime(refresh=True)
+            != self.runtime
+        ):
+            return _failure(
+                started,
+                ExecutionStatus.ERROR,
+                (
+                    "The installed SymPy runtime no longer matches the capability "
+                    "descriptor; no normalization evidence was retained."
+                ),
+            )
+        command = [
+            sys.executable,
+            "-I",
+            "-m",
+            "jacobian.sympy_polynomial_worker",
+        ]
+        worker_request = {
+            "protocol": SYMPY_POLYNOMIAL_WORKER_PROTOCOL,
+            "expression": request.expression.model_dump(mode="json"),
+        }
+        try:
+            completed = run_bounded_process(
+                command,
+                input_bytes=canonicalize_json(worker_request),
+                timeout_seconds=float(request.resource_budget.wall_seconds),
+                environment={
+                    "LANG": "C",
+                    "LC_ALL": "C",
+                    "TZ": "UTC",
+                    "PYTHONHASHSEED": "0",
+                },
+                stdout_limit=SYMPY_NORMALIZATION_STDOUT_LIMIT,
+                stderr_limit=SYMPY_NORMALIZATION_STDERR_LIMIT,
+            )
+        except OSError:
+            return _failure(
+                started,
+                ExecutionStatus.ERROR,
+                "The isolated SymPy normalization worker could not be started.",
+            )
+        operational = _operational_failure(started, completed)
+        if operational is not None:
+            return operational
+        try:
+            normalized = _parse_worker_output(
+                completed.stdout,
+                variables=request.expression.variables,
+            )
+        except (UnicodeDecodeError, ValueError, ValidationError):
+            return _failure(
+                started,
+                ExecutionStatus.ERROR,
+                (
+                    "The SymPy worker returned output outside its exact bounded "
+                    "protocol; no normalization evidence was retained."
+                ),
+            )
+        if (
+            sympy_polynomial_normalization_provider_runtime(refresh=True)
+            != self.runtime
+        ):
+            return _failure(
+                started,
+                ExecutionStatus.ERROR,
+                (
+                    "The installed SymPy runtime changed during execution; no "
+                    "normalization evidence was retained."
+                ),
+            )
+        return _SympyNormalizationRun(
+            execution_status=ExecutionStatus.COMPLETED,
+            runtime_ms=_runtime_ms(started),
+            normalized=normalized,
+        )
+
+
+class SympyPolynomialExpressionNormalizeAdapter:
+    """Normalize one safe typed expression to canonical sparse coefficients."""
+
+    def __init__(
+        self,
+        *,
+        expressions: PolynomialExpressionArtifactService,
+        runtime: CapabilityProviderRuntime,
+    ) -> None:
+        self.expressions = expressions
+        self.backend = _SympyPolynomialNormalizationBackend(runtime)
+        self._descriptor = CapabilityDescriptor(
+            capability_id="polynomial.expression.normalize",
+            version="1",
+            title="Normalize a typed rational polynomial expression",
+            description=(
+                "Convert one bounded, versioned QQ-polynomial AST to canonical "
+                "sparse coefficients without parsing or evaluating user strings. "
+                "Verify the full expression relation separately."
+            ),
+            provider="jacobian.sympy",
+            provider_runtime=runtime,
+            modes=(CapabilityMode.EXPLORE,),
+            input_schema=model_schema(PolynomialExpressionNormalizeRequest),
+            output_schema=model_schema(PolynomialExpressionNormalizeOutput),
+            tags=(
+                "polynomial",
+                "symbolic",
+                "normalization",
+                "typed-expression",
+                "exact-rational",
+                "sympy",
+            ),
+        )
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        return self._descriptor
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        try:
+            validated = PolynomialExpressionNormalizeRequest.model_validate(
+                request.input
+            )
+            expression_uri = self.expressions.put_expression(
+                validated.expression
+            ).artifact_uri
+            resolved = self.expressions.resolve_expression(expression_uri)
+        except (ValidationError, ValueError) as exc:
+            raise CapabilityInvocationError(
+                CapabilityDiagnostic(
+                    code="INVALID_TYPED_POLYNOMIAL_EXPRESSION",
+                    stage="input_validation",
+                    message=str(exc),
+                    path="expression",
+                    schema_uri=self.expressions.installation.expression_schema_uri,
+                    expected=(
+                        "one bounded v1 AST over an explicit ordered QQ polynomial "
+                        "ring using rational, variable, add, multiply, negate, and "
+                        "nonnegative power nodes"
+                    ),
+                    hint=(
+                        "Declare every variable and use typed nodes; do not pass "
+                        "formula strings or expression denominators."
+                    ),
+                )
+            ) from exc
+
+        run = self.backend.run(validated)
+        normalization_uri: str | None = None
+        if (
+            run.execution_status is ExecutionStatus.COMPLETED
+            and run.normalized is not None
+        ):
+            normalization_uri = self.expressions.put_normalization(
+                expression_uri=expression_uri,
+                normalized=run.normalized,
+                producer=self.backend.runtime,
+                resource_budget=validated.resource_budget,
+            ).artifact_uri
+        output = PolynomialExpressionNormalizeOutput(
+            status=(
+                "NORMALIZATION_PRODUCED"
+                if normalization_uri is not None
+                else "NO_NORMALIZATION_PRODUCED"
+            ),
+            expression_uri=expression_uri,
+            normalization_uri=normalization_uri,
+            normalized=run.normalized if normalization_uri is not None else None,
+            verification_candidate_available=normalization_uri is not None,
+            detail=(
+                "Pinned SymPy produced canonical exact sparse QQ coefficients; "
+                "equality with the typed source expression remains unverified."
+                if normalization_uri is not None
+                else (
+                    run.detail
+                    or "No normalization evidence was produced; no conclusion follows."
+                )
+            ),
+        )
+        relationships = (
+            (
+                CapabilityRelationship(
+                    relation_id="polynomial.relation.expression-normalization-of",
+                    source_artifact_uris=(normalization_uri,),
+                    target_artifact_uris=(expression_uri,),
+                ),
+            )
+            if normalization_uri is not None
+            else ()
+        )
+        return CapabilityResult(
+            capability_id=self.descriptor.capability_id,
+            capability_version=self.descriptor.version,
+            mode=request.mode,
+            execution=Execution(
+                status=run.execution_status,
+                runtime_ms=run.runtime_ms,
+                detail=run.detail,
+            ),
+            output=output.model_dump(mode="json"),
+            scope=CapabilityScope(
+                description="the full declared typed QQ-polynomial expression",
+                parameters={
+                    "declared_scope": "FULL_EXPRESSION",
+                    "variables": list(resolved.expression.variables),
+                    "node_count": resolved.binding.node_count,
+                    "depth": resolved.binding.depth,
+                    "expanded_term_upper_bound": (
+                        resolved.binding.expanded_term_upper_bound
+                    ),
+                    "coefficient_digit_budget": (
+                        resolved.binding.coefficient_digit_budget
+                    ),
+                    "wall_seconds": validated.resource_budget.wall_seconds,
+                },
+                artifact_uri=expression_uri,
+            ),
+            completeness=CapabilityCompleteness(
+                status=(
+                    CapabilityCompletenessStatus.COMPLETE
+                    if normalization_uri is not None
+                    else CapabilityCompletenessStatus.UNKNOWN
+                ),
+                basis=(
+                    "one full canonical sparse coefficient map was produced; "
+                    "provider completion is not independent verification"
+                    if normalization_uri is not None
+                    else "the bounded provider attempt produced no normalization "
+                    "evidence; no mathematical conclusion follows"
+                ),
+                assurance_level=(
+                    CapabilityAssuranceLevel.COMPUTED
+                    if run.execution_status is ExecutionStatus.COMPLETED
+                    else CapabilityAssuranceLevel.HEURISTIC
+                ),
+            ),
+            assurance=CapabilityAssurance(
+                level=(
+                    CapabilityAssuranceLevel.COMPUTED
+                    if run.execution_status is ExecutionStatus.COMPLETED
+                    else CapabilityAssuranceLevel.HEURISTIC
+                ),
+                basis=(
+                    "the pinned exact SymPy provider produced bound canonical "
+                    "coefficients, but provider success does not verify equivalence"
+                    if normalization_uri is not None
+                    else "provider execution did not complete; no mathematical "
+                    "conclusion follows"
+                ),
+            ),
+            artifact_uris=(
+                (expression_uri, normalization_uri)
+                if normalization_uri is not None
+                else (expression_uri,)
+            ),
+            relationships=relationships,
+        )
+
+
+def _parse_worker_output(
+    stdout: bytes,
+    *,
+    variables: tuple[str, ...],
+) -> SparseRationalPolynomial:
+    if not stdout.endswith(b"\n") or stdout.count(b"\n") != 1:
+        raise ValueError("worker output is not exactly one line")
+    payload: Any = loads_strict_json(stdout[:-1])
+    if (
+        not isinstance(payload, dict)
+        or set(payload)
+        != {
+            "protocol",
+            "status",
+            "backend_version",
+            "normalized",
+        }
+        or payload.get("protocol") != SYMPY_POLYNOMIAL_WORKER_PROTOCOL
+        or payload.get("status") != "NORMALIZATION_PRODUCED"
+        or payload.get("backend_version") != SYMPY_VERSION
+    ):
+        raise ValueError("worker protocol is invalid")
+    polynomial = RationalPolynomial(
+        variables=variables,
+        polynomial=SparseRationalPolynomial.model_validate(payload["normalized"]),
+    )
+    return polynomial.polynomial
+
+
+def _operational_failure(
+    started: float,
+    completed: BoundedProcessResult,
+) -> _SympyNormalizationRun | None:
+    if completed.timed_out:
+        return _failure(
+            started,
+            ExecutionStatus.TIMEOUT,
+            "The bounded SymPy normalization attempt timed out; no conclusion follows.",
+        )
+    if completed.stdout_exceeded or completed.stderr_exceeded:
+        return _failure(
+            started,
+            ExecutionStatus.ERROR,
+            "The SymPy normalization worker exceeded its output limit.",
+        )
+    if completed.returncode != 0 or completed.stderr or not completed.stdout:
+        return _failure(
+            started,
+            ExecutionStatus.ERROR,
+            "The SymPy normalization worker failed; no evidence was retained.",
+        )
+    return None
+
+
+def _failure(
+    started: float,
+    status: ExecutionStatus,
+    detail: str,
+) -> _SympyNormalizationRun:
+    return _SympyNormalizationRun(
+        execution_status=status,
+        runtime_ms=_runtime_ms(started),
+        detail=detail,
+    )
+
+
+def _runtime_ms(started: float) -> int:
+    return max(0, round((time.monotonic() - started) * 1000))

--- a/src/jacobian/sympy_polynomial_worker.py
+++ b/src/jacobian/sympy_polynomial_worker.py
@@ -1,0 +1,120 @@
+"""Isolated strict worker for typed SymPy polynomial normalization."""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+import sympy
+from pydantic import ValidationError
+from sympy import QQ, Poly
+
+from jacobian.canonical import canonicalize_json, loads_strict_json
+from jacobian.contracts.exact import CanonicalRational
+from jacobian.contracts.polynomial_expressions import (
+    PolynomialAddExpression,
+    PolynomialExpressionArtifact,
+    PolynomialExpressionNode,
+    PolynomialMultiplyExpression,
+    PolynomialNegateExpression,
+    PolynomialPowerExpression,
+    PolynomialRationalExpression,
+    PolynomialVariableExpression,
+)
+from jacobian.contracts.polynomials import (
+    RationalPolynomialTerm,
+    SparseRationalPolynomial,
+)
+from jacobian.provider_runtime import SYMPY_VERSION
+
+SYMPY_POLYNOMIAL_WORKER_PROTOCOL = "jacobian.sympy-polynomial-normalization/v1"
+
+
+def _sympy_expression(
+    expression: PolynomialExpressionNode,
+    symbols: dict[str, Any],
+) -> Any:
+    if isinstance(expression, PolynomialRationalExpression):
+        return sympy.Rational(int(expression.value.num), int(expression.value.den))
+    if isinstance(expression, PolynomialVariableExpression):
+        return symbols[expression.name]
+    if isinstance(expression, PolynomialAddExpression):
+        return sympy.Add(
+            *(_sympy_expression(operand, symbols) for operand in expression.operands)
+        )
+    if isinstance(expression, PolynomialMultiplyExpression):
+        return sympy.Mul(
+            *(_sympy_expression(operand, symbols) for operand in expression.operands)
+        )
+    if isinstance(expression, PolynomialNegateExpression):
+        return -_sympy_expression(expression.operand, symbols)
+    if isinstance(expression, PolynomialPowerExpression):
+        return sympy.Pow(
+            _sympy_expression(expression.base, symbols),
+            expression.exponent,
+        )
+    raise TypeError("unsupported typed polynomial expression")
+
+
+def _wire_polynomial(polynomial: Poly) -> SparseRationalPolynomial:
+    return SparseRationalPolynomial(
+        terms=tuple(
+            RationalPolynomialTerm(
+                coefficient=CanonicalRational(
+                    num=str(coefficient.numerator),
+                    den=str(coefficient.denominator),
+                ),
+                exponents=tuple(int(exponent) for exponent in exponents),
+            )
+            for exponents, coefficient in polynomial.terms()
+            if coefficient != 0
+        )
+    )
+
+
+def _run(payload: object) -> dict[str, Any]:
+    if (
+        not isinstance(payload, dict)
+        or set(payload) != {"protocol", "expression"}
+        or payload.get("protocol") != SYMPY_POLYNOMIAL_WORKER_PROTOCOL
+    ):
+        raise ValueError("invalid worker request")
+    if sympy.__version__ != SYMPY_VERSION:
+        raise RuntimeError("unexpected SymPy version")
+    expression = PolynomialExpressionArtifact.model_validate(payload["expression"])
+    generators = tuple(sympy.Symbol(name) for name in expression.variables)
+    symbol_table = dict(zip(expression.variables, generators, strict=True))
+    polynomial = Poly(
+        _sympy_expression(expression.expression, symbol_table),
+        *generators,
+        domain=QQ,
+    )
+    normalized = _wire_polynomial(polynomial)
+    return {
+        "protocol": SYMPY_POLYNOMIAL_WORKER_PROTOCOL,
+        "status": "NORMALIZATION_PRODUCED",
+        "backend_version": SYMPY_VERSION,
+        "normalized": normalized.model_dump(mode="json"),
+    }
+
+
+def main() -> int:
+    try:
+        request = loads_strict_json(sys.stdin.buffer.read())
+        response = _run(request)
+    except (
+        ArithmeticError,
+        KeyError,
+        RuntimeError,
+        TypeError,
+        ValidationError,
+        ValueError,
+    ):
+        sys.stderr.write("typed polynomial normalization failed\n")
+        return 1
+    sys.stdout.buffer.write(canonicalize_json(response) + b"\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jacobian_checkers/polynomial_expressions.py
+++ b/src/jacobian_checkers/polynomial_expressions.py
@@ -1,0 +1,630 @@
+"""Independent replay for typed rational-polynomial normalization.
+
+This checker intentionally uses only the Python standard library. It does not
+import Jacobian contracts, SymPy, or producer code.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from fractions import Fraction
+from math import comb
+from typing import Any
+
+_ARTIFACT_URI = re.compile(r"^artifact://sha256/[0-9a-f]{64}$")
+_DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
+_INTEGER = re.compile(r"^-?(?:0|[1-9][0-9]*)$")
+_VARIABLE = re.compile(r"^[A-Za-z][A-Za-z0-9_]{0,31}$")
+_ARTIFACT_KEYS = {
+    "artifact_uri",
+    "object_digest",
+    "payload_digest",
+    "schema_uri",
+    "semantics_uri",
+    "parents",
+    "payload",
+}
+_BINDING_KEYS = {
+    "claim_digest",
+    "semantics_digest",
+    "candidate_digest",
+    "scope_digest",
+    "encoding_digest",
+}
+_EXPRESSION_BINDING_KEYS = {
+    "binding_version",
+    "expression_artifact_uri",
+    "expression_object_digest",
+    "expression_payload_digest",
+    "variables",
+    "node_count",
+    "depth",
+    "expanded_term_upper_bound",
+    "coefficient_digit_budget",
+}
+_PROVIDER_KEYS = {
+    "runtime_version",
+    "provider",
+    "availability",
+    "version",
+    "digest",
+    "digest_kind",
+    "platform",
+    "install_tier",
+    "license_id",
+    "license_files",
+    "features",
+    "checker_ids",
+    "configuration",
+    "diagnostic",
+}
+_NORMALIZATION_CONFIGURATION = {
+    "distribution": "sympy",
+    "domain": "QQ",
+    "operation": "Poly(expression, *variables, domain=QQ).terms()",
+    "expression_schema_version": "1",
+    "maximum_variables": 4,
+    "maximum_nodes": 128,
+    "maximum_depth": 16,
+    "maximum_expanded_terms": 1024,
+    "maximum_exponent_per_variable": 127,
+    "maximum_coefficient_digit_budget": 4096,
+}
+_MAX_VARIABLES = 4
+_MAX_NODES = 128
+_MAX_DEPTH = 16
+_MAX_OPERANDS = 16
+_MAX_POWER = 32
+_MAX_TERMS = 1024
+_MAX_EXPONENT = 127
+_MAX_INTEGER_DIGITS = 256
+_MAX_COEFFICIENT_DIGIT_BUDGET = 4096
+_Polynomial = dict[tuple[int, ...], Fraction]
+
+
+@dataclass(frozen=True, slots=True)
+class _Analysis:
+    nodes: int
+    depth: int
+    term_upper_bound: int
+    maximum_exponents: tuple[int, ...]
+    coefficient_digit_budget: int
+
+
+def _reject(detail: str) -> dict[str, Any]:
+    return {
+        "accepted": False,
+        "conclusion": "UNKNOWN",
+        "arithmetic": "EXACT_RATIONAL",
+        "method": "DIRECT_WITNESS",
+        "coverage": "NOT_APPLICABLE",
+        "detail": detail,
+    }
+
+
+def _sha256(value: bytes) -> str:
+    return "sha256:" + hashlib.sha256(value).hexdigest()
+
+
+def _canonical_json(value: object) -> bytes:
+    return json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _valid_artifact(value: object) -> bool:
+    if not isinstance(value, dict) or set(value) != _ARTIFACT_KEYS:
+        return False
+    if (
+        not isinstance(value["artifact_uri"], str)
+        or _ARTIFACT_URI.fullmatch(value["artifact_uri"]) is None
+        or not isinstance(value["object_digest"], str)
+        or _DIGEST.fullmatch(value["object_digest"]) is None
+        or not isinstance(value["payload_digest"], str)
+        or _DIGEST.fullmatch(value["payload_digest"]) is None
+        or not isinstance(value["schema_uri"], str)
+        or _ARTIFACT_URI.fullmatch(value["schema_uri"]) is None
+        or not isinstance(value["semantics_uri"], str)
+        or _ARTIFACT_URI.fullmatch(value["semantics_uri"]) is None
+    ):
+        return False
+    parents = value["parents"]
+    return (
+        isinstance(parents, list)
+        and len(parents) == len(set(parents))
+        and all(
+            isinstance(parent, str) and _ARTIFACT_URI.fullmatch(parent) is not None
+            for parent in parents
+        )
+    )
+
+
+def _valid_bindings(value: object) -> bool:
+    if not isinstance(value, dict) or set(value) != _BINDING_KEYS:
+        return False
+    if value["scope_digest"] is not None or value["encoding_digest"] is not None:
+        return False
+    return all(
+        isinstance(value[key], str) and _DIGEST.fullmatch(value[key]) is not None
+        for key in ("claim_digest", "semantics_digest", "candidate_digest")
+    )
+
+
+def _canonical_integer(value: object) -> int:
+    if (
+        not isinstance(value, str)
+        or _INTEGER.fullmatch(value) is None
+        or len(value.lstrip("-")) > _MAX_INTEGER_DIGITS
+    ):
+        raise ValueError("value is not a bounded canonical integer")
+    result = int(value)
+    if str(result) != value:
+        raise ValueError("integer is not canonical")
+    return result
+
+
+def _rational(value: object) -> Fraction:
+    if not isinstance(value, dict) or set(value) != {"num", "den"}:
+        raise ValueError("rational literal is malformed")
+    numerator = _canonical_integer(value["num"])
+    denominator = _canonical_integer(value["den"])
+    if denominator <= 0:
+        raise ValueError("rational denominator must be positive")
+    result = Fraction(numerator, denominator)
+    if str(result.numerator) != value["num"] or str(result.denominator) != value["den"]:
+        raise ValueError("rational literal is not reduced and canonical")
+    return result
+
+
+def _expression_artifact(
+    payload: object,
+) -> tuple[list[str], _Polynomial, _Analysis]:
+    if not isinstance(payload, dict) or set(payload) != {
+        "expression_schema_version",
+        "domain",
+        "variables",
+        "expression",
+    }:
+        raise ValueError("typed polynomial expression has an invalid shape")
+    variables = payload["variables"]
+    if (
+        payload["expression_schema_version"] != "1"
+        or payload["domain"] != "QQ"
+        or not isinstance(variables, list)
+        or not 1 <= len(variables) <= _MAX_VARIABLES
+        or any(
+            not isinstance(variable, str) or _VARIABLE.fullmatch(variable) is None
+            for variable in variables
+        )
+        or len(set(variables)) != len(variables)
+    ):
+        raise ValueError("typed polynomial expression has an invalid ring")
+    variable_indices = {variable: index for index, variable in enumerate(variables)}
+    polynomial, analysis = _expression(payload["expression"], variable_indices)
+    _require_analysis_bounds(analysis)
+    return variables, polynomial, analysis
+
+
+def _expression(
+    value: object,
+    variable_indices: dict[str, int],
+) -> tuple[_Polynomial, _Analysis]:
+    if not isinstance(value, dict) or not isinstance(value.get("kind"), str):
+        raise ValueError("expression node is malformed")
+    dimension = len(variable_indices)
+    zero_exponents = (0,) * dimension
+    kind = value["kind"]
+    if kind == "rational":
+        if set(value) != {"kind", "value"}:
+            raise ValueError("rational node is malformed")
+        coefficient = _rational(value["value"])
+        literal_polynomial = {} if coefficient == 0 else {zero_exponents: coefficient}
+        analysis = _Analysis(
+            nodes=1,
+            depth=1,
+            term_upper_bound=int(coefficient != 0),
+            maximum_exponents=zero_exponents,
+            coefficient_digit_budget=(
+                len(value["value"]["num"].lstrip("-")) + len(value["value"]["den"])
+            ),
+        )
+        return literal_polynomial, analysis
+    if kind == "variable":
+        if set(value) != {"kind", "name"}:
+            raise ValueError("variable node is malformed")
+        name = value["name"]
+        if not isinstance(name, str) or name not in variable_indices:
+            raise ValueError("expression uses an undeclared variable")
+        exponents = [0] * dimension
+        exponents[variable_indices[name]] = 1
+        return {tuple(exponents): Fraction(1)}, _Analysis(
+            1,
+            1,
+            1,
+            tuple(exponents),
+            1,
+        )
+    if kind == "negate":
+        if set(value) != {"kind", "operand"}:
+            raise ValueError("negate node is malformed")
+        operand, child = _expression(value["operand"], variable_indices)
+        return {monomial: -coefficient for monomial, coefficient in operand.items()}, (
+            _Analysis(
+                1 + child.nodes,
+                1 + child.depth,
+                child.term_upper_bound,
+                child.maximum_exponents,
+                child.coefficient_digit_budget,
+            )
+        )
+    if kind == "power":
+        if set(value) != {"kind", "base", "exponent"}:
+            raise ValueError("power node is malformed")
+        exponent = value["exponent"]
+        if type(exponent) is not int or not 0 <= exponent <= _MAX_POWER:
+            raise ValueError("power exponent is outside the declared bound")
+        base, child = _expression(value["base"], variable_indices)
+        if exponent == 0:
+            terms = 1
+            degrees = zero_exponents
+            digit_budget = 1
+        elif child.term_upper_bound == 0:
+            terms = 0
+            degrees = zero_exponents
+            digit_budget = child.coefficient_digit_budget * exponent
+        else:
+            terms = min(
+                comb(child.term_upper_bound + exponent - 1, exponent),
+                _MAX_TERMS + 1,
+            )
+            degrees = tuple(
+                child_exponent * exponent for child_exponent in child.maximum_exponents
+            )
+            digit_budget = child.coefficient_digit_budget * exponent
+        analysis = _Analysis(
+            1 + child.nodes,
+            1 + child.depth,
+            terms,
+            degrees,
+            digit_budget,
+        )
+        _require_analysis_bounds(analysis)
+        return _power(base, exponent, dimension), analysis
+    if kind not in {"add", "multiply"}:
+        raise ValueError("expression node kind is unsupported")
+    if set(value) != {"kind", "operands"}:
+        raise ValueError("variadic expression node is malformed")
+    operands = value["operands"]
+    if not isinstance(operands, list) or not 2 <= len(operands) <= _MAX_OPERANDS:
+        raise ValueError("variadic expression node has invalid arity")
+    children = tuple(_expression(operand, variable_indices) for operand in operands)
+    analyses = tuple(child[1] for child in children)
+    nodes = 1 + sum(child.nodes for child in analyses)
+    depth = 1 + max(child.depth for child in analyses)
+    if kind == "add":
+        term_bound = _bounded_sum(child.term_upper_bound for child in analyses)
+        degrees = tuple(
+            max(child.maximum_exponents[index] for child in analyses)
+            for index in range(dimension)
+        )
+        digit_budget = sum(child.coefficient_digit_budget for child in analyses) + len(
+            analyses
+        )
+        combined_polynomial: _Polynomial = {}
+        for child_polynomial, _ in children:
+            combined_polynomial = _add(combined_polynomial, child_polynomial)
+    else:
+        if any(child.term_upper_bound == 0 for child in analyses):
+            term_bound = 0
+            degrees = zero_exponents
+        else:
+            term_bound = _bounded_product(child.term_upper_bound for child in analyses)
+            degrees = tuple(
+                sum(child.maximum_exponents[index] for child in analyses)
+                for index in range(dimension)
+            )
+        digit_budget = sum(child.coefficient_digit_budget for child in analyses)
+        combined_polynomial = {zero_exponents: Fraction(1)}
+        for child_polynomial, _ in children:
+            combined_polynomial = _multiply(
+                combined_polynomial,
+                child_polynomial,
+            )
+    analysis = _Analysis(nodes, depth, term_bound, degrees, digit_budget)
+    _require_analysis_bounds(analysis)
+    return combined_polynomial, analysis
+
+
+def _require_analysis_bounds(analysis: _Analysis) -> None:
+    if analysis.nodes > _MAX_NODES or analysis.depth > _MAX_DEPTH:
+        raise ValueError("expression AST exceeds its structural bound")
+    if analysis.term_upper_bound > _MAX_TERMS:
+        raise ValueError("expression exceeds its expansion budget")
+    if any(exponent > _MAX_EXPONENT for exponent in analysis.maximum_exponents):
+        raise ValueError("expression exponent exceeds its ring bound")
+    if analysis.coefficient_digit_budget > _MAX_COEFFICIENT_DIGIT_BUDGET:
+        raise ValueError("expression exceeds its coefficient digit budget")
+
+
+def _bounded_sum(values: Any) -> int:
+    total = 0
+    for value in values:
+        total += value
+        if total > _MAX_TERMS:
+            return _MAX_TERMS + 1
+    return total
+
+
+def _bounded_product(values: Any) -> int:
+    total = 1
+    for value in values:
+        total *= value
+        if total > _MAX_TERMS:
+            return _MAX_TERMS + 1
+    return total
+
+
+def _add(left: _Polynomial, right: _Polynomial) -> _Polynomial:
+    result = dict(left)
+    for monomial, coefficient in right.items():
+        combined = result.get(monomial, Fraction(0)) + coefficient
+        if combined:
+            result[monomial] = combined
+        else:
+            result.pop(monomial, None)
+    if len(result) > _MAX_TERMS:
+        raise ValueError("expanded polynomial exceeds the term budget")
+    return result
+
+
+def _multiply(left: _Polynomial, right: _Polynomial) -> _Polynomial:
+    if not left or not right:
+        return {}
+    result: _Polynomial = {}
+    for left_monomial, left_coefficient in left.items():
+        for right_monomial, right_coefficient in right.items():
+            monomial = tuple(
+                left_exponent + right_exponent
+                for left_exponent, right_exponent in zip(
+                    left_monomial,
+                    right_monomial,
+                    strict=True,
+                )
+            )
+            if any(exponent > _MAX_EXPONENT for exponent in monomial):
+                raise ValueError("expanded exponent exceeds the ring bound")
+            coefficient = (
+                result.get(monomial, Fraction(0)) + left_coefficient * right_coefficient
+            )
+            if coefficient:
+                result[monomial] = coefficient
+            else:
+                result.pop(monomial, None)
+            if len(result) > _MAX_TERMS:
+                raise ValueError("expanded polynomial exceeds the term budget")
+    return result
+
+
+def _power(base: _Polynomial, exponent: int, dimension: int) -> _Polynomial:
+    result: _Polynomial = {(0,) * dimension: Fraction(1)}
+    for _ in range(exponent):
+        result = _multiply(result, base)
+    return result
+
+
+def _normalized_polynomial(payload: object, dimension: int) -> _Polynomial:
+    if not isinstance(payload, dict) or set(payload) != {"terms"}:
+        raise ValueError("normalized sparse polynomial is malformed")
+    terms = payload["terms"]
+    if not isinstance(terms, list) or len(terms) > _MAX_TERMS:
+        raise ValueError("normalized sparse polynomial has too many terms")
+    result: _Polynomial = {}
+    ordered_exponents: list[tuple[int, ...]] = []
+    for term in terms:
+        if not isinstance(term, dict) or set(term) != {"coefficient", "exponents"}:
+            raise ValueError("normalized polynomial term is malformed")
+        coefficient = _rational(term["coefficient"])
+        exponents = term["exponents"]
+        if (
+            coefficient == 0
+            or not isinstance(exponents, list)
+            or len(exponents) != dimension
+            or any(
+                type(exponent) is not int or not 0 <= exponent <= _MAX_EXPONENT
+                for exponent in exponents
+            )
+        ):
+            raise ValueError("normalized polynomial term is invalid")
+        monomial = tuple(exponents)
+        if monomial in result:
+            raise ValueError("normalized polynomial contains duplicate monomials")
+        result[monomial] = coefficient
+        ordered_exponents.append(monomial)
+    if ordered_exponents != sorted(ordered_exponents, reverse=True):
+        raise ValueError("normalized polynomial term order is not canonical")
+    return result
+
+
+def _validate_candidate(
+    payload: object,
+    *,
+    claim: dict[str, Any],
+    candidate: dict[str, Any],
+    variables: list[str],
+    analysis: _Analysis,
+) -> _Polynomial:
+    if not isinstance(payload, dict) or set(payload) != {
+        "normalization_schema_version",
+        "source",
+        "declared_scope",
+        "normalized",
+        "producer",
+        "resource_budget",
+        "method",
+    }:
+        raise ValueError("normalization candidate has an invalid shape")
+    if (
+        payload["normalization_schema_version"] != "1"
+        or payload["declared_scope"] != "FULL_EXPRESSION"
+        or payload["method"] != "SYMPY_POLY_QQ_CANONICAL_TERMS"
+    ):
+        raise ValueError("normalization candidate uses unsupported semantics")
+    binding = payload["source"]
+    if not isinstance(binding, dict) or set(binding) != _EXPRESSION_BINDING_KEYS:
+        raise ValueError("normalization source binding is malformed")
+    if binding != {
+        "binding_version": "1",
+        "expression_artifact_uri": claim["artifact_uri"],
+        "expression_object_digest": claim["object_digest"],
+        "expression_payload_digest": claim["payload_digest"],
+        "variables": variables,
+        "node_count": analysis.nodes,
+        "depth": analysis.depth,
+        "expanded_term_upper_bound": analysis.term_upper_bound,
+        "coefficient_digit_budget": analysis.coefficient_digit_budget,
+    }:
+        raise ValueError("normalization is not exactly bound to its source expression")
+    if claim["artifact_uri"] not in candidate["parents"]:
+        raise ValueError("normalization is missing source-expression lineage")
+    provider = payload["producer"]
+    if (
+        not isinstance(provider, dict)
+        or set(provider) != _PROVIDER_KEYS
+        or provider["runtime_version"] != "1"
+        or provider["provider"] != "jacobian.sympy"
+        or provider["availability"] != "AVAILABLE"
+        or provider["version"] != "1.14.0"
+        or not isinstance(provider["digest"], str)
+        or _DIGEST.fullmatch(provider["digest"]) is None
+        or provider["digest_kind"] != "PYTHON_DISTRIBUTION_RECORD"
+        or provider["install_tier"] != "T0"
+        or provider["license_id"] != "BSD-3-Clause"
+        or provider["configuration"] != _NORMALIZATION_CONFIGURATION
+    ):
+        raise ValueError("normalization producer identity is malformed")
+    budget = payload["resource_budget"]
+    if (
+        not isinstance(budget, dict)
+        or set(budget) != {"budget_version", "wall_seconds"}
+        or budget["budget_version"] != "1"
+        or type(budget["wall_seconds"]) is not int
+        or not 1 <= budget["wall_seconds"] <= 60
+    ):
+        raise ValueError("normalization resource budget is malformed")
+    return _normalized_polynomial(payload["normalized"], len(variables))
+
+
+def check_polynomial_expression_normalization(
+    request: dict[str, Any],
+) -> dict[str, Any]:
+    """Accept only exact coefficient equality with the full typed AST."""
+
+    try:
+        if not isinstance(request, dict) or set(request) != {
+            "request_version",
+            "claim",
+            "candidate",
+            "scope",
+            "witness",
+            "expected_bindings",
+        }:
+            return _reject("malformed checker request")
+        if request["request_version"] != "1" or request["scope"] is not None:
+            return _reject("unsupported checker request")
+        claim = request["claim"]
+        candidate = request["candidate"]
+        witness = request["witness"]
+        if not all(_valid_artifact(item) for item in (claim, candidate, witness)):
+            return _reject("checker artifact metadata is malformed")
+        expected_bindings = request["expected_bindings"]
+        if not _valid_bindings(expected_bindings):
+            return _reject("expected evidence bindings are malformed")
+        if (
+            claim["semantics_uri"] != candidate["semantics_uri"]
+            or claim["semantics_uri"] != witness["semantics_uri"]
+        ):
+            return _reject("checker artifacts use different semantics")
+        for artifact, label in (
+            (claim, "source expression"),
+            (candidate, "normalization candidate"),
+            (witness, "normalization witness"),
+        ):
+            if artifact["payload_digest"] != _sha256(
+                _canonical_json(artifact["payload"])
+            ):
+                return _reject(f"{label} payload digest does not match")
+
+        variables, expanded, analysis = _expression_artifact(claim["payload"])
+        normalized = _validate_candidate(
+            candidate["payload"],
+            claim=claim,
+            candidate=candidate,
+            variables=variables,
+            analysis=analysis,
+        )
+        if (
+            expected_bindings["claim_digest"] != claim["object_digest"]
+            or expected_bindings["candidate_digest"] != candidate["object_digest"]
+        ):
+            return _reject("expected evidence bindings do not match artifacts")
+        envelope = witness["payload"]
+        if not isinstance(envelope, dict) or set(envelope) != {
+            "evidence_schema_version",
+            "witness_format",
+            "format_version",
+            "role",
+            "bindings",
+            "payload",
+        }:
+            return _reject("normalization witness envelope is malformed")
+        if (
+            envelope["evidence_schema_version"] != "1"
+            or envelope["witness_format"] != "polynomial.expression_normalization"
+            or envelope["format_version"] != "1"
+            or envelope["role"] != "SUPPORTS_CLAIM"
+            or envelope["bindings"] != expected_bindings
+        ):
+            return _reject("normalization witness is not exactly bound")
+        if envelope["payload"] != {
+            "expression_uri": claim["artifact_uri"],
+            "normalization_uri": candidate["artifact_uri"],
+        }:
+            return _reject("normalization witness points at different artifacts")
+        if not {
+            claim["artifact_uri"],
+            candidate["artifact_uri"],
+        }.issubset(set(witness["parents"])):
+            return _reject("normalization witness is missing required lineage")
+        if expanded != normalized:
+            return _reject(
+                "canonical coefficients do not equal the full typed expression"
+            )
+        return {
+            "accepted": True,
+            "conclusion": "TRUE",
+            "arithmetic": "EXACT_RATIONAL",
+            "method": "DIRECT_WITNESS",
+            "coverage": "NOT_APPLICABLE",
+            "relation_id": "polynomial.relation.expression-normalization-of",
+            "relationship_source_artifact_uris": [candidate["artifact_uri"]],
+            "relationship_target_artifact_uris": [claim["artifact_uri"]],
+            "detail": (
+                f"independently expanded all {analysis.nodes} AST nodes and matched "
+                f"{len(normalized)} canonical coefficients over QQ"
+            ),
+        }
+    except (
+        ArithmeticError,
+        KeyError,
+        TypeError,
+        ValueError,
+        OverflowError,
+    ):
+        return _reject("malformed polynomial normalization request")

--- a/tests/checkers/test_polynomial_expression_checker.py
+++ b/tests/checkers/test_polynomial_expression_checker.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from typing import Any
+
+import pytest
+
+from jacobian_checkers.polynomial_expressions import (
+    check_polynomial_expression_normalization,
+)
+
+
+def _uri(character: str) -> str:
+    return "artifact://sha256/" + character * 64
+
+
+def _digest(value: object) -> str:
+    encoded = json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _artifact(
+    *,
+    uri_character: str,
+    object_character: str,
+    schema_character: str,
+    semantics_uri: str,
+    payload: dict[str, Any],
+    parents: list[str],
+) -> dict[str, Any]:
+    return {
+        "artifact_uri": _uri(uri_character),
+        "object_digest": "sha256:" + object_character * 64,
+        "payload_digest": _digest(payload),
+        "schema_uri": _uri(schema_character),
+        "semantics_uri": semantics_uri,
+        "parents": parents,
+        "payload": payload,
+    }
+
+
+def _expression() -> dict[str, Any]:
+    return {
+        "kind": "multiply",
+        "operands": [
+            {
+                "kind": "add",
+                "operands": [
+                    {"kind": "variable", "name": "x"},
+                    {"kind": "variable", "name": "y"},
+                ],
+            },
+            {
+                "kind": "add",
+                "operands": [
+                    {"kind": "variable", "name": "x"},
+                    {
+                        "kind": "negate",
+                        "operand": {"kind": "variable", "name": "y"},
+                    },
+                ],
+            },
+        ],
+    }
+
+
+def _request() -> dict[str, Any]:
+    semantics_uri = _uri("e")
+    source_payload = {
+        "expression_schema_version": "1",
+        "domain": "QQ",
+        "variables": ["x", "y"],
+        "expression": _expression(),
+    }
+    claim = _artifact(
+        uri_character="a",
+        object_character="1",
+        schema_character="b",
+        semantics_uri=semantics_uri,
+        payload=source_payload,
+        parents=[],
+    )
+    candidate_payload = {
+        "normalization_schema_version": "1",
+        "source": {
+            "binding_version": "1",
+            "expression_artifact_uri": claim["artifact_uri"],
+            "expression_object_digest": claim["object_digest"],
+            "expression_payload_digest": claim["payload_digest"],
+            "variables": ["x", "y"],
+            "node_count": 8,
+            "depth": 4,
+            "expanded_term_upper_bound": 4,
+            "coefficient_digit_budget": 8,
+        },
+        "declared_scope": "FULL_EXPRESSION",
+        "normalized": {
+            "terms": [
+                {
+                    "coefficient": {"num": "1", "den": "1"},
+                    "exponents": [2, 0],
+                },
+                {
+                    "coefficient": {"num": "-1", "den": "1"},
+                    "exponents": [0, 2],
+                },
+            ]
+        },
+        "producer": {
+            "runtime_version": "1",
+            "provider": "jacobian.sympy",
+            "availability": "AVAILABLE",
+            "version": "1.14.0",
+            "digest": "sha256:" + "9" * 64,
+            "digest_kind": "PYTHON_DISTRIBUTION_RECORD",
+            "platform": "linux-x86_64",
+            "install_tier": "T0",
+            "license_id": "BSD-3-Clause",
+            "license_files": ["sympy-1.14.0.dist-info/LICENSE"],
+            "features": [
+                "typed-polynomial-expression",
+                "exact-rational",
+                "canonical-sparse-normalization",
+            ],
+            "checker_ids": [],
+            "configuration": {
+                "distribution": "sympy",
+                "domain": "QQ",
+                "operation": "Poly(expression, *variables, domain=QQ).terms()",
+                "expression_schema_version": "1",
+                "maximum_variables": 4,
+                "maximum_nodes": 128,
+                "maximum_depth": 16,
+                "maximum_expanded_terms": 1024,
+                "maximum_exponent_per_variable": 127,
+                "maximum_coefficient_digit_budget": 4096,
+            },
+            "diagnostic": None,
+        },
+        "resource_budget": {"budget_version": "1", "wall_seconds": 5},
+        "method": "SYMPY_POLY_QQ_CANONICAL_TERMS",
+    }
+    candidate = _artifact(
+        uri_character="c",
+        object_character="2",
+        schema_character="d",
+        semantics_uri=semantics_uri,
+        payload=candidate_payload,
+        parents=[claim["artifact_uri"]],
+    )
+    bindings = {
+        "claim_digest": claim["object_digest"],
+        "semantics_digest": "sha256:" + "3" * 64,
+        "candidate_digest": candidate["object_digest"],
+        "scope_digest": None,
+        "encoding_digest": None,
+    }
+    witness_payload = {
+        "evidence_schema_version": "1",
+        "witness_format": "polynomial.expression_normalization",
+        "format_version": "1",
+        "role": "SUPPORTS_CLAIM",
+        "bindings": bindings,
+        "payload": {
+            "expression_uri": claim["artifact_uri"],
+            "normalization_uri": candidate["artifact_uri"],
+        },
+    }
+    witness = _artifact(
+        uri_character="f",
+        object_character="4",
+        schema_character="5",
+        semantics_uri=semantics_uri,
+        payload=witness_payload,
+        parents=[claim["artifact_uri"], candidate["artifact_uri"]],
+    )
+    return {
+        "request_version": "1",
+        "claim": claim,
+        "candidate": candidate,
+        "scope": None,
+        "witness": witness,
+        "expected_bindings": bindings,
+    }
+
+
+def _refresh_payload_digest(artifact: dict[str, Any]) -> None:
+    artifact["payload_digest"] = _digest(artifact["payload"])
+
+
+def test_checker_accepts_full_typed_ast_normalization() -> None:
+    decision = check_polynomial_expression_normalization(_request())
+
+    assert decision["accepted"] is True
+    assert decision["conclusion"] == "TRUE"
+    assert decision["arithmetic"] == "EXACT_RATIONAL"
+    assert decision["relation_id"] == (
+        "polynomial.relation.expression-normalization-of"
+    )
+
+
+def test_checker_rejects_wrong_coefficient_with_refreshed_digest() -> None:
+    request = _request()
+    request["candidate"]["payload"]["normalized"]["terms"][1]["coefficient"]["num"] = (
+        "-2"
+    )
+    _refresh_payload_digest(request["candidate"])
+
+    decision = check_polynomial_expression_normalization(request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+def test_checker_rejects_noncanonical_output_order() -> None:
+    request = _request()
+    request["candidate"]["payload"]["normalized"]["terms"].reverse()
+    _refresh_payload_digest(request["candidate"])
+
+    decision = check_polynomial_expression_normalization(request)
+
+    assert decision["accepted"] is False
+
+
+def test_checker_rejects_mutated_source_even_when_payload_digest_is_refreshed() -> None:
+    request = _request()
+    request["claim"]["payload"]["expression"]["operands"][0]["operands"][0]["name"] = (
+        "y"
+    )
+    _refresh_payload_digest(request["claim"])
+
+    decision = check_polynomial_expression_normalization(request)
+
+    assert decision["accepted"] is False
+
+
+def test_checker_rejects_rebound_source_identity() -> None:
+    request = _request()
+    request["candidate"]["payload"]["source"]["expression_object_digest"] = (
+        "sha256:" + "8" * 64
+    )
+    _refresh_payload_digest(request["candidate"])
+
+    decision = check_polynomial_expression_normalization(request)
+
+    assert decision["accepted"] is False
+
+
+@pytest.mark.parametrize(
+    ("path", "value"),
+    [
+        (
+            ("claim", "payload", "expression"),
+            {"kind": "parsed_string", "value": "__import__('os').system('id')"},
+        ),
+        (
+            ("candidate", "payload", "producer", "version"),
+            "1.13.3",
+        ),
+        (
+            ("candidate", "payload", "source", "expanded_term_upper_bound"),
+            3,
+        ),
+        (
+            ("witness", "payload", "payload", "normalization_uri"),
+            _uri("7"),
+        ),
+    ],
+    ids=("unsafe_node", "wrong_provider", "wrong_bound", "rebound_witness"),
+)
+def test_checker_rejects_malformed_or_misbound_evidence(
+    path: tuple[str, ...],
+    value: object,
+) -> None:
+    request = _request()
+    target: Any = request
+    for key in path[:-1]:
+        target = target[key]
+    target[path[-1]] = value
+    if path[0] in {"claim", "candidate", "witness"}:
+        _refresh_payload_digest(request[path[0]])
+
+    decision = check_polynomial_expression_normalization(copy.deepcopy(request))
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+def test_checker_rejects_noncanonical_rational_literal() -> None:
+    request = _request()
+    request["claim"]["payload"]["expression"] = {
+        "kind": "rational",
+        "value": {"num": "2", "den": "2"},
+    }
+    _refresh_payload_digest(request["claim"])
+
+    decision = check_polynomial_expression_normalization(request)
+
+    assert decision["accepted"] is False
+
+
+def test_checker_rejects_missing_lineage_and_payload_digest_forgery() -> None:
+    requests = []
+
+    missing_parent = _request()
+    missing_parent["candidate"]["parents"] = []
+    requests.append(missing_parent)
+
+    forged_digest = _request()
+    forged_digest["candidate"]["payload_digest"] = "sha256:" + "0" * 64
+    requests.append(forged_digest)
+
+    duplicate_parent = _request()
+    duplicate_parent["witness"]["parents"].append(
+        duplicate_parent["claim"]["artifact_uri"]
+    )
+    requests.append(duplicate_parent)
+
+    for request in requests:
+        decision = check_polynomial_expression_normalization(request)
+        assert decision["accepted"] is False
+        assert decision["conclusion"] == "UNKNOWN"

--- a/tests/contract/test_polynomial_expression_contracts.py
+++ b/tests/contract/test_polynomial_expression_contracts.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.contracts.polynomial_expressions import (
+    PolynomialExpressionArtifact,
+    PolynomialExpressionNormalizeRequest,
+    analyze_polynomial_expression,
+)
+from jacobian.schema_registry import model_schema
+
+
+def _variable(name: str = "x") -> dict[str, object]:
+    return {"kind": "variable", "name": name}
+
+
+def _artifact(expression: dict[str, object]) -> dict[str, object]:
+    return {
+        "variables": ["x", "y"],
+        "expression": expression,
+    }
+
+
+def test_typed_expression_contract_accepts_bounded_polynomial_ast() -> None:
+    artifact = PolynomialExpressionArtifact.model_validate(
+        _artifact(
+            {
+                "kind": "add",
+                "operands": [
+                    {
+                        "kind": "multiply",
+                        "operands": [
+                            {
+                                "kind": "rational",
+                                "value": {"num": "3", "den": "2"},
+                            },
+                            {
+                                "kind": "power",
+                                "base": _variable("x"),
+                                "exponent": 2,
+                            },
+                        ],
+                    },
+                    {"kind": "negate", "operand": _variable("y")},
+                ],
+            }
+        )
+    )
+
+    analysis = analyze_polynomial_expression(
+        artifact.expression,
+        artifact.variables,
+    )
+
+    assert artifact.domain == "QQ"
+    assert analysis.node_count == 7
+    assert analysis.depth == 4
+    assert analysis.expanded_term_upper_bound == 2
+    assert analysis.maximum_exponents == (2, 1)
+
+
+def test_expression_schema_is_a_closed_discriminated_ast() -> None:
+    schema = model_schema(PolynomialExpressionNormalizeRequest)
+    serialized = str(schema)
+
+    assert "PolynomialAddExpression" in serialized
+    assert "PolynomialPowerExpression" in serialized
+    assert "discriminator" in serialized
+    assert "formula" not in schema["properties"]["expression"]["$ref"]
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [
+        {"kind": "variable", "name": "z"},
+        {"kind": "formula", "value": "__import__('os').system('id')"},
+        {"kind": "power", "base": _variable(), "exponent": True},
+        {
+            "kind": "rational",
+            "value": {"num": "2", "den": "2"},
+        },
+    ],
+    ids=(
+        "undeclared_variable",
+        "untyped_formula_string",
+        "boolean_exponent",
+        "noncanonical_rational",
+    ),
+)
+def test_expression_contract_rejects_unsafe_or_ambiguous_nodes(
+    expression: dict[str, object],
+) -> None:
+    with pytest.raises(ValidationError):
+        PolynomialExpressionArtifact.model_validate(_artifact(expression))
+
+
+def test_expression_contract_rejects_expansion_term_blowup() -> None:
+    with pytest.raises(ValidationError, match="1024-term budget"):
+        PolynomialExpressionArtifact.model_validate(
+            _artifact(
+                {
+                    "kind": "power",
+                    "base": {
+                        "kind": "add",
+                        "operands": [_variable("x") for _ in range(16)],
+                    },
+                    "exponent": 4,
+                }
+            )
+        )
+
+
+def test_expression_contract_rejects_derived_exponent_beyond_output_ring() -> None:
+    with pytest.raises(ValidationError, match="exponent exceeds 127"):
+        PolynomialExpressionArtifact.model_validate(
+            _artifact(
+                {
+                    "kind": "power",
+                    "base": {
+                        "kind": "power",
+                        "base": _variable("x"),
+                        "exponent": 32,
+                    },
+                    "exponent": 4,
+                }
+            )
+        )
+
+
+def test_expression_contract_rejects_coefficient_growth_budget() -> None:
+    with pytest.raises(ValidationError, match="coefficient digit budget"):
+        PolynomialExpressionArtifact.model_validate(
+            _artifact(
+                {
+                    "kind": "power",
+                    "base": {
+                        "kind": "rational",
+                        "value": {"num": "9" * 256, "den": "1"},
+                    },
+                    "exponent": 32,
+                }
+            )
+        )
+
+
+def test_expression_contract_rejects_excessive_depth() -> None:
+    expression: dict[str, object] = _variable()
+    for _ in range(16):
+        expression = {"kind": "negate", "operand": expression}
+
+    with pytest.raises(ValidationError, match="depth 16"):
+        PolynomialExpressionArtifact.model_validate(_artifact(expression))

--- a/tests/integration/test_agent_ab_benchmark.py
+++ b/tests/integration/test_agent_ab_benchmark.py
@@ -263,6 +263,91 @@ def _hnf_report(
     }
 
 
+def _polynomial_normalization_case() -> dict[str, Any]:
+    return {
+        "case_id": "POLY-NORMALIZE-PRIVATE-TEST-001",
+        "version": "1",
+        "task_type": "polynomial_expression_normalization",
+        "prompt": "Normalize the exact supplied typed polynomial expression.",
+        "expression": {
+            "variables": ["x", "y"],
+            "expression": {
+                "kind": "multiply",
+                "operands": [
+                    {
+                        "kind": "add",
+                        "operands": [
+                            {"kind": "variable", "name": "x"},
+                            {"kind": "variable", "name": "y"},
+                        ],
+                    },
+                    {
+                        "kind": "add",
+                        "operands": [
+                            {"kind": "variable", "name": "x"},
+                            {
+                                "kind": "negate",
+                                "operand": {"kind": "variable", "name": "y"},
+                            },
+                        ],
+                    },
+                ],
+            },
+        },
+        "expected_normalized": {
+            "terms": [
+                {
+                    "coefficient": {"num": "1", "den": "1"},
+                    "exponents": [2, 0],
+                },
+                {
+                    "coefficient": {"num": "-1", "den": "1"},
+                    "exponents": [0, 2],
+                },
+            ]
+        },
+    }
+
+
+def _polynomial_normalization_report(
+    *,
+    expression_uri: str | None,
+    normalization_uri: str | None,
+    record_uri: str | None,
+    assurance: str,
+    final_verification: str,
+) -> dict[str, Any]:
+    return {
+        "case_id": "POLY-NORMALIZE-PRIVATE-TEST-001",
+        "status": "NORMALIZATION_PRODUCED",
+        "conclusion": "TRUE",
+        "variables": ["x", "y"],
+        "normalized": {
+            "terms": [
+                {
+                    "coefficient": {"num": "1", "den": "1"},
+                    "exponents": [2, 0],
+                },
+                {
+                    "coefficient": {"num": "-1", "den": "1"},
+                    "exponents": [0, 2],
+                },
+            ]
+        },
+        "assurance": assurance,
+        "final_verification": final_verification,
+        "expression_uri": expression_uri,
+        "normalization_uri": normalization_uri,
+        "verification_record_uri": record_uri,
+        "limitations": ["the exact supplied QQ-polynomial expression only"],
+        "feedback": {
+            "reasoning_focus": ["preserve the declared variable order"],
+            "infrastructure_work": [],
+            "tooling_gaps": [],
+        },
+    }
+
+
 def test_ab_sat_report_contract_identifies_the_producer_evidence_uri() -> None:
     schema_path = PROJECT_ROOT / "benchmarks" / "ab_cases" / "sat-report.schema.json"
     schema = json.loads(schema_path.read_text(encoding="utf-8"))
@@ -1723,6 +1808,101 @@ def test_ab_hnf_scorer_requires_bound_independently_replayed_evidence(
     with pytest.raises(
         cast(type[Exception], BENCHMARK["BenchmarkError"]),
         match="independent exact oracle",
+    ):
+        score_report(
+            case,
+            wrong,
+            condition="control",
+            state_dir=state_dir,
+            mcp_calls=[],
+        )
+
+
+def test_ab_polynomial_normalization_scorer_requires_bound_replay(
+    tmp_path: Path,
+) -> None:
+    score_report = cast(Any, BENCHMARK["score_report"])
+    case = _polynomial_normalization_case()
+    state_dir = tmp_path / "state"
+    kernel = JacobianKernel(state_dir, install_references=True)
+    computed = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="polynomial.expression.normalize",
+            mode=CapabilityMode.EXPLORE,
+            input={"expression": case["expression"]},
+        )
+    )
+    expression_uri = cast(str, computed.output["expression_uri"])
+    normalization_uri = cast(str, computed.output["normalization_uri"])
+    verified = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="polynomial.expression_normalization.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"normalization_uri": normalization_uri},
+        )
+    )
+    record_uri = verified.assurance.verification_record_uri
+    assert record_uri is not None
+
+    control = score_report(
+        case,
+        _polynomial_normalization_report(
+            expression_uri=None,
+            normalization_uri=None,
+            record_uri=None,
+            assurance="SELF_CHECKED",
+            final_verification="UNVERIFIED",
+        ),
+        condition="control",
+        state_dir=state_dir,
+        mcp_calls=[],
+    )
+    assert control["passed"] is True
+
+    treatment = score_report(
+        case,
+        _polynomial_normalization_report(
+            expression_uri=expression_uri,
+            normalization_uri=normalization_uri,
+            record_uri=record_uri,
+            assurance="VERIFIED",
+            final_verification="VERIFIED",
+        ),
+        condition="treatment",
+        state_dir=state_dir,
+        mcp_calls=["capability.invoke"],
+        capability_invocations=[
+            {
+                "capability_id": "polynomial.expression.normalize",
+                "input": {"expression": case["expression"]},
+                "output": computed.output,
+                "artifact_uris": computed.artifact_uris,
+            },
+            {
+                "capability_id": "polynomial.expression_normalization.verify",
+                "input": {"normalization_uri": normalization_uri},
+                "output": verified.output,
+                "artifact_uris": verified.artifact_uris,
+                "assurance": verified.assurance.model_dump(mode="json"),
+            },
+        ],
+    )
+
+    assert treatment["passed"] is True
+    assert treatment["false_certification"] is False
+    assert treatment["replay_success"] is True
+
+    wrong = _polynomial_normalization_report(
+        expression_uri=None,
+        normalization_uri=None,
+        record_uri=None,
+        assurance="SELF_CHECKED",
+        final_verification="UNVERIFIED",
+    )
+    wrong["normalized"]["terms"][1]["coefficient"]["num"] = "-2"
+    with pytest.raises(
+        cast(type[Exception], BENCHMARK["BenchmarkError"]),
+        match="held-out exact oracle",
     ):
         score_report(
             case,

--- a/tests/integration/test_polynomial_expression_normalization.py
+++ b/tests/integration/test_polynomial_expression_normalization.py
@@ -1,0 +1,528 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import jacobian.provider_runtime as provider_runtime
+from jacobian.bounded_process import BoundedProcessResult
+from jacobian.canonical import canonicalize_json
+from jacobian.contracts.capabilities import (
+    CapabilityAssuranceLevel,
+    CapabilityInstallTier,
+    CapabilityMode,
+    CapabilityProviderAvailability,
+    CapabilityRequest,
+    CapabilityResult,
+)
+from jacobian.contracts.results import ExecutionStatus
+from jacobian.kernel import JacobianKernel
+from jacobian.polynomial_expression_capabilities import (
+    install_polynomial_expression_checker,
+)
+
+pytestmark = pytest.mark.usefixtures("initialized_kernel_store")
+
+
+def _q(num: int | str, den: int | str = 1) -> dict[str, str]:
+    return {"num": str(num), "den": str(den)}
+
+
+def _variable(name: str) -> dict[str, Any]:
+    return {"kind": "variable", "name": name}
+
+
+def _expression(
+    node: dict[str, Any],
+    *,
+    variables: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "variables": variables or ["x", "y"],
+        "expression": node,
+    }
+
+
+def _invoke(
+    kernel: JacobianKernel,
+    capability_id: str,
+    payload: dict[str, Any],
+    *,
+    mode: CapabilityMode,
+) -> CapabilityResult:
+    return kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id=capability_id,
+            mode=mode,
+            input=payload,
+        )
+    )
+
+
+def _kernel_with_checker(root: Path) -> JacobianKernel:
+    kernel = JacobianKernel(root)
+    adapter, _installation = install_polynomial_expression_checker(
+        kernel.store,
+        kernel.schemas,
+        kernel.artifacts,
+        kernel.polynomial_expressions,
+        kernel.verification,
+        kernel.checkers,
+        authorize_checker=True,
+    )
+    assert adapter is not None
+    kernel.register_capability(adapter)
+    return kernel
+
+
+def _difference_of_squares_plus_half_x() -> dict[str, Any]:
+    return _expression(
+        {
+            "kind": "add",
+            "operands": [
+                {
+                    "kind": "multiply",
+                    "operands": [
+                        {
+                            "kind": "add",
+                            "operands": [_variable("x"), _variable("y")],
+                        },
+                        {
+                            "kind": "add",
+                            "operands": [
+                                _variable("x"),
+                                {"kind": "negate", "operand": _variable("y")},
+                            ],
+                        },
+                    ],
+                },
+                {
+                    "kind": "multiply",
+                    "operands": [
+                        {"kind": "rational", "value": _q(1, 2)},
+                        _variable("x"),
+                    ],
+                },
+            ],
+        }
+    )
+
+
+def test_sympy_normalizes_typed_multivariate_expression(tmp_path: Path) -> None:
+    kernel = JacobianKernel(tmp_path)
+
+    result = _invoke(
+        kernel,
+        "polynomial.expression.normalize",
+        {
+            "expression": _difference_of_squares_plus_half_x(),
+            "resource_budget": {"wall_seconds": 5},
+        },
+        mode=CapabilityMode.EXPLORE,
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output["status"] == "NORMALIZATION_PRODUCED"
+    assert result.output["conclusion"] == "UNKNOWN"
+    assert result.output["verification"] == "UNVERIFIED"
+    assert result.output["normalized"] == {
+        "terms": [
+            {"coefficient": _q(1), "exponents": [2, 0]},
+            {"coefficient": _q(1, 2), "exponents": [1, 0]},
+            {"coefficient": _q(-1), "exponents": [0, 2]},
+        ]
+    }
+    assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert result.relationships[0].relation_id == (
+        "polynomial.relation.expression-normalization-of"
+    )
+
+    resolved = kernel.polynomial_expressions.resolve_normalization(
+        result.output["normalization_uri"]
+    )
+    assert (
+        resolved.candidate.source.expression_artifact_uri
+        == result.output["expression_uri"]
+    )
+    assert result.output["expression_uri"] in resolved.artifact.manifest.parents
+
+
+def test_sympy_normalization_preserves_exact_zero(tmp_path: Path) -> None:
+    kernel = JacobianKernel(tmp_path)
+    result = _invoke(
+        kernel,
+        "polynomial.expression.normalize",
+        {
+            "expression": _expression(
+                {
+                    "kind": "add",
+                    "operands": [
+                        _variable("x"),
+                        {"kind": "negate", "operand": _variable("x")},
+                    ],
+                },
+                variables=["x"],
+            )
+        },
+        mode=CapabilityMode.EXPLORE,
+    )
+
+    assert result.output["normalized"] == {"terms": []}
+    assert result.output["status"] == "NORMALIZATION_PRODUCED"
+
+
+def test_sympy_normalization_runtime_has_exact_profile(tmp_path: Path) -> None:
+    runtime = JacobianKernel(tmp_path).sympy_polynomial_normalization_runtime
+
+    assert runtime.availability is CapabilityProviderAvailability.AVAILABLE
+    assert runtime.version == "1.14.0"
+    assert runtime.install_tier is CapabilityInstallTier.T0
+    assert runtime.digest is not None and runtime.digest.startswith("sha256:")
+    assert runtime.configuration == {
+        "distribution": "sympy",
+        "domain": "QQ",
+        "operation": "Poly(expression, *variables, domain=QQ).terms()",
+        "expression_schema_version": "1",
+        "maximum_variables": 4,
+        "maximum_nodes": 128,
+        "maximum_depth": 16,
+        "maximum_expanded_terms": 1024,
+        "maximum_exponent_per_variable": 127,
+        "maximum_coefficient_digit_budget": 4096,
+    }
+
+
+def test_sympy_normalization_runtime_rejects_unpinned_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    available = provider_runtime.sympy_polynomial_normalization_provider_runtime()
+    wrong = available.model_copy(update={"version": "1.13.3"})
+    monkeypatch.setattr(
+        provider_runtime,
+        "python_distribution_provider_runtime",
+        lambda *_args, **_kwargs: wrong,
+    )
+
+    rejected = provider_runtime.sympy_polynomial_normalization_provider_runtime(
+        refresh=True
+    )
+
+    assert rejected.availability is CapabilityProviderAvailability.UNAVAILABLE
+    assert rejected.version is None
+    assert rejected.digest is None
+    assert "pinned 1.14.0" in rejected.diagnostic
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [
+        {
+            "variables": ["x"],
+            "expression": {"kind": "variable", "name": "undeclared"},
+        },
+        {
+            "variables": ["x"],
+            "expression": {
+                "kind": "formula",
+                "value": "__import__('os').system('id')",
+            },
+        },
+        {
+            "variables": ["x"],
+            "expression": {
+                "kind": "power",
+                "base": {
+                    "kind": "add",
+                    "operands": [_variable("x") for _ in range(16)],
+                },
+                "exponent": 4,
+            },
+        },
+    ],
+    ids=("undeclared_variable", "formula_string", "expansion_blowup"),
+)
+def test_normalization_rejects_inputs_outside_typed_ast_contract(
+    tmp_path: Path,
+    expression: dict[str, Any],
+) -> None:
+    result = _invoke(
+        JacobianKernel(tmp_path),
+        "polynomial.expression.normalize",
+        {"expression": expression},
+        mode=CapabilityMode.EXPLORE,
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.output["error"]["stage"] in {
+        "capability_input_validation",
+        "input_validation",
+    }
+
+
+def test_independent_checker_verifies_full_ast_relation(tmp_path: Path) -> None:
+    kernel = _kernel_with_checker(tmp_path)
+    computed = _invoke(
+        kernel,
+        "polynomial.expression.normalize",
+        {"expression": _difference_of_squares_plus_half_x()},
+        mode=CapabilityMode.EXPLORE,
+    )
+    verified = _invoke(
+        kernel,
+        "polynomial.expression_normalization.verify",
+        {"normalization_uri": computed.output["normalization_uri"]},
+        mode=CapabilityMode.VERIFY,
+    )
+
+    assert verified.execution.status is ExecutionStatus.COMPLETED
+    assert verified.output["status"] == "VERIFIED_NORMALIZATION"
+    assert verified.output["conclusion"] == "TRUE"
+    assert verified.output["verification_record_uri"].startswith("artifact://sha256/")
+    assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED
+    assert verified.relationships[0].status.value == "VERIFIED"
+
+
+def test_independent_checker_rejects_wrong_bound_coefficients(
+    tmp_path: Path,
+) -> None:
+    kernel = _kernel_with_checker(tmp_path)
+    expression_uri = kernel.polynomial_expressions.put_expression(
+        _expression(_variable("x"), variables=["x"])
+    ).artifact_uri
+    candidate = kernel.polynomial_expressions.put_normalization(
+        expression_uri=expression_uri,
+        normalized={"terms": []},
+        producer=kernel.sympy_polynomial_normalization_runtime,
+        resource_budget={"wall_seconds": 5},
+    )
+
+    rejected = _invoke(
+        kernel,
+        "polynomial.expression_normalization.verify",
+        {"normalization_uri": candidate.artifact_uri},
+        mode=CapabilityMode.VERIFY,
+    )
+
+    assert rejected.execution.status is ExecutionStatus.COMPLETED
+    assert rejected.output["status"] == "REJECTED"
+    assert rejected.output["conclusion"] == "UNKNOWN"
+    assert rejected.output["verification_record_uri"] is None
+    assert rejected.assurance.level is not CapabilityAssuranceLevel.VERIFIED
+
+
+def test_sympy_normalization_timeout_is_operational(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    monkeypatch.setattr(
+        "jacobian.sympy_polynomial_normalization.run_bounded_process",
+        lambda *_args, **_kwargs: BoundedProcessResult(
+            returncode=None,
+            stdout=b"",
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=True,
+        ),
+    )
+
+    result = _invoke(
+        kernel,
+        "polynomial.expression.normalize",
+        {"expression": _expression(_variable("x"), variables=["x"])},
+        mode=CapabilityMode.EXPLORE,
+    )
+
+    assert result.execution.status is ExecutionStatus.TIMEOUT
+    assert result.output["status"] == "NO_NORMALIZATION_PRODUCED"
+    assert result.output["conclusion"] == "UNKNOWN"
+    assert result.output["normalization_uri"] is None
+    assert result.assurance.level is not CapabilityAssuranceLevel.VERIFIED
+
+
+def test_sympy_worker_gets_only_fixed_environment_and_budget(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JACOBIAN_SYMPY_SECRET", "must-not-propagate")
+    observed: dict[str, Any] = {}
+
+    def fake_worker(*_args: Any, **kwargs: Any) -> BoundedProcessResult:
+        observed.update(kwargs)
+        stdout = (
+            canonicalize_json(
+                {
+                    "protocol": "jacobian.sympy-polynomial-normalization/v1",
+                    "status": "NORMALIZATION_PRODUCED",
+                    "backend_version": "1.14.0",
+                    "normalized": {
+                        "terms": [
+                            {
+                                "coefficient": _q(1),
+                                "exponents": [1],
+                            }
+                        ]
+                    },
+                }
+            )
+            + b"\n"
+        )
+        return BoundedProcessResult(
+            returncode=0,
+            stdout=stdout,
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=False,
+        )
+
+    kernel = JacobianKernel(tmp_path)
+    monkeypatch.setattr(
+        "jacobian.sympy_polynomial_normalization.run_bounded_process",
+        fake_worker,
+    )
+    result = _invoke(
+        kernel,
+        "polynomial.expression.normalize",
+        {
+            "expression": _expression(_variable("x"), variables=["x"]),
+            "resource_budget": {"wall_seconds": 7},
+        },
+        mode=CapabilityMode.EXPLORE,
+    )
+
+    assert result.output["status"] == "NORMALIZATION_PRODUCED"
+    assert observed["timeout_seconds"] == 7.0
+    assert observed["environment"] == {
+        "LANG": "C",
+        "LC_ALL": "C",
+        "TZ": "UTC",
+        "PYTHONHASHSEED": "0",
+    }
+    assert "JACOBIAN_SYMPY_SECRET" in os.environ
+    assert "JACOBIAN_SYMPY_SECRET" not in observed["environment"]
+
+
+def test_normalization_output_is_discarded_if_runtime_identity_changes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    original = kernel.sympy_polynomial_normalization_runtime
+    changed = original.model_copy(update={"digest": "sha256:" + "f" * 64})
+    observations = iter((original, changed))
+    monkeypatch.setattr(
+        (
+            "jacobian.sympy_polynomial_normalization."
+            "sympy_polynomial_normalization_provider_runtime"
+        ),
+        lambda **_kwargs: next(observations),
+    )
+    monkeypatch.setattr(
+        "jacobian.sympy_polynomial_normalization.run_bounded_process",
+        lambda *_args, **_kwargs: BoundedProcessResult(
+            returncode=0,
+            stdout=canonicalize_json(
+                {
+                    "protocol": "jacobian.sympy-polynomial-normalization/v1",
+                    "status": "NORMALIZATION_PRODUCED",
+                    "backend_version": "1.14.0",
+                    "normalized": {
+                        "terms": [
+                            {
+                                "coefficient": _q(1),
+                                "exponents": [1],
+                            }
+                        ]
+                    },
+                }
+            )
+            + b"\n",
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=False,
+        ),
+    )
+
+    result = _invoke(
+        kernel,
+        "polynomial.expression.normalize",
+        {"expression": _expression(_variable("x"), variables=["x"])},
+        mode=CapabilityMode.EXPLORE,
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.output["status"] == "NO_NORMALIZATION_PRODUCED"
+    assert result.output["normalization_uri"] is None
+    assert "changed during execution" in result.output["detail"]
+
+
+def test_invalid_worker_protocol_retains_no_normalization_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    monkeypatch.setattr(
+        "jacobian.sympy_polynomial_normalization.run_bounded_process",
+        lambda *_args, **_kwargs: BoundedProcessResult(
+            returncode=0,
+            stdout=b'{"status":"NORMALIZATION_PRODUCED"}\n',
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=False,
+        ),
+    )
+
+    result = _invoke(
+        kernel,
+        "polynomial.expression.normalize",
+        {"expression": _expression(_variable("x"), variables=["x"])},
+        mode=CapabilityMode.EXPLORE,
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.output["status"] == "NO_NORMALIZATION_PRODUCED"
+    assert result.output["normalization_uri"] is None
+    assert result.output["conclusion"] == "UNKNOWN"
+
+
+def test_normalization_checker_timeout_is_operational(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = _kernel_with_checker(tmp_path)
+    computed = _invoke(
+        kernel,
+        "polynomial.expression.normalize",
+        {"expression": _expression(_variable("x"), variables=["x"])},
+        mode=CapabilityMode.EXPLORE,
+    )
+    monkeypatch.setattr(
+        "jacobian.verification.run_bounded_process",
+        lambda *_args, **_kwargs: BoundedProcessResult(
+            returncode=None,
+            stdout=b"",
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=True,
+        ),
+    )
+
+    result = _invoke(
+        kernel,
+        "polynomial.expression_normalization.verify",
+        {"normalization_uri": computed.output["normalization_uri"]},
+        mode=CapabilityMode.VERIFY,
+    )
+
+    assert result.execution.status is ExecutionStatus.TIMEOUT
+    assert result.output["status"] == "TIMEOUT"
+    assert result.output["conclusion"] == "UNKNOWN"
+    assert result.output["verification_record_uri"] is None
+    assert result.assurance.level is not CapabilityAssuranceLevel.VERIFIED

--- a/uv.lock
+++ b/uv.lock
@@ -536,7 +536,7 @@ requires-dist = [
     { name = "pydantic-core", specifier = ">=2.41,<3" },
     { name = "python-flint", marker = "extra == 'flint'", specifier = "==0.9.0" },
     { name = "rfc8785", specifier = "==0.1.4" },
-    { name = "sympy", specifier = ">=1.14,<2" },
+    { name = "sympy", specifier = "==1.14.0" },
     { name = "typer", specifier = ">=0.20,<1" },
     { name = "z3-solver", specifier = ">=4.15.4,<5" },
 ]


### PR DESCRIPTION
## Problem

Jacobian has exact polynomial capabilities, but it did not expose a safe atomic operation for turning a symbolic expression into canonical coefficients. Accepting formula strings would make parsing part of the trust boundary, and a successful CAS computation must not certify its own equivalence claim.

## Change

- Add `polynomial.expression.normalize`, backed by pinned SymPy 1.14.0 in an isolated bounded worker.
- Accept only a closed, versioned AST over an explicitly ordered `QQ` polynomial ring; reject strings, division, functions, assumptions, and over-budget expressions.
- Materialize separately bound source-expression and normalization artifacts with exact runtime provenance.
- Add `polynomial.expression_normalization.verify`, whose standard-library-only checker independently expands the full AST with `Fraction`, checks canonical sparse coefficients and every artifact binding, and promotes only clean-process acceptance to `VERIFIED`.
- Install the capabilities through the runtime catalog, document the contract and trust boundary, and add a private-case A/B scorer with clean replay.

## Compatibility and normative impact

This adds two experimental version-1 capability contracts and new artifact schemas. It does not add a top-level MCP tool. The base SymPy dependency is narrowed from `>=1.14,<2` to exactly `1.14.0` so producer provenance and replay behavior remain reproducible. Provider completion remains `COMPUTED/UNVERIFIED`; only the authorized independent checker can return `VERIFIED`.

## Validation

- `make check` — 347 passed, 4 deselected
- `make check-static` — Ruff, format, deptry, vulture, mypy, and wheel/sdist build passed
- focused contract/checker/integration/scorer suite — 36 passed, 29 deselected
- MCP/provider/reference-kernel integration set — 59 passed, 3 deselected
- deterministic differential probe — 30/30 random bounded expressions verified by clean replay
- `gpt-5.6-terra`, high, two private held-out expressions, four runs: control 2/2 passed; treatment 2/2 passed and 2/2 clean-replayed; zero false certifications, tool errors, parameter errors, capability rejections, or operational failures
- `git diff --check`
