### PR TITLE
Extend Lean statement proposal with direct elaboration

### DIFF
--- a/docs/reference/lean-statement-elaboration.md
+++ b/docs/reference/lean-statement-elaboration.md
@@ -1,0 +1,52 @@
+# Lean statement proposal and direct elaboration
+
+[Documentation home](../index.md) · [Capability surface](tools.md)
+
+`lean.statement.propose` has two operations over one canonical statement
+artifact:
+
+- `PROPOSE` checks a formal statement supplied alongside an informal claim;
+- `ELABORATE_PROPOSITION` directly elaborates one proposition and requires the
+  informal claim to be omitted.
+
+The direct operation resolves the `lean.statement.elaborate` inventory
+contract without adding an alias. Both operations remain available through
+`lean.statement.propose` because they use the same statement input, Lean
+execution boundary, artifact ownership, and non-verification semantics.
+
+## Direct proposition contract
+
+`ELABORATE_PROPOSITION` accepts one bounded, single-expression Lean
+proposition. It rejects declarations, imports, option commands, `sorry`,
+`admit`, metaprogramming commands, and other structural input. Version 1
+supports the `CORE` environment; `MATHLIB` remains unavailable through this
+capability.
+
+Lean elaborates the expression against expected type `Prop` with fixed
+pretty-printing options. A completed result records:
+
+- the pretty-printed elaborated core expression, when elaboration succeeds;
+- structured compiler diagnostics;
+- the fixed imports used to establish the environment;
+- declaration names occurring in the emitted elaborated expression;
+- every fixed elaboration/printing option;
+- Lean version and commit identifiers; and
+- an environment digest binding those identifiers, imports, and options.
+
+The artifact is durable and content-addressed. Failed elaboration is also a
+completed inspection result, but has no elaborated expression. Backend
+absence, timeout, invalid input, and unsupported environments are execution
+errors rather than mathematical conclusions.
+
+## Assurance boundary
+
+Successful elaboration means only that Lean produced a well-typed expression
+of type `Prop` in the bound environment. The artifact therefore always reports:
+
+- `semantic_scope = ELABORATION_ONLY`;
+- `truth_status = NOT_ASSESSED`; and
+- `verification = UNVERIFIED`.
+
+It does not show that the proposition is true, provable, equivalent to an
+informal claim, or appropriate for a proof task. No proof-state or session
+identity is created by this capability.

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -131,7 +131,8 @@ of catalog membership:
 - [exact rational matrix determinants](matrix-rational-determinant.md);
 - [integer matrix Hermite normal form](matrix-hermite-normal-form.md);
 - [typed polynomial expression normalization](polynomial-expression-normalization.md);
-- [Lean declaration discovery contract](lean-declaration-discovery.md).
+- [Lean declaration discovery contract](lean-declaration-discovery.md);
+- [Lean statement proposal and direct elaboration](lean-statement-elaboration.md).
 
 ## Mathematical operation portfolio
 

--- a/src/jacobian/contracts/lean_statement.py
+++ b/src/jacobian/contracts/lean_statement.py
@@ -13,7 +13,7 @@ from typing import Literal, Self
 
 from pydantic import Field, model_validator
 
-from jacobian.contracts.common import ArtifactUri
+from jacobian.contracts.common import ArtifactUri, Sha256Digest
 from jacobian.contracts.lean import LeanEnvironment
 from jacobian.contracts.results import ContractModel
 
@@ -25,8 +25,9 @@ from jacobian.contracts.results import ContractModel
 class LeanStatementProposalRequest(ContractModel):
     """Type-check one proposed Lean statement against an informal claim."""
 
+    operation: Literal["PROPOSE", "ELABORATE_PROPOSITION"] = "PROPOSE"
     environment: LeanEnvironment = LeanEnvironment.CORE
-    informal_claim: str = Field(min_length=1, max_length=4_000)
+    informal_claim: str | None = Field(default=None, min_length=1, max_length=4_000)
     proposed_statement: str = Field(min_length=1, max_length=2_000)
     source_locator: str | None = Field(default=None, max_length=512)
 
@@ -36,32 +37,75 @@ class LeanStatementProposalRequest(ContractModel):
             raise ValueError("proposed_statement must be one Lean expression")
         if ":=" in self.proposed_statement:
             raise ValueError("proposed_statement must not contain ':='")
+        if self.operation == "PROPOSE" and self.informal_claim is None:
+            raise ValueError("informal_claim is required for PROPOSE")
+        if (
+            self.operation == "ELABORATE_PROPOSITION"
+            and self.informal_claim is not None
+        ):
+            raise ValueError("informal_claim must be omitted for ELABORATE_PROPOSITION")
         return self
+
+
+class LeanElaborationDiagnostic(ContractModel):
+    severity: Literal["ERROR", "WARNING", "INFO"]
+    message: str = Field(min_length=1, max_length=20_000)
+
+
+class LeanElaborationOption(ContractModel):
+    name: str = Field(min_length=1, max_length=128)
+    value: str = Field(min_length=1, max_length=128)
 
 
 class LeanStatementProposalArtifact(ContractModel):
     """One type-checked Lean statement proposal with elaboration status."""
 
-    proposal_schema_version: Literal["1"] = "1"
+    proposal_schema_version: Literal["2"] = "2"
+    operation: Literal["PROPOSE", "ELABORATE_PROPOSITION"] = "PROPOSE"
     environment: LeanEnvironment
-    informal_claim: str
+    environment_digest: Sha256Digest
+    informal_claim: str | None = None
     proposed_statement: str
     elaborates: bool
+    elaborated_expression: str | None = Field(default=None, max_length=20_000)
     sorry_count: int = Field(ge=0)
     goals: tuple[str, ...]
     messages: tuple[str, ...]
+    diagnostics: tuple[LeanElaborationDiagnostic, ...] = ()
+    used_imports: tuple[str, ...] = ()
+    used_declarations: tuple[str, ...] = ()
+    options: tuple[LeanElaborationOption, ...] = ()
     lean_version: str
     lean_commit: str
     mathlib_commit: str | None = None
     source_locator: str | None = None
+    semantic_scope: Literal["ELABORATION_ONLY"] = "ELABORATION_ONLY"
+    truth_status: Literal["NOT_ASSESSED"] = "NOT_ASSESSED"
 
     @model_validator(mode="after")
-    def require_nonnegative_sorry_when_elaborates(self) -> Self:
-        if self.elaborates and self.sorry_count < 1:
+    def require_operation_specific_shape(self) -> Self:
+        if self.operation == "PROPOSE" and self.informal_claim is None:
+            raise ValueError("a proposal artifact requires an informal claim")
+        if self.operation == "PROPOSE" and self.elaborates and self.sorry_count < 1:
             raise ValueError(
                 "an elaborating proposal must report at least one sorry "
                 "because the type-check proof uses sorry"
             )
+        if self.operation == "ELABORATE_PROPOSITION":
+            if self.informal_claim is not None:
+                raise ValueError("direct elaboration cannot bind an informal claim")
+            if self.sorry_count != 0:
+                raise ValueError("direct proposition elaboration does not use sorry")
+            if self.elaborates != (self.elaborated_expression is not None):
+                raise ValueError(
+                    "direct elaboration must return an expression exactly on success"
+                )
+        if len(set(self.used_imports)) != len(self.used_imports):
+            raise ValueError("used imports must be unique")
+        if len(set(self.used_declarations)) != len(self.used_declarations):
+            raise ValueError("used declarations must be unique")
+        if len({option.name for option in self.options}) != len(self.options):
+            raise ValueError("elaboration option names must be unique")
         return self
 
 

--- a/src/jacobian/lean_statement_capabilities.py
+++ b/src/jacobian/lean_statement_capabilities.py
@@ -3,9 +3,10 @@
 Three domain-atomic capabilities, each producing exactly one inspectable
 artifact:
 
-* ``lean.statement.propose`` — type-check one proposed Lean statement
-  against an informal claim. Returns elaboration status; does NOT certify
-  that the formal statement matches the informal claim.
+* ``lean.statement.propose`` — either type-check one proposed Lean statement
+  against an informal claim or directly elaborate one proposition. Returns
+  durable environment-bound elaboration details; does NOT certify truth or
+  that a formal statement matches an informal claim.
 
 * ``lean.proof.repair_once`` — apply one deterministic syntactic repair
   to a failing Lean proof using compiler feedback. Returns a diff artifact
@@ -23,6 +24,7 @@ unavailable/diagnostic behavior rather than a silent success.
 from __future__ import annotations
 
 import difflib
+import hashlib
 import os
 import re
 import shutil
@@ -31,10 +33,12 @@ import tempfile
 from dataclasses import dataclass
 from functools import cache
 from pathlib import Path
+from typing import Literal
 
 from pydantic import ValidationError
 
 from jacobian.artifacts import ArtifactService
+from jacobian.canonical import canonicalize_json
 from jacobian.capabilities import CapabilityInvocationError
 from jacobian.contracts.capabilities import (
     CapabilityAssurance,
@@ -51,6 +55,8 @@ from jacobian.contracts.capabilities import (
 )
 from jacobian.contracts.lean import LeanEnvironment
 from jacobian.contracts.lean_statement import (
+    LeanElaborationDiagnostic,
+    LeanElaborationOption,
     LeanProofRepairArtifact,
     LeanProofRepairOutput,
     LeanProofRepairRequest,
@@ -101,6 +107,31 @@ class _ElaborationResult:
     sorry_count: int
     messages: tuple[str, ...]
     errors: tuple[str, ...]
+    elaborated_expression: str | None = None
+    used_imports: tuple[str, ...] = ()
+    used_declarations: tuple[str, ...] = ()
+    options: tuple[LeanElaborationOption, ...] = ()
+
+
+_DIRECT_ELABORATION_IMPORTS = ("Init.Prelude",)
+_DIRECT_ELABORATION_OPTIONS = (
+    LeanElaborationOption(name="pp.all", value="true"),
+    LeanElaborationOption(name="pp.explicit", value="true"),
+    LeanElaborationOption(name="pp.universes", value="true"),
+)
+_LEAN_NAME = re.compile(r"\b[A-Za-z_][A-Za-z0-9_']*(?:\.[A-Za-z0-9_']+)*\b")
+_LEAN_KEYWORDS = frozenset(
+    {
+        "Prop",
+        "Sort",
+        "Type",
+        "false",
+        "fun",
+        "let",
+        "match",
+        "true",
+    }
+)
 
 
 @cache
@@ -143,6 +174,54 @@ def _elaborate_statement(
     return _run_lean_source(source, timeout_seconds=timeout_seconds)
 
 
+def _elaborate_proposition(
+    statement: str,
+    *,
+    timeout_seconds: int = _ELAPSED_TIMEOUT_SECONDS,
+) -> _ElaborationResult:
+    """Elaborate one expression against expected type ``Prop``."""
+
+    if shutil.which("lean") is None:
+        raise _LeanUnavailableError("lean is not on PATH")
+    _validate_statement(statement)
+    source = "\n".join(
+        (
+            "set_option pp.all true in",
+            "set_option pp.explicit true in",
+            "set_option pp.universes true in",
+            f"#check ({statement} : Prop)",
+        )
+    )
+    output = _execute_lean_source(source, timeout_seconds=timeout_seconds)
+    messages = tuple(_parse_lean_messages(output))
+    errors = tuple(message for message in messages if "error:" in message.lower())
+    expression = None if errors else _parse_elaborated_expression(output)
+    if not errors and expression is None:
+        errors = ("error: Lean did not emit the elaborated proposition",)
+        messages = (*messages, *errors)
+    declarations = (
+        tuple(
+            sorted(
+                name
+                for name in set(_LEAN_NAME.findall(expression))
+                if name not in _LEAN_KEYWORDS
+            )
+        )
+        if expression is not None
+        else ()
+    )
+    return _ElaborationResult(
+        elaborates=expression is not None,
+        sorry_count=0,
+        messages=messages,
+        errors=errors,
+        elaborated_expression=expression,
+        used_imports=_DIRECT_ELABORATION_IMPORTS,
+        used_declarations=declarations,
+        options=_DIRECT_ELABORATION_OPTIONS,
+    )
+
+
 def _check_proof(
     statement: str,
     proof: str,
@@ -165,6 +244,19 @@ def _run_lean_source(
     *,
     timeout_seconds: int,
 ) -> _ElaborationResult:
+    output = _execute_lean_source(source, timeout_seconds=timeout_seconds)
+    messages = _parse_lean_messages(output)
+    errors = tuple(m for m in messages if "error:" in m.lower())
+    elaborates = len(errors) == 0
+    return _ElaborationResult(
+        elaborates=elaborates,
+        sorry_count=1 if elaborates else 0,
+        messages=tuple(messages),
+        errors=errors,
+    )
+
+
+def _execute_lean_source(source: str, *, timeout_seconds: int) -> str:
     fd, temp_path = tempfile.mkstemp(suffix=".lean")
     try:
         with os.fdopen(fd, "w") as handle:
@@ -182,16 +274,14 @@ def _run_lean_source(
         raise _LeanUnavailableError(f"lean timed out after {timeout_seconds}s") from exc
     finally:
         Path(temp_path).unlink(missing_ok=True)
-    output = (result.stdout or "") + (result.stderr or "")
-    messages = _parse_lean_messages(output)
-    errors = tuple(m for m in messages if "error:" in m.lower())
-    elaborates = len(errors) == 0
-    return _ElaborationResult(
-        elaborates=elaborates,
-        sorry_count=1 if elaborates else 0,
-        messages=tuple(messages),
-        errors=errors,
-    )
+    return (result.stdout or "") + (result.stderr or "")
+
+
+def _parse_elaborated_expression(output: str) -> str | None:
+    match = re.search(r"\binfo:\s*(.+?)\s*:\s*Prop(?:\s|$)", output, re.DOTALL)
+    if match is None:
+        return None
+    return " ".join(match.group(1).split())
 
 
 def _parse_lean_messages(output: str) -> list[str]:
@@ -205,6 +295,41 @@ def _parse_lean_messages(output: str) -> list[str]:
         ) or stripped.lower().startswith(("error:", "warning:", "info:")):
             messages.append(stripped)
     return messages
+
+
+def _diagnostics(messages: tuple[str, ...]) -> tuple[LeanElaborationDiagnostic, ...]:
+    diagnostics: list[LeanElaborationDiagnostic] = []
+    for message in messages:
+        lowered = message.lower()
+        severity: Literal["ERROR", "WARNING", "INFO"] = (
+            "ERROR"
+            if "error:" in lowered
+            else ("WARNING" if "warning:" in lowered else "INFO")
+        )
+        diagnostics.append(
+            LeanElaborationDiagnostic(severity=severity, message=message)
+        )
+    return tuple(diagnostics)
+
+
+def _environment_digest(
+    *,
+    environment: LeanEnvironment,
+    lean_version: str,
+    lean_commit: str,
+    mathlib_commit: str | None,
+    imports: tuple[str, ...],
+    options: tuple[LeanElaborationOption, ...],
+) -> str:
+    payload = {
+        "environment": environment.value,
+        "lean_version": lean_version,
+        "lean_commit": lean_commit,
+        "mathlib_commit": mathlib_commit,
+        "imports": list(imports),
+        "options": [option.model_dump(mode="json") for option in options],
+    }
+    return "sha256:" + hashlib.sha256(canonicalize_json(payload)).hexdigest()
 
 
 def _indent_proof(proof: str) -> str:
@@ -335,16 +460,19 @@ def install_lean_statement_capabilities(
         version="1",
         definition={
             "description": (
-                "atomic Lean statement proposal, proof repair, and "
-                "statement comparison; none certify theoremhood or "
-                "semantic intent"
+                "atomic Lean statement proposal, direct proposition "
+                "elaboration, proof repair, and statement comparison; "
+                "none certify theoremhood, truth, or semantic intent"
             ),
-            "verification": "none; type-checking does not certify intent",
+            "verification": (
+                "none; elaboration establishes a well-typed Prop expression "
+                "in the bound environment but does not establish truth"
+            ),
         },
     )
     proposal_schema_uri = schemas.register(
         name="jacobian.lean4-statement-proposal",
-        version="1",
+        version="2",
         schema=LeanStatementProposalArtifact.model_json_schema(),
     )
     repair_schema_uri = schemas.register(
@@ -395,17 +523,17 @@ class LeanStatementProposalAdapter:
             version="1",
             title="Propose one Lean statement with type-check status",
             description=(
-                "Validate that a proposed Lean statement elaborates under the "
-                "pinned Lean kernel. Returns elaboration status, sorry count, "
-                "and compiler messages. Does NOT certify that the formal "
-                "statement matches the informal claim."
+                "Validate either a proposed statement against an informal "
+                "claim or directly elaborate one proposition without an "
+                "informal claim. Returns durable environment-bound elaboration "
+                "details. It does not establish truth or semantic intent."
             ),
             provider="jacobian.lean4",
             provider_runtime=resources.provider_runtime,
             modes=(CapabilityMode.EXPLORE,),
             input_schema=LeanStatementProposalRequest.model_json_schema(),
             output_schema=LeanStatementProposalOutput.model_json_schema(),
-            tags=("lean", "statement", "elaboration", "proposal"),
+            tags=("lean", "statement", "elaboration", "proposal", "proposition"),
         )
 
     @property
@@ -442,7 +570,11 @@ class LeanStatementProposalAdapter:
                 )
             )
         try:
-            elaboration = _elaborate_statement(validated.proposed_statement)
+            elaboration = (
+                _elaborate_statement(validated.proposed_statement)
+                if validated.operation == "PROPOSE"
+                else _elaborate_proposition(validated.proposed_statement)
+            )
         except _LeanUnavailableError as exc:
             raise CapabilityInvocationError(
                 CapabilityDiagnostic(
@@ -456,14 +588,30 @@ class LeanStatementProposalAdapter:
                 )
             ) from exc
         version, commit = _lean_version_info()
+        imports = elaboration.used_imports
+        options = elaboration.options
         artifact_payload = LeanStatementProposalArtifact(
+            operation=validated.operation,
             environment=validated.environment,
+            environment_digest=_environment_digest(
+                environment=validated.environment,
+                lean_version=version,
+                lean_commit=commit,
+                mathlib_commit=None,
+                imports=imports,
+                options=options,
+            ),
             informal_claim=validated.informal_claim,
             proposed_statement=validated.proposed_statement,
             elaborates=elaboration.elaborates,
+            elaborated_expression=elaboration.elaborated_expression,
             sorry_count=elaboration.sorry_count,
             goals=(),
             messages=elaboration.messages,
+            diagnostics=_diagnostics(elaboration.messages),
+            used_imports=imports,
+            used_declarations=elaboration.used_declarations,
+            options=options,
             lean_version=version,
             lean_commit=commit,
             source_locator=validated.source_locator,
@@ -473,7 +621,7 @@ class LeanStatementProposalAdapter:
             semantics_uri=self.resources.semantics_uri,
             payload=artifact_payload.model_dump(mode="json"),
             summary=(
-                "Lean statement proposal with type-check status "
+                "Lean statement operation with elaboration status "
                 f"(elaborates={elaboration.elaborates})"
             ),
         )
@@ -488,27 +636,33 @@ class LeanStatementProposalAdapter:
             execution=Execution(status=ExecutionStatus.COMPLETED),
             output=output.model_dump(mode="json"),
             scope=CapabilityScope(
-                description="one Lean statement elaborated with sorry as proof",
+                description=(
+                    "one Lean proposition directly elaborated against Prop"
+                    if validated.operation == "ELABORATE_PROPOSITION"
+                    else "one Lean statement elaborated with sorry as proof"
+                ),
                 parameters={
+                    "operation": validated.operation,
                     "environment": validated.environment.value,
                     "proposed_statement": validated.proposed_statement,
+                    "environment_digest": artifact_payload.environment_digest,
                 },
                 artifact_uri=artifact.artifact_uri,
             ),
             completeness=CapabilityCompleteness(
                 status=CapabilityCompletenessStatus.COMPLETE,
                 basis=(
-                    "the pinned Lean kernel elaborated the statement or "
-                    "reported elaboration errors"
+                    "the pinned Lean frontend elaborated the proposition or "
+                    "reported complete diagnostics for this bounded request"
                 ),
                 assurance_level=CapabilityAssuranceLevel.COMPUTED,
             ),
             assurance=CapabilityAssurance(
                 level=CapabilityAssuranceLevel.COMPUTED,
                 basis=(
-                    "Lean elaboration confirms the statement type-checks; "
-                    "this does not certify that the formal statement matches "
-                    "the informal claim"
+                    "Lean elaboration reports whether the expression is a "
+                    "well-typed proposition in the bound environment; it does "
+                    "not establish truth, theoremhood, or semantic intent"
                 ),
             ),
             artifact_uris=(artifact.artifact_uri,),

--- a/tests/contract/test_lean_statement_contracts.py
+++ b/tests/contract/test_lean_statement_contracts.py
@@ -15,6 +15,7 @@ from jacobian.contracts.lean_statement import (
 )
 
 ARTIFACT_URI = "artifact://sha256/" + "a" * 64
+DIGEST = "sha256:" + "b" * 64
 
 
 # ---------------------------------------------------------------------------
@@ -51,6 +52,26 @@ def test_proposal_request_accepts_valid_input() -> None:
     assert req.source_locator == "https://example.com/claim"
 
 
+@pytest.mark.contract
+def test_direct_elaboration_does_not_require_informal_claim() -> None:
+    request = LeanStatementProposalRequest(
+        operation="ELABORATE_PROPOSITION",
+        proposed_statement="1 + 1 = 2",
+    )
+
+    assert request.informal_claim is None
+
+
+@pytest.mark.contract
+def test_direct_elaboration_rejects_informal_claim() -> None:
+    with pytest.raises(ValidationError, match="must be omitted"):
+        LeanStatementProposalRequest(
+            operation="ELABORATE_PROPOSITION",
+            informal_claim="one plus one equals two",
+            proposed_statement="1 + 1 = 2",
+        )
+
+
 # ---------------------------------------------------------------------------
 # LeanStatementProposalArtifact
 # ---------------------------------------------------------------------------
@@ -61,6 +82,7 @@ def test_proposal_artifact_requires_sorry_when_elaborates() -> None:
     with pytest.raises(ValidationError, match="at least one sorry"):
         LeanStatementProposalArtifact(
             environment="CORE",
+            environment_digest=DIGEST,
             informal_claim="trivial",
             proposed_statement="1 + 1 = 2",
             elaborates=True,
@@ -76,6 +98,7 @@ def test_proposal_artifact_requires_sorry_when_elaborates() -> None:
 def test_proposal_artifact_accepts_non_elaborating_with_zero_sorry() -> None:
     artifact = LeanStatementProposalArtifact(
         environment="CORE",
+        environment_digest=DIGEST,
         informal_claim="trivial",
         proposed_statement="bogus syntax",
         elaborates=False,
@@ -87,6 +110,23 @@ def test_proposal_artifact_accepts_non_elaborating_with_zero_sorry() -> None:
     )
     assert artifact.elaborates is False
     assert artifact.sorry_count == 0
+
+
+@pytest.mark.contract
+def test_direct_elaboration_artifact_requires_expression_on_success() -> None:
+    with pytest.raises(ValidationError, match="return an expression"):
+        LeanStatementProposalArtifact(
+            operation="ELABORATE_PROPOSITION",
+            environment="CORE",
+            environment_digest=DIGEST,
+            proposed_statement="True",
+            elaborates=True,
+            sorry_count=0,
+            goals=(),
+            messages=(),
+            lean_version="4.31.0",
+            lean_commit="abc",
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_lean_statement_capabilities.py
+++ b/tests/integration/test_lean_statement_capabilities.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+import jacobian.lean_statement_capabilities as lean_statements
 from jacobian.artifacts import ArtifactService
 from jacobian.capabilities import CapabilityInvocationError
 from jacobian.contracts.capabilities import (
@@ -14,6 +15,7 @@ from jacobian.contracts.capabilities import (
     CapabilityCompletenessStatus,
     CapabilityRequest,
 )
+from jacobian.contracts.lean_statement import LeanElaborationOption
 from jacobian.contracts.results import ExecutionStatus
 from jacobian.lean_statement_capabilities import (
     LeanProofRepairAdapter,
@@ -155,6 +157,90 @@ def test_propose_returns_diagnostic_when_lean_unavailable(
         )
 
     assert exc_info.value.diagnostic.code == "LEAN_BACKEND_UNAVAILABLE"
+
+
+def test_propose_directly_elaborates_environment_bound_proposition(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        lean_statements,
+        "_elaborate_proposition",
+        lambda _statement: lean_statements._ElaborationResult(
+            elaborates=True,
+            sorry_count=0,
+            messages=(
+                "fixture.lean:4:0: info: "
+                "@Eq.{1} Nat (@OfNat.ofNat Nat 1 instOfNatNat) "
+                "(@OfNat.ofNat Nat 1 instOfNatNat) : Prop",
+            ),
+            errors=(),
+            elaborated_expression=(
+                "@Eq.{1} Nat (@OfNat.ofNat Nat 1 instOfNatNat) "
+                "(@OfNat.ofNat Nat 1 instOfNatNat)"
+            ),
+            used_imports=("Init.Prelude",),
+            used_declarations=("Eq", "Nat", "OfNat.ofNat", "instOfNatNat"),
+            options=(
+                LeanElaborationOption(name="pp.all", value="true"),
+                LeanElaborationOption(name="pp.explicit", value="true"),
+                LeanElaborationOption(name="pp.universes", value="true"),
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        lean_statements,
+        "_lean_version_info",
+        lambda: ("4.31.0", "lean-commit"),
+    )
+    propose, _, _ = _build_adapters(tmp_path)
+
+    result = propose.invoke(
+        CapabilityRequest(
+            capability_id="lean.statement.propose",
+            input={
+                "operation": "ELABORATE_PROPOSITION",
+                "environment": "CORE",
+                "proposed_statement": "1 = 1",
+            },
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output["operation"] == "ELABORATE_PROPOSITION"
+    assert result.output["informal_claim"] is None
+    assert result.output["elaborates"] is True
+    assert result.output["sorry_count"] == 0
+    assert result.output["elaborated_expression"].startswith("@Eq")
+    assert result.output["used_imports"] == ["Init.Prelude"]
+    assert "Eq" in result.output["used_declarations"]
+    assert result.output["options"][0] == {"name": "pp.all", "value": "true"}
+    assert result.output["semantic_scope"] == "ELABORATION_ONLY"
+    assert result.output["truth_status"] == "NOT_ASSESSED"
+    assert result.output["verification"] == "UNVERIFIED"
+    assert result.output["environment_digest"].startswith("sha256:")
+
+    artifact = propose.resources.store.get(result.output["proposal_uri"])
+    assert artifact.payload["environment_digest"] == result.output["environment_digest"]
+    assert (
+        artifact.payload["elaborated_expression"]
+        == result.output["elaborated_expression"]
+    )
+    assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert "does not establish truth" in result.assurance.basis
+
+
+def test_direct_elaboration_parser_preserves_multiline_core_expression() -> None:
+    output = (
+        "fixture.lean:4:0: info: @Eq.{1} Nat\n"
+        "  (@OfNat.ofNat Nat 1 instOfNatNat)\n"
+        "  (@OfNat.ofNat Nat 1 instOfNatNat) : Prop\n"
+    )
+
+    assert lean_statements._parse_elaborated_expression(output) == (
+        "@Eq.{1} Nat (@OfNat.ofNat Nat 1 instOfNatNat) "
+        "(@OfNat.ofNat Nat 1 instOfNatNat)"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- extend the canonical `lean.statement.propose` capability with an `ELABORATE_PROPOSITION` operation
- allow direct proposition elaboration without an informal claim while preserving `PROPOSE` as the backward-compatible default
- persist a version 2 environment-bound statement artifact containing the elaborated expression, structured diagnostics, imports, referenced declarations, fixed options, Lean identity, and environment digest
- state the assurance boundary explicitly with `ELABORATION_ONLY`, `NOT_ASSESSED`, and `UNVERIFIED`
- document the inventory mapping and add focused contract and artifact tests

Closes the `lean.statement.elaborate` partial mapping covered by the Lean environment design tracked in #95.

## Design decisions

This PR extends the existing canonical capability instead of introducing an alias. Proposal and direct elaboration share the same bounded statement input, Lean execution boundary, artifact owner, and non-truth semantics.

Direct elaboration checks the expression against expected type `Prop` and uses fixed pretty-printing options so the emitted expression and environment digest are reproducible. V1 remains limited to the CORE environment. It does not create proof states, durable sessions, or successor-state artifacts.

A successful elaboration means only that Lean produced a well-typed proposition in the bound environment. It does not establish truth, provability, or correspondence with an informal claim.

## Validation

- Ruff and formatting: passed
- mypy: 161 source files passed
- focused Lean statement contract/integration tests: 30 passed, 6 skipped because Lean is not installed locally
- repository fast suite: 383 passed; 6 known local-environment failures remain (five Bash 4 associative-array checks and one external SMT checker fixture)
