### PR TITLE
feat(claims): add deterministic logical decomposition

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -161,6 +161,13 @@ Useful low-level operations may retain descriptive IDs such as
 `certificate.verify`. Those names identify capabilities invoked through
 `capability.invoke`; they are not separate MCP tools.
 
+`claim.conjunction.split` and `claim.implication.obligations` operate on the
+registered v1 `PROPOSITIONAL_STRUCTURE` artifact. They return only immediate,
+ordered subtrees plus source-bound reconstruction data, preserve nested
+grouping, and report `COMPUTED` rather than proof verification. Raw natural
+language and printed Lean expressions are outside this contract; exact Lean
+decomposition requires a future typed elaborated-expression artifact.
+
 Opaque multi-stage commands are not part of the public surface. Agents should
 compose generation, evaluation, ranking, falsification,
 refinement, and verification from separately invocable capabilities. An

--- a/src/jacobian/claim_decomposition_capabilities.py
+++ b/src/jacobian/claim_decomposition_capabilities.py
@@ -1,0 +1,310 @@
+"""Deterministic top-level decomposition of validated structured claims."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Literal, cast
+
+from pydantic import ValidationError
+
+from jacobian.artifacts import ArtifactService
+from jacobian.canonical import canonicalize_json
+from jacobian.capabilities import CapabilityInvocationError
+from jacobian.contracts.capabilities import (
+    CapabilityAssurance,
+    CapabilityAssuranceLevel,
+    CapabilityCompleteness,
+    CapabilityCompletenessStatus,
+    CapabilityDescriptor,
+    CapabilityDiagnostic,
+    CapabilityMode,
+    CapabilityRelationship,
+    CapabilityRequest,
+    CapabilityResult,
+    CapabilityScope,
+)
+from jacobian.contracts.claim_decomposition import (
+    ClaimDecompositionArtifact,
+    ClaimDecompositionOutput,
+    ClaimDecompositionRequest,
+    DecomposedOccurrence,
+    LogicalClaimNode,
+    LogicalConnective,
+    ReconstructionRecord,
+    SourceArtifactBinding,
+    StructuredClaimArtifact,
+)
+from jacobian.contracts.results import Execution, ExecutionStatus
+from jacobian.provider_runtime import known_provider_runtime
+from jacobian.schema_registry import SchemaRegistry, model_schema
+from jacobian.store import ArtifactStore, StoreError
+
+
+def _digest(node: LogicalClaimNode) -> str:
+    payload = canonicalize_json(node.model_dump(mode="json"))
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def reconstruct(artifact: ClaimDecompositionArtifact) -> LogicalClaimNode:
+    """Rebuild the exact source root from ordered occurrence records."""
+
+    actual_child_digests = tuple(_digest(item.node) for item in artifact.occurrences)
+    if actual_child_digests != artifact.reconstruction.ordered_child_digests:
+        raise ValueError("ordered child digest binding does not match occurrences")
+    children = tuple(item.node for item in artifact.occurrences)
+    root = LogicalClaimNode(
+        node_id=artifact.reconstruction.root_node_id,
+        connective=LogicalConnective(artifact.reconstruction.operator),
+        children=children,
+        source_span=artifact.reconstruction.root_source_span,
+    )
+    if _digest(root) != artifact.reconstruction.source_root_digest:
+        raise ValueError("reconstructed root does not match the bound source root")
+    return root
+
+
+@dataclass(frozen=True, slots=True)
+class ClaimDecompositionInstallation:
+    semantics_uri: str
+    structured_claim_schema_uri: str
+    decomposition_schema_uri: str
+
+
+@dataclass(frozen=True, slots=True)
+class _Resources:
+    store: ArtifactStore
+    artifacts: ArtifactService
+    semantics_uri: str
+    structured_claim_schema_uri: str
+    decomposition_schema_uri: str
+
+
+class ClaimDecompositionAdapter:
+    def __init__(self, resources: _Resources, *, connective: LogicalConnective) -> None:
+        self.resources = resources
+        self.connective = connective
+        capability_id = (
+            "claim.conjunction.split"
+            if connective is LogicalConnective.CONJUNCTION
+            else "claim.implication.obligations"
+        )
+        self._descriptor = CapabilityDescriptor(
+            capability_id=capability_id,
+            version="1",
+            title=(
+                "Split one top-level structured conjunction"
+                if connective is LogicalConnective.CONJUNCTION
+                else "Expose one implication's ordered obligations"
+            ),
+            description=(
+                "Decompose only the requested top-level connective while preserving "
+                "the exact ordered subtrees and a deterministic reconstruction record."
+            ),
+            provider="jacobian.kernel",
+            provider_runtime=known_provider_runtime(
+                "jacobian.kernel", features=("claim", "structured-decomposition")
+            ),
+            modes=(CapabilityMode.EXPLORE,),
+            input_schema=model_schema(ClaimDecompositionRequest),
+            output_schema=model_schema(ClaimDecompositionOutput),
+            tags=("claim", "decomposition", "deterministic"),
+        )
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        return self._descriptor
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        try:
+            validated = ClaimDecompositionRequest.model_validate(request.input)
+            source = self.resources.store.get(validated.source_uri)
+            if source.manifest.schema_uri != self.resources.structured_claim_schema_uri:
+                raise ValueError("source is not a registered structured-claim artifact")
+            if source.manifest.semantics_uri != self.resources.semantics_uri:
+                raise ValueError("source does not use structured-claim semantics")
+            normalized = self.resources.artifacts.schemas.validate(
+                self.resources.structured_claim_schema_uri, source.payload
+            )
+            claim = StructuredClaimArtifact.model_validate(normalized)
+        except (ValidationError, StoreError, ValueError) as exc:
+            raise CapabilityInvocationError(
+                CapabilityDiagnostic(
+                    code="INVALID_STRUCTURED_CLAIM",
+                    stage="request_validation",
+                    message="The source is not a valid registered structured claim.",
+                    hint="Provide a stored v1 PROPOSITIONAL_STRUCTURE claim artifact.",
+                )
+            ) from exc
+        if claim.root.connective is not self.connective:
+            raise CapabilityInvocationError(
+                CapabilityDiagnostic(
+                    code="UNSUPPORTED_TOP_LEVEL_CONNECTIVE",
+                    stage="claim_decomposition",
+                    message=(
+                        f"{self.descriptor.capability_id} does not accept top-level "
+                        f"{claim.root.connective.value}."
+                    ),
+                    expected=self.connective.value,
+                    actual_type=claim.root.connective.value,
+                )
+            )
+
+        roles: tuple[
+            Literal[
+                "CONJUNCT",
+                "ASSUME_ANTECEDENT",
+                "PROVE_CONSEQUENT_UNDER_ANTECEDENT",
+            ],
+            ...,
+        ]
+        if self.connective is LogicalConnective.CONJUNCTION:
+            roles = cast(
+                tuple[
+                    Literal[
+                        "CONJUNCT",
+                        "ASSUME_ANTECEDENT",
+                        "PROVE_CONSEQUENT_UNDER_ANTECEDENT",
+                    ],
+                    ...,
+                ],
+                ("CONJUNCT",) * len(claim.root.children),
+            )
+        else:
+            roles = (
+                "ASSUME_ANTECEDENT",
+                "PROVE_CONSEQUENT_UNDER_ANTECEDENT",
+            )
+        occurrences = tuple(
+            DecomposedOccurrence(
+                position=index,
+                role=role,
+                path=f"{claim.root.node_id}.children[{index}]",
+                node=child,
+                node_digest=_digest(child),
+            )
+            for index, (role, child) in enumerate(
+                zip(roles, claim.root.children, strict=True)
+            )
+        )
+        root_digest = _digest(claim.root)
+        payload = ClaimDecompositionArtifact(
+            capability_id=cast(
+                Literal[
+                    "claim.conjunction.split",
+                    "claim.implication.obligations",
+                ],
+                self.descriptor.capability_id,
+            ),
+            source_binding=SourceArtifactBinding(
+                source_uri=validated.source_uri,
+                object_digest=source.manifest.object_digest,
+                payload_digest=source.manifest.payload_digest,
+                schema_uri=source.manifest.schema_uri,
+                semantics_uri=source.manifest.semantics_uri,
+                canonicalizer_digest=source.manifest.canonicalizer_digest,
+            ),
+            occurrences=occurrences,
+            reconstruction=ReconstructionRecord(
+                operator=cast(
+                    Literal["CONJUNCTION", "IMPLICATION"],
+                    self.connective.value,
+                ),
+                root_node_id=claim.root.node_id,
+                root_source_span=claim.root.source_span,
+                source_root_digest=root_digest,
+                ordered_child_digests=tuple(item.node_digest for item in occurrences),
+            ),
+        )
+        saved = self.resources.artifacts.put(
+            schema_uri=self.resources.decomposition_schema_uri,
+            semantics_uri=self.resources.semantics_uri,
+            payload=payload.model_dump(mode="json"),
+            parents=(validated.source_uri,),
+            summary=f"{self.descriptor.capability_id} exact reconstruction record",
+        )
+        output = ClaimDecompositionOutput(
+            **payload.model_dump(mode="python"),
+            decomposition_uri=saved.artifact_uri,
+        )
+        return CapabilityResult(
+            capability_id=self.descriptor.capability_id,
+            capability_version="1",
+            mode=request.mode,
+            execution=Execution(status=ExecutionStatus.COMPLETED),
+            output=output.model_dump(mode="json"),
+            scope=CapabilityScope(
+                description="one exact top-level structured-claim decomposition",
+                parameters={"top_level_connective": self.connective.value},
+                artifact_uri=saved.artifact_uri,
+            ),
+            completeness=CapabilityCompleteness(
+                status=CapabilityCompletenessStatus.COMPLETE,
+                basis="all immediate ordered children of the supported root were returned",
+                assurance_level=CapabilityAssuranceLevel.COMPUTED,
+            ),
+            relationships=(
+                CapabilityRelationship(
+                    relation_id="claim.reconstruction.proposed",
+                    source_artifact_uris=(saved.artifact_uri,),
+                    target_artifact_uris=(validated.source_uri,),
+                ),
+            ),
+            assurance=CapabilityAssurance(
+                level=CapabilityAssuranceLevel.COMPUTED,
+                basis="deterministic structural projection; no truth claim or proof",
+            ),
+            artifact_uris=(validated.source_uri, saved.artifact_uri),
+        )
+
+
+def install_claim_decomposition_capabilities(
+    store: ArtifactStore,
+    schemas: SchemaRegistry,
+    artifacts: ArtifactService,
+) -> tuple[
+    tuple[ClaimDecompositionAdapter, ClaimDecompositionAdapter],
+    ClaimDecompositionInstallation,
+]:
+    semantics_uri = store.register_descriptor(
+        kind="semantics",
+        name="jacobian.structured-logical-claim",
+        version="1",
+        definition={
+            "logic": "PROPOSITIONAL_STRUCTURE",
+            "meaning": "ordered, explicitly grouped, opaque-atom logical syntax",
+            "verification": "structural computation only; no truth or proof claim",
+        },
+    )
+    claim_schema_uri = schemas.register_model(
+        name="jacobian.structured-logical-claim",
+        version="1",
+        model=StructuredClaimArtifact,
+    )
+    decomposition_schema_uri = schemas.register_model(
+        name="jacobian.claim-decomposition",
+        version="1",
+        model=ClaimDecompositionArtifact,
+    )
+    resources = _Resources(
+        store=store,
+        artifacts=artifacts,
+        semantics_uri=semantics_uri,
+        structured_claim_schema_uri=claim_schema_uri,
+        decomposition_schema_uri=decomposition_schema_uri,
+    )
+    return (
+        (
+            ClaimDecompositionAdapter(
+                resources, connective=LogicalConnective.CONJUNCTION
+            ),
+            ClaimDecompositionAdapter(
+                resources, connective=LogicalConnective.IMPLICATION
+            ),
+        ),
+        ClaimDecompositionInstallation(
+            semantics_uri=semantics_uri,
+            structured_claim_schema_uri=claim_schema_uri,
+            decomposition_schema_uri=decomposition_schema_uri,
+        ),
+    )

--- a/src/jacobian/contracts/claim_decomposition.py
+++ b/src/jacobian/contracts/claim_decomposition.py
@@ -1,0 +1,136 @@
+"""Bounded structured-claim and deterministic decomposition contracts."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any, Literal, Self
+
+from pydantic import Field, model_validator
+
+from jacobian.canonical import canonicalize_json
+from jacobian.contracts.common import ArtifactUri, Sha256Digest
+from jacobian.contracts.results import ContractModel
+
+
+class LogicalConnective(StrEnum):
+    ATOM = "ATOM"
+    CONJUNCTION = "CONJUNCTION"
+    IMPLICATION = "IMPLICATION"
+    DISJUNCTION = "DISJUNCTION"
+    NEGATION = "NEGATION"
+    BICONDITIONAL = "BICONDITIONAL"
+    QUANTIFIER = "QUANTIFIER"
+
+
+class LogicalClaimNode(ContractModel):
+    """One explicitly grouped logical node; unsupported kinds remain representable."""
+
+    node_id: str = Field(pattern=r"^[A-Za-z_][A-Za-z0-9_.-]*$", max_length=128)
+    connective: LogicalConnective
+    atom: dict[str, Any] | None = None
+    children: tuple[LogicalClaimNode, ...] = ()
+    source_span: tuple[int, int] | None = None
+
+    @model_validator(mode="after")
+    def validate_shape(self) -> Self:
+        if self.source_span is not None and self.source_span[0] > self.source_span[1]:
+            raise ValueError("source_span start must not exceed its end")
+        canonicalize_json(self.atom)
+        expected = {
+            LogicalConnective.ATOM: 0,
+            LogicalConnective.IMPLICATION: 2,
+            LogicalConnective.NEGATION: 1,
+            LogicalConnective.BICONDITIONAL: 2,
+            LogicalConnective.QUANTIFIER: 1,
+        }.get(self.connective)
+        if self.connective is LogicalConnective.CONJUNCTION:
+            if len(self.children) < 2:
+                raise ValueError("CONJUNCTION requires at least two ordered children")
+        elif self.connective is LogicalConnective.DISJUNCTION:
+            if len(self.children) < 2:
+                raise ValueError("DISJUNCTION requires at least two ordered children")
+        elif expected is not None and len(self.children) != expected:
+            raise ValueError(
+                f"{self.connective.value} requires exactly {expected} children"
+            )
+        if self.connective is LogicalConnective.ATOM:
+            if self.atom is None:
+                raise ValueError("ATOM requires an opaque canonical atom payload")
+        elif self.atom is not None:
+            raise ValueError("only ATOM may carry an atom payload")
+        return self
+
+
+class StructuredClaimArtifact(ContractModel):
+    structured_claim_schema_version: Literal["1"] = "1"
+    logic: Literal["PROPOSITIONAL_STRUCTURE"] = "PROPOSITIONAL_STRUCTURE"
+    root: LogicalClaimNode
+
+    @model_validator(mode="after")
+    def enforce_bounds_and_ids(self) -> Self:
+        pending = [(self.root, 1)]
+        identifiers: set[str] = set()
+        count = 0
+        while pending:
+            node, depth = pending.pop()
+            count += 1
+            if count > 1024:
+                raise ValueError("structured claim exceeds 1024 nodes")
+            if depth > 64:
+                raise ValueError("structured claim exceeds depth 64")
+            if node.node_id in identifiers:
+                raise ValueError("structured claim node_id values must be unique")
+            identifiers.add(node.node_id)
+            pending.extend((child, depth + 1) for child in node.children)
+        return self
+
+
+class ClaimDecompositionRequest(ContractModel):
+    source_uri: ArtifactUri
+
+
+class SourceArtifactBinding(ContractModel):
+    source_uri: ArtifactUri
+    object_digest: Sha256Digest
+    payload_digest: Sha256Digest
+    schema_uri: ArtifactUri
+    semantics_uri: ArtifactUri
+    canonicalizer_digest: Sha256Digest
+
+
+class DecomposedOccurrence(ContractModel):
+    position: int = Field(ge=0)
+    role: Literal[
+        "CONJUNCT",
+        "ASSUME_ANTECEDENT",
+        "PROVE_CONSEQUENT_UNDER_ANTECEDENT",
+    ]
+    path: str
+    node: LogicalClaimNode
+    node_digest: Sha256Digest
+
+
+class ReconstructionRecord(ContractModel):
+    operator: Literal["CONJUNCTION", "IMPLICATION"]
+    root_node_id: str
+    root_source_span: tuple[int, int] | None = None
+    source_root_digest: Sha256Digest
+    ordered_child_digests: tuple[Sha256Digest, ...]
+
+
+class ClaimDecompositionArtifact(ContractModel):
+    decomposition_schema_version: Literal["1"] = "1"
+    capability_id: Literal[
+        "claim.conjunction.split",
+        "claim.implication.obligations",
+    ]
+    source_binding: SourceArtifactBinding
+    occurrences: tuple[DecomposedOccurrence, ...]
+    reconstruction: ReconstructionRecord
+
+
+class ClaimDecompositionOutput(ClaimDecompositionArtifact):
+    decomposition_uri: ArtifactUri
+
+
+LogicalClaimNode.model_rebuild()

--- a/src/jacobian/kernel.py
+++ b/src/jacobian/kernel.py
@@ -19,6 +19,9 @@ from jacobian.capabilities import (
     CapabilityService,
     load_capability_adapter,
 )
+from jacobian.claim_decomposition_capabilities import (
+    install_claim_decomposition_capabilities,
+)
 from jacobian.claims import ClaimValidationService
 from jacobian.conjectures import ConjectureService
 from jacobian.contracts.capabilities import (
@@ -224,6 +227,13 @@ class JacobianKernel:
             self.schemas,
             self.plugins,
         )
+        claim_decomposition_adapters, self.claim_decomposition = (
+            install_claim_decomposition_capabilities(
+                self.store,
+                self.schemas,
+                self.artifacts,
+            )
+        )
         self.plugin_executor = PluginExecutor()
         self.structures = StructureService(
             self.store,
@@ -426,6 +436,8 @@ class JacobianKernel:
                 self.register_capability(cvc5_adapter)
         for atomic_adapter in install_atomic_capabilities(self):
             self.register_capability(atomic_adapter)
+        for claim_decomposition_adapter in claim_decomposition_adapters:
+            self.register_capability(claim_decomposition_adapter)
         self.register_capability(KnowledgeSearchAdapter(self.memory))
         self.finite_partition: FinitePartitionInstallation
         finite_partition, self.finite_partition = install_finite_partition(

--- a/tests/contract/test_claim_decomposition_contracts.py
+++ b/tests/contract/test_claim_decomposition_contracts.py
@@ -1,0 +1,67 @@
+"""Contract tests for the bounded structured logical-claim AST."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.contracts.claim_decomposition import (
+    LogicalClaimNode,
+    LogicalConnective,
+    StructuredClaimArtifact,
+)
+
+
+def _atom(node_id: str) -> LogicalClaimNode:
+    return LogicalClaimNode(
+        node_id=node_id,
+        connective=LogicalConnective.ATOM,
+        atom={"symbol": node_id},
+    )
+
+
+def test_nested_grouping_and_duplicate_occurrences_are_valid() -> None:
+    nested = LogicalClaimNode(
+        node_id="nested",
+        connective=LogicalConnective.CONJUNCTION,
+        children=(_atom("b"), _atom("c")),
+    )
+    claim = StructuredClaimArtifact(
+        root=LogicalClaimNode(
+            node_id="root",
+            connective=LogicalConnective.CONJUNCTION,
+            children=(_atom("a"), nested),
+        )
+    )
+    assert claim.root.children[1] == nested
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"node_id": "bad", "connective": "CONJUNCTION", "children": []},
+        {"node_id": "bad", "connective": "IMPLICATION", "children": []},
+        {"node_id": "bad", "connective": "ATOM"},
+        {
+            "node_id": "bad",
+            "connective": "ATOM",
+            "atom": {"symbol": "A"},
+            "unknown": True,
+        },
+        {"node_id": "bad", "connective": "UNKNOWN"},
+    ],
+)
+def test_malformed_nodes_are_rejected(payload: dict[str, object]) -> None:
+    with pytest.raises(ValidationError):
+        LogicalClaimNode.model_validate(payload)
+
+
+def test_duplicate_node_ids_are_rejected() -> None:
+    with pytest.raises(ValidationError, match="node_id values must be unique"):
+        StructuredClaimArtifact(
+            root=LogicalClaimNode(
+                node_id="root",
+                connective=LogicalConnective.CONJUNCTION,
+                children=(_atom("same"), _atom("same")),
+            )
+        )

--- a/tests/integration/test_claim_decomposition.py
+++ b/tests/integration/test_claim_decomposition.py
@@ -1,0 +1,180 @@
+"""Integration tests for deterministic structured-claim decomposition."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from jacobian.claim_decomposition_capabilities import reconstruct
+from jacobian.contracts.capabilities import (
+    CapabilityAssuranceLevel,
+    CapabilityRequest,
+)
+from jacobian.contracts.claim_decomposition import (
+    ClaimDecompositionArtifact,
+    LogicalClaimNode,
+    LogicalConnective,
+    StructuredClaimArtifact,
+)
+from jacobian.kernel import JacobianKernel
+
+pytestmark = pytest.mark.usefixtures("initialized_kernel_store")
+
+
+def _atom(node_id: str, symbol: str | None = None) -> LogicalClaimNode:
+    return LogicalClaimNode(
+        node_id=node_id,
+        connective=LogicalConnective.ATOM,
+        atom={"symbol": symbol or node_id},
+    )
+
+
+def _store_claim(kernel: JacobianKernel, root: LogicalClaimNode) -> str:
+    stored = kernel.artifacts.put(
+        schema_uri=kernel.claim_decomposition.structured_claim_schema_uri,
+        semantics_uri=kernel.claim_decomposition.semantics_uri,
+        payload=StructuredClaimArtifact(root=root).model_dump(mode="json"),
+    )
+    return stored.artifact_uri
+
+
+def _invoke(kernel: JacobianKernel, capability_id: str, source_uri: str):
+    return kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id=capability_id,
+            input={"source_uri": source_uri},
+        )
+    )
+
+
+@pytest.mark.integration
+def test_conjunction_split_preserves_order_grouping_and_reconstructs(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    nested = LogicalClaimNode(
+        node_id="nested",
+        connective=LogicalConnective.CONJUNCTION,
+        children=(_atom("b"), _atom("c")),
+    )
+    root = LogicalClaimNode(
+        node_id="root",
+        connective=LogicalConnective.CONJUNCTION,
+        children=(_atom("a"), nested),
+        source_span=(0, 17),
+    )
+    source_uri = _store_claim(kernel, root)
+
+    result = _invoke(kernel, "claim.conjunction.split", source_uri)
+
+    assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert [item["node"]["node_id"] for item in result.output["occurrences"]] == [
+        "a",
+        "nested",
+    ]
+    stored = kernel.store.get(result.output["decomposition_uri"])
+    record = ClaimDecompositionArtifact.model_validate(stored.payload)
+    assert reconstruct(record) == root
+    assert stored.manifest.parents == (source_uri,)
+    assert (
+        record.source_binding.object_digest
+        == kernel.store.get(source_uri).manifest.object_digest
+    )
+
+
+@pytest.mark.integration
+def test_conjunction_split_preserves_duplicate_subtrees_as_occurrences(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    root = LogicalClaimNode(
+        node_id="root",
+        connective=LogicalConnective.CONJUNCTION,
+        children=(_atom("left", "A"), _atom("right", "A")),
+    )
+    result = _invoke(kernel, "claim.conjunction.split", _store_claim(kernel, root))
+    occurrences = result.output["occurrences"]
+    assert [item["position"] for item in occurrences] == [0, 1]
+    assert [item["node"]["atom"] for item in occurrences] == [
+        {"symbol": "A"},
+        {"symbol": "A"},
+    ]
+
+
+@pytest.mark.integration
+def test_implication_obligations_are_directional_and_reconstruct(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    consequent = LogicalClaimNode(
+        node_id="bc",
+        connective=LogicalConnective.IMPLICATION,
+        children=(_atom("b"), _atom("c")),
+    )
+    root = LogicalClaimNode(
+        node_id="root",
+        connective=LogicalConnective.IMPLICATION,
+        children=(_atom("a"), consequent),
+    )
+    result = _invoke(
+        kernel, "claim.implication.obligations", _store_claim(kernel, root)
+    )
+    assert [item["role"] for item in result.output["occurrences"]] == [
+        "ASSUME_ANTECEDENT",
+        "PROVE_CONSEQUENT_UNDER_ANTECEDENT",
+    ]
+    record = ClaimDecompositionArtifact.model_validate(
+        kernel.store.get(result.output["decomposition_uri"]).payload
+    )
+    assert reconstruct(record) == root
+
+
+@pytest.mark.integration
+def test_reconstruction_rejects_tampered_ordered_child(tmp_path: Path) -> None:
+    kernel = JacobianKernel(tmp_path)
+    root = LogicalClaimNode(
+        node_id="root",
+        connective=LogicalConnective.CONJUNCTION,
+        children=(_atom("a"), _atom("b")),
+    )
+    result = _invoke(kernel, "claim.conjunction.split", _store_claim(kernel, root))
+    record = ClaimDecompositionArtifact.model_validate(
+        kernel.store.get(result.output["decomposition_uri"]).payload
+    )
+    tampered = record.model_copy(
+        update={"occurrences": tuple(reversed(record.occurrences))}
+    )
+    with pytest.raises(ValueError, match="digest binding"):
+        reconstruct(tampered)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    ("capability_id", "connective"),
+    [
+        ("claim.conjunction.split", LogicalConnective.ATOM),
+        ("claim.conjunction.split", LogicalConnective.IMPLICATION),
+        ("claim.implication.obligations", LogicalConnective.ATOM),
+        ("claim.implication.obligations", LogicalConnective.CONJUNCTION),
+    ],
+)
+def test_unsupported_top_level_connective_is_explicitly_rejected(
+    tmp_path: Path,
+    capability_id: str,
+    connective: LogicalConnective,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+    children = (
+        () if connective is LogicalConnective.ATOM else (_atom("left"), _atom("right"))
+    )
+    root = LogicalClaimNode(
+        node_id="root",
+        connective=connective,
+        atom={"symbol": "A"} if connective is LogicalConnective.ATOM else None,
+        children=children,
+    )
+    source_uri = _store_claim(kernel, root)
+    result = _invoke(kernel, capability_id, source_uri)
+    assert result.execution.status.value == "ERROR"
+    assert result.diagnostics[0].code == "UNSUPPORTED_TOP_LEVEL_CONNECTIVE"


### PR DESCRIPTION
## Summary

Implements the smallest safe structured-claim slice from #96:

- adds `claim.conjunction.split` for exact, immediate, ordered conjunction children;
- adds `claim.implication.obligations` with directional antecedent/consequent roles;
- introduces a bounded v1 `PROPOSITIONAL_STRUCTURE` artifact with explicit grouping;
- records source manifest bindings, ordered child digests, paths, roles, and an exact reconstruction relationship;
- rejects unsupported top-level connectives and malformed structured claims explicitly;
- documents the `COMPUTED`/non-proof verification boundary.

## Design decisions

- Existing `ClaimSpec` was not overloaded because it is flat predicate metadata, not a logical AST.
- Nested conjunctions are not flattened or reordered.
- Duplicate-looking operands remain separate ordered occurrences.
- Capability relationships link the reconstruction artifact to the source, while occurrence ordering remains in the payload because relationship endpoint sets cannot represent duplicates.
- Raw natural language and printed Lean expressions are excluded. Current `main` has no typed Lean expression-tree artifact, so text parsing would not preserve exact elaborated grouping safely.
- Assurance remains `COMPUTED`; this slice makes no truth or proof-verification claim.

## Validation

- `ruff check .`
- `ruff format --check .`
- focused mypy checks for the new contracts and adapter
- `15 passed` across the new contract and integration suites
- broader fast suite: `387 passed`; six unrelated environment-sensitive failures occurred (five macOS Bash 3 `declare -A` failures in CI-plan tests and one existing SMT checker fixture failure)

Part of #96. This PR intentionally does not close the issue because the broader proof IR and typed Lean-expression integration remain open.