### PR TITLE
feat(math): add verified rational inconsistency certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ availability can depend on local backends.
 | --- | --- |
 | Polynomial maps | Evaluate maps, compute Jacobians, search for collisions, independently verify collisions |
 | Polynomial algebra | Normalize typed expressions, factor univariate polynomials, verify identities, verify exact system solutions |
-| Exact linear algebra | Compute determinants, rank, kernels, and integer row Hermite normal forms; find and verify rational solutions to `Ax = b` |
+| Exact linear algebra | Compute determinants, rank, kernels, and integer row Hermite normal forms; find and independently verify rational solutions or inconsistency certificates for `Ax = b` |
 | Graphs | Construct and inspect graphs, enumerate paths, realize degree sequences, test isomorphism, search colorings |
 | SAT and SMT | Find models or proof artifacts; independently replay assignments, DRAT proofs, and Alethe proofs |
 | Universal algebra | Evaluate finite magma laws and search for countermodels |
@@ -160,7 +160,7 @@ agent-authored state; workspace entries remain `UNVERIFIED`.
 Specialized contracts cover
 [SAT artifacts](docs/reference/sat-artifacts.md),
 [SMT/Alethe artifacts](docs/reference/smt-artifacts.md),
-[exact rational solutions](docs/reference/linear-rational-solutions.md),
+[exact rational linear-system evidence](docs/reference/linear-rational-solutions.md),
 [integer matrix HNF](docs/reference/matrix-hermite-normal-form.md), and
 [Lean declaration discovery](docs/reference/lean-declaration-discovery.md).
 Architecture decisions are recorded in the
@@ -183,8 +183,8 @@ Some capabilities use backends that are not installed by default:
 
 - CaDiCaL finds SAT models and UNSAT proof artifacts.
 - cvc5 produces SMT UNSAT proofs; Carcara independently checks Alethe.
-- The `flint` extra accelerates exact rational linear algebra and integer row
-  Hermite normal forms.
+- The `flint` extra produces exact rational solution and inconsistency
+  witnesses and integer row Hermite normal forms.
 - Pinned Lean `CORE` and `MATHLIB` environments check formal certificates.
 
 Backend availability is not verification authority. Provider output remains

--- a/docs/contributing/atomic-capability-portfolio.md
+++ b/docs/contributing/atomic-capability-portfolio.md
@@ -473,8 +473,9 @@ proof-support claim. See
 
 ### Python-FLINT first
 
-The rational-solution and integer row-HNF slices are implemented; see the
-[exact rational solution contract](../reference/linear-rational-solutions.md)
+The rational solution, rational inconsistency-certificate, and integer row-HNF
+slices are implemented; see the
+[exact rational linear-system evidence contract](../reference/linear-rational-solutions.md)
 and [integer matrix HNF contract](../reference/matrix-hermite-normal-form.md).
 The rational-solution usability evidence is recorded in the
 [Python-FLINT rational-solution pilot](../reference/capability-workflow-evaluations.md#python-flint-rational-solution-pilot).
@@ -485,8 +486,10 @@ Implement one vertical slice at a time:
 1. `linear.rational_solution.find` returns one exact vector for a declared
    rational system. `linear.rational_solution.verify` independently checks
    `A x = b`. Failure to find a vector says nothing about consistency.
-2. Add an inconsistent-system outcome only with a separately checkable
-   left-nullspace or equivalent certificate.
+2. `linear.rational_inconsistency.find` is implemented with a normalized
+   left-nullspace witness `y^T A = 0`, `y^T b = 1`;
+   `linear.rational_inconsistency.verify` independently replays the exact
+   certificate. Failure to produce or accept a witness remains `UNKNOWN`.
 3. `matrix.normal_form.hermite` is implemented with the binding's complete
    left transformation. Independent replay checks `H = U A`, unimodularity,
    and every FLINT row-HNF condition.
@@ -588,7 +591,10 @@ backlog.
     [typed polynomial expression normalization contract](../reference/polynomial-expression-normalization.md)
     and the
     [SymPy normalization pilot](../reference/capability-workflow-evaluations.md#sympy-typed-polynomial-normalization-pilot).
-14. Re-rank E/Vampire, Metamath, nauty, Singular, PARI, Normaliz, GAP, fplll,
+14. Python-FLINT rational inconsistency-certificate find and verify slice.
+    Implemented; see the
+    [exact rational linear-system evidence contract](../reference/linear-rational-solutions.md#inconsistency-certificate).
+15. Re-rank E/Vampire, Metamath, nauty, Singular, PARI, Normaliz, GAP, fplll,
     and HiGHS from accumulated workflow evidence.
 
 Stop after each paired evaluation long enough to decide whether the next

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,7 +60,7 @@ expectations.
 - [Lean declaration discovery](reference/lean-declaration-discovery.md)
 - [SAT artifact contracts](reference/sat-artifacts.md)
 - [SMT Alethe artifact contracts](reference/smt-artifacts.md)
-- [Exact rational solution artifacts](reference/linear-rational-solutions.md)
+- [Exact rational linear-system evidence](reference/linear-rational-solutions.md)
 - [Integer matrix Hermite normal form](reference/matrix-hermite-normal-form.md)
 - [Typed polynomial expression normalization](reference/polynomial-expression-normalization.md)
 - [v0.2 specification](reference/specifications/v0.2.md)

--- a/docs/reference/linear-rational-solutions.md
+++ b/docs/reference/linear-rational-solutions.md
@@ -1,4 +1,4 @@
-# Exact rational solution artifacts
+# Exact rational linear-system evidence
 
 [Documentation home](../index.md)
 
@@ -9,22 +9,24 @@
 
 ## Capability boundary
 
-`linear.rational_solution.find` and
-`linear.rational_solution.verify` are separate mathematical operations:
+Solution vectors and inconsistency certificates are separate mathematical
+outcomes. Their producers and verifiers are also separate operations:
 
 | Capability | Observable outcome | Assurance |
 | --- | --- | --- |
 | `linear.rational_solution.find` | One exact vector bound to one stored rational system, or no vector | `COMPUTED` when the bounded provider attempt completes; never self-verified |
 | `linear.rational_solution.verify` | Independent replay of every equation for one bound vector | `VERIFIED` only after the operator-authorized checker creates a durable verification record |
+| `linear.rational_inconsistency.find` | One normalized left witness `y` with proposed relations `y^T A = 0` and `y^T b = 1`, or no witness | `COMPUTED` when the bounded provider attempt completes; never self-verified |
+| `linear.rational_inconsistency.verify` | Independent replay of every left-witness equation and the nonzero pairing | `VERIFIED` only after the operator-authorized checker creates a durable verification record |
 
-The producer runs only when the exact optional Python-FLINT distribution is
+The producers run only when the exact optional Python-FLINT distribution is
 available. Install the pinned wheel with:
 
 ```sh
 uv sync --extra flint
 ```
 
-The verifier does not import Python-FLINT, SymPy, or the producer. It uses
+The verifiers do not import Python-FLINT, SymPy, or the producers. They use
 standard-library `fractions.Fraction` arithmetic in the existing clean-process
 checker boundary. Bundled checker authorization remains an explicit
 `install_references=True` operator decision.
@@ -70,7 +72,7 @@ The variable order is semantic. A digest of the ordered list is included in
 the durable system binding so a vector cannot be silently rebound to permuted
 columns.
 
-## Producer behavior
+## Solution producer behavior
 
 The producer starts an isolated Python process with a fixed locale, timezone,
 and hash seed. Input, output, and wall time are bounded. The worker:
@@ -89,11 +91,9 @@ resource budget, and system-parent lineage. Its relationship to the system is
 still only proposed.
 
 `NO_SOLUTION_PRODUCED` has `UNKNOWN` conclusion and unknown completeness. It
-does not assert that the system is inconsistent. A later inconsistent-system
-capability requires a separately checkable left-nullspace or equivalent
-certificate.
+does not assert that the system is inconsistent.
 
-## Independent verification
+## Solution verification
 
 The authorized `linear.rational_solution.verify` checker accepts only when all
 of these hold:
@@ -112,6 +112,43 @@ and artifacts rebound to another system are rejected. Rejection, timeout,
 cancellation, runtime replacement, or malformed checker output remains
 `UNKNOWN` and cannot carry a verification record.
 
+## Inconsistency certificate
+
+For an inconsistent system, the certificate producer solves the dual exact
+rational system
+
+```text
+A^T y = 0
+b^T y = 1
+```
+
+with the same bounded isolated RREF worker. The second equality normalizes the
+witness and makes its nonzero pairing explicit. For example,
+
+```text
+A = [[1, 1], [2, 2]]
+b = [1, 3]
+y = [-2, 1]
+```
+
+has `y^T A = [0, 0]` and `y^T b = 1`. The durable certificate binds this
+ordered row witness to the full system URI, digests, dimensions, producer
+identity, budget, and system-parent lineage.
+
+The producer returns `CERTIFICATE_PRODUCED` with `UNKNOWN` conclusion and
+`UNVERIFIED` assurance. `NO_CERTIFICATE_PRODUCED`, timeout, cancellation,
+runtime replacement, or malformed output also remains `UNKNOWN`; none proves
+that the system is consistent.
+
+The authorized `linear.rational_inconsistency.verify` checker imports neither
+FLINT nor the producer. In a clean process it uses standard-library exact
+rational arithmetic to check every column sum
+`sum(y[i] * A[i][j]) == 0`, recompute `sum(y[i] * b[i])`, and require the
+stored and recomputed pairing to equal one. It also rechecks closed artifact
+shapes, canonical rationals, exact bindings, semantics, witness digests, and
+parent lineage. Only acceptance creates a verification record and the
+`VERIFIED_INCONSISTENT` result.
+
 ## Runtime identity and measurements
 
 The supported provider identity is:
@@ -121,8 +158,9 @@ The supported provider identity is:
 - license expression: `MIT AND LGPL-3.0-or-later`;
 - install tier: `T1`;
 - required API: `flint.fmpq` and `flint.fmpq_mat`;
-- operation profile: exact `QQ` reduced row-echelon form with free variables
-  fixed to zero.
+- operation profile: exact `QQ` reduced row-echelon form, either with free
+  variables fixed to zero for a solution vector or with the dual pairing
+  normalized to one for an inconsistency witness.
 
 On the 2026-07-26 Linux x86-64 development host, the repository measurement
 protocol recorded:
@@ -146,7 +184,7 @@ Python-FLINT is a maintained exact-arithmetic provider, not an independent
 verifier of its own output. Provider success, RREF rank, deterministic output,
 and durable storage remain computed evidence. Only the separately registered
 checker may authorize a `VERIFIED` result, and that promotion is bound to the
-exact system, vector, semantics, witness, checker digest, and verification
+exact system, candidate, semantics, witness, checker digest, and verification
 request.
 
 Primary provider references are the

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -127,7 +127,7 @@ of catalog membership:
 
 - [SAT artifact contracts](sat-artifacts.md);
 - [SMT Alethe artifact contracts](smt-artifacts.md);
-- [exact rational solution artifacts](linear-rational-solutions.md);
+- [exact rational linear-system evidence](linear-rational-solutions.md);
 - [integer matrix Hermite normal form](matrix-hermite-normal-form.md);
 - [typed polynomial expression normalization](polynomial-expression-normalization.md);
 - [Lean declaration discovery contract](lean-declaration-discovery.md).

--- a/src/jacobian/contracts/linear.py
+++ b/src/jacobian/contracts/linear.py
@@ -220,3 +220,127 @@ class LinearRationalSolutionVerificationOutput(ContractModel):
                 "non-verified solution output cannot carry a conclusion or record"
             )
         return self
+
+
+class LinearRationalInconsistencyArtifact(ContractModel):
+    """One normalized left-nullspace witness that proves ``A x = b`` inconsistent."""
+
+    certificate_schema_version: Literal["1"] = "1"
+    system: LinearSystemBinding
+    declared_scope: Literal["FULL_SYSTEM"] = "FULL_SYSTEM"
+    left_witness: tuple[CanonicalRational, ...] = Field(
+        min_length=1,
+        max_length=MAX_LINEAR_DIMENSION,
+    )
+    rhs_pairing: CanonicalRational
+    producer: CapabilityProviderRuntime
+    resource_budget: LinearRationalResourceBudget
+    method: Literal["DUAL_RREF_PAIRING_ONE"] = "DUAL_RREF_PAIRING_ONE"
+
+    @model_validator(mode="after")
+    def require_normalized_bound_certificate(self) -> Self:
+        if len(self.left_witness) != self.system.row_count:
+            raise ValueError(
+                "inconsistency witness must contain one value per system row"
+            )
+        if self.rhs_pairing.as_fraction() != 1:
+            raise ValueError("inconsistency witness must be normalized to y^T b = 1")
+        _require_bounded_rationals((*self.left_witness, self.rhs_pairing))
+        if (
+            self.producer.provider != "python-flint"
+            or self.producer.availability
+            is not CapabilityProviderAvailability.AVAILABLE
+            or self.producer.version != "0.9.0"
+        ):
+            raise ValueError(
+                "inconsistency producer must be the available pinned "
+                "Python-FLINT 0.9.0 runtime"
+            )
+        return self
+
+
+class LinearRationalInconsistencyFindRequest(ContractModel):
+    """Ask the pinned provider for one normalized inconsistency witness."""
+
+    system: LinearRationalSystem
+    resource_budget: LinearRationalResourceBudget = Field(
+        default_factory=LinearRationalResourceBudget
+    )
+
+
+class LinearRationalInconsistencyFindOutput(ContractModel):
+    """Unverified outcome of one bounded inconsistency-certificate attempt."""
+
+    status: Literal["CERTIFICATE_PRODUCED", "NO_CERTIFICATE_PRODUCED"]
+    conclusion: Literal["UNKNOWN"] = "UNKNOWN"
+    system_uri: ArtifactUri
+    certificate_uri: ArtifactUri | None = None
+    left_witness: tuple[CanonicalRational, ...] | None = None
+    rhs_pairing: CanonicalRational | None = None
+    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
+    determinism: Literal["DETERMINISTIC"] = "DETERMINISTIC"
+    verification: Literal["UNVERIFIED"] = "UNVERIFIED"
+    verification_candidate_available: bool
+    method: Literal["DUAL_RREF_PAIRING_ONE"] = "DUAL_RREF_PAIRING_ONE"
+    backend: Literal["python-flint"] = "python-flint"
+    backend_version: Literal["0.9.0"] = "0.9.0"
+    detail: str = Field(min_length=1, max_length=1024)
+
+    @model_validator(mode="after")
+    def bind_candidate_projection(self) -> Self:
+        produced = self.status == "CERTIFICATE_PRODUCED"
+        if produced != (
+            self.certificate_uri is not None
+            and self.left_witness is not None
+            and self.rhs_pairing is not None
+            and self.verification_candidate_available
+        ):
+            raise ValueError(
+                "produced output requires one durable normalized inconsistency witness"
+            )
+        if not produced and (
+            self.certificate_uri is not None
+            or self.left_witness is not None
+            or self.rhs_pairing is not None
+            or self.verification_candidate_available
+        ):
+            raise ValueError("not-found output cannot carry inconsistency evidence")
+        return self
+
+
+class LinearRationalInconsistencyVerificationRequest(ContractModel):
+    """Verify one stored normalized left-nullspace witness."""
+
+    certificate_uri: ArtifactUri
+
+
+class LinearRationalInconsistencyVerificationOutput(ContractModel):
+    """Model-facing projection of independent inconsistency replay."""
+
+    status: Literal[
+        "VERIFIED_INCONSISTENT",
+        "REJECTED",
+        "TIMEOUT",
+        "CANCELLED",
+        "ERROR",
+    ]
+    conclusion: Literal["TRUE", "UNKNOWN"]
+    system_uri: ArtifactUri
+    certificate_uri: ArtifactUri
+    witness_uri: ArtifactUri
+    checker_id: CheckerUri
+    verification_record_uri: ArtifactUri | None = None
+    detail: str = Field(min_length=1, max_length=1024)
+
+    @model_validator(mode="after")
+    def bind_verified_projection(self) -> Self:
+        if self.status == "VERIFIED_INCONSISTENT":
+            if self.conclusion != "TRUE" or self.verification_record_uri is None:
+                raise ValueError(
+                    "verified inconsistency requires TRUE and a verification record"
+                )
+        elif self.conclusion != "UNKNOWN" or self.verification_record_uri is not None:
+            raise ValueError(
+                "non-verified inconsistency cannot carry a conclusion or record"
+            )
+        return self

--- a/src/jacobian/flint_linear.py
+++ b/src/jacobian/flint_linear.py
@@ -1,4 +1,4 @@
-"""Bounded Python-FLINT rational-solution producer capability."""
+"""Bounded Python-FLINT rational linear-system evidence producers."""
 
 from __future__ import annotations
 
@@ -29,11 +29,16 @@ from jacobian.contracts.capabilities import (
 )
 from jacobian.contracts.exact import CanonicalRational
 from jacobian.contracts.linear import (
+    LinearRationalInconsistencyFindOutput,
+    LinearRationalInconsistencyFindRequest,
     LinearRationalSolutionFindOutput,
     LinearRationalSolutionFindRequest,
 )
 from jacobian.contracts.results import Execution, ExecutionStatus
-from jacobian.flint_linear_worker import FLINT_LINEAR_WORKER_PROTOCOL
+from jacobian.flint_linear_worker import (
+    FLINT_LINEAR_INCONSISTENCY_WORKER_PROTOCOL,
+    FLINT_LINEAR_WORKER_PROTOCOL,
+)
 from jacobian.linear import LinearArtifactService
 from jacobian.provider_runtime import (
     PYTHON_FLINT_VERSION,
@@ -53,6 +58,15 @@ class _FlintLinearRun:
     detail: str | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class _FlintLinearInconsistencyRun:
+    execution_status: ExecutionStatus
+    runtime_ms: int
+    left_witness: tuple[CanonicalRational, ...] | None = None
+    rhs_pairing: CanonicalRational | None = None
+    detail: str | None = None
+
+
 def install_python_flint_linear_capability(
     linear: LinearArtifactService,
     runtime: CapabilityProviderRuntime,
@@ -66,6 +80,24 @@ def install_python_flint_linear_capability(
     ):
         raise ValueError("the pinned Python-FLINT runtime is not available")
     return PythonFlintRationalSolutionFindAdapter(linear=linear, runtime=runtime)
+
+
+def install_python_flint_inconsistency_capability(
+    linear: LinearArtifactService,
+    runtime: CapabilityProviderRuntime,
+) -> CapabilityAdapter:
+    """Install the exact inconsistency-certificate producer."""
+
+    if (
+        runtime.availability is not CapabilityProviderAvailability.AVAILABLE
+        or runtime.provider != "python-flint"
+        or runtime.version != PYTHON_FLINT_VERSION
+    ):
+        raise ValueError("the pinned Python-FLINT runtime is not available")
+    return PythonFlintRationalInconsistencyFindAdapter(
+        linear=linear,
+        runtime=runtime,
+    )
 
 
 class _PythonFlintBackend:
@@ -316,6 +348,263 @@ class PythonFlintRationalSolutionFindAdapter:
         )
 
 
+class _PythonFlintInconsistencyBackend:
+    def __init__(self, runtime: CapabilityProviderRuntime) -> None:
+        self.runtime = runtime
+
+    def run(
+        self,
+        request: LinearRationalInconsistencyFindRequest,
+    ) -> _FlintLinearInconsistencyRun:
+        started = time.monotonic()
+        if python_flint_provider_runtime(refresh=True) != self.runtime:
+            return _inconsistency_failure(
+                started,
+                ExecutionStatus.ERROR,
+                (
+                    "The installed Python-FLINT runtime no longer matches the "
+                    "capability descriptor; no inconsistency evidence was retained."
+                ),
+            )
+        worker_request = {
+            "protocol": FLINT_LINEAR_INCONSISTENCY_WORKER_PROTOCOL,
+            "system": request.system.model_dump(mode="json"),
+        }
+        try:
+            completed = run_bounded_process(
+                [sys.executable, "-I", "-m", "jacobian.flint_linear_worker"],
+                input_bytes=canonicalize_json(worker_request),
+                timeout_seconds=float(request.resource_budget.wall_seconds),
+                environment={
+                    "LANG": "C",
+                    "LC_ALL": "C",
+                    "TZ": "UTC",
+                    "PYTHONHASHSEED": "0",
+                },
+                stdout_limit=FLINT_LINEAR_STDOUT_LIMIT,
+                stderr_limit=FLINT_LINEAR_STDERR_LIMIT,
+            )
+        except OSError:
+            return _inconsistency_failure(
+                started,
+                ExecutionStatus.ERROR,
+                "The isolated Python-FLINT worker could not be started.",
+            )
+        operational = _inconsistency_operational_failure(started, completed)
+        if operational is not None:
+            return operational
+        try:
+            left_witness, rhs_pairing = _parse_inconsistency_worker_output(
+                completed.stdout
+            )
+        except (UnicodeDecodeError, ValueError, ValidationError):
+            return _inconsistency_failure(
+                started,
+                ExecutionStatus.ERROR,
+                (
+                    "The Python-FLINT worker returned output outside its exact "
+                    "bounded protocol; no inconsistency evidence was retained."
+                ),
+            )
+        if python_flint_provider_runtime(refresh=True) != self.runtime:
+            return _inconsistency_failure(
+                started,
+                ExecutionStatus.ERROR,
+                (
+                    "The installed Python-FLINT runtime changed during execution; "
+                    "no inconsistency evidence was retained."
+                ),
+            )
+        return _FlintLinearInconsistencyRun(
+            execution_status=ExecutionStatus.COMPLETED,
+            runtime_ms=_runtime_ms(started),
+            left_witness=left_witness,
+            rhs_pairing=rhs_pairing,
+        )
+
+
+class PythonFlintRationalInconsistencyFindAdapter:
+    """Produce a normalized left witness without certifying it."""
+
+    def __init__(
+        self,
+        *,
+        linear: LinearArtifactService,
+        runtime: CapabilityProviderRuntime,
+    ) -> None:
+        self.linear = linear
+        self.backend = _PythonFlintInconsistencyBackend(runtime)
+        self._descriptor = CapabilityDescriptor(
+            capability_id="linear.rational_inconsistency.find",
+            version="1",
+            title="Find an exact rational inconsistency certificate",
+            description=(
+                "Use pinned Python-FLINT to seek a normalized left witness y for "
+                "a declared A x = b system, with y^T A = 0 and y^T b = 1. "
+                "A not-found outcome makes no consistency conclusion."
+            ),
+            provider="python-flint",
+            provider_runtime=runtime,
+            modes=(CapabilityMode.EXPLORE,),
+            input_schema=model_schema(LinearRationalInconsistencyFindRequest),
+            output_schema=model_schema(LinearRationalInconsistencyFindOutput),
+            tags=(
+                "linear-algebra",
+                "rational",
+                "exact",
+                "inconsistency",
+                "certificate",
+                "python-flint",
+            ),
+        )
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        return self._descriptor
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        try:
+            validated = LinearRationalInconsistencyFindRequest.model_validate(
+                request.input
+            )
+            system_uri = self.linear.put_system(validated.system).artifact_uri
+            resolved = self.linear.resolve_system(system_uri)
+        except (ValidationError, ValueError) as exc:
+            raise CapabilityInvocationError(
+                CapabilityDiagnostic(
+                    code="INVALID_RATIONAL_LINEAR_SYSTEM",
+                    stage="input_validation",
+                    message=str(exc),
+                    path="system",
+                    schema_uri=self.linear.installation.system_schema_uri,
+                    expected=(
+                        "one 1..32 by 1..32 exact rational A x = b system with "
+                        "unique ordered variable names and canonical reduced entries"
+                    ),
+                    hint=(
+                        'Encode each rational as {"num":"integer","den":"positive '
+                        'integer"} and keep coefficient, variable, and RHS dimensions '
+                        "aligned."
+                    ),
+                )
+            ) from exc
+        run = self.backend.run(validated)
+        certificate_uri: str | None = None
+        if (
+            run.execution_status is ExecutionStatus.COMPLETED
+            and run.left_witness is not None
+            and run.rhs_pairing is not None
+        ):
+            certificate_uri = self.linear.put_inconsistency(
+                system_uri=system_uri,
+                left_witness=run.left_witness,
+                rhs_pairing=run.rhs_pairing,
+                producer=self.backend.runtime,
+                resource_budget=validated.resource_budget,
+            ).artifact_uri
+        output = LinearRationalInconsistencyFindOutput(
+            status=(
+                "CERTIFICATE_PRODUCED"
+                if certificate_uri is not None
+                else "NO_CERTIFICATE_PRODUCED"
+            ),
+            system_uri=system_uri,
+            certificate_uri=certificate_uri,
+            left_witness=run.left_witness if certificate_uri is not None else None,
+            rhs_pairing=run.rhs_pairing if certificate_uri is not None else None,
+            verification_candidate_available=certificate_uri is not None,
+            detail=(
+                "Python-FLINT produced a normalized exact left witness; the "
+                "inconsistency claim remains unverified until independent replay."
+                if certificate_uri is not None
+                else (
+                    run.detail
+                    or "No normalized left witness was produced; no consistency "
+                    "conclusion follows."
+                )
+            ),
+        )
+        artifact_uris = (
+            (system_uri, certificate_uri)
+            if certificate_uri is not None
+            else (system_uri,)
+        )
+        relationships = (
+            (
+                CapabilityRelationship(
+                    relation_id="linear.relation.inconsistency-certificate-of",
+                    source_artifact_uris=(certificate_uri,),
+                    target_artifact_uris=(system_uri,),
+                ),
+            )
+            if certificate_uri is not None
+            else ()
+        )
+        return CapabilityResult(
+            capability_id=self.descriptor.capability_id,
+            capability_version=self.descriptor.version,
+            mode=request.mode,
+            execution=Execution(
+                status=run.execution_status,
+                runtime_ms=run.runtime_ms,
+                detail=run.detail,
+            ),
+            output=output.model_dump(mode="json"),
+            scope=CapabilityScope(
+                description="the full declared exact rational A x = b system",
+                parameters={
+                    "declared_scope": "FULL_SYSTEM",
+                    "row_count": resolved.binding.row_count,
+                    "column_count": resolved.binding.column_count,
+                    "variable_order_digest": resolved.binding.variable_order_digest,
+                    "normalization": "Y_TRANSPOSE_B_EQUALS_ONE",
+                    "wall_seconds": validated.resource_budget.wall_seconds,
+                },
+                artifact_uri=system_uri,
+            ),
+            completeness=CapabilityCompleteness(
+                status=(
+                    CapabilityCompletenessStatus.NOT_APPLICABLE
+                    if certificate_uri is not None
+                    else CapabilityCompletenessStatus.UNKNOWN
+                ),
+                basis=(
+                    "one directly checkable inconsistency witness was requested and "
+                    "produced"
+                    if certificate_uri is not None
+                    else "the attempt produced no witness; no consistency or "
+                    "inconsistency conclusion follows"
+                ),
+                assurance_level=(
+                    CapabilityAssuranceLevel.COMPUTED
+                    if run.execution_status is ExecutionStatus.COMPLETED
+                    else CapabilityAssuranceLevel.HEURISTIC
+                ),
+            ),
+            assurance=CapabilityAssurance(
+                level=(
+                    CapabilityAssuranceLevel.COMPUTED
+                    if run.execution_status is ExecutionStatus.COMPLETED
+                    else CapabilityAssuranceLevel.HEURISTIC
+                ),
+                basis=(
+                    "the pinned exact-arithmetic provider produced a bound left "
+                    "witness, but provider success does not verify its equations"
+                    if certificate_uri is not None
+                    else (
+                        "the bounded provider attempt completed without witness "
+                        "evidence; no opposite conclusion follows"
+                        if run.execution_status is ExecutionStatus.COMPLETED
+                        else "provider execution did not complete; no mathematical "
+                        "conclusion follows"
+                    )
+                ),
+            ),
+            artifact_uris=artifact_uris,
+            relationships=relationships,
+        )
+
+
 def _parse_worker_output(
     stdout: bytes,
 ) -> tuple[CanonicalRational, ...] | None:
@@ -345,6 +634,42 @@ def _parse_worker_output(
     if not isinstance(values, list) or not 1 <= len(values) <= 32:
         raise ValueError("worker solution shape is invalid")
     return tuple(CanonicalRational.model_validate(value) for value in values)
+
+
+def _parse_inconsistency_worker_output(
+    stdout: bytes,
+) -> tuple[tuple[CanonicalRational, ...] | None, CanonicalRational | None]:
+    if not stdout.endswith(b"\n") or stdout.count(b"\n") != 1:
+        raise ValueError("worker output is not exactly one line")
+    payload: Any = loads_strict_json(stdout[:-1])
+    if (
+        not isinstance(payload, dict)
+        or payload.get("protocol") != FLINT_LINEAR_INCONSISTENCY_WORKER_PROTOCOL
+    ):
+        raise ValueError("worker protocol mismatch")
+    status = payload.get("status")
+    if payload.get("backend_version") != PYTHON_FLINT_VERSION:
+        raise ValueError("worker backend version mismatch")
+    if status == "NO_CERTIFICATE_PRODUCED":
+        if set(payload) != {"protocol", "status", "backend_version"}:
+            raise ValueError("not-found output carries unexpected fields")
+        return None, None
+    if status != "CERTIFICATE_PRODUCED" or set(payload) != {
+        "protocol",
+        "status",
+        "backend_version",
+        "left_witness",
+        "rhs_pairing",
+    }:
+        raise ValueError("worker status is invalid")
+    values = payload["left_witness"]
+    if not isinstance(values, list) or not 1 <= len(values) <= 32:
+        raise ValueError("worker inconsistency-witness shape is invalid")
+    witness = tuple(CanonicalRational.model_validate(value) for value in values)
+    pairing = CanonicalRational.model_validate(payload["rhs_pairing"])
+    if pairing.as_fraction() != 1:
+        raise ValueError("worker witness is not normalized")
+    return witness, pairing
 
 
 def _operational_failure(
@@ -378,6 +703,43 @@ def _failure(
     detail: str,
 ) -> _FlintLinearRun:
     return _FlintLinearRun(
+        execution_status=status,
+        runtime_ms=_runtime_ms(started),
+        detail=detail,
+    )
+
+
+def _inconsistency_operational_failure(
+    started: float,
+    completed: BoundedProcessResult,
+) -> _FlintLinearInconsistencyRun | None:
+    if completed.timed_out:
+        return _inconsistency_failure(
+            started,
+            ExecutionStatus.TIMEOUT,
+            "The bounded Python-FLINT attempt timed out; no conclusion follows.",
+        )
+    if completed.stdout_exceeded or completed.stderr_exceeded:
+        return _inconsistency_failure(
+            started,
+            ExecutionStatus.ERROR,
+            "The Python-FLINT worker exceeded its output limit.",
+        )
+    if completed.returncode != 0 or completed.stderr or not completed.stdout:
+        return _inconsistency_failure(
+            started,
+            ExecutionStatus.ERROR,
+            ("The Python-FLINT worker failed; no inconsistency evidence was retained."),
+        )
+    return None
+
+
+def _inconsistency_failure(
+    started: float,
+    status: ExecutionStatus,
+    detail: str,
+) -> _FlintLinearInconsistencyRun:
+    return _FlintLinearInconsistencyRun(
         execution_status=status,
         runtime_ms=_runtime_ms(started),
         detail=detail,

--- a/src/jacobian/flint_linear_worker.py
+++ b/src/jacobian/flint_linear_worker.py
@@ -1,4 +1,4 @@
-"""Isolated Python-FLINT worker for one exact rational solution candidate."""
+"""Isolated Python-FLINT worker for exact rational linear-system candidates."""
 
 from __future__ import annotations
 
@@ -10,6 +10,9 @@ from fractions import Fraction
 from typing import Any
 
 FLINT_LINEAR_WORKER_PROTOCOL = "jacobian.flint-linear-worker/v1"
+FLINT_LINEAR_INCONSISTENCY_WORKER_PROTOCOL = (
+    "jacobian.flint-linear-inconsistency-worker/v1"
+)
 FLINT_LINEAR_INPUT_LIMIT = 1_000_000
 MAX_LINEAR_DIMENSION = 32
 MAX_RATIONAL_DIGITS = 256
@@ -25,10 +28,14 @@ class FlintLinearWorkerError(RuntimeError):
         self.code = code
 
 
-def _emit(payload: dict[str, object]) -> None:
+def _emit(
+    payload: dict[str, object],
+    *,
+    protocol: str = FLINT_LINEAR_WORKER_PROTOCOL,
+) -> None:
     sys.stdout.write(
         json.dumps(
-            {"protocol": FLINT_LINEAR_WORKER_PROTOCOL, **payload},
+            {"protocol": protocol, **payload},
             sort_keys=True,
             separators=(",", ":"),
         )
@@ -84,11 +91,10 @@ def _rational(value: Any) -> Fraction:
 
 def _validate_system(
     request: dict[str, Any],
+    *,
+    protocol: str,
 ) -> tuple[list[list[Fraction]], list[Fraction]]:
-    if (
-        set(request) != {"protocol", "system"}
-        or request.get("protocol") != FLINT_LINEAR_WORKER_PROTOCOL
-    ):
+    if set(request) != {"protocol", "system"} or request.get("protocol") != protocol:
         raise FlintLinearWorkerError("FLINT_LINEAR_INPUT_INVALID")
     system = request["system"]
     if not isinstance(system, dict) or set(system) != {
@@ -144,23 +150,19 @@ def _validate_system(
     )
 
 
-def _run(request: dict[str, Any]) -> dict[str, object]:
-    coefficients, rhs = _validate_system(request)
-    try:
-        flint: Any = importlib.import_module("flint")
-        if getattr(flint, "__version__", None) != "0.9.0":
-            raise FlintLinearWorkerError("FLINT_LINEAR_VERSION_MISMATCH")
-        augmented = flint.fmpq_mat(
-            [
-                [flint.fmpq(value.numerator, value.denominator) for value in row]
-                + [flint.fmpq(bound.numerator, bound.denominator)]
-                for row, bound in zip(coefficients, rhs, strict=True)
-            ]
-        )
-        reduced, _ = augmented.rref()
-    except (AttributeError, ImportError, OSError, RuntimeError, TypeError) as exc:
-        raise FlintLinearWorkerError("FLINT_LINEAR_EXECUTION_FAILED") from exc
-
+def _solve(
+    coefficients: list[list[Fraction]],
+    rhs: list[Fraction],
+    flint: Any,
+) -> list[Any] | None:
+    augmented = flint.fmpq_mat(
+        [
+            [flint.fmpq(value.numerator, value.denominator) for value in row]
+            + [flint.fmpq(bound.numerator, bound.denominator)]
+            for row, bound in zip(coefficients, rhs, strict=True)
+        ]
+    )
+    reduced, _ = augmented.rref()
     column_count = len(coefficients[0])
     values = [flint.fmpq(0) for _ in range(column_count)]
     for row_index in range(reduced.nrows()):
@@ -174,13 +176,58 @@ def _run(request: dict[str, Any]) -> dict[str, object]:
         )
         if pivot is None:
             if reduced[row_index, column_count] != 0:
-                return {
-                    "status": "NO_SOLUTION_PRODUCED",
-                    "backend_version": "0.9.0",
-                }
+                return None
             continue
         values[pivot] = reduced[row_index, column_count]
+    return values
 
+
+def _run(request: dict[str, Any]) -> dict[str, object]:
+    protocol = request.get("protocol")
+    if protocol not in {
+        FLINT_LINEAR_WORKER_PROTOCOL,
+        FLINT_LINEAR_INCONSISTENCY_WORKER_PROTOCOL,
+    }:
+        raise FlintLinearWorkerError("FLINT_LINEAR_INPUT_INVALID")
+    assert isinstance(protocol, str)
+    coefficients, rhs = _validate_system(request, protocol=protocol)
+    try:
+        flint: Any = importlib.import_module("flint")
+        if getattr(flint, "__version__", None) != "0.9.0":
+            raise FlintLinearWorkerError("FLINT_LINEAR_VERSION_MISMATCH")
+        if protocol == FLINT_LINEAR_INCONSISTENCY_WORKER_PROTOCOL:
+            row_count = len(coefficients)
+            column_count = len(coefficients[0])
+            dual_coefficients = [
+                [coefficients[row][column] for row in range(row_count)]
+                for column in range(column_count)
+            ]
+            dual_coefficients.append(rhs)
+            dual_rhs = [Fraction(0) for _ in range(column_count)] + [Fraction(1)]
+            values = _solve(dual_coefficients, dual_rhs, flint)
+        else:
+            values = _solve(coefficients, rhs, flint)
+    except (AttributeError, ImportError, OSError, RuntimeError, TypeError) as exc:
+        raise FlintLinearWorkerError("FLINT_LINEAR_EXECUTION_FAILED") from exc
+    if values is None:
+        return {
+            "status": (
+                "NO_CERTIFICATE_PRODUCED"
+                if protocol == FLINT_LINEAR_INCONSISTENCY_WORKER_PROTOCOL
+                else "NO_SOLUTION_PRODUCED"
+            ),
+            "backend_version": "0.9.0",
+        }
+    if protocol == FLINT_LINEAR_INCONSISTENCY_WORKER_PROTOCOL:
+        return {
+            "status": "CERTIFICATE_PRODUCED",
+            "backend_version": "0.9.0",
+            "left_witness": [
+                {"num": str(value.numerator), "den": str(value.denominator)}
+                for value in values
+            ],
+            "rhs_pairing": {"num": "1", "den": "1"},
+        }
     return {
         "status": "SOLUTION_PRODUCED",
         "backend_version": "0.9.0",
@@ -192,12 +239,16 @@ def _run(request: dict[str, Any]) -> dict[str, object]:
 
 
 def main() -> int:
+    protocol = FLINT_LINEAR_WORKER_PROTOCOL
     try:
-        result = _run(_read_request())
+        request = _read_request()
+        if request.get("protocol") == FLINT_LINEAR_INCONSISTENCY_WORKER_PROTOCOL:
+            protocol = FLINT_LINEAR_INCONSISTENCY_WORKER_PROTOCOL
+        result = _run(request)
     except FlintLinearWorkerError as exc:
-        _emit({"error_code": exc.code})
+        _emit({"error_code": exc.code}, protocol=protocol)
         return 2
-    _emit(result)
+    _emit(result, protocol=protocol)
     return 0
 
 

--- a/src/jacobian/kernel.py
+++ b/src/jacobian/kernel.py
@@ -35,7 +35,10 @@ from jacobian.finite_partition import (
     install_finite_partition,
 )
 from jacobian.flint_hnf import install_python_flint_hnf_capability
-from jacobian.flint_linear import install_python_flint_linear_capability
+from jacobian.flint_linear import (
+    install_python_flint_inconsistency_capability,
+    install_python_flint_linear_capability,
+)
 from jacobian.graph_capabilities import GraphInstallation, install_graph_capabilities
 from jacobian.graph_isomorphism import (
     GraphIsomorphismInstallation,
@@ -52,7 +55,9 @@ from jacobian.lean_exploration import (
 )
 from jacobian.linear import LinearArtifactService, install_linear_artifacts
 from jacobian.linear_capabilities import (
+    LinearRationalInconsistencyCheckerInstallation,
     LinearRationalSolutionCheckerInstallation,
+    install_linear_rational_inconsistency_checker,
     install_linear_rational_solution_checker,
 )
 from jacobian.matrix_capabilities import (
@@ -335,25 +340,24 @@ class JacobianKernel:
         )
         if linear_verification_adapter is not None:
             self.register_capability(linear_verification_adapter)
-        self.python_flint_runtime: CapabilityProviderRuntime = (
-            python_flint_provider_runtime()
+        self.linear_inconsistency_checker: (
+            LinearRationalInconsistencyCheckerInstallation
         )
-        if (
-            self.python_flint_runtime.availability
-            is CapabilityProviderAvailability.AVAILABLE
-        ):
-            try:
-                linear_find_adapter = install_python_flint_linear_capability(
-                    self.linear,
-                    self.python_flint_runtime,
-                )
-            except (OSError, ValueError) as exc:
-                _LOGGER.warning(
-                    "Python-FLINT rational solution exploration is not installed: %s",
-                    exc,
-                )
-            else:
-                self.register_capability(linear_find_adapter)
+        (
+            linear_inconsistency_verification_adapter,
+            self.linear_inconsistency_checker,
+        ) = install_linear_rational_inconsistency_checker(
+            self.store,
+            self.schemas,
+            self.artifacts,
+            self.linear,
+            self.verification,
+            self.checkers,
+            authorize_checker=install_references,
+        )
+        if linear_inconsistency_verification_adapter is not None:
+            self.register_capability(linear_inconsistency_verification_adapter)
+        self._install_python_flint_capabilities()
         self._install_matrix_normal_form_capabilities(
             authorize_checker=install_references
         )
@@ -589,6 +593,40 @@ class JacobianKernel:
             )
         else:
             self.register_capability(adapter)
+
+    def _install_python_flint_capabilities(self) -> None:
+        """Install exact rational linear producers when the pin is available."""
+
+        self.python_flint_runtime = python_flint_provider_runtime()
+        if (
+            self.python_flint_runtime.availability
+            is not CapabilityProviderAvailability.AVAILABLE
+        ):
+            return
+        try:
+            solution_adapter = install_python_flint_linear_capability(
+                self.linear,
+                self.python_flint_runtime,
+            )
+        except (OSError, ValueError) as exc:
+            _LOGGER.warning(
+                "Python-FLINT rational solution exploration is not installed: %s",
+                exc,
+            )
+        else:
+            self.register_capability(solution_adapter)
+        try:
+            inconsistency_adapter = install_python_flint_inconsistency_capability(
+                self.linear,
+                self.python_flint_runtime,
+            )
+        except (OSError, ValueError) as exc:
+            _LOGGER.warning(
+                "Python-FLINT rational inconsistency exploration is not installed: %s",
+                exc,
+            )
+        else:
+            self.register_capability(inconsistency_adapter)
 
     def _install_polynomial_expression_capabilities(
         self,

--- a/src/jacobian/linear.py
+++ b/src/jacobian/linear.py
@@ -12,6 +12,7 @@ from jacobian.artifacts import ArtifactService
 from jacobian.contracts.artifacts import ArtifactPutResult
 from jacobian.contracts.capabilities import CapabilityProviderRuntime
 from jacobian.contracts.linear import (
+    LinearRationalInconsistencyArtifact,
     LinearRationalResourceBudget,
     LinearRationalSolutionArtifact,
     LinearRationalSystem,
@@ -31,6 +32,7 @@ class LinearArtifactInstallation:
     semantics_uri: str
     system_schema_uri: str
     solution_schema_uri: str
+    inconsistency_schema_uri: str
 
 
 @dataclass(frozen=True, slots=True)
@@ -48,8 +50,16 @@ class ResolvedLinearSolution:
     system: LinearRationalSystem
 
 
+@dataclass(frozen=True, slots=True)
+class ResolvedLinearInconsistency:
+    artifact: StoredArtifact
+    certificate: LinearRationalInconsistencyArtifact
+    system_artifact: StoredArtifact
+    system: LinearRationalSystem
+
+
 class LinearArtifactService:
-    """Materialize exact systems and unverified vectors with strict bindings."""
+    """Materialize exact systems and unverified evidence with strict bindings."""
 
     def __init__(
         self,
@@ -185,13 +195,85 @@ class LinearArtifactService:
             system=resolved_system.system,
         )
 
+    def put_inconsistency(
+        self,
+        *,
+        system_uri: str,
+        left_witness: Sequence[Any],
+        rhs_pairing: Any,
+        producer: CapabilityProviderRuntime,
+        resource_budget: LinearRationalResourceBudget | dict[str, Any],
+    ) -> ArtifactPutResult:
+        """Materialize one normalized inconsistency witness without checking it."""
+
+        resolved = self.resolve_system(system_uri)
+        certificate = LinearRationalInconsistencyArtifact(
+            system=resolved.binding,
+            left_witness=tuple(left_witness),
+            rhs_pairing=rhs_pairing,
+            producer=producer,
+            resource_budget=LinearRationalResourceBudget.model_validate(
+                resource_budget
+            ),
+        )
+        return self.artifacts.put(
+            schema_uri=self.installation.inconsistency_schema_uri,
+            semantics_uri=self.installation.semantics_uri,
+            payload=certificate.model_dump(mode="json"),
+            parents=(resolved.artifact.artifact_uri,),
+            summary="unverified exact rational inconsistency certificate",
+        )
+
+    def resolve_inconsistency(
+        self,
+        certificate_uri: str,
+    ) -> ResolvedLinearInconsistency:
+        """Resolve a certificate whose payload and lineage bind one exact system."""
+
+        try:
+            artifact = self.store.get(certificate_uri)
+        except StoreError as exc:
+            raise LinearArtifactError(
+                "source is not an available rational inconsistency artifact"
+            ) from exc
+        if (
+            artifact.manifest.schema_uri != self.installation.inconsistency_schema_uri
+            or artifact.manifest.semantics_uri != self.installation.semantics_uri
+        ):
+            raise LinearArtifactError("source is not a rational inconsistency artifact")
+        try:
+            normalized = self.schemas.validate(
+                self.installation.inconsistency_schema_uri,
+                artifact.payload,
+            )
+            certificate = LinearRationalInconsistencyArtifact.model_validate(normalized)
+        except (SchemaRegistryError, ValueError, ValidationError) as exc:
+            raise LinearArtifactError(
+                "source is not a valid rational inconsistency artifact"
+            ) from exc
+        resolved_system = self.resolve_system(certificate.system.system_artifact_uri)
+        if certificate.system != resolved_system.binding:
+            raise LinearArtifactError(
+                "inconsistency binding does not match its exact rational system"
+            )
+        if resolved_system.artifact.artifact_uri not in artifact.manifest.parents:
+            raise LinearArtifactError(
+                "inconsistency certificate is missing its rational-system parent"
+            )
+        return ResolvedLinearInconsistency(
+            artifact=artifact,
+            certificate=certificate,
+            system_artifact=resolved_system.artifact,
+            system=resolved_system.system,
+        )
+
 
 def install_linear_artifacts(
     store: ArtifactStore,
     schemas: SchemaRegistry,
     artifacts: ArtifactService,
 ) -> LinearArtifactService:
-    """Register exact rational system and candidate-vector contracts."""
+    """Register exact rational system and evidence-candidate contracts."""
 
     semantics_uri = store.register_descriptor(
         kind="semantics",
@@ -199,7 +281,13 @@ def install_linear_artifacts(
         version="1",
         definition={
             "domain": "finite linear systems over the rational field QQ",
-            "relation": "A candidate x supports the exact claim A x = b",
+            "relations": {
+                "solution": "a candidate x supports the exact claim A x = b",
+                "inconsistency": (
+                    "a left witness y with y^T A = 0 and y^T b = 1 supports "
+                    "that A x = b has no solution"
+                ),
+            },
             "variable_order": (
                 "coefficient columns and candidate entries follow the declared "
                 "ordered unique variable list"
@@ -207,6 +295,10 @@ def install_linear_artifacts(
             "candidate": (
                 "a total exact rational vector bound by payload and lineage to one "
                 "system; producing or storing it does not verify the relation"
+            ),
+            "inconsistency_certificate": (
+                "a normalized exact left witness bound by payload and lineage to "
+                "one system; producing or storing it does not verify the relation"
             ),
             "not_found": (
                 "failure to produce a candidate makes no consistency or "
@@ -230,6 +322,11 @@ def install_linear_artifacts(
             name="jacobian.linear-rational-solution",
             version="1",
             model=LinearRationalSolutionArtifact,
+        ),
+        inconsistency_schema_uri=schemas.register_model(
+            name="jacobian.linear-rational-inconsistency",
+            version="1",
+            model=LinearRationalInconsistencyArtifact,
         ),
     )
     return LinearArtifactService(store, schemas, artifacts, installation)

--- a/src/jacobian/linear_capabilities.py
+++ b/src/jacobian/linear_capabilities.py
@@ -1,4 +1,4 @@
-"""Independent verification capability for exact rational solution vectors."""
+"""Independent verification of exact rational linear-system evidence."""
 
 from __future__ import annotations
 
@@ -15,6 +15,8 @@ from jacobian.contracts.capabilities import (
     CapabilityDescriptor,
     CapabilityDiagnostic,
     CapabilityMode,
+    CapabilityRelationship,
+    CapabilityRelationshipStatus,
     CapabilityRequest,
     CapabilityResult,
     CapabilityScope,
@@ -25,6 +27,8 @@ from jacobian.contracts.evidence import (
     WitnessRole,
 )
 from jacobian.contracts.linear import (
+    LinearRationalInconsistencyVerificationOutput,
+    LinearRationalInconsistencyVerificationRequest,
     LinearRationalSolutionVerificationOutput,
     LinearRationalSolutionVerificationRequest,
 )
@@ -41,6 +45,61 @@ from jacobian.verification import VerificationService
 class LinearRationalSolutionCheckerInstallation:
     witness_schema_uri: str
     checker_id: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class LinearRationalInconsistencyCheckerInstallation:
+    witness_schema_uri: str
+    checker_id: str | None
+
+
+def install_linear_rational_inconsistency_checker(
+    store: ArtifactStore,
+    schemas: SchemaRegistry,
+    artifacts: ArtifactService,
+    linear: LinearArtifactService,
+    verification: VerificationService,
+    checkers: CheckerRegistry,
+    *,
+    authorize_checker: bool,
+) -> tuple[
+    CapabilityAdapter | None,
+    LinearRationalInconsistencyCheckerInstallation,
+]:
+    """Install the witness schema and optionally authorize exact replay."""
+
+    witness_schema_uri = schemas.register_model(
+        name="jacobian.witness-envelope",
+        version="1",
+        model=WitnessEnvelope,
+    )
+    checker_id = None
+    if authorize_checker:
+        checker_id = checkers.authorize(
+            name="exact rational linear-inconsistency replay checker",
+            entrypoint="jacobian_checkers.linear:check_rational_inconsistency",
+            evidence_kind="WITNESS",
+            format_id="linear.rational_inconsistency",
+            format_version="1",
+            claim_schema_uris=(linear.installation.system_schema_uri,),
+            semantics_uris=(linear.installation.semantics_uri,),
+            candidate_schema_uris=(linear.installation.inconsistency_schema_uri,),
+            reason="bundled independent exact rational left-witness checker",
+        ).checker_id
+    installation = LinearRationalInconsistencyCheckerInstallation(
+        witness_schema_uri=witness_schema_uri,
+        checker_id=checker_id,
+    )
+    adapter: CapabilityAdapter | None = None
+    if checker_id is not None:
+        adapter = LinearRationalInconsistencyVerificationAdapter(
+            store=store,
+            artifacts=artifacts,
+            linear=linear,
+            verification=verification,
+            installation=installation,
+        )
+    return adapter, installation
 
 
 def install_linear_rational_solution_checker(
@@ -316,4 +375,245 @@ class LinearRationalSolutionVerificationAdapter:
                 verification_record_uri=record_uri,
             ),
             artifact_uris=tuple(artifact_uris),
+        )
+
+
+class LinearRationalInconsistencyVerificationAdapter:
+    """Independently replay a normalized left inconsistency witness."""
+
+    def __init__(
+        self,
+        *,
+        store: ArtifactStore,
+        artifacts: ArtifactService,
+        linear: LinearArtifactService,
+        verification: VerificationService,
+        installation: LinearRationalInconsistencyCheckerInstallation,
+    ) -> None:
+        checker_id = installation.checker_id
+        if checker_id is None:
+            raise ValueError("rational inconsistency checker is not authorized")
+        self.store = store
+        self.artifacts = artifacts
+        self.linear = linear
+        self.verification = verification
+        self.installation = installation
+        self._descriptor = CapabilityDescriptor(
+            capability_id="linear.rational_inconsistency.verify",
+            version="1",
+            title="Verify an exact rational inconsistency certificate",
+            description=(
+                "Independently check every column of y^T A = 0 and the normalized "
+                "pairing y^T b = 1 for one stored exact rational system."
+            ),
+            provider="jacobian.linear",
+            provider_runtime=known_provider_runtime(
+                "jacobian.linear",
+                features=(
+                    "exact-rational-left-witness-replay",
+                    "normalized-nonzero-pairing",
+                    "clean-process-checker",
+                ),
+                checker_ids=(checker_id,),
+            ),
+            modes=(CapabilityMode.VERIFY,),
+            input_schema=model_schema(LinearRationalInconsistencyVerificationRequest),
+            output_schema=model_schema(LinearRationalInconsistencyVerificationOutput),
+            tags=(
+                "linear-algebra",
+                "rational",
+                "inconsistency",
+                "certificate",
+                "verification",
+            ),
+        )
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        return self._descriptor
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        validated = LinearRationalInconsistencyVerificationRequest.model_validate(
+            request.input
+        )
+        try:
+            resolved = self.linear.resolve_inconsistency(validated.certificate_uri)
+            semantics = self.store.get(self.linear.installation.semantics_uri)
+        except (LinearArtifactError, StoreError) as exc:
+            raise CapabilityInvocationError(
+                CapabilityDiagnostic(
+                    code="INVALID_RATIONAL_INCONSISTENCY_CERTIFICATE",
+                    stage="artifact_resolution",
+                    message=str(exc),
+                    path="certificate_uri",
+                    schema_uri=self.linear.installation.inconsistency_schema_uri,
+                    expected=(
+                        "a normalized exact rational left witness bound by payload "
+                        "and lineage to one rational linear-system artifact"
+                    ),
+                    hint=(
+                        "Use linear.rational_inconsistency.find or materialize a "
+                        "candidate against the intended system."
+                    ),
+                )
+            ) from exc
+
+        checker_id = self.installation.checker_id
+        assert checker_id is not None
+        bindings = EvidenceBindings(
+            claim_digest=resolved.system_artifact.manifest.object_digest,
+            semantics_digest=semantics.manifest.object_digest,
+            candidate_digest=resolved.artifact.manifest.object_digest,
+        )
+        witness = WitnessEnvelope(
+            witness_format="linear.rational_inconsistency",
+            format_version="1",
+            role=WitnessRole.SUPPORTS_CLAIM,
+            bindings=bindings,
+            payload={
+                "system_uri": resolved.system_artifact.artifact_uri,
+                "certificate_uri": resolved.artifact.artifact_uri,
+            },
+        )
+        witness_artifact = self.artifacts.put(
+            schema_uri=self.installation.witness_schema_uri,
+            semantics_uri=self.linear.installation.semantics_uri,
+            payload=witness.model_dump(mode="json"),
+            parents=(
+                resolved.system_artifact.artifact_uri,
+                resolved.artifact.artifact_uri,
+            ),
+            summary="rational linear-inconsistency verification witness",
+        )
+        checked = self.verification.verify_witness(
+            claim_uri=resolved.system_artifact.artifact_uri,
+            candidate_uri=resolved.artifact.artifact_uri,
+            witness_uri=witness_artifact.artifact_uri,
+            checker_id=checker_id,
+            include_artifact_metadata=True,
+        )
+        verified = (
+            checked.execution.status is ExecutionStatus.COMPLETED
+            and checked.conclusion is Conclusion.TRUE
+            and checked.assurance.verification is Verification.VERIFIED
+            and checked.verification_record_uri is not None
+        )
+        status: Literal[
+            "VERIFIED_INCONSISTENT",
+            "REJECTED",
+            "TIMEOUT",
+            "CANCELLED",
+            "ERROR",
+        ]
+        if verified:
+            status = "VERIFIED_INCONSISTENT"
+        elif checked.execution.status is ExecutionStatus.COMPLETED:
+            status = "REJECTED"
+        elif checked.execution.status is ExecutionStatus.TIMEOUT:
+            status = "TIMEOUT"
+        elif checked.execution.status is ExecutionStatus.CANCELLED:
+            status = "CANCELLED"
+        else:
+            status = "ERROR"
+        detail = checked.execution.detail
+        if detail is None and checked.input.errors:
+            detail = checked.input.errors[0]
+        if detail is None:
+            detail = (
+                "the authorized checker accepted every exact left-witness equation"
+                if verified
+                else "the candidate was not independently accepted"
+            )
+        output = LinearRationalInconsistencyVerificationOutput(
+            status=status,
+            conclusion="TRUE" if verified else "UNKNOWN",
+            system_uri=resolved.system_artifact.artifact_uri,
+            certificate_uri=resolved.artifact.artifact_uri,
+            witness_uri=witness_artifact.artifact_uri,
+            checker_id=checker_id,
+            verification_record_uri=(
+                checked.verification_record_uri if verified else None
+            ),
+            detail=detail,
+        )
+        record_uri = checked.verification_record_uri if verified else None
+        artifact_uris = [
+            resolved.system_artifact.artifact_uri,
+            resolved.artifact.artifact_uri,
+            witness_artifact.artifact_uri,
+        ]
+        if record_uri is not None:
+            artifact_uris.append(record_uri)
+        assurance_level = (
+            CapabilityAssuranceLevel.VERIFIED
+            if verified
+            else (
+                CapabilityAssuranceLevel.COMPUTED
+                if checked.execution.status is ExecutionStatus.COMPLETED
+                else CapabilityAssuranceLevel.HEURISTIC
+            )
+        )
+        return CapabilityResult(
+            capability_id=self.descriptor.capability_id,
+            capability_version=self.descriptor.version,
+            mode=request.mode,
+            execution=checked.execution,
+            output=output.model_dump(mode="json"),
+            scope=CapabilityScope(
+                description=(
+                    "the full exact rational A x = b system bound by the left witness"
+                ),
+                parameters={
+                    "declared_scope": "FULL_SYSTEM",
+                    "row_count": len(resolved.system.coefficients.entries),
+                    "column_count": len(resolved.system.variables),
+                    "variable_order_digest": (
+                        resolved.certificate.system.variable_order_digest
+                    ),
+                    "normalization": "Y_TRANSPOSE_B_EQUALS_ONE",
+                },
+                artifact_uri=resolved.system_artifact.artifact_uri,
+            ),
+            completeness=CapabilityCompleteness(
+                status=CapabilityCompletenessStatus.NOT_APPLICABLE,
+                basis=(
+                    "direct exact replay of one left witness establishes "
+                    "inconsistency when accepted"
+                ),
+                assurance_level=(
+                    CapabilityAssuranceLevel.COMPUTED
+                    if checked.execution.status is ExecutionStatus.COMPLETED
+                    else CapabilityAssuranceLevel.HEURISTIC
+                ),
+            ),
+            assurance=CapabilityAssurance(
+                level=assurance_level,
+                basis=(
+                    "accepted in a clean process by the operator-authorized "
+                    "independent exact rational left-witness checker"
+                    if verified
+                    else (
+                        "checker replay completed without accepting the witness; no "
+                        "opposite conclusion follows"
+                        if checked.execution.status is ExecutionStatus.COMPLETED
+                        else "checker execution did not complete; no mathematical "
+                        "conclusion follows"
+                    )
+                ),
+                verification_record_uri=record_uri,
+            ),
+            artifact_uris=tuple(artifact_uris),
+            relationships=(
+                (
+                    CapabilityRelationship(
+                        relation_id=("linear.relation.inconsistency-certificate-of"),
+                        source_artifact_uris=(resolved.artifact.artifact_uri,),
+                        target_artifact_uris=(resolved.system_artifact.artifact_uri,),
+                        status=CapabilityRelationshipStatus.VERIFIED,
+                        verification_record_uri=record_uri,
+                    ),
+                )
+                if verified
+                else ()
+            ),
         )

--- a/src/jacobian_checkers/linear.py
+++ b/src/jacobian_checkers/linear.py
@@ -273,6 +273,80 @@ def _validate_solution(
     return [_rational(value) for value in values]
 
 
+def _validate_inconsistency(
+    payload: object,
+    *,
+    claim: dict[str, Any],
+    candidate: dict[str, Any],
+    rows: int,
+    columns: int,
+    variables: list[str],
+) -> tuple[list[Fraction], Fraction]:
+    if not isinstance(payload, dict) or set(payload) != {
+        "certificate_schema_version",
+        "system",
+        "declared_scope",
+        "left_witness",
+        "rhs_pairing",
+        "producer",
+        "resource_budget",
+        "method",
+    }:
+        raise ValueError("rational inconsistency certificate has an invalid shape")
+    if (
+        payload["certificate_schema_version"] != "1"
+        or payload["declared_scope"] != "FULL_SYSTEM"
+        or payload["method"] != "DUAL_RREF_PAIRING_ONE"
+    ):
+        raise ValueError("rational inconsistency uses unsupported semantics")
+    binding = payload["system"]
+    if not isinstance(binding, dict) or set(binding) != _SYSTEM_BINDING_KEYS:
+        raise ValueError("rational inconsistency system binding is malformed")
+    expected_variable_digest = _sha256(_canonical_json({"variables": variables}))
+    if binding != {
+        "binding_version": "1",
+        "system_artifact_uri": claim["artifact_uri"],
+        "system_object_digest": claim["object_digest"],
+        "system_payload_digest": claim["payload_digest"],
+        "variable_order_digest": expected_variable_digest,
+        "row_count": rows,
+        "column_count": columns,
+    }:
+        raise ValueError("rational inconsistency is not exactly bound to the system")
+    if claim["artifact_uri"] not in candidate["parents"]:
+        raise ValueError("rational inconsistency is missing system lineage")
+    values = payload["left_witness"]
+    if not isinstance(values, list) or len(values) != rows:
+        raise ValueError("left witness must contain one exact value per system row")
+    provider = payload["producer"]
+    if (
+        not isinstance(provider, dict)
+        or set(provider) != _PROVIDER_KEYS
+        or provider["runtime_version"] != "1"
+        or provider["provider"] != "python-flint"
+        or provider["availability"] != "AVAILABLE"
+        or provider["version"] != "0.9.0"
+        or not isinstance(provider["digest"], str)
+        or _DIGEST.fullmatch(provider["digest"]) is None
+        or provider["digest_kind"] != "PYTHON_DISTRIBUTION_RECORD"
+        or provider["install_tier"] != "T1"
+    ):
+        raise ValueError("rational inconsistency producer identity is malformed")
+    budget = payload["resource_budget"]
+    if (
+        not isinstance(budget, dict)
+        or set(budget) != {"budget_version", "wall_seconds"}
+        or budget["budget_version"] != "1"
+        or type(budget["wall_seconds"]) is not int
+        or not 1 <= budget["wall_seconds"] <= 60
+    ):
+        raise ValueError("rational inconsistency resource budget is malformed")
+    pairing = _rational(payload["rhs_pairing"])
+    if pairing != 1:
+        raise ValueError("rational inconsistency witness is not normalized")
+    return [_rational(value) for value in values], pairing
+
+
 def check_rational_solution(request: dict[str, Any]) -> dict[str, Any]:
     """Accept only a total exact vector satisfying every bound equation."""
 
@@ -379,3 +453,120 @@ def check_rational_solution(request: dict[str, Any]) -> dict[str, Any]:
         }
     except (KeyError, TypeError, ValueError, ZeroDivisionError, OverflowError):
         return _reject("malformed checker request")
+
+
+def check_rational_inconsistency(request: dict[str, Any]) -> dict[str, Any]:
+    """Accept only a left witness proving the exact bound system inconsistent."""
+
+    try:
+        if not isinstance(request, dict) or set(request) != {
+            "request_version",
+            "claim",
+            "candidate",
+            "scope",
+            "witness",
+            "expected_bindings",
+        }:
+            return _reject("malformed checker request")
+        if request["request_version"] != "1" or request["scope"] is not None:
+            return _reject("unsupported checker request")
+        claim = request["claim"]
+        candidate = request["candidate"]
+        witness = request["witness"]
+        if not all(_valid_artifact(item) for item in (claim, candidate, witness)):
+            return _reject("checker artifact metadata is malformed")
+        expected_bindings = request["expected_bindings"]
+        if not _valid_bindings(expected_bindings):
+            return _reject("expected evidence bindings are malformed")
+        if (
+            claim["semantics_uri"] != candidate["semantics_uri"]
+            or claim["semantics_uri"] != witness["semantics_uri"]
+        ):
+            return _reject("checker artifacts use different semantics")
+        for artifact, label in (
+            (claim, "linear-system"),
+            (candidate, "inconsistency"),
+            (witness, "linear witness"),
+        ):
+            if artifact["payload_digest"] != _sha256(
+                _canonical_json(artifact["payload"])
+            ):
+                return _reject(f"{label} payload digest does not match")
+
+        coefficients, rhs, variables = _validate_system(claim["payload"])
+        values, declared_pairing = _validate_inconsistency(
+            candidate["payload"],
+            claim=claim,
+            candidate=candidate,
+            rows=len(coefficients),
+            columns=len(variables),
+            variables=variables,
+        )
+        if (
+            expected_bindings["claim_digest"] != claim["object_digest"]
+            or expected_bindings["candidate_digest"] != candidate["object_digest"]
+        ):
+            return _reject("expected evidence bindings do not match artifacts")
+        envelope = witness["payload"]
+        if not isinstance(envelope, dict) or set(envelope) != {
+            "evidence_schema_version",
+            "witness_format",
+            "format_version",
+            "role",
+            "bindings",
+            "payload",
+        }:
+            return _reject("linear witness envelope is malformed")
+        if (
+            envelope["evidence_schema_version"] != "1"
+            or envelope["witness_format"] != "linear.rational_inconsistency"
+            or envelope["format_version"] != "1"
+            or envelope["role"] != "SUPPORTS_CLAIM"
+            or envelope["bindings"] != expected_bindings
+        ):
+            return _reject("linear witness envelope is not exactly bound")
+        if envelope["payload"] != {
+            "system_uri": claim["artifact_uri"],
+            "certificate_uri": candidate["artifact_uri"],
+        }:
+            return _reject("linear witness points at different artifacts")
+        if not {
+            claim["artifact_uri"],
+            candidate["artifact_uri"],
+        }.issubset(set(witness["parents"])):
+            return _reject("linear witness is missing required lineage")
+
+        for column in range(len(variables)):
+            if (
+                sum(
+                    (
+                        values[row] * coefficients[row][column]
+                        for row in range(len(coefficients))
+                    ),
+                    Fraction(0),
+                )
+                != 0
+            ):
+                return _reject("left witness does not annihilate every column")
+        actual_pairing = sum(
+            (value * bound for value, bound in zip(values, rhs, strict=True)),
+            Fraction(0),
+        )
+        if actual_pairing != declared_pairing or actual_pairing == 0:
+            return _reject("left witness has no nonzero right-hand-side pairing")
+        return {
+            "accepted": True,
+            "conclusion": "TRUE",
+            "arithmetic": "EXACT_RATIONAL",
+            "method": "DIRECT_WITNESS",
+            "coverage": "NOT_APPLICABLE",
+            "relation_id": "linear.relation.inconsistency-certificate-of",
+            "relationship_source_artifact_uris": [candidate["artifact_uri"]],
+            "relationship_target_artifact_uris": [claim["artifact_uri"]],
+            "detail": (
+                f"replayed a {len(values)}-entry left witness over "
+                f"{len(variables)} exact rational columns"
+            ),
+        }
+    except (KeyError, TypeError, ValueError, ZeroDivisionError, OverflowError):
+        return _reject("malformed rational inconsistency request")

--- a/tests/checkers/test_linear_inconsistency_checker.py
+++ b/tests/checkers/test_linear_inconsistency_checker.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+from typing import Any
+
+from jacobian.canonical import canonicalize_json
+from jacobian.contracts.capabilities import (
+    CapabilityInstallTier,
+    CapabilityProviderAvailability,
+    CapabilityProviderDigestKind,
+    CapabilityProviderRuntime,
+)
+from jacobian.contracts.evidence import EvidenceBindings, WitnessEnvelope
+from jacobian.contracts.linear import (
+    LinearRationalInconsistencyArtifact,
+    LinearRationalResourceBudget,
+    LinearRationalSystem,
+    LinearSystemBinding,
+    linear_variable_order_digest,
+)
+from jacobian_checkers.linear import check_rational_inconsistency
+
+_SYSTEM_URI = "artifact://sha256/" + "1" * 64
+_CERTIFICATE_URI = "artifact://sha256/" + "2" * 64
+_WITNESS_URI = "artifact://sha256/" + "3" * 64
+_SCHEMA_URI = "artifact://sha256/" + "4" * 64
+_SEMANTICS_URI = "artifact://sha256/" + "5" * 64
+_SYSTEM_OBJECT_DIGEST = "sha256:" + "a" * 64
+_CERTIFICATE_OBJECT_DIGEST = "sha256:" + "b" * 64
+_SEMANTICS_DIGEST = "sha256:" + "c" * 64
+
+
+def _digest(value: object) -> str:
+    return "sha256:" + hashlib.sha256(canonicalize_json(value)).hexdigest()
+
+
+def _q(num: int, den: int = 1) -> dict[str, str]:
+    return {"num": str(num), "den": str(den)}
+
+
+def _producer() -> CapabilityProviderRuntime:
+    return CapabilityProviderRuntime(
+        provider="python-flint",
+        availability=CapabilityProviderAvailability.AVAILABLE,
+        version="0.9.0",
+        digest="sha256:" + "d" * 64,
+        digest_kind=CapabilityProviderDigestKind.PYTHON_DISTRIBUTION_RECORD,
+        platform="linux-x86_64",
+        install_tier=CapabilityInstallTier.T1,
+        license_id="MIT AND LGPL-3.0-or-later",
+        license_files=("python_flint-0.9.0.dist-info/licenses/LICENSE",),
+        features=("exact-rational", "dense-matrix", "reduced-row-echelon-form"),
+        configuration={
+            "distribution": "python-flint",
+            "domain": "QQ",
+            "operation": "fmpq_mat.rref",
+            "maximum_rows": 32,
+            "maximum_columns": 32,
+            "free_variable_policy": "ZERO",
+        },
+    )
+
+
+def _request() -> dict[str, Any]:
+    system = LinearRationalSystem.model_validate(
+        {
+            "variables": ["x", "y"],
+            "coefficients": {
+                "entries": [
+                    [_q(1), _q(1)],
+                    [_q(2), _q(2)],
+                ]
+            },
+            "rhs": [_q(1), _q(3)],
+        }
+    )
+    system_payload = system.model_dump(mode="json")
+    system_payload_digest = _digest(system_payload)
+    certificate = LinearRationalInconsistencyArtifact(
+        system=LinearSystemBinding(
+            system_artifact_uri=_SYSTEM_URI,
+            system_object_digest=_SYSTEM_OBJECT_DIGEST,
+            system_payload_digest=system_payload_digest,
+            variable_order_digest=linear_variable_order_digest(system.variables),
+            row_count=2,
+            column_count=2,
+        ),
+        left_witness=(_q(-2), _q(1)),
+        rhs_pairing=_q(1),
+        producer=_producer(),
+        resource_budget=LinearRationalResourceBudget(wall_seconds=5),
+    )
+    certificate_payload = certificate.model_dump(mode="json")
+    bindings = EvidenceBindings(
+        claim_digest=_SYSTEM_OBJECT_DIGEST,
+        semantics_digest=_SEMANTICS_DIGEST,
+        candidate_digest=_CERTIFICATE_OBJECT_DIGEST,
+    )
+    witness = WitnessEnvelope(
+        witness_format="linear.rational_inconsistency",
+        format_version="1",
+        role="SUPPORTS_CLAIM",
+        bindings=bindings,
+        payload={
+            "system_uri": _SYSTEM_URI,
+            "certificate_uri": _CERTIFICATE_URI,
+        },
+    )
+    witness_payload = witness.model_dump(mode="json")
+    return {
+        "request_version": "1",
+        "claim": {
+            "artifact_uri": _SYSTEM_URI,
+            "object_digest": _SYSTEM_OBJECT_DIGEST,
+            "payload_digest": system_payload_digest,
+            "schema_uri": _SCHEMA_URI,
+            "semantics_uri": _SEMANTICS_URI,
+            "parents": [],
+            "payload": system_payload,
+        },
+        "candidate": {
+            "artifact_uri": _CERTIFICATE_URI,
+            "object_digest": _CERTIFICATE_OBJECT_DIGEST,
+            "payload_digest": _digest(certificate_payload),
+            "schema_uri": _SCHEMA_URI,
+            "semantics_uri": _SEMANTICS_URI,
+            "parents": [_SYSTEM_URI],
+            "payload": certificate_payload,
+        },
+        "scope": None,
+        "witness": {
+            "artifact_uri": _WITNESS_URI,
+            "object_digest": "sha256:" + "e" * 64,
+            "payload_digest": _digest(witness_payload),
+            "schema_uri": _SCHEMA_URI,
+            "semantics_uri": _SEMANTICS_URI,
+            "parents": [_CERTIFICATE_URI, _SYSTEM_URI],
+            "payload": witness_payload,
+        },
+        "expected_bindings": bindings.model_dump(mode="json"),
+    }
+
+
+def test_checker_accepts_exact_left_nullspace_inconsistency_witness() -> None:
+    decision = check_rational_inconsistency(_request())
+
+    assert decision["accepted"] is True
+    assert decision["conclusion"] == "TRUE"
+    assert decision["relation_id"] == "linear.relation.inconsistency-certificate-of"
+
+
+def test_checker_rejects_mutated_witness_even_with_refreshed_digest() -> None:
+    request = _request()
+    request["candidate"]["payload"]["left_witness"][0] = _q(-3)
+    request["candidate"]["payload_digest"] = _digest(request["candidate"]["payload"])
+
+    decision = check_rational_inconsistency(copy.deepcopy(request))
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+def test_checker_rejects_forged_pairing_and_rebound_system() -> None:
+    forged_pairing = _request()
+    forged_pairing["candidate"]["payload"]["rhs_pairing"] = _q(2)
+    forged_pairing["candidate"]["payload_digest"] = _digest(
+        forged_pairing["candidate"]["payload"]
+    )
+
+    rebound = _request()
+    rebound["candidate"]["payload"]["system"]["system_object_digest"] = (
+        "sha256:" + "9" * 64
+    )
+    rebound["candidate"]["payload_digest"] = _digest(rebound["candidate"]["payload"])
+
+    for request in (forged_pairing, rebound):
+        decision = check_rational_inconsistency(copy.deepcopy(request))
+        assert decision["accepted"] is False
+        assert decision["conclusion"] == "UNKNOWN"

--- a/tests/contract/test_linear_contracts.py
+++ b/tests/contract/test_linear_contracts.py
@@ -4,10 +4,13 @@ import pytest
 from pydantic import ValidationError
 
 from jacobian.contracts.linear import (
+    LinearRationalInconsistencyArtifact,
+    LinearRationalInconsistencyVerificationOutput,
     LinearRationalSolutionFindRequest,
     LinearRationalSolutionVerificationOutput,
     LinearRationalSystem,
 )
+from jacobian.provider_runtime import known_provider_runtime
 
 
 def _q(num: int, den: int = 1) -> dict[str, str]:
@@ -82,6 +85,74 @@ def test_only_verified_solution_output_can_carry_true_and_record() -> None:
 
     with pytest.raises(ValidationError):
         LinearRationalSolutionVerificationOutput.model_validate(
+            {
+                **common,
+                "status": "REJECTED",
+                "conclusion": "TRUE",
+                "verification_record_uri": "artifact://sha256/" + "5" * 64,
+            }
+        )
+
+
+def test_inconsistency_artifact_requires_normalized_row_witness() -> None:
+    binding = {
+        "system_artifact_uri": "artifact://sha256/" + "1" * 64,
+        "system_object_digest": "sha256:" + "2" * 64,
+        "system_payload_digest": "sha256:" + "3" * 64,
+        "variable_order_digest": "sha256:" + "4" * 64,
+        "row_count": 2,
+        "column_count": 2,
+    }
+    producer = known_provider_runtime("python-flint").model_copy(
+        update={"version": "0.9.0"}
+    )
+    accepted = LinearRationalInconsistencyArtifact.model_validate(
+        {
+            "system": binding,
+            "left_witness": [_q(-2), _q(1)],
+            "rhs_pairing": _q(1),
+            "producer": producer,
+            "resource_budget": {"wall_seconds": 5},
+        }
+    )
+    assert accepted.rhs_pairing.as_fraction() == 1
+
+    with pytest.raises(ValidationError, match="one value per system row"):
+        LinearRationalInconsistencyArtifact.model_validate(
+            {
+                **accepted.model_dump(mode="json"),
+                "left_witness": [_q(1)],
+            }
+        )
+    with pytest.raises(ValidationError, match="normalized"):
+        LinearRationalInconsistencyArtifact.model_validate(
+            {
+                **accepted.model_dump(mode="json"),
+                "rhs_pairing": _q(2),
+            }
+        )
+
+
+def test_only_verified_inconsistency_can_carry_true_and_record() -> None:
+    common = {
+        "system_uri": "artifact://sha256/" + "1" * 64,
+        "certificate_uri": "artifact://sha256/" + "2" * 64,
+        "witness_uri": "artifact://sha256/" + "3" * 64,
+        "checker_id": "checker://sha256/" + "4" * 64,
+        "detail": "checked",
+    }
+    verified = LinearRationalInconsistencyVerificationOutput.model_validate(
+        {
+            **common,
+            "status": "VERIFIED_INCONSISTENT",
+            "conclusion": "TRUE",
+            "verification_record_uri": "artifact://sha256/" + "5" * 64,
+        }
+    )
+    assert verified.conclusion == "TRUE"
+
+    with pytest.raises(ValidationError):
+        LinearRationalInconsistencyVerificationOutput.model_validate(
             {
                 **common,
                 "status": "REJECTED",

--- a/tests/integration/test_linear_rational_inconsistency.py
+++ b/tests/integration/test_linear_rational_inconsistency.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from jacobian.bounded_process import BoundedProcessResult
+from jacobian.contracts.capabilities import (
+    CapabilityAssuranceLevel,
+    CapabilityCompletenessStatus,
+    CapabilityMode,
+    CapabilityProviderAvailability,
+    CapabilityRequest,
+    CapabilityResult,
+)
+from jacobian.contracts.results import ExecutionStatus
+from jacobian.kernel import JacobianKernel
+from jacobian.linear_capabilities import (
+    install_linear_rational_inconsistency_checker,
+)
+
+pytestmark = pytest.mark.usefixtures("initialized_kernel_store")
+
+
+def _q(num: int, den: int = 1) -> dict[str, str]:
+    return {"num": str(num), "den": str(den)}
+
+
+def _system(coefficients: list[list[int]], rhs: list[int]) -> dict[str, Any]:
+    return {
+        "variables": [f"x{index}" for index in range(len(coefficients[0]))],
+        "coefficients": {
+            "entries": [[_q(value) for value in row] for row in coefficients]
+        },
+        "rhs": [_q(value) for value in rhs],
+    }
+
+
+def _invoke(
+    kernel: JacobianKernel,
+    capability_id: str,
+    payload: dict[str, Any],
+    *,
+    mode: CapabilityMode,
+) -> CapabilityResult:
+    return kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id=capability_id,
+            mode=mode,
+            input=payload,
+        )
+    )
+
+
+def _kernel_with_checker(root: Path) -> JacobianKernel:
+    kernel = JacobianKernel(root)
+    adapter, _installation = install_linear_rational_inconsistency_checker(
+        kernel.store,
+        kernel.schemas,
+        kernel.artifacts,
+        kernel.linear,
+        kernel.verification,
+        kernel.checkers,
+        authorize_checker=True,
+    )
+    assert adapter is not None
+    kernel.register_capability(adapter)
+    return kernel
+
+
+def test_python_flint_finds_normalized_unverified_inconsistency_witness(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    assert (
+        kernel.python_flint_runtime.availability
+        is CapabilityProviderAvailability.AVAILABLE
+    )
+    result = _invoke(
+        kernel,
+        "linear.rational_inconsistency.find",
+        {
+            "system": _system([[1, 1], [2, 2]], [1, 3]),
+            "resource_budget": {"wall_seconds": 5},
+        },
+        mode=CapabilityMode.EXPLORE,
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output["status"] == "CERTIFICATE_PRODUCED"
+    assert result.output["left_witness"] == [_q(-2), _q(1)]
+    assert result.output["rhs_pairing"] == _q(1)
+    assert result.output["conclusion"] == "UNKNOWN"
+    assert result.output["verification"] == "UNVERIFIED"
+    assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert (
+        result.relationships[0].relation_id
+        == "linear.relation.inconsistency-certificate-of"
+    )
+    resolved = kernel.linear.resolve_inconsistency(result.output["certificate_uri"])
+    assert (
+        resolved.certificate.system.system_artifact_uri == result.output["system_uri"]
+    )
+    assert result.output["system_uri"] in resolved.artifact.manifest.parents
+
+
+def test_no_certificate_is_not_a_consistency_conclusion(tmp_path: Path) -> None:
+    kernel = JacobianKernel(tmp_path)
+    result = _invoke(
+        kernel,
+        "linear.rational_inconsistency.find",
+        {"system": _system([[1, 0], [0, 1]], [2, 3])},
+        mode=CapabilityMode.EXPLORE,
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output["status"] == "NO_CERTIFICATE_PRODUCED"
+    assert result.output["conclusion"] == "UNKNOWN"
+    assert result.output["certificate_uri"] is None
+    assert result.completeness.status is CapabilityCompletenessStatus.UNKNOWN
+
+
+def test_independent_checker_verifies_inconsistency(tmp_path: Path) -> None:
+    kernel = _kernel_with_checker(tmp_path)
+    found = _invoke(
+        kernel,
+        "linear.rational_inconsistency.find",
+        {"system": _system([[1, 1], [2, 2]], [1, 3])},
+        mode=CapabilityMode.EXPLORE,
+    )
+    verified = _invoke(
+        kernel,
+        "linear.rational_inconsistency.verify",
+        {"certificate_uri": found.output["certificate_uri"]},
+        mode=CapabilityMode.VERIFY,
+    )
+
+    assert verified.output["status"] == "VERIFIED_INCONSISTENT"
+    assert verified.output["conclusion"] == "TRUE"
+    assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED
+    assert verified.relationships[0].status.value == "VERIFIED"
+    assert verified.output["verification_record_uri"].startswith("artifact://sha256/")
+
+
+def test_inconsistency_timeout_retains_no_certificate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    monkeypatch.setattr(
+        "jacobian.flint_linear.run_bounded_process",
+        lambda *_args, **_kwargs: BoundedProcessResult(
+            returncode=None,
+            stdout=b"",
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=True,
+        ),
+    )
+    result = _invoke(
+        kernel,
+        "linear.rational_inconsistency.find",
+        {"system": _system([[1]], [1])},
+        mode=CapabilityMode.EXPLORE,
+    )
+
+    assert result.execution.status is ExecutionStatus.TIMEOUT
+    assert result.output["status"] == "NO_CERTIFICATE_PRODUCED"
+    assert result.output["conclusion"] == "UNKNOWN"
+    assert result.output["certificate_uri"] is None
+    assert result.assurance.level is not CapabilityAssuranceLevel.VERIFIED


### PR DESCRIPTION
## Summary

- add `linear.rational_inconsistency.find`, backed by pinned Python-FLINT, to produce a normalized exact left witness `y` with proposed equations `y^T A = 0` and `y^T b = 1`
- add a standard-library clean-process checker and `linear.rational_inconsistency.verify`, with `VERIFIED` reserved for the operator-authorized independent replay
- add strictly bound inconsistency artifacts, fail-closed operational outcomes, attack/integration tests, a public worked reproduction, and portfolio documentation

## Why

The atomic capability portfolio explicitly deferred inconsistent-system outcomes until Jacobian could expose a separately checkable left-nullspace certificate. This is a small formal-facing slice that reuses the existing exact rational system artifacts and Python-FLINT runtime without adding a dependency or a workflow-shaped tool.

The linear semantics descriptor is extended to name both solution and inconsistency relations. These contracts are experimental and pre-stable.

## Validation

- `make check` (352 passed, 4 deselected)
- `make check-static` (Ruff, deptry, vulture, strict mypy, sdist/wheel build)
- `uv run pytest -q tests/integration/test_linear_rational_inconsistency.py tests/integration/test_linear_rational_solution.py` (16 passed)
- focused checker, contract, and integration suite (33 relevant tests passed before final handoff run)