### PR TITLE
Add preservation-checked graph counterexample shrinking

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -62,6 +62,7 @@ expectations.
 - [SMT Alethe artifact contracts](reference/smt-artifacts.md)
 - [Exact rational linear-system evidence](reference/linear-rational-solutions.md)
 - [Exact rational matrix determinants](reference/matrix-rational-determinant.md)
+- [Graph counterexample shrinking](reference/graph-counterexample-shrinking.md)
 - [Integer matrix Hermite normal form](reference/matrix-hermite-normal-form.md)
 - [Typed polynomial expression normalization](reference/polynomial-expression-normalization.md)
 - [v0.2 specification](reference/specifications/v0.2.md)

--- a/docs/reference/graph-counterexample-shrinking.md
+++ b/docs/reference/graph-counterexample-shrinking.md
@@ -1,0 +1,43 @@
+# Graph counterexample shrinking
+
+[Documentation home](../index.md)
+
+`graph.counterexample.shrink` is a bounded exploration capability for finite
+simple undirected graphs. Version 1 supports the registered
+`graph.property.non_bipartite` property and two deterministic reducers:
+
+- `delete_vertex`, which removes one vertex and every incident edge;
+- `delete_edge`, which removes one edge.
+
+The adapter delegates proposal search to the generic `shrink.run` service.
+The graph reducer is therefore an untrusted proposal source. Every accepted
+reduction must be replayed by the operator-selected active preservation
+checker compatible with the graph schema, semantics, property-claim schema,
+and `graph.property.non_bipartite.preservation` format.
+
+## Result and trace
+
+The result records every attempted reduction in execution order. Each attempt
+identifies the source graph, proposed graph, exact deleted vertex or edge,
+outcome, and—only for accepted steps—the independent verification record.
+Possible outcomes distinguish verified acceptance, mathematical property
+rejection, checker failure, and invalid reduction.
+
+The trace is an immutable artifact bound to the initial graph, final graph,
+property claim, all proposed graph artifacts, and accepted-step verification
+records.
+
+## Minimality boundary
+
+Version 1 reports only the tested single-deletion neighborhood of the final
+graph. It sets `one_step_locally_minimal` only when:
+
+1. the final graph itself was accepted by the property checker;
+2. every requested single vertex or edge deletion was attempted exactly once;
+3. every such deletion was mathematically rejected by the checker; and
+4. execution completed without a timeout, checker error, invalid proposal, or
+   budget omission.
+
+The result separately lists tested and untested deletions. It never claims
+global minimality. Restricting the reducer set restricts the meaning of the
+local-minimality result to that declared reducer set.

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -129,6 +129,7 @@ of catalog membership:
 - [SMT Alethe artifact contracts](smt-artifacts.md);
 - [exact rational linear-system evidence](linear-rational-solutions.md);
 - [exact rational matrix determinants](matrix-rational-determinant.md);
+- [graph counterexample shrinking](graph-counterexample-shrinking.md);
 - [integer matrix Hermite normal form](matrix-hermite-normal-form.md);
 - [typed polynomial expression normalization](polynomial-expression-normalization.md);
 - [Lean declaration discovery contract](lean-declaration-discovery.md).

--- a/src/jacobian/contracts/graph_shrinking.py
+++ b/src/jacobian/contracts/graph_shrinking.py
@@ -1,0 +1,121 @@
+"""Contracts for preservation-checked shrinking of simple graph counterexamples."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Literal, Self
+
+from pydantic import Field, StrictBool, StrictInt, model_validator
+
+from jacobian.contracts.common import ArtifactUri, CheckerUri
+from jacobian.contracts.results import ContractModel, ExecutionStatus
+
+
+class GraphReduction(StrEnum):
+    DELETE_VERTEX = "delete_vertex"
+    DELETE_EDGE = "delete_edge"
+
+
+class GraphReductionOutcome(StrEnum):
+    ACCEPTED_VERIFIED = "ACCEPTED_VERIFIED"
+    PROPERTY_REJECTED = "PROPERTY_REJECTED"
+    CHECKER_ERROR = "CHECKER_ERROR"
+    INVALID_REDUCTION = "INVALID_REDUCTION"
+
+
+class GraphCounterexampleShrinkRequest(ContractModel):
+    graph_uri: ArtifactUri
+    property_id: Literal["graph.property.non_bipartite"]
+    property_checker_id: CheckerUri
+    reducers: tuple[GraphReduction, ...] = (
+        GraphReduction.DELETE_VERTEX,
+        GraphReduction.DELETE_EDGE,
+    )
+    evaluation_budget: StrictInt = Field(ge=1, le=100_000)
+    reducer_timeout_seconds: StrictInt = Field(default=30, ge=1, le=30)
+
+    @model_validator(mode="after")
+    def require_unique_reducers(self) -> Self:
+        if not self.reducers:
+            raise ValueError("at least one graph reducer is required")
+        if len(set(self.reducers)) != len(self.reducers):
+            raise ValueError("graph reducers must be unique")
+        return self
+
+
+class GraphReductionAttempt(ContractModel):
+    index: StrictInt = Field(ge=0)
+    reducer: GraphReduction
+    from_graph_uri: ArtifactUri
+    proposed_graph_uri: ArtifactUri | None = None
+    deleted_vertex: str | None = None
+    deleted_edge: tuple[str, str] | None = None
+    outcome: GraphReductionOutcome
+    verification_record_uri: ArtifactUri | None = None
+    detail: str
+
+    @model_validator(mode="after")
+    def require_one_deletion_target(self) -> Self:
+        targets = int(self.deleted_vertex is not None) + int(
+            self.deleted_edge is not None
+        )
+        if self.proposed_graph_uri is not None and targets != 1:
+            raise ValueError("a graph reduction proposal must identify one deletion")
+        if self.outcome is GraphReductionOutcome.ACCEPTED_VERIFIED:
+            if self.verification_record_uri is None:
+                raise ValueError("an accepted reduction requires verification evidence")
+        elif self.verification_record_uri is not None:
+            raise ValueError("only accepted reductions may bind verification evidence")
+        return self
+
+
+class GraphLocalMinimalityScope(ContractModel):
+    scope_kind: Literal["TESTED_SINGLE_DELETIONS"] = "TESTED_SINGLE_DELETIONS"
+    requested_reducers: tuple[GraphReduction, ...]
+    tested_vertex_deletions: tuple[str, ...] = ()
+    tested_edge_deletions: tuple[tuple[str, str], ...] = ()
+    untested_vertex_deletions: tuple[str, ...] = ()
+    untested_edge_deletions: tuple[tuple[str, str], ...] = ()
+    complete_for_requested_reducers: StrictBool
+    one_step_locally_minimal: StrictBool
+    global_minimality_claimed: Literal[False] = False
+    basis: str
+
+    @model_validator(mode="after")
+    def keep_scope_claim_fail_closed(self) -> Self:
+        if self.one_step_locally_minimal and not self.complete_for_requested_reducers:
+            raise ValueError("local minimality requires complete requested scope")
+        if self.complete_for_requested_reducers and (
+            self.untested_vertex_deletions or self.untested_edge_deletions
+        ):
+            raise ValueError("complete scope cannot contain untested deletions")
+        return self
+
+
+class GraphShrinkTraceArtifact(ContractModel):
+    trace_schema_version: Literal["1"] = "1"
+    property_id: Literal["graph.property.non_bipartite"]
+    property_checker_id: CheckerUri
+    claim_uri: ArtifactUri
+    initial_graph_uri: ArtifactUri
+    final_graph_uri: ArtifactUri
+    reducers: tuple[GraphReduction, ...]
+    evaluation_budget: StrictInt = Field(ge=1)
+    execution_status: ExecutionStatus
+    attempts: tuple[GraphReductionAttempt, ...]
+    local_minimality_scope: GraphLocalMinimalityScope
+
+
+class GraphCounterexampleShrinkOutput(ContractModel):
+    property_id: Literal["graph.property.non_bipartite"]
+    property_checker_id: CheckerUri
+    claim_uri: ArtifactUri
+    initial_graph_uri: ArtifactUri
+    final_graph_uri: ArtifactUri
+    trace_uri: ArtifactUri
+    attempts: tuple[GraphReductionAttempt, ...]
+    local_minimality_scope: GraphLocalMinimalityScope
+    assurance: Literal["COMPUTED_WITH_VERIFIED_ACCEPTED_STEPS"] = (
+        "COMPUTED_WITH_VERIFIED_ACCEPTED_STEPS"
+    )
+    global_minimality_claimed: Literal[False] = False

--- a/src/jacobian/contracts/shrinking.py
+++ b/src/jacobian/contracts/shrinking.py
@@ -12,6 +12,8 @@ from jacobian.contracts.common import ArtifactUri
 from jacobian.contracts.results import (
     ContractModel,
     Execution,
+    ExecutionStatus,
+    InputStatus,
     InputValidation,
     ResultEnvelope,
 )
@@ -60,6 +62,8 @@ class ShrinkStep(ContractModel):
     from_uri: ArtifactUri
     proposed_uri: ArtifactUri | None = None
     accepted: StrictBool
+    execution_status: ExecutionStatus | None = None
+    input_status: InputStatus | None = None
     verification_record_uri: ArtifactUri | None = None
     objectives: dict[str, Any] = Field(default_factory=dict)
     detail: str = ""

--- a/src/jacobian/graph_shrinking.py
+++ b/src/jacobian/graph_shrinking.py
@@ -1,0 +1,488 @@
+"""Graph-owned adapter over the generic preservation-checked shrink engine."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, cast
+
+from jacobian.artifacts import ArtifactService
+from jacobian.capabilities import CapabilityInvocationError
+from jacobian.contracts.capabilities import (
+    CapabilityAssurance,
+    CapabilityAssuranceLevel,
+    CapabilityCompleteness,
+    CapabilityCompletenessStatus,
+    CapabilityDescriptor,
+    CapabilityDiagnostic,
+    CapabilityMode,
+    CapabilityRequest,
+    CapabilityResult,
+    CapabilityScope,
+)
+from jacobian.contracts.checkers import EvidenceKind
+from jacobian.contracts.claims import ClaimSpec, CorrespondenceStatus, PredicateSpec
+from jacobian.contracts.graph_shrinking import (
+    GraphCounterexampleShrinkOutput,
+    GraphCounterexampleShrinkRequest,
+    GraphLocalMinimalityScope,
+    GraphReduction,
+    GraphReductionAttempt,
+    GraphReductionOutcome,
+    GraphShrinkTraceArtifact,
+)
+from jacobian.contracts.plugins import (
+    CapabilityDescriptor as PluginCapabilityDescriptor,
+)
+from jacobian.contracts.plugins import CapabilityName, PluginManifest
+from jacobian.contracts.results import ExecutionStatus, InputStatus, Verification
+from jacobian.graph_capabilities import GraphInstallation
+from jacobian.plugins.registry import PluginRegistry
+from jacobian.provider_runtime import known_provider_runtime
+from jacobian.references import ReferenceInstaller
+from jacobian.registry import CheckerRegistry, CheckerRegistryError
+from jacobian.schema_registry import SchemaRegistry, model_schema
+from jacobian.shrinking import ShrinkService
+from jacobian.store import ArtifactStore, StoreError
+
+_DOMAIN_ID = "jacobian.graph-shrinking"
+_PROPERTY_ID = "graph.property.non_bipartite"
+_PRESERVATION_FORMAT = "graph.property.non_bipartite.preservation"
+
+
+@dataclass(frozen=True, slots=True)
+class GraphShrinkingInstallation:
+    plugin_id: str
+    claim_schema_uri: str
+    trace_schema_uri: str
+    property_checker_id: str | None
+
+
+def install_graph_shrinking(
+    store: ArtifactStore,
+    schemas: SchemaRegistry,
+    artifacts: ArtifactService,
+    plugins: PluginRegistry,
+    checkers: CheckerRegistry,
+    shrinking: ShrinkService,
+    graph: GraphInstallation,
+    reference_installer: ReferenceInstaller,
+    *,
+    authorize_checker: bool,
+) -> tuple[GraphCounterexampleShrinkAdapter, GraphShrinkingInstallation]:
+    """Install the graph reducer plugin, contracts, optional checker, and adapter."""
+
+    claim_schema_uri = schemas.register(
+        name="jacobian.graph-counterexample-property-claim",
+        version="1",
+        schema=model_schema(ClaimSpec),
+    )
+    trace_schema_uri = schemas.register(
+        name="jacobian.graph-counterexample-shrink-trace",
+        version="1",
+        schema=model_schema(GraphShrinkTraceArtifact),
+    )
+    entrypoint = "jacobian.plugins.graph_shrinking:reduce_simple_graph"
+    implementation_uri = plugins.register_implementation(entrypoint)
+    manifest = artifacts.put(
+        schema_uri=reference_installer.manifest_schema_uri,
+        semantics_uri=reference_installer.manifest_semantics_uri,
+        payload=PluginManifest(
+            domain_id=_DOMAIN_ID,
+            domain_version="1",
+            semantics_uri=graph.semantics_uri,
+            claim_schema_uri=claim_schema_uri,
+            candidate_schema_uri=graph.graph_schema_uri,
+            capabilities={
+                CapabilityName.REDUCER: PluginCapabilityDescriptor(
+                    implementation_uri=implementation_uri,
+                    entrypoint=entrypoint,
+                    version="1",
+                )
+            },
+        ).model_dump(mode="json"),
+        summary="untrusted simple-graph deletion reducer plugin",
+    )
+    plugins.install(manifest.artifact_uri)
+    checker_id = None
+    if authorize_checker:
+        checker_id = checkers.authorize(
+            name="exact non-bipartite graph property preservation checker",
+            entrypoint=(
+                "jacobian_checkers.graph_shrinking:check_non_bipartite_preservation"
+            ),
+            evidence_kind="PRESERVATION",
+            format_id=_PRESERVATION_FORMAT,
+            format_version="1",
+            claim_schema_uris=(claim_schema_uri,),
+            semantics_uris=(graph.semantics_uri,),
+            candidate_schema_uris=(graph.graph_schema_uri,),
+            reason="bundled independent finite simple-graph property checker",
+        ).checker_id
+    installation = GraphShrinkingInstallation(
+        plugin_id=manifest.artifact_uri,
+        claim_schema_uri=claim_schema_uri,
+        trace_schema_uri=trace_schema_uri,
+        property_checker_id=checker_id,
+    )
+    return (
+        GraphCounterexampleShrinkAdapter(
+            store=store,
+            artifacts=artifacts,
+            checkers=checkers,
+            shrinking=shrinking,
+            graph=graph,
+            installation=installation,
+        ),
+        installation,
+    )
+
+
+class GraphCounterexampleShrinkAdapter:
+    """Shrink one non-bipartite graph over an explicitly tested deletion scope."""
+
+    def __init__(
+        self,
+        *,
+        store: ArtifactStore,
+        artifacts: ArtifactService,
+        checkers: CheckerRegistry,
+        shrinking: ShrinkService,
+        graph: GraphInstallation,
+        installation: GraphShrinkingInstallation,
+    ) -> None:
+        self.store = store
+        self.artifacts = artifacts
+        self.checkers = checkers
+        self.shrinking = shrinking
+        self.graph = graph
+        self.installation = installation
+        checker_ids = (
+            (installation.property_checker_id,)
+            if installation.property_checker_id is not None
+            else ()
+        )
+        self._descriptor = CapabilityDescriptor(
+            capability_id="graph.counterexample.shrink",
+            version="1",
+            title="Shrink a simple-graph counterexample",
+            description=(
+                "Greedily test deterministic single vertex and edge deletions, "
+                "independently checking every accepted non-bipartite reduction."
+            ),
+            provider="jacobian.graph-shrinking",
+            provider_runtime=known_provider_runtime(
+                "jacobian.graph-shrinking",
+                features=("simple-undirected-graph", "single-deletion", "shrink.run"),
+                checker_ids=checker_ids,
+            ),
+            modes=(CapabilityMode.EXPLORE,),
+            input_schema=model_schema(GraphCounterexampleShrinkRequest),
+            output_schema=model_schema(GraphCounterexampleShrinkOutput),
+            tags=("graph", "counterexample", "shrinking", "local-minimality"),
+        )
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        return self._descriptor
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        validated = GraphCounterexampleShrinkRequest.model_validate(request.input)
+        self._load_graph(validated.graph_uri)
+        try:
+            self.checkers.require_compatible(
+                validated.property_checker_id,
+                evidence_kind=EvidenceKind.PRESERVATION,
+                format_id=_PRESERVATION_FORMAT,
+                format_version="1",
+                claim_schema_uri=self.installation.claim_schema_uri,
+                semantics_uri=self.graph.semantics_uri,
+                candidate_schema_uri=self.graph.graph_schema_uri,
+            )
+        except CheckerRegistryError as exc:
+            raise CapabilityInvocationError(
+                CapabilityDiagnostic(
+                    code="GRAPH_PROPERTY_CHECKER_INVALID",
+                    stage="checker_selection",
+                    message=(
+                        "The selected checker is not an active compatible graph "
+                        "property preservation checker."
+                    ),
+                    hint=(
+                        "Select an operator-registered checker advertised for "
+                        "graph.property.non_bipartite."
+                    ),
+                )
+            ) from exc
+        claim = self.artifacts.put(
+            schema_uri=self.installation.claim_schema_uri,
+            semantics_uri=self.graph.semantics_uri,
+            payload=ClaimSpec(
+                domain_id=_DOMAIN_ID,
+                domain_version="1",
+                semantics_uri=self.graph.semantics_uri,
+                predicate=PredicateSpec(name=validated.property_id),
+                required_capabilities=(CapabilityName.REDUCER,),
+                correspondence_status=CorrespondenceStatus.FORMALLY_LINKED,
+            ).model_dump(mode="json"),
+            parents=(validated.graph_uri,),
+            summary="registered simple-graph counterexample property",
+        )
+        reducers = tuple(item.value for item in validated.reducers)
+        shrunk = self.shrinking.run(
+            target_kind="candidate",
+            target_uri=validated.graph_uri,
+            claim_uri=claim.artifact_uri,
+            plugin_id=self.installation.plugin_id,
+            preservation_checker_id=validated.property_checker_id,
+            reducers=reducers,
+            objectives=("vertices", "edges"),
+            evaluation_budget=validated.evaluation_budget,
+            reducer_timeout_seconds=validated.reducer_timeout_seconds,
+        )
+        attempts = tuple(self._attempt(step) for step in shrunk.steps)
+        final = self._load_graph(shrunk.final_target_uri)
+        local_scope = _local_scope(
+            graph=final,
+            final_uri=shrunk.final_target_uri,
+            reducers=validated.reducers,
+            attempts=attempts,
+            final_property_verified=(
+                shrunk.result.assurance.verification is Verification.VERIFIED
+            ),
+            execution_status=shrunk.execution.status,
+        )
+        parent_uris = tuple(
+            dict.fromkeys(
+                (
+                    validated.graph_uri,
+                    shrunk.final_target_uri,
+                    claim.artifact_uri,
+                    *(
+                        attempt.proposed_graph_uri
+                        for attempt in attempts
+                        if attempt.proposed_graph_uri is not None
+                    ),
+                    *(
+                        attempt.verification_record_uri
+                        for attempt in attempts
+                        if attempt.verification_record_uri is not None
+                    ),
+                )
+            )
+        )
+        trace = self.artifacts.put(
+            schema_uri=self.installation.trace_schema_uri,
+            semantics_uri=self.graph.semantics_uri,
+            payload=GraphShrinkTraceArtifact(
+                property_id=validated.property_id,
+                property_checker_id=validated.property_checker_id,
+                claim_uri=claim.artifact_uri,
+                initial_graph_uri=validated.graph_uri,
+                final_graph_uri=shrunk.final_target_uri,
+                reducers=validated.reducers,
+                evaluation_budget=validated.evaluation_budget,
+                execution_status=shrunk.execution.status,
+                attempts=attempts,
+                local_minimality_scope=local_scope,
+            ).model_dump(mode="json"),
+            parents=parent_uris,
+            summary="tested simple-graph counterexample shrinking trace",
+        )
+        output = GraphCounterexampleShrinkOutput(
+            property_id=validated.property_id,
+            property_checker_id=validated.property_checker_id,
+            claim_uri=claim.artifact_uri,
+            initial_graph_uri=validated.graph_uri,
+            final_graph_uri=shrunk.final_target_uri,
+            trace_uri=trace.artifact_uri,
+            attempts=attempts,
+            local_minimality_scope=local_scope,
+        )
+        completed = shrunk.execution.status is ExecutionStatus.COMPLETED
+        return CapabilityResult(
+            capability_id=self.descriptor.capability_id,
+            capability_version=self.descriptor.version,
+            mode=request.mode,
+            execution=shrunk.execution,
+            output=output.model_dump(mode="json"),
+            scope=CapabilityScope(
+                description=(
+                    "only the recorded requested single deletions from each "
+                    "encountered finite simple undirected graph"
+                ),
+                parameters={
+                    "property_id": validated.property_id,
+                    "reducers": list(reducers),
+                    "evaluation_budget": validated.evaluation_budget,
+                    "global_minimality": False,
+                },
+                artifact_uri=trace.artifact_uri,
+            ),
+            completeness=CapabilityCompleteness(
+                status=(
+                    CapabilityCompletenessStatus.COMPLETE
+                    if local_scope.complete_for_requested_reducers
+                    else CapabilityCompletenessStatus.PARTIAL
+                ),
+                basis=local_scope.basis,
+                assurance_level=CapabilityAssuranceLevel.COMPUTED,
+            ),
+            assurance=CapabilityAssurance(
+                level=(
+                    CapabilityAssuranceLevel.COMPUTED
+                    if completed
+                    else CapabilityAssuranceLevel.HEURISTIC
+                ),
+                basis=(
+                    "accepted reductions have independent verification records; "
+                    "minimality is limited to the explicitly tested deletion scope"
+                    if completed
+                    else "shrinking did not complete; the incumbent and trace remain"
+                ),
+            ),
+            artifact_uris=(*parent_uris, trace.artifact_uri),
+        )
+
+    def _load_graph(self, graph_uri: str) -> dict[str, Any]:
+        try:
+            artifact = self.store.get(graph_uri)
+            if (
+                artifact.manifest.schema_uri != self.graph.graph_schema_uri
+                or artifact.manifest.semantics_uri != self.graph.semantics_uri
+            ):
+                raise ValueError
+            payload = artifact.payload
+            vertices = payload["vertices"]
+            edges = payload["edges"]
+            if vertices != sorted(vertices) or edges != sorted(edges):
+                raise ValueError
+            return cast(dict[str, Any], payload)
+        except (StoreError, KeyError, TypeError, ValueError) as exc:
+            raise CapabilityInvocationError(
+                CapabilityDiagnostic(
+                    code="GRAPH_SHRINK_INPUT_INVALID",
+                    stage="input_validation",
+                    message=(
+                        "The graph artifact is unavailable or is not a canonical "
+                        "finite simple undirected graph."
+                    ),
+                    hint="Use a graph URI produced by a Jacobian graph capability.",
+                )
+            ) from exc
+
+    def _attempt(self, step: Any) -> GraphReductionAttempt:
+        deleted_vertex = None
+        deleted_edge = None
+        if step.proposed_uri is not None:
+            before = self._load_graph(step.from_uri)
+            after = self._load_graph(step.proposed_uri)
+            removed_vertices = sorted(set(before["vertices"]) - set(after["vertices"]))
+            removed_edges = sorted(
+                set(map(tuple, before["edges"])) - set(map(tuple, after["edges"]))
+            )
+            if step.reducer == GraphReduction.DELETE_VERTEX.value:
+                if len(removed_vertices) != 1:
+                    return _invalid_attempt(step, "vertex reduction was not atomic")
+                deleted_vertex = removed_vertices[0]
+            elif step.reducer == GraphReduction.DELETE_EDGE.value:
+                if removed_vertices or len(removed_edges) != 1:
+                    return _invalid_attempt(step, "edge reduction was not atomic")
+                deleted_edge = removed_edges[0]
+        if step.accepted:
+            outcome = GraphReductionOutcome.ACCEPTED_VERIFIED
+        elif step.execution_status is not ExecutionStatus.COMPLETED:
+            outcome = GraphReductionOutcome.CHECKER_ERROR
+        elif (
+            step.input_status is InputStatus.REJECTED and step.proposed_uri is not None
+        ):
+            outcome = GraphReductionOutcome.PROPERTY_REJECTED
+        else:
+            outcome = GraphReductionOutcome.INVALID_REDUCTION
+        return GraphReductionAttempt(
+            index=step.index,
+            reducer=GraphReduction(step.reducer),
+            from_graph_uri=step.from_uri,
+            proposed_graph_uri=step.proposed_uri,
+            deleted_vertex=deleted_vertex,
+            deleted_edge=deleted_edge,
+            outcome=outcome,
+            verification_record_uri=step.verification_record_uri,
+            detail=step.detail,
+        )
+
+
+def _invalid_attempt(step: Any, detail: str) -> GraphReductionAttempt:
+    return GraphReductionAttempt(
+        index=step.index,
+        reducer=GraphReduction(step.reducer),
+        from_graph_uri=step.from_uri,
+        proposed_graph_uri=None,
+        outcome=GraphReductionOutcome.INVALID_REDUCTION,
+        detail=detail,
+    )
+
+
+def _local_scope(
+    *,
+    graph: dict[str, Any],
+    final_uri: str,
+    reducers: tuple[GraphReduction, ...],
+    attempts: tuple[GraphReductionAttempt, ...],
+    final_property_verified: bool,
+    execution_status: ExecutionStatus,
+) -> GraphLocalMinimalityScope:
+    expected_vertices = (
+        tuple(graph["vertices"]) if GraphReduction.DELETE_VERTEX in reducers else ()
+    )
+    expected_edges = (
+        tuple(tuple(edge) for edge in graph["edges"])
+        if GraphReduction.DELETE_EDGE in reducers
+        else ()
+    )
+    final_attempts = tuple(
+        attempt for attempt in attempts if attempt.from_graph_uri == final_uri
+    )
+    tested_vertices = tuple(
+        sorted(
+            attempt.deleted_vertex
+            for attempt in final_attempts
+            if attempt.deleted_vertex is not None
+        )
+    )
+    tested_edges = tuple(
+        sorted(
+            attempt.deleted_edge
+            for attempt in final_attempts
+            if attempt.deleted_edge is not None
+        )
+    )
+    untested_vertices = tuple(sorted(set(expected_vertices) - set(tested_vertices)))
+    untested_edges = tuple(sorted(set(expected_edges) - set(tested_edges)))
+    all_rejected = all(
+        attempt.outcome is GraphReductionOutcome.PROPERTY_REJECTED
+        for attempt in final_attempts
+    )
+    complete = (
+        execution_status is ExecutionStatus.COMPLETED
+        and final_property_verified
+        and not untested_vertices
+        and not untested_edges
+        and len(final_attempts) == len(expected_vertices) + len(expected_edges)
+        and all_rejected
+    )
+    return GraphLocalMinimalityScope(
+        requested_reducers=reducers,
+        tested_vertex_deletions=tested_vertices,
+        tested_edge_deletions=tested_edges,
+        untested_vertex_deletions=untested_vertices,
+        untested_edge_deletions=untested_edges,
+        complete_for_requested_reducers=complete,
+        one_step_locally_minimal=complete,
+        basis=(
+            "every requested single deletion from the final graph was tested "
+            "exactly once and mathematically rejected by the registered checker"
+            if complete
+            else "only the listed single deletions were tested; timeout, budget, "
+            "checker, or preservation status left the local boundary incomplete"
+        ),
+    )

--- a/src/jacobian/kernel.py
+++ b/src/jacobian/kernel.py
@@ -54,6 +54,10 @@ from jacobian.graph_isomorphism import (
     GraphIsomorphismInstallation,
     install_graph_isomorphism,
 )
+from jacobian.graph_shrinking import (
+    GraphShrinkingInstallation,
+    install_graph_shrinking,
+)
 from jacobian.lean import LeanService
 from jacobian.lean_declarations import (
     LeanDeclarationService,
@@ -447,6 +451,19 @@ class JacobianKernel:
         )
         for graph_adapter in graph_adapters:
             self.register_capability(graph_adapter)
+        self.graph_shrinking: GraphShrinkingInstallation
+        graph_shrinking, self.graph_shrinking = install_graph_shrinking(
+            self.store,
+            self.schemas,
+            self.artifacts,
+            self.plugins,
+            self.checkers,
+            self.shrinking,
+            self.graph,
+            self.reference_installer,
+            authorize_checker=install_references,
+        )
+        self.register_capability(graph_shrinking)
         self._install_graph_coloring_capabilities(install_references)
         self._install_geometry_capabilities()
         self.graph_isomorphism: GraphIsomorphismInstallation

--- a/src/jacobian/plugins/graph_shrinking.py
+++ b/src/jacobian/plugins/graph_shrinking.py
@@ -1,0 +1,57 @@
+"""Untrusted deterministic reducers for finite simple undirected graphs."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def reduce_simple_graph(request: dict[str, Any]) -> dict[str, Any]:
+    """Propose every requested single deletion in canonical order."""
+
+    target = request["target"]
+    vertices = tuple(target["vertices"])
+    edges = tuple(tuple(edge) for edge in target["edges"])
+    requested = tuple(request["reducers"])
+    objectives = tuple(request["objectives"])
+    proposals: list[dict[str, Any]] = []
+
+    if "delete_vertex" in requested:
+        for vertex in vertices:
+            reduced_edges = tuple(edge for edge in edges if vertex not in edge)
+            payload = {
+                "graph_schema_version": "1",
+                "vertices": [item for item in vertices if item != vertex],
+                "edges": [list(edge) for edge in reduced_edges],
+            }
+            values = {"vertices": len(vertices) - 1, "edges": len(reduced_edges)}
+            proposals.append(
+                {
+                    "reducer": "delete_vertex",
+                    "payload": payload,
+                    "objectives": {name: values[name] for name in objectives},
+                }
+            )
+
+    if "delete_edge" in requested:
+        for edge in edges:
+            payload = {
+                "graph_schema_version": "1",
+                "vertices": list(vertices),
+                "edges": [list(item) for item in edges if item != edge],
+            }
+            values = {"vertices": len(vertices), "edges": len(edges) - 1}
+            proposals.append(
+                {
+                    "reducer": "delete_edge",
+                    "payload": payload,
+                    "objectives": {name: values[name] for name in objectives},
+                }
+            )
+
+    current = {"vertices": len(vertices), "edges": len(edges)}
+    return {
+        "response_version": "1",
+        "current_objectives": {name: current[name] for name in objectives},
+        "reductions": proposals,
+        "detail": "complete deterministic requested single-deletion neighborhood",
+    }

--- a/src/jacobian/shrinking.py
+++ b/src/jacobian/shrinking.py
@@ -72,6 +72,7 @@ class ShrinkService:
         reducers: tuple[str, ...] | list[str],
         objectives: tuple[str, ...] | list[str],
         evaluation_budget: int,
+        reducer_timeout_seconds: int = 30,
     ) -> ShrinkResult:
         """Run bounded shrinking and report the achieved minimality level."""
 
@@ -182,7 +183,7 @@ class ShrinkService:
                         "semantics_digest": semantics_digest,
                     },
                 },
-                timeout_seconds=30,
+                timeout_seconds=reducer_timeout_seconds,
             )
             if execution.status != ExecutionStatus.COMPLETED:
                 operational_failure = (
@@ -236,6 +237,8 @@ class ShrinkService:
                             reducer=proposal.reducer,
                             from_uri=current.artifact_uri,
                             accepted=False,
+                            execution_status=ExecutionStatus.COMPLETED,
+                            input_status=InputStatus.REJECTED,
                             objectives=proposal.objectives,
                             detail="plugin used a reducer that was not requested",
                         )
@@ -279,6 +282,8 @@ class ShrinkService:
                             from_uri=current.artifact_uri,
                             proposed_uri=proposed.artifact_uri,
                             accepted=accepted,
+                            execution_status=decision.execution.status,
+                            input_status=decision.input.status,
                             verification_record_uri=(
                                 decision.verification_record_uri if accepted else None
                             ),
@@ -308,6 +313,8 @@ class ShrinkService:
                             reducer=proposal.reducer,
                             from_uri=current.artifact_uri,
                             accepted=False,
+                            execution_status=ExecutionStatus.ERROR,
+                            input_status=InputStatus.REJECTED,
                             objectives=proposal.objectives,
                             detail=_shrink_failure_detail(exc),
                         )

--- a/src/jacobian_checkers/graph_shrinking.py
+++ b/src/jacobian_checkers/graph_shrinking.py
@@ -1,0 +1,109 @@
+"""Independent property checker for simple-graph counterexample reductions."""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import Any
+
+
+def check_non_bipartite_preservation(request: dict[str, Any]) -> dict[str, Any]:
+    """Check independently that the reduced graph remains non-bipartite."""
+
+    try:
+        if request.get("request_version") != "1":
+            return _reject("unsupported request version")
+        claim = request["claim"]["payload"]
+        reduced = request["reduced"]["payload"]
+        preservation = request["preservation"]["payload"]
+        if claim["predicate"]["name"] != "graph.property.non_bipartite":
+            return _reject("unsupported graph property")
+        if preservation["preservation_format"] != (
+            "graph.property.non_bipartite.preservation"
+        ):
+            return _reject("unexpected preservation format")
+        if preservation["format_version"] != "1":
+            return _reject("unsupported preservation version")
+        if preservation["bindings"] != request["expected_bindings"]:
+            return _reject("preservation bindings do not match the request")
+        graph = _parse_simple_graph(reduced)
+        if graph is None:
+            return _reject("reduced graph is not a finite simple undirected graph")
+        if _is_bipartite(graph):
+            return _reject("reduced graph no longer satisfies non-bipartiteness")
+        return {
+            "accepted": True,
+            "conclusion": "TRUE",
+            "arithmetic": "EXACT_INTEGER",
+            "method": "EXHAUSTIVE_FINITE",
+            "coverage": "EXHAUSTIVE",
+            "detail": "reduced graph remains non-bipartite",
+        }
+    except (KeyError, TypeError, ValueError):
+        return _reject("malformed graph-property preservation request")
+
+
+def _parse_simple_graph(payload: dict[str, Any]) -> dict[str, set[str]] | None:
+    vertices = payload.get("vertices")
+    edges = payload.get("edges")
+    if (
+        payload.get("graph_schema_version") != "1"
+        or not isinstance(vertices, list)
+        or not all(isinstance(vertex, str) and vertex for vertex in vertices)
+        or len(vertices) != len(set(vertices))
+        or vertices != sorted(vertices)
+        or not isinstance(edges, list)
+    ):
+        return None
+    adjacency: dict[str, set[str]] = {vertex: set() for vertex in vertices}
+    seen: set[tuple[str, str]] = set()
+    for raw_edge in edges:
+        if (
+            not isinstance(raw_edge, list)
+            or len(raw_edge) != 2
+            or not all(isinstance(vertex, str) for vertex in raw_edge)
+        ):
+            return None
+        left, right = raw_edge
+        edge = (left, right)
+        if (
+            left >= right
+            or left not in adjacency
+            or right not in adjacency
+            or edge in seen
+        ):
+            return None
+        seen.add(edge)
+        adjacency[left].add(right)
+        adjacency[right].add(left)
+    if edges != [list(edge) for edge in sorted(seen)]:
+        return None
+    return adjacency
+
+
+def _is_bipartite(adjacency: dict[str, set[str]]) -> bool:
+    colors: dict[str, bool] = {}
+    for start in sorted(adjacency):
+        if start in colors:
+            continue
+        colors[start] = False
+        queue = deque((start,))
+        while queue:
+            vertex = queue.popleft()
+            for neighbor in sorted(adjacency[vertex]):
+                if neighbor not in colors:
+                    colors[neighbor] = not colors[vertex]
+                    queue.append(neighbor)
+                elif colors[neighbor] == colors[vertex]:
+                    return False
+    return True
+
+
+def _reject(detail: str) -> dict[str, Any]:
+    return {
+        "accepted": False,
+        "conclusion": "UNKNOWN",
+        "arithmetic": "EXACT_INTEGER",
+        "method": "EXHAUSTIVE_FINITE",
+        "coverage": "EXHAUSTIVE",
+        "detail": detail,
+    }

--- a/tests/contract/test_graph_shrinking_contracts.py
+++ b/tests/contract/test_graph_shrinking_contracts.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.contracts.graph_shrinking import (
+    GraphCounterexampleShrinkRequest,
+    GraphLocalMinimalityScope,
+    GraphReductionAttempt,
+)
+
+_ARTIFACT_URI = "artifact://sha256/" + "1" * 64
+_CHECKER_URI = "checker://sha256/" + "2" * 64
+
+
+@pytest.mark.contract
+def test_graph_shrink_request_requires_a_registered_checker_and_reducer() -> None:
+    with pytest.raises(ValidationError):
+        GraphCounterexampleShrinkRequest(
+            graph_uri=_ARTIFACT_URI,
+            property_id="graph.property.non_bipartite",
+            property_checker_id=_CHECKER_URI,
+            reducers=(),
+            evaluation_budget=10,
+        )
+
+
+@pytest.mark.contract
+def test_graph_shrink_contract_cannot_claim_unchecked_local_minimality() -> None:
+    with pytest.raises(ValidationError):
+        GraphLocalMinimalityScope(
+            requested_reducers=("delete_vertex",),
+            untested_vertex_deletions=("v",),
+            complete_for_requested_reducers=False,
+            one_step_locally_minimal=True,
+            basis="invalid fixture",
+        )
+
+
+@pytest.mark.contract
+def test_accepted_graph_reduction_requires_verification_record() -> None:
+    with pytest.raises(ValidationError):
+        GraphReductionAttempt(
+            index=0,
+            reducer="delete_vertex",
+            from_graph_uri=_ARTIFACT_URI,
+            proposed_graph_uri="artifact://sha256/" + "3" * 64,
+            deleted_vertex="v",
+            outcome="ACCEPTED_VERIFIED",
+            detail="invalid fixture",
+        )

--- a/tests/integration/test_graph_counterexample_shrinking.py
+++ b/tests/integration/test_graph_counterexample_shrinking.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from jacobian.contracts.capabilities import (
+    CapabilityAssuranceLevel,
+    CapabilityCompletenessStatus,
+    CapabilityRequest,
+)
+from jacobian.contracts.results import ExecutionStatus
+from jacobian.kernel import JacobianKernel
+from jacobian.plugin_execution import PluginExecutionResult
+
+pytestmark = pytest.mark.usefixtures("initialized_kernel_store")
+
+
+@pytest.mark.integration
+@pytest.mark.contract
+def test_graph_counterexample_shrink_records_verified_steps_and_exact_local_scope(
+    tmp_path: Path,
+) -> None:
+    kernel, graph_uri = _kernel_with_redundant_odd_cycle(tmp_path)
+
+    result = _shrink(kernel, graph_uri)
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert result.completeness.status is CapabilityCompletenessStatus.COMPLETE
+    assert kernel.store.get(result.output["final_graph_uri"]).payload == {
+        "graph_schema_version": "1",
+        "vertices": ["a", "b", "c"],
+        "edges": [["a", "b"], ["a", "c"], ["b", "c"]],
+    }
+    accepted = [
+        attempt
+        for attempt in result.output["attempts"]
+        if attempt["outcome"] == "ACCEPTED_VERIFIED"
+    ]
+    assert [attempt["deleted_vertex"] for attempt in accepted] == ["d"]
+    assert all(
+        attempt["verification_record_uri"] in result.artifact_uris
+        for attempt in accepted
+    )
+    scope = result.output["local_minimality_scope"]
+    assert scope["tested_vertex_deletions"] == ["a", "b", "c"]
+    assert scope["tested_edge_deletions"] == [
+        ["a", "b"],
+        ["a", "c"],
+        ["b", "c"],
+    ]
+    assert scope["complete_for_requested_reducers"] is True
+    assert scope["one_step_locally_minimal"] is True
+    assert scope["global_minimality_claimed"] is False
+    trace = kernel.store.get(result.output["trace_uri"])
+    assert trace.payload["attempts"] == result.output["attempts"]
+    assert trace.payload["local_minimality_scope"] == scope
+
+
+@pytest.mark.integration
+@pytest.mark.contract
+def test_graph_counterexample_shrink_budget_reports_only_tested_scope(
+    tmp_path: Path,
+) -> None:
+    kernel, graph_uri = _kernel_with_redundant_odd_cycle(tmp_path)
+
+    result = _shrink(kernel, graph_uri, evaluation_budget=2)
+
+    scope = result.output["local_minimality_scope"]
+    assert scope["complete_for_requested_reducers"] is False
+    assert scope["one_step_locally_minimal"] is False
+    assert scope["global_minimality_claimed"] is False
+    assert scope["untested_vertex_deletions"] or scope["untested_edge_deletions"]
+
+
+@pytest.mark.integration
+@pytest.mark.contract
+def test_graph_counterexample_shrink_timeout_returns_incumbent_without_minimality(
+    tmp_path: Path,
+) -> None:
+    kernel, graph_uri = _kernel_with_redundant_odd_cycle(tmp_path)
+    kernel.shrinking.executor = _TimeoutExecutor()  # type: ignore[assignment]
+
+    result = _shrink(kernel, graph_uri)
+
+    assert result.execution.status is ExecutionStatus.TIMEOUT
+    assert result.output["final_graph_uri"] == graph_uri
+    assert result.output["attempts"] == []
+    assert result.output["local_minimality_scope"]["one_step_locally_minimal"] is False
+    assert result.assurance.level is CapabilityAssuranceLevel.HEURISTIC
+
+
+@pytest.mark.integration
+@pytest.mark.contract
+def test_graph_counterexample_shrink_requires_compatible_registered_checker(
+    tmp_path: Path,
+) -> None:
+    kernel, graph_uri = _kernel_with_redundant_odd_cycle(tmp_path)
+    incompatible = kernel.graph.degree_sequence_checker_id
+    assert incompatible is not None
+
+    result = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.counterexample.shrink",
+            input={
+                "graph_uri": graph_uri,
+                "property_id": "graph.property.non_bipartite",
+                "property_checker_id": incompatible,
+                "reducers": ["delete_vertex", "delete_edge"],
+                "evaluation_budget": 20,
+            },
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.diagnostics[0].code == "GRAPH_PROPERTY_CHECKER_INVALID"
+
+
+@pytest.mark.integration
+@pytest.mark.contract
+def test_graph_counterexample_shrink_fails_closed_on_tampered_graph(
+    tmp_path: Path,
+) -> None:
+    kernel, graph_uri = _kernel_with_redundant_odd_cycle(tmp_path)
+    graph = kernel.store.get(graph_uri)
+    kernel.store._blob_path(graph.manifest.payload_digest).write_bytes(b"tampered")
+
+    result = _shrink(kernel, graph_uri)
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.output["error"]["code"] == "GRAPH_SHRINK_INPUT_INVALID"
+    assert result.diagnostics[0].code == "GRAPH_SHRINK_INPUT_INVALID"
+
+
+@pytest.mark.integration
+@pytest.mark.contract
+def test_graph_counterexample_shrink_order_is_deterministic(tmp_path: Path) -> None:
+    first_root = tmp_path / "first"
+    second_root = tmp_path / "second"
+    first, first_graph = _kernel_with_redundant_odd_cycle(first_root)
+    second, second_graph = _kernel_with_redundant_odd_cycle(second_root)
+
+    first_result = _shrink(first, first_graph)
+    second_result = _shrink(second, second_graph)
+
+    def signature(output: dict[str, Any]) -> list[tuple[Any, ...]]:
+        return [
+            (
+                attempt["reducer"],
+                attempt["deleted_vertex"],
+                attempt["deleted_edge"],
+                attempt["outcome"],
+            )
+            for attempt in output["attempts"]
+        ]
+
+    assert signature(first_result.output) == signature(second_result.output)
+    assert first.store.get(first_result.output["final_graph_uri"]).payload == (
+        second.store.get(second_result.output["final_graph_uri"]).payload
+    )
+
+
+class _TimeoutExecutor:
+    def run(self, **_: Any) -> PluginExecutionResult:
+        return PluginExecutionResult(
+            status=ExecutionStatus.TIMEOUT,
+            output=None,
+            diagnostics="",
+            detail="fixture reducer timeout",
+            runtime_ms=1,
+        )
+
+
+def _kernel_with_redundant_odd_cycle(root: Path) -> tuple[JacobianKernel, str]:
+    root.mkdir(parents=True, exist_ok=True)
+    kernel = JacobianKernel(root, install_references=True)
+    graph = kernel.artifacts.put(
+        schema_uri=kernel.graph.graph_schema_uri,
+        semantics_uri=kernel.graph.semantics_uri,
+        payload={
+            "graph_schema_version": "1",
+            "vertices": ["a", "b", "c", "d"],
+            "edges": [["a", "b"], ["a", "c"], ["b", "c"], ["c", "d"]],
+        },
+        summary="non-bipartite graph with one redundant leaf",
+    )
+    return kernel, graph.artifact_uri
+
+
+def _shrink(
+    kernel: JacobianKernel,
+    graph_uri: str,
+    *,
+    evaluation_budget: int = 20,
+) -> Any:
+    checker_id = kernel.graph_shrinking.property_checker_id
+    assert checker_id is not None
+    return kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.counterexample.shrink",
+            input={
+                "graph_uri": graph_uri,
+                "property_id": "graph.property.non_bipartite",
+                "property_checker_id": checker_id,
+                "reducers": ["delete_vertex", "delete_edge"],
+                "evaluation_budget": evaluation_budget,
+            },
+        )
+    )


### PR DESCRIPTION
## Summary

- add `graph.counterexample.shrink` for finite simple undirected graphs
- reuse the generic `shrink.run` engine with deterministic vertex- and edge-deletion reducers
- require an operator-registered preservation checker and independently verify every accepted reduction
- materialize a bound trace for every attempted reduction and report only the exact tested single-deletion scope
- support the bounded v1 `graph.property.non_bipartite` property without claiming global minimality
- document the contract and verification boundary

Closes #97.

## Design decisions

- The graph reducer remains an untrusted plugin; it cannot authorize its checker or certify preservation.
- Accepted steps carry immutable preservation verification records.
- Local minimality is reported only when the final graph is checker-accepted and every requested single deletion is tested exactly once and mathematically rejected.
- Timeout, budget exhaustion, checker error, tampering, and invalid reductions preserve the incumbent but leave local minimality incomplete.
- The generic shrinking trace now records execution and input status per step so graph-level reporting can distinguish mathematical rejection from operational failure.

## Validation

- Ruff check: passed
- Ruff format check: passed
- mypy over `src/jacobian` and `src/jacobian_checkers`: passed
- focused contract/integration/generic shrinking tests: 13 passed
- broader non-integration suite excluding two known local-environment files: 360 passed
- full local non-integration attempt: 370 passed; 5 pre-existing Bash 3.2 associative-array failures and 1 pre-existing SMT fixture failure; initial collection also lacked Hypothesis, which was installed before the clean 360-test rerun

The worktree used a macOS-compatible local Z3 4.15.4 wheel because the locked 4.16.0.0 package requires a source-build toolchain on this host. CI remains authoritative for the locked Linux environment.