### PR TITLE
Add exact two-sided polynomial map inverse verification

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -64,6 +64,7 @@ expectations.
 - [Exact rational matrix determinants](reference/matrix-rational-determinant.md)
 - [Integer matrix Hermite normal form](reference/matrix-hermite-normal-form.md)
 - [Typed polynomial expression normalization](reference/polynomial-expression-normalization.md)
+- [Polynomial-map inverse verification](reference/polynomial-map-inverse-verification.md)
 - [v0.2 specification](reference/specifications/v0.2.md)
 - [v0.2 conformance specification](reference/conformance-v0.2.md)
 - [Plugin conformance contract](reference/plugin-conformance.md)

--- a/docs/reference/polynomial-map-inverse-verification.md
+++ b/docs/reference/polynomial-map-inverse-verification.md
@@ -1,0 +1,40 @@
+# Polynomial-map inverse verification
+
+`polynomial.map.inverse.verify` verifies a proposed inverse of a square sparse
+polynomial map over `QQ`. It is a verification capability, not an inverse
+search or synthesis operation.
+
+The request supplies:
+
+- a forward map whose ordered input variables equal `source_variables`;
+- an inverse map whose ordered input variables equal `target_variables`;
+- explicit source and target variable orders of the same dimension.
+
+The adapter computes and stores both residual families:
+
+1. `inverse_after_forward`, in the source-variable ring;
+2. `forward_after_inverse`, in the target-variable ring.
+
+Every residual coordinate is sent through `polynomial.identity.verify` against
+zero, and the resulting checker-record URIs are bound into the residual
+artifact and the aggregate certificate. The authorized aggregate checker does
+not trust those records as a substitute for checking: in a clean process it
+parses both source maps, recomputes both compositions using independent sparse
+rational arithmetic, compares every declared residual exactly, and accepts an
+inverse only if every residual in both directions is zero.
+
+The output binds the two source-map artifacts, coefficient domain, both
+variable orders, both residual families, both checker-record families, the
+claim, certificate, and aggregate verification record. A nonzero residual
+produces a verified `FALSE`; malformed, substituted, incomplete, or
+inconsistently ordered evidence fails closed as `UNKNOWN`.
+
+The v1 bounds and canonical term rules are inherited from
+`jacobian.rational-polynomial-map`: dimensions are at most four, coefficients
+are canonical reduced rationals, and monomials use the declared variable order.
+The request is rejected before artifact creation when conservative composition
+bounds exceed 1,024 residual terms or total degree 127; this keeps both the
+producer and independent replay within the registered sparse-polynomial
+contract.
+Rational-map inverses and inverse-candidate synthesis are outside this
+capability.

--- a/src/jacobian/contracts/polynomials.py
+++ b/src/jacobian/contracts/polynomials.py
@@ -224,6 +224,61 @@ class PolynomialIdentityRequest(ContractModel):
         return self
 
 
+class PolynomialMapInverseVerifyRequest(ContractModel):
+    forward_map: RationalPolynomialMap
+    inverse_map: RationalPolynomialMap
+    source_variables: tuple[PolynomialVariable, ...] = Field(min_length=1, max_length=4)
+    target_variables: tuple[PolynomialVariable, ...] = Field(min_length=1, max_length=4)
+
+    @model_validator(mode="after")
+    def require_compatible_ordered_rings(self) -> Self:
+        if self.forward_map.variables != self.source_variables:
+            raise ValueError("forward map variables must equal source_variables")
+        if self.inverse_map.variables != self.target_variables:
+            raise ValueError("inverse map variables must equal target_variables")
+        if len(self.source_variables) != len(self.target_variables):
+            raise ValueError("source and target dimensions must agree")
+        if len(set(self.source_variables)) != len(self.source_variables):
+            raise ValueError("source variables must be unique")
+        if len(set(self.target_variables)) != len(self.target_variables):
+            raise ValueError("target variables must be unique")
+        for outer, inner in (
+            (self.inverse_map, self.forward_map),
+            (self.forward_map, self.inverse_map),
+        ):
+            inner_term_counts = tuple(
+                len(coordinate.terms) for coordinate in inner.coordinates
+            )
+            for coordinate in outer.coordinates:
+                term_bound = 0
+                for term in coordinate.terms:
+                    term_bound += prod(
+                        count**exponent
+                        for count, exponent in zip(
+                            inner_term_counts,
+                            term.exponents,
+                            strict=True,
+                        )
+                    )
+                    if term_bound > 1024:
+                        raise ValueError("composition residual term bound exceeds 1024")
+                outer_degree = max(
+                    (sum(term.exponents) for term in coordinate.terms),
+                    default=0,
+                )
+                inner_degree = max(
+                    (
+                        sum(term.exponents)
+                        for inner_coordinate in inner.coordinates
+                        for term in inner_coordinate.terms
+                    ),
+                    default=0,
+                )
+                if outer_degree * inner_degree > _MAX_DERIVED_EXPONENT:
+                    raise ValueError("composition residual degree bound exceeds 127")
+        return self
+
+
 class PolynomialCollisionSearchRequest(ContractModel):
     map: RationalPolynomialMap
     max_abs_numerator: int = Field(ge=0, le=8)
@@ -337,6 +392,58 @@ class PolynomialIdentityReplayPayload(ContractModel):
     variables: tuple[PolynomialVariable, ...] = Field(min_length=1, max_length=4)
     left_uri: ArtifactUri
     right_uri: ArtifactUri
+
+
+class PolynomialMapInverseClaim(ContractModel):
+    claim_schema_version: Literal["1"] = "1"
+    predicate: Literal["POLYNOMIAL_MAP_TWO_SIDED_INVERSE"] = (
+        "POLYNOMIAL_MAP_TWO_SIDED_INVERSE"
+    )
+    domain: Literal["QQ"] = "QQ"
+    forward_map_uri: ArtifactUri
+    inverse_map_uri: ArtifactUri
+    source_variables: tuple[PolynomialVariable, ...]
+    target_variables: tuple[PolynomialVariable, ...]
+
+
+class PolynomialMapCompositionResiduals(ContractModel):
+    residual_schema_version: Literal["1"] = "1"
+    domain: Literal["QQ"] = "QQ"
+    forward_map_uri: ArtifactUri
+    inverse_map_uri: ArtifactUri
+    source_variables: tuple[PolynomialVariable, ...]
+    target_variables: tuple[PolynomialVariable, ...]
+    inverse_after_forward: tuple[SparseRationalPolynomial, ...]
+    forward_after_inverse: tuple[SparseRationalPolynomial, ...]
+    inverse_after_forward_checker_records: tuple[ArtifactUri, ...]
+    forward_after_inverse_checker_records: tuple[ArtifactUri, ...]
+
+    @model_validator(mode="after")
+    def require_complete_two_sided_bundle(self) -> Self:
+        dimension = len(self.source_variables)
+        if not (
+            dimension
+            == len(self.target_variables)
+            == len(self.inverse_after_forward)
+            == len(self.forward_after_inverse)
+            == len(self.inverse_after_forward_checker_records)
+            == len(self.forward_after_inverse_checker_records)
+        ):
+            raise ValueError(
+                "both residual and checker-record families must be complete"
+            )
+        return self
+
+
+class PolynomialMapInverseReplayPayload(ContractModel):
+    method: Literal["DIRECT_TWO_SIDED_SPARSE_REPLAY"] = "DIRECT_TWO_SIDED_SPARSE_REPLAY"
+    forward_map_uri: ArtifactUri
+    inverse_map_uri: ArtifactUri
+    residuals_uri: ArtifactUri
+    source_variables: tuple[PolynomialVariable, ...]
+    target_variables: tuple[PolynomialVariable, ...]
+    inverse_after_forward_checker_records: tuple[ArtifactUri, ...]
+    forward_after_inverse_checker_records: tuple[ArtifactUri, ...]
 
 
 class PolynomialJacobianReplayPayload(ContractModel):
@@ -478,6 +585,37 @@ class PolynomialIdentityOutput(ContractModel):
             )
         if self.identical is not expected[self.conclusion]:
             raise ValueError("identical must preserve an unknown checker conclusion")
+        return self
+
+
+class PolynomialMapInverseVerifyOutput(ContractModel):
+    inverse_verified: bool | None
+    conclusion: Conclusion
+    forward_map_uri: ArtifactUri
+    inverse_map_uri: ArtifactUri
+    residuals_uri: ArtifactUri
+    claim_uri: ArtifactUri
+    certificate_uri: ArtifactUri
+    inverse_after_forward_checker_records: tuple[ArtifactUri, ...]
+    forward_after_inverse_checker_records: tuple[ArtifactUri, ...]
+    verification_record_uri: ArtifactUri | None = None
+    checker_id: CheckerUri
+    domain: Literal["QQ"] = "QQ"
+    source_variables: tuple[PolynomialVariable, ...]
+    target_variables: tuple[PolynomialVariable, ...]
+    exactness: PolynomialExactness = PolynomialExactness.EXACT
+
+    @model_validator(mode="after")
+    def inverse_matches_conclusion(self) -> Self:
+        expected = {
+            Conclusion.TRUE: True,
+            Conclusion.FALSE: False,
+            Conclusion.UNKNOWN: None,
+        }
+        if self.conclusion not in expected:
+            raise ValueError("inverse conclusion must be TRUE, FALSE, or UNKNOWN")
+        if self.inverse_verified is not expected[self.conclusion]:
+            raise ValueError("inverse_verified must preserve checker conclusion")
         return self
 
 

--- a/src/jacobian/polynomial_capabilities.py
+++ b/src/jacobian/polynomial_capabilities.py
@@ -63,7 +63,12 @@ from jacobian.contracts.polynomials import (
     PolynomialJacobianOutput,
     PolynomialJacobianReplayPayload,
     PolynomialJacobianRequest,
+    PolynomialMapCompositionResiduals,
     PolynomialMapEvaluation,
+    PolynomialMapInverseClaim,
+    PolynomialMapInverseReplayPayload,
+    PolynomialMapInverseVerifyOutput,
+    PolynomialMapInverseVerifyRequest,
     RationalPolynomial,
     RationalPolynomialMap,
     RationalPolynomialPoint,
@@ -90,6 +95,7 @@ class PolynomialInstallation:
     polynomial_semantics_uri: str
     factorization_semantics_uri: str
     identity_semantics_uri: str
+    inverse_semantics_uri: str
     map_schema_uri: str
     evaluation_schema_uri: str
     jacobian_schema_uri: str
@@ -98,6 +104,8 @@ class PolynomialInstallation:
     right_polynomial_schema_uri: str
     left_polynomial_schema_uri: str
     identity_claim_schema_uri: str
+    inverse_claim_schema_uri: str
+    inverse_residual_schema_uri: str
     witness_schema_uri: str
     certificate_schema_uri: str
     polynomial_schema_uri: str
@@ -105,6 +113,7 @@ class PolynomialInstallation:
     collision_checker_id: str | None
     jacobian_checker_id: str | None
     identity_checker_id: str | None
+    inverse_checker_id: str | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -132,6 +141,7 @@ def install_polynomial_capabilities(
         PolynomialCollisionSearchAdapter,
         PolynomialCollisionVerifyAdapter,
         PolynomialFactorAdapter,
+        PolynomialMapInverseVerifyAdapter,
     ],
     PolynomialInstallation,
 ]:
@@ -170,6 +180,20 @@ def install_polynomial_capabilities(
             "maximum_exponent": 127,
             "monomial_order": "descending lexicographic",
             "zero_terms": "omitted",
+        },
+    )
+    inverse_semantics_uri = store.register_descriptor(
+        kind="semantics",
+        name="jacobian.rational-polynomial-map-two-sided-inverse",
+        version="1",
+        definition={
+            "description": (
+                "two square sparse polynomial maps over QQ are inverse only when "
+                "both ordered exact compositions are identity"
+            ),
+            "coefficient_field": "QQ",
+            "directions": ["inverse_after_forward", "forward_after_inverse"],
+            "one_sided_identity": "insufficient",
         },
     )
     polynomial_semantics_uri = store.register_descriptor(
@@ -242,6 +266,16 @@ def install_polynomial_capabilities(
         version="1",
         schema=model_schema(PolynomialIdentityClaim),
     )
+    inverse_claim_schema_uri = schemas.register(
+        name="jacobian.polynomial-map-inverse-claim",
+        version="1",
+        schema=model_schema(PolynomialMapInverseClaim),
+    )
+    inverse_residual_schema_uri = schemas.register(
+        name="jacobian.polynomial-map-composition-residuals",
+        version="1",
+        schema=model_schema(PolynomialMapCompositionResiduals),
+    )
     witness_schema_uri = schemas.register(
         name="jacobian.witness-envelope",
         version="1",
@@ -265,6 +299,7 @@ def install_polynomial_capabilities(
     collision_checker_id = None
     jacobian_checker_id = None
     identity_checker_id = None
+    inverse_checker_id = None
     if authorize_checker:
         collision_checker_id = checkers.authorize(
             name="exact rational polynomial-map collision checker",
@@ -299,11 +334,23 @@ def install_polynomial_capabilities(
             candidate_schema_uris=(right_polynomial_schema_uri,),
             reason="bundled independent sparse-polynomial identity checker",
         ).checker_id
+        inverse_checker_id = checkers.authorize(
+            name="exact two-sided polynomial-map inverse checker",
+            entrypoint="jacobian_checkers.polynomial_maps:check_map_inverse",
+            evidence_kind="CERTIFICATE",
+            format_id="polynomial.map.inverse.two_sided_replay",
+            format_version="1",
+            claim_schema_uris=(inverse_claim_schema_uri,),
+            semantics_uris=(inverse_semantics_uri,),
+            candidate_schema_uris=(inverse_residual_schema_uri,),
+            reason="bundled independent two-sided sparse-polynomial map checker",
+        ).checker_id
     installation = PolynomialInstallation(
         semantics_uri=semantics_uri,
         polynomial_semantics_uri=polynomial_semantics_uri,
         factorization_semantics_uri=factorization_semantics_uri,
         identity_semantics_uri=identity_semantics_uri,
+        inverse_semantics_uri=inverse_semantics_uri,
         map_schema_uri=map_schema_uri,
         evaluation_schema_uri=evaluation_schema_uri,
         jacobian_schema_uri=jacobian_schema_uri,
@@ -312,6 +359,8 @@ def install_polynomial_capabilities(
         right_polynomial_schema_uri=right_polynomial_schema_uri,
         left_polynomial_schema_uri=left_polynomial_schema_uri,
         identity_claim_schema_uri=identity_claim_schema_uri,
+        inverse_claim_schema_uri=inverse_claim_schema_uri,
+        inverse_residual_schema_uri=inverse_residual_schema_uri,
         witness_schema_uri=witness_schema_uri,
         certificate_schema_uri=certificate_schema_uri,
         polynomial_schema_uri=polynomial_schema_uri,
@@ -319,6 +368,7 @@ def install_polynomial_capabilities(
         collision_checker_id=collision_checker_id,
         jacobian_checker_id=jacobian_checker_id,
         identity_checker_id=identity_checker_id,
+        inverse_checker_id=inverse_checker_id,
     )
     resources = PolynomialResources(
         store=store,
@@ -339,6 +389,11 @@ def install_polynomial_capabilities(
                 else ()
             ),
             PolynomialFactorAdapter(resources),
+            *(
+                (PolynomialMapInverseVerifyAdapter(resources),)
+                if inverse_checker_id is not None and identity_checker_id is not None
+                else ()
+            ),
         ),
         installation,
     )
@@ -1615,6 +1670,311 @@ class PolynomialIdentityAdapter:
                 ),
             ),
         )
+
+
+class PolynomialMapInverseVerifyAdapter:
+    """Verify both exact compositions of two square polynomial maps."""
+
+    def __init__(self, resources: PolynomialResources) -> None:
+        self.resources = resources
+        checker_id = resources.installation.inverse_checker_id
+        self._descriptor = CapabilityDescriptor(
+            capability_id="polynomial.map.inverse.verify",
+            version="1",
+            title="Verify a two-sided polynomial-map inverse",
+            description=(
+                "Independently replay both ordered polynomial-map compositions "
+                "over QQ and accept an inverse only when both are identity."
+            ),
+            provider="jacobian.sparse-polynomial-checker",
+            provider_runtime=known_provider_runtime(
+                "jacobian.sparse-polynomial-checker",
+                features=("polynomial-map-composition", "two-sided-inverse"),
+                checker_ids=((checker_id,) if checker_id is not None else ()),
+            ),
+            modes=(CapabilityMode.VERIFY,),
+            input_schema=model_schema(PolynomialMapInverseVerifyRequest),
+            output_schema=model_schema(PolynomialMapInverseVerifyOutput),
+            tags=("polynomial", "map", "inverse", "verification", "exact-rational"),
+        )
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        return self._descriptor
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        validated = _validate_request(
+            PolynomialMapInverseVerifyRequest,
+            request.input,
+            code="INVALID_POLYNOMIAL_MAP_INVERSE_REQUEST",
+            operation="map inverse verification",
+        )
+        checker_id = self.resources.installation.inverse_checker_id
+        if checker_id is None:
+            raise _polynomial_error(
+                "POLYNOMIAL_MAP_INVERSE_CHECKER_UNAVAILABLE",
+                "inverse_verification",
+                "No authorized polynomial-map inverse checker is installed.",
+            )
+        semantics_uri = self.resources.installation.inverse_semantics_uri
+        forward = self.resources.artifacts.put(
+            schema_uri=self.resources.installation.map_schema_uri,
+            semantics_uri=semantics_uri,
+            payload=validated.forward_map.model_dump(mode="json"),
+            summary="forward sparse rational polynomial map",
+        )
+        inverse = self.resources.artifacts.put(
+            schema_uri=self.resources.installation.map_schema_uri,
+            semantics_uri=semantics_uri,
+            payload=validated.inverse_map.model_dump(mode="json"),
+            summary="candidate inverse sparse rational polynomial map",
+        )
+        left_residuals, right_residuals = _map_inverse_residuals(validated)
+        identity_adapter = PolynomialIdentityAdapter(self.resources)
+        zero = SparseRationalPolynomial()
+        left_records: list[str] = []
+        right_records: list[str] = []
+        identity_artifacts: list[str] = []
+        for variables, residuals, records in (
+            (validated.source_variables, left_residuals, left_records),
+            (validated.target_variables, right_residuals, right_records),
+        ):
+            for residual in residuals:
+                checked = identity_adapter.invoke(
+                    CapabilityRequest(
+                        capability_id="polynomial.identity.verify",
+                        mode=CapabilityMode.VERIFY,
+                        input=PolynomialIdentityRequest(
+                            variables=variables,
+                            left=residual,
+                            right=zero,
+                        ).model_dump(mode="json"),
+                    )
+                )
+                record_uri = checked.output.get("verification_record_uri")
+                if not isinstance(record_uri, str):
+                    raise _polynomial_error(
+                        "POLYNOMIAL_IDENTITY_REPLAY_UNAVAILABLE",
+                        "composition_identity_replay",
+                        "A composition residual could not obtain a checker record.",
+                    )
+                records.append(record_uri)
+                identity_artifacts.extend(checked.artifact_uris)
+        residual_payload = PolynomialMapCompositionResiduals(
+            forward_map_uri=forward.artifact_uri,
+            inverse_map_uri=inverse.artifact_uri,
+            source_variables=validated.source_variables,
+            target_variables=validated.target_variables,
+            inverse_after_forward=left_residuals,
+            forward_after_inverse=right_residuals,
+            inverse_after_forward_checker_records=tuple(left_records),
+            forward_after_inverse_checker_records=tuple(right_records),
+        )
+        residual_artifact = self.resources.artifacts.put(
+            schema_uri=self.resources.installation.inverse_residual_schema_uri,
+            semantics_uri=semantics_uri,
+            payload=residual_payload.model_dump(mode="json"),
+            parents=tuple(
+                dict.fromkeys(
+                    (
+                        forward.artifact_uri,
+                        inverse.artifact_uri,
+                        *left_records,
+                        *right_records,
+                    )
+                )
+            ),
+            summary="both exact polynomial-map composition residual families",
+        )
+        claim = self.resources.artifacts.put(
+            schema_uri=self.resources.installation.inverse_claim_schema_uri,
+            semantics_uri=semantics_uri,
+            payload=PolynomialMapInverseClaim(
+                forward_map_uri=forward.artifact_uri,
+                inverse_map_uri=inverse.artifact_uri,
+                source_variables=validated.source_variables,
+                target_variables=validated.target_variables,
+            ).model_dump(mode="json"),
+            parents=(forward.artifact_uri, inverse.artifact_uri),
+            summary="two-sided polynomial-map inverse claim",
+        )
+        semantics = self.resources.store.get(semantics_uri)
+        replay = PolynomialMapInverseReplayPayload(
+            forward_map_uri=forward.artifact_uri,
+            inverse_map_uri=inverse.artifact_uri,
+            residuals_uri=residual_artifact.artifact_uri,
+            source_variables=validated.source_variables,
+            target_variables=validated.target_variables,
+            inverse_after_forward_checker_records=tuple(left_records),
+            forward_after_inverse_checker_records=tuple(right_records),
+        )
+        replay_payload = replay.model_dump(mode="json")
+        certificate = CertificateEnvelope(
+            certificate_type="polynomial.map.inverse.two_sided_replay",
+            format_version="1",
+            bindings=EvidenceBindings(
+                claim_digest=claim.object_digest,
+                semantics_digest=semantics.manifest.object_digest,
+                candidate_digest=residual_artifact.object_digest,
+                scope_digest=forward.object_digest,
+            ),
+            payload_digest=(
+                "sha256:"
+                + hashlib.sha256(canonicalize_json(replay_payload)).hexdigest()
+            ),
+            payload=replay_payload,
+        )
+        certificate_artifact = self.resources.artifacts.put(
+            schema_uri=self.resources.installation.certificate_schema_uri,
+            semantics_uri=semantics_uri,
+            payload=certificate.model_dump(mode="json"),
+            parents=tuple(
+                dict.fromkeys(
+                    (
+                        claim.artifact_uri,
+                        residual_artifact.artifact_uri,
+                        forward.artifact_uri,
+                        inverse.artifact_uri,
+                        *left_records,
+                        *right_records,
+                    )
+                )
+            ),
+            summary="two-sided exact polynomial-map inverse replay certificate",
+        )
+        supporting = (inverse.artifact_uri, *left_records, *right_records)
+        aggregate_checked = self.resources.verification.verify_certificate(
+            certificate_uri=certificate_artifact.artifact_uri,
+            checker_id=checker_id,
+            supporting_artifact_uris=supporting,
+        )
+        verified = aggregate_checked.verification_record_uri is not None
+        conclusion = aggregate_checked.conclusion
+        output = PolynomialMapInverseVerifyOutput(
+            inverse_verified={
+                Conclusion.TRUE: True,
+                Conclusion.FALSE: False,
+                Conclusion.UNKNOWN: None,
+            }[conclusion],
+            conclusion=conclusion,
+            forward_map_uri=forward.artifact_uri,
+            inverse_map_uri=inverse.artifact_uri,
+            residuals_uri=residual_artifact.artifact_uri,
+            claim_uri=claim.artifact_uri,
+            certificate_uri=certificate_artifact.artifact_uri,
+            inverse_after_forward_checker_records=tuple(left_records),
+            forward_after_inverse_checker_records=tuple(right_records),
+            verification_record_uri=aggregate_checked.verification_record_uri,
+            checker_id=checker_id,
+            source_variables=validated.source_variables,
+            target_variables=validated.target_variables,
+        )
+        return CapabilityResult(
+            capability_id=self.descriptor.capability_id,
+            capability_version=self.descriptor.version,
+            mode=request.mode,
+            execution=aggregate_checked.execution,
+            output=output.model_dump(mode="json"),
+            scope=CapabilityScope(
+                description="both ordered polynomial compositions over QQ",
+                parameters={
+                    "source_variables": list(validated.source_variables),
+                    "target_variables": list(validated.target_variables),
+                },
+                artifact_uri=forward.artifact_uri,
+            ),
+            completeness=CapabilityCompleteness(
+                status=(
+                    CapabilityCompletenessStatus.COMPLETE
+                    if verified
+                    else CapabilityCompletenessStatus.UNKNOWN
+                ),
+                basis=(
+                    "both complete composition residual families were independently replayed"
+                    if verified
+                    else "the aggregate independent checker did not accept the replay"
+                ),
+                assurance_level=(
+                    CapabilityAssuranceLevel.VERIFIED
+                    if verified
+                    else CapabilityAssuranceLevel.COMPUTED
+                ),
+                verification_record_uri=aggregate_checked.verification_record_uri,
+            ),
+            relationships=(),
+            assurance=CapabilityAssurance(
+                level=(
+                    CapabilityAssuranceLevel.VERIFIED
+                    if verified
+                    else CapabilityAssuranceLevel.HEURISTIC
+                ),
+                basis=(
+                    "accepted by the authorized independent two-sided map checker"
+                    if verified
+                    else "the independent checker did not accept the inverse request"
+                ),
+                verification_record_uri=aggregate_checked.verification_record_uri,
+            ),
+            artifact_uris=tuple(
+                dict.fromkeys(
+                    (
+                        forward.artifact_uri,
+                        inverse.artifact_uri,
+                        residual_artifact.artifact_uri,
+                        claim.artifact_uri,
+                        certificate_artifact.artifact_uri,
+                        *identity_artifacts,
+                        *(
+                            (aggregate_checked.verification_record_uri,)
+                            if aggregate_checked.verification_record_uri is not None
+                            else ()
+                        ),
+                    )
+                )
+            ),
+        )
+
+
+def _map_inverse_residuals(
+    request: PolynomialMapInverseVerifyRequest,
+) -> tuple[
+    tuple[SparseRationalPolynomial, ...],
+    tuple[SparseRationalPolynomial, ...],
+]:
+    source_generators, forward = _sympy_map(request.forward_map)
+    target_generators, inverse = _sympy_map(request.inverse_map)
+
+    def compose_residuals(
+        outer: tuple[Poly, ...],
+        outer_generators: tuple[Any, ...],
+        inner: tuple[Poly, ...],
+        result_generators: tuple[Any, ...],
+    ) -> tuple[SparseRationalPolynomial, ...]:
+        substitutions = {
+            generator: polynomial.as_expr()
+            for generator, polynomial in zip(outer_generators, inner, strict=True)
+        }
+        return tuple(
+            _wire_polynomial(
+                Poly(
+                    expand(
+                        polynomial.as_expr().subs(
+                            substitutions,
+                            simultaneous=True,
+                        )
+                    )
+                    - result_generators[index],
+                    *result_generators,
+                    domain=QQ,
+                )
+            )
+            for index, polynomial in enumerate(outer)
+        )
+
+    return (
+        compose_residuals(inverse, target_generators, forward, source_generators),
+        compose_residuals(forward, source_generators, inverse, target_generators),
+    )
 
 
 def _validate_request[RequestModel: ContractModel](

--- a/src/jacobian_checkers/polynomial_maps.py
+++ b/src/jacobian_checkers/polynomial_maps.py
@@ -1,4 +1,4 @@
-"""Independent exact replay for sparse rational polynomial-map collisions."""
+"""Independent exact replay for sparse rational polynomial-map claims."""
 
 from __future__ import annotations
 
@@ -330,6 +330,188 @@ def check_identity(request: dict[str, Any]) -> dict[str, Any]:
         }
     except (KeyError, TypeError, ValueError, ZeroDivisionError):
         return _reject("malformed polynomial identity request")
+
+
+def check_map_inverse(request: dict[str, Any]) -> dict[str, Any]:
+    """Independently replay both polynomial-map compositions over QQ."""
+
+    try:
+        if request.get("request_version") != "1":
+            return _reject("unsupported request version")
+        claim_artifact = request["claim"]
+        claim = claim_artifact["payload"]
+        forward_artifact = request["scope"]
+        residual_artifact = request["candidate"]
+        certificate = request["certificate"]["payload"]
+        supporting = request.get("supporting_artifacts", [])
+        if (
+            not isinstance(claim, dict)
+            or claim.get("claim_schema_version") != "1"
+            or claim.get("predicate") != "POLYNOMIAL_MAP_TWO_SIDED_INVERSE"
+            or claim.get("domain") != "QQ"
+            or not isinstance(forward_artifact, dict)
+            or not isinstance(residual_artifact, dict)
+            or not isinstance(supporting, list)
+        ):
+            return _reject("unexpected polynomial-map inverse claim")
+        inverse_matches = [
+            artifact
+            for artifact in supporting
+            if artifact.get("artifact_uri") == claim.get("inverse_map_uri")
+        ]
+        if len(inverse_matches) != 1:
+            return _reject("inverse source artifact is missing or duplicated")
+        inverse_artifact = inverse_matches[0]
+        forward_uri = forward_artifact.get("artifact_uri")
+        inverse_uri = inverse_artifact.get("artifact_uri")
+        residual_uri = residual_artifact.get("artifact_uri")
+        if (
+            claim.get("forward_map_uri") != forward_uri
+            or claim.get("inverse_map_uri") != inverse_uri
+        ):
+            return _reject("source map artifact bindings do not match")
+        dimension, source_variables, forward = _parse_map(
+            forward_artifact.get("payload")
+        )
+        inverse_dimension, target_variables, inverse = _parse_map(
+            inverse_artifact.get("payload")
+        )
+        if (
+            dimension != inverse_dimension
+            or claim.get("source_variables") != list(source_variables)
+            or claim.get("target_variables") != list(target_variables)
+        ):
+            return _reject("coefficient domain, dimension, or variable order mismatch")
+        residual = residual_artifact.get("payload")
+        if (
+            not isinstance(residual, dict)
+            or residual.get("residual_schema_version") != "1"
+            or residual.get("domain") != "QQ"
+            or residual.get("forward_map_uri") != forward_uri
+            or residual.get("inverse_map_uri") != inverse_uri
+            or residual.get("source_variables") != list(source_variables)
+            or residual.get("target_variables") != list(target_variables)
+        ):
+            return _reject("composition residual artifact binding mismatch")
+        replay_payload = certificate.get("payload")
+        expected_records = residual.get(
+            "inverse_after_forward_checker_records", []
+        ) + residual.get("forward_after_inverse_checker_records", [])
+        supporting_uris = [artifact.get("artifact_uri") for artifact in supporting]
+        if (
+            certificate.get("certificate_type")
+            != "polynomial.map.inverse.two_sided_replay"
+            or certificate.get("format_version") != "1"
+            or certificate.get("bindings") != request.get("expected_bindings")
+            or not isinstance(replay_payload, dict)
+            or replay_payload.get("method") != "DIRECT_TWO_SIDED_SPARSE_REPLAY"
+            or replay_payload.get("forward_map_uri") != forward_uri
+            or replay_payload.get("inverse_map_uri") != inverse_uri
+            or replay_payload.get("residuals_uri") != residual_uri
+            or replay_payload.get("source_variables") != list(source_variables)
+            or replay_payload.get("target_variables") != list(target_variables)
+            or replay_payload.get("inverse_after_forward_checker_records")
+            != residual.get("inverse_after_forward_checker_records")
+            or replay_payload.get("forward_after_inverse_checker_records")
+            != residual.get("forward_after_inverse_checker_records")
+            or not isinstance(
+                residual.get("inverse_after_forward_checker_records"), list
+            )
+            or len(residual["inverse_after_forward_checker_records"]) != dimension
+            or not isinstance(
+                residual.get("forward_after_inverse_checker_records"), list
+            )
+            or len(residual["forward_after_inverse_checker_records"]) != dimension
+            or any(uri not in supporting_uris for uri in expected_records)
+        ):
+            return _reject("two-sided replay certificate or checker records mismatch")
+        expected_left = _composition_residuals(
+            outer=inverse, inner=forward, dimension=dimension
+        )
+        expected_right = _composition_residuals(
+            outer=forward, inner=inverse, dimension=dimension
+        )
+        declared_left = _parse_residual_family(
+            residual.get("inverse_after_forward"), dimension
+        )
+        declared_right = _parse_residual_family(
+            residual.get("forward_after_inverse"), dimension
+        )
+        if declared_left != expected_left or declared_right != expected_right:
+            return _reject("declared composition residuals do not replay exactly")
+        inverse_holds = all(not polynomial for polynomial in expected_left) and all(
+            not polynomial for polynomial in expected_right
+        )
+        return {
+            "accepted": True,
+            "conclusion": "TRUE" if inverse_holds else "FALSE",
+            "arithmetic": "EXACT_RATIONAL",
+            "method": "CHECKED_CERTIFICATE",
+            "coverage": "EXHAUSTIVE",
+            "detail": (
+                "both exact polynomial compositions are identity"
+                if inverse_holds
+                else "at least one exact polynomial composition is not identity"
+            ),
+            **(
+                {
+                    "relation_id": "polynomial.relation.two-sided-inverse",
+                    "relationship_source_artifact_uris": [forward_uri, inverse_uri],
+                    "relationship_target_artifact_uris": [
+                        claim_artifact["artifact_uri"]
+                    ],
+                }
+                if inverse_holds
+                else {}
+            ),
+        }
+    except (KeyError, TypeError, ValueError, ZeroDivisionError):
+        return _reject("malformed polynomial-map inverse replay request")
+
+
+def _parse_residual_family(value: object, dimension: int) -> tuple[Polynomial, ...]:
+    if not isinstance(value, list) or len(value) != dimension:
+        raise ValueError("residual family dimension mismatch")
+    return tuple(
+        _as_polynomial(
+            _parse_polynomial(item, dimension, maximum_exponent=_MAX_DERIVED_EXPONENT)
+        )
+        for item in value
+    )
+
+
+def _composition_residuals(
+    *,
+    outer: tuple[ParsedPolynomial, ...],
+    inner: tuple[ParsedPolynomial, ...],
+    dimension: int,
+) -> tuple[Polynomial, ...]:
+    inner_polynomials = tuple(_as_polynomial(item) for item in inner)
+    result: list[Polynomial] = []
+    one = {(0,) * dimension: Fraction(1)}
+    for coordinate_index, coordinate in enumerate(outer):
+        composed: Polynomial = {}
+        for coefficient, exponents in coordinate:
+            term = one
+            for polynomial, exponent in zip(inner_polynomials, exponents, strict=True):
+                power = one
+                for _ in range(exponent):
+                    power = _multiply(power, polynomial)
+                term = _multiply(term, power)
+            for monomial, value in term.items():
+                composed[monomial] = (
+                    composed.get(monomial, Fraction(0)) + coefficient * value
+                )
+                if composed[monomial] == 0:
+                    del composed[monomial]
+        identity_exponent = tuple(
+            1 if index == coordinate_index else 0 for index in range(dimension)
+        )
+        composed[identity_exponent] = composed.get(identity_exponent, Fraction(0)) - 1
+        if composed[identity_exponent] == 0:
+            del composed[identity_exponent]
+        result.append(composed)
+    return tuple(result)
 
 
 def check_jacobian(request: dict[str, Any]) -> dict[str, Any]:

--- a/tests/checkers/test_polynomial_map_inverse_checker.py
+++ b/tests/checkers/test_polynomial_map_inverse_checker.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+import pytest
+
+from jacobian_checkers.polynomial_maps import check_map_inverse
+
+
+def _uri(digit: str) -> str:
+    return "artifact://sha256/" + digit * 64
+
+
+def _term(coefficient: str, exponents: list[int]) -> dict[str, Any]:
+    return {
+        "coefficient": {"num": coefficient, "den": "1"},
+        "exponents": exponents,
+    }
+
+
+def _map(variables: list[str], *, inverse: bool) -> dict[str, Any]:
+    return {
+        "map_schema_version": "1",
+        "domain": "QQ",
+        "variables": variables,
+        "coordinates": [
+            {
+                "terms": [
+                    _term("1", [1, 0]),
+                    _term("-1" if inverse else "1", [0, 2]),
+                ]
+            },
+            {"terms": [_term("1", [0, 1])]},
+        ],
+    }
+
+
+def _request() -> dict[str, Any]:
+    forward_uri = _uri("1")
+    inverse_uri = _uri("2")
+    residual_uri = _uri("3")
+    left_records = [_uri("4"), _uri("5")]
+    right_records = [_uri("6"), _uri("7")]
+    bindings = {
+        "claim_digest": "sha256:" + "8" * 64,
+        "semantics_digest": "sha256:" + "9" * 64,
+        "candidate_digest": "sha256:" + "a" * 64,
+        "scope_digest": "sha256:" + "b" * 64,
+        "encoding_digest": None,
+    }
+    replay = {
+        "method": "DIRECT_TWO_SIDED_SPARSE_REPLAY",
+        "forward_map_uri": forward_uri,
+        "inverse_map_uri": inverse_uri,
+        "residuals_uri": residual_uri,
+        "source_variables": ["x", "y"],
+        "target_variables": ["u", "v"],
+        "inverse_after_forward_checker_records": left_records,
+        "forward_after_inverse_checker_records": right_records,
+    }
+    return {
+        "request_version": "1",
+        "claim": {
+            "artifact_uri": _uri("c"),
+            "payload": {
+                "claim_schema_version": "1",
+                "predicate": "POLYNOMIAL_MAP_TWO_SIDED_INVERSE",
+                "domain": "QQ",
+                "forward_map_uri": forward_uri,
+                "inverse_map_uri": inverse_uri,
+                "source_variables": ["x", "y"],
+                "target_variables": ["u", "v"],
+            },
+        },
+        "scope": {
+            "artifact_uri": forward_uri,
+            "payload": _map(["x", "y"], inverse=False),
+        },
+        "candidate": {
+            "artifact_uri": residual_uri,
+            "payload": {
+                "residual_schema_version": "1",
+                "domain": "QQ",
+                "forward_map_uri": forward_uri,
+                "inverse_map_uri": inverse_uri,
+                "source_variables": ["x", "y"],
+                "target_variables": ["u", "v"],
+                "inverse_after_forward": [{"terms": []}, {"terms": []}],
+                "forward_after_inverse": [{"terms": []}, {"terms": []}],
+                "inverse_after_forward_checker_records": left_records,
+                "forward_after_inverse_checker_records": right_records,
+            },
+        },
+        "certificate": {
+            "payload": {
+                "evidence_schema_version": "1",
+                "certificate_type": "polynomial.map.inverse.two_sided_replay",
+                "format_version": "1",
+                "bindings": deepcopy(bindings),
+                "payload_digest": "sha256:" + "d" * 64,
+                "payload": replay,
+            }
+        },
+        "supporting_artifacts": [
+            {"artifact_uri": inverse_uri, "payload": _map(["u", "v"], inverse=True)},
+            *[
+                {"artifact_uri": uri, "payload": {}}
+                for uri in (*left_records, *right_records)
+            ],
+        ],
+        "expected_bindings": deepcopy(bindings),
+    }
+
+
+def test_inverse_checker_accepts_both_exact_compositions() -> None:
+    decision = check_map_inverse(_request())
+
+    assert decision["accepted"] is True
+    assert decision["conclusion"] == "TRUE"
+
+
+@pytest.mark.parametrize(
+    ("zero_direction", "forged_direction"),
+    (
+        ("inverse_after_forward", "forward_after_inverse"),
+        ("forward_after_inverse", "inverse_after_forward"),
+    ),
+)
+def test_inverse_checker_never_accepts_one_declared_identity_direction(
+    zero_direction: str,
+    forged_direction: str,
+) -> None:
+    request = _request()
+    request["candidate"]["payload"][zero_direction] = [
+        {"terms": []},
+        {"terms": []},
+    ]
+    request["candidate"]["payload"][forged_direction] = [
+        {"terms": [_term("1", [0, 0])]},
+        {"terms": []},
+    ]
+
+    decision = check_map_inverse(request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+@pytest.mark.parametrize("source", ("forward", "inverse"))
+def test_inverse_checker_rejects_source_coefficient_tampering(source: str) -> None:
+    request = _request()
+    artifact = (
+        request["scope"] if source == "forward" else request["supporting_artifacts"][0]
+    )
+    artifact["payload"]["coordinates"][0]["terms"][0]["coefficient"]["num"] = "2"
+
+    decision = check_map_inverse(request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+@pytest.mark.parametrize("tamper", ("domain", "source_order", "target_order"))
+def test_inverse_checker_rejects_domain_and_order_mismatch(tamper: str) -> None:
+    request = _request()
+    if tamper == "domain":
+        request["scope"]["payload"]["domain"] = "ZZ"
+    elif tamper == "source_order":
+        request["candidate"]["payload"]["source_variables"] = ["y", "x"]
+    else:
+        request["candidate"]["payload"]["target_variables"] = ["v", "u"]
+
+    decision = check_map_inverse(request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+@pytest.mark.parametrize(
+    "family",
+    (
+        "inverse_after_forward_checker_records",
+        "forward_after_inverse_checker_records",
+    ),
+)
+def test_inverse_checker_rejects_incomplete_checker_record_family(
+    family: str,
+) -> None:
+    request = _request()
+    request["candidate"]["payload"][family] = request["candidate"]["payload"][family][
+        :-1
+    ]
+    request["certificate"]["payload"]["payload"][family] = request["certificate"][
+        "payload"
+    ]["payload"][family][:-1]
+
+    decision = check_map_inverse(request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"

--- a/tests/integration/test_polynomial_map_inverse_verify.py
+++ b/tests/integration/test_polynomial_map_inverse_verify.py
@@ -1,0 +1,309 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from jacobian.contracts.capabilities import (
+    CapabilityAssuranceLevel,
+    CapabilityMode,
+    CapabilityRequest,
+)
+from jacobian.contracts.results import Conclusion, ExecutionStatus
+from jacobian.kernel import JacobianKernel
+from jacobian_checkers.polynomial_maps import check_map_inverse
+
+
+def _term(coefficient: int, exponents: list[int]) -> dict[str, Any]:
+    return {
+        "coefficient": {"num": str(coefficient), "den": "1"},
+        "exponents": exponents,
+    }
+
+
+def _triangular_maps() -> tuple[dict[str, Any], dict[str, Any]]:
+    return (
+        {
+            "map_schema_version": "1",
+            "domain": "QQ",
+            "variables": ["x", "y"],
+            "coordinates": [
+                {"terms": [_term(1, [1, 0]), _term(1, [0, 2])]},
+                {"terms": [_term(1, [0, 1])]},
+            ],
+        },
+        {
+            "map_schema_version": "1",
+            "domain": "QQ",
+            "variables": ["u", "v"],
+            "coordinates": [
+                {"terms": [_term(1, [1, 0]), _term(-1, [0, 2])]},
+                {"terms": [_term(1, [0, 1])]},
+            ],
+        },
+    )
+
+
+def _request(forward: dict[str, Any], inverse: dict[str, Any]) -> CapabilityRequest:
+    return CapabilityRequest(
+        capability_id="polynomial.map.inverse.verify",
+        mode=CapabilityMode.VERIFY,
+        input={
+            "forward_map": forward,
+            "inverse_map": inverse,
+            "source_variables": ["x", "y"],
+            "target_variables": ["u", "v"],
+        },
+    )
+
+
+def _checker_request(kernel: JacobianKernel, output: dict[str, Any]) -> dict[str, Any]:
+    def artifact(uri: str) -> dict[str, Any]:
+        stored = kernel.store.get(uri)
+        return {"artifact_uri": uri, "payload": deepcopy(stored.payload)}
+
+    certificate = artifact(output["certificate_uri"])
+    return {
+        "request_version": "1",
+        "claim": artifact(output["claim_uri"]),
+        "candidate": artifact(output["residuals_uri"]),
+        "scope": artifact(output["forward_map_uri"]),
+        "certificate": certificate,
+        "supporting_artifacts": [
+            artifact(uri)
+            for uri in dict.fromkeys(
+                (
+                    output["inverse_map_uri"],
+                    *output["inverse_after_forward_checker_records"],
+                    *output["forward_after_inverse_checker_records"],
+                )
+            )
+        ],
+        "expected_bindings": deepcopy(certificate["payload"]["bindings"]),
+    }
+
+
+@pytest.mark.integration
+def test_two_sided_triangular_inverse_is_verified(tmp_path: Path) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+    forward, inverse = _triangular_maps()
+
+    result = kernel.capabilities.invoke(_request(forward, inverse))
+
+    assert result.output["inverse_verified"] is True
+    assert result.output["conclusion"] == Conclusion.TRUE.value
+    assert result.assurance.level is CapabilityAssuranceLevel.VERIFIED
+    assert result.output["verification_record_uri"] is not None
+    assert len(result.output["inverse_after_forward_checker_records"]) == 2
+    assert len(result.output["forward_after_inverse_checker_records"]) == 2
+    residuals = kernel.store.get(result.output["residuals_uri"]).payload
+    assert residuals["domain"] == "QQ"
+    assert residuals["source_variables"] == ["x", "y"]
+    assert residuals["target_variables"] == ["u", "v"]
+    assert residuals["inverse_after_forward"] == [{"terms": []}, {"terms": []}]
+    assert residuals["forward_after_inverse"] == [{"terms": []}, {"terms": []}]
+
+
+@pytest.mark.integration
+def test_overlapping_variable_names_use_simultaneous_composition(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+    forward = {
+        "map_schema_version": "1",
+        "domain": "QQ",
+        "variables": ["x", "y"],
+        "coordinates": [
+            {"terms": [_term(1, [0, 1])]},
+            {"terms": [_term(1, [1, 0]), _term(1, [0, 0])]},
+        ],
+    }
+    inverse = {
+        "map_schema_version": "1",
+        "domain": "QQ",
+        "variables": ["x", "y"],
+        "coordinates": [
+            {"terms": [_term(1, [0, 1]), _term(-1, [0, 0])]},
+            {"terms": [_term(1, [1, 0])]},
+        ],
+    }
+
+    result = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="polynomial.map.inverse.verify",
+            mode=CapabilityMode.VERIFY,
+            input={
+                "forward_map": forward,
+                "inverse_map": inverse,
+                "source_variables": ["x", "y"],
+                "target_variables": ["x", "y"],
+            },
+        )
+    )
+
+    assert result.output["inverse_verified"] is True
+    assert result.output["conclusion"] == Conclusion.TRUE.value
+    assert result.assurance.level is CapabilityAssuranceLevel.VERIFIED
+
+
+@pytest.mark.integration
+def test_unrepresentable_composition_is_rejected_before_artifacts(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+    high_degree = {
+        "map_schema_version": "1",
+        "domain": "QQ",
+        "variables": ["x"],
+        "coordinates": [{"terms": [_term(1, [32])]}],
+    }
+    request = CapabilityRequest(
+        capability_id="polynomial.map.inverse.verify",
+        mode=CapabilityMode.VERIFY,
+        input={
+            "forward_map": high_degree,
+            "inverse_map": deepcopy(high_degree),
+            "source_variables": ["x"],
+            "target_variables": ["x"],
+        },
+    )
+
+    result = kernel.capabilities.invoke(request)
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.output["error"]["code"] == "INVALID_POLYNOMIAL_MAP_INVERSE_REQUEST"
+    assert result.artifact_uris == ()
+
+
+@pytest.mark.integration
+def test_perturbed_inverse_coefficient_is_verified_false(tmp_path: Path) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+    forward, inverse = _triangular_maps()
+    inverse["coordinates"][0]["terms"][1]["coefficient"]["num"] = "-2"
+
+    result = kernel.capabilities.invoke(_request(forward, inverse))
+
+    assert result.output["inverse_verified"] is False
+    assert result.output["conclusion"] == Conclusion.FALSE.value
+    assert result.assurance.level is CapabilityAssuranceLevel.VERIFIED
+    residuals = kernel.store.get(result.output["residuals_uri"]).payload
+    assert any(item["terms"] for item in residuals["inverse_after_forward"])
+    assert any(item["terms"] for item in residuals["forward_after_inverse"])
+
+
+@pytest.mark.integration
+def test_checker_rejects_residual_coefficient_tampering(tmp_path: Path) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+    forward, inverse = _triangular_maps()
+    result = kernel.capabilities.invoke(_request(forward, inverse))
+    checker_request = _checker_request(kernel, result.output)
+    checker_request["candidate"]["payload"]["inverse_after_forward"][0] = {
+        "terms": [_term(1, [0, 0])]
+    }
+
+    decision = check_map_inverse(checker_request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == Conclusion.UNKNOWN.value
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    ("zero_direction", "nonzero_direction"),
+    (
+        ("inverse_after_forward", "forward_after_inverse"),
+        ("forward_after_inverse", "inverse_after_forward"),
+    ),
+)
+def test_one_declared_identity_direction_never_verifies(
+    tmp_path: Path, zero_direction: str, nonzero_direction: str
+) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+    forward, inverse = _triangular_maps()
+    result = kernel.capabilities.invoke(_request(forward, inverse))
+    checker_request = _checker_request(kernel, result.output)
+    residuals = checker_request["candidate"]["payload"]
+    residuals[zero_direction] = [{"terms": []}, {"terms": []}]
+    residuals[nonzero_direction] = [
+        {"terms": [_term(1, [0, 0])]},
+        {"terms": []},
+    ]
+
+    decision = check_map_inverse(checker_request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == Conclusion.UNKNOWN.value
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("tamper", ("domain", "source_order", "target_order"))
+def test_checker_rejects_domain_and_order_substitution(
+    tmp_path: Path, tamper: str
+) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+    forward, inverse = _triangular_maps()
+    result = kernel.capabilities.invoke(_request(forward, inverse))
+    checker_request = _checker_request(kernel, result.output)
+    if tamper == "domain":
+        checker_request["scope"]["payload"]["domain"] = "ZZ"
+    elif tamper == "source_order":
+        checker_request["candidate"]["payload"]["source_variables"] = ["y", "x"]
+    else:
+        checker_request["candidate"]["payload"]["target_variables"] = ["v", "u"]
+
+    decision = check_map_inverse(checker_request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == Conclusion.UNKNOWN.value
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("source", ("scope", "inverse"))
+def test_checker_rejects_source_map_coefficient_tampering(
+    tmp_path: Path, source: str
+) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+    forward, inverse = _triangular_maps()
+    result = kernel.capabilities.invoke(_request(forward, inverse))
+    checker_request = _checker_request(kernel, result.output)
+    artifact = (
+        checker_request["scope"]
+        if source == "scope"
+        else checker_request["supporting_artifacts"][0]
+    )
+    artifact["payload"]["coordinates"][0]["terms"][0]["coefficient"]["num"] = "2"
+
+    decision = check_map_inverse(checker_request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == Conclusion.UNKNOWN.value
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "family",
+    (
+        "inverse_after_forward_checker_records",
+        "forward_after_inverse_checker_records",
+    ),
+)
+def test_checker_rejects_incomplete_checker_record_family(
+    tmp_path: Path, family: str
+) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+    forward, inverse = _triangular_maps()
+    result = kernel.capabilities.invoke(_request(forward, inverse))
+    checker_request = _checker_request(kernel, result.output)
+    checker_request["candidate"]["payload"][family] = checker_request["candidate"][
+        "payload"
+    ][family][:-1]
+    checker_request["certificate"]["payload"]["payload"][family] = checker_request[
+        "certificate"
+    ]["payload"]["payload"][family][:-1]
+
+    decision = check_map_inverse(checker_request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == Conclusion.UNKNOWN.value


### PR DESCRIPTION
## Summary

- add atomic `polynomial.map.inverse.verify` for square canonical sparse polynomial maps over `QQ`
- compute and bind both `inverse_after_forward` and `forward_after_inverse` residual families
- reuse `polynomial.identity.verify` for per-coordinate residual records while independently replaying both full compositions in the aggregate checker
- bind the forward and inverse source artifacts, coefficient domain, source and target variable orders, residuals, checker records, claim, certificate, and verification record
- fail closed for missing directions, tampered coefficients or residuals, mismatched domains or variable orders, malformed checker-record families, and unsupported composition bounds
- document the verification boundary and add focused integration and independent-checker tests

Addresses the first independent verification slice of #94.

## Design decisions

- verification requires both exact compositions to be identity; one-sided evidence can never verify an inverse
- the independent checker uses standard-library `Fraction` sparse-polynomial arithmetic and does not import the SymPy-backed producer
- overlapping source and target variable names use simultaneous substitution in the producer
- requests whose conservative composition bounds exceed 1,024 residual terms or total degree 127 are rejected before artifact creation
- exact `FALSE` conclusions are independently verifiable when at least one recomputed residual is nonzero
- inverse candidate synthesis is deliberately out of scope

## Validation

- Ruff lint and formatting checks: passed
- mypy over the changed source modules: passed
- focused inverse capability integration suite: 14 passed
- focused independent inverse checker suite: 10 passed
- broader non-integration suite: 390 passed; 6 unrelated local-environment failures remain (five macOS Bash 3.2 associative-array failures and one pre-existing SMT checker fixture failure)
- earlier polynomial capability regression run: 24 passed

Draft for human review; do not merge automatically.