### PR TITLE
feat(matrices): add exact rational determinant verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Specialized contracts cover
 [SAT artifacts](docs/reference/sat-artifacts.md),
 [SMT/Alethe artifacts](docs/reference/smt-artifacts.md),
 [exact rational linear-system evidence](docs/reference/linear-rational-solutions.md),
+[exact rational matrix determinants](docs/reference/matrix-rational-determinant.md),
 [integer matrix HNF](docs/reference/matrix-hermite-normal-form.md), and
 [Lean declaration discovery](docs/reference/lean-declaration-discovery.md).
 Architecture decisions are recorded in the

--- a/docs/contributing/atomic-capability-portfolio.md
+++ b/docs/contributing/atomic-capability-portfolio.md
@@ -493,10 +493,15 @@ Implement one vertical slice at a time:
 3. `matrix.normal_form.hermite` is implemented with the binding's complete
    left transformation. Independent replay checks `H = U A`, unimodularity,
    and every FLINT row-HNF condition.
-4. Add `polynomial.factor` with a product relation. Checking that the factors
+4. `matrix.determinant.verify` is implemented as a small shared exact
+   primitive. It checks the existing SymPy determinant artifact by
+   standard-library rational Gaussian elimination in an independent clean
+   process; see the
+   [exact rational determinant contract](../reference/matrix-rational-determinant.md).
+5. Add `polynomial.factor` with a product relation. Checking that the factors
    multiply to the input does not by itself certify irreducibility or
    completeness; keep those as open obligations until separately checked.
-5. Add rigorous Arb enclosures as computed evidence. The provider's rigorous
+6. Add rigorous Arb enclosures as computed evidence. The provider's rigorous
    error tracking is valuable, but it is not Jacobian `VERIFIED` until an
    authorized independent implementation checks the exact enclosure claim.
 
@@ -594,7 +599,10 @@ backlog.
 14. Python-FLINT rational inconsistency-certificate find and verify slice.
     Implemented; see the
     [exact rational linear-system evidence contract](../reference/linear-rational-solutions.md#inconsistency-certificate).
-15. Re-rank E/Vampire, Metamath, nauty, Singular, PARI, Normaliz, GAP, fplll,
+15. Independent exact rational matrix-determinant verification. Implemented;
+    see the
+    [exact rational determinant contract](../reference/matrix-rational-determinant.md).
+16. Re-rank E/Vampire, Metamath, nauty, Singular, PARI, Normaliz, GAP, fplll,
     and HiGHS from accumulated workflow evidence.
 
 Stop after each paired evaluation long enough to decide whether the next

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,6 +61,7 @@ expectations.
 - [SAT artifact contracts](reference/sat-artifacts.md)
 - [SMT Alethe artifact contracts](reference/smt-artifacts.md)
 - [Exact rational linear-system evidence](reference/linear-rational-solutions.md)
+- [Exact rational matrix determinants](reference/matrix-rational-determinant.md)
 - [Integer matrix Hermite normal form](reference/matrix-hermite-normal-form.md)
 - [Typed polynomial expression normalization](reference/polynomial-expression-normalization.md)
 - [v0.2 specification](reference/specifications/v0.2.md)

--- a/docs/reference/matrix-rational-determinant.md
+++ b/docs/reference/matrix-rational-determinant.md
@@ -1,0 +1,73 @@
+# Exact rational matrix determinants
+
+`matrix.determinant.compute` computes one exact determinant for a square matrix
+over `QQ`. `matrix.determinant.verify` independently recomputes and checks one
+stored result. Computation and verification are separate trust boundaries.
+
+## Input and result contracts
+
+The matrix artifact contains a nonempty square matrix with at most 32 rows and
+columns. Every entry is a canonical reduced rational:
+
+```json
+{"num": "-3", "den": "7"}
+```
+
+`matrix.determinant.compute` uses SymPy's exact matrix determinant API with the
+fraction-free Bareiss method. It stores:
+
+- the canonical source matrix;
+- one determinant artifact whose payload identifies that matrix;
+- exact source-parent lineage; and
+- the SymPy backend version and method.
+
+The compute result remains `COMPUTED` and `UNVERIFIED`. Backend success is an
+execution result, not independent assurance. SymPy documents both the
+[`Matrix.det` API][sympy-det] and its Bareiss method.
+
+## Independent verification
+
+With bundled references enabled, `matrix.determinant.verify` runs an
+operator-authorized standard-library checker in a clean process. The verifier
+accepts only when all of the following hold:
+
+1. claim, candidate, and witness schemas, semantics, payload digests, and
+   parent lineage agree;
+2. the candidate and witness identify the exact stored source matrix and
+   determinant artifact;
+3. all rational values are canonical, reduced, and have positive
+   denominators; and
+4. exact Gaussian elimination over `fractions.Fraction`, including row-swap
+   signs, recomputes the declared determinant.
+
+The checker does not import SymPy or producer code. Accepted replay creates a
+verification record and may report `VERIFIED`. A wrong value, malformed
+binding, timeout, cancellation, or checker error reports `UNKNOWN` and creates
+no verification record.
+
+Verification covers only the equality
+
+```text
+declared value = det(stored source matrix)
+```
+
+It does not separately conclude invertibility, rank, orientation, volume, or
+any downstream theorem. An agent can compose those later from the verified
+artifact.
+
+## Public reproduction
+
+The integration reproduction uses
+
+```text
+[[1, 0, 1],
+ [2, -1, 3],
+ [4, 3, 2]]
+```
+
+The producer stores determinant `-1`; the independent checker recomputes the
+same exact value and emits a bound verification record. Attack cases mutate
+the value while refreshing its payload digest, rebind the source URI, supply
+noncanonical rationals, add unexpected fields, and force a checker timeout.
+
+[sympy-det]: https://docs.sympy.org/latest/modules/matrices/matrices.html#sympy.matrices.matrixbase.MatrixBase.det

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -128,6 +128,7 @@ of catalog membership:
 - [SAT artifact contracts](sat-artifacts.md);
 - [SMT Alethe artifact contracts](smt-artifacts.md);
 - [exact rational linear-system evidence](linear-rational-solutions.md);
+- [exact rational matrix determinants](matrix-rational-determinant.md);
 - [integer matrix Hermite normal form](matrix-hermite-normal-form.md);
 - [typed polynomial expression normalization](polynomial-expression-normalization.md);
 - [Lean declaration discovery contract](lean-declaration-discovery.md).

--- a/src/jacobian/contracts/matrices.py
+++ b/src/jacobian/contracts/matrices.py
@@ -118,6 +118,42 @@ class MatrixDeterminantOutput(ContractModel):
     backend_version: str
 
 
+class MatrixDeterminantVerificationRequest(ContractModel):
+    determinant_uri: ArtifactUri
+
+
+class MatrixDeterminantVerificationOutput(ContractModel):
+    """Projection of an independent exact determinant recomputation."""
+
+    status: Literal[
+        "VERIFIED_DETERMINANT",
+        "REJECTED",
+        "TIMEOUT",
+        "CANCELLED",
+        "ERROR",
+    ]
+    conclusion: Literal["TRUE", "UNKNOWN"]
+    matrix_uri: ArtifactUri
+    determinant_uri: ArtifactUri
+    witness_uri: ArtifactUri
+    checker_id: CheckerUri
+    verification_record_uri: ArtifactUri | None = None
+    detail: str = Field(min_length=1, max_length=1024)
+
+    @model_validator(mode="after")
+    def bind_verified_projection(self) -> Self:
+        if self.status == "VERIFIED_DETERMINANT":
+            if self.conclusion != "TRUE" or self.verification_record_uri is None:
+                raise ValueError(
+                    "verified determinant output requires TRUE and a verification record"
+                )
+        elif self.conclusion != "UNKNOWN" or self.verification_record_uri is not None:
+            raise ValueError(
+                "non-verified determinant output cannot carry a conclusion or record"
+            )
+        return self
+
+
 class MatrixRankOutput(ContractModel):
     matrix_uri: ArtifactUri
     rank_uri: ArtifactUri

--- a/src/jacobian/kernel.py
+++ b/src/jacobian/kernel.py
@@ -64,6 +64,10 @@ from jacobian.matrix_capabilities import (
     MatrixInstallation,
     install_matrix_capabilities,
 )
+from jacobian.matrix_determinant_capabilities import (
+    MatrixDeterminantCheckerInstallation,
+    install_matrix_determinant_checker,
+)
 from jacobian.matrix_normal_form_capabilities import (
     MatrixNormalFormCheckerInstallation,
     install_matrix_normal_form_checker,
@@ -450,6 +454,20 @@ class JacobianKernel:
         )
         for matrix_adapter in matrix_adapters:
             self.register_capability(matrix_adapter)
+        self.matrix_determinant_checker: MatrixDeterminantCheckerInstallation
+        determinant_verification, self.matrix_determinant_checker = (
+            install_matrix_determinant_checker(
+                self.store,
+                self.schemas,
+                self.artifacts,
+                self.matrix,
+                self.verification,
+                self.checkers,
+                authorize_checker=install_references,
+            )
+        )
+        if determinant_verification is not None:
+            self.register_capability(determinant_verification)
         self.polynomial_system: PolynomialSystemInstallation
         polynomial_system_adapter, self.polynomial_system = (
             install_polynomial_system_capabilities(

--- a/src/jacobian/matrix_determinant_capabilities.py
+++ b/src/jacobian/matrix_determinant_capabilities.py
@@ -1,0 +1,402 @@
+"""Independent verification capability for exact rational determinants."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from pydantic import ValidationError
+
+from jacobian.artifacts import ArtifactService
+from jacobian.capabilities import CapabilityAdapter, CapabilityInvocationError
+from jacobian.contracts.capabilities import (
+    CapabilityAssurance,
+    CapabilityAssuranceLevel,
+    CapabilityCompleteness,
+    CapabilityCompletenessStatus,
+    CapabilityDescriptor,
+    CapabilityDiagnostic,
+    CapabilityMode,
+    CapabilityRequest,
+    CapabilityResult,
+    CapabilityScope,
+)
+from jacobian.contracts.evidence import (
+    EvidenceBindings,
+    WitnessEnvelope,
+    WitnessRole,
+)
+from jacobian.contracts.matrices import (
+    ExactRationalMatrix,
+    MatrixDeterminantArtifact,
+    MatrixDeterminantVerificationOutput,
+    MatrixDeterminantVerificationRequest,
+)
+from jacobian.contracts.results import Conclusion, ExecutionStatus, Verification
+from jacobian.matrix_capabilities import MatrixInstallation
+from jacobian.provider_runtime import known_provider_runtime
+from jacobian.registry import CheckerRegistry
+from jacobian.schema_registry import (
+    SchemaRegistry,
+    SchemaRegistryError,
+    model_schema,
+)
+from jacobian.store import ArtifactStore, StoredArtifact, StoreError
+from jacobian.verification import VerificationService
+
+
+class MatrixDeterminantArtifactError(ValueError):
+    """A stored determinant candidate is invalid or incompletely bound."""
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedMatrixDeterminant:
+    matrix_artifact: StoredArtifact
+    matrix: ExactRationalMatrix
+    artifact: StoredArtifact
+    candidate: MatrixDeterminantArtifact
+
+
+@dataclass(frozen=True, slots=True)
+class MatrixDeterminantCheckerInstallation:
+    witness_schema_uri: str
+    checker_id: str | None
+
+
+def install_matrix_determinant_checker(
+    store: ArtifactStore,
+    schemas: SchemaRegistry,
+    artifacts: ArtifactService,
+    matrices: MatrixInstallation,
+    verification: VerificationService,
+    checkers: CheckerRegistry,
+    *,
+    authorize_checker: bool,
+) -> tuple[CapabilityAdapter | None, MatrixDeterminantCheckerInstallation]:
+    """Install the determinant witness schema and optionally authorize replay."""
+
+    witness_schema_uri = schemas.register_model(
+        name="jacobian.witness-envelope",
+        version="1",
+        model=WitnessEnvelope,
+    )
+    checker_id = None
+    if authorize_checker:
+        checker_id = checkers.authorize(
+            name="exact rational determinant recomputation checker",
+            entrypoint=(
+                "jacobian_checkers.rational_determinants:check_rational_determinant"
+            ),
+            evidence_kind="WITNESS",
+            format_id="matrix.rational_determinant",
+            format_version="1",
+            claim_schema_uris=(matrices.matrix_schema_uri,),
+            semantics_uris=(matrices.semantics_uri,),
+            candidate_schema_uris=(matrices.determinant_schema_uri,),
+            reason=(
+                "bundled independent standard-library exact rational "
+                "determinant recomputation"
+            ),
+        ).checker_id
+    installation = MatrixDeterminantCheckerInstallation(
+        witness_schema_uri=witness_schema_uri,
+        checker_id=checker_id,
+    )
+    adapter: CapabilityAdapter | None = None
+    if checker_id is not None:
+        adapter = MatrixDeterminantVerificationAdapter(
+            store=store,
+            schemas=schemas,
+            artifacts=artifacts,
+            matrices=matrices,
+            verification=verification,
+            installation=installation,
+        )
+    return adapter, installation
+
+
+class MatrixDeterminantVerificationAdapter:
+    """Independently recompute one stored exact rational determinant."""
+
+    def __init__(
+        self,
+        *,
+        store: ArtifactStore,
+        schemas: SchemaRegistry,
+        artifacts: ArtifactService,
+        matrices: MatrixInstallation,
+        verification: VerificationService,
+        installation: MatrixDeterminantCheckerInstallation,
+    ) -> None:
+        checker_id = installation.checker_id
+        if checker_id is None:
+            raise ValueError("matrix determinant checker is not authorized")
+        self.store = store
+        self.schemas = schemas
+        self.artifacts = artifacts
+        self.matrices = matrices
+        self.verification = verification
+        self.installation = installation
+        self._descriptor = CapabilityDescriptor(
+            capability_id="matrix.determinant.verify",
+            version="1",
+            title="Verify an exact rational matrix determinant",
+            description=(
+                "Independently recompute and check the exact determinant of one "
+                "bound stored square rational matrix."
+            ),
+            provider="jacobian.rational-matrix",
+            provider_runtime=known_provider_runtime(
+                "jacobian.rational-matrix",
+                features=(
+                    "exact-rational-recomputation",
+                    "gaussian-elimination",
+                    "clean-process-checker",
+                ),
+                checker_ids=(checker_id,),
+            ),
+            modes=(CapabilityMode.VERIFY,),
+            input_schema=model_schema(MatrixDeterminantVerificationRequest),
+            output_schema=model_schema(MatrixDeterminantVerificationOutput),
+            tags=(
+                "linear-algebra",
+                "rational",
+                "matrix",
+                "determinant",
+                "verification",
+            ),
+        )
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        return self._descriptor
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        validated = MatrixDeterminantVerificationRequest.model_validate(request.input)
+        try:
+            resolved = self._resolve(validated.determinant_uri)
+            semantics = self.store.get(self.matrices.semantics_uri)
+        except (MatrixDeterminantArtifactError, StoreError) as exc:
+            raise CapabilityInvocationError(
+                CapabilityDiagnostic(
+                    code="INVALID_MATRIX_DETERMINANT",
+                    stage="artifact_resolution",
+                    message=str(exc),
+                    path="determinant_uri",
+                    schema_uri=self.matrices.determinant_schema_uri,
+                    expected=(
+                        "a valid exact determinant bound by payload and lineage "
+                        "to one square rational matrix"
+                    ),
+                    hint=(
+                        "Use matrix.determinant.compute or materialize a candidate "
+                        "with the registered determinant schema."
+                    ),
+                )
+            ) from exc
+
+        checker_id = self.installation.checker_id
+        assert checker_id is not None
+        bindings = EvidenceBindings(
+            claim_digest=resolved.matrix_artifact.manifest.object_digest,
+            semantics_digest=semantics.manifest.object_digest,
+            candidate_digest=resolved.artifact.manifest.object_digest,
+        )
+        witness = WitnessEnvelope(
+            witness_format="matrix.rational_determinant",
+            format_version="1",
+            role=WitnessRole.SUPPORTS_CLAIM,
+            bindings=bindings,
+            payload={
+                "matrix_uri": resolved.matrix_artifact.artifact_uri,
+                "determinant_uri": resolved.artifact.artifact_uri,
+            },
+        )
+        witness_artifact = self.artifacts.put(
+            schema_uri=self.installation.witness_schema_uri,
+            semantics_uri=self.matrices.semantics_uri,
+            payload=witness.model_dump(mode="json"),
+            parents=(
+                resolved.matrix_artifact.artifact_uri,
+                resolved.artifact.artifact_uri,
+            ),
+            summary="exact rational determinant verification witness",
+        )
+        checked = self.verification.verify_witness(
+            claim_uri=resolved.matrix_artifact.artifact_uri,
+            candidate_uri=resolved.artifact.artifact_uri,
+            witness_uri=witness_artifact.artifact_uri,
+            checker_id=checker_id,
+            include_artifact_metadata=True,
+        )
+        verified = (
+            checked.execution.status is ExecutionStatus.COMPLETED
+            and checked.conclusion is Conclusion.TRUE
+            and checked.assurance.verification is Verification.VERIFIED
+            and checked.verification_record_uri is not None
+        )
+        status: Literal[
+            "VERIFIED_DETERMINANT",
+            "REJECTED",
+            "TIMEOUT",
+            "CANCELLED",
+            "ERROR",
+        ]
+        if verified:
+            status = "VERIFIED_DETERMINANT"
+        elif checked.execution.status is ExecutionStatus.COMPLETED:
+            status = "REJECTED"
+        elif checked.execution.status is ExecutionStatus.TIMEOUT:
+            status = "TIMEOUT"
+        elif checked.execution.status is ExecutionStatus.CANCELLED:
+            status = "CANCELLED"
+        else:
+            status = "ERROR"
+        detail = checked.execution.detail
+        if detail is None and checked.input.errors:
+            detail = checked.input.errors[0]
+        if detail is None:
+            detail = (
+                "the authorized checker accepted the exact determinant"
+                if verified
+                else "the determinant was not independently accepted"
+            )
+        output = MatrixDeterminantVerificationOutput(
+            status=status,
+            conclusion="TRUE" if verified else "UNKNOWN",
+            matrix_uri=resolved.matrix_artifact.artifact_uri,
+            determinant_uri=resolved.artifact.artifact_uri,
+            witness_uri=witness_artifact.artifact_uri,
+            checker_id=checker_id,
+            verification_record_uri=(
+                checked.verification_record_uri if verified else None
+            ),
+            detail=detail,
+        )
+        record_uri = checked.verification_record_uri if verified else None
+        artifact_uris = [
+            resolved.matrix_artifact.artifact_uri,
+            resolved.artifact.artifact_uri,
+            witness_artifact.artifact_uri,
+        ]
+        if record_uri is not None:
+            artifact_uris.append(record_uri)
+        assurance_level = (
+            CapabilityAssuranceLevel.VERIFIED
+            if verified
+            else (
+                CapabilityAssuranceLevel.COMPUTED
+                if checked.execution.status is ExecutionStatus.COMPLETED
+                else CapabilityAssuranceLevel.HEURISTIC
+            )
+        )
+        dimension = len(resolved.matrix.entries)
+        return CapabilityResult(
+            capability_id=self.descriptor.capability_id,
+            capability_version=self.descriptor.version,
+            mode=request.mode,
+            execution=checked.execution,
+            output=output.model_dump(mode="json"),
+            scope=CapabilityScope(
+                description="the full exact square rational matrix",
+                parameters={
+                    "declared_scope": "FULL_MATRIX",
+                    "row_count": dimension,
+                    "column_count": dimension,
+                    "arithmetic": "EXACT_RATIONAL",
+                    "method": "GAUSSIAN_ELIMINATION",
+                },
+                artifact_uri=resolved.matrix_artifact.artifact_uri,
+            ),
+            completeness=CapabilityCompleteness(
+                status=CapabilityCompletenessStatus.NOT_APPLICABLE,
+                basis=(
+                    "direct exact recomputation checks the full finite matrix; "
+                    "no search or enumeration claim is made"
+                ),
+                assurance_level=(
+                    CapabilityAssuranceLevel.COMPUTED
+                    if checked.execution.status is ExecutionStatus.COMPLETED
+                    else CapabilityAssuranceLevel.HEURISTIC
+                ),
+            ),
+            assurance=CapabilityAssurance(
+                level=assurance_level,
+                basis=(
+                    "accepted in a clean process by the operator-authorized "
+                    "independent exact rational determinant checker"
+                    if verified
+                    else (
+                        "checker recomputation completed without accepting the "
+                        "candidate; no opposite conclusion follows"
+                        if checked.execution.status is ExecutionStatus.COMPLETED
+                        else "checker execution did not complete; no mathematical "
+                        "conclusion follows"
+                    )
+                ),
+                verification_record_uri=record_uri,
+            ),
+            artifact_uris=tuple(artifact_uris),
+        )
+
+    def _resolve(self, determinant_uri: str) -> ResolvedMatrixDeterminant:
+        try:
+            artifact = self.store.get(determinant_uri)
+        except StoreError as exc:
+            raise MatrixDeterminantArtifactError(
+                "candidate is not an available determinant artifact"
+            ) from exc
+        if (
+            artifact.manifest.schema_uri != self.matrices.determinant_schema_uri
+            or artifact.manifest.semantics_uri != self.matrices.semantics_uri
+        ):
+            raise MatrixDeterminantArtifactError(
+                "candidate is not an exact rational determinant artifact"
+            )
+        try:
+            normalized = self.schemas.validate(
+                self.matrices.determinant_schema_uri,
+                artifact.payload,
+            )
+            candidate = MatrixDeterminantArtifact.model_validate(normalized)
+        except (SchemaRegistryError, ValidationError, ValueError) as exc:
+            raise MatrixDeterminantArtifactError(
+                "candidate is not a valid determinant artifact"
+            ) from exc
+        try:
+            matrix_artifact = self.store.get(candidate.matrix_uri)
+        except StoreError as exc:
+            raise MatrixDeterminantArtifactError(
+                "candidate source matrix is unavailable"
+            ) from exc
+        if (
+            matrix_artifact.manifest.schema_uri != self.matrices.matrix_schema_uri
+            or matrix_artifact.manifest.semantics_uri != self.matrices.semantics_uri
+        ):
+            raise MatrixDeterminantArtifactError(
+                "candidate source is not an exact rational matrix"
+            )
+        if artifact.manifest.parents != (matrix_artifact.artifact_uri,):
+            raise MatrixDeterminantArtifactError(
+                "candidate lineage does not exactly identify its source matrix"
+            )
+        try:
+            normalized_matrix = self.schemas.validate(
+                self.matrices.matrix_schema_uri,
+                matrix_artifact.payload,
+            )
+            matrix = ExactRationalMatrix.model_validate(normalized_matrix)
+        except (SchemaRegistryError, ValidationError, ValueError) as exc:
+            raise MatrixDeterminantArtifactError(
+                "candidate source is not a valid rational matrix"
+            ) from exc
+        if len(matrix.entries) != len(matrix.entries[0]):
+            raise MatrixDeterminantArtifactError(
+                "candidate source matrix is not square"
+            )
+        return ResolvedMatrixDeterminant(
+            matrix_artifact=matrix_artifact,
+            matrix=matrix,
+            artifact=artifact,
+            candidate=candidate,
+        )

--- a/src/jacobian_checkers/rational_determinants.py
+++ b/src/jacobian_checkers/rational_determinants.py
@@ -1,0 +1,289 @@
+"""Independent exact determinant replay over rational matrices.
+
+This checker intentionally uses only the Python standard library. It does not
+import Jacobian contracts, SymPy, or determinant producer code.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from fractions import Fraction
+from typing import Any
+
+_ARTIFACT_URI = re.compile(r"^artifact://sha256/[0-9a-f]{64}$")
+_DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
+_INTEGER = re.compile(r"^-?(?:0|[1-9][0-9]*)$")
+_ARTIFACT_KEYS = {
+    "artifact_uri",
+    "object_digest",
+    "payload_digest",
+    "schema_uri",
+    "semantics_uri",
+    "parents",
+    "payload",
+}
+_BINDING_KEYS = {
+    "claim_digest",
+    "semantics_digest",
+    "candidate_digest",
+    "scope_digest",
+    "encoding_digest",
+}
+_MAX_DIMENSION = 32
+
+
+def _reject(detail: str) -> dict[str, Any]:
+    return {
+        "accepted": False,
+        "conclusion": "UNKNOWN",
+        "arithmetic": "EXACT_RATIONAL",
+        "method": "DIRECT_WITNESS",
+        "coverage": "NOT_APPLICABLE",
+        "detail": detail,
+    }
+
+
+def _sha256(value: bytes) -> str:
+    return "sha256:" + hashlib.sha256(value).hexdigest()
+
+
+def _canonical_json(value: object) -> bytes:
+    return json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _valid_artifact(value: object) -> bool:
+    if not isinstance(value, dict) or set(value) != _ARTIFACT_KEYS:
+        return False
+    if (
+        not isinstance(value["artifact_uri"], str)
+        or _ARTIFACT_URI.fullmatch(value["artifact_uri"]) is None
+        or not isinstance(value["object_digest"], str)
+        or _DIGEST.fullmatch(value["object_digest"]) is None
+        or not isinstance(value["payload_digest"], str)
+        or _DIGEST.fullmatch(value["payload_digest"]) is None
+        or not isinstance(value["schema_uri"], str)
+        or _ARTIFACT_URI.fullmatch(value["schema_uri"]) is None
+        or not isinstance(value["semantics_uri"], str)
+        or _ARTIFACT_URI.fullmatch(value["semantics_uri"]) is None
+    ):
+        return False
+    parents = value["parents"]
+    return (
+        isinstance(parents, list)
+        and len(parents) == len(set(parents))
+        and all(
+            isinstance(parent, str) and _ARTIFACT_URI.fullmatch(parent) is not None
+            for parent in parents
+        )
+    )
+
+
+def _valid_bindings(value: object) -> bool:
+    if not isinstance(value, dict) or set(value) != _BINDING_KEYS:
+        return False
+    if value["scope_digest"] is not None or value["encoding_digest"] is not None:
+        return False
+    return all(
+        isinstance(value[key], str) and _DIGEST.fullmatch(value[key]) is not None
+        for key in ("claim_digest", "semantics_digest", "candidate_digest")
+    )
+
+
+def _integer(value: object) -> int:
+    if not isinstance(value, str) or _INTEGER.fullmatch(value) is None:
+        raise ValueError("rational component is not a canonical integer")
+    result = int(value)
+    if str(result) != value:
+        raise ValueError("rational component is not canonical")
+    return result
+
+
+def _rational(value: object) -> Fraction:
+    if not isinstance(value, dict) or set(value) != {"num", "den"}:
+        raise ValueError("rational value has an invalid shape")
+    numerator = _integer(value["num"])
+    denominator = _integer(value["den"])
+    if denominator <= 0:
+        raise ValueError("rational denominator must be positive")
+    result = Fraction(numerator, denominator)
+    if result.numerator != numerator or result.denominator != denominator:
+        raise ValueError("rational value is not reduced")
+    return result
+
+
+def _matrix(payload: object) -> list[list[Fraction]]:
+    if not isinstance(payload, dict) or set(payload) != {
+        "matrix_schema_version",
+        "domain",
+        "entries",
+    }:
+        raise ValueError("rational matrix has an invalid shape")
+    if payload["matrix_schema_version"] != "1" or payload["domain"] != "QQ":
+        raise ValueError("rational matrix uses unsupported semantics")
+    entries = payload["entries"]
+    if (
+        not isinstance(entries, list)
+        or not 1 <= len(entries) <= _MAX_DIMENSION
+        or not isinstance(entries[0], list)
+        or len(entries[0]) != len(entries)
+        or any(not isinstance(row, list) or len(row) != len(entries) for row in entries)
+    ):
+        raise ValueError("determinant requires a bounded square matrix")
+    return [[_rational(value) for value in row] for row in entries]
+
+
+def _candidate(
+    payload: object,
+    *,
+    claim: dict[str, Any],
+    candidate: dict[str, Any],
+) -> Fraction:
+    if not isinstance(payload, dict) or set(payload) != {
+        "result_schema_version",
+        "matrix_uri",
+        "determinant",
+        "method",
+        "backend",
+        "backend_version",
+    }:
+        raise ValueError("determinant candidate has an invalid shape")
+    if (
+        payload["result_schema_version"] != "1"
+        or payload["matrix_uri"] != claim["artifact_uri"]
+        or payload["method"] != "FRACTION_FREE_BAREISS"
+        or payload["backend"] != "sympy"
+        or not isinstance(payload["backend_version"], str)
+        or not payload["backend_version"]
+        or candidate["parents"] != [claim["artifact_uri"]]
+    ):
+        raise ValueError("determinant candidate is not bound to the source matrix")
+    return _rational(payload["determinant"])
+
+
+def _determinant(matrix: list[list[Fraction]]) -> Fraction:
+    """Exact Gaussian-elimination determinant with explicit row swaps."""
+
+    work = [row[:] for row in matrix]
+    determinant = Fraction(1)
+    for column in range(len(work)):
+        pivot_row = next(
+            (row for row in range(column, len(work)) if work[row][column] != 0),
+            None,
+        )
+        if pivot_row is None:
+            return Fraction(0)
+        if pivot_row != column:
+            work[column], work[pivot_row] = work[pivot_row], work[column]
+            determinant = -determinant
+        pivot = work[column][column]
+        determinant *= pivot
+        for row in range(column + 1, len(work)):
+            multiplier = work[row][column] / pivot
+            for target_column in range(column + 1, len(work)):
+                work[row][target_column] -= multiplier * work[column][target_column]
+            work[row][column] = Fraction(0)
+    return determinant
+
+
+def check_rational_determinant(request: dict[str, Any]) -> dict[str, Any]:
+    """Accept only a fully bound candidate equal to an exact independent replay."""
+
+    try:
+        if not isinstance(request, dict) or set(request) != {
+            "request_version",
+            "claim",
+            "candidate",
+            "scope",
+            "witness",
+            "expected_bindings",
+        }:
+            return _reject("malformed checker request")
+        if request["request_version"] != "1" or request["scope"] is not None:
+            return _reject("unsupported checker request")
+        claim = request["claim"]
+        candidate = request["candidate"]
+        witness = request["witness"]
+        if not all(_valid_artifact(item) for item in (claim, candidate, witness)):
+            return _reject("checker artifact metadata is malformed")
+        expected_bindings = request["expected_bindings"]
+        if not _valid_bindings(expected_bindings):
+            return _reject("expected evidence bindings are malformed")
+        if (
+            claim["semantics_uri"] != candidate["semantics_uri"]
+            or claim["semantics_uri"] != witness["semantics_uri"]
+        ):
+            return _reject("checker artifacts use different semantics")
+        for artifact, label in (
+            (claim, "source matrix"),
+            (candidate, "determinant candidate"),
+            (witness, "determinant witness"),
+        ):
+            if artifact["payload_digest"] != _sha256(
+                _canonical_json(artifact["payload"])
+            ):
+                return _reject(f"{label} payload digest does not match")
+
+        matrix = _matrix(claim["payload"])
+        declared = _candidate(
+            candidate["payload"],
+            claim=claim,
+            candidate=candidate,
+        )
+        if (
+            expected_bindings["claim_digest"] != claim["object_digest"]
+            or expected_bindings["candidate_digest"] != candidate["object_digest"]
+        ):
+            return _reject("expected evidence bindings do not match artifacts")
+        envelope = witness["payload"]
+        if not isinstance(envelope, dict) or set(envelope) != {
+            "evidence_schema_version",
+            "witness_format",
+            "format_version",
+            "role",
+            "bindings",
+            "payload",
+        }:
+            return _reject("determinant witness envelope is malformed")
+        if (
+            envelope["evidence_schema_version"] != "1"
+            or envelope["witness_format"] != "matrix.rational_determinant"
+            or envelope["format_version"] != "1"
+            or envelope["role"] != "SUPPORTS_CLAIM"
+            or envelope["bindings"] != expected_bindings
+        ):
+            return _reject("determinant witness envelope is not exactly bound")
+        if envelope["payload"] != {
+            "matrix_uri": claim["artifact_uri"],
+            "determinant_uri": candidate["artifact_uri"],
+        }:
+            return _reject("determinant witness points at different artifacts")
+        if len(witness["parents"]) != 2 or set(witness["parents"]) != {
+            claim["artifact_uri"],
+            candidate["artifact_uri"],
+        }:
+            return _reject("determinant witness is missing required lineage")
+
+        computed = _determinant(matrix)
+        if computed != declared:
+            return _reject("declared determinant does not match exact recomputation")
+        return {
+            "accepted": True,
+            "conclusion": "TRUE",
+            "arithmetic": "EXACT_RATIONAL",
+            "method": "DIRECT_WITNESS",
+            "coverage": "NOT_APPLICABLE",
+            "detail": (
+                f"recomputed the determinant exactly for the full "
+                f"{len(matrix)} by {len(matrix)} rational matrix"
+            ),
+        }
+    except (KeyError, TypeError, ValueError, ZeroDivisionError, OverflowError):
+        return _reject("malformed checker request")

--- a/tests/checkers/test_rational_determinant_checker.py
+++ b/tests/checkers/test_rational_determinant_checker.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from typing import Any
+
+import pytest
+
+from jacobian_checkers.rational_determinants import check_rational_determinant
+
+
+def _uri(character: str) -> str:
+    return "artifact://sha256/" + character * 64
+
+
+def _digest(value: object) -> str:
+    encoded = json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _rational(numerator: int, denominator: int = 1) -> dict[str, str]:
+    return {"num": str(numerator), "den": str(denominator)}
+
+
+def _artifact(
+    *,
+    uri_character: str,
+    object_character: str,
+    schema_character: str,
+    semantics_uri: str,
+    payload: dict[str, Any],
+    parents: list[str],
+) -> dict[str, Any]:
+    return {
+        "artifact_uri": _uri(uri_character),
+        "object_digest": "sha256:" + object_character * 64,
+        "payload_digest": _digest(payload),
+        "schema_uri": _uri(schema_character),
+        "semantics_uri": semantics_uri,
+        "parents": parents,
+        "payload": payload,
+    }
+
+
+def _request() -> dict[str, Any]:
+    semantics_uri = _uri("e")
+    source_payload = {
+        "matrix_schema_version": "1",
+        "domain": "QQ",
+        "entries": [
+            [_rational(1), _rational(0), _rational(1)],
+            [_rational(2), _rational(-1), _rational(3)],
+            [_rational(4), _rational(3), _rational(2)],
+        ],
+    }
+    claim = _artifact(
+        uri_character="a",
+        object_character="1",
+        schema_character="b",
+        semantics_uri=semantics_uri,
+        payload=source_payload,
+        parents=[],
+    )
+    candidate_payload = {
+        "result_schema_version": "1",
+        "matrix_uri": claim["artifact_uri"],
+        "determinant": _rational(-1),
+        "method": "FRACTION_FREE_BAREISS",
+        "backend": "sympy",
+        "backend_version": "1.14.0",
+    }
+    candidate = _artifact(
+        uri_character="c",
+        object_character="2",
+        schema_character="d",
+        semantics_uri=semantics_uri,
+        payload=candidate_payload,
+        parents=[claim["artifact_uri"]],
+    )
+    bindings = {
+        "claim_digest": claim["object_digest"],
+        "semantics_digest": "sha256:" + "3" * 64,
+        "candidate_digest": candidate["object_digest"],
+        "scope_digest": None,
+        "encoding_digest": None,
+    }
+    witness_payload = {
+        "evidence_schema_version": "1",
+        "witness_format": "matrix.rational_determinant",
+        "format_version": "1",
+        "role": "SUPPORTS_CLAIM",
+        "bindings": bindings,
+        "payload": {
+            "matrix_uri": claim["artifact_uri"],
+            "determinant_uri": candidate["artifact_uri"],
+        },
+    }
+    witness = _artifact(
+        uri_character="f",
+        object_character="4",
+        schema_character="5",
+        semantics_uri=semantics_uri,
+        payload=witness_payload,
+        parents=[claim["artifact_uri"], candidate["artifact_uri"]],
+    )
+    return {
+        "request_version": "1",
+        "claim": claim,
+        "candidate": candidate,
+        "scope": None,
+        "witness": witness,
+        "expected_bindings": bindings,
+    }
+
+
+def _refresh_payload_digest(artifact: dict[str, Any]) -> None:
+    artifact["payload_digest"] = _digest(artifact["payload"])
+
+
+def test_checker_accepts_exact_rational_determinant() -> None:
+    decision = check_rational_determinant(_request())
+
+    assert decision["accepted"] is True
+    assert decision["conclusion"] == "TRUE"
+    assert decision["arithmetic"] == "EXACT_RATIONAL"
+    assert decision["method"] == "DIRECT_WITNESS"
+
+
+def test_checker_rejects_mutated_determinant_with_refreshed_digest() -> None:
+    request = _request()
+    request["candidate"]["payload"]["determinant"] = _rational(1)
+    _refresh_payload_digest(request["candidate"])
+
+    decision = check_rational_determinant(request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+def test_checker_rejects_rebound_source_identity() -> None:
+    request = _request()
+    request["candidate"]["payload"]["matrix_uri"] = _uri("9")
+    _refresh_payload_digest(request["candidate"])
+
+    decision = check_rational_determinant(request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda request: request["claim"]["payload"]["entries"][0][0].update(num="01"),
+        lambda request: request["candidate"]["payload"]["determinant"].update(den="0"),
+        lambda request: request["candidate"]["payload"].update(extra=True),
+        lambda request: request["candidate"]["parents"].append(_uri("7")),
+        lambda request: request["witness"]["payload"]["bindings"].update(
+            claim_digest="sha256:" + "8" * 64
+        ),
+    ],
+    ids=(
+        "noncanonical_rational",
+        "zero_denominator",
+        "extra_candidate_field",
+        "ambiguous_candidate_lineage",
+        "rebound_witness",
+    ),
+)
+def test_checker_rejects_malformed_or_rebound_payloads(mutation: Any) -> None:
+    request = copy.deepcopy(_request())
+    mutation(request)
+    for key in ("claim", "candidate", "witness"):
+        _refresh_payload_digest(request[key])
+
+    decision = check_rational_determinant(request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"

--- a/tests/integration/test_matrix_capabilities.py
+++ b/tests/integration/test_matrix_capabilities.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import subprocess
 from fractions import Fraction
 from itertools import permutations
 from pathlib import Path
@@ -11,10 +12,15 @@ import sympy
 
 from jacobian.contracts.capabilities import (
     CapabilityAssuranceLevel,
+    CapabilityMode,
     CapabilityProviderAvailability,
     CapabilityRequest,
 )
+from jacobian.contracts.results import ExecutionStatus
 from jacobian.kernel import JacobianKernel
+from jacobian.matrix_determinant_capabilities import (
+    install_matrix_determinant_checker,
+)
 
 
 def _rational(value: int | Fraction) -> dict[str, str]:
@@ -43,6 +49,22 @@ def _reference_determinant(rows: list[list[Fraction]]) -> Fraction:
             term *= rows[row][column]
         total += term
     return total
+
+
+def _kernel_with_determinant_checker(root: Path) -> JacobianKernel:
+    kernel = JacobianKernel(root)
+    adapter, _installation = install_matrix_determinant_checker(
+        kernel.store,
+        kernel.schemas,
+        kernel.artifacts,
+        kernel.matrix,
+        kernel.verification,
+        kernel.checkers,
+        authorize_checker=True,
+    )
+    assert adapter is not None
+    kernel.register_capability(adapter)
+    return kernel
 
 
 @pytest.mark.integration
@@ -82,6 +104,112 @@ def test_matrix_determinant_compute_is_exact_and_unverified(
     determinant_artifact = kernel.store.get(result.output["determinant_uri"])
     assert determinant_artifact.payload["backend"] == "sympy"
     assert determinant_artifact.payload["backend_version"] == sympy.__version__
+
+
+@pytest.mark.integration
+def test_matrix_determinant_verify_independently_recomputes_exact_value(
+    tmp_path: Path,
+) -> None:
+    kernel = _kernel_with_determinant_checker(tmp_path)
+    computed = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="matrix.determinant.compute",
+            input={
+                "matrix": _matrix(
+                    [
+                        [1, 0, 1],
+                        [2, -1, 3],
+                        [4, 3, 2],
+                    ]
+                )
+            },
+        )
+    )
+
+    verified = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="matrix.determinant.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"determinant_uri": computed.output["determinant_uri"]},
+        )
+    )
+
+    assert verified.execution.status is ExecutionStatus.COMPLETED
+    assert verified.output["status"] == "VERIFIED_DETERMINANT"
+    assert verified.output["conclusion"] == "TRUE"
+    assert verified.output["verification_record_uri"].startswith("artifact://sha256/")
+    assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED
+
+
+@pytest.mark.integration
+def test_matrix_determinant_verify_rejects_wrong_bound_value(tmp_path: Path) -> None:
+    kernel = _kernel_with_determinant_checker(tmp_path)
+    computed = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="matrix.determinant.compute",
+            input={"matrix": _matrix([[1, 2], [3, 4]])},
+        )
+    )
+    source_uri = computed.output["matrix_uri"]
+    wrong = kernel.artifacts.put(
+        schema_uri=kernel.matrix.determinant_schema_uri,
+        semantics_uri=kernel.matrix.semantics_uri,
+        payload={
+            **kernel.store.get(computed.output["determinant_uri"]).payload,
+            "determinant": _rational(2),
+        },
+        parents=(source_uri,),
+        summary="deliberately incorrect determinant candidate",
+    )
+
+    rejected = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="matrix.determinant.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"determinant_uri": wrong.artifact_uri},
+        )
+    )
+
+    assert rejected.execution.status is ExecutionStatus.COMPLETED
+    assert rejected.output["status"] == "REJECTED"
+    assert rejected.output["conclusion"] == "UNKNOWN"
+    assert rejected.output["verification_record_uri"] is None
+    assert rejected.assurance.level is not CapabilityAssuranceLevel.VERIFIED
+
+
+@pytest.mark.integration
+def test_matrix_determinant_verify_timeout_is_not_a_conclusion(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = _kernel_with_determinant_checker(tmp_path)
+    computed = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="matrix.determinant.compute",
+            input={"matrix": _matrix([[1]])},
+        )
+    )
+    monkeypatch.setattr(
+        kernel.verification,
+        "_run_checker",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            subprocess.TimeoutExpired("determinant-checker", 1)
+        ),
+    )
+
+    timed_out = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="matrix.determinant.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"determinant_uri": computed.output["determinant_uri"]},
+        )
+    )
+
+    assert timed_out.execution.status is ExecutionStatus.TIMEOUT
+    assert timed_out.output["status"] == "TIMEOUT"
+    assert timed_out.output["conclusion"] == "UNKNOWN"
+    assert timed_out.output["verification_record_uri"] is None
+    assert timed_out.assurance.level is not CapabilityAssuranceLevel.VERIFIED
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary

- add `matrix.determinant.verify` for one stored exact rational determinant
- authorize a clean-process standard-library checker that independently recomputes with `fractions.Fraction` Gaussian elimination instead of SymPy/Bareiss producer code
- bind claim, candidate, witness, semantics, payload digests, and exact lineage before accepting
- preserve fail-closed behavior: rejection, timeout, cancellation, and error remain `UNKNOWN` and create no verification record
- document the contract, public reproduction, and portfolio decision

## Why

`matrix.determinant.compute` already produced exact SymPy determinant artifacts, but those results remained computed and unverified. Determinants are a small shared primitive used by many later mathematical workflows, so a separate atomic verifier closes that trust boundary without adding a new backend or workflow policy.

## Validation

- `uv run --frozen pytest -q -n 0 tests/checkers/test_rational_determinant_checker.py tests/integration/test_matrix_capabilities.py` — 19 passed
- `make check-static` — passed (ruff, format, deptry, vulture, mypy, build)
- `make check` — 360 passed, 4 deselected
- clean `JacobianKernel(..., install_references=True)` catalog probe — `matrix.determinant.verify` installed

Attack coverage includes refreshed-digest wrong values, rebound source identity, ambiguous lineage, noncanonical rationals, unexpected fields, rebound witness bindings, and checker timeout.