### PR TITLE
Strengthen fixed-registry graph invariant batch contracts

### DIFF
--- a/benchmarks/agent_mcp.py
+++ b/benchmarks/agent_mcp.py
@@ -361,15 +361,16 @@ def _require_descriptor(
     *,
     kind: str,
     name: str,
+    version: str = "1",
 ) -> None:
     descriptor = _as_object(store.get(uri).payload, f"{name} descriptor")
     if (
         descriptor.get("descriptor_version") != "1"
         or descriptor.get("kind") != kind
         or descriptor.get("name") != name
-        or descriptor.get("version") != "1"
+        or descriptor.get("version") != version
     ):
-        raise BenchmarkError(f"artifact does not use {name}@1")
+        raise BenchmarkError(f"artifact does not use {name}@{version}")
 
 
 def _find_graph_invocations(
@@ -490,6 +491,7 @@ def _score_graph_capability_run(
             property_artifact.manifest.schema_uri,
             kind="schema",
             name="jacobian.graph-property-batch",
+            version="2",
         )
         if (
             property_artifact.manifest.semantics_uri

--- a/docs/reference/graph-invariant-batch.md
+++ b/docs/reference/graph-invariant-batch.md
@@ -1,0 +1,94 @@
+# Fixed-registry graph invariant batches
+
+[Documentation home](../index.md) · [Capability surface](tools.md)
+
+`graph.compute.properties@2` is the canonical batch operation corresponding to
+the inventory concept `graph.invariants.compute`. The inventory name is not an
+installed alias.
+
+## Supported registry
+
+Registry version `1` contains exactly these invariant names:
+
+```text
+average_eccentricity
+bipartite
+connected
+degree_sequence
+diameter
+eccentricities
+girth
+harmonic_index
+havel_hakimi_trace
+independence_number
+maximum_degree
+minimum_degree
+order
+radius
+residue
+size
+tree
+triangle_count
+triangle_frequencies
+```
+
+The complete registry is exposed as `x-supported-invariants` in the input
+schema and as `supported_invariants` in every completed output and batch
+artifact. An invariant name that satisfies the input syntax but is absent from
+this registry is retained with `UNSUPPORTED` status. It is not silently
+ignored and does not abort other requested computations.
+
+## Request and per-invariant results
+
+The request supplies one compatible simple-undirected-graph artifact URI and
+between one and 32 unique invariant names. Results are sorted by invariant
+name. Every requested name receives exactly one result:
+
+| Status | Meaning | Value | Backend |
+| --- | --- | --- | --- |
+| `COMPUTED` | The registered exact operation completed. | Present; JSON `null` is valid for invariants such as acyclic girth. | Exact producing backend is named. |
+| `NOT_APPLICABLE` | The invariant is registered but undefined for this graph, such as diameter on a disconnected graph. | `null` | Attempted backend and a bounded explanation are retained. |
+| `UNSUPPORTED` | Registry version `1` does not contain the requested name. | `null` | No backend is claimed. |
+
+`properties` remains in the output and batch artifact as a compatibility
+projection containing only computed values in the version-1 shape. New
+consumers should use `results`, which preserves all terminal outcomes
+uniformly.
+
+## Artifacts and assurance
+
+Each per-invariant result is stored in its own
+`jacobian.graph-invariant-result@1` artifact with the source graph as parent.
+The `jacobian.graph-property-batch@2` artifact binds the source graph, registry
+version, supported and requested names, backend version, per-invariant results,
+and their artifact URIs. The capability relationship targets both the batch
+artifact and every individual result artifact.
+
+A completed batch is `COMPLETE` when every requested name has one of the three
+terminal statuses above. Completeness does not mean every requested invariant
+was mathematically applicable or supported. Computation remains `COMPUTED`;
+neither NetworkX nor the producing adapter independently verifies its own
+results.
+
+## Relationship to `graph.invariant.*`
+
+Standalone `graph.invariant.*` capabilities are not aliases of the batch.
+They accept inline bounded graphs, may expose operation-specific witnesses or
+budgets, and in some cases use a different backend:
+
+| Standalone invariant | Batch registry relationship |
+| --- | --- |
+| `graph.invariant.independence_number.compute` | Same mathematical value; different input and artifact contract. |
+| `graph.invariant.girth.compute` | Same invariant; the standalone operation uses `0` for acyclic graphs while the batch uses `null`. |
+| `graph.invariant.diameter.compute` | Same invariant; the standalone operation uses `-1` for disconnected graphs while the batch reports `NOT_APPLICABLE`. |
+| `graph.invariant.clique_number.compute` | Not in registry version `1`. |
+| `graph.invariant.chromatic_number.compute` | Not in registry version `1`; it has a bounded Z3 search and explicit `UNKNOWN` outcome. |
+| `graph.invariant.edge_connectivity.compute` | Not in registry version `1`. |
+| `graph.invariant.vertex_connectivity.compute` | Not in registry version `1`. |
+| `graph.invariant.is_eulerian.compute` | Not in registry version `1`. |
+| `graph.invariant.spanning_tree_count.compute` | Not in registry version `1`. |
+| `graph.invariant.maximum_matching.compute` | Not in registry version `1`. |
+
+Adding those operations to a later registry requires an explicit contract
+decision about semantics, bounds, and result normalization. Version `2` does
+not add or duplicate their algorithms.

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -130,6 +130,7 @@ of catalog membership:
 - [exact rational linear-system evidence](linear-rational-solutions.md);
 - [exact rational matrix determinants](matrix-rational-determinant.md);
 - [integer matrix Hermite normal form](matrix-hermite-normal-form.md);
+- [fixed-registry graph invariant batches](graph-invariant-batch.md);
 - [typed polynomial expression normalization](polynomial-expression-normalization.md);
 - [Lean declaration discovery contract](lean-declaration-discovery.md).
 

--- a/src/jacobian/contracts/graph_invariants.py
+++ b/src/jacobian/contracts/graph_invariants.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from fractions import Fraction
-from typing import Annotated, Literal, Self
+from typing import Annotated, Any, Literal, Self
 
 from pydantic import Field, StringConstraints, model_validator
 
@@ -15,6 +15,116 @@ GraphVertex = Annotated[
     str,
     StringConstraints(min_length=1, max_length=128, strict=True),
 ]
+GraphInvariantName = Annotated[
+    str,
+    StringConstraints(
+        pattern=r"^[a-z][a-z0-9_]{0,63}$",
+        min_length=1,
+        max_length=64,
+        strict=True,
+    ),
+]
+
+
+class GraphInvariantBatchRequest(ContractModel):
+    graph_uri: ArtifactUri
+    properties: tuple[GraphInvariantName, ...] = Field(min_length=1, max_length=32)
+
+    @model_validator(mode="after")
+    def require_unique_properties(self) -> Self:
+        if len(set(self.properties)) != len(self.properties):
+            raise ValueError("requested graph invariants must be unique")
+        return self
+
+
+class GraphInvariantResult(ContractModel):
+    invariant: GraphInvariantName
+    status: Literal["COMPUTED", "NOT_APPLICABLE", "UNSUPPORTED"]
+    value: Any = None
+    exactness: Literal["EXACT", "NOT_APPLICABLE"]
+    backend: str | None = Field(default=None, min_length=1, max_length=128)
+    detail: str | None = Field(default=None, min_length=1, max_length=512)
+
+    @model_validator(mode="after")
+    def require_status_consistency(self) -> Self:
+        if self.status == "COMPUTED":
+            if self.exactness != "EXACT" or self.backend is None:
+                raise ValueError("computed invariants require an exact backend")
+            if self.detail is not None:
+                raise ValueError("computed invariants cannot carry failure detail")
+        else:
+            if self.exactness != "NOT_APPLICABLE" or self.detail is None:
+                raise ValueError(
+                    "unsupported or inapplicable invariants require explicit detail"
+                )
+            if self.value is not None:
+                raise ValueError(
+                    "unsupported or inapplicable invariants cannot carry a value"
+                )
+        if self.status == "UNSUPPORTED" and self.backend is not None:
+            raise ValueError("unsupported invariants cannot name a backend")
+        return self
+
+
+class GraphInvariantResultArtifact(ContractModel):
+    invariant_result_version: Literal["1"] = "1"
+    graph_uri: ArtifactUri
+    registry_version: Literal["1"] = "1"
+    backend_version: str = Field(min_length=1, max_length=64)
+    result: GraphInvariantResult
+
+
+class GraphInvariantBinding(ContractModel):
+    invariant: GraphInvariantName
+    artifact_uri: ArtifactUri
+    result: GraphInvariantResult
+
+    @model_validator(mode="after")
+    def bind_invariant_name(self) -> Self:
+        if self.invariant != self.result.invariant:
+            raise ValueError("invariant binding must match its result")
+        return self
+
+
+class GraphInvariantBatchArtifact(ContractModel):
+    invariant_batch_version: Literal["2"] = "2"
+    graph_uri: ArtifactUri
+    registry_version: Literal["1"] = "1"
+    supported_invariants: tuple[GraphInvariantName, ...]
+    requested_invariants: tuple[GraphInvariantName, ...]
+    backend_version: str = Field(min_length=1, max_length=64)
+    results: tuple[GraphInvariantBinding, ...]
+    properties: dict[str, Any]
+
+    @model_validator(mode="after")
+    def require_complete_ordered_bindings(self) -> Self:
+        if self.supported_invariants != tuple(sorted(set(self.supported_invariants))):
+            raise ValueError("supported invariant registry must be unique and sorted")
+        if self.requested_invariants != tuple(sorted(set(self.requested_invariants))):
+            raise ValueError("requested invariants must be unique and sorted")
+        if tuple(binding.invariant for binding in self.results) != (
+            self.requested_invariants
+        ):
+            raise ValueError("batch results must cover requested invariants in order")
+        expected_properties = {
+            binding.invariant: {
+                "value": binding.result.value,
+                "exactness": binding.result.exactness,
+                "backend": binding.result.backend,
+            }
+            for binding in self.results
+            if binding.result.status == "COMPUTED"
+        }
+        if self.properties != expected_properties:
+            raise ValueError(
+                "properties must be the exact compatibility projection of "
+                "computed results"
+            )
+        return self
+
+
+class GraphInvariantBatchOutput(GraphInvariantBatchArtifact):
+    property_artifact_uri: ArtifactUri
 
 
 class GraphNeighborhoodIndependenceRequest(ContractModel):

--- a/src/jacobian/graph_capabilities.py
+++ b/src/jacobian/graph_capabilities.py
@@ -39,6 +39,12 @@ from jacobian.contracts.graph_degree_sequence import (
     GraphDegreeSequenceResultArtifact,
 )
 from jacobian.contracts.graph_invariants import (
+    GraphInvariantBatchArtifact,
+    GraphInvariantBatchOutput,
+    GraphInvariantBatchRequest,
+    GraphInvariantBinding,
+    GraphInvariantResult,
+    GraphInvariantResultArtifact,
     GraphNeighborhoodIndependenceArtifact,
     GraphNeighborhoodIndependenceClaim,
     GraphNeighborhoodIndependenceOutput,
@@ -54,6 +60,7 @@ from jacobian.store import ArtifactStore, StoreError
 
 _ARTIFACT_URI_PATTERN = r"^artifact://sha256/[0-9a-f]{64}$"
 _PROPERTY_NAMES = (
+    "average_eccentricity",
     "bipartite",
     "connected",
     "degree_sequence",
@@ -72,7 +79,6 @@ _PROPERTY_NAMES = (
     "tree",
     "triangle_count",
     "triangle_frequencies",
-    "average_eccentricity",
 )
 _GRAPH_PAYLOAD_SCHEMA: dict[str, Any] = {
     "type": "object",
@@ -122,6 +128,7 @@ class GraphCapabilityResources:
     graph_schema_uri: str
     scope_schema_uri: str
     property_schema_uri: str
+    invariant_result_schema_uri: str
     degree_sequence_claim_schema_uri: str
     degree_sequence_result_schema_uri: str
     neighborhood_schema_uri: str
@@ -137,6 +144,7 @@ class GraphInstallation:
     graph_schema_uri: str
     scope_schema_uri: str
     property_schema_uri: str
+    invariant_result_schema_uri: str
     degree_sequence_claim_schema_uri: str
     degree_sequence_result_schema_uri: str
     neighborhood_schema_uri: str
@@ -207,26 +215,13 @@ def install_graph_capabilities(
     )
     property_schema_uri = schemas.register(
         name="jacobian.graph-property-batch",
+        version="2",
+        schema=model_schema(GraphInvariantBatchArtifact),
+    )
+    invariant_result_schema_uri = schemas.register(
+        name="jacobian.graph-invariant-result",
         version="1",
-        schema={
-            "type": "object",
-            "properties": {
-                "property_schema_version": {"const": "1"},
-                "graph_uri": {
-                    "type": "string",
-                    "pattern": _ARTIFACT_URI_PATTERN,
-                },
-                "backend_version": {"type": "string"},
-                "properties": {"type": "object"},
-            },
-            "required": [
-                "property_schema_version",
-                "graph_uri",
-                "backend_version",
-                "properties",
-            ],
-            "additionalProperties": False,
-        },
+        schema=model_schema(GraphInvariantResultArtifact),
     )
     degree_sequence_claim_schema_uri = schemas.register(
         name="jacobian.graph-degree-sequence-claim",
@@ -287,6 +282,7 @@ def install_graph_capabilities(
         graph_schema_uri=graph_schema_uri,
         scope_schema_uri=scope_schema_uri,
         property_schema_uri=property_schema_uri,
+        invariant_result_schema_uri=invariant_result_schema_uri,
         degree_sequence_claim_schema_uri=degree_sequence_claim_schema_uri,
         degree_sequence_result_schema_uri=degree_sequence_result_schema_uri,
         neighborhood_schema_uri=neighborhood_schema_uri,
@@ -302,6 +298,7 @@ def install_graph_capabilities(
         graph_schema_uri=graph_schema_uri,
         scope_schema_uri=scope_schema_uri,
         property_schema_uri=property_schema_uri,
+        invariant_result_schema_uri=invariant_result_schema_uri,
         degree_sequence_claim_schema_uri=degree_sequence_claim_schema_uri,
         degree_sequence_result_schema_uri=degree_sequence_result_schema_uri,
         neighborhood_schema_uri=neighborhood_schema_uri,
@@ -504,13 +501,15 @@ class GraphPropertyAdapter:
 
     def __init__(self, resources: GraphCapabilityResources) -> None:
         self.resources = resources
+        input_schema = model_schema(GraphInvariantBatchRequest)
+        input_schema["x-supported-invariants"] = list(_PROPERTY_NAMES)
         self._descriptor = CapabilityDescriptor(
             capability_id="graph.compute.properties",
-            version="1",
+            version="2",
             title="Compute exact graph properties",
             description=(
-                "Compute a requested batch of exact NetworkX properties for one "
-                "Jacobian simple-undirected-graph artifact."
+                "Classify and compute a requested batch against the fixed exact "
+                "graph-invariant registry, preserving every per-invariant outcome."
             ),
             provider="jacobian.networkx",
             provider_runtime=known_provider_runtime(
@@ -518,45 +517,8 @@ class GraphPropertyAdapter:
                 features=("graph-properties", "simple-undirected-graphs"),
             ),
             modes=(CapabilityMode.EXPLORE,),
-            input_schema={
-                "type": "object",
-                "properties": {
-                    "graph_uri": {
-                        "type": "string",
-                        "pattern": _ARTIFACT_URI_PATTERN,
-                    },
-                    "properties": {
-                        "type": "array",
-                        "items": {"enum": list(_PROPERTY_NAMES)},
-                        "minItems": 1,
-                        "uniqueItems": True,
-                    },
-                },
-                "required": ["graph_uri", "properties"],
-                "additionalProperties": False,
-            },
-            output_schema={
-                "type": "object",
-                "properties": {
-                    "graph_uri": {
-                        "type": "string",
-                        "pattern": _ARTIFACT_URI_PATTERN,
-                    },
-                    "property_artifact_uri": {
-                        "type": "string",
-                        "pattern": _ARTIFACT_URI_PATTERN,
-                    },
-                    "properties": {"type": "object"},
-                    "backend_version": {"type": "string"},
-                },
-                "required": [
-                    "graph_uri",
-                    "property_artifact_uri",
-                    "properties",
-                    "backend_version",
-                ],
-                "additionalProperties": False,
-            },
+            input_schema=input_schema,
+            output_schema=model_schema(GraphInvariantBatchOutput),
             tags=("graph", "properties", "exact-computation"),
         )
 
@@ -566,37 +528,72 @@ class GraphPropertyAdapter:
 
     def invoke(self, request: CapabilityRequest) -> CapabilityResult:
         started = time.monotonic()
-        graph_uri = str(request.input["graph_uri"])
-        graph = _load_graph(self.resources, graph_uri)
-        names = sorted(str(item) for item in request.input["properties"])
         try:
-            selected = {
-                name: _property_result(name, _compute_property(graph, name))
-                for name in names
-            }
-        except nx.NetworkXError as exc:
+            validated = GraphInvariantBatchRequest.model_validate(request.input)
+        except ValidationError as exc:
             raise CapabilityInvocationError(
                 CapabilityDiagnostic(
-                    code="GRAPH_PROPERTY_NOT_APPLICABLE",
-                    stage="graph_property_computation",
-                    message=str(exc),
+                    code="INVALID_GRAPH_INVARIANT_BATCH_REQUEST",
+                    stage="request_validation",
+                    message=(
+                        "The complete graph-invariant batch request is invalid: "
+                        f"{exc.errors()[0].get('msg', 'validation failed')}"
+                    ),
                     hint=(
-                        "Distance-based properties require a nonempty connected "
-                        "graph; request structural properties separately."
+                        "Supply one compatible graph artifact URI and 1 to 32 "
+                        "unique lowercase invariant names."
                     ),
                 )
             ) from exc
+        graph_uri = validated.graph_uri
+        graph = _load_graph(self.resources, graph_uri)
+        names = tuple(sorted(validated.properties))
+        bindings: list[GraphInvariantBinding] = []
+        selected: dict[str, Any] = {}
+        for name in names:
+            result = _compute_invariant_result(graph, name)
+            if result.status == "COMPUTED":
+                selected[name] = {
+                    "value": result.value,
+                    "exactness": result.exactness,
+                    "backend": result.backend,
+                }
+            result_artifact = self.resources.artifacts.put(
+                schema_uri=self.resources.invariant_result_schema_uri,
+                semantics_uri=self.resources.semantics_uri,
+                payload=GraphInvariantResultArtifact(
+                    graph_uri=graph_uri,
+                    backend_version=nx.__version__,
+                    result=result,
+                ).model_dump(mode="json"),
+                parents=(graph_uri,),
+                summary=f"{result.status.lower()} graph invariant: {name}",
+            )
+            bindings.append(
+                GraphInvariantBinding(
+                    invariant=name,
+                    artifact_uri=result_artifact.artifact_uri,
+                    result=result,
+                )
+            )
+        batch = GraphInvariantBatchArtifact(
+            graph_uri=graph_uri,
+            supported_invariants=tuple(sorted(_PROPERTY_NAMES)),
+            requested_invariants=names,
+            backend_version=nx.__version__,
+            results=tuple(bindings),
+            properties=selected,
+        )
         property_artifact = self.resources.artifacts.put(
             schema_uri=self.resources.property_schema_uri,
             semantics_uri=self.resources.semantics_uri,
-            payload={
-                "property_schema_version": "1",
-                "graph_uri": graph_uri,
-                "backend_version": nx.__version__,
-                "properties": selected,
-            },
-            parents=(graph_uri,),
-            summary="exact NetworkX graph-property batch",
+            payload=batch.model_dump(mode="json"),
+            parents=(graph_uri, *(binding.artifact_uri for binding in bindings)),
+            summary="fixed-registry graph-invariant batch",
+        )
+        output = GraphInvariantBatchOutput(
+            **batch.model_dump(mode="python"),
+            property_artifact_uri=property_artifact.artifact_uri,
         )
         return CapabilityResult(
             capability_id=self.descriptor.capability_id,
@@ -606,27 +603,21 @@ class GraphPropertyAdapter:
                 status=ExecutionStatus.COMPLETED,
                 runtime_ms=_runtime_ms(started),
             ),
-            output={
-                "graph_uri": graph_uri,
-                "property_artifact_uri": property_artifact.artifact_uri,
-                "properties": selected,
-                "backend_version": nx.__version__,
-            },
+            output=output.model_dump(mode="json"),
             scope=CapabilityScope(
                 description="the requested property batch for one exact graph artifact",
                 parameters={
                     "graph_uri": graph_uri,
-                    "properties": sorted(
-                        str(item) for item in request.input["properties"]
-                    ),
+                    "registry_version": "1",
+                    "properties": list(names),
                 },
                 artifact_uri=graph_uri,
             ),
             completeness=CapabilityCompleteness(
                 status=CapabilityCompletenessStatus.COMPLETE,
                 basis=(
-                    "every requested property was computed; no mathematical "
-                    "conclusion or independent verification is claimed"
+                    "every requested invariant received a terminal COMPUTED, "
+                    "NOT_APPLICABLE, or UNSUPPORTED result under registry version 1"
                 ),
                 assurance_level=CapabilityAssuranceLevel.COMPUTED,
             ),
@@ -634,7 +625,10 @@ class GraphPropertyAdapter:
                 CapabilityRelationship(
                     relation_id="graph.relation.properties-of",
                     source_artifact_uris=(graph_uri,),
-                    target_artifact_uris=(property_artifact.artifact_uri,),
+                    target_artifact_uris=(
+                        property_artifact.artifact_uri,
+                        *(binding.artifact_uri for binding in bindings),
+                    ),
                 ),
             ),
             assurance=CapabilityAssurance(
@@ -644,7 +638,11 @@ class GraphPropertyAdapter:
                     "checker was invoked"
                 ),
             ),
-            artifact_uris=(graph_uri, property_artifact.artifact_uri),
+            artifact_uris=(
+                graph_uri,
+                property_artifact.artifact_uri,
+                *(binding.artifact_uri for binding in bindings),
+            ),
         )
 
 
@@ -1402,17 +1400,46 @@ def _matches_constraints(
     )
 
 
-def _property_result(name: str, value: Any) -> dict[str, Any]:
+def _property_backend(name: str) -> str:
     backend = (
         "networkx.max_weight_clique(complement)"
         if name == "independence_number"
         else "networkx"
     )
-    return {
-        "value": value,
-        "exactness": "EXACT",
-        "backend": backend,
-    }
+    return backend
+
+
+def _compute_invariant_result(
+    graph: nx.Graph[Any],
+    name: str,
+) -> GraphInvariantResult:
+    if name not in _PROPERTY_NAMES:
+        return GraphInvariantResult(
+            invariant=name,
+            status="UNSUPPORTED",
+            exactness="NOT_APPLICABLE",
+            detail=(
+                "the invariant is not present in graph.compute.properties "
+                "registry version 1"
+            ),
+        )
+    try:
+        value = _compute_property(graph, name)
+    except nx.NetworkXError as exc:
+        return GraphInvariantResult(
+            invariant=name,
+            status="NOT_APPLICABLE",
+            exactness="NOT_APPLICABLE",
+            backend=_property_backend(name),
+            detail=str(exc),
+        )
+    return GraphInvariantResult(
+        invariant=name,
+        status="COMPUTED",
+        value=value,
+        exactness="EXACT",
+        backend=_property_backend(name),
+    )
 
 
 def _runtime_ms(started: float) -> int:

--- a/tests/integration/test_graph_capabilities.py
+++ b/tests/integration/test_graph_capabilities.py
@@ -209,11 +209,31 @@ def test_graph_property_batch_materializes_exact_computed_artifact(
     relationship = result.relationships[0]
     assert relationship.status is CapabilityRelationshipStatus.PROPOSED
     assert relationship.source_artifact_uris == (graph_uri,)
-    assert relationship.target_artifact_uris == (
-        result.output["property_artifact_uri"],
+    assert (
+        relationship.target_artifact_uris[0] == (result.output["property_artifact_uri"])
     )
+    assert set(relationship.target_artifact_uris[1:]) == {
+        binding["artifact_uri"] for binding in result.output["results"]
+    }
     property_artifact = kernel.store.get(result.output["property_artifact_uri"])
-    assert property_artifact.manifest.parents == (graph_uri,)
+    assert set(property_artifact.manifest.parents) == {
+        graph_uri,
+        *(binding["artifact_uri"] for binding in result.output["results"]),
+    }
+    assert property_artifact.payload["registry_version"] == "1"
+    assert property_artifact.payload["requested_invariants"] == [
+        "bipartite",
+        "connected",
+        "degree_sequence",
+        "independence_number",
+        "order",
+        "size",
+        "triangle_count",
+    ]
+    for binding in result.output["results"]:
+        invariant_artifact = kernel.store.get(binding["artifact_uri"])
+        assert invariant_artifact.manifest.parents == (graph_uri,)
+        assert invariant_artifact.payload["result"] == binding["result"]
 
 
 @pytest.mark.integration
@@ -272,7 +292,9 @@ def test_graph_counterexample_invariant_batch_reproduces_path_five(
 
 
 @pytest.mark.integration
-def test_distance_property_on_disconnected_graph_fails_closed(tmp_path: Path) -> None:
+def test_graph_invariant_batch_preserves_unsupported_and_not_applicable_results(
+    tmp_path: Path,
+) -> None:
     kernel = JacobianKernel(tmp_path)
     searched = kernel.capabilities.invoke(
         CapabilityRequest(
@@ -290,11 +312,76 @@ def test_distance_property_on_disconnected_graph_fails_closed(tmp_path: Path) ->
             capability_id="graph.compute.properties",
             input={
                 "graph_uri": searched.output["candidates"][0]["graph_uri"],
-                "properties": ["diameter"],
+                "properties": ["order", "diameter", "made_up_invariant"],
             },
         )
     )
 
-    assert result.execution.status is ExecutionStatus.ERROR
-    assert result.diagnostics[0].code == "GRAPH_PROPERTY_NOT_APPLICABLE"
-    assert result.assurance.level is CapabilityAssuranceLevel.HEURISTIC
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.completeness.status is CapabilityCompletenessStatus.COMPLETE
+    assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    outcomes = {
+        binding["invariant"]: binding["result"] for binding in result.output["results"]
+    }
+    assert outcomes["order"] == {
+        "invariant": "order",
+        "status": "COMPUTED",
+        "value": 4,
+        "exactness": "EXACT",
+        "backend": "networkx",
+        "detail": None,
+    }
+    assert outcomes["diameter"]["status"] == "NOT_APPLICABLE"
+    assert outcomes["diameter"]["value"] is None
+    assert outcomes["diameter"]["exactness"] == "NOT_APPLICABLE"
+    assert outcomes["diameter"]["backend"] == "networkx"
+    assert outcomes["diameter"]["detail"]
+    assert outcomes["made_up_invariant"] == {
+        "invariant": "made_up_invariant",
+        "status": "UNSUPPORTED",
+        "value": None,
+        "exactness": "NOT_APPLICABLE",
+        "backend": None,
+        "detail": (
+            "the invariant is not present in graph.compute.properties "
+            "registry version 1"
+        ),
+    }
+    assert set(result.output["properties"]) == {"order"}
+    assert result.output["supported_invariants"] == sorted(
+        result.output["supported_invariants"]
+    )
+    assert "made_up_invariant" not in result.output["supported_invariants"]
+
+
+@pytest.mark.integration
+def test_graph_invariant_registry_is_fixed_and_discoverable(tmp_path: Path) -> None:
+    kernel = JacobianKernel(tmp_path)
+    descriptor = next(
+        item
+        for item in kernel.capabilities.catalog().capabilities
+        if item.capability_id == "graph.compute.properties"
+    )
+
+    assert descriptor.version == "2"
+    assert descriptor.input_schema["x-supported-invariants"] == [
+        "average_eccentricity",
+        "bipartite",
+        "connected",
+        "degree_sequence",
+        "diameter",
+        "eccentricities",
+        "girth",
+        "harmonic_index",
+        "havel_hakimi_trace",
+        "independence_number",
+        "maximum_degree",
+        "minimum_degree",
+        "order",
+        "radius",
+        "residue",
+        "size",
+        "tree",
+        "triangle_count",
+        "triangle_frequencies",
+    ]


### PR DESCRIPTION
## Summary

- upgrade canonical `graph.compute.properties` to version 2; do not add a `graph.invariants.compute` alias
- freeze and expose the existing 19-invariant registry without adding graph algorithms
- return one uniform `COMPUTED`, `NOT_APPLICABLE`, or `UNSUPPORTED` result for every requested invariant
- preserve successful results when another requested invariant is unsupported or undefined for the exact graph
- materialize one source-bound artifact per invariant plus a versioned batch artifact and explicit relationships
- retain the version-1 `properties` projection for computed values while exposing complete outcomes through `results`
- audit and document the overlap and semantic differences with the standalone `graph.invariant.*` family
- update the graph benchmark artifact contract from `jacobian.graph-property-batch@1` to `@2`

## Design decisions

- the fixed registry contains only algorithms already owned by `graph.compute.properties`; standalone clique, chromatic, connectivity, Eulerian, spanning-tree, and matching algorithms were not copied into the batch
- syntactically valid unknown names reach the adapter and receive `UNSUPPORTED`, making registry gaps explicit instead of schema errors
- registered invariants that are undefined on the supplied graph receive `NOT_APPLICABLE`; this is distinct from operational failure
- batch completeness means every request received a terminal typed outcome, not that every invariant was applicable or independently verified
- all computations remain `COMPUTED`; no producer-side result is promoted to `VERIFIED`

## Validation

- focused graph and benchmark compatibility suite: 12 passed, 1 Lean-dependent test skipped because Lean is unavailable
- Ruff lint and formatting pass across the repository
- strict mypy passes for the changed source and benchmark modules
- broader non-integration suite: 380 passed; 6 unrelated local-environment failures remain (five macOS Bash 3.2 CI-plan validator failures and one SMT checker-runtime fixture failure)

Draft for human review; do not merge automatically.