### PR TITLE
Implement bounded finite coverage verification

### DIFF
--- a/docs/reference/finite-coverage-verification.md
+++ b/docs/reference/finite-coverage-verification.md
@@ -1,0 +1,59 @@
+# Bounded finite coverage verification
+
+[Documentation home](../index.md) · [Capability surface](tools.md)
+
+`finite.coverage.verify` verifies that a bounded paged archive contains every
+member of an explicit finite scope exactly once. It is a distinct verification
+contract, not an alias for `case.partition.finite`: the latter checks named
+case membership, while this capability binds typed archive pages and replays
+an exactly-once archive claim.
+
+## Bounded v1 contract
+
+Version 1 accepts:
+
+- one non-empty scope of at most 4096 items;
+- between 1 and 64 archive pages;
+- at most 1024 items per page and 4096 archive items in total;
+- either `finite.string.nfc@1` or `finite.integer.decimal@1`.
+
+The canonicalizer IDs are versioned registrations. The string registration
+uses Unicode NFC semantics; the integer registration uses exact decimal
+integer semantics. Canonical keys use a SHA-256 digest over a tagged,
+canonically encoded value. Unknown canonicalizer IDs and mixed item types are
+request errors. Canonically equivalent scope members are rejected because the
+scope must identify a finite set unambiguously.
+
+## Artifacts and bindings
+
+An invocation materializes:
+
+1. the selected canonicalizer registration;
+2. a typed finite-scope artifact with unique canonical keys;
+3. one typed artifact per archive page;
+4. an archive manifest binding each page URI, object digest, payload digest,
+   item digest, index, and item count;
+5. an exactly-once claim and certificate;
+6. a verification record only when the authorized checker accepts.
+
+The scope-key digest, page bindings, archive digest, claim, candidate, scope,
+semantics, and canonicalizer specification are all bound into the certificate
+or its artifact lineage. Replacing or reordering a page therefore changes a
+bound digest.
+
+## Diagnostics and assurance
+
+The output reports canonical keys for omissions, items outside the scope, and
+duplicates. Duplicate occurrences include page and item indices. These
+diagnostics are computed by the producer for inspection, but they do not
+certify the result.
+
+`VERIFIED` is returned only after the operator-authorized independent checker
+recomputes canonical keys, validates every registration and digest binding,
+checks contiguous page indices and bounds, and establishes that every scope
+key has count exactly one. Invalid coverage returns `UNKNOWN`, leaves the
+claim obligation open, and does not create a verification record.
+
+The capability does not infer a finite scope, stream unbounded archives,
+accept caller-defined canonicalization code, or prove that an external data
+source was completely exported into the supplied pages.

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -130,6 +130,7 @@ of catalog membership:
 - [exact rational linear-system evidence](linear-rational-solutions.md);
 - [exact rational matrix determinants](matrix-rational-determinant.md);
 - [integer matrix Hermite normal form](matrix-hermite-normal-form.md);
+- [bounded finite exactly-once coverage](finite-coverage-verification.md);
 - [typed polynomial expression normalization](polynomial-expression-normalization.md);
 - [Lean declaration discovery contract](lean-declaration-discovery.md).
 

--- a/src/jacobian/contracts/finite_coverage.py
+++ b/src/jacobian/contracts/finite_coverage.py
@@ -1,0 +1,236 @@
+"""Typed contracts for bounded exactly-once finite coverage verification."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any, Literal, Self
+
+from pydantic import Field, StrictInt, StrictStr, model_validator
+
+from jacobian.canonical import canonicalize_json
+from jacobian.contracts.common import ArtifactUri, CheckerUri, Sha256Digest
+from jacobian.contracts.results import ContractModel
+
+FiniteItem = StrictStr | StrictInt
+FiniteCanonicalizerId = Literal[
+    "finite.integer.decimal@1",
+    "finite.string.nfc@1",
+]
+FiniteCanonicalKey = Sha256Digest
+_MAX_ITEMS = 4096
+_MAX_PAGES = 64
+_MAX_PAGE_ITEMS = 1024
+
+
+def _digest(value: Any) -> str:
+    return "sha256:" + hashlib.sha256(canonicalize_json(value)).hexdigest()
+
+
+class FiniteCoveragePageInput(ContractModel):
+    items: tuple[FiniteItem, ...] = Field(max_length=_MAX_PAGE_ITEMS)
+
+
+class FiniteCoverageVerifyRequest(ContractModel):
+    request_version: Literal["1"] = "1"
+    canonicalizer_id: FiniteCanonicalizerId
+    scope_items: tuple[FiniteItem, ...] = Field(
+        min_length=1,
+        max_length=_MAX_ITEMS,
+    )
+    pages: tuple[FiniteCoveragePageInput, ...] = Field(
+        min_length=1,
+        max_length=_MAX_PAGES,
+    )
+
+    @model_validator(mode="after")
+    def require_typed_bounded_items(self) -> Self:
+        expected_type = str if self.canonicalizer_id == "finite.string.nfc@1" else int
+        items = (
+            *self.scope_items,
+            *(item for page in self.pages for item in page.items),
+        )
+        if any(type(item) is not expected_type for item in items):
+            raise ValueError(
+                "scope and archive items must match the canonicalizer item type"
+            )
+        if sum(len(page.items) for page in self.pages) > _MAX_ITEMS:
+            raise ValueError("paged archive exceeds 4096 total items")
+        return self
+
+
+class FiniteCanonicalizerRegistration(ContractModel):
+    registration_version: Literal["1"] = "1"
+    canonicalizer_id: FiniteCanonicalizerId
+    item_type: Literal["INTEGER", "STRING"]
+    algorithm: Literal["DECIMAL_INTEGER", "NFC_STRING"]
+    key_format: Literal["SHA256_RFC8785_TAGGED_VALUE"] = "SHA256_RFC8785_TAGGED_VALUE"
+    specification_digest: Sha256Digest
+
+    @model_validator(mode="after")
+    def bind_registered_specification(self) -> Self:
+        expected = {
+            "finite.integer.decimal@1": ("INTEGER", "DECIMAL_INTEGER"),
+            "finite.string.nfc@1": ("STRING", "NFC_STRING"),
+        }[self.canonicalizer_id]
+        if (self.item_type, self.algorithm) != expected:
+            raise ValueError("canonicalizer ID, item type, and algorithm disagree")
+        specification = {
+            "canonicalizer_id": self.canonicalizer_id,
+            "item_type": self.item_type,
+            "algorithm": self.algorithm,
+            "key_format": self.key_format,
+        }
+        if self.specification_digest != _digest(specification):
+            raise ValueError("canonicalizer specification digest is invalid")
+        return self
+
+
+class FiniteCoverageScopeArtifact(ContractModel):
+    scope_version: Literal["1"] = "1"
+    canonicalizer_uri: ArtifactUri
+    canonicalizer_object_digest: Sha256Digest
+    canonicalizer_specification_digest: Sha256Digest
+    canonicalizer_id: FiniteCanonicalizerId
+    items: tuple[FiniteItem, ...] = Field(min_length=1, max_length=_MAX_ITEMS)
+    canonical_keys: tuple[FiniteCanonicalKey, ...] = Field(
+        min_length=1,
+        max_length=_MAX_ITEMS,
+    )
+    scope_keys_digest: Sha256Digest
+
+    @model_validator(mode="after")
+    def require_aligned_unique_scope(self) -> Self:
+        if len(self.items) != len(self.canonical_keys):
+            raise ValueError("scope items and canonical keys must align")
+        if len(set(self.canonical_keys)) != len(self.canonical_keys):
+            raise ValueError("finite scope canonical keys must be unique")
+        if self.scope_keys_digest != _digest(list(self.canonical_keys)):
+            raise ValueError("scope key digest is invalid")
+        return self
+
+
+class FiniteCoveragePageArtifact(ContractModel):
+    page_version: Literal["1"] = "1"
+    page_index: StrictInt = Field(ge=0, lt=_MAX_PAGES)
+    canonicalizer_uri: ArtifactUri
+    canonicalizer_object_digest: Sha256Digest
+    canonicalizer_id: FiniteCanonicalizerId
+    items: tuple[FiniteItem, ...] = Field(max_length=_MAX_PAGE_ITEMS)
+    canonical_keys: tuple[FiniteCanonicalKey, ...] = Field(max_length=_MAX_PAGE_ITEMS)
+    items_digest: Sha256Digest
+
+    @model_validator(mode="after")
+    def require_aligned_page(self) -> Self:
+        if len(self.items) != len(self.canonical_keys):
+            raise ValueError("page items and canonical keys must align")
+        if self.items_digest != _digest(
+            {
+                "items": list(self.items),
+                "canonical_keys": list(self.canonical_keys),
+            }
+        ):
+            raise ValueError("page items digest is invalid")
+        return self
+
+
+class FiniteCoveragePageBinding(ContractModel):
+    page_index: StrictInt = Field(ge=0, lt=_MAX_PAGES)
+    page_uri: ArtifactUri
+    page_object_digest: Sha256Digest
+    page_payload_digest: Sha256Digest
+    items_digest: Sha256Digest
+    item_count: StrictInt = Field(ge=0, le=_MAX_PAGE_ITEMS)
+
+
+class FiniteCoverageArchiveArtifact(ContractModel):
+    archive_version: Literal["1"] = "1"
+    scope_uri: ArtifactUri
+    scope_object_digest: Sha256Digest
+    canonicalizer_uri: ArtifactUri
+    canonicalizer_object_digest: Sha256Digest
+    canonicalizer_specification_digest: Sha256Digest
+    canonicalizer_id: FiniteCanonicalizerId
+    page_bindings: tuple[FiniteCoveragePageBinding, ...] = Field(
+        min_length=1,
+        max_length=_MAX_PAGES,
+    )
+    total_item_count: StrictInt = Field(ge=0, le=_MAX_ITEMS)
+    archive_digest: Sha256Digest
+
+    @model_validator(mode="after")
+    def require_contiguous_bound_pages(self) -> Self:
+        if tuple(binding.page_index for binding in self.page_bindings) != tuple(
+            range(len(self.page_bindings))
+        ):
+            raise ValueError("archive page indices must be contiguous from zero")
+        if self.total_item_count != sum(
+            binding.item_count for binding in self.page_bindings
+        ):
+            raise ValueError("archive total must equal bound page item counts")
+        digest_payload = {
+            "scope_uri": self.scope_uri,
+            "scope_object_digest": self.scope_object_digest,
+            "canonicalizer_uri": self.canonicalizer_uri,
+            "canonicalizer_object_digest": self.canonicalizer_object_digest,
+            "canonicalizer_specification_digest": (
+                self.canonicalizer_specification_digest
+            ),
+            "canonicalizer_id": self.canonicalizer_id,
+            "page_bindings": [
+                binding.model_dump(mode="json") for binding in self.page_bindings
+            ],
+            "total_item_count": self.total_item_count,
+        }
+        if self.archive_digest != _digest(digest_payload):
+            raise ValueError("archive digest is invalid")
+        return self
+
+
+class FiniteCoverageClaim(ContractModel):
+    claim_version: Literal["1"] = "1"
+    predicate: Literal["FINITE_EXACTLY_ONCE_COVERAGE"] = "FINITE_EXACTLY_ONCE_COVERAGE"
+    scope_uri: ArtifactUri
+    archive_uri: ArtifactUri
+    canonicalizer_uri: ArtifactUri
+    canonicalizer_id: FiniteCanonicalizerId
+    scope_keys_digest: Sha256Digest
+    archive_digest: Sha256Digest
+
+
+class FiniteCoverageOccurrence(ContractModel):
+    canonical_key: FiniteCanonicalKey
+    page_index: StrictInt = Field(ge=0, lt=_MAX_PAGES)
+    item_index: StrictInt = Field(ge=0, lt=_MAX_PAGE_ITEMS)
+
+
+class FiniteCoverageDiagnostics(ContractModel):
+    missing_keys: tuple[FiniteCanonicalKey, ...] = ()
+    duplicate_keys: tuple[FiniteCanonicalKey, ...] = ()
+    outside_keys: tuple[FiniteCanonicalKey, ...] = ()
+    duplicate_occurrences: tuple[FiniteCoverageOccurrence, ...] = ()
+
+
+class FiniteCoverageVerifyOutput(ContractModel):
+    coverage_status: Literal["EXACTLY_ONCE", "INVALID"]
+    conclusion: Literal["TRUE", "UNKNOWN"]
+    canonicalizer_id: FiniteCanonicalizerId
+    canonicalizer_uri: ArtifactUri
+    scope_uri: ArtifactUri
+    archive_uri: ArtifactUri
+    page_uris: tuple[ArtifactUri, ...]
+    claim_uri: ArtifactUri
+    certificate_uri: ArtifactUri
+    verification_record_uri: ArtifactUri | None = None
+    diagnostics: FiniteCoverageDiagnostics
+    scope_keys_digest: Sha256Digest
+    archive_digest: Sha256Digest
+    checker_id: CheckerUri
+    detail: str = Field(min_length=1, max_length=512)
+
+    @model_validator(mode="after")
+    def bind_verified_conclusion_shape(self) -> Self:
+        if (self.coverage_status == "EXACTLY_ONCE") != (self.conclusion == "TRUE"):
+            raise ValueError("only exactly-once coverage may carry a true conclusion")
+        if self.conclusion == "TRUE" and self.verification_record_uri is None:
+            raise ValueError("true coverage requires a verification record")
+        return self

--- a/src/jacobian/finite_coverage.py
+++ b/src/jacobian/finite_coverage.py
@@ -1,0 +1,597 @@
+"""Bounded exactly-once finite coverage verification."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic import ValidationError
+
+from jacobian.artifacts import ArtifactService
+from jacobian.canonical import canonicalize_json
+from jacobian.capabilities import (
+    CapabilityAdapter,
+    CapabilityInvocationError,
+)
+from jacobian.contracts.capabilities import (
+    CapabilityAssurance,
+    CapabilityAssuranceLevel,
+    CapabilityCompleteness,
+    CapabilityCompletenessStatus,
+    CapabilityDescriptor,
+    CapabilityDiagnostic,
+    CapabilityMode,
+    CapabilityObligation,
+    CapabilityObligationStatus,
+    CapabilityRelationship,
+    CapabilityRelationshipStatus,
+    CapabilityRequest,
+    CapabilityResult,
+    CapabilityScope,
+)
+from jacobian.contracts.checkers import EvidenceKind
+from jacobian.contracts.evidence import CertificateEnvelope, EvidenceBindings
+from jacobian.contracts.finite_coverage import (
+    FiniteCanonicalizerId,
+    FiniteCanonicalizerRegistration,
+    FiniteCoverageArchiveArtifact,
+    FiniteCoverageClaim,
+    FiniteCoverageDiagnostics,
+    FiniteCoverageOccurrence,
+    FiniteCoveragePageArtifact,
+    FiniteCoveragePageBinding,
+    FiniteCoverageScopeArtifact,
+    FiniteCoverageVerifyOutput,
+    FiniteCoverageVerifyRequest,
+)
+from jacobian.contracts.results import Conclusion, ExecutionStatus, Verification
+from jacobian.provider_runtime import known_provider_runtime
+from jacobian.registry import CheckerRegistry
+from jacobian.schema_registry import SchemaRegistry, model_schema
+from jacobian.store import ArtifactStore
+from jacobian.verification import VerificationService
+
+
+@dataclass(frozen=True, slots=True)
+class FiniteCoverageInstallation:
+    semantics_uri: str
+    canonicalizer_schema_uri: str
+    scope_schema_uri: str
+    page_schema_uri: str
+    archive_schema_uri: str
+    claim_schema_uri: str
+    certificate_schema_uri: str
+    canonicalizer_uris: dict[str, str]
+    checker_id: str | None
+
+
+_CANONICALIZER_SPECS: dict[str, dict[str, str]] = {
+    "finite.integer.decimal@1": {
+        "item_type": "INTEGER",
+        "algorithm": "DECIMAL_INTEGER",
+        "key_format": "SHA256_RFC8785_TAGGED_VALUE",
+    },
+    "finite.string.nfc@1": {
+        "item_type": "STRING",
+        "algorithm": "NFC_STRING",
+        "key_format": "SHA256_RFC8785_TAGGED_VALUE",
+    },
+}
+
+
+def install_finite_coverage(
+    store: ArtifactStore,
+    schemas: SchemaRegistry,
+    artifacts: ArtifactService,
+    verification: VerificationService,
+    checkers: CheckerRegistry,
+    *,
+    authorize_checker: bool,
+) -> tuple[CapabilityAdapter | None, FiniteCoverageInstallation]:
+    """Register v1 finite-coverage artifacts and optionally authorize replay."""
+
+    semantics_uri = store.register_descriptor(
+        kind="semantics",
+        name="jacobian.finite-exactly-once-coverage",
+        version="1",
+        definition={
+            "domain": "bounded explicit finite scopes and paged archives",
+            "coverage": "every canonical scope key appears exactly once",
+            "maximum_scope_items": 4096,
+            "maximum_pages": 64,
+            "maximum_page_items": 1024,
+        },
+    )
+    canonicalizer_schema_uri = schemas.register_model(
+        name="jacobian.finite-canonicalizer-registration",
+        version="1",
+        model=FiniteCanonicalizerRegistration,
+    )
+    scope_schema_uri = schemas.register_model(
+        name="jacobian.finite-coverage-scope",
+        version="1",
+        model=FiniteCoverageScopeArtifact,
+    )
+    page_schema_uri = schemas.register_model(
+        name="jacobian.finite-coverage-page",
+        version="1",
+        model=FiniteCoveragePageArtifact,
+    )
+    archive_schema_uri = schemas.register_model(
+        name="jacobian.finite-coverage-archive",
+        version="1",
+        model=FiniteCoverageArchiveArtifact,
+    )
+    claim_schema_uri = schemas.register_model(
+        name="jacobian.finite-coverage-claim",
+        version="1",
+        model=FiniteCoverageClaim,
+    )
+    certificate_schema_uri = schemas.register(
+        name="jacobian.certificate-envelope",
+        version="1",
+        schema=model_schema(CertificateEnvelope),
+    )
+    canonicalizer_uris: dict[str, str] = {}
+    for canonicalizer_id, spec in sorted(_CANONICALIZER_SPECS.items()):
+        specification_digest = _digest({"canonicalizer_id": canonicalizer_id, **spec})
+        registration = FiniteCanonicalizerRegistration.model_validate(
+            {
+                "canonicalizer_id": canonicalizer_id,
+                "specification_digest": specification_digest,
+                **spec,
+            }
+        )
+        stored = artifacts.put(
+            schema_uri=canonicalizer_schema_uri,
+            semantics_uri=semantics_uri,
+            payload=registration.model_dump(mode="json"),
+            summary=f"registered finite canonicalizer {canonicalizer_id}",
+        )
+        canonicalizer_uris[canonicalizer_id] = stored.artifact_uri
+
+    checker_id = None
+    if authorize_checker:
+        checker_id = checkers.authorize(
+            name="finite exactly-once paged coverage checker",
+            entrypoint="jacobian_checkers.finite_coverage:check_finite_coverage",
+            evidence_kind=EvidenceKind.CERTIFICATE,
+            format_id="finite.coverage",
+            format_version="1",
+            claim_schema_uris=(claim_schema_uri,),
+            semantics_uris=(semantics_uri,),
+            candidate_schema_uris=(archive_schema_uri,),
+            reason=(
+                "operator requested independent standard-library replay of every "
+                "canonical scope and archive item"
+            ),
+        ).checker_id
+    installation = FiniteCoverageInstallation(
+        semantics_uri=semantics_uri,
+        canonicalizer_schema_uri=canonicalizer_schema_uri,
+        scope_schema_uri=scope_schema_uri,
+        page_schema_uri=page_schema_uri,
+        archive_schema_uri=archive_schema_uri,
+        claim_schema_uri=claim_schema_uri,
+        certificate_schema_uri=certificate_schema_uri,
+        canonicalizer_uris=canonicalizer_uris,
+        checker_id=checker_id,
+    )
+    adapter = (
+        FiniteCoverageVerifyAdapter(
+            store=store,
+            artifacts=artifacts,
+            verification=verification,
+            installation=installation,
+        )
+        if checker_id is not None
+        else None
+    )
+    return adapter, installation
+
+
+class FiniteCoverageVerifyAdapter:
+    """Materialize and independently verify one bounded paged archive."""
+
+    def __init__(
+        self,
+        *,
+        store: ArtifactStore,
+        artifacts: ArtifactService,
+        verification: VerificationService,
+        installation: FiniteCoverageInstallation,
+    ) -> None:
+        checker_id = installation.checker_id
+        if checker_id is None:
+            raise ValueError("finite coverage checker is not authorized")
+        self.store = store
+        self.artifacts = artifacts
+        self.verification = verification
+        self.installation = installation
+        self._descriptor = CapabilityDescriptor(
+            capability_id="finite.coverage.verify",
+            version="1",
+            title="Verify exactly-once coverage of a finite paged archive",
+            description=(
+                "Materialize one typed finite scope and bounded page archive, then "
+                "independently replay canonical-key coverage exactly once."
+            ),
+            provider="jacobian.finite",
+            provider_runtime=known_provider_runtime(
+                "jacobian.finite",
+                features=(
+                    "finite-coverage",
+                    "paged-archive",
+                    "registered-canonicalizers",
+                    "exactly-once",
+                    "clean-process-checker",
+                ),
+                checker_ids=(checker_id,),
+            ),
+            modes=(CapabilityMode.VERIFY,),
+            input_schema=model_schema(FiniteCoverageVerifyRequest),
+            output_schema=model_schema(FiniteCoverageVerifyOutput),
+            tags=("finite", "coverage", "verification", "paged-archive"),
+        )
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        return self._descriptor
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        try:
+            validated = FiniteCoverageVerifyRequest.model_validate(request.input)
+        except ValidationError as exc:
+            raise CapabilityInvocationError(
+                CapabilityDiagnostic(
+                    code="INVALID_FINITE_COVERAGE_REQUEST",
+                    stage="request_validation",
+                    message=(
+                        "The complete finite-coverage request is invalid: "
+                        f"{exc.errors()[0].get('msg', 'validation failed')}"
+                    ),
+                    hint=(
+                        "Use one registered v1 canonicalizer, 1 to 4096 typed scope "
+                        "items, and 1 to 64 pages containing at most 4096 items total."
+                    ),
+                )
+            ) from exc
+
+        canonicalizer_id = validated.canonicalizer_id
+        canonicalizer_uri = self.installation.canonicalizer_uris[canonicalizer_id]
+        canonicalizer = self.store.get(canonicalizer_uri)
+        registration = FiniteCanonicalizerRegistration.model_validate(
+            canonicalizer.payload
+        )
+        scope_keys = tuple(
+            _canonical_key(canonicalizer_id, item) for item in validated.scope_items
+        )
+        if len(set(scope_keys)) != len(scope_keys):
+            raise CapabilityInvocationError(
+                CapabilityDiagnostic(
+                    code="DUPLICATE_FINITE_SCOPE_KEY",
+                    stage="scope_canonicalization",
+                    message=(
+                        "The finite scope contains items that collide under the "
+                        "selected registered canonicalizer."
+                    ),
+                    path="scope_items",
+                    hint="Remove duplicate or canonically equivalent scope items.",
+                )
+            )
+        scope_payload = FiniteCoverageScopeArtifact(
+            canonicalizer_uri=canonicalizer_uri,
+            canonicalizer_object_digest=canonicalizer.manifest.object_digest,
+            canonicalizer_specification_digest=registration.specification_digest,
+            canonicalizer_id=canonicalizer_id,
+            items=validated.scope_items,
+            canonical_keys=scope_keys,
+            scope_keys_digest=_digest(list(scope_keys)),
+        )
+        scope = self.artifacts.put(
+            schema_uri=self.installation.scope_schema_uri,
+            semantics_uri=self.installation.semantics_uri,
+            payload=scope_payload.model_dump(mode="json"),
+            parents=(canonicalizer_uri,),
+            summary="typed finite coverage scope",
+        )
+
+        page_uris: list[str] = []
+        page_bindings: list[FiniteCoveragePageBinding] = []
+        page_payloads: list[FiniteCoveragePageArtifact] = []
+        for page_index, page_input in enumerate(validated.pages):
+            keys = tuple(
+                _canonical_key(canonicalizer_id, item) for item in page_input.items
+            )
+            items_digest = _digest(
+                {"items": list(page_input.items), "canonical_keys": list(keys)}
+            )
+            page_payload = FiniteCoveragePageArtifact(
+                page_index=page_index,
+                canonicalizer_uri=canonicalizer_uri,
+                canonicalizer_object_digest=canonicalizer.manifest.object_digest,
+                canonicalizer_id=canonicalizer_id,
+                items=page_input.items,
+                canonical_keys=keys,
+                items_digest=items_digest,
+            )
+            page = self.artifacts.put(
+                schema_uri=self.installation.page_schema_uri,
+                semantics_uri=self.installation.semantics_uri,
+                payload=page_payload.model_dump(mode="json"),
+                parents=(canonicalizer_uri,),
+                summary=f"finite coverage archive page {page_index}",
+            )
+            stored_page = self.store.get(page.artifact_uri)
+            page_uris.append(page.artifact_uri)
+            page_payloads.append(page_payload)
+            page_bindings.append(
+                FiniteCoveragePageBinding(
+                    page_index=page_index,
+                    page_uri=page.artifact_uri,
+                    page_object_digest=stored_page.manifest.object_digest,
+                    page_payload_digest=stored_page.manifest.payload_digest,
+                    items_digest=items_digest,
+                    item_count=len(page_input.items),
+                )
+            )
+
+        stored_scope = self.store.get(scope.artifact_uri)
+        archive_digest_payload = {
+            "scope_uri": scope.artifact_uri,
+            "scope_object_digest": stored_scope.manifest.object_digest,
+            "canonicalizer_uri": canonicalizer_uri,
+            "canonicalizer_object_digest": canonicalizer.manifest.object_digest,
+            "canonicalizer_specification_digest": registration.specification_digest,
+            "canonicalizer_id": canonicalizer_id,
+            "page_bindings": [
+                binding.model_dump(mode="json") for binding in page_bindings
+            ],
+            "total_item_count": sum(len(page.items) for page in validated.pages),
+        }
+        archive_payload = FiniteCoverageArchiveArtifact(
+            scope_uri=scope.artifact_uri,
+            scope_object_digest=stored_scope.manifest.object_digest,
+            canonicalizer_uri=canonicalizer_uri,
+            canonicalizer_object_digest=canonicalizer.manifest.object_digest,
+            canonicalizer_specification_digest=registration.specification_digest,
+            canonicalizer_id=canonicalizer_id,
+            page_bindings=tuple(page_bindings),
+            total_item_count=sum(len(page.items) for page in validated.pages),
+            archive_digest=_digest(archive_digest_payload),
+        )
+        archive = self.artifacts.put(
+            schema_uri=self.installation.archive_schema_uri,
+            semantics_uri=self.installation.semantics_uri,
+            payload=archive_payload.model_dump(mode="json"),
+            parents=(scope.artifact_uri, canonicalizer_uri, *page_uris),
+            summary="bounded finite coverage archive manifest",
+        )
+        claim_payload = FiniteCoverageClaim(
+            scope_uri=scope.artifact_uri,
+            archive_uri=archive.artifact_uri,
+            canonicalizer_uri=canonicalizer_uri,
+            canonicalizer_id=canonicalizer_id,
+            scope_keys_digest=scope_payload.scope_keys_digest,
+            archive_digest=archive_payload.archive_digest,
+        )
+        claim = self.artifacts.put(
+            schema_uri=self.installation.claim_schema_uri,
+            semantics_uri=self.installation.semantics_uri,
+            payload=claim_payload.model_dump(mode="json"),
+            parents=(scope.artifact_uri, archive.artifact_uri, canonicalizer_uri),
+            summary="finite exactly-once coverage claim",
+        )
+        diagnostics = _coverage_diagnostics(scope_keys, page_payloads)
+        stored_archive = self.store.get(archive.artifact_uri)
+        semantics = self.store.get(self.installation.semantics_uri)
+        certificate_payload = {
+            "relation_id": "finite.relation.covers-exactly-once",
+            "obligation_uri": claim.artifact_uri,
+            "canonicalizer_uri": canonicalizer_uri,
+            "canonicalizer_object_digest": canonicalizer.manifest.object_digest,
+            "canonicalizer_specification_digest": registration.specification_digest,
+            "scope_keys_digest": scope_payload.scope_keys_digest,
+            "archive_digest": archive_payload.archive_digest,
+            "page_binding_digest": _digest(
+                [
+                    binding.model_dump(mode="json")
+                    for binding in archive_payload.page_bindings
+                ]
+            ),
+        }
+        envelope = CertificateEnvelope(
+            certificate_type="finite.coverage",
+            format_version="1",
+            bindings=EvidenceBindings(
+                claim_digest=self.store.get(claim.artifact_uri).manifest.object_digest,
+                semantics_digest=semantics.manifest.object_digest,
+                candidate_digest=stored_archive.manifest.object_digest,
+                scope_digest=stored_scope.manifest.object_digest,
+            ),
+            payload_digest=_digest(certificate_payload),
+            payload=certificate_payload,
+        )
+        certificate = self.artifacts.put(
+            schema_uri=self.installation.certificate_schema_uri,
+            semantics_uri=self.installation.semantics_uri,
+            payload=envelope.model_dump(mode="json"),
+            parents=(
+                claim.artifact_uri,
+                archive.artifact_uri,
+                scope.artifact_uri,
+                canonicalizer_uri,
+                *page_uris,
+            ),
+            summary="finite exactly-once coverage replay certificate",
+        )
+        checker_id = self.installation.checker_id
+        assert checker_id is not None
+        checked = self.verification.verify_certificate(
+            certificate_uri=certificate.artifact_uri,
+            checker_id=checker_id,
+            include_artifact_metadata=True,
+            supporting_artifact_uris=(canonicalizer_uri, *page_uris),
+        )
+        verified = (
+            checked.execution.status is ExecutionStatus.COMPLETED
+            and checked.conclusion is Conclusion.TRUE
+            and checked.assurance.verification is Verification.VERIFIED
+            and checked.verification_record_uri is not None
+        )
+        detail = checked.execution.detail
+        if detail is None and checked.input.errors:
+            detail = checked.input.errors[0]
+        if detail is None:
+            detail = (
+                "the authorized checker accepted exactly-once finite coverage"
+                if verified
+                else "the archive did not establish exactly-once finite coverage"
+            )
+        output = FiniteCoverageVerifyOutput(
+            coverage_status="EXACTLY_ONCE" if verified else "INVALID",
+            conclusion="TRUE" if verified else "UNKNOWN",
+            canonicalizer_id=canonicalizer_id,
+            canonicalizer_uri=canonicalizer_uri,
+            scope_uri=scope.artifact_uri,
+            archive_uri=archive.artifact_uri,
+            page_uris=tuple(page_uris),
+            claim_uri=claim.artifact_uri,
+            certificate_uri=certificate.artifact_uri,
+            verification_record_uri=(
+                checked.verification_record_uri if verified else None
+            ),
+            diagnostics=diagnostics,
+            scope_keys_digest=scope_payload.scope_keys_digest,
+            archive_digest=archive_payload.archive_digest,
+            checker_id=checker_id,
+            detail=detail,
+        )
+        record_uri = checked.verification_record_uri if verified else None
+        assurance_level = (
+            CapabilityAssuranceLevel.VERIFIED
+            if verified
+            else (
+                CapabilityAssuranceLevel.COMPUTED
+                if checked.execution.status is ExecutionStatus.COMPLETED
+                else CapabilityAssuranceLevel.HEURISTIC
+            )
+        )
+        complete = verified
+        artifact_uris = [
+            canonicalizer_uri,
+            scope.artifact_uri,
+            *page_uris,
+            archive.artifact_uri,
+            claim.artifact_uri,
+            certificate.artifact_uri,
+        ]
+        if record_uri is not None:
+            artifact_uris.append(record_uri)
+        return CapabilityResult(
+            capability_id=self.descriptor.capability_id,
+            capability_version=self.descriptor.version,
+            mode=request.mode,
+            execution=checked.execution,
+            output=output.model_dump(mode="json"),
+            scope=CapabilityScope(
+                description="the exact typed finite scope bound to the page archive",
+                parameters={
+                    "canonicalizer_id": canonicalizer_id,
+                    "scope_item_count": len(validated.scope_items),
+                    "page_count": len(validated.pages),
+                    "archive_item_count": sum(
+                        len(page.items) for page in validated.pages
+                    ),
+                },
+                artifact_uri=scope.artifact_uri,
+            ),
+            completeness=CapabilityCompleteness(
+                status=(
+                    CapabilityCompletenessStatus.COMPLETE
+                    if complete
+                    else CapabilityCompletenessStatus.PARTIAL
+                ),
+                basis=(
+                    "operator-authorized independent checker replayed every bound "
+                    "scope and page item exactly once"
+                    if verified
+                    else "exactly-once coverage was not independently accepted"
+                ),
+                assurance_level=assurance_level,
+                verification_record_uri=record_uri,
+            ),
+            relationships=(
+                CapabilityRelationship(
+                    relation_id="finite.relation.covers-exactly-once",
+                    source_artifact_uris=(scope.artifact_uri,),
+                    target_artifact_uris=(archive.artifact_uri,),
+                    status=(
+                        CapabilityRelationshipStatus.VERIFIED
+                        if verified
+                        else CapabilityRelationshipStatus.PROPOSED
+                    ),
+                    obligation_uris=(claim.artifact_uri,),
+                    verification_record_uri=record_uri,
+                ),
+            ),
+            obligations=(
+                CapabilityObligation(
+                    obligation_uri=claim.artifact_uri,
+                    status=(
+                        CapabilityObligationStatus.DISCHARGED
+                        if verified
+                        else CapabilityObligationStatus.OPEN
+                    ),
+                    verification_record_uri=record_uri,
+                ),
+            ),
+            assurance=CapabilityAssurance(
+                level=assurance_level,
+                basis=(
+                    "operator-authorized independent finite coverage checker accepted"
+                    if verified
+                    else "coverage diagnostics were computed but not verified"
+                ),
+                verification_record_uri=record_uri,
+            ),
+            artifact_uris=tuple(artifact_uris),
+        )
+
+
+def _digest(value: Any) -> str:
+    return "sha256:" + hashlib.sha256(canonicalize_json(value)).hexdigest()
+
+
+def _canonical_key(canonicalizer_id: FiniteCanonicalizerId, item: Any) -> str:
+    return _digest({"canonicalizer_id": canonicalizer_id, "value": item})
+
+
+def _coverage_diagnostics(
+    scope_keys: tuple[str, ...],
+    pages: list[FiniteCoveragePageArtifact],
+) -> FiniteCoverageDiagnostics:
+    scope = set(scope_keys)
+    occurrences: dict[str, list[FiniteCoverageOccurrence]] = {}
+    for page in pages:
+        for item_index, key in enumerate(page.canonical_keys):
+            occurrences.setdefault(key, []).append(
+                FiniteCoverageOccurrence(
+                    canonical_key=key,
+                    page_index=page.page_index,
+                    item_index=item_index,
+                )
+            )
+    present = set(occurrences)
+    duplicate_keys = tuple(
+        sorted(key for key, locations in occurrences.items() if len(locations) > 1)
+    )
+    return FiniteCoverageDiagnostics(
+        missing_keys=tuple(sorted(scope - present)),
+        duplicate_keys=duplicate_keys,
+        outside_keys=tuple(sorted(present - scope)),
+        duplicate_occurrences=tuple(
+            location for key in duplicate_keys for location in occurrences[key]
+        ),
+    )

--- a/src/jacobian/kernel.py
+++ b/src/jacobian/kernel.py
@@ -31,6 +31,10 @@ from jacobian.domain_atomic_extras import install_domain_atomic_extras
 from jacobian.evaluation import EvaluationService
 from jacobian.experiment_router import ExperimentRouter
 from jacobian.experiments import ExperimentService
+from jacobian.finite_coverage import (
+    FiniteCoverageInstallation,
+    install_finite_coverage,
+)
 from jacobian.finite_partition import (
     FinitePartitionInstallation,
     install_finite_partition,
@@ -437,6 +441,17 @@ class JacobianKernel:
             authorize_checker=install_references,
         )
         self.register_capability(finite_partition)
+        self.finite_coverage: FiniteCoverageInstallation
+        finite_coverage, self.finite_coverage = install_finite_coverage(
+            self.store,
+            self.schemas,
+            self.artifacts,
+            self.verification,
+            self.checkers,
+            authorize_checker=install_references,
+        )
+        if finite_coverage is not None:
+            self.register_capability(finite_coverage)
         self.graph: GraphInstallation
         graph_adapters, self.graph = install_graph_capabilities(
             self.store,

--- a/src/jacobian_checkers/finite_coverage.py
+++ b/src/jacobian_checkers/finite_coverage.py
@@ -1,0 +1,276 @@
+"""Independent replay for bounded exactly-once finite archive coverage."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+from jacobian.canonical import canonicalize_json
+
+_SPECS: dict[str, dict[str, str]] = {
+    "finite.integer.decimal@1": {
+        "item_type": "INTEGER",
+        "algorithm": "DECIMAL_INTEGER",
+        "key_format": "SHA256_RFC8785_TAGGED_VALUE",
+    },
+    "finite.string.nfc@1": {
+        "item_type": "STRING",
+        "algorithm": "NFC_STRING",
+        "key_format": "SHA256_RFC8785_TAGGED_VALUE",
+    },
+}
+
+
+def _reject(detail: str) -> dict[str, Any]:
+    return {
+        "accepted": False,
+        "conclusion": "UNKNOWN",
+        "arithmetic": "EXACT_INTEGER",
+        "method": "EXHAUSTIVE_FINITE",
+        "coverage": "EXHAUSTIVE",
+        "detail": detail,
+    }
+
+
+def _digest(value: Any) -> str:
+    return "sha256:" + hashlib.sha256(canonicalize_json(value)).hexdigest()
+
+
+def _canonical_key(canonicalizer_id: str, item: Any) -> str:
+    return _digest({"canonicalizer_id": canonicalizer_id, "value": item})
+
+
+def check_finite_coverage(request: dict[str, Any]) -> dict[str, Any]:  # noqa: C901
+    """Recompute every canonical key without importing producer code."""
+
+    try:
+        if request.get("request_version") != "1":
+            return _reject("unsupported checker request version")
+        claim_artifact = request["claim"]
+        archive_artifact = request["candidate"]
+        scope_artifact = request["scope"]
+        certificate_artifact = request["certificate"]
+        supporting = request.get("supporting_artifacts")
+        if not isinstance(supporting, list):
+            return _reject("canonicalizer and page artifacts are required")
+        claim = claim_artifact["payload"]
+        archive = archive_artifact["payload"]
+        scope = scope_artifact["payload"]
+        certificate = certificate_artifact["payload"]
+        if claim.get("predicate") != "FINITE_EXACTLY_ONCE_COVERAGE":
+            return _reject("unsupported finite coverage claim")
+        if certificate.get("certificate_type") != "finite.coverage":
+            return _reject("unexpected certificate type")
+        if certificate.get("format_version") != "1":
+            return _reject("unsupported certificate format")
+        if certificate.get("bindings") != request["expected_bindings"]:
+            return _reject("certificate bindings do not match the request")
+
+        canonicalizer_id = scope.get("canonicalizer_id")
+        spec = _SPECS.get(canonicalizer_id)
+        if spec is None:
+            return _reject("unregistered finite canonicalizer")
+        registration_artifacts = [
+            artifact
+            for artifact in supporting
+            if isinstance(artifact.get("payload"), dict)
+            and artifact["payload"].get("registration_version") == "1"
+        ]
+        if len(registration_artifacts) != 1:
+            return _reject("exactly one canonicalizer registration is required")
+        registration_artifact = registration_artifacts[0]
+        registration = registration_artifact["payload"]
+        expected_specification_digest = _digest(
+            {"canonicalizer_id": canonicalizer_id, **spec}
+        )
+        if (
+            registration.get("canonicalizer_id") != canonicalizer_id
+            or registration.get("item_type") != spec["item_type"]
+            or registration.get("algorithm") != spec["algorithm"]
+            or registration.get("key_format") != spec["key_format"]
+            or registration.get("specification_digest") != expected_specification_digest
+            or registration_artifact.get("artifact_uri")
+            != scope.get("canonicalizer_uri")
+            or registration_artifact.get("object_digest")
+            != scope.get("canonicalizer_object_digest")
+        ):
+            return _reject("canonicalizer registration or digest is not bound")
+        expected_type = str if spec["item_type"] == "STRING" else int
+        scope_items = scope.get("items")
+        scope_keys = scope.get("canonical_keys")
+        if (
+            not isinstance(scope_items, list)
+            or not 1 <= len(scope_items) <= 4096
+            or not all(type(item) is expected_type for item in scope_items)
+            or not isinstance(scope_keys, list)
+            or len(scope_items) != len(scope_keys)
+        ):
+            return _reject("finite scope is malformed or uses the wrong item type")
+        recomputed_scope_keys = [
+            _canonical_key(canonicalizer_id, item) for item in scope_items
+        ]
+        if (
+            recomputed_scope_keys != scope_keys
+            or len(set(scope_keys)) != len(scope_keys)
+            or scope.get("scope_keys_digest") != _digest(scope_keys)
+            or scope.get("canonicalizer_specification_digest")
+            != expected_specification_digest
+        ):
+            return _reject("scope canonical keys or digest are invalid")
+
+        if (
+            archive.get("archive_version") != "1"
+            or archive.get("scope_uri") != scope_artifact.get("artifact_uri")
+            or archive.get("scope_object_digest") != scope_artifact.get("object_digest")
+            or archive.get("canonicalizer_uri")
+            != registration_artifact.get("artifact_uri")
+            or archive.get("canonicalizer_object_digest")
+            != registration_artifact.get("object_digest")
+            or archive.get("canonicalizer_specification_digest")
+            != expected_specification_digest
+            or archive.get("canonicalizer_id") != canonicalizer_id
+        ):
+            return _reject("archive scope or canonicalizer binding is invalid")
+        page_bindings = archive.get("page_bindings")
+        if not isinstance(page_bindings, list) or not 1 <= len(page_bindings) <= 64:
+            return _reject("archive page bindings are malformed")
+        page_artifacts = {
+            artifact.get("artifact_uri"): artifact
+            for artifact in supporting
+            if isinstance(artifact.get("payload"), dict)
+            and artifact["payload"].get("page_version") == "1"
+        }
+        if len(page_artifacts) != len(page_bindings):
+            return _reject("archive page artifacts do not match the manifest")
+        archive_keys: list[str] = []
+        total_items = 0
+        expected_page_uris: list[str] = []
+        for expected_index, binding in enumerate(page_bindings):
+            if not isinstance(binding, dict) or binding.get("page_index") != (
+                expected_index
+            ):
+                return _reject("archive page indices are not contiguous")
+            page_uri = binding.get("page_uri")
+            if not isinstance(page_uri, str):
+                return _reject("a bound archive page URI is malformed")
+            page_artifact = page_artifacts.get(page_uri)
+            if page_artifact is None:
+                return _reject("a bound archive page is unavailable")
+            page = page_artifact["payload"]
+            items = page.get("items")
+            keys = page.get("canonical_keys")
+            if (
+                page_artifact.get("object_digest") != binding.get("page_object_digest")
+                or page.get("page_index") != expected_index
+                or page.get("canonicalizer_uri")
+                != registration_artifact.get("artifact_uri")
+                or page.get("canonicalizer_object_digest")
+                != registration_artifact.get("object_digest")
+                or page.get("canonicalizer_id") != canonicalizer_id
+                or not isinstance(items, list)
+                or len(items) > 1024
+                or not all(type(item) is expected_type for item in items)
+                or not isinstance(keys, list)
+                or len(items) != len(keys)
+            ):
+                return _reject("a bound archive page is malformed")
+            recomputed_keys = [_canonical_key(canonicalizer_id, item) for item in items]
+            items_digest = _digest({"items": items, "canonical_keys": recomputed_keys})
+            payload_digest = _digest(page)
+            if (
+                keys != recomputed_keys
+                or page.get("items_digest") != items_digest
+                or binding.get("items_digest") != items_digest
+                or binding.get("page_payload_digest") != payload_digest
+                or binding.get("item_count") != len(items)
+            ):
+                return _reject("page keys, counts, or digest bindings are invalid")
+            archive_keys.extend(recomputed_keys)
+            total_items += len(items)
+            expected_page_uris.append(page_uri)
+        if total_items > 4096 or archive.get("total_item_count") != total_items:
+            return _reject("archive total item count is invalid")
+        digest_payload = {
+            "scope_uri": archive["scope_uri"],
+            "scope_object_digest": archive["scope_object_digest"],
+            "canonicalizer_uri": archive["canonicalizer_uri"],
+            "canonicalizer_object_digest": archive["canonicalizer_object_digest"],
+            "canonicalizer_specification_digest": archive[
+                "canonicalizer_specification_digest"
+            ],
+            "canonicalizer_id": archive["canonicalizer_id"],
+            "page_bindings": page_bindings,
+            "total_item_count": total_items,
+        }
+        if archive.get("archive_digest") != _digest(digest_payload):
+            return _reject("archive digest is invalid")
+
+        certificate_payload = certificate.get("payload")
+        claim_uri = claim_artifact.get("artifact_uri")
+        if (
+            not isinstance(certificate_payload, dict)
+            or certificate_payload.get("relation_id")
+            != "finite.relation.covers-exactly-once"
+            or certificate_payload.get("obligation_uri") != claim_uri
+            or certificate_payload.get("canonicalizer_uri")
+            != registration_artifact.get("artifact_uri")
+            or certificate_payload.get("canonicalizer_object_digest")
+            != registration_artifact.get("object_digest")
+            or certificate_payload.get("canonicalizer_specification_digest")
+            != expected_specification_digest
+            or certificate_payload.get("scope_keys_digest")
+            != scope.get("scope_keys_digest")
+            or certificate_payload.get("archive_digest")
+            != archive.get("archive_digest")
+            or certificate_payload.get("page_binding_digest") != _digest(page_bindings)
+        ):
+            return _reject("certificate coverage metadata is not bound")
+        if (
+            claim.get("scope_uri") != scope_artifact.get("artifact_uri")
+            or claim.get("archive_uri") != archive_artifact.get("artifact_uri")
+            or claim.get("canonicalizer_uri")
+            != registration_artifact.get("artifact_uri")
+            or claim.get("canonicalizer_id") != canonicalizer_id
+            or claim.get("scope_keys_digest") != scope.get("scope_keys_digest")
+            or claim.get("archive_digest") != archive.get("archive_digest")
+        ):
+            return _reject("claim does not bind the exact scope and archive")
+
+        scope_set = set(scope_keys)
+        counts: dict[str, int] = {}
+        for key in archive_keys:
+            counts[key] = counts.get(key, 0) + 1
+        missing = scope_set - set(counts)
+        outside = set(counts) - scope_set
+        duplicates = {key for key, count in counts.items() if count != 1}
+        if missing:
+            return _reject("paged archive omits one or more finite scope items")
+        if outside:
+            return _reject("paged archive contains items outside the finite scope")
+        if duplicates:
+            return _reject("paged archive repeats one or more finite scope items")
+
+        candidate_parents = archive_artifact.get("parents")
+        if not isinstance(candidate_parents, list) or not {
+            scope_artifact.get("artifact_uri"),
+            registration_artifact.get("artifact_uri"),
+            *expected_page_uris,
+        }.issubset(set(candidate_parents)):
+            return _reject("archive lineage does not bind scope and pages")
+        return {
+            "accepted": True,
+            "conclusion": "TRUE",
+            "arithmetic": "EXACT_INTEGER",
+            "method": "EXHAUSTIVE_FINITE",
+            "coverage": "EXHAUSTIVE",
+            "detail": (
+                f"replayed {len(scope_keys)} scope keys across "
+                f"{len(page_bindings)} bound pages exactly once"
+            ),
+            "relation_id": "finite.relation.covers-exactly-once",
+            "relationship_source_artifact_uris": [scope_artifact["artifact_uri"]],
+            "relationship_target_artifact_uris": [archive_artifact["artifact_uri"]],
+            "obligation_uri": claim_uri,
+        }
+    except (KeyError, TypeError, ValueError):
+        return _reject("malformed finite coverage checker request")

--- a/tests/integration/test_finite_coverage_capability.py
+++ b/tests/integration/test_finite_coverage_capability.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import pytest
+
+from jacobian.contracts.capabilities import (
+    CapabilityAssuranceLevel,
+    CapabilityCompletenessStatus,
+    CapabilityMode,
+    CapabilityObligationStatus,
+    CapabilityRelationshipStatus,
+    CapabilityRequest,
+)
+from jacobian.contracts.results import ExecutionStatus
+from jacobian.kernel import JacobianKernel
+
+pytestmark = pytest.mark.usefixtures("initialized_kernel_store")
+
+
+def _request(
+    scope: list[str | int],
+    pages: list[list[str | int]],
+    *,
+    canonicalizer_id: str = "finite.string.nfc@1",
+) -> CapabilityRequest:
+    return CapabilityRequest(
+        capability_id="finite.coverage.verify",
+        mode=CapabilityMode.VERIFY,
+        input={
+            "canonicalizer_id": canonicalizer_id,
+            "scope_items": scope,
+            "pages": [{"items": items} for items in pages],
+        },
+    )
+
+
+def test_finite_coverage_verifies_exactly_once_across_pages(tmp_path) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+
+    result = kernel.capabilities.invoke(
+        _request(["alpha", "beta", "gamma"], [["alpha"], ["beta", "gamma"]])
+    )
+
+    assert result.assurance.level is CapabilityAssuranceLevel.VERIFIED
+    assert result.completeness.status is CapabilityCompletenessStatus.COMPLETE
+    assert result.output["coverage_status"] == "EXACTLY_ONCE"
+    assert result.output["conclusion"] == "TRUE"
+    assert result.output["diagnostics"] == {
+        "missing_keys": [],
+        "duplicate_keys": [],
+        "outside_keys": [],
+        "duplicate_occurrences": [],
+    }
+    assert len(result.output["page_uris"]) == 2
+    assert result.output["verification_record_uri"] is not None
+    assert result.relationships[0].status is CapabilityRelationshipStatus.VERIFIED
+    assert result.obligations[0].status is CapabilityObligationStatus.DISCHARGED
+
+    archive = kernel.store.get(result.output["archive_uri"])
+    assert set(result.output["page_uris"]).issubset(set(archive.manifest.parents))
+    assert result.output["scope_uri"] in archive.manifest.parents
+    assert result.output["canonicalizer_uri"] in archive.manifest.parents
+
+
+def test_finite_coverage_reports_omission_and_duplicate(tmp_path) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+
+    result = kernel.capabilities.invoke(
+        _request(["alpha", "beta", "gamma"], [["alpha", "beta"], ["beta"]])
+    )
+
+    diagnostics = result.output["diagnostics"]
+    assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert result.completeness.status is CapabilityCompletenessStatus.PARTIAL
+    assert result.output["coverage_status"] == "INVALID"
+    assert result.output["conclusion"] == "UNKNOWN"
+    assert len(diagnostics["missing_keys"]) == 1
+    assert len(diagnostics["duplicate_keys"]) == 1
+    assert len(diagnostics["duplicate_occurrences"]) == 2
+    assert result.output["verification_record_uri"] is None
+    assert result.relationships[0].status is CapabilityRelationshipStatus.PROPOSED
+    assert result.obligations[0].status is CapabilityObligationStatus.OPEN
+
+
+def test_finite_coverage_reports_items_outside_scope(tmp_path) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+
+    result = kernel.capabilities.invoke(
+        _request(["alpha", "beta"], [["alpha", "beta", "gamma"]])
+    )
+
+    assert result.output["coverage_status"] == "INVALID"
+    assert len(result.output["diagnostics"]["outside_keys"]) == 1
+    assert result.output["verification_record_uri"] is None
+
+
+def test_finite_coverage_supports_registered_integer_canonicalizer(tmp_path) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+
+    result = kernel.capabilities.invoke(
+        _request(
+            [1, 2, 3],
+            [[3], [1, 2]],
+            canonicalizer_id="finite.integer.decimal@1",
+        )
+    )
+
+    assert result.assurance.level is CapabilityAssuranceLevel.VERIFIED
+    assert result.output["canonicalizer_id"] == "finite.integer.decimal@1"
+
+
+def test_finite_coverage_rejects_nfc_collisions_in_scope(tmp_path) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+
+    result = kernel.capabilities.invoke(_request(["é", "e\u0301"], [["é"]]))
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.output["error"]["code"] == "DUPLICATE_FINITE_SCOPE_KEY"
+
+
+def test_finite_coverage_is_unavailable_without_authorized_checker(tmp_path) -> None:
+    kernel = JacobianKernel(tmp_path)
+
+    result = kernel.capabilities.invoke(_request(["alpha"], [["alpha"]]))
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.output["error"]["code"] == "UNKNOWN_CAPABILITY"


### PR DESCRIPTION
## Summary

- add a distinct `finite.coverage.verify` capability for bounded exactly-once coverage of typed paged archives
- register versioned NFC-string and exact-integer canonicalizers and bind their specifications into scope, page, archive, claim, and certificate artifacts
- add omission, duplicate, outside-item, and occurrence diagnostics
- add an independent checker that recomputes canonical keys and validates lineage, page ordering, counts, and digest bindings without importing producer logic
- document the bounded v1 contract and verification boundary

## Design decisions

This is not an alias for `case.partition.finite`. It reuses the repository's artifact, certificate, and verification infrastructure while owning a separate paged-archive contract.

V1 is intentionally bounded to 4,096 scope/archive items, 64 pages, 1,024 items per page, and two registered canonicalizers: `finite.string.nfc@1` and `finite.integer.decimal@1`. Caller-defined canonicalization and unbounded streaming are out of scope.

The capability is installed only when the independent checker is operator-authorized. Invalid coverage returns `UNKNOWN`, leaves the obligation open, and creates no verification record.

## Validation

- Ruff: passed
- formatting check: passed
- mypy: 164 source files passed
- focused finite coverage + finite partition integration: 11 passed
- broader non-integration suite: 89 passed; 5 pre-existing local failures require Bash 4 associative arrays
- checker + contract suites: 291 passed; 1 pre-existing environment-sensitive SMT checker fixture failed locally
