### PR TITLE
Add independent exact rational matrix rank verification

### DIFF
--- a/src/jacobian/contracts/matrices.py
+++ b/src/jacobian/contracts/matrices.py
@@ -168,6 +168,32 @@ class MatrixRankOutput(ContractModel):
     backend_version: str
 
 
+class MatrixRankVerificationRequest(ContractModel):
+    rank_uri: ArtifactUri
+
+
+class MatrixRankVerificationOutput(ContractModel):
+    status: Literal["VERIFIED_RANK", "REJECTED", "TIMEOUT", "CANCELLED", "ERROR"]
+    conclusion: Literal["TRUE", "UNKNOWN"]
+    matrix_uri: ArtifactUri
+    rank_uri: ArtifactUri
+    witness_uri: ArtifactUri
+    checker_id: CheckerUri
+    verification_record_uri: ArtifactUri | None = None
+    detail: str = Field(min_length=1, max_length=1024)
+
+    @model_validator(mode="after")
+    def bind_verified_projection(self) -> Self:
+        if self.status == "VERIFIED_RANK":
+            if self.conclusion != "TRUE" or self.verification_record_uri is None:
+                raise ValueError(
+                    "verified rank requires TRUE and a verification record"
+                )
+        elif self.conclusion != "UNKNOWN" or self.verification_record_uri is not None:
+            raise ValueError("non-verified rank cannot carry a conclusion or record")
+        return self
+
+
 class MatrixHermiteResourceBudget(ContractModel):
     """Wall-clock bound for one isolated Python-FLINT HNF attempt."""
 

--- a/src/jacobian/kernel.py
+++ b/src/jacobian/kernel.py
@@ -76,6 +76,10 @@ from jacobian.matrix_normal_forms import (
     MatrixNormalFormArtifactService,
     install_matrix_normal_form_artifacts,
 )
+from jacobian.matrix_rank_capabilities import (
+    MatrixRankCheckerInstallation,
+    install_matrix_rank_checker,
+)
 from jacobian.memory import ResearchMemory
 from jacobian.plugin_execution import PluginExecutor
 from jacobian.plugins.registry import PluginRegistry
@@ -468,6 +472,18 @@ class JacobianKernel:
         )
         if determinant_verification is not None:
             self.register_capability(determinant_verification)
+        self.matrix_rank_checker: MatrixRankCheckerInstallation
+        rank_verification, self.matrix_rank_checker = install_matrix_rank_checker(
+            self.store,
+            self.schemas,
+            self.artifacts,
+            self.matrix,
+            self.verification,
+            self.checkers,
+            authorize_checker=install_references,
+        )
+        if rank_verification is not None:
+            self.register_capability(rank_verification)
         self.polynomial_system: PolynomialSystemInstallation
         polynomial_system_adapter, self.polynomial_system = (
             install_polynomial_system_capabilities(

--- a/src/jacobian/matrix_rank_capabilities.py
+++ b/src/jacobian/matrix_rank_capabilities.py
@@ -1,0 +1,262 @@
+"""Independent verification of one stored exact rational matrix rank."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from pydantic import ValidationError
+
+from jacobian.artifacts import ArtifactService
+from jacobian.capabilities import CapabilityInvocationError
+from jacobian.contracts.capabilities import (
+    CapabilityAssurance,
+    CapabilityAssuranceLevel,
+    CapabilityCompleteness,
+    CapabilityCompletenessStatus,
+    CapabilityDescriptor,
+    CapabilityDiagnostic,
+    CapabilityMode,
+    CapabilityRequest,
+    CapabilityResult,
+    CapabilityScope,
+)
+from jacobian.contracts.evidence import EvidenceBindings, WitnessEnvelope, WitnessRole
+from jacobian.contracts.matrices import (
+    ExactRationalMatrix,
+    MatrixRankArtifact,
+    MatrixRankVerificationOutput,
+    MatrixRankVerificationRequest,
+)
+from jacobian.contracts.results import Conclusion, ExecutionStatus, Verification
+from jacobian.matrix_capabilities import MatrixInstallation
+from jacobian.provider_runtime import known_provider_runtime
+from jacobian.registry import CheckerRegistry
+from jacobian.schema_registry import SchemaRegistry, SchemaRegistryError, model_schema
+from jacobian.store import ArtifactStore, StoreError
+from jacobian.verification import VerificationService
+
+
+@dataclass(frozen=True, slots=True)
+class MatrixRankCheckerInstallation:
+    witness_schema_uri: str
+    checker_id: str | None
+
+
+def install_matrix_rank_checker(
+    store: ArtifactStore,
+    schemas: SchemaRegistry,
+    artifacts: ArtifactService,
+    matrices: MatrixInstallation,
+    verification: VerificationService,
+    checkers: CheckerRegistry,
+    *,
+    authorize_checker: bool,
+) -> tuple[MatrixRankVerificationAdapter | None, MatrixRankCheckerInstallation]:
+    witness_schema_uri = schemas.register_model(
+        name="jacobian.witness-envelope", version="1", model=WitnessEnvelope
+    )
+    checker_id = None
+    if authorize_checker:
+        checker_id = checkers.authorize(
+            name="exact rational rank recomputation checker",
+            entrypoint="jacobian_checkers.rational_determinants:check_rational_rank",
+            evidence_kind="WITNESS",
+            format_id="matrix.rational_rank",
+            format_version="1",
+            claim_schema_uris=(matrices.matrix_schema_uri,),
+            semantics_uris=(matrices.semantics_uri,),
+            candidate_schema_uris=(matrices.rank_schema_uri,),
+            reason="bundled standard-library exact rational row reduction",
+        ).checker_id
+    installation = MatrixRankCheckerInstallation(witness_schema_uri, checker_id)
+    if checker_id is None:
+        return None, installation
+    return (
+        MatrixRankVerificationAdapter(
+            store, schemas, artifacts, matrices, verification, installation
+        ),
+        installation,
+    )
+
+
+class MatrixRankVerificationAdapter:
+    def __init__(
+        self,
+        store: ArtifactStore,
+        schemas: SchemaRegistry,
+        artifacts: ArtifactService,
+        matrices: MatrixInstallation,
+        verification: VerificationService,
+        installation: MatrixRankCheckerInstallation,
+    ) -> None:
+        self.store, self.schemas, self.artifacts = store, schemas, artifacts
+        self.matrices, self.verification, self.installation = (
+            matrices,
+            verification,
+            installation,
+        )
+        assert installation.checker_id is not None
+        self._descriptor = CapabilityDescriptor(
+            capability_id="matrix.rank.verify",
+            version="1",
+            title="Verify exact rational matrix rank",
+            description="Independently recompute and verify one stored rank over QQ.",
+            provider="jacobian.rational-matrix",
+            provider_runtime=known_provider_runtime(
+                "jacobian.rational-matrix",
+                features=("rank", "exact-rational-recomputation"),
+                checker_ids=(installation.checker_id,),
+            ),
+            modes=(CapabilityMode.VERIFY,),
+            input_schema=model_schema(MatrixRankVerificationRequest),
+            output_schema=model_schema(MatrixRankVerificationOutput),
+            tags=("matrix", "rank", "verification"),
+        )
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        return self._descriptor
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        rank_uri = MatrixRankVerificationRequest.model_validate(request.input).rank_uri
+        try:
+            candidate_artifact = self.store.get(rank_uri)
+            candidate = MatrixRankArtifact.model_validate(
+                self.schemas.validate(
+                    self.matrices.rank_schema_uri, candidate_artifact.payload
+                )
+            )
+            matrix_artifact = self.store.get(candidate.matrix_uri)
+            matrix = ExactRationalMatrix.model_validate(
+                self.schemas.validate(
+                    self.matrices.matrix_schema_uri, matrix_artifact.payload
+                )
+            )
+            if (
+                candidate_artifact.manifest.schema_uri != self.matrices.rank_schema_uri
+                or candidate_artifact.manifest.semantics_uri
+                != self.matrices.semantics_uri
+                or matrix_artifact.manifest.schema_uri
+                != self.matrices.matrix_schema_uri
+                or candidate_artifact.manifest.parents
+                != (matrix_artifact.artifact_uri,)
+            ):
+                raise ValueError("rank candidate is not exactly bound to its matrix")
+        except (StoreError, SchemaRegistryError, ValidationError, ValueError) as exc:
+            raise CapabilityInvocationError(
+                CapabilityDiagnostic(
+                    code="INVALID_MATRIX_RANK",
+                    stage="artifact_resolution",
+                    message=str(exc),
+                    path="rank_uri",
+                    hint="Use an artifact returned by matrix.rank.compute.",
+                )
+            ) from exc
+        checker_id = self.installation.checker_id
+        assert checker_id is not None
+        semantics = self.store.get(self.matrices.semantics_uri)
+        witness = WitnessEnvelope(
+            witness_format="matrix.rational_rank",
+            format_version="1",
+            role=WitnessRole.SUPPORTS_CLAIM,
+            bindings=EvidenceBindings(
+                claim_digest=matrix_artifact.manifest.object_digest,
+                semantics_digest=semantics.manifest.object_digest,
+                candidate_digest=candidate_artifact.manifest.object_digest,
+            ),
+            payload={
+                "matrix_uri": matrix_artifact.artifact_uri,
+                "rank_uri": candidate_artifact.artifact_uri,
+            },
+        )
+        evidence = self.artifacts.put(
+            schema_uri=self.installation.witness_schema_uri,
+            semantics_uri=self.matrices.semantics_uri,
+            payload=witness.model_dump(mode="json"),
+            parents=(matrix_artifact.artifact_uri, candidate_artifact.artifact_uri),
+            summary="exact rational rank verification witness",
+        )
+        checked = self.verification.verify_witness(
+            claim_uri=matrix_artifact.artifact_uri,
+            candidate_uri=candidate_artifact.artifact_uri,
+            witness_uri=evidence.artifact_uri,
+            checker_id=checker_id,
+            include_artifact_metadata=True,
+        )
+        verified = (
+            checked.execution.status is ExecutionStatus.COMPLETED
+            and checked.conclusion is Conclusion.TRUE
+            and checked.assurance.verification is Verification.VERIFIED
+            and checked.verification_record_uri is not None
+        )
+        status: Literal["VERIFIED_RANK", "REJECTED", "TIMEOUT", "CANCELLED", "ERROR"]
+        if verified:
+            status = "VERIFIED_RANK"
+        elif checked.execution.status is ExecutionStatus.COMPLETED:
+            status = "REJECTED"
+        elif checked.execution.status is ExecutionStatus.TIMEOUT:
+            status = "TIMEOUT"
+        elif checked.execution.status is ExecutionStatus.CANCELLED:
+            status = "CANCELLED"
+        else:
+            status = "ERROR"
+        detail = checked.execution.detail or (
+            checked.input.errors[0]
+            if checked.input.errors
+            else (
+                "rank verified" if verified else "rank was not independently accepted"
+            )
+        )
+        output = MatrixRankVerificationOutput(
+            status=status,
+            conclusion="TRUE" if verified else "UNKNOWN",
+            matrix_uri=matrix_artifact.artifact_uri,
+            rank_uri=candidate_artifact.artifact_uri,
+            witness_uri=evidence.artifact_uri,
+            checker_id=checker_id,
+            verification_record_uri=checked.verification_record_uri
+            if verified
+            else None,
+            detail=detail,
+        )
+        uris = [
+            matrix_artifact.artifact_uri,
+            candidate_artifact.artifact_uri,
+            evidence.artifact_uri,
+        ]
+        if verified:
+            assert checked.verification_record_uri is not None
+            uris.append(checked.verification_record_uri)
+        return CapabilityResult(
+            capability_id=self.descriptor.capability_id,
+            capability_version=self.descriptor.version,
+            mode=request.mode,
+            execution=checked.execution,
+            output=output.model_dump(mode="json"),
+            scope=CapabilityScope(
+                description="the full rectangular exact rational matrix",
+                parameters={
+                    "row_count": len(matrix.entries),
+                    "column_count": len(matrix.entries[0]),
+                },
+                artifact_uri=matrix_artifact.artifact_uri,
+            ),
+            completeness=CapabilityCompleteness(
+                status=CapabilityCompletenessStatus.NOT_APPLICABLE,
+                basis="direct exact row reduction makes no search claim",
+                assurance_level=CapabilityAssuranceLevel.COMPUTED,
+            ),
+            assurance=CapabilityAssurance(
+                level=CapabilityAssuranceLevel.VERIFIED
+                if verified
+                else CapabilityAssuranceLevel.COMPUTED,
+                basis="independent exact rational row reduction"
+                if verified
+                else "checker did not accept the candidate",
+                verification_record_uri=checked.verification_record_uri
+                if verified
+                else None,
+            ),
+            artifact_uris=tuple(uris),
+        )

--- a/src/jacobian_checkers/rational_determinants.py
+++ b/src/jacobian_checkers/rational_determinants.py
@@ -287,3 +287,131 @@ def check_rational_determinant(request: dict[str, Any]) -> dict[str, Any]:
         }
     except (KeyError, TypeError, ValueError, ZeroDivisionError, OverflowError):
         return _reject("malformed checker request")
+
+
+def check_rational_rank(request: dict[str, Any]) -> dict[str, Any]:
+    """Independently recompute the rank of one bound rectangular QQ matrix."""
+
+    try:
+        if not isinstance(request, dict) or set(request) != {
+            "request_version",
+            "claim",
+            "candidate",
+            "scope",
+            "witness",
+            "expected_bindings",
+        }:
+            return _reject("malformed checker request")
+        claim, candidate, witness = (
+            request["claim"],
+            request["candidate"],
+            request["witness"],
+        )
+        if request["request_version"] != "1" or request["scope"] is not None:
+            return _reject("unsupported checker request")
+        if not all(_valid_artifact(item) for item in (claim, candidate, witness)):
+            return _reject("checker artifact metadata is malformed")
+        if (
+            claim["semantics_uri"] != candidate["semantics_uri"]
+            or claim["semantics_uri"] != witness["semantics_uri"]
+            or any(
+                artifact["payload_digest"]
+                != _sha256(_canonical_json(artifact["payload"]))
+                for artifact in (claim, candidate, witness)
+            )
+        ):
+            return _reject("rank artifacts have changed payloads or semantics")
+        bindings = request["expected_bindings"]
+        if (
+            not _valid_bindings(bindings)
+            or bindings["claim_digest"] != claim["object_digest"]
+            or bindings["candidate_digest"] != candidate["object_digest"]
+            or len(witness["parents"]) != 2
+            or set(witness["parents"])
+            != {claim["artifact_uri"], candidate["artifact_uri"]}
+        ):
+            return _reject("rank evidence bindings or lineage do not match")
+        payload = claim["payload"]
+        entries = payload.get("entries") if isinstance(payload, dict) else None
+        if (
+            not isinstance(payload, dict)
+            or set(payload) != {"matrix_schema_version", "domain", "entries"}
+            or payload["matrix_schema_version"] != "1"
+            or payload["domain"] != "QQ"
+            or not isinstance(entries, list)
+            or not 1 <= len(entries) <= _MAX_DIMENSION
+            or not isinstance(entries[0], list)
+            or not 1 <= len(entries[0]) <= _MAX_DIMENSION
+            or any(
+                not isinstance(row, list) or len(row) != len(entries[0])
+                for row in entries
+            )
+        ):
+            return _reject("rank source matrix is malformed")
+        matrix = [[_rational(value) for value in row] for row in entries]
+        declared = candidate["payload"]
+        if (
+            not isinstance(declared, dict)
+            or set(declared)
+            != {
+                "result_schema_version",
+                "matrix_uri",
+                "rank",
+                "pivot_columns",
+                "method",
+                "backend",
+                "backend_version",
+            }
+            or declared["result_schema_version"] != "1"
+            or declared["matrix_uri"] != claim["artifact_uri"]
+            or candidate["parents"] != [claim["artifact_uri"]]
+            or declared["method"] != "EXACT_RATIONAL_ROW_REDUCTION"
+            or declared["backend"] != "sympy"
+            or not isinstance(declared["rank"], int)
+            or isinstance(declared["rank"], bool)
+        ):
+            return _reject("rank candidate is malformed or misbound")
+        envelope = witness["payload"]
+        if (
+            not isinstance(envelope, dict)
+            or envelope.get("witness_format") != "matrix.rational_rank"
+            or envelope.get("format_version") != "1"
+            or envelope.get("role") != "SUPPORTS_CLAIM"
+            or envelope.get("bindings") != bindings
+            or envelope.get("payload")
+            != {
+                "matrix_uri": claim["artifact_uri"],
+                "rank_uri": candidate["artifact_uri"],
+            }
+        ):
+            return _reject("rank witness is malformed or misbound")
+        rank = 0
+        column_count = len(matrix[0])
+        for column in range(column_count):
+            pivot = next(
+                (row for row in range(rank, len(matrix)) if matrix[row][column] != 0),
+                None,
+            )
+            if pivot is None:
+                continue
+            matrix[rank], matrix[pivot] = matrix[pivot], matrix[rank]
+            pivot_value = matrix[rank][column]
+            for row in range(rank + 1, len(matrix)):
+                multiplier = matrix[row][column] / pivot_value
+                for target in range(column, column_count):
+                    matrix[row][target] -= multiplier * matrix[rank][target]
+            rank += 1
+            if rank == len(matrix):
+                break
+        if rank != declared["rank"]:
+            return _reject("declared rank does not match exact recomputation")
+        return {
+            "accepted": True,
+            "conclusion": "TRUE",
+            "arithmetic": "EXACT_RATIONAL",
+            "method": "DIRECT_WITNESS",
+            "coverage": "NOT_APPLICABLE",
+            "detail": f"recomputed exact rank {rank} for the full rectangular matrix",
+        }
+    except (KeyError, TypeError, ValueError, ZeroDivisionError, OverflowError):
+        return _reject("malformed checker request")

--- a/tests/integration/test_matrix_rank_verification.py
+++ b/tests/integration/test_matrix_rank_verification.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from jacobian.contracts.capabilities import (
+    CapabilityAssuranceLevel,
+    CapabilityMode,
+    CapabilityRequest,
+)
+from jacobian.kernel import JacobianKernel
+
+
+def _matrix() -> dict[str, object]:
+    def q(value: int) -> dict[str, str]:
+        return {"num": str(value), "den": "1"}
+
+    return {
+        "entries": [
+            [q(1), q(2), q(3)],
+            [q(2), q(4), q(6)],
+            [q(0), q(1), q(1)],
+        ]
+    }
+
+
+@pytest.mark.integration
+def test_matrix_rank_verify_independently_recomputes_rank(tmp_path: Path) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+    computed = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="matrix.rank.compute", input={"matrix": _matrix()}
+        )
+    )
+    verified = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="matrix.rank.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"rank_uri": computed.output["rank_uri"]},
+        )
+    )
+    assert verified.output["status"] == "VERIFIED_RANK"
+    assert verified.output["conclusion"] == "TRUE"
+    assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED
+
+
+@pytest.mark.integration
+def test_matrix_rank_verify_rejects_wrong_rank(tmp_path: Path) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+    computed = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="matrix.rank.compute", input={"matrix": _matrix()}
+        )
+    )
+    source_uri = computed.output["matrix_uri"]
+    wrong = kernel.artifacts.put(
+        schema_uri=kernel.matrix.rank_schema_uri,
+        semantics_uri=kernel.matrix.semantics_uri,
+        payload={
+            **kernel.store.get(computed.output["rank_uri"]).payload,
+            "rank": 3,
+            "pivot_columns": [0, 1, 2],
+        },
+        parents=(source_uri,),
+        summary="deliberately incorrect rank candidate",
+    )
+    rejected = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="matrix.rank.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"rank_uri": wrong.artifact_uri},
+        )
+    )
+    assert rejected.output["status"] == "REJECTED"
+    assert rejected.output["conclusion"] == "UNKNOWN"
+    assert rejected.output["verification_record_uri"] is None


### PR DESCRIPTION
## Summary

- add atomic `matrix.rank.verify` over stored `matrix.rank.compute` artifacts
- authorize a clean-process standard-library checker that independently performs exact Fraction-based row reduction
- bind the source matrix, rank candidate, semantics, witness, payload digests, lineage, and checker identity
- return VERIFIED/TRUE only when independent recomputation accepts the declared rank
- fail closed to UNKNOWN for wrong ranks, malformed artifacts, substitutions, timeouts, or checker errors

## Design decisions

- reuse the merged exact rational matrix and rank artifact contracts
- verify rank only; producer pivot columns remain provenance/evidence but are not conflated with the mathematical rank conclusion
- the checker imports neither SymPy nor the rank computation adapter
- direct verification makes no enumeration or search-completeness claim

## Validation

- lint and configured mypy pass
- focused matrix/checker suite: 21 passed
- final rank integration tests: 2 passed
- package build succeeded
- broader non-integration suite: 360 passed, with 5 unrelated macOS Bash 3.2 failures in the newly merged CI-plan validator (`declare -A` requires newer Bash)

Draft for human review; do not merge automatically.