### PR TITLE
Add replayable Lean tactic states

### DIFF
--- a/docs/reference/lean-replayable-proof-states.md
+++ b/docs/reference/lean-replayable-proof-states.md
@@ -1,0 +1,66 @@
+# Replayable Lean proof-state transitions
+
+[Documentation home](../index.md) · [Capability surface](tools.md)
+
+`lean.proof_state.apply_tactic` is the canonical implementation covering the
+`lean.tactic.apply` inventory operation. Version 2 applies one bounded tactic
+to an immutable, replayable Lean proof state. It does not expose or depend on
+a long-lived session identifier. A replayable chain is limited to 64 tactics,
+and each tactic remains limited to 1,000 characters.
+
+## State artifact
+
+Every state artifact binds:
+
+- the exact proposition;
+- the pinned `CORE` or `MATHLIB` environment and imports;
+- Lean and Mathlib revision identifiers;
+- an environment digest;
+- the exact tactic prefix and generated replay source digest;
+- the ordered, normalized Lean goals; and
+- a state digest over all of those fields.
+
+State artifacts are immutable and do not expire. A state is stale when its
+environment digest, source digest, state digest, or cleanly replayed normalized
+goals no longer match. Stale or malformed state artifacts are rejected before
+the requested tactic is applied.
+
+An invocation may start from an explicit statement and tactic prefix. That
+form first creates the bound input-state artifact. Later invocations may pass
+the returned state URI instead; a state URI cannot be combined with replacement
+statement or prefix text.
+
+## Clean replay
+
+Each tactic invocation starts a clean pinned Lean REPL process. It:
+
+1. reconstructs the exact statement and tactic prefix;
+2. runs a no-op inspection transition to obtain the current goals;
+3. normalizes and validates those goals against the supplied state artifact;
+4. applies exactly one requested tactic; and
+5. terminates the process.
+
+No process-local proof-state number is persisted. If Lean rejects
+reconstruction, the request fails without a mathematical conclusion. If
+reconstruction succeeds but the tactic is rejected, the operation returns
+structured diagnostics, `accepted = false`, and no successor states.
+
+An accepted transition returns one successor-state artifact containing all
+ordered goals produced by Lean. A completed successor has an empty goal list.
+The transition artifact binds its input state, successor state, tactic,
+diagnostics, environment digest, and replay-source digest through artifact
+lineage.
+
+## Verification boundary
+
+Proof states and transitions have `COMPUTED` assurance only. A completed state
+means that exploratory Lean reported no remaining goals for that replayed
+prefix. It is not a theorem-verification record.
+
+Every result reports `verification = UNVERIFIED` and
+`verification_boundary = LEAN_CHECK_REQUIRED`. Only `lean.check`, using its
+separate operator-authorized clean verification path, may verify the complete
+statement and proof.
+
+This version does not add persistent sessions, term-application semantics,
+proof-axiom inspection, or trust-policy decisions.

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -131,7 +131,8 @@ of catalog membership:
 - [exact rational matrix determinants](matrix-rational-determinant.md);
 - [integer matrix Hermite normal form](matrix-hermite-normal-form.md);
 - [typed polynomial expression normalization](polynomial-expression-normalization.md);
-- [Lean declaration discovery contract](lean-declaration-discovery.md).
+- [Lean declaration discovery contract](lean-declaration-discovery.md);
+- [replayable Lean proof-state transitions](lean-replayable-proof-states.md).
 
 ## Mathematical operation portfolio
 

--- a/src/jacobian/contracts/lean_exploration.py
+++ b/src/jacobian/contracts/lean_exploration.py
@@ -2,51 +2,116 @@
 
 from __future__ import annotations
 
-from typing import Literal, Self
+from typing import Annotated, Literal, Self
 
 from pydantic import Field, model_validator
 
-from jacobian.contracts.common import ArtifactUri
+from jacobian.contracts.common import ArtifactUri, Sha256Digest
 from jacobian.contracts.lean import LeanEnvironment
 from jacobian.contracts.results import ContractModel
 
+LeanNormalizedGoal = Annotated[str, Field(min_length=1, max_length=20_000)]
+
 
 class LeanProofStateRequest(ContractModel):
+    state_uri: ArtifactUri | None = None
     environment: LeanEnvironment = LeanEnvironment.CORE
-    statement: str = Field(min_length=1, max_length=2_000)
+    statement: str | None = Field(default=None, min_length=1, max_length=2_000)
     proof_prefix: tuple[str, ...] = Field(default=(), max_length=32)
     tactic: str = Field(min_length=1, max_length=1_000)
 
     @model_validator(mode="after")
-    def require_bounded_prefix(self) -> Self:
+    def require_one_state_source_and_bounded_prefix(self) -> Self:
         if any(
             not tactic.strip() or len(tactic) > 1_000 for tactic in self.proof_prefix
         ):
             raise ValueError("proof-prefix tactics must be nonempty and bounded")
+        if self.state_uri is None and self.statement is None:
+            raise ValueError("statement is required when state_uri is omitted")
+        if self.state_uri is not None and (
+            self.statement is not None or self.proof_prefix
+        ):
+            raise ValueError(
+                "state_uri cannot be combined with statement or proof_prefix"
+            )
         return self
 
 
-class LeanProofStateTransitionArtifact(ContractModel):
-    transition_schema_version: Literal["1"] = "1"
+class LeanProofStateArtifact(ContractModel):
+    state_schema_version: Literal["1"] = "1"
     environment: LeanEnvironment
+    environment_digest: Sha256Digest
+    source_digest: Sha256Digest
     statement: str
-    proof_prefix: tuple[str, ...]
-    tactic: str
-    replay_source: str
-    goals: tuple[str, ...]
-    goal_count: int = Field(ge=0)
+    tactic_prefix: tuple[str, ...] = Field(max_length=64)
+    normalized_goals: tuple[LeanNormalizedGoal, ...] = Field(max_length=128)
+    state_digest: Sha256Digest
     completed: bool
-    messages: tuple[str, ...]
+    imports: tuple[str, ...]
     lean_version: str
     lean_commit: str
     mathlib_commit: str | None = None
+    expiry: Literal["IMMUTABLE_NO_EXPIRY"] = "IMMUTABLE_NO_EXPIRY"
+    verification: Literal["UNVERIFIED"] = "UNVERIFIED"
+
+    @model_validator(mode="after")
+    def require_completion_shape(self) -> Self:
+        if self.completed != (len(self.normalized_goals) == 0):
+            raise ValueError("state completion differs from normalized goals")
+        if len(set(self.imports)) != len(self.imports):
+            raise ValueError("state imports must be unique")
+        return self
+
+
+class LeanTacticDiagnostic(ContractModel):
+    severity: Literal["ERROR", "WARNING", "INFO"]
+    message: str = Field(min_length=1, max_length=20_000)
+
+
+class LeanProofSuccessorState(ContractModel):
+    state_uri: ArtifactUri
+    state_digest: Sha256Digest
+    normalized_goals: tuple[LeanNormalizedGoal, ...] = Field(max_length=128)
+    completed: bool
+
+
+class LeanProofStateTransitionArtifact(ContractModel):
+    transition_schema_version: Literal["2"] = "2"
+    environment: LeanEnvironment
+    environment_digest: Sha256Digest
+    source_digest: Sha256Digest
+    statement: str
+    proof_prefix: tuple[str, ...]
+    tactic: str
+    input_state_uri: ArtifactUri
+    input_state_digest: Sha256Digest
+    replay_source: str
+    goals: tuple[str, ...]
+    goal_count: int = Field(ge=0)
+    successor_states: tuple[LeanProofSuccessorState, ...] = Field(max_length=1)
+    accepted: bool
+    completed: bool
+    messages: tuple[str, ...]
+    diagnostics: tuple[LeanTacticDiagnostic, ...]
+    lean_version: str
+    lean_commit: str
+    mathlib_commit: str | None = None
+    verification_boundary: Literal["LEAN_CHECK_REQUIRED"] = "LEAN_CHECK_REQUIRED"
 
     @model_validator(mode="after")
     def require_consistent_goal_summary(self) -> Self:
         if self.goal_count != len(self.goals):
             raise ValueError("goal count differs from returned goals")
-        if self.completed != (self.goal_count == 0):
-            raise ValueError("completion differs from returned goals")
+        if self.accepted:
+            if len(self.successor_states) != 1:
+                raise ValueError("an accepted tactic must return one successor state")
+            successor = self.successor_states[0]
+            if successor.normalized_goals != self.goals:
+                raise ValueError("flattened goals differ from the successor state")
+            if self.completed != successor.completed:
+                raise ValueError("completion differs from the successor state")
+        elif self.successor_states or self.goals or self.completed:
+            raise ValueError("a rejected tactic cannot return successor state")
         return self
 
 

--- a/src/jacobian/lean_exploration.py
+++ b/src/jacobian/lean_exploration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import queue
@@ -21,6 +22,7 @@ from typing import Any
 from pydantic import ValidationError
 
 from jacobian.artifacts import ArtifactService
+from jacobian.canonical import canonicalize_json
 from jacobian.capabilities import CapabilityInvocationError
 from jacobian.contracts.capabilities import (
     CapabilityAssurance,
@@ -41,14 +43,17 @@ from jacobian.contracts.lean_exploration import (
     LeanPremiseRetrievalArtifact,
     LeanPremiseRetrievalOutput,
     LeanPremiseRetrievalRequest,
+    LeanProofStateArtifact,
     LeanProofStateOutput,
     LeanProofStateRequest,
     LeanProofStateTransitionArtifact,
+    LeanProofSuccessorState,
+    LeanTacticDiagnostic,
 )
 from jacobian.contracts.results import Execution, ExecutionStatus
 from jacobian.references import LeanCheckerInstallation
 from jacobian.schema_registry import SchemaRegistry
-from jacobian.store import ArtifactStore
+from jacobian.store import ArtifactStore, StoreError
 
 _FORBIDDEN = re.compile(
     r"\b(?:admit|axiom|elab|import|macro|native_decide|opaque|run_tac|"
@@ -122,6 +127,33 @@ class PersistentLeanRepl:
             )
             self._requests += 1
             return command_response, tactic_response
+
+    def execute_validated(
+        self,
+        *,
+        command: str,
+        tactic: str,
+    ) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+        """Reconstruct, inspect, then advance one state in this process."""
+
+        with self._lock:
+            self._ensure_process()
+            command_request: dict[str, Any] = {"cmd": command}
+            if self._base_env is not None:
+                command_request["env"] = self._base_env
+            command_response = self._exchange(command_request)
+            proof_state = _single_proof_state(command_response)
+            validation_response = self._exchange(
+                {"tactic": "skip", "proofState": proof_state}
+            )
+            validated_state = validation_response.get("proofState")
+            if not isinstance(validated_state, int):
+                raise RuntimeError("Lean REPL did not return the validated proof state")
+            tactic_response = self._exchange(
+                {"tactic": tactic, "proofState": validated_state}
+            )
+            self._requests += 1
+            return command_response, validation_response, tactic_response
 
     def close(self) -> None:
         """Stop the process and discard all retained snapshots."""
@@ -322,6 +354,21 @@ class LeanExplorationReplRuntime:
                 self._sessions[environment] = session
             return session.execute(command=command, tactic=tactic)
 
+    def execute_clean(
+        self,
+        *,
+        command: str,
+        tactic: str,
+        environment: LeanEnvironment,
+    ) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+        """Replay and apply in a new process that is always discarded."""
+
+        session = self._create_session(environment)
+        try:
+            return session.execute_validated(command=command, tactic=tactic)
+        finally:
+            session.close()
+
     def close(self) -> None:
         """Stop every exploration process without affecting independent checkers."""
 
@@ -376,6 +423,7 @@ def _close_repls(
 @dataclass(frozen=True, slots=True)
 class LeanExplorationInstallation:
     semantics_uri: str
+    state_schema_uri: str
     transition_schema_uri: str
     retrieval_schema_uri: str
 
@@ -385,6 +433,7 @@ class _Resources:
     store: ArtifactStore
     artifacts: ArtifactService
     semantics_uri: str
+    state_schema_uri: str
     transition_schema_uri: str
     retrieval_schema_uri: str
     installations: Mapping[LeanEnvironment, LeanCheckerInstallation]
@@ -413,17 +462,24 @@ def install_lean_exploration_capabilities(
         version="1",
         definition={
             "description": (
-                "exploratory Lean proof-state transitions and premise suggestions"
+                "immutable replayable Lean proof states, one-step tactic "
+                "transitions, and premise suggestions"
             ),
             "lean_version": core.lean_version,
             "lean_commit": core.lean_commit,
             "mathlib_commit": mathlib.mathlib_commit,
+            "state_expiry": "immutable artifacts do not expire",
             "verification": "none; completed source must pass lean.check",
         },
     )
+    state_schema_uri = schemas.register(
+        name="jacobian.lean4-proof-state",
+        version="1",
+        schema=LeanProofStateArtifact.model_json_schema(),
+    )
     transition_schema_uri = schemas.register(
         name="jacobian.lean4-proof-state-transition",
-        version="1",
+        version="2",
         schema=LeanProofStateTransitionArtifact.model_json_schema(),
     )
     retrieval_schema_uri = schemas.register(
@@ -437,6 +493,7 @@ def install_lean_exploration_capabilities(
         store=store,
         artifacts=artifacts,
         semantics_uri=semantics_uri,
+        state_schema_uri=state_schema_uri,
         transition_schema_uri=transition_schema_uri,
         retrieval_schema_uri=retrieval_schema_uri,
         installations=installations,
@@ -451,6 +508,7 @@ def install_lean_exploration_capabilities(
         ),
         LeanExplorationInstallation(
             semantics_uri=semantics_uri,
+            state_schema_uri=state_schema_uri,
             transition_schema_uri=transition_schema_uri,
             retrieval_schema_uri=retrieval_schema_uri,
         ),
@@ -462,11 +520,12 @@ class LeanProofStateAdapter:
         self.resources = resources
         self._descriptor = CapabilityDescriptor(
             capability_id="lean.proof_state.apply_tactic",
-            version="1",
-            title="Apply one Lean tactic",
+            version="2",
+            title="Apply one Lean tactic to a replayable proof state",
             description=(
-                "Replay an explicit proof prefix, apply one tactic, and expose the "
-                "resulting Lean goals or a structured rejection."
+                "Reconstruct and validate an immutable proof state in a clean "
+                "Lean process, apply one tactic, and return every durable "
+                "successor state or structured rejection diagnostics."
             ),
             provider="jacobian.lean4",
             provider_runtime=resources.provider_runtime,
@@ -483,10 +542,13 @@ class LeanProofStateAdapter:
     def invoke(self, request: CapabilityRequest) -> CapabilityResult:
         try:
             validated = LeanProofStateRequest.model_validate(request.input)
-            _validate_source_parts(
-                validated.statement,
-                (*validated.proof_prefix, validated.tactic),
-            )
+            if validated.statement is not None:
+                _validate_source_parts(
+                    validated.statement,
+                    (*validated.proof_prefix, validated.tactic),
+                )
+            else:
+                _validate_source_parts("True", (validated.tactic,))
         except (ValidationError, ValueError) as exc:
             raise CapabilityInvocationError(
                 CapabilityDiagnostic(
@@ -501,55 +563,178 @@ class LeanProofStateAdapter:
             ) from exc
         started = time.monotonic()
         installation = self.resources.installations[validated.environment]
-        command = _proof_state_command(
-            statement=validated.statement,
-            proof_prefix=validated.proof_prefix,
+        environment_digest = _environment_digest(
+            validated.environment,
+            installation,
         )
-        responses = _run_repl(
-            self.resources,
+        if validated.state_uri is None:
+            assert validated.statement is not None
+            statement = validated.statement
+            proof_prefix = validated.proof_prefix
+            bound_state = None
+        else:
+            bound_state = self._load_bound_state(
+                validated.state_uri,
+                expected_environment=validated.environment,
+                expected_environment_digest=environment_digest,
+            )
+            if bound_state.completed:
+                raise CapabilityInvocationError(
+                    CapabilityDiagnostic(
+                        code="LEAN_PROOF_STATE_COMPLETED",
+                        stage="state_validation",
+                        message="The supplied proof state has no remaining goals.",
+                        hint=(
+                            "Send the complete statement and proof to lean.check; "
+                            "no further tactic transition is applicable."
+                        ),
+                    )
+                )
+            if len(bound_state.tactic_prefix) >= 64:
+                raise CapabilityInvocationError(
+                    CapabilityDiagnostic(
+                        code="LEAN_PROOF_STATE_PREFIX_LIMIT",
+                        stage="state_validation",
+                        message="The replayable proof state reached the 64-tactic limit.",
+                        hint=(
+                            "Submit a complete proof to lean.check or begin a new "
+                            "bounded exploration."
+                        ),
+                    )
+                )
+            statement = bound_state.statement
+            proof_prefix = bound_state.tactic_prefix
+            _validate_source_parts(statement, (*proof_prefix, validated.tactic))
+        command = _proof_state_command(
+            statement=statement,
+            proof_prefix=proof_prefix,
+        )
+        responses = self.resources.repl.execute_clean(
             command=command,
             tactic=validated.tactic,
             environment=validated.environment,
         )
-        command_response, tactic_response = responses
-        errors = (
+        command_response, validation_response, tactic_response = responses
+        reconstruction_errors = (
             *_response_errors(command_response),
-            *_response_errors(tactic_response),
+            *_response_errors(validation_response),
         )
-        if errors:
+        if reconstruction_errors:
             raise CapabilityInvocationError(
                 CapabilityDiagnostic(
-                    code="LEAN_TACTIC_REJECTED",
-                    stage="tactic_application",
-                    message=f"Lean rejected the tactic transition: {errors[0][:500]}",
+                    code="LEAN_STATE_RECONSTRUCTION_FAILED",
+                    stage="state_reconstruction",
+                    message=(
+                        "Lean could not reconstruct the bound proof state: "
+                        f"{reconstruction_errors[0][:500]}"
+                    ),
                     hint=(
-                        "Inspect the current goals, revise the tactic or prefix, "
-                        "and retry. A rejection is not a mathematical conclusion."
+                        "Recreate the state from the current pinned environment; "
+                        "a reconstruction failure is not a proof conclusion."
                     ),
                 )
             )
-        goals_value = tactic_response.get("goals", [])
-        if not isinstance(goals_value, list) or any(
-            not isinstance(goal, str) for goal in goals_value
-        ):
-            raise RuntimeError("Lean REPL returned malformed goals")
-        goals = tuple(goals_value)
-        replay_source = "\n  ".join((*validated.proof_prefix, validated.tactic))
-        messages = tuple(
-            message
-            for response in responses
-            for message in _response_messages(response)
+        replayed_goals = _normalized_response_goals(validation_response)
+        if bound_state is not None and replayed_goals != bound_state.normalized_goals:
+            raise CapabilityInvocationError(
+                CapabilityDiagnostic(
+                    code="STALE_LEAN_PROOF_STATE",
+                    stage="state_validation",
+                    message=(
+                        "The clean replay produced goals different from the "
+                        "state artifact."
+                    ),
+                    hint=(
+                        "Recreate the state under the current source and "
+                        "environment before applying another tactic."
+                    ),
+                )
+            )
+        if bound_state is None:
+            input_state_payload = _state_payload(
+                environment=validated.environment,
+                environment_digest=environment_digest,
+                statement=statement,
+                tactic_prefix=proof_prefix,
+                normalized_goals=replayed_goals,
+                installation=installation,
+            )
+            input_state_artifact = self.resources.artifacts.put(
+                schema_uri=self.resources.state_schema_uri,
+                semantics_uri=self.resources.semantics_uri,
+                payload=input_state_payload.model_dump(mode="json"),
+                summary="replayable immutable Lean proof state",
+            )
+            input_state_uri = input_state_artifact.artifact_uri
+            input_state = input_state_payload
+        else:
+            assert validated.state_uri is not None
+            input_state_uri = validated.state_uri
+            input_state = bound_state
+
+        tactic_errors = _response_errors(tactic_response)
+        accepted = not tactic_errors
+        diagnostics = _tactic_diagnostics(responses)
+        successor_states: tuple[LeanProofSuccessorState, ...] = ()
+        successor_artifact_uris: tuple[str, ...] = ()
+        goals: tuple[str, ...] = ()
+        completed = False
+        if accepted:
+            goals = _normalized_response_goals(tactic_response)
+            proof_status = tactic_response.get("proofStatus")
+            if (proof_status == "Completed") != (len(goals) == 0):
+                raise RuntimeError(
+                    "Lean REPL returned inconsistent completion and goals"
+                )
+            successor_payload = _state_payload(
+                environment=validated.environment,
+                environment_digest=environment_digest,
+                statement=statement,
+                tactic_prefix=(*proof_prefix, validated.tactic),
+                normalized_goals=goals,
+                installation=installation,
+            )
+            successor_artifact = self.resources.artifacts.put(
+                schema_uri=self.resources.state_schema_uri,
+                semantics_uri=self.resources.semantics_uri,
+                payload=successor_payload.model_dump(mode="json"),
+                parents=(input_state_uri,),
+                summary="successor immutable Lean proof state",
+            )
+            completed = successor_payload.completed
+            successor_states = (
+                LeanProofSuccessorState(
+                    state_uri=successor_artifact.artifact_uri,
+                    state_digest=successor_payload.state_digest,
+                    normalized_goals=goals,
+                    completed=completed,
+                ),
+            )
+            successor_artifact_uris = (successor_artifact.artifact_uri,)
+
+        replay_source = "\n  ".join((*proof_prefix, validated.tactic))
+        transition_source_digest = _source_digest(
+            statement,
+            (*proof_prefix, validated.tactic),
         )
+        messages = tuple(diagnostic.message for diagnostic in diagnostics)
         artifact_payload = LeanProofStateTransitionArtifact(
             environment=validated.environment,
-            statement=validated.statement,
-            proof_prefix=validated.proof_prefix,
+            environment_digest=environment_digest,
+            source_digest=transition_source_digest,
+            statement=statement,
+            proof_prefix=proof_prefix,
             tactic=validated.tactic,
+            input_state_uri=input_state_uri,
+            input_state_digest=input_state.state_digest,
             replay_source=replay_source,
             goals=goals,
             goal_count=len(goals),
-            completed=(tactic_response.get("proofStatus") == "Completed" and not goals),
+            successor_states=successor_states,
+            accepted=accepted,
+            completed=completed,
             messages=messages,
+            diagnostics=diagnostics,
             lean_version=installation.lean_version,
             lean_commit=installation.lean_commit,
             mathlib_commit=installation.mathlib_commit,
@@ -558,11 +743,21 @@ class LeanProofStateAdapter:
             schema_uri=self.resources.transition_schema_uri,
             semantics_uri=self.resources.semantics_uri,
             payload=artifact_payload.model_dump(mode="json"),
-            summary="replayable exploratory Lean proof-state transition",
+            parents=(input_state_uri, *successor_artifact_uris),
+            summary=(
+                "accepted replayable Lean tactic transition"
+                if accepted
+                else "rejected replayable Lean tactic transition"
+            ),
         )
         output = LeanProofStateOutput(
             **artifact_payload.model_dump(mode="python"),
             transition_uri=artifact.artifact_uri,
+        )
+        artifact_uris = (
+            input_state_uri,
+            *successor_artifact_uris,
+            artifact.artifact_uri,
         )
         return CapabilityResult(
             capability_id=self.descriptor.capability_id,
@@ -571,30 +766,87 @@ class LeanProofStateAdapter:
             execution=Execution(
                 status=ExecutionStatus.COMPLETED,
                 runtime_ms=_runtime_ms(started),
+                detail=(
+                    None
+                    if accepted
+                    else "Lean rejected the tactic; no successor state was created"
+                ),
             ),
             output=output.model_dump(mode="json"),
             scope=CapabilityScope(
-                description="one tactic applied after one explicit Lean proof prefix",
+                description=(
+                    "one tactic applied after clean replay and state validation"
+                ),
                 parameters={
                     "environment": validated.environment.value,
-                    "statement": validated.statement,
+                    "statement": statement,
+                    "input_state_digest": input_state.state_digest,
+                    "environment_digest": environment_digest,
                 },
                 artifact_uri=artifact.artifact_uri,
             ),
             completeness=CapabilityCompleteness(
                 status=CapabilityCompletenessStatus.COMPLETE,
-                basis="Lean returned the complete successor-goal list for this step",
+                basis=(
+                    "Lean returned the complete successor-state list for this "
+                    "single tactic application"
+                ),
                 assurance_level=CapabilityAssuranceLevel.COMPUTED,
             ),
             assurance=CapabilityAssurance(
                 level=CapabilityAssuranceLevel.COMPUTED,
                 basis=(
-                    "pinned Lean elaboration of one replayable tactic transition; "
-                    "this does not verify the theorem"
+                    "a clean pinned Lean process reconstructed the bound state "
+                    "and computed one transition; only lean.check can verify a "
+                    "completed theorem"
                 ),
             ),
-            artifact_uris=(artifact.artifact_uri,),
+            artifact_uris=artifact_uris,
         )
+
+    def _load_bound_state(
+        self,
+        state_uri: str,
+        *,
+        expected_environment: LeanEnvironment,
+        expected_environment_digest: str,
+    ) -> LeanProofStateArtifact:
+        try:
+            stored = self.resources.store.get(state_uri)
+            if (
+                stored.manifest.schema_uri != self.resources.state_schema_uri
+                or stored.manifest.semantics_uri != self.resources.semantics_uri
+            ):
+                raise ValueError("artifact is not a Lean proof state")
+            state = LeanProofStateArtifact.model_validate(stored.payload)
+        except (StoreError, ValidationError, ValueError) as exc:
+            raise CapabilityInvocationError(
+                CapabilityDiagnostic(
+                    code="INVALID_LEAN_PROOF_STATE",
+                    stage="state_loading",
+                    message="The supplied state artifact is unavailable or invalid.",
+                    hint="Use a state URI returned by this capability.",
+                )
+            ) from exc
+        if (
+            state.environment is not expected_environment
+            or state.environment_digest != expected_environment_digest
+            or state.source_digest
+            != _source_digest(state.statement, state.tactic_prefix)
+            or state.state_digest != _state_digest_payload(state)
+        ):
+            raise CapabilityInvocationError(
+                CapabilityDiagnostic(
+                    code="STALE_LEAN_PROOF_STATE",
+                    stage="state_validation",
+                    message=(
+                        "The proof state no longer matches its source or the "
+                        "current pinned Lean environment."
+                    ),
+                    hint="Recreate the proof state under the current environment.",
+                )
+            )
+        return state
 
 
 class LeanPremiseRetrievalAdapter:
@@ -750,6 +1002,165 @@ def _validate_source_parts(statement: str, tactics: tuple[str, ...]) -> None:
 def _proof_state_command(*, statement: str, proof_prefix: tuple[str, ...]) -> str:
     proof = "\n".join(f"  {line}" for line in (*proof_prefix, "sorry"))
     return f"example : {statement} := by\n{proof}"
+
+
+def _digest(value: Any) -> str:
+    return "sha256:" + hashlib.sha256(canonicalize_json(value)).hexdigest()
+
+
+def _environment_imports(environment: LeanEnvironment) -> tuple[str, ...]:
+    return ("Mathlib",) if environment is LeanEnvironment.MATHLIB else ("Init",)
+
+
+def _environment_digest(
+    environment: LeanEnvironment,
+    installation: LeanCheckerInstallation,
+) -> str:
+    return _digest(
+        {
+            "environment": environment.value,
+            "imports": list(_environment_imports(environment)),
+            "lean_version": installation.lean_version,
+            "lean_commit": installation.lean_commit,
+            "mathlib_commit": installation.mathlib_commit,
+        }
+    )
+
+
+def _source_digest(statement: str, tactic_prefix: tuple[str, ...]) -> str:
+    return _digest(
+        {
+            "statement": statement,
+            "tactic_prefix": list(tactic_prefix),
+            "replay_command": _proof_state_command(
+                statement=statement,
+                proof_prefix=tactic_prefix,
+            ),
+        }
+    )
+
+
+def _state_digest_data(
+    *,
+    environment: LeanEnvironment,
+    environment_digest: str,
+    source_digest: str,
+    statement: str,
+    tactic_prefix: tuple[str, ...],
+    normalized_goals: tuple[str, ...],
+    completed: bool,
+    imports: tuple[str, ...],
+    lean_version: str,
+    lean_commit: str,
+    mathlib_commit: str | None,
+) -> dict[str, Any]:
+    return {
+        "environment": environment.value,
+        "environment_digest": environment_digest,
+        "source_digest": source_digest,
+        "statement": statement,
+        "tactic_prefix": list(tactic_prefix),
+        "normalized_goals": list(normalized_goals),
+        "completed": completed,
+        "imports": list(imports),
+        "lean_version": lean_version,
+        "lean_commit": lean_commit,
+        "mathlib_commit": mathlib_commit,
+    }
+
+
+def _state_payload(
+    *,
+    environment: LeanEnvironment,
+    environment_digest: str,
+    statement: str,
+    tactic_prefix: tuple[str, ...],
+    normalized_goals: tuple[str, ...],
+    installation: LeanCheckerInstallation,
+) -> LeanProofStateArtifact:
+    source_digest = _source_digest(statement, tactic_prefix)
+    imports = _environment_imports(environment)
+    completed = len(normalized_goals) == 0
+    digest_data = _state_digest_data(
+        environment=environment,
+        environment_digest=environment_digest,
+        source_digest=source_digest,
+        statement=statement,
+        tactic_prefix=tactic_prefix,
+        normalized_goals=normalized_goals,
+        completed=completed,
+        imports=imports,
+        lean_version=installation.lean_version,
+        lean_commit=installation.lean_commit,
+        mathlib_commit=installation.mathlib_commit,
+    )
+    return LeanProofStateArtifact(
+        **digest_data,
+        state_digest=_digest(digest_data),
+    )
+
+
+def _state_digest_payload(state: LeanProofStateArtifact) -> str:
+    return _digest(
+        _state_digest_data(
+            environment=state.environment,
+            environment_digest=state.environment_digest,
+            source_digest=state.source_digest,
+            statement=state.statement,
+            tactic_prefix=state.tactic_prefix,
+            normalized_goals=state.normalized_goals,
+            completed=state.completed,
+            imports=state.imports,
+            lean_version=state.lean_version,
+            lean_commit=state.lean_commit,
+            mathlib_commit=state.mathlib_commit,
+        )
+    )
+
+
+def _normalized_response_goals(response: Mapping[str, Any]) -> tuple[str, ...]:
+    goals_value = response.get("goals", [])
+    if not isinstance(goals_value, list) or any(
+        not isinstance(goal, str) for goal in goals_value
+    ):
+        raise RuntimeError("Lean REPL returned malformed goals")
+    return tuple(_normalize_goal(goal) for goal in goals_value)
+
+
+def _normalize_goal(goal: str) -> str:
+    lines = goal.replace("\r\n", "\n").replace("\r", "\n").splitlines()
+    return "\n".join(line.rstrip() for line in lines).strip()
+
+
+def _tactic_diagnostics(
+    responses: tuple[dict[str, Any], dict[str, Any], dict[str, Any]],
+) -> tuple[LeanTacticDiagnostic, ...]:
+    diagnostics: list[LeanTacticDiagnostic] = []
+    for response in responses:
+        message = response.get("message")
+        if isinstance(message, str):
+            diagnostics.append(LeanTacticDiagnostic(severity="ERROR", message=message))
+        structured = response.get("messages")
+        if not isinstance(structured, list):
+            continue
+        for item in structured:
+            if not isinstance(item, Mapping):
+                continue
+            data = item.get("data")
+            if not isinstance(data, str):
+                continue
+            raw_severity = item.get("severity")
+            severity = (
+                "ERROR"
+                if raw_severity == "error"
+                else ("WARNING" if raw_severity == "warning" else "INFO")
+            )
+            diagnostics.append(
+                LeanTacticDiagnostic.model_validate(
+                    {"severity": severity, "message": data}
+                )
+            )
+    return tuple(diagnostics)
 
 
 def _run_repl(

--- a/tests/contract/test_lean_replayable_state_contracts.py
+++ b/tests/contract/test_lean_replayable_state_contracts.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.contracts.lean_exploration import (
+    LeanProofStateArtifact,
+    LeanProofStateRequest,
+)
+
+STATE_URI = "artifact://sha256/" + "a" * 64
+DIGEST = "sha256:" + "b" * 64
+
+
+@pytest.mark.contract
+def test_state_request_accepts_uri_without_replacement_source() -> None:
+    request = LeanProofStateRequest(state_uri=STATE_URI, tactic="constructor")
+
+    assert request.statement is None
+    assert request.proof_prefix == ()
+
+
+@pytest.mark.contract
+def test_state_request_rejects_uri_with_replacement_prefix() -> None:
+    with pytest.raises(ValidationError, match="cannot be combined"):
+        LeanProofStateRequest(
+            state_uri=STATE_URI,
+            proof_prefix=("intro P",),
+            tactic="constructor",
+        )
+
+
+@pytest.mark.contract
+def test_state_artifact_binds_completion_to_normalized_goals() -> None:
+    with pytest.raises(ValidationError, match="completion"):
+        LeanProofStateArtifact(
+            environment="CORE",
+            environment_digest=DIGEST,
+            source_digest=DIGEST,
+            statement="True",
+            tactic_prefix=(),
+            normalized_goals=("⊢ True",),
+            state_digest=DIGEST,
+            completed=True,
+            imports=("Init",),
+            lean_version="4.31.0",
+            lean_commit="lean-commit",
+        )

--- a/tests/integration/test_lean_exploration_capabilities.py
+++ b/tests/integration/test_lean_exploration_capabilities.py
@@ -39,6 +39,10 @@ def test_apply_tactic_exposes_child_goals_and_replay_source(tmp_path: Path) -> N
     assert result.output["completed"] is False
     assert result.output["goal_count"] == 2
     assert all("⊢" in goal for goal in result.output["goals"])
+    assert result.output["accepted"] is True
+    assert len(result.output["successor_states"]) == 1
+    assert result.output["input_state_uri"] in result.artifact_uris
+    assert result.output["successor_states"][0]["state_uri"] in result.artifact_uris
     assert result.output["transition_uri"] in result.artifact_uris
     assert result.output["replay_source"].endswith("intro P Q hP hQ\n  constructor")
 
@@ -60,9 +64,11 @@ def test_apply_tactic_returns_structured_failure_without_conclusion(
         )
     )
 
-    assert result.execution.status.value == "ERROR"
-    assert result.assurance.level is CapabilityAssuranceLevel.HEURISTIC
-    assert result.diagnostics[0].code == "LEAN_TACTIC_REJECTED"
+    assert result.execution.status.value == "COMPLETED"
+    assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert result.output["accepted"] is False
+    assert result.output["successor_states"] == []
+    assert result.output["diagnostics"][0]["severity"] == "ERROR"
 
 
 def test_retrieve_premises_returns_exact_mathlib_suggestion(tmp_path: Path) -> None:

--- a/tests/integration/test_lean_exploration_capabilities.py
+++ b/tests/integration/test_lean_exploration_capabilities.py
@@ -68,7 +68,10 @@ def test_apply_tactic_returns_structured_failure_without_conclusion(
     assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
     assert result.output["accepted"] is False
     assert result.output["successor_states"] == []
-    assert result.output["diagnostics"][0]["severity"] == "ERROR"
+    assert any(
+        diagnostic["severity"] == "ERROR"
+        for diagnostic in result.output["diagnostics"]
+    )
 
 
 def test_retrieve_premises_returns_exact_mathlib_suggestion(tmp_path: Path) -> None:

--- a/tests/integration/test_lean_exploration_capabilities.py
+++ b/tests/integration/test_lean_exploration_capabilities.py
@@ -69,8 +69,7 @@ def test_apply_tactic_returns_structured_failure_without_conclusion(
     assert result.output["accepted"] is False
     assert result.output["successor_states"] == []
     assert any(
-        diagnostic["severity"] == "ERROR"
-        for diagnostic in result.output["diagnostics"]
+        diagnostic["severity"] == "ERROR" for diagnostic in result.output["diagnostics"]
     )
 
 

--- a/tests/integration/test_lean_replayable_state_capability.py
+++ b/tests/integration/test_lean_replayable_state_capability.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from jacobian.artifacts import ArtifactService
+from jacobian.capabilities import CapabilityInvocationError
+from jacobian.contracts.capabilities import CapabilityRequest
+from jacobian.contracts.lean import LeanEnvironment
+from jacobian.lean_exploration import (
+    LeanProofStateAdapter,
+    install_lean_exploration_capabilities,
+)
+from jacobian.provider_runtime import jacobian_provider_runtime
+from jacobian.references import LeanCheckerInstallation
+from jacobian.schema_registry import SchemaRegistry
+from jacobian.store import ArtifactStore
+
+pytestmark = pytest.mark.integration
+
+
+def _installation(environment: LeanEnvironment) -> LeanCheckerInstallation:
+    digest = "artifact://sha256/" + (
+        "a" * 64 if environment is LeanEnvironment.CORE else "b" * 64
+    )
+    return LeanCheckerInstallation(
+        environment=environment,
+        lean_version="4.31.0",
+        lean_commit="lean-commit",
+        import_name=None if environment is LeanEnvironment.CORE else "Mathlib",
+        mathlib_commit=(
+            None if environment is LeanEnvironment.CORE else "mathlib-commit"
+        ),
+        allowed_axioms=(),
+        checker_timeout_seconds=30,
+        semantics_uri=digest,
+        claim_schema_uri=digest,
+        candidate_schema_uri=digest,
+        certificate_schema_uri=digest,
+        checker_id="checker://sha256/" + "c" * 64,
+    )
+
+
+def _adapter(tmp_path: Path) -> LeanProofStateAdapter:
+    store = ArtifactStore(tmp_path)
+    schemas = SchemaRegistry(store)
+    artifacts = ArtifactService(store, schemas)
+    installations = {
+        environment: _installation(environment) for environment in LeanEnvironment
+    }
+    adapters, _ = install_lean_exploration_capabilities(
+        store,
+        schemas,
+        artifacts,
+        installations,
+        jacobian_provider_runtime(
+            "jacobian.lean4",
+            features=("clean-replay", "immutable-proof-state"),
+        ),
+    )
+    return adapters[0]
+
+
+def _responses(
+    *,
+    before: list[str],
+    after: list[str],
+    completed: bool = False,
+    error: str | None = None,
+) -> tuple[dict[str, object], dict[str, object], dict[str, object]]:
+    tactic: dict[str, object] = {
+        "proofState": 2,
+        "proofStatus": "Completed" if completed else "Goals",
+        "goals": after,
+    }
+    if error is not None:
+        tactic["messages"] = [{"severity": "error", "data": error}]
+    return (
+        {"env": 0, "sorries": [{"proofState": 0}]},
+        {"proofState": 1, "proofStatus": "Goals", "goals": before},
+        tactic,
+    )
+
+
+def test_apply_tactic_materializes_and_reuses_replayable_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _adapter(tmp_path)
+    calls = iter(
+        (
+            _responses(
+                before=["P Q : Prop  \r\n⊢ P ∧ Q"],
+                after=["P Q : Prop\n⊢ P", "P Q : Prop\n⊢ Q"],
+            ),
+            _responses(
+                before=["P Q : Prop\n⊢ P", "P Q : Prop\n⊢ Q"],
+                after=[],
+                completed=True,
+            ),
+        )
+    )
+    monkeypatch.setattr(
+        adapter.resources.repl,
+        "execute_clean",
+        lambda **_: next(calls),
+    )
+
+    first = adapter.invoke(
+        CapabilityRequest(
+            capability_id="lean.proof_state.apply_tactic",
+            input={
+                "environment": "CORE",
+                "statement": "(P Q : Prop) → P ∧ Q",
+                "proof_prefix": ["intro P Q"],
+                "tactic": "constructor",
+            },
+        )
+    )
+    successor_uri = first.output["successor_states"][0]["state_uri"]
+    second = adapter.invoke(
+        CapabilityRequest(
+            capability_id="lean.proof_state.apply_tactic",
+            input={
+                "environment": "CORE",
+                "state_uri": successor_uri,
+                "tactic": "all_goals assumption",
+            },
+        )
+    )
+
+    assert first.output["accepted"] is True
+    assert first.output["completed"] is False
+    assert first.output["goals"] == ["P Q : Prop\n⊢ P", "P Q : Prop\n⊢ Q"]
+    assert first.output["input_state_uri"] in first.artifact_uris
+    assert successor_uri in first.artifact_uris
+    assert second.output["accepted"] is True
+    assert second.output["completed"] is True
+    assert second.output["successor_states"][0]["normalized_goals"] == []
+    assert second.output["verification_boundary"] == "LEAN_CHECK_REQUIRED"
+    assert second.output["verification"] == "UNVERIFIED"
+    successor = adapter.resources.store.get(successor_uri)
+    assert successor.payload["expiry"] == "IMMUTABLE_NO_EXPIRY"
+    assert successor.payload["environment_digest"].startswith("sha256:")
+    assert successor.payload["source_digest"].startswith("sha256:")
+    assert successor.payload["state_digest"].startswith("sha256:")
+
+
+def test_apply_tactic_returns_rejection_without_successor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _adapter(tmp_path)
+    monkeypatch.setattr(
+        adapter.resources.repl,
+        "execute_clean",
+        lambda **_: _responses(
+            before=["P Q : Prop\nhP : P\n⊢ Q"],
+            after=[],
+            error="type mismatch: hP has type P",
+        ),
+    )
+
+    result = adapter.invoke(
+        CapabilityRequest(
+            capability_id="lean.proof_state.apply_tactic",
+            input={
+                "environment": "CORE",
+                "statement": "(P Q : Prop) → P → Q",
+                "proof_prefix": ["intro P Q hP"],
+                "tactic": "exact hP",
+            },
+        )
+    )
+
+    assert result.execution.status.value == "COMPLETED"
+    assert result.output["accepted"] is False
+    assert result.output["completed"] is False
+    assert result.output["successor_states"] == []
+    assert result.output["diagnostics"][0]["severity"] == "ERROR"
+
+
+def test_apply_tactic_rejects_environment_stale_state_before_replay(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _adapter(tmp_path)
+    monkeypatch.setattr(
+        adapter.resources.repl,
+        "execute_clean",
+        lambda **_: _responses(before=["⊢ True"], after=[], completed=True),
+    )
+    opened = adapter.invoke(
+        CapabilityRequest(
+            capability_id="lean.proof_state.apply_tactic",
+            input={
+                "environment": "CORE",
+                "statement": "True",
+                "tactic": "trivial",
+            },
+        )
+    )
+    state = adapter.resources.store.get(opened.output["input_state_uri"])
+    stale_payload = dict(state.payload)
+    stale_payload["environment_digest"] = "sha256:" + "f" * 64
+    stale = adapter.resources.artifacts.put(
+        schema_uri=adapter.resources.state_schema_uri,
+        semantics_uri=adapter.resources.semantics_uri,
+        payload=stale_payload,
+        summary="fixture with stale environment binding",
+    )
+
+    with pytest.raises(CapabilityInvocationError) as raised:
+        adapter.invoke(
+            CapabilityRequest(
+                capability_id="lean.proof_state.apply_tactic",
+                input={
+                    "environment": "CORE",
+                    "state_uri": stale.artifact_uri,
+                    "tactic": "trivial",
+                },
+            )
+        )
+
+    assert raised.value.diagnostic.code == "STALE_LEAN_PROOF_STATE"

--- a/tests/unit/test_lean_repl_runtime.py
+++ b/tests/unit/test_lean_repl_runtime.py
@@ -6,7 +6,12 @@ from pathlib import Path
 
 import pytest
 
-from jacobian.lean_exploration import LeanReplPolicy, PersistentLeanRepl
+from jacobian.contracts.lean import LeanEnvironment
+from jacobian.lean_exploration import (
+    LeanExplorationReplRuntime,
+    LeanReplPolicy,
+    PersistentLeanRepl,
+)
 
 _FAKE_REPL = r"""
 import json
@@ -72,6 +77,29 @@ def test_persistent_repl_reuses_import_then_restarts_at_request_limit(
     assert starts.read_text() == "xx"
 
 
+def test_validated_execution_inspects_state_before_requested_tactic(
+    tmp_path: Path,
+) -> None:
+    starts = tmp_path / "starts"
+    repl = PersistentLeanRepl(
+        command=(sys.executable, "-u", "-c", _FAKE_REPL, str(starts)),
+        cwd=tmp_path,
+        base_command="import Mathlib",
+        policy=LeanReplPolicy(max_requests=1, max_age_seconds=60, max_rss_kb=0),
+    )
+
+    command, validation, transition = repl.execute_validated(
+        command="example : True := by sorry",
+        tactic="trivial",
+    )
+    repl.close()
+
+    assert command["sorries"]
+    assert validation["proofState"] == 1
+    assert transition["proofState"] == 2
+    assert starts.read_text() == "x"
+
+
 def test_persistent_repl_kills_a_timed_out_process(tmp_path: Path) -> None:
     repl = PersistentLeanRepl(
         command=(sys.executable, "-u", "-c", "import time; time.sleep(10)"),
@@ -117,3 +145,49 @@ def test_persistent_repl_kills_a_process_that_exceeds_rss_limit(
         repl.execute(command="example : True := by sorry", tactic="trivial")
 
     assert time.monotonic() - started < 2
+
+
+def test_clean_execution_discards_every_repl_instance(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = LeanExplorationReplRuntime(tmp_path, {})
+
+    class FakeSession:
+        closed = False
+
+        def execute_validated(
+            self,
+            *,
+            command: str,
+            tactic: str,
+        ) -> tuple[dict[str, object], dict[str, object], dict[str, object]]:
+            assert command
+            assert tactic
+            return ({}, {}, {})
+
+        def close(self) -> None:
+            self.closed = True
+
+    sessions: list[FakeSession] = []
+
+    def create(_environment: LeanEnvironment) -> FakeSession:
+        session = FakeSession()
+        sessions.append(session)
+        return session
+
+    monkeypatch.setattr(runtime, "_create_session", create)
+
+    runtime.execute_clean(
+        command="example : True := by sorry",
+        tactic="trivial",
+        environment=LeanEnvironment.CORE,
+    )
+    runtime.execute_clean(
+        command="example : True := by sorry",
+        tactic="trivial",
+        environment=LeanEnvironment.CORE,
+    )
+
+    assert len(sessions) == 2
+    assert all(session.closed for session in sessions)


### PR DESCRIPTION
## Summary

- upgrade the canonical `lean.proof_state.apply_tactic` capability to version 2, covering the `lean.tactic.apply` inventory contract
- add immutable proof-state artifacts binding the exact statement, pinned environment/import identity, source digest, tactic prefix, normalized goals, and state digest
- reconstruct and inspect every supplied state in a fresh Lean REPL process before applying one requested tactic
- reject malformed, environment-drifted, source-drifted, goal-mismatched, completed, and over-limit states fail-closed
- return durable successor-state artifacts, structured diagnostics, acceptance, and completion status
- keep every transition `COMPUTED`/`UNVERIFIED` with `LEAN_CHECK_REQUIRED` as the exclusive theorem-verification boundary

Addresses the replayable immutable-state portion of #95.

## Design decisions

The request resolves issue #95's session decision for this slice: states are immutable replay artifacts, not long-lived worker/session IDs. They use `IMMUTABLE_NO_EXPIRY`; staleness is defined by digest or clean-replay mismatch. Each process is discarded after reconstruction, no-op goal inspection, and one tactic application.

The canonical capability ID remains `lean.proof_state.apply_tactic`; no shallow `lean.tactic.apply` alias is added. A request can begin from an explicit statement/prefix or continue from a returned state URI. Replay chains are bounded to 64 tactics.

Lean returns one successor proof state containing the complete ordered goal list. A rejected tactic returns diagnostics and no successor. A completed successor only means no goals remained in exploratory replay; it is never promoted to theorem verification.

Persistent sessions, term-application semantics, axiom/trust inspection, and changes to `lean.check` are out of scope.

## Validation

- Ruff and formatting: passed
- mypy: 161 source files passed
- focused contract, clean-process runtime, replay, chaining, rejection, and stale-state tests: 11 passed
- repository fast suite: 385 passed; 6 known local-environment failures remain (five Bash 4 associative-array checks and one external SMT checker fixture)
- real Lean runtime tests were not run locally because Lean is unavailable; CI owns the pinned Lean lane
