### PR TITLE
Add bounded polynomial-map inverse candidate synthesis

### DIFF
--- a/docs/reference/polynomial-map-inverse-verification.md
+++ b/docs/reference/polynomial-map-inverse-verification.md
@@ -1,4 +1,29 @@
-# Polynomial-map inverse verification
+# Polynomial-map inverse synthesis and verification
+
+`polynomial.map.inverse.candidate_synthesize` searches one finite polynomial
+ansatz over `QQ`. The request fixes the forward map, ordered source and target
+variables, inverse degree bound, either explicit coordinate supports or the
+deterministically generated full total-degree support, the `sympy.solve`
+backend, and explicit timeout, unknown, equation, degree, and residual-term
+limits.
+
+The synthesis artifact records the complete ordered support and coefficient
+symbols, every exact coefficient equation from both compositions, solver
+provenance, and—when found—the candidate and both residual families. Supported
+statuses are:
+
+- `FOUND`;
+- `NO_CANDIDATE_WITHIN_ANSATZ`;
+- `UNDERDETERMINED`;
+- `TIMEOUT`;
+- `BUDGET_EXHAUSTED`;
+- `UNSUPPORTED`.
+
+`NO_CANDIDATE_WITHIN_ANSATZ` means only that the declared finite coefficient
+system has no solution. It never proves noninvertibility. Synthesis always
+remains `COMPUTED` and `UNVERIFIED`; every found candidate is submitted to
+`polynomial.map.inverse.verify`, and the synthesis result records either that
+verifier's certificate/output or an explicit verification failure.
 
 `polynomial.map.inverse.verify` verifies a proposed inverse of a square sparse
 polynomial map over `QQ`. It is a verification capability, not an inverse
@@ -36,5 +61,6 @@ The request is rejected before artifact creation when conservative composition
 bounds exceed 1,024 residual terms or total degree 127; this keeps both the
 producer and independent replay within the registered sparse-polynomial
 contract.
-Rational-map inverses and inverse-candidate synthesis are outside this
-capability.
+The v1 synthesis and verification contracts support polynomial maps over `QQ`
+only. Rational-map inverses, denominator ansatzes, and pole-domain reasoning
+are outside scope.

--- a/src/jacobian/contracts/polynomials.py
+++ b/src/jacobian/contracts/polynomials.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from enum import StrEnum
 from itertools import permutations
 from math import prod
-from typing import Annotated, Literal, Self
+from typing import Annotated, Any, Literal, Self
 
 from pydantic import Field, StringConstraints, model_validator
 
@@ -277,6 +277,147 @@ class PolynomialMapInverseVerifyRequest(ContractModel):
                 if outer_degree * inner_degree > _MAX_DERIVED_EXPONENT:
                     raise ValueError("composition residual degree bound exceeds 127")
         return self
+
+
+class PolynomialInverseSynthesisStatus(StrEnum):
+    FOUND = "FOUND"
+    NO_CANDIDATE_WITHIN_ANSATZ = "NO_CANDIDATE_WITHIN_ANSATZ"
+    UNDERDETERMINED = "UNDERDETERMINED"
+    TIMEOUT = "TIMEOUT"
+    BUDGET_EXHAUSTED = "BUDGET_EXHAUSTED"
+    UNSUPPORTED = "UNSUPPORTED"
+
+
+class PolynomialInverseSupportMode(StrEnum):
+    EXPLICIT = "EXPLICIT"
+    FULL_TOTAL_DEGREE = "FULL_TOTAL_DEGREE"
+
+
+class PolynomialInverseSynthesisLimits(ContractModel):
+    timeout_ms: int = Field(ge=0, le=120_000)
+    max_inverse_degree: int = Field(ge=0, le=8)
+    max_composition_degree: int = Field(ge=1, le=_MAX_DERIVED_EXPONENT)
+    max_unknown_coefficients: int = Field(ge=1, le=512)
+    max_coefficient_equations: int = Field(ge=1, le=4096)
+    max_residual_terms: int = Field(ge=1, le=8192)
+
+
+class PolynomialMapInverseSynthesisRequest(ContractModel):
+    forward_map: RationalPolynomialMap
+    source_variables: tuple[PolynomialVariable, ...] = Field(min_length=1, max_length=4)
+    target_variables: tuple[PolynomialVariable, ...] = Field(min_length=1, max_length=4)
+    inverse_degree_bound: int = Field(ge=0, le=8)
+    support_mode: PolynomialInverseSupportMode
+    explicit_support: tuple[tuple[tuple[int, ...], ...], ...] | None = None
+    solver: str = Field(min_length=1, max_length=64)
+    limits: PolynomialInverseSynthesisLimits
+
+    @model_validator(mode="after")
+    def require_bounded_square_qq_ansatz(self) -> Self:
+        if self.forward_map.variables != self.source_variables:
+            raise ValueError("forward map variables must equal source_variables")
+        if len(self.source_variables) != len(self.target_variables):
+            raise ValueError("source and target dimensions must agree")
+        if len(set(self.source_variables)) != len(self.source_variables):
+            raise ValueError("source variables must be unique")
+        if len(set(self.target_variables)) != len(self.target_variables):
+            raise ValueError("target variables must be unique")
+        if self.inverse_degree_bound > self.limits.max_inverse_degree:
+            raise ValueError("inverse_degree_bound exceeds the declared degree limit")
+        if self.support_mode is PolynomialInverseSupportMode.EXPLICIT:
+            if self.explicit_support is None:
+                raise ValueError("EXPLICIT support_mode requires explicit_support")
+            if len(self.explicit_support) != len(self.target_variables):
+                raise ValueError(
+                    "explicit_support must contain one support per coordinate"
+                )
+            for coordinate in self.explicit_support:
+                if not coordinate:
+                    raise ValueError(
+                        "each explicit coordinate support must be nonempty"
+                    )
+                if coordinate != tuple(sorted(coordinate, reverse=True)):
+                    raise ValueError(
+                        "explicit support must use descending lexicographic order"
+                    )
+                for exponents in coordinate:
+                    if len(exponents) != len(self.target_variables):
+                        raise ValueError(
+                            "support monomials must match target variable order"
+                        )
+                    if any(exponent < 0 for exponent in exponents):
+                        raise ValueError("support exponents must be nonnegative")
+                    if sum(exponents) > self.inverse_degree_bound:
+                        raise ValueError(
+                            "explicit support exceeds inverse_degree_bound"
+                        )
+        elif self.explicit_support is not None:
+            raise ValueError(
+                "FULL_TOTAL_DEGREE support_mode must not carry explicit_support"
+            )
+        return self
+
+
+class PolynomialInverseAnsatzSpecification(ContractModel):
+    support_mode: PolynomialInverseSupportMode
+    inverse_degree_bound: int
+    source_variables: tuple[PolynomialVariable, ...]
+    target_variables: tuple[PolynomialVariable, ...]
+    coordinate_supports: tuple[tuple[tuple[int, ...], ...], ...]
+    coefficient_symbols: tuple[tuple[str, ...], ...]
+
+
+class PolynomialInverseCoefficientEquation(ContractModel):
+    direction: Literal["INVERSE_AFTER_FORWARD", "FORWARD_AFTER_INVERSE"]
+    coordinate: int = Field(ge=0, le=3)
+    monomial_exponents: tuple[int, ...]
+    expression: str = Field(min_length=1, max_length=100_000)
+
+
+class PolynomialInverseSolverProvenance(ContractModel):
+    solver: str
+    backend: Literal["sympy"] = "sympy"
+    backend_version: str
+    exact_domain: Literal["QQ"] = "QQ"
+    timeout_ms: int
+    unknown_count: int = Field(ge=0)
+    equation_count: int = Field(ge=0)
+    residual_term_count: int = Field(ge=0)
+    elapsed_ms: int = Field(ge=0)
+
+
+class PolynomialMapInverseSynthesisArtifact(ContractModel):
+    synthesis_schema_version: Literal["1"] = "1"
+    status: PolynomialInverseSynthesisStatus
+    forward_map: RationalPolynomialMap
+    ansatz: PolynomialInverseAnsatzSpecification
+    coefficient_equations: tuple[PolynomialInverseCoefficientEquation, ...]
+    solver_provenance: PolynomialInverseSolverProvenance
+    candidate_inverse_map: RationalPolynomialMap | None = None
+    inverse_after_forward: tuple[SparseRationalPolynomial, ...] = ()
+    forward_after_inverse: tuple[SparseRationalPolynomial, ...] = ()
+    verification_output: dict[str, Any] | None = None
+    verification_artifact_uri: ArtifactUri | None = None
+    verification_failure: str | None = None
+    noninvertibility_proved: Literal[False] = False
+
+    @model_validator(mode="after")
+    def require_status_consistent_candidate_bundle(self) -> Self:
+        found = self.status is PolynomialInverseSynthesisStatus.FOUND
+        if found != (self.candidate_inverse_map is not None):
+            raise ValueError("FOUND status must agree with candidate_inverse_map")
+        if found and (not self.inverse_after_forward or not self.forward_after_inverse):
+            raise ValueError("FOUND requires both composition residual families")
+        if not found and (self.inverse_after_forward or self.forward_after_inverse):
+            raise ValueError("only FOUND may carry composition residual families")
+        if self.verification_artifact_uri is not None and not found:
+            raise ValueError("only FOUND may carry a verification artifact")
+        return self
+
+
+class PolynomialMapInverseSynthesisOutput(PolynomialMapInverseSynthesisArtifact):
+    synthesis_uri: ArtifactUri
+    forward_map_uri: ArtifactUri
 
 
 class PolynomialCollisionSearchRequest(ContractModel):

--- a/src/jacobian/polynomial_capabilities.py
+++ b/src/jacobian/polynomial_capabilities.py
@@ -3,15 +3,18 @@
 from __future__ import annotations
 
 import hashlib
+import multiprocessing
 import time
 from dataclasses import dataclass
 from fractions import Fraction
 from itertools import product
+from math import prod as multiply
+from queue import Empty
 from typing import Any, cast
 
 import sympy
 from pydantic import ValidationError
-from sympy import QQ, Matrix, Poly, expand, symbols
+from sympy import QQ, Matrix, Poly, expand, solve, symbols, sympify
 from sympy.polys.polyerrors import PolynomialError
 
 from jacobian.artifacts import ArtifactService
@@ -58,6 +61,11 @@ from jacobian.contracts.polynomials import (
     PolynomialIdentityReplayPayload,
     PolynomialIdentityRequest,
     PolynomialInjectivityClaim,
+    PolynomialInverseAnsatzSpecification,
+    PolynomialInverseCoefficientEquation,
+    PolynomialInverseSolverProvenance,
+    PolynomialInverseSupportMode,
+    PolynomialInverseSynthesisStatus,
     PolynomialJacobian,
     PolynomialJacobianClaim,
     PolynomialJacobianOutput,
@@ -67,6 +75,9 @@ from jacobian.contracts.polynomials import (
     PolynomialMapEvaluation,
     PolynomialMapInverseClaim,
     PolynomialMapInverseReplayPayload,
+    PolynomialMapInverseSynthesisArtifact,
+    PolynomialMapInverseSynthesisOutput,
+    PolynomialMapInverseSynthesisRequest,
     PolynomialMapInverseVerifyOutput,
     PolynomialMapInverseVerifyRequest,
     RationalPolynomial,
@@ -106,6 +117,7 @@ class PolynomialInstallation:
     identity_claim_schema_uri: str
     inverse_claim_schema_uri: str
     inverse_residual_schema_uri: str
+    inverse_synthesis_schema_uri: str
     witness_schema_uri: str
     certificate_schema_uri: str
     polynomial_schema_uri: str
@@ -141,6 +153,7 @@ def install_polynomial_capabilities(
         PolynomialCollisionSearchAdapter,
         PolynomialCollisionVerifyAdapter,
         PolynomialFactorAdapter,
+        PolynomialMapInverseSynthesizeAdapter,
         PolynomialMapInverseVerifyAdapter,
     ],
     PolynomialInstallation,
@@ -194,6 +207,9 @@ def install_polynomial_capabilities(
             "coefficient_field": "QQ",
             "directions": ["inverse_after_forward", "forward_after_inverse"],
             "one_sided_identity": "insufficient",
+            "synthesis_scope": "bounded polynomial coefficient ansatz only",
+            "bounded_no_candidate": "does not prove noninvertibility",
+            "rational_map_inverses": "unsupported",
         },
     )
     polynomial_semantics_uri = store.register_descriptor(
@@ -275,6 +291,11 @@ def install_polynomial_capabilities(
         name="jacobian.polynomial-map-composition-residuals",
         version="1",
         schema=model_schema(PolynomialMapCompositionResiduals),
+    )
+    inverse_synthesis_schema_uri = schemas.register(
+        name="jacobian.polynomial-map-inverse-synthesis",
+        version="1",
+        schema=model_schema(PolynomialMapInverseSynthesisArtifact),
     )
     witness_schema_uri = schemas.register(
         name="jacobian.witness-envelope",
@@ -361,6 +382,7 @@ def install_polynomial_capabilities(
         identity_claim_schema_uri=identity_claim_schema_uri,
         inverse_claim_schema_uri=inverse_claim_schema_uri,
         inverse_residual_schema_uri=inverse_residual_schema_uri,
+        inverse_synthesis_schema_uri=inverse_synthesis_schema_uri,
         witness_schema_uri=witness_schema_uri,
         certificate_schema_uri=certificate_schema_uri,
         polynomial_schema_uri=polynomial_schema_uri,
@@ -389,6 +411,7 @@ def install_polynomial_capabilities(
                 else ()
             ),
             PolynomialFactorAdapter(resources),
+            PolynomialMapInverseSynthesizeAdapter(resources),
             *(
                 (PolynomialMapInverseVerifyAdapter(resources),)
                 if inverse_checker_id is not None and identity_checker_id is not None
@@ -1670,6 +1693,550 @@ class PolynomialIdentityAdapter:
                 ),
             ),
         )
+
+
+def _inverse_solver_worker(
+    equation_texts: tuple[str, ...],
+    unknown_names: tuple[str, ...],
+    result_queue: Any,
+) -> None:
+    """Solve one exact coefficient system in an isolated process."""
+
+    try:
+        unknowns = symbols(" ".join(unknown_names), seq=True)
+        locals_by_name = dict(zip(unknown_names, unknowns, strict=True))
+        equations = tuple(
+            sympify(expression, locals=locals_by_name) for expression in equation_texts
+        )
+        solutions = solve(equations, unknowns, dict=True, simplify=False)
+        serialized = tuple(
+            tuple(
+                (name, str(solution.get(symbol, symbol)))
+                for name, symbol in zip(
+                    unknown_names,
+                    unknowns,
+                    strict=True,
+                )
+            )
+            for solution in solutions
+        )
+        result_queue.put(("OK", tuple(sorted(serialized))))
+    except Exception as exc:  # pragma: no cover - defensive child boundary
+        result_queue.put(("ERROR", type(exc).__name__))
+
+
+class PolynomialMapInverseSynthesizeAdapter:
+    """Solve one bounded exact polynomial inverse ansatz over QQ."""
+
+    def __init__(self, resources: PolynomialResources) -> None:
+        self.resources = resources
+        self._descriptor = CapabilityDescriptor(
+            capability_id="polynomial.map.inverse.candidate_synthesize",
+            version="1",
+            title="Synthesize a bounded polynomial-map inverse candidate",
+            description=(
+                "Solve an explicit finite polynomial inverse ansatz over QQ, "
+                "then submit every found candidate to the independent two-sided "
+                "inverse verifier."
+            ),
+            provider="jacobian.sympy",
+            provider_runtime=known_provider_runtime(
+                "jacobian.sympy",
+                features=("polynomial-map-inverse-ansatz", "exact-equation-solving"),
+            ),
+            modes=(CapabilityMode.EXPLORE,),
+            input_schema=model_schema(PolynomialMapInverseSynthesisRequest),
+            output_schema=model_schema(PolynomialMapInverseSynthesisOutput),
+            tags=("polynomial", "map", "inverse", "synthesis", "exact-rational"),
+        )
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        return self._descriptor
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        started = time.monotonic()
+        validated = _validate_request(
+            PolynomialMapInverseSynthesisRequest,
+            request.input,
+            code="INVALID_POLYNOMIAL_MAP_INVERSE_SYNTHESIS_REQUEST",
+            operation="map inverse candidate synthesis",
+        )
+        forward_artifact = self.resources.artifacts.put(
+            schema_uri=self.resources.installation.map_schema_uri,
+            semantics_uri=self.resources.installation.inverse_semantics_uri,
+            payload=validated.forward_map.model_dump(mode="json"),
+            summary="forward map for bounded inverse synthesis",
+        )
+        supports = _inverse_supports(validated)
+        coefficient_names = tuple(
+            tuple(f"c_{coordinate}_{index}" for index in range(len(support)))
+            for coordinate, support in enumerate(supports)
+        )
+        ansatz = PolynomialInverseAnsatzSpecification(
+            support_mode=validated.support_mode,
+            inverse_degree_bound=validated.inverse_degree_bound,
+            source_variables=validated.source_variables,
+            target_variables=validated.target_variables,
+            coordinate_supports=supports,
+            coefficient_symbols=coefficient_names,
+        )
+        unknown_names = tuple(name for row in coefficient_names for name in row)
+
+        status: PolynomialInverseSynthesisStatus
+        equations: tuple[PolynomialInverseCoefficientEquation, ...] = ()
+        candidate: RationalPolynomialMap | None = None
+        left_residuals: tuple[SparseRationalPolynomial, ...] = ()
+        right_residuals: tuple[SparseRationalPolynomial, ...] = ()
+        verification_output: dict[str, Any] | None = None
+        verification_artifact_uri: str | None = None
+        verification_failure: str | None = None
+        residual_term_count = 0
+
+        if validated.solver != "sympy.solve":
+            status = PolynomialInverseSynthesisStatus.UNSUPPORTED
+            verification_failure = (
+                f"solver {validated.solver!r} is unsupported; use 'sympy.solve'"
+            )
+        elif validated.limits.timeout_ms == 0:
+            status = PolynomialInverseSynthesisStatus.TIMEOUT
+        elif len(unknown_names) > validated.limits.max_unknown_coefficients:
+            status = PolynomialInverseSynthesisStatus.BUDGET_EXHAUSTED
+            verification_failure = "ansatz unknown count exceeds the declared limit"
+        else:
+            forward_degree = max(
+                (
+                    sum(term.exponents)
+                    for coordinate in validated.forward_map.coordinates
+                    for term in coordinate.terms
+                ),
+                default=0,
+            )
+            residual_term_bound = _inverse_residual_term_bound(validated, supports)
+            precheck_exhausted = (
+                forward_degree * validated.inverse_degree_bound
+                > validated.limits.max_composition_degree
+                or residual_term_bound > validated.limits.max_residual_terms
+            )
+            if precheck_exhausted:
+                status = PolynomialInverseSynthesisStatus.BUDGET_EXHAUSTED
+                verification_failure = (
+                    "conservative composition degree or residual-term bound "
+                    "exceeds a declared limit"
+                )
+                ansatz_expressions = ()
+                unknown_symbols = ()
+            else:
+                (
+                    ansatz_expressions,
+                    unknown_symbols,
+                    equations,
+                    residual_term_count,
+                ) = _inverse_coefficient_system(
+                    validated,
+                    supports,
+                    coefficient_names,
+                )
+            if precheck_exhausted:
+                pass
+            elif (
+                residual_term_count > validated.limits.max_residual_terms
+                or len(equations) > validated.limits.max_coefficient_equations
+            ):
+                status = PolynomialInverseSynthesisStatus.BUDGET_EXHAUSTED
+                verification_failure = (
+                    "derived coefficient system exceeds a declared residual "
+                    "or equation limit"
+                )
+            elif not equations:
+                status = PolynomialInverseSynthesisStatus.UNDERDETERMINED
+                verification_failure = "the ansatz produced no coefficient equations"
+            else:
+                remaining_ms = validated.limits.timeout_ms - int(
+                    (time.monotonic() - started) * 1000
+                )
+                if remaining_ms <= 0:
+                    solve_status, solution = "TIMEOUT", None
+                else:
+                    solve_status, solution = _solve_inverse_system(
+                        equations,
+                        unknown_names,
+                        timeout_ms=remaining_ms,
+                    )
+                if solve_status == "TIMEOUT":
+                    status = PolynomialInverseSynthesisStatus.TIMEOUT
+                elif solve_status == "ERROR":
+                    status = PolynomialInverseSynthesisStatus.UNSUPPORTED
+                    verification_failure = "the configured exact solver failed"
+                elif solution is None:
+                    status = PolynomialInverseSynthesisStatus.NO_CANDIDATE_WITHIN_ANSATZ
+                elif any(value.free_symbols for value in solution.values()) or set(
+                    solution
+                ) != set(unknown_symbols):
+                    status = PolynomialInverseSynthesisStatus.UNDERDETERMINED
+                    verification_failure = (
+                        "the coefficient equations have free parameters"
+                    )
+                elif not all(value.is_Rational for value in solution.values()):
+                    status = PolynomialInverseSynthesisStatus.UNSUPPORTED
+                    verification_failure = (
+                        "the selected solution is not rational over QQ"
+                    )
+                else:
+                    candidate = _inverse_candidate_map(
+                        validated,
+                        ansatz_expressions,
+                        solution,
+                    )
+                    verify_request = PolynomialMapInverseVerifyRequest(
+                        forward_map=validated.forward_map,
+                        inverse_map=candidate,
+                        source_variables=validated.source_variables,
+                        target_variables=validated.target_variables,
+                    )
+                    left_residuals, right_residuals = _map_inverse_residuals(
+                        verify_request
+                    )
+                    status = PolynomialInverseSynthesisStatus.FOUND
+                    try:
+                        verified = PolynomialMapInverseVerifyAdapter(
+                            self.resources
+                        ).invoke(
+                            CapabilityRequest(
+                                capability_id="polynomial.map.inverse.verify",
+                                mode=CapabilityMode.VERIFY,
+                                input=verify_request.model_dump(mode="json"),
+                            )
+                        )
+                        verification_output = verified.output
+                        artifact = (
+                            verified.output.get("verification_record_uri")
+                            or verified.output.get("certificate_uri")
+                        )
+                        verification_artifact_uri = (
+                            artifact if isinstance(artifact, str) else None
+                        )
+                        if verified.output.get("inverse_verified") is not True:
+                            verification_failure = (
+                                "the independent two-sided verifier rejected "
+                                "the synthesized candidate"
+                            )
+                    except CapabilityInvocationError as exc:
+                        verification_failure = exc.diagnostic.message
+
+        elapsed_ms = max(0, int((time.monotonic() - started) * 1000))
+        provenance = PolynomialInverseSolverProvenance(
+            solver=validated.solver,
+            backend_version=sympy.__version__,
+            timeout_ms=validated.limits.timeout_ms,
+            unknown_count=len(unknown_names),
+            equation_count=len(equations),
+            residual_term_count=residual_term_count,
+            elapsed_ms=elapsed_ms,
+        )
+        payload = PolynomialMapInverseSynthesisArtifact(
+            status=status,
+            forward_map=validated.forward_map,
+            ansatz=ansatz,
+            coefficient_equations=equations,
+            solver_provenance=provenance,
+            candidate_inverse_map=candidate,
+            inverse_after_forward=left_residuals,
+            forward_after_inverse=right_residuals,
+            verification_output=verification_output,
+            verification_artifact_uri=verification_artifact_uri,
+            verification_failure=verification_failure,
+        )
+        parents = tuple(
+            dict.fromkeys(
+                (
+                    forward_artifact.artifact_uri,
+                    *(
+                        (verification_artifact_uri,)
+                        if verification_artifact_uri
+                        else ()
+                    ),
+                )
+            )
+        )
+        synthesis = self.resources.artifacts.put(
+            schema_uri=self.resources.installation.inverse_synthesis_schema_uri,
+            semantics_uri=self.resources.installation.inverse_semantics_uri,
+            payload=payload.model_dump(mode="json"),
+            parents=parents,
+            summary=f"bounded polynomial inverse synthesis: {status.value}",
+        )
+        output = PolynomialMapInverseSynthesisOutput(
+            **payload.model_dump(mode="python"),
+            synthesis_uri=synthesis.artifact_uri,
+            forward_map_uri=forward_artifact.artifact_uri,
+        )
+        artifact_uris = tuple(
+            dict.fromkeys(
+                (
+                    forward_artifact.artifact_uri,
+                    synthesis.artifact_uri,
+                    *(
+                        (verification_artifact_uri,)
+                        if verification_artifact_uri
+                        else ()
+                    ),
+                )
+            )
+        )
+        return CapabilityResult(
+            capability_id=self.descriptor.capability_id,
+            capability_version=self.descriptor.version,
+            mode=request.mode,
+            execution=Execution(
+                status=(
+                    ExecutionStatus.TIMEOUT
+                    if status is PolynomialInverseSynthesisStatus.TIMEOUT
+                    else ExecutionStatus.COMPLETED
+                ),
+                runtime_ms=elapsed_ms,
+            ),
+            output=output.model_dump(mode="json"),
+            scope=CapabilityScope(
+                description="one finite polynomial inverse coefficient ansatz over QQ",
+                parameters={
+                    "inverse_degree_bound": validated.inverse_degree_bound,
+                    "support_mode": validated.support_mode.value,
+                    "unknown_count": len(unknown_names),
+                },
+                artifact_uri=synthesis.artifact_uri,
+            ),
+            completeness=CapabilityCompleteness(
+                status=(
+                    CapabilityCompletenessStatus.COMPLETE
+                    if status
+                    in {
+                        PolynomialInverseSynthesisStatus.FOUND,
+                        PolynomialInverseSynthesisStatus.NO_CANDIDATE_WITHIN_ANSATZ,
+                        PolynomialInverseSynthesisStatus.UNDERDETERMINED,
+                    }
+                    else CapabilityCompletenessStatus.PARTIAL
+                ),
+                basis=(
+                    "the declared finite ansatz and exact coefficient system were solved"
+                    if status
+                    in {
+                        PolynomialInverseSynthesisStatus.FOUND,
+                        PolynomialInverseSynthesisStatus.NO_CANDIDATE_WITHIN_ANSATZ,
+                        PolynomialInverseSynthesisStatus.UNDERDETERMINED,
+                    }
+                    else "the declared synthesis operation did not complete"
+                ),
+                assurance_level=CapabilityAssuranceLevel.COMPUTED,
+            ),
+            assurance=CapabilityAssurance(
+                level=CapabilityAssuranceLevel.COMPUTED,
+                basis=(
+                    "bounded exact symbolic synthesis; no failure status proves "
+                    "noninvertibility and only the separate verifier may certify "
+                    "a found candidate"
+                ),
+            ),
+            artifact_uris=artifact_uris,
+        )
+
+
+def _inverse_supports(
+    request: PolynomialMapInverseSynthesisRequest,
+) -> tuple[tuple[tuple[int, ...], ...], ...]:
+    if request.support_mode is PolynomialInverseSupportMode.EXPLICIT:
+        assert request.explicit_support is not None
+        return request.explicit_support
+    dimension = len(request.target_variables)
+    support = tuple(
+        sorted(
+            (
+                exponents
+                for exponents in product(
+                    range(request.inverse_degree_bound + 1),
+                    repeat=dimension,
+                )
+                if sum(exponents) <= request.inverse_degree_bound
+            ),
+            reverse=True,
+        )
+    )
+    return tuple(support for _ in range(dimension))
+
+
+def _inverse_residual_term_bound(
+    request: PolynomialMapInverseSynthesisRequest,
+    supports: tuple[tuple[tuple[int, ...], ...], ...],
+) -> int:
+    forward_counts = tuple(
+        len(coordinate.terms) for coordinate in request.forward_map.coordinates
+    )
+    support_counts = tuple(len(support) for support in supports)
+    left = sum(
+        multiply(
+            count**exponent
+            for count, exponent in zip(
+                forward_counts,
+                monomial,
+                strict=True,
+            )
+        )
+        for support in supports
+        for monomial in support
+    )
+    right = sum(
+        multiply(
+            count**exponent
+            for count, exponent in zip(
+                support_counts,
+                term.exponents,
+                strict=True,
+            )
+        )
+        for coordinate in request.forward_map.coordinates
+        for term in coordinate.terms
+    )
+    return int(left + right + 2 * len(request.source_variables))
+
+
+def _inverse_coefficient_system(
+    request: PolynomialMapInverseSynthesisRequest,
+    supports: tuple[tuple[tuple[int, ...], ...], ...],
+    coefficient_names: tuple[tuple[str, ...], ...],
+) -> tuple[
+    tuple[Any, ...],
+    tuple[Any, ...],
+    tuple[PolynomialInverseCoefficientEquation, ...],
+    int,
+]:
+    source_generators, forward = _sympy_map(request.forward_map)
+    target_generators = tuple(symbols(request.target_variables))
+    flat_names = tuple(name for row in coefficient_names for name in row)
+    unknowns = tuple(symbols(" ".join(flat_names), seq=True))
+    unknown_by_name = dict(zip(flat_names, unknowns, strict=True))
+    ansatz = tuple(
+        expand(
+            sum(
+                unknown_by_name[name]
+                * multiply(
+                    generator**exponent
+                    for generator, exponent in zip(
+                        target_generators,
+                        exponents,
+                        strict=True,
+                    )
+                )
+                for name, exponents in zip(names, support, strict=True)
+            )
+        )
+        for names, support in zip(coefficient_names, supports, strict=True)
+    )
+    left_substitutions = {
+        generator: polynomial.as_expr()
+        for generator, polynomial in zip(
+            target_generators,
+            forward,
+            strict=True,
+        )
+    }
+    left = tuple(
+        expand(
+            expression.subs(left_substitutions, simultaneous=True)
+            - source_generators[index]
+        )
+        for index, expression in enumerate(ansatz)
+    )
+    right_substitutions = dict(zip(source_generators, ansatz, strict=True))
+    right = tuple(
+        expand(
+            polynomial.as_expr().subs(right_substitutions, simultaneous=True)
+            - target_generators[index]
+        )
+        for index, polynomial in enumerate(forward)
+    )
+    records: list[PolynomialInverseCoefficientEquation] = []
+    residual_term_count = 0
+    for direction, generators, residuals in (
+        ("INVERSE_AFTER_FORWARD", source_generators, left),
+        ("FORWARD_AFTER_INVERSE", target_generators, right),
+    ):
+        for coordinate, residual in enumerate(residuals):
+            polynomial = Poly(residual, *generators)
+            terms = polynomial.terms()
+            residual_term_count += len(terms)
+            records.extend(
+                PolynomialInverseCoefficientEquation(
+                    direction=cast(Any, direction),
+                    coordinate=coordinate,
+                    monomial_exponents=monomial,
+                    expression=str(coefficient),
+                )
+                for monomial, coefficient in terms
+                if coefficient != 0
+            )
+    return ansatz, unknowns, tuple(records), residual_term_count
+
+
+def _solve_inverse_system(
+    equations: tuple[PolynomialInverseCoefficientEquation, ...],
+    unknown_names: tuple[str, ...],
+    *,
+    timeout_ms: int,
+) -> tuple[str, dict[Any, Any] | None]:
+    context = multiprocessing.get_context("spawn")
+    result_queue = context.Queue(maxsize=1)
+    process = context.Process(
+        target=_inverse_solver_worker,
+        args=(
+            tuple(item.expression for item in equations),
+            unknown_names,
+            result_queue,
+        ),
+    )
+    process.start()
+    process.join(timeout_ms / 1000)
+    if process.is_alive():
+        process.terminate()
+        process.join()
+        return "TIMEOUT", None
+    try:
+        status, raw = result_queue.get_nowait()
+    except Empty:
+        return "ERROR", None
+    if status != "OK":
+        return "ERROR", None
+    if not raw:
+        return "OK", None
+    symbols_by_name = dict(
+        zip(unknown_names, symbols(" ".join(unknown_names), seq=True), strict=True)
+    )
+    first = raw[0]
+    solution = {
+        symbols_by_name[name]: sympify(value, locals=symbols_by_name)
+        for name, value in first
+    }
+    return "OK", solution
+
+
+def _inverse_candidate_map(
+    request: PolynomialMapInverseSynthesisRequest,
+    ansatz: tuple[Any, ...],
+    solution: dict[Any, Any],
+) -> RationalPolynomialMap:
+    target_generators = tuple(symbols(request.target_variables))
+    return RationalPolynomialMap(
+        variables=request.target_variables,
+        coordinates=tuple(
+            _wire_polynomial(
+                Poly(
+                    expand(expression.subs(solution, simultaneous=True)),
+                    *target_generators,
+                    domain=QQ,
+                )
+            )
+            for expression in ansatz
+        ),
+    )
 
 
 class PolynomialMapInverseVerifyAdapter:

--- a/tests/integration/test_polynomial_map_inverse_synthesize.py
+++ b/tests/integration/test_polynomial_map_inverse_synthesize.py
@@ -1,0 +1,242 @@
+"""Acceptance tests for bounded polynomial-map inverse synthesis."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from jacobian.contracts.capabilities import CapabilityMode, CapabilityRequest
+from jacobian.contracts.results import ExecutionStatus
+from jacobian.kernel import JacobianKernel
+
+
+def _term(coefficient: int, exponents: list[int]) -> dict[str, Any]:
+    return {
+        "coefficient": {"num": str(coefficient), "den": "1"},
+        "exponents": exponents,
+    }
+
+
+def _triangular_forward() -> dict[str, Any]:
+    return {
+        "map_schema_version": "1",
+        "domain": "QQ",
+        "variables": ["x", "y"],
+        "coordinates": [
+            {"terms": [_term(1, [1, 0]), _term(1, [0, 2])]},
+            {"terms": [_term(1, [0, 1])]},
+        ],
+    }
+
+
+def _request(
+    *,
+    degree: int,
+    timeout_ms: int = 10_000,
+    max_unknowns: int = 64,
+    explicit_support: list[list[list[int]]] | None = None,
+) -> CapabilityRequest:
+    return CapabilityRequest(
+        capability_id="polynomial.map.inverse.candidate_synthesize",
+        input={
+            "forward_map": _triangular_forward(),
+            "source_variables": ["x", "y"],
+            "target_variables": ["u", "v"],
+            "inverse_degree_bound": degree,
+            "support_mode": (
+                "EXPLICIT" if explicit_support is not None else "FULL_TOTAL_DEGREE"
+            ),
+            "explicit_support": explicit_support,
+            "solver": "sympy.solve",
+            "limits": {
+                "timeout_ms": timeout_ms,
+                "max_inverse_degree": 4,
+                "max_composition_degree": 32,
+                "max_unknown_coefficients": max_unknowns,
+                "max_coefficient_equations": 512,
+                "max_residual_terms": 1024,
+            },
+        },
+    )
+
+
+@pytest.mark.integration
+def test_triangular_automorphism_is_found_and_verified(tmp_path: Path) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+    result = kernel.capabilities.invoke(_request(degree=2))
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output["status"] == "FOUND"
+    assert result.output["candidate_inverse_map"]["coordinates"] == [
+        {"terms": [_term(1, [1, 0]), _term(-1, [0, 2])]},
+        {"terms": [_term(1, [0, 1])]},
+    ]
+    assert result.output["verification_output"]["inverse_verified"] is True
+    assert result.output["verification_artifact_uri"] is not None
+    assert result.output["noninvertibility_proved"] is False
+    assert result.output["inverse_after_forward"] == [
+        {"terms": []},
+        {"terms": []},
+    ]
+    assert result.output["forward_after_inverse"] == [
+        {"terms": []},
+        {"terms": []},
+    ]
+
+
+@pytest.mark.integration
+def test_degree_below_required_returns_bounded_no_candidate(tmp_path: Path) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+    result = kernel.capabilities.invoke(_request(degree=1))
+
+    assert result.output["status"] == "NO_CANDIDATE_WITHIN_ANSATZ"
+    assert result.output["candidate_inverse_map"] is None
+    assert result.output["noninvertibility_proved"] is False
+
+
+@pytest.mark.integration
+def test_redundant_explicit_ansatz_is_underdetermined(tmp_path: Path) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+    identity = {
+        "map_schema_version": "1",
+        "domain": "QQ",
+        "variables": ["x"],
+        "coordinates": [{"terms": [_term(1, [1])]}],
+    }
+    request = CapabilityRequest(
+        capability_id="polynomial.map.inverse.candidate_synthesize",
+        input={
+            "forward_map": identity,
+            "source_variables": ["x"],
+            "target_variables": ["u"],
+            "inverse_degree_bound": 1,
+            "support_mode": "EXPLICIT",
+            "explicit_support": [[[1], [1]]],
+            "solver": "sympy.solve",
+            "limits": {
+                "timeout_ms": 10_000,
+                "max_inverse_degree": 1,
+                "max_composition_degree": 8,
+                "max_unknown_coefficients": 4,
+                "max_coefficient_equations": 16,
+                "max_residual_terms": 16,
+            },
+        },
+    )
+
+    result = kernel.capabilities.invoke(request)
+
+    assert result.output["status"] == "UNDERDETERMINED"
+    assert result.output["candidate_inverse_map"] is None
+    assert "free parameters" in result.output["verification_failure"]
+
+
+@pytest.mark.integration
+def test_zero_timeout_and_unknown_budget_are_explicit(tmp_path: Path) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+
+    timeout = kernel.capabilities.invoke(_request(degree=2, timeout_ms=0))
+    exhausted = kernel.capabilities.invoke(_request(degree=2, max_unknowns=1))
+
+    assert timeout.execution.status is ExecutionStatus.TIMEOUT
+    assert timeout.output["status"] == "TIMEOUT"
+    assert exhausted.output["status"] == "BUDGET_EXHAUSTED"
+
+
+@pytest.mark.integration
+def test_unknown_solver_is_unsupported_without_truth_claim(tmp_path: Path) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+    payload = deepcopy(_request(degree=2).input)
+    payload["solver"] = "unknown.exact_solver"
+
+    result = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="polynomial.map.inverse.candidate_synthesize",
+            input=payload,
+        )
+    )
+
+    assert result.output["status"] == "UNSUPPORTED"
+    assert result.output["candidate_inverse_map"] is None
+    assert result.output["noninvertibility_proved"] is False
+
+
+@pytest.mark.integration
+def test_full_support_and_coefficient_order_are_deterministic(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+    first = kernel.capabilities.invoke(_request(degree=2))
+    second = kernel.capabilities.invoke(_request(degree=2))
+
+    assert first.output["ansatz"] == second.output["ansatz"]
+    assert (
+        first.output["coefficient_equations"] == second.output["coefficient_equations"]
+    )
+    supports = first.output["ansatz"]["coordinate_supports"]
+    assert supports[0] == [
+        [2, 0],
+        [1, 1],
+        [1, 0],
+        [0, 2],
+        [0, 1],
+        [0, 0],
+    ]
+    assert first.output["ansatz"]["coefficient_symbols"][0] == [
+        "c_0_0",
+        "c_0_1",
+        "c_0_2",
+        "c_0_3",
+        "c_0_4",
+        "c_0_5",
+    ]
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "mutation",
+    ["variable_order", "coefficient_domain"],
+)
+def test_ring_mismatches_fail_closed(tmp_path: Path, mutation: str) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+    payload = deepcopy(_request(degree=2).input)
+    if mutation == "variable_order":
+        payload["source_variables"] = ["y", "x"]
+    else:
+        payload["forward_map"]["domain"] = "RR"
+
+    result = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="polynomial.map.inverse.candidate_synthesize",
+            input=payload,
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.artifact_uris == ()
+
+
+@pytest.mark.integration
+def test_corrupted_found_candidate_does_not_verify(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+    synthesized = kernel.capabilities.invoke(_request(degree=2))
+    corrupted = deepcopy(synthesized.output["candidate_inverse_map"])
+    corrupted["coordinates"][0]["terms"][1]["coefficient"]["num"] = "-2"
+    checked = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="polynomial.map.inverse.verify",
+            mode=CapabilityMode.VERIFY,
+            input={
+                "forward_map": _triangular_forward(),
+                "inverse_map": corrupted,
+                "source_variables": ["x", "y"],
+                "target_variables": ["u", "v"],
+            },
+        )
+    )
+    assert checked.output["inverse_verified"] is False


### PR DESCRIPTION
## Summary

- add `polynomial.map.inverse.candidate_synthesize` on top of PR #105
- support square canonical sparse polynomial maps over `QQ`
- accept explicit ordered supports or deterministic full total-degree supports
- construct exact rational symbolic coefficient ansatzes and both composition equation families
- enforce explicit solver timeout, inverse/composition degree, unknown, equation, and residual-term limits
- report `FOUND`, `NO_CANDIDATE_WITHIN_ANSATZ`, `UNDERDETERMINED`, `TIMEOUT`, `BUDGET_EXHAUSTED`, and `UNSUPPORTED`
- submit every found candidate to `polynomial.map.inverse.verify`
- emit the candidate, complete ansatz, exact coefficient equations, solver provenance, both residual families, and verifier output/artifact or explicit failure

## Safety and verification boundary

- synthesis is always `COMPUTED` and never self-verifies
- `NO_CANDIDATE_WITHIN_ANSATZ` explicitly carries `noninvertibility_proved: false`
- the exact solver runs in an isolated process that is terminated on timeout
- conservative composition-degree and residual-term checks run before symbolic expansion
- only PR #105's independent two-sided verifier can certify a found candidate
- checking or declaring one composition alone remains insufficient
- rational-map inverses, denominator ansatzes, and pole-domain reasoning remain outside v1

## Validation

- Ruff lint: passed
- Ruff formatting: passed
- focused mypy over changed source modules: passed
- synthesis acceptance suite: 9 passed
- combined synthesis, verifier integration, and independent checker suites: 32 passed
- broader non-integration suite: 390 passed; six unrelated local-environment failures remain (five macOS Bash 3 associative-array failures and one pre-existing SMT checker fixture failure)

This PR is intentionally stacked on draft PR #105. Retarget it to `main` after #105 merges.

Closes #94
