### PR TITLE
Add bounded rational polynomial-system solution search

### DIFF
--- a/src/jacobian/contracts/polynomial_systems.py
+++ b/src/jacobian/contracts/polynomial_systems.py
@@ -55,6 +55,41 @@ class PolynomialSystemSolutionRequest(ContractModel):
         return self
 
 
+class PolynomialSystemRationalSearchRequest(ContractModel):
+    system: RationalPolynomialSystem
+    max_abs_numerator: int = Field(ge=0, le=8)
+    max_denominator: int = Field(ge=1, le=8)
+
+    @model_validator(mode="after")
+    def require_bounded_grid(self) -> Self:
+        scalar_bound = (2 * self.max_abs_numerator + 1) * self.max_denominator
+        if scalar_bound ** len(self.system.variables) > 10_000:
+            raise ValueError("declared rational grid exceeds 10,000 points")
+        return self
+
+
+class PolynomialSystemRationalSearchOutput(ContractModel):
+    found: bool
+    system_uri: ArtifactUri
+    assignment_uri: ArtifactUri | None = None
+    assignment: tuple[CanonicalRational, ...] | None = None
+    examined_assignment_count: int = Field(ge=0, le=10_000)
+    grid_assignment_count: int = Field(ge=1, le=10_000)
+    checker_id: CheckerUri | None = None
+    verification: Literal["UNVERIFIED"] = "UNVERIFIED"
+    coverage: Literal["COMPLETE_SEARCH_OBJECTIVE"] = "COMPLETE_SEARCH_OBJECTIVE"
+
+    @model_validator(mode="after")
+    def bind_candidate(self) -> Self:
+        if self.found != (
+            self.assignment_uri is not None and self.assignment is not None
+        ):
+            raise ValueError("found status must match the assignment candidate")
+        if self.examined_assignment_count > self.grid_assignment_count:
+            raise ValueError("examined count cannot exceed the grid size")
+        return self
+
+
 class PolynomialSystemSolutionClaim(ContractModel):
     claim_schema_version: Literal["1"] = "1"
     predicate: Literal["ASSIGNMENT_SATISFIES_POLYNOMIAL_SYSTEM"] = (

--- a/src/jacobian/kernel.py
+++ b/src/jacobian/kernel.py
@@ -95,6 +95,7 @@ from jacobian.polynomial_system_capabilities import (
     PolynomialSystemInstallation,
     install_polynomial_system_capabilities,
 )
+from jacobian.polynomial_system_search import PolynomialSystemRationalSearchAdapter
 from jacobian.polytope import PolytopeService
 from jacobian.provider_runtime import (
     cadical_provider_runtime,
@@ -481,6 +482,11 @@ class JacobianKernel:
         )
         if polynomial_system_adapter is not None:
             self.register_capability(polynomial_system_adapter)
+        self.register_capability(
+            PolynomialSystemRationalSearchAdapter(
+                self.artifacts, self.polynomial_system
+            )
+        )
         self.universal_algebra: UniversalAlgebraInstallation
         universal_algebra_adapters, self.universal_algebra = (
             install_universal_algebra_capabilities(

--- a/src/jacobian/polynomial_system_search.py
+++ b/src/jacobian/polynomial_system_search.py
@@ -1,0 +1,159 @@
+"""Bounded exact rational search for polynomial-system solutions."""
+
+from __future__ import annotations
+
+import time
+from fractions import Fraction
+from itertools import product
+
+from pydantic import ValidationError
+
+from jacobian.artifacts import ArtifactService
+from jacobian.capabilities import CapabilityInvocationError
+from jacobian.contracts.capabilities import (
+    CapabilityAssurance,
+    CapabilityAssuranceLevel,
+    CapabilityCompleteness,
+    CapabilityCompletenessStatus,
+    CapabilityDescriptor,
+    CapabilityDiagnostic,
+    CapabilityMode,
+    CapabilityRequest,
+    CapabilityResult,
+    CapabilityScope,
+)
+from jacobian.contracts.exact import CanonicalRational
+from jacobian.contracts.polynomial_systems import (
+    PolynomialSystemRationalSearchOutput,
+    PolynomialSystemRationalSearchRequest,
+    PolynomialSystemSolutionRequest,
+    RationalPolynomialAssignment,
+)
+from jacobian.contracts.results import Execution, ExecutionStatus
+from jacobian.polynomial_system_capabilities import (
+    PolynomialSystemInstallation,
+    _evaluate_request,
+)
+from jacobian.provider_runtime import known_provider_runtime
+
+
+class PolynomialSystemRationalSearchAdapter:
+    def __init__(
+        self, artifacts: ArtifactService, installation: PolynomialSystemInstallation
+    ) -> None:
+        self.artifacts, self.installation = artifacts, installation
+        self._descriptor = CapabilityDescriptor(
+            capability_id="polynomial.system.rational_solution.search",
+            version="1",
+            title="Search a bounded rational grid for a polynomial-system solution",
+            description="Return the first exact satisfying assignment in one declared finite grid.",
+            provider="jacobian.exact-polynomial-system-search",
+            provider_runtime=known_provider_runtime(
+                "jacobian.exact-polynomial-system-search",
+                features=("bounded-rational-enumeration",),
+            ),
+            modes=(CapabilityMode.EXPLORE,),
+            input_schema=PolynomialSystemRationalSearchRequest.model_json_schema(),
+            output_schema=PolynomialSystemRationalSearchOutput.model_json_schema(),
+            tags=("polynomial", "system", "solution", "bounded-search"),
+        )
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        return self._descriptor
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        try:
+            validated = PolynomialSystemRationalSearchRequest.model_validate(
+                request.input
+            )
+        except ValidationError as exc:
+            raise CapabilityInvocationError(
+                CapabilityDiagnostic(
+                    code="INVALID_POLYNOMIAL_SYSTEM_SEARCH_REQUEST",
+                    stage="request_validation",
+                    message="The bounded rational solution search request is invalid.",
+                )
+            ) from exc
+        started = time.monotonic()
+        values = tuple(
+            CanonicalRational(num=str(value.numerator), den=str(value.denominator))
+            for value in sorted(
+                {
+                    Fraction(numerator, denominator)
+                    for denominator in range(1, validated.max_denominator + 1)
+                    for numerator in range(
+                        -validated.max_abs_numerator,
+                        validated.max_abs_numerator + 1,
+                    )
+                }
+            )
+        )
+        grid = tuple(product(values, repeat=len(validated.system.variables)))
+        system = self.artifacts.put(
+            schema_uri=self.installation.system_schema_uri,
+            semantics_uri=self.installation.semantics_uri,
+            payload=validated.system.model_dump(mode="json"),
+            summary="bounded-search rational polynomial system",
+        )
+        assignment_uri = None
+        assignment = None
+        examined = 0
+        for candidate in grid:
+            examined += 1
+            residuals, inequations = _evaluate_request(
+                PolynomialSystemSolutionRequest(
+                    system=validated.system, assignment=candidate
+                )
+            )
+            if all(value.as_fraction() == 0 for value in residuals) and all(
+                value.as_fraction() != 0 for value in inequations
+            ):
+                assignment = candidate
+                assignment_uri = self.artifacts.put(
+                    schema_uri=self.installation.assignment_schema_uri,
+                    semantics_uri=self.installation.semantics_uri,
+                    payload=RationalPolynomialAssignment(values=candidate).model_dump(
+                        mode="json"
+                    ),
+                    parents=(system.artifact_uri,),
+                    summary="unverified bounded-search rational solution candidate",
+                ).artifact_uri
+                break
+        output = PolynomialSystemRationalSearchOutput(
+            found=assignment is not None,
+            system_uri=system.artifact_uri,
+            assignment_uri=assignment_uri,
+            assignment=assignment,
+            examined_assignment_count=examined,
+            grid_assignment_count=len(grid),
+            checker_id=self.installation.checker_id,
+        )
+        uris = (system.artifact_uri,) + (
+            (assignment_uri,) if assignment_uri is not None else ()
+        )
+        return CapabilityResult(
+            capability_id=self.descriptor.capability_id,
+            capability_version=self.descriptor.version,
+            mode=request.mode,
+            execution=Execution(
+                status=ExecutionStatus.COMPLETED,
+                runtime_ms=max(0, round((time.monotonic() - started) * 1000)),
+            ),
+            output=output.model_dump(mode="json"),
+            scope=CapabilityScope(
+                description="one complete declared finite rational grid",
+                parameters={"grid_assignment_count": len(grid), "examined": examined},
+                artifact_uri=system.artifact_uri,
+            ),
+            completeness=CapabilityCompleteness(
+                status=CapabilityCompletenessStatus.COMPLETE,
+                basis="the search stopped at its first match or exhausted the declared grid",
+                assurance_level=CapabilityAssuranceLevel.COMPUTED,
+            ),
+            assurance=CapabilityAssurance(
+                level=CapabilityAssuranceLevel.COMPUTED,
+                basis="deterministic exact rational enumeration; candidate remains unverified",
+            ),
+            artifact_uris=uris,
+        )

--- a/tests/integration/test_polynomial_system_search.py
+++ b/tests/integration/test_polynomial_system_search.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+
+import pytest
+
+from jacobian.contracts.capabilities import CapabilityAssuranceLevel, CapabilityRequest
+from jacobian.kernel import JacobianKernel
+
+
+def _request(constant: int) -> CapabilityRequest:
+    return CapabilityRequest(
+        capability_id="polynomial.system.rational_solution.search",
+        input={
+            "system": {
+                "variables": ["x"],
+                "equations": [
+                    {
+                        "terms": [
+                            {"coefficient": {"num": "1", "den": "1"}, "exponents": [1]},
+                            {
+                                "coefficient": {"num": str(constant), "den": "1"},
+                                "exponents": [0],
+                            },
+                        ]
+                    }
+                ],
+            },
+            "max_abs_numerator": 1,
+            "max_denominator": 1,
+        },
+    )
+
+
+@pytest.mark.integration
+def test_rational_solution_search_returns_first_exact_candidate(tmp_path: Path) -> None:
+    result = JacobianKernel(tmp_path, install_references=True).capabilities.invoke(
+        _request(1)
+    )
+    assert result.output["found"] is True
+    assert result.output["assignment"] == [{"num": "-1", "den": "1"}]
+    assert result.output["examined_assignment_count"] == 1
+    assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
+
+
+@pytest.mark.integration
+def test_rational_solution_search_reports_completed_bounded_absence(
+    tmp_path: Path,
+) -> None:
+    result = JacobianKernel(tmp_path).capabilities.invoke(_request(2))
+    assert result.output["found"] is False
+    assert result.output["examined_assignment_count"] == 3
+    assert result.output["grid_assignment_count"] == 3
+    assert result.output["verification"] == "UNVERIFIED"


### PR DESCRIPTION
## Summary

- add atomic `polynomial.system.rational_solution.search`
- enumerate a canonical deduplicated finite rational grid under explicit numerator and denominator bounds
- return the first exact assignment satisfying every equation and inequation, or a completed bounded not-found result
- materialize the exact system and any assignment candidate using the merged verifier-compatible schemas
- expose the authorized solution checker ID when installed without invoking it or self-certifying the search result

## Design decisions

- reject requests whose conservative grid bound exceeds 10,000 assignments
- search remains COMPUTED/UNVERIFIED; `polynomial.system.solution.verify` is the separate trust boundary
- a not-found result applies only to the exact declared finite grid and never proves global unsatisfiability
- deterministic ordering and exact examined/grid counts make the search replayable

## Validation

- lint and configured mypy pass
- focused polynomial-system suite: 7 passed
- package build succeeded
- broader non-integration baseline currently has 360 passing tests and 5 unrelated macOS Bash 3.2 CI-plan-validator failures (`declare -A`)

Draft for human review; do not merge automatically.