### PR TITLE
Extend knowledge search with structured episode and failure filters

### DIFF
--- a/src/jacobian/builtin_capabilities.py
+++ b/src/jacobian/builtin_capabilities.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any
 
 from jacobian.capabilities import CapabilityInvocationError
@@ -26,6 +27,7 @@ from jacobian.contracts.lean import (
     LeanDeclarationSearchStopReason,
     LeanEnvironment,
 )
+from jacobian.contracts.memory import MemorySearchResult
 from jacobian.contracts.results import (
     Execution,
     ExecutionStatus,
@@ -48,11 +50,11 @@ class KnowledgeSearchAdapter:
         self.memory = memory
         self._descriptor = CapabilityDescriptor(
             capability_id="knowledge.search",
-            version="1",
+            version="2",
             title="Search research memory",
             description=(
-                "Retrieve trust-labeled prior capability episodes; retrieval does "
-                "not promote their mathematical assurance."
+                "Retrieve trust-labeled prior capability episodes with exact domain, "
+                "tag, and failure filters; retrieval does not promote assurance."
             ),
             provider="jacobian.memory",
             provider_runtime=known_provider_runtime(
@@ -65,12 +67,43 @@ class KnowledgeSearchAdapter:
                 "properties": {
                     "query": {"type": "string", "maxLength": 512},
                     "capability_id": {"type": "string"},
+                    "domains": {
+                        "type": "array",
+                        "items": {"type": "string", "minLength": 1, "maxLength": 128},
+                        "maxItems": 32,
+                        "uniqueItems": True,
+                    },
+                    "tags_all": {
+                        "type": "array",
+                        "items": {"type": "string", "minLength": 1, "maxLength": 128},
+                        "maxItems": 32,
+                        "uniqueItems": True,
+                    },
+                    "tags_any": {
+                        "type": "array",
+                        "items": {"type": "string", "minLength": 1, "maxLength": 128},
+                        "maxItems": 32,
+                        "uniqueItems": True,
+                    },
+                    "failure_stages": {
+                        "type": "array",
+                        "items": {"type": "string", "minLength": 1, "maxLength": 128},
+                        "maxItems": 32,
+                        "uniqueItems": True,
+                    },
+                    "failure_classifications": {
+                        "type": "array",
+                        "items": {"type": "string", "minLength": 1, "maxLength": 128},
+                        "maxItems": 32,
+                        "uniqueItems": True,
+                    },
                     "assurance_level": {"enum": ["HEURISTIC", "COMPUTED", "VERIFIED"]},
+                    "cutoff": {"type": "string", "format": "date-time"},
                     "limit": {"type": "integer", "minimum": 1, "maximum": 100},
                 },
                 "additionalProperties": False,
             },
-            output_schema=_OBJECT_SCHEMA,
+            output_schema=model_schema(MemorySearchResult),
             read_only=True,
             records_episode=False,
             tags=("memory", "retrieval"),
@@ -87,7 +120,21 @@ class KnowledgeSearchAdapter:
             capability_id=(
                 str(selected["capability_id"]) if "capability_id" in selected else None
             ),
+            domains=tuple(str(value) for value in selected.get("domains", ())),
+            tags_all=tuple(str(value) for value in selected.get("tags_all", ())),
+            tags_any=tuple(str(value) for value in selected.get("tags_any", ())),
+            failure_stages=tuple(
+                str(value) for value in selected.get("failure_stages", ())
+            ),
+            failure_classifications=tuple(
+                str(value) for value in selected.get("failure_classifications", ())
+            ),
             assurance_level=selected.get("assurance_level"),
+            cutoff=(
+                datetime.fromisoformat(str(selected["cutoff"]).replace("Z", "+00:00"))
+                if "cutoff" in selected
+                else None
+            ),
             limit=int(selected.get("limit", 10)),
         )
         return CapabilityResult(
@@ -96,6 +143,39 @@ class KnowledgeSearchAdapter:
             mode=request.mode,
             execution=Execution(status=ExecutionStatus.COMPLETED),
             output=result.model_dump(mode="json"),
+            scope=CapabilityScope(
+                description="exact filters evaluated against one immutable index snapshot",
+                parameters={
+                    "index_snapshot": result.index_snapshot,
+                    "indexed_episode_count": result.indexed_episode_count,
+                    "query": result.query,
+                    "capability_id": selected.get("capability_id"),
+                    "domains": selected.get("domains", []),
+                    "tags_all": selected.get("tags_all", []),
+                    "tags_any": selected.get("tags_any", []),
+                    "failure_stages": selected.get("failure_stages", []),
+                    "failure_classifications": selected.get(
+                        "failure_classifications", []
+                    ),
+                    "assurance_level": selected.get("assurance_level"),
+                    "cutoff": selected.get("cutoff"),
+                    "limit": int(selected.get("limit", 10)),
+                },
+            ),
+            completeness=CapabilityCompleteness(
+                status=(
+                    CapabilityCompletenessStatus.PARTIAL
+                    if result.truncated
+                    else CapabilityCompletenessStatus.COMPLETE
+                ),
+                basis=(
+                    "all matching episodes in the bound index snapshot were returned"
+                    if not result.truncated
+                    else "the result limit omitted matching episodes from the bound "
+                    "index snapshot"
+                ),
+                assurance_level=CapabilityAssuranceLevel.COMPUTED,
+            ),
             assurance=CapabilityAssurance(
                 level=CapabilityAssuranceLevel.COMPUTED,
                 basis=(

--- a/src/jacobian/contracts/memory.py
+++ b/src/jacobian/contracts/memory.py
@@ -3,16 +3,16 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Literal
+from typing import Any, Literal, Self
 
-from pydantic import Field, StrictInt
+from pydantic import Field, StrictInt, model_validator
 
 from jacobian.contracts.capabilities import (
     CapabilityAssuranceLevel,
     CapabilityId,
     CapabilityMode,
 )
-from jacobian.contracts.common import ArtifactUri
+from jacobian.contracts.common import ArtifactUri, Sha256Digest
 from jacobian.contracts.results import ContractModel
 
 
@@ -39,9 +39,31 @@ class MemoryHit(ContractModel):
     tags: tuple[str, ...] = ()
     created_at: datetime
     score: StrictInt = Field(ge=0, le=1000)
+    matched_query_terms: tuple[str, ...] = ()
+    matched_filters: tuple[str, ...] = ()
 
 
 class MemorySearchResult(ContractModel):
     query: str
     hits: tuple[MemoryHit, ...]
     cutoff: datetime | None = None
+    index_snapshot: Sha256Digest
+    indexed_episode_count: StrictInt = Field(ge=0)
+    total_matches: StrictInt = Field(ge=0)
+    returned_count: StrictInt = Field(ge=0)
+    truncated: bool
+    completeness: Literal["COMPLETE", "PARTIAL"]
+
+    @model_validator(mode="after")
+    def bind_counts_and_completeness(self) -> Self:
+        if self.returned_count != len(self.hits):
+            raise ValueError("returned_count must equal the number of hits")
+        if self.returned_count > self.total_matches:
+            raise ValueError("returned_count cannot exceed total_matches")
+        expected_truncated = self.returned_count < self.total_matches
+        if self.truncated != expected_truncated:
+            raise ValueError("truncated must reflect omitted matching hits")
+        expected_completeness = "PARTIAL" if self.truncated else "COMPLETE"
+        if self.completeness != expected_completeness:
+            raise ValueError("completeness must reflect result truncation")
+        return self

--- a/src/jacobian/memory.py
+++ b/src/jacobian/memory.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import sqlite3
 from datetime import datetime
 from typing import Any
 
+from jacobian.canonical import canonicalize_json
 from jacobian.contracts.capabilities import (
     CapabilityAssuranceLevel,
     CapabilityMode,
@@ -67,6 +69,86 @@ class ResearchMemory:
                 ON research_episodes(capability_id, assurance_level, created_at)
                 """
             )
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS research_episode_tags (
+                    episode_uri TEXT NOT NULL,
+                    tag TEXT NOT NULL,
+                    PRIMARY KEY (episode_uri, tag)
+                )
+                """
+            )
+            connection.execute(
+                """
+                CREATE INDEX IF NOT EXISTS research_episode_tags_lookup
+                ON research_episode_tags(tag, episode_uri)
+                """
+            )
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS research_episode_failures (
+                    episode_uri TEXT NOT NULL,
+                    stage TEXT NOT NULL,
+                    classification TEXT NOT NULL,
+                    PRIMARY KEY (episode_uri, stage, classification)
+                )
+                """
+            )
+            connection.execute(
+                """
+                CREATE INDEX IF NOT EXISTS research_episode_failures_lookup
+                ON research_episode_failures(stage, classification, episode_uri)
+                """
+            )
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS research_episode_index_versions (
+                    episode_uri TEXT PRIMARY KEY,
+                    index_version TEXT NOT NULL
+                )
+                """
+            )
+            existing = connection.execute(
+                """
+                SELECT episode_uri, tags_json
+                FROM research_episodes
+                WHERE episode_uri NOT IN (
+                    SELECT episode_uri
+                    FROM research_episode_index_versions
+                    WHERE index_version = '2'
+                )
+                """
+            ).fetchall()
+            for row in existing:
+                for tag in json.loads(row["tags_json"]):
+                    connection.execute(
+                        """
+                        INSERT OR IGNORE INTO research_episode_tags(episode_uri, tag)
+                        VALUES (?, ?)
+                        """,
+                        (row["episode_uri"], tag),
+                    )
+                stored = self.store.get(row["episode_uri"])
+                episode = ResearchEpisode.model_validate(stored.payload)
+                connection.executemany(
+                    """
+                    INSERT OR IGNORE INTO research_episode_failures(
+                        episode_uri, stage, classification
+                    ) VALUES (?, ?, ?)
+                    """,
+                    (
+                        (row["episode_uri"], stage, classification)
+                        for stage, classification in _failure_metadata(episode.result)
+                    ),
+                )
+                connection.execute(
+                    """
+                    INSERT OR REPLACE INTO research_episode_index_versions(
+                        episode_uri, index_version
+                    ) VALUES (?, '2')
+                    """,
+                    (row["episode_uri"],),
+                )
 
     def record(self, episode: ResearchEpisode) -> str:
         normalized = self.schemas.validate(
@@ -123,6 +205,33 @@ class ResearchMemory:
                     search_text,
                 ),
             )
+            connection.executemany(
+                """
+                INSERT OR IGNORE INTO research_episode_tags(episode_uri, tag)
+                VALUES (?, ?)
+                """,
+                ((stored.artifact_uri, tag) for tag in episode.tags),
+            )
+            failure_metadata = _failure_metadata(episode.result)
+            connection.executemany(
+                """
+                INSERT OR IGNORE INTO research_episode_failures(
+                    episode_uri, stage, classification
+                ) VALUES (?, ?, ?)
+                """,
+                (
+                    (stored.artifact_uri, stage, classification)
+                    for stage, classification in failure_metadata
+                ),
+            )
+            connection.execute(
+                """
+                INSERT OR REPLACE INTO research_episode_index_versions(
+                    episode_uri, index_version
+                ) VALUES (?, '2')
+                """,
+                (stored.artifact_uri,),
+            )
         return stored.artifact_uri
 
     def search(
@@ -130,6 +239,11 @@ class ResearchMemory:
         *,
         query: str = "",
         capability_id: str | None = None,
+        domains: tuple[str, ...] = (),
+        tags_all: tuple[str, ...] = (),
+        tags_any: tuple[str, ...] = (),
+        failure_stages: tuple[str, ...] = (),
+        failure_classifications: tuple[str, ...] = (),
         assurance_level: CapabilityAssuranceLevel | str | None = None,
         cutoff: datetime | None = None,
         limit: int = 10,
@@ -138,6 +252,10 @@ class ResearchMemory:
             raise ValueError("memory query exceeds 512 characters")
         if not 1 <= limit <= 100:
             raise ValueError("memory search limit must be between 1 and 100")
+        _validate_filter_values("domain", domains)
+        _validate_filter_values("tag", (*tags_all, *tags_any))
+        _validate_filter_values("failure stage", failure_stages)
+        _validate_filter_values("failure classification", failure_classifications)
         clauses: list[str] = []
         parameters: list[Any] = []
         terms = [term.casefold() for term in query.split() if term]
@@ -147,6 +265,65 @@ class ResearchMemory:
         if capability_id is not None:
             clauses.append("capability_id = ?")
             parameters.append(capability_id)
+        if domains:
+            placeholders = ", ".join("?" for _ in domains)
+            clauses.append(
+                f"""
+                CASE
+                    WHEN instr(capability_id, '.') > 0
+                    THEN substr(capability_id, 1, instr(capability_id, '.') - 1)
+                    ELSE capability_id
+                END IN ({placeholders})
+                """
+            )
+            parameters.extend(domains)
+        for tag in tags_all:
+            clauses.append(
+                """
+                EXISTS (
+                    SELECT 1 FROM research_episode_tags tag_match
+                    WHERE tag_match.episode_uri = research_episodes.episode_uri
+                      AND tag_match.tag = ?
+                )
+                """
+            )
+            parameters.append(tag)
+        if tags_any:
+            placeholders = ", ".join("?" for _ in tags_any)
+            clauses.append(
+                f"""
+                EXISTS (
+                    SELECT 1 FROM research_episode_tags tag_match
+                    WHERE tag_match.episode_uri = research_episodes.episode_uri
+                      AND tag_match.tag IN ({placeholders})
+                )
+                """
+            )
+            parameters.extend(tags_any)
+        if failure_stages:
+            placeholders = ", ".join("?" for _ in failure_stages)
+            clauses.append(
+                f"""
+                EXISTS (
+                    SELECT 1 FROM research_episode_failures failure_match
+                    WHERE failure_match.episode_uri = research_episodes.episode_uri
+                      AND failure_match.stage IN ({placeholders})
+                )
+                """
+            )
+            parameters.extend(failure_stages)
+        if failure_classifications:
+            placeholders = ", ".join("?" for _ in failure_classifications)
+            clauses.append(
+                f"""
+                EXISTS (
+                    SELECT 1 FROM research_episode_failures failure_match
+                    WHERE failure_match.episode_uri = research_episodes.episode_uri
+                      AND failure_match.classification IN ({placeholders})
+                )
+                """
+            )
+            parameters.extend(failure_classifications)
         if assurance_level is not None:
             selected = CapabilityAssuranceLevel(assurance_level)
             clauses.append("assurance_level = ?")
@@ -155,8 +332,16 @@ class ResearchMemory:
             clauses.append("created_at <= ?")
             parameters.append(cutoff.isoformat())
         where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
-        parameters.append(limit)
         with self._connect() as connection:
+            snapshot_rows = connection.execute(
+                "SELECT episode_uri FROM research_episodes ORDER BY episode_uri"
+            ).fetchall()
+            total_matches = int(
+                connection.execute(
+                    f"SELECT COUNT(*) FROM research_episodes {where}",
+                    parameters,
+                ).fetchone()[0]
+            )
             rows = connection.execute(
                 f"""
                 SELECT episode_uri, capability_id, mode, assurance_level,
@@ -166,8 +351,30 @@ class ResearchMemory:
                 ORDER BY created_at DESC, episode_uri
                 LIMIT ?
                 """,
-                parameters,
+                [*parameters, limit],
             ).fetchall()
+        snapshot_uris = [row["episode_uri"] for row in snapshot_rows]
+        index_snapshot = (
+            "sha256:"
+            + hashlib.sha256(
+                canonicalize_json(
+                    {
+                        "index_version": "2",
+                        "episode_uris": snapshot_uris,
+                    }
+                )
+            ).hexdigest()
+        )
+        matched_filters = _matched_filter_labels(
+            capability_id=capability_id,
+            domains=domains,
+            tags_all=tags_all,
+            tags_any=tags_any,
+            failure_stages=failure_stages,
+            failure_classifications=failure_classifications,
+            assurance_level=assurance_level,
+            cutoff=cutoff,
+        )
         hits = tuple(
             MemoryHit(
                 episode_uri=row["episode_uri"],
@@ -178,11 +385,86 @@ class ResearchMemory:
                 tags=tuple(json.loads(row["tags_json"])),
                 created_at=datetime.fromisoformat(row["created_at"]),
                 score=(1000 if terms else 500),
+                matched_query_terms=tuple(terms),
+                matched_filters=matched_filters,
             )
             for row in rows
         )
-        return MemorySearchResult(query=query, hits=hits, cutoff=cutoff)
+        return MemorySearchResult(
+            query=query,
+            hits=hits,
+            cutoff=cutoff,
+            index_snapshot=index_snapshot,
+            indexed_episode_count=len(snapshot_uris),
+            total_matches=total_matches,
+            returned_count=len(hits),
+            truncated=len(hits) < total_matches,
+            completeness=("PARTIAL" if len(hits) < total_matches else "COMPLETE"),
+        )
 
 
 def _escape_like(value: str) -> str:
     return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def _validate_filter_values(label: str, values: tuple[str, ...]) -> None:
+    if len(values) > 32:
+        raise ValueError(f"memory search accepts at most 32 {label} filters")
+    if len(set(values)) != len(values):
+        raise ValueError(f"memory search {label} filters must be unique")
+    if any(not value or len(value) > 128 for value in values):
+        raise ValueError(
+            f"memory search {label} filters must contain 1 to 128 characters"
+        )
+
+
+def _failure_metadata(result: dict[str, Any]) -> tuple[tuple[str, str], ...]:
+    metadata: set[tuple[str, str]] = set()
+    diagnostics = result.get("diagnostics", ())
+    if isinstance(diagnostics, (list, tuple)):
+        for diagnostic in diagnostics:
+            if not isinstance(diagnostic, dict):
+                continue
+            stage = diagnostic.get("stage")
+            classification = diagnostic.get("code")
+            if isinstance(stage, str) and isinstance(classification, str):
+                metadata.add((stage, classification))
+    output = result.get("output")
+    if isinstance(output, dict):
+        classifications = output.get("failure_classifications", ())
+        if isinstance(classifications, (list, tuple)):
+            for classification in classifications:
+                if isinstance(classification, str):
+                    metadata.add(("mathematical_evaluation", classification))
+    return tuple(sorted(metadata))
+
+
+def _matched_filter_labels(
+    *,
+    capability_id: str | None,
+    domains: tuple[str, ...],
+    tags_all: tuple[str, ...],
+    tags_any: tuple[str, ...],
+    failure_stages: tuple[str, ...],
+    failure_classifications: tuple[str, ...],
+    assurance_level: CapabilityAssuranceLevel | str | None,
+    cutoff: datetime | None,
+) -> tuple[str, ...]:
+    labels: list[str] = []
+    if capability_id is not None:
+        labels.append("capability_id")
+    if domains:
+        labels.append("domains")
+    if tags_all:
+        labels.append("tags_all")
+    if tags_any:
+        labels.append("tags_any")
+    if failure_stages:
+        labels.append("failure_stages")
+    if failure_classifications:
+        labels.append("failure_classifications")
+    if assurance_level is not None:
+        labels.append("assurance_level")
+    if cutoff is not None:
+        labels.append("cutoff")
+    return tuple(labels)

--- a/tests/integration/test_capability_service.py
+++ b/tests/integration/test_capability_service.py
@@ -21,6 +21,7 @@ from jacobian.contracts.capabilities import (
     CapabilityRequest,
     CapabilityResult,
 )
+from jacobian.contracts.memory import ResearchEpisode
 from jacobian.contracts.results import (
     Execution,
     ExecutionStatus,
@@ -291,6 +292,111 @@ def test_external_adapter_invocation_is_recorded_and_retrievable(
     assert episode.payload["result"]["completeness"]["status"] == "NOT_APPLICABLE"
     hits = kernel.memory.search(query="double computed").hits
     assert [hit.episode_uri for hit in hits] == [result.episode_uri]
+
+
+@pytest.mark.integration
+def test_knowledge_search_filters_episode_domain_tags_and_failures(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    graph_episode = ResearchEpisode(
+        capability_id="graph.compute.properties",
+        capability_version="1",
+        mode=CapabilityMode.EXPLORE,
+        request={"graph": "K5"},
+        result={
+            "output": {"failure_classifications": ["nonplanar_obstruction"]},
+            "diagnostics": [],
+        },
+        assurance_level=CapabilityAssuranceLevel.COMPUTED,
+        summary="K5 counterexample with a nonplanar obstruction",
+        tags=("graph", "counterexample", "failure"),
+    )
+    graph_uri = kernel.memory.record(graph_episode)
+    kernel.memory.record(
+        ResearchEpisode(
+            capability_id="lean.check",
+            capability_version="1",
+            mode=CapabilityMode.VERIFY,
+            request={"statement": "True"},
+            result={"output": {"conclusion": "TRUE"}, "diagnostics": []},
+            assurance_level=CapabilityAssuranceLevel.VERIFIED,
+            summary="Lean replay succeeded",
+            tags=("lean", "proof"),
+        )
+    )
+
+    result = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="knowledge.search",
+            input={
+                "query": "counterexample",
+                "domains": ["graph"],
+                "tags_all": ["failure"],
+                "tags_any": ["counterexample", "proof"],
+                "failure_stages": ["mathematical_evaluation"],
+                "failure_classifications": ["nonplanar_obstruction"],
+                "limit": 10,
+            },
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.capability_version == "2"
+    assert result.completeness.status.value == "COMPLETE"
+    assert result.scope is not None
+    assert [hit["episode_uri"] for hit in result.output["hits"]] == [graph_uri]
+    assert result.output["hits"][0]["matched_query_terms"] == ["counterexample"]
+    assert result.output["hits"][0]["matched_filters"] == [
+        "domains",
+        "tags_all",
+        "tags_any",
+        "failure_stages",
+        "failure_classifications",
+    ]
+    assert result.output["indexed_episode_count"] == 2
+    assert result.scope.parameters["index_snapshot"] == result.output["index_snapshot"]
+    assert result.output["total_matches"] == 1
+    assert result.output["returned_count"] == 1
+    assert result.output["truncated"] is False
+    assert result.output["completeness"] == "COMPLETE"
+    assert result.output["index_snapshot"].startswith("sha256:")
+
+
+@pytest.mark.integration
+def test_knowledge_search_reports_snapshot_bounded_partial_results(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    for value in (1, 2):
+        kernel.memory.record(
+            ResearchEpisode(
+                capability_id="polynomial.factor.compute",
+                capability_version="1",
+                mode=CapabilityMode.EXPLORE,
+                request={"value": value},
+                result={"output": {"value": value}, "diagnostics": []},
+                assurance_level=CapabilityAssuranceLevel.COMPUTED,
+                summary=f"factor episode {value}",
+                tags=("polynomial",),
+            )
+        )
+
+    result = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="knowledge.search",
+            input={"domains": ["polynomial"], "limit": 1},
+        )
+    )
+
+    assert result.output["indexed_episode_count"] == 2
+    assert result.completeness.status.value == "PARTIAL"
+    assert result.scope is not None
+    assert result.scope.parameters["index_snapshot"] == result.output["index_snapshot"]
+    assert result.output["total_matches"] == 2
+    assert result.output["returned_count"] == 1
+    assert result.output["truncated"] is True
+    assert result.output["completeness"] == "PARTIAL"
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary

- extend canonical `knowledge.search` to version 2 instead of adding aliases for `knowledge.episodes.search` or `knowledge.failures.search`
- add exact capability-domain, all/any tag, failure-stage, failure-classification, assurance, and cutoff filters
- bind each query to an immutable index snapshot digest and report indexed, matched, returned, truncated, and completeness metadata
- expose query-term and filter match explanations on every hit
- index tags and structured failure metadata in normalized SQLite tables, including a fail-closed one-time migration for existing episodes
- express complete versus limit-truncated retrieval through Jacobian's typed scope and completeness envelope

## Design decisions

- inventory names remain mappings to the canonical `knowledge.search@2`; no shallow wrapper IDs are introduced
- capability domain means the first component of the capability ID
- diagnostic codes are indexed as failure classifications under their diagnostic stage; domain evaluator classifications use the `mathematical_evaluation` stage
- retrieval remains `COMPUTED`; it never promotes the assurance carried by a retrieved episode
- `COMPLETE` means all matches in the exact bound snapshot were returned, not that the memory contains all relevant mathematical knowledge

## Validation

- focused knowledge-search/capability-service tests: 3 passed
- Ruff lint and format checks pass across the repository
- strict mypy passes for all changed source modules
- broader non-integration suite: 380 passed; 6 unrelated local-environment failures remain (five macOS Bash 3.2 CI-plan validator failures and one SMT checker-runtime fixture failure)

Draft for human review; do not merge automatically.