### PR TITLE
Add exact finite magma table enumeration

### DIFF
--- a/src/jacobian/contracts/universal_algebra.py
+++ b/src/jacobian/contracts/universal_algebra.py
@@ -133,6 +133,60 @@ class UniversalAlgebraCountermodelSearchRequest(ContractModel):
         return self
 
 
+class FiniteMagmaTableEnumerationRequest(ContractModel):
+    order: int = Field(ge=1, le=2)
+
+
+class FiniteMagmaTableEnumerationArtifact(ContractModel):
+    enumeration_schema_version: Literal["1"] = "1"
+    order: int = Field(ge=1, le=2)
+    table_uris: tuple[ArtifactUri, ...] = Field(min_length=1, max_length=16)
+    enumerated_count: int = Field(ge=1, le=16)
+    total_count: int = Field(ge=1, le=16)
+    ordering: Literal["LEXICOGRAPHIC_ROW_MAJOR"] = "LEXICOGRAPHIC_ROW_MAJOR"
+    complete: Literal[True] = True
+
+    @model_validator(mode="after")
+    def require_exact_complete_enumeration(self) -> Self:
+        expected = self.order ** (self.order * self.order)
+        if (
+            self.total_count != expected
+            or self.enumerated_count != expected
+            or len(self.table_uris) != expected
+            or len(set(self.table_uris)) != expected
+        ):
+            raise ValueError(
+                "complete magma-table enumeration must contain every table once"
+            )
+        return self
+
+
+class FiniteMagmaTableEnumerationOutput(ContractModel):
+    enumeration_uri: ArtifactUri
+    order: int = Field(ge=1, le=2)
+    table_uris: tuple[ArtifactUri, ...] = Field(min_length=1, max_length=16)
+    enumerated_count: int = Field(ge=1, le=16)
+    total_count: int = Field(ge=1, le=16)
+    ordering: Literal["LEXICOGRAPHIC_ROW_MAJOR"] = "LEXICOGRAPHIC_ROW_MAJOR"
+    exactness: Literal["EXACT_FINITE"] = "EXACT_FINITE"
+    completeness: Literal["COMPLETE"] = "COMPLETE"
+    verification: Literal["UNVERIFIED"] = "UNVERIFIED"
+
+    @model_validator(mode="after")
+    def require_exact_output_count(self) -> Self:
+        expected = self.order ** (self.order * self.order)
+        if (
+            self.total_count != expected
+            or self.enumerated_count != expected
+            or len(self.table_uris) != expected
+            or len(set(self.table_uris)) != expected
+        ):
+            raise ValueError(
+                "complete magma-table output must contain every table once"
+            )
+        return self
+
+
 class MagmaAssignmentValue(ContractModel):
     variable: Identifier
     value: int = Field(ge=0, le=7)

--- a/src/jacobian/universal_algebra_capabilities.py
+++ b/src/jacobian/universal_algebra_capabilities.py
@@ -37,6 +37,9 @@ from jacobian.contracts.universal_algebra import (
     FiniteMagmaLawEvaluationClaim,
     FiniteMagmaLawProblem,
     FiniteMagmaLawReplayPayload,
+    FiniteMagmaTableEnumerationArtifact,
+    FiniteMagmaTableEnumerationOutput,
+    FiniteMagmaTableEnumerationRequest,
     MagmaAssignmentValue,
     MagmaLaw,
     MagmaLawCounterexample,
@@ -59,9 +62,11 @@ _COUNTERMODEL_TIMEOUT_MS = 10_000
 @dataclass(frozen=True, slots=True)
 class UniversalAlgebraInstallation:
     semantics_uri: str
+    magma_schema_uri: str
     problem_schema_uri: str
     evaluation_schema_uri: str
     countermodel_schema_uri: str
+    table_enumeration_schema_uri: str
     claim_schema_uri: str
     certificate_schema_uri: str
     evaluation_checker_id: str | None
@@ -85,6 +90,7 @@ def install_universal_algebra_capabilities(
     tuple[
         UniversalAlgebraEvaluateLawsAdapter,
         UniversalAlgebraSearchCountermodelAdapter,
+        FiniteMagmaTableEnumerateAdapter,
     ],
     UniversalAlgebraInstallation,
 ]:
@@ -107,6 +113,11 @@ def install_universal_algebra_capabilities(
             "countermodel_timeout_ms": _COUNTERMODEL_TIMEOUT_MS,
         },
     )
+    magma_schema_uri = schemas.register(
+        name="jacobian.finite-magma",
+        version="1",
+        schema=model_schema(FiniteMagma),
+    )
     problem_schema_uri = schemas.register(
         name="jacobian.finite-magma-law-problem",
         version="1",
@@ -121,6 +132,11 @@ def install_universal_algebra_capabilities(
         name="jacobian.finite-magma-countermodel-search",
         version="1",
         schema=model_schema(FiniteMagmaCountermodelArtifact),
+    )
+    table_enumeration_schema_uri = schemas.register(
+        name="jacobian.finite-magma-table-enumeration",
+        version="1",
+        schema=model_schema(FiniteMagmaTableEnumerationArtifact),
     )
     claim_schema_uri = schemas.register(
         name="jacobian.finite-magma-law-evaluation-claim",
@@ -147,9 +163,11 @@ def install_universal_algebra_capabilities(
         ).checker_id
     installation = UniversalAlgebraInstallation(
         semantics_uri=semantics_uri,
+        magma_schema_uri=magma_schema_uri,
         problem_schema_uri=problem_schema_uri,
         evaluation_schema_uri=evaluation_schema_uri,
         countermodel_schema_uri=countermodel_schema_uri,
+        table_enumeration_schema_uri=table_enumeration_schema_uri,
         claim_schema_uri=claim_schema_uri,
         certificate_schema_uri=certificate_schema_uri,
         evaluation_checker_id=evaluation_checker_id,
@@ -162,6 +180,7 @@ def install_universal_algebra_capabilities(
     return (
         UniversalAlgebraEvaluateLawsAdapter(resources),
         UniversalAlgebraSearchCountermodelAdapter(resources),
+        FiniteMagmaTableEnumerateAdapter(resources),
     ), installation
 
 
@@ -449,6 +468,135 @@ class UniversalAlgebraSearchCountermodelAdapter:
                 ),
             ),
             artifact_uris=(search_artifact.artifact_uri,),
+        )
+
+
+class FiniteMagmaTableEnumerateAdapter:
+    """Enumerate every small finite-magma table in canonical order."""
+
+    def __init__(self, resources: UniversalAlgebraResources) -> None:
+        self.resources = resources
+        self._descriptor = CapabilityDescriptor(
+            capability_id="finite_magma.table.enumerate",
+            version="1",
+            title="Enumerate finite magma tables",
+            description=(
+                "Enumerate every total binary-operation table of order one or two "
+                "in exact lexicographic row-major order."
+            ),
+            provider="jacobian.finite-table",
+            provider_runtime=known_provider_runtime(
+                "jacobian.finite-table",
+                features=("finite-magma-table-enumeration",),
+            ),
+            modes=(CapabilityMode.EXPLORE,),
+            input_schema=model_schema(FiniteMagmaTableEnumerationRequest),
+            output_schema=model_schema(FiniteMagmaTableEnumerationOutput),
+            tags=("universal-algebra", "finite-model", "enumeration"),
+        )
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        return self._descriptor
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        try:
+            validated = FiniteMagmaTableEnumerationRequest.model_validate(request.input)
+        except ValidationError as exc:
+            raise CapabilityInvocationError(
+                CapabilityDiagnostic(
+                    code="INVALID_FINITE_MAGMA_TABLE_ENUMERATION_REQUEST",
+                    stage="request_validation",
+                    message=(
+                        "Finite-magma table enumeration supports exact carrier "
+                        "orders one and two."
+                    ),
+                )
+            ) from exc
+        started = time.monotonic()
+        order = validated.order
+        table_uris: list[str] = []
+        for cells in product(range(order), repeat=order * order):
+            structure = FiniteMagma(
+                order=order,
+                table=tuple(
+                    tuple(cells[row * order : (row + 1) * order])
+                    for row in range(order)
+                ),
+            )
+            table = self.resources.artifacts.put(
+                schema_uri=self.resources.installation.magma_schema_uri,
+                semantics_uri=self.resources.installation.semantics_uri,
+                payload=structure.model_dump(mode="json"),
+                summary=f"finite magma table of order {order}",
+            )
+            table_uris.append(table.artifact_uri)
+        total_count = order ** (order * order)
+        enumeration = FiniteMagmaTableEnumerationArtifact(
+            order=order,
+            table_uris=tuple(table_uris),
+            enumerated_count=len(table_uris),
+            total_count=total_count,
+        )
+        enumeration_artifact = self.resources.artifacts.put(
+            schema_uri=self.resources.installation.table_enumeration_schema_uri,
+            semantics_uri=self.resources.installation.semantics_uri,
+            payload=enumeration.model_dump(mode="json"),
+            parents=tuple(table_uris),
+            summary=f"complete finite magma table enumeration of order {order}",
+        )
+        output = FiniteMagmaTableEnumerationOutput(
+            enumeration_uri=enumeration_artifact.artifact_uri,
+            order=order,
+            table_uris=tuple(table_uris),
+            enumerated_count=len(table_uris),
+            total_count=total_count,
+        )
+        return CapabilityResult(
+            capability_id=self.descriptor.capability_id,
+            capability_version=self.descriptor.version,
+            mode=request.mode,
+            execution=Execution(
+                status=ExecutionStatus.COMPLETED,
+                runtime_ms=max(0, round((time.monotonic() - started) * 1000)),
+            ),
+            output=output.model_dump(mode="json"),
+            scope=CapabilityScope(
+                description=(
+                    "all total binary operations on the fixed carrier "
+                    f"0 through {order - 1}"
+                ),
+                parameters={
+                    "order": order,
+                    "table_count": total_count,
+                    "ordering": "LEXICOGRAPHIC_ROW_MAJOR",
+                },
+                artifact_uri=enumeration_artifact.artifact_uri,
+            ),
+            completeness=CapabilityCompleteness(
+                status=CapabilityCompletenessStatus.COMPLETE,
+                basis=(
+                    "the bounded Cartesian product of all row-major table cells "
+                    "was exhausted exactly once"
+                ),
+                assurance_level=CapabilityAssuranceLevel.COMPUTED,
+            ),
+            relationships=tuple(
+                CapabilityRelationship(
+                    relation_id="universal_algebra.relation.enumeration-member",
+                    source_artifact_uris=(enumeration_artifact.artifact_uri,),
+                    target_artifact_uris=(table_uri,),
+                )
+                for table_uri in table_uris
+            ),
+            assurance=CapabilityAssurance(
+                level=CapabilityAssuranceLevel.COMPUTED,
+                basis=(
+                    "deterministic exact standard-library enumeration; no "
+                    "independent coverage checker was invoked"
+                ),
+            ),
+            artifact_uris=(enumeration_artifact.artifact_uri, *table_uris),
         )
 
 

--- a/tests/integration/test_universal_algebra_capabilities.py
+++ b/tests/integration/test_universal_algebra_capabilities.py
@@ -7,6 +7,7 @@ import pytest
 
 from jacobian.contracts.capabilities import (
     CapabilityAssuranceLevel,
+    CapabilityCompletenessStatus,
     CapabilityMode,
     CapabilityRequest,
 )
@@ -252,4 +253,77 @@ def test_countermodel_request_validation_precedes_artifact_writes(
 
     assert result.execution.status.value == "ERROR"
     assert result.diagnostics[0].code == "INVALID_FINITE_MAGMA_COUNTERMODEL_REQUEST"
+    assert artifact_put_calls == 0
+
+
+@pytest.mark.integration
+def test_finite_magma_table_enumeration_is_exact_and_canonical(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+
+    result = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="finite_magma.table.enumerate",
+            input={"order": 2},
+        )
+    )
+
+    assert result.output["enumerated_count"] == 16
+    assert result.output["total_count"] == 16
+    assert result.output["ordering"] == "LEXICOGRAPHIC_ROW_MAJOR"
+    assert result.output["completeness"] == "COMPLETE"
+    assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert result.completeness.status is CapabilityCompletenessStatus.COMPLETE
+    table_payloads = [
+        kernel.store.get(uri).payload for uri in result.output["table_uris"]
+    ]
+    assert table_payloads[0]["table"] == [[0, 0], [0, 0]]
+    assert table_payloads[-1]["table"] == [[1, 1], [1, 1]]
+    assert len({str(payload["table"]) for payload in table_payloads}) == 16
+    enumeration = kernel.store.get(result.output["enumeration_uri"])
+    assert enumeration.payload["table_uris"] == result.output["table_uris"]
+    assert set(enumeration.manifest.parents) == set(result.output["table_uris"])
+
+
+@pytest.mark.integration
+def test_finite_magma_table_enumeration_handles_order_one(tmp_path: Path) -> None:
+    kernel = JacobianKernel(tmp_path)
+
+    result = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="finite_magma.table.enumerate",
+            input={"order": 1},
+        )
+    )
+
+    assert result.output["enumerated_count"] == 1
+    table = kernel.store.get(result.output["table_uris"][0])
+    assert table.payload["table"] == [[0]]
+
+
+@pytest.mark.integration
+def test_finite_magma_table_enumeration_rejects_unsupported_order_before_writes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    artifact_put_calls = 0
+    original_put = kernel.artifacts.put
+
+    def recording_put(*args: Any, **kwargs: Any) -> Any:
+        nonlocal artifact_put_calls
+        artifact_put_calls += 1
+        return original_put(*args, **kwargs)
+
+    monkeypatch.setattr(kernel.artifacts, "put", recording_put)
+    result = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="finite_magma.table.enumerate",
+            input={"order": 3},
+        )
+    )
+
+    assert result.execution.status.value == "ERROR"
+    assert result.diagnostics[0].code == "INVALID_REQUEST"
     assert artifact_put_calls == 0


### PR DESCRIPTION
## Summary

- add atomic `finite_magma.table.enumerate`
- exhaust every total binary-operation table of carrier order 1 or 2
- emit tables in deterministic lexicographic row-major order
- materialize one typed artifact per table plus a complete enumeration artifact and membership relationships
- keep assurance at COMPUTED; no independent coverage checker is claimed

## Design decisions

- restrict v1 to orders 1–2, where the full scope is at most 16 tables and can be returned atomically without pagination or a new runtime
- reuse the existing `FiniteMagma` semantics and standard-library Cartesian-product enumeration
- reject order 3+ before any operation artifact is written; larger orders need a paged/resumable archive and separate coverage contract
- do not alias `search.enumerate`, whose plugin-oriented input, paging, and candidate contracts do not expose this domain-owned complete enumeration outcome

## Validation

- focused universal-algebra integration suite: 8 passed
- Ruff lint and format checks pass
- strict mypy passes
- broader fast suite: 354 passed, 4 deselected, with 5 existing macOS Bash 3.2 CI-plan-validator failures (`declare -A`) and 1 unrelated SMT checker environment failure
- package build was not run because the local environment does not include the `build` module and `uv` is unavailable

Draft for human review; do not merge automatically.