### PR TITLE
feat: add bounded LRAT UNSAT certificate replay

### DIFF
--- a/docs/reference/sat-artifacts.md
+++ b/docs/reference/sat-artifacts.md
@@ -6,8 +6,8 @@
 - Optional operations: `sat.model.find` and `sat.unsat_proof.find` when exact
   CaDiCaL 3.0.1 is installed; `sat.unsat_proof.verify` when the operator
   installs bundled references and an exactly identified DRAT-trim runtime
-- Installed operations: `sat.model.verify` when the operator installs the
-  bundled reference checkers
+- Installed operations: `sat.model.verify` and `sat.lrat.verify` when the
+  operator installs the bundled reference checkers
 - Related plan:
   [Atomic capability portfolio](../contributing/atomic-capability-portfolio.md#wave-2-sat-certificate-vertical-slice)
 
@@ -20,6 +20,13 @@ operator may separately authorize the bundled assignment checker and expose
 `sat.model.verify`. Proof verification additionally requires a pinned
 DRAT-trim executable with operator-supplied provenance.
 
+`sat.lrat.verify` is deliberately separate from the DRAT operation. Its
+bounded v1 accepts ASCII LRAT additions with ordered positive RUP hints and
+deletions. It binds the exact CNF object, variable map, DIMACS projection,
+proof bytes, limits, checker, and certificate. Negative RAT hints are
+`UNSUPPORTED`; malformed, truncated, timed-out, cancelled, or rejected proofs
+return `UNKNOWN` and never provide evidence that the formula is satisfiable.
+
 ## Registered descriptors
 
 `JacobianKernel.sat.installation` exposes the content-addressed descriptor URIs
@@ -31,6 +38,7 @@ registered by the current kernel:
 | Schema | `jacobian.canonical-cnf@1` | Canonical named-variable CNF and DIMACS binding |
 | Schema | `jacobian.sat-assignment@1` | Total assignment candidate bound to one CNF |
 | Schema | `jacobian.sat-proof@1` | Preserved raw DRAT bytes bound to one CNF |
+| Schema | `jacobian.sat-lrat-proof@1` | Preserved ASCII LRAT RUP-profile bytes and replay limits |
 | Schema | `jacobian.witness-envelope@1` | Exact assignment replay evidence |
 | Schema | `jacobian.certificate-envelope@1` | Exact UNSAT proof replay evidence |
 

--- a/src/jacobian/contracts/sat.py
+++ b/src/jacobian/contracts/sat.py
@@ -389,6 +389,106 @@ class SatUnsatProofVerificationOutput(ContractModel):
         return self
 
 
+class SatLratResourceLimits(ContractModel):
+    """Explicit limits for bounded ASCII LRAT replay."""
+
+    timeout_ms: StrictInt = Field(default=30_000, ge=0, le=120_000)
+    max_proof_bytes: StrictInt = Field(default=4_194_304, ge=1, le=67_108_864)
+    max_steps: StrictInt = Field(default=100_000, ge=1, le=2_000_000)
+    max_hints_per_step: StrictInt = Field(default=100_000, ge=1, le=1_000_000)
+    max_clause_literals: StrictInt = Field(default=100_000, ge=0, le=1_000_000)
+
+
+class SatLratProofArtifact(ContractModel):
+    """Exact, unverified ASCII LRAT bytes bound to one canonical CNF."""
+
+    proof_format: Literal["LRAT-ASCII"] = "LRAT-ASCII"
+    proof_format_version: Literal["jacobian.lrat.rup/v1"] = "jacobian.lrat.rup/v1"
+    cnf: SatCnfBinding
+    proof_base64: str = Field(min_length=1)
+    proof_digest: Sha256Digest
+    proof_byte_count: StrictInt = Field(ge=1)
+    limits: SatLratResourceLimits
+
+    @model_validator(mode="after")
+    def bind_exact_bytes(self) -> Self:
+        raw = _decode_base64(self.proof_base64)
+        if self.proof_base64 != base64.b64encode(raw).decode("ascii"):
+            raise ValueError("LRAT proof must use canonical base64")
+        if self.proof_digest != _sha256(raw) or self.proof_byte_count != len(raw):
+            raise ValueError("LRAT proof digest or byte count does not match")
+        if len(raw) > self.limits.max_proof_bytes:
+            raise ValueError("LRAT proof exceeds its declared byte limit")
+        return self
+
+    @classmethod
+    def from_bytes(
+        cls,
+        *,
+        cnf: SatCnfBinding,
+        proof: bytes,
+        limits: SatLratResourceLimits,
+    ) -> Self:
+        return cls(
+            cnf=cnf,
+            proof_base64=base64.b64encode(proof).decode("ascii"),
+            proof_digest=_sha256(proof),
+            proof_byte_count=len(proof),
+            limits=limits,
+        )
+
+
+class SatLratVerificationRequest(ContractModel):
+    """Replay exact ASCII LRAT against one canonical CNF."""
+
+    cnf_uri: ArtifactUri
+    proof_base64: str = Field(min_length=1)
+    limits: SatLratResourceLimits = SatLratResourceLimits()
+    cancelled: bool = False
+
+    @model_validator(mode="after")
+    def validate_proof_encoding(self) -> Self:
+        raw = _decode_base64(self.proof_base64)
+        if self.proof_base64 != base64.b64encode(raw).decode("ascii"):
+            raise ValueError("LRAT proof must use canonical base64")
+        if not raw:
+            raise ValueError("LRAT proof must not be empty")
+        if len(raw) > self.limits.max_proof_bytes:
+            raise ValueError("LRAT proof exceeds max_proof_bytes")
+        return self
+
+
+class SatLratVerificationOutput(ContractModel):
+    """Fail-closed projection of independent LRAT replay."""
+
+    status: Literal[
+        "VERIFIED_UNSAT",
+        "REJECTED",
+        "UNSUPPORTED",
+        "TIMEOUT",
+        "CANCELLED",
+        "ERROR",
+    ]
+    conclusion: Literal["TRUE", "UNKNOWN"]
+    cnf_uri: ArtifactUri
+    proof_uri: ArtifactUri
+    certificate_uri: ArtifactUri
+    checker_id: CheckerUri
+    verification_record_uri: ArtifactUri | None = None
+    detail: str = Field(min_length=1, max_length=1024)
+
+    @model_validator(mode="after")
+    def bind_verified_projection(self) -> Self:
+        if self.status == "VERIFIED_UNSAT":
+            if self.conclusion != "TRUE" or self.verification_record_uri is None:
+                raise ValueError(
+                    "verified LRAT requires TRUE and a verification record"
+                )
+        elif self.conclusion != "UNKNOWN" or self.verification_record_uri is not None:
+            raise ValueError("non-verified LRAT cannot carry a conclusion or record")
+        return self
+
+
 def canonicalize_cnf(
     *,
     variable_names: Sequence[str],

--- a/src/jacobian/kernel.py
+++ b/src/jacobian/kernel.py
@@ -144,6 +144,9 @@ from jacobian.sat_capabilities import (
     install_sat_assignment_checker,
     install_sat_unsat_proof_checker,
 )
+from jacobian.sat_lrat_capabilities import (
+    install_sat_lrat_verifier,
+)
 from jacobian.schema_registry import SchemaRegistry
 from jacobian.search import SearchService
 from jacobian.shrinking import ShrinkService
@@ -338,6 +341,17 @@ class JacobianKernel:
         )
         if proof_adapter is not None:
             self.register_capability(proof_adapter)
+        lrat_adapter, self.sat_lrat = install_sat_lrat_verifier(
+            self.store,
+            self.schemas,
+            self.artifacts,
+            self.sat,
+            self.verification,
+            self.checkers,
+            authorize_checker=install_references,
+        )
+        if lrat_adapter is not None:
+            self.register_capability(lrat_adapter)
         self.carcara_runtime: CapabilityProviderRuntime = carcara_provider_runtime()
         self.smt_unsat_proof_checker: SmtUnsatProofCheckerInstallation
         smt_proof_adapter, self.smt_unsat_proof_checker = (

--- a/src/jacobian/sat_lrat_capabilities.py
+++ b/src/jacobian/sat_lrat_capabilities.py
@@ -1,0 +1,342 @@
+"""Independent, bounded verification for exact ASCII LRAT artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Literal
+
+from jacobian.artifacts import ArtifactService
+from jacobian.canonical import canonicalize_json
+from jacobian.capabilities import CapabilityAdapter, CapabilityInvocationError
+from jacobian.contracts.capabilities import (
+    CapabilityAssurance,
+    CapabilityAssuranceLevel,
+    CapabilityCompleteness,
+    CapabilityCompletenessStatus,
+    CapabilityDescriptor,
+    CapabilityDiagnostic,
+    CapabilityMode,
+    CapabilityRequest,
+    CapabilityResult,
+    CapabilityScope,
+)
+from jacobian.contracts.evidence import CertificateEnvelope, EvidenceBindings
+from jacobian.contracts.results import (
+    Conclusion,
+    Execution,
+    ExecutionStatus,
+    Verification,
+)
+from jacobian.contracts.sat import (
+    SatLratProofArtifact,
+    SatLratVerificationOutput,
+    SatLratVerificationRequest,
+)
+from jacobian.provider_runtime import known_provider_runtime
+from jacobian.registry import CheckerRegistry
+from jacobian.sat import SatArtifactError, SatArtifactService
+from jacobian.schema_registry import SchemaRegistry, model_schema
+from jacobian.store import ArtifactStore, StoreError
+from jacobian.verification import VerificationService
+
+
+@dataclass(frozen=True, slots=True)
+class SatLratInstallation:
+    proof_schema_uri: str
+    certificate_schema_uri: str
+    checker_id: str | None
+
+
+def install_sat_lrat_verifier(
+    store: ArtifactStore,
+    schemas: SchemaRegistry,
+    artifacts: ArtifactService,
+    sat: SatArtifactService,
+    verification: VerificationService,
+    checkers: CheckerRegistry,
+    *,
+    authorize_checker: bool,
+) -> tuple[CapabilityAdapter | None, SatLratInstallation]:
+    proof_schema_uri = schemas.register_model(
+        name="jacobian.sat-lrat-proof", version="1", model=SatLratProofArtifact
+    )
+    certificate_schema_uri = schemas.register_model(
+        name="jacobian.certificate-envelope", version="1", model=CertificateEnvelope
+    )
+    checker_id = None
+    if authorize_checker:
+        checker_id = checkers.authorize(
+            name="bounded independent ASCII LRAT RUP checker",
+            entrypoint="jacobian_checkers.sat_lrat:check_lrat",
+            evidence_kind="CERTIFICATE",
+            format_id="sat.lrat-proof",
+            format_version="1",
+            claim_schema_uris=(sat.installation.cnf_schema_uri,),
+            semantics_uris=(sat.installation.semantics_uri,),
+            candidate_schema_uris=(proof_schema_uri,),
+            reason="operator-authorized standard-library LRAT RUP replay",
+        ).checker_id
+    installation = SatLratInstallation(
+        proof_schema_uri=proof_schema_uri,
+        certificate_schema_uri=certificate_schema_uri,
+        checker_id=checker_id,
+    )
+    if checker_id is None:
+        return None, installation
+    return (
+        SatLratVerificationAdapter(
+            store=store,
+            artifacts=artifacts,
+            sat=sat,
+            verification=verification,
+            installation=installation,
+        ),
+        installation,
+    )
+
+
+class SatLratVerificationAdapter:
+    def __init__(
+        self,
+        *,
+        store: ArtifactStore,
+        artifacts: ArtifactService,
+        sat: SatArtifactService,
+        verification: VerificationService,
+        installation: SatLratInstallation,
+    ) -> None:
+        self.store = store
+        self.artifacts = artifacts
+        self.sat = sat
+        self.verification = verification
+        self.installation = installation
+        checker_id = installation.checker_id
+        assert checker_id is not None
+        self._descriptor = CapabilityDescriptor(
+            capability_id="sat.lrat.verify",
+            version="1",
+            title="Verify an LRAT UNSAT certificate",
+            description=(
+                "Independently replay the deterministic ASCII LRAT RUP profile "
+                "against an exact canonical CNF; negative RAT hints are unsupported."
+            ),
+            provider="jacobian.sat-lrat",
+            provider_runtime=known_provider_runtime(
+                "jacobian.sat-lrat",
+                features=("ascii-lrat", "ordered-rup-hints", "bounded-replay"),
+                checker_ids=(checker_id,),
+            ),
+            modes=(CapabilityMode.VERIFY,),
+            input_schema=model_schema(SatLratVerificationRequest),
+            output_schema=model_schema(SatLratVerificationOutput),
+            tags=("sat", "cnf", "lrat", "unsat", "certificate", "verification"),
+        )
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        return self._descriptor
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        validated = SatLratVerificationRequest.model_validate(request.input)
+        try:
+            resolved = self.sat.resolve_cnf(validated.cnf_uri)
+            semantics = self.store.get(self.sat.installation.semantics_uri)
+        except (SatArtifactError, StoreError) as exc:
+            raise CapabilityInvocationError(
+                CapabilityDiagnostic(
+                    code="INVALID_SAT_CNF",
+                    stage="artifact_resolution",
+                    message=str(exc),
+                    path="cnf_uri",
+                    schema_uri=self.sat.installation.cnf_schema_uri,
+                    expected="an exact canonical CNF artifact",
+                )
+            ) from exc
+        proof = SatLratProofArtifact.from_bytes(
+            cnf=resolved.binding,
+            proof=__import__("base64").b64decode(validated.proof_base64, validate=True),
+            limits=validated.limits,
+        )
+        proof_artifact = self.artifacts.put(
+            schema_uri=self.installation.proof_schema_uri,
+            semantics_uri=self.sat.installation.semantics_uri,
+            payload=proof.model_dump(mode="json"),
+            parents=(resolved.artifact.artifact_uri,),
+            summary="unverified exact ASCII LRAT proof",
+        )
+        checker_id = self.installation.checker_id
+        assert checker_id is not None
+        bindings = EvidenceBindings(
+            claim_digest=resolved.artifact.manifest.object_digest,
+            semantics_digest=semantics.manifest.object_digest,
+            candidate_digest=proof_artifact.object_digest,
+        )
+        payload = {
+            "cnf_uri": resolved.artifact.artifact_uri,
+            "proof_uri": proof_artifact.artifact_uri,
+            "proof_digest": proof.proof_digest,
+            "limits": validated.limits.model_dump(mode="json"),
+        }
+        certificate = CertificateEnvelope(
+            certificate_type="sat.lrat-proof",
+            format_version="1",
+            bindings=bindings,
+            payload_digest="sha256:"
+            + hashlib.sha256(canonicalize_json(payload)).hexdigest(),
+            payload=payload,
+        )
+        certificate_artifact = self.artifacts.put(
+            schema_uri=self.installation.certificate_schema_uri,
+            semantics_uri=self.sat.installation.semantics_uri,
+            payload=certificate.model_dump(mode="json"),
+            parents=(resolved.artifact.artifact_uri, proof_artifact.artifact_uri),
+            summary="LRAT verification certificate",
+        )
+        if validated.cancelled:
+            output = SatLratVerificationOutput(
+                status="CANCELLED",
+                conclusion="UNKNOWN",
+                cnf_uri=resolved.artifact.artifact_uri,
+                proof_uri=proof_artifact.artifact_uri,
+                certificate_uri=certificate_artifact.artifact_uri,
+                checker_id=checker_id,
+                detail="request was cancelled before replay; no conclusion follows",
+            )
+            return CapabilityResult(
+                capability_id=self.descriptor.capability_id,
+                capability_version=self.descriptor.version,
+                mode=request.mode,
+                execution=Execution(
+                    status=ExecutionStatus.CANCELLED,
+                    detail="cancelled before independent LRAT replay",
+                ),
+                output=output.model_dump(mode="json"),
+                scope=CapabilityScope(
+                    description="the exact canonical CNF and exact LRAT proof bytes",
+                    parameters={
+                        "proof_format": proof.proof_format,
+                        "proof_format_version": proof.proof_format_version,
+                        "proof_digest": proof.proof_digest,
+                        "variable_map_digest": proof.cnf.variable_map_digest,
+                        "dimacs_digest": proof.cnf.dimacs_digest,
+                        "limits": validated.limits.model_dump(mode="json"),
+                    },
+                    artifact_uri=resolved.artifact.artifact_uri,
+                ),
+                completeness=CapabilityCompleteness(
+                    status=CapabilityCompletenessStatus.NOT_APPLICABLE,
+                    basis="cancelled certificate replay makes no completeness claim",
+                    assurance_level=CapabilityAssuranceLevel.HEURISTIC,
+                ),
+                assurance=CapabilityAssurance(
+                    level=CapabilityAssuranceLevel.HEURISTIC,
+                    basis="cancelled before checker execution; no conclusion follows",
+                ),
+                artifact_uris=(
+                    resolved.artifact.artifact_uri,
+                    proof_artifact.artifact_uri,
+                    certificate_artifact.artifact_uri,
+                ),
+            )
+        checked = self.verification.verify_certificate(
+            certificate_uri=certificate_artifact.artifact_uri,
+            checker_id=checker_id,
+            include_artifact_metadata=True,
+        )
+        verified = (
+            checked.execution.status is ExecutionStatus.COMPLETED
+            and checked.conclusion is Conclusion.TRUE
+            and checked.assurance.verification is Verification.VERIFIED
+            and checked.verification_record_uri is not None
+        )
+        detail = checked.execution.detail or (
+            checked.input.errors[0] if checked.input.errors else "LRAT proof rejected"
+        )
+        status: Literal[
+            "VERIFIED_UNSAT",
+            "REJECTED",
+            "UNSUPPORTED",
+            "TIMEOUT",
+            "CANCELLED",
+            "ERROR",
+        ]
+        if verified:
+            status = "VERIFIED_UNSAT"
+        elif "unsupported LRAT feature" in detail:
+            status = "UNSUPPORTED"
+        elif "timed out" in detail:
+            status = "TIMEOUT"
+        elif checked.execution.status is ExecutionStatus.COMPLETED:
+            status = "REJECTED"
+        else:
+            status = "ERROR"
+        record_uri = checked.verification_record_uri if verified else None
+        projected_execution = (
+            Execution(status=ExecutionStatus.TIMEOUT, detail=detail)
+            if status == "TIMEOUT"
+            else checked.execution
+        )
+        output = SatLratVerificationOutput(
+            status=status,
+            conclusion="TRUE" if verified else "UNKNOWN",
+            cnf_uri=resolved.artifact.artifact_uri,
+            proof_uri=proof_artifact.artifact_uri,
+            certificate_uri=certificate_artifact.artifact_uri,
+            checker_id=checker_id,
+            verification_record_uri=record_uri,
+            detail=detail,
+        )
+        uris = [
+            resolved.artifact.artifact_uri,
+            proof_artifact.artifact_uri,
+            certificate_artifact.artifact_uri,
+        ]
+        if record_uri:
+            uris.append(record_uri)
+        return CapabilityResult(
+            capability_id=self.descriptor.capability_id,
+            capability_version=self.descriptor.version,
+            mode=request.mode,
+            execution=projected_execution,
+            output=output.model_dump(mode="json"),
+            scope=CapabilityScope(
+                description="the exact canonical CNF and exact LRAT proof bytes",
+                parameters={
+                    "proof_format": proof.proof_format,
+                    "proof_format_version": proof.proof_format_version,
+                    "proof_digest": proof.proof_digest,
+                    "variable_map_digest": proof.cnf.variable_map_digest,
+                    "dimacs_digest": proof.cnf.dimacs_digest,
+                    "limits": validated.limits.model_dump(mode="json"),
+                },
+                artifact_uri=resolved.artifact.artifact_uri,
+            ),
+            completeness=CapabilityCompleteness(
+                status=CapabilityCompletenessStatus.NOT_APPLICABLE,
+                basis="certificate replay makes no search-completeness claim",
+                assurance_level=(
+                    CapabilityAssuranceLevel.HEURISTIC
+                    if status == "TIMEOUT"
+                    else CapabilityAssuranceLevel.COMPUTED
+                ),
+            ),
+            assurance=CapabilityAssurance(
+                level=(
+                    CapabilityAssuranceLevel.VERIFIED
+                    if verified
+                    else (
+                        CapabilityAssuranceLevel.HEURISTIC
+                        if status == "TIMEOUT"
+                        else CapabilityAssuranceLevel.COMPUTED
+                    )
+                ),
+                basis=(
+                    "independent checker accepted the exact bound LRAT proof"
+                    if verified
+                    else "proof was not accepted; this is not evidence of satisfiability"
+                ),
+                verification_record_uri=record_uri,
+            ),
+            artifact_uris=tuple(uris),
+        )

--- a/src/jacobian_checkers/sat_lrat.py
+++ b/src/jacobian_checkers/sat_lrat.py
@@ -1,0 +1,278 @@
+"""Independent bounded replay of the Jacobian ASCII LRAT RUP profile."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import re
+import time
+from typing import Any
+
+_URI = re.compile(r"^artifact://sha256/[0-9a-f]{64}$")
+_DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+def _sha(value: bytes) -> str:
+    return "sha256:" + hashlib.sha256(value).hexdigest()
+
+
+def _json(value: object) -> bytes:
+    return json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+
+
+def _result(accepted: bool, detail: str) -> dict[str, Any]:
+    return {
+        "accepted": accepted,
+        "conclusion": "TRUE" if accepted else "UNKNOWN",
+        "arithmetic": "EXACT_INTEGER",
+        "method": "CHECKED_CERTIFICATE",
+        "coverage": "NOT_APPLICABLE",
+        "detail": detail,
+    }
+
+
+def _artifact(value: object) -> bool:
+    return (
+        isinstance(value, dict)
+        and set(value)
+        == {
+            "artifact_uri",
+            "object_digest",
+            "payload_digest",
+            "schema_uri",
+            "semantics_uri",
+            "parents",
+            "payload",
+        }
+        and isinstance(value["artifact_uri"], str)
+        and _URI.fullmatch(value["artifact_uri"]) is not None
+        and isinstance(value["object_digest"], str)
+        and _DIGEST.fullmatch(value["object_digest"]) is not None
+        and isinstance(value["payload_digest"], str)
+        and value["payload_digest"] == _sha(_json(value["payload"]))
+        and isinstance(value["parents"], list)
+    )
+
+
+def _cnf(payload: object) -> tuple[list[tuple[int, ...]], int]:
+    if not isinstance(payload, dict) or payload.get("cnf_schema_version") != "1":
+        raise ValueError("invalid canonical CNF")
+    variables, rows = payload.get("variables"), payload.get("clauses")
+    if not isinstance(variables, list) or not isinstance(rows, list):
+        raise ValueError("invalid canonical CNF")
+    clauses: list[tuple[int, ...]] = []
+    for row in rows:
+        if not isinstance(row, dict) or set(row) != {"literals"}:
+            raise ValueError("invalid canonical CNF")
+        lits = row["literals"]
+        if not isinstance(lits, list) or any(type(x) is not int for x in lits):
+            raise ValueError("invalid canonical CNF")
+        if any(x == 0 or abs(x) > len(variables) for x in lits):
+            raise ValueError("invalid canonical CNF")
+        clauses.append(tuple(lits))
+    return clauses, len(variables)
+
+
+def _integers(fields: list[str], number: int, kind: str = "token") -> list[int]:
+    try:
+        return [int(field) for field in fields]
+    except ValueError as exc:
+        raise ValueError(f"line {number}: non-integer {kind}") from exc
+
+
+def _replay(
+    clauses: list[tuple[int, ...]], proof: bytes, limits: dict[str, int]
+) -> tuple[bool, str]:
+    try:
+        text = proof.decode("ascii")
+    except UnicodeDecodeError as exc:
+        raise ValueError("proof is not ASCII") from exc
+    started = time.monotonic()
+    active = dict(enumerate(clauses, 1))
+    last_id = len(clauses)
+    empty = False
+    steps = 0
+    for number, raw_line in enumerate(text.splitlines(), 1):
+        if (time.monotonic() - started) * 1000 >= limits["timeout_ms"]:
+            raise TimeoutError("LRAT replay exceeded timeout_ms")
+        line = raw_line.strip()
+        if not line or line.startswith("c "):
+            continue
+        steps += 1
+        if steps > limits["max_steps"]:
+            raise OverflowError("LRAT replay exceeded max_steps")
+        fields = line.split()
+        clause_id = _integers(fields[:1], number, "clause id")[0]
+        if clause_id <= 0:
+            raise ValueError(f"line {number}: invalid clause id")
+        if len(fields) > 1 and fields[1] == "d":
+            deleted_ids = _integers(fields[2:], number, "deletion")
+            if not deleted_ids or deleted_ids[-1] != 0:
+                raise ValueError(f"line {number}: malformed deletion")
+            for deleted in deleted_ids[:-1]:
+                if deleted not in active:
+                    raise ValueError(
+                        f"line {number}: deletion references inactive clause"
+                    )
+                del active[deleted]
+            continue
+        values = _integers(fields, number)
+        if clause_id <= last_id or values.count(0) != 2:
+            raise ValueError(f"line {number}: invalid addition framing")
+        first_zero = values.index(0, 1)
+        candidate = tuple(values[1:first_zero])
+        hints = values[first_zero + 1 : -1]
+        if any(lit == 0 or abs(lit) > limits["variable_count"] for lit in candidate):
+            raise ValueError(f"line {number}: invalid literal")
+        if len(candidate) > limits["max_clause_literals"]:
+            raise OverflowError("LRAT replay exceeded max_clause_literals")
+        if not hints or len(hints) > limits["max_hints_per_step"]:
+            raise ValueError(f"line {number}: invalid hint count")
+        if any(hint <= 0 for hint in hints):
+            raise NotImplementedError("negative RAT hints are unsupported in v1")
+        assignment: dict[int, bool] = {}
+        for lit in candidate:
+            var, assumed_value = abs(lit), lit < 0
+            if var in assignment and assignment[var] != assumed_value:
+                raise ValueError(f"line {number}: tautological candidate")
+            assignment[var] = assumed_value
+        conflicted = False
+        for hint in hints:
+            clause = active.get(hint)
+            if clause is None:
+                raise ValueError(f"line {number}: hint references inactive clause")
+            unassigned: list[int] = []
+            satisfied: bool = False
+            for lit in clause:
+                assigned_value = assignment.get(abs(lit))
+                if assigned_value is None:
+                    unassigned.append(lit)
+                elif assigned_value == (lit > 0):
+                    satisfied = True
+            if satisfied or len(unassigned) > 1:
+                raise ValueError(f"line {number}: hint is not unit or conflicting")
+            if not unassigned:
+                conflicted = True
+                break
+            lit = unassigned[0]
+            assignment[abs(lit)] = lit > 0
+        if not conflicted:
+            raise ValueError(f"line {number}: hints do not establish RUP")
+        active[clause_id] = candidate
+        last_id = clause_id
+        empty = empty or not candidate
+    return empty, f"replayed {steps} LRAT steps"
+
+
+def check_lrat(request: dict[str, Any]) -> dict[str, Any]:
+    """Accept only a bound proof whose RUP hints derive the empty clause."""
+    try:
+        if not isinstance(request, dict) or set(request) != {
+            "request_version",
+            "claim",
+            "candidate",
+            "scope",
+            "certificate",
+            "expected_bindings",
+        }:
+            return _result(False, "malformed checker request")
+        claim, candidate, certificate = (
+            request["claim"],
+            request["candidate"],
+            request["certificate"],
+        )
+        if request["request_version"] != "1" or request["scope"] is not None:
+            return _result(False, "unsupported checker request")
+        if not all(_artifact(item) for item in (claim, candidate, certificate)):
+            return _result(False, "malformed checker artifacts")
+        if (
+            claim["semantics_uri"] != candidate["semantics_uri"]
+            or claim["semantics_uri"] != certificate["semantics_uri"]
+            or claim["artifact_uri"] not in candidate["parents"]
+            or not {claim["artifact_uri"], candidate["artifact_uri"]}.issubset(
+                certificate["parents"]
+            )
+        ):
+            return _result(False, "proof is missing CNF lineage")
+        bindings = request["expected_bindings"]
+        if (
+            not isinstance(bindings, dict)
+            or set(bindings)
+            != {
+                "claim_digest",
+                "semantics_digest",
+                "candidate_digest",
+                "scope_digest",
+                "encoding_digest",
+            }
+            or bindings.get("claim_digest") != claim["object_digest"]
+            or bindings.get("candidate_digest") != candidate["object_digest"]
+            or bindings.get("scope_digest") is not None
+            or bindings.get("encoding_digest") is not None
+        ):
+            return _result(False, "evidence bindings do not match")
+        payload = candidate["payload"]
+        if (
+            not isinstance(payload, dict)
+            or payload.get("proof_format") != "LRAT-ASCII"
+            or payload.get("proof_format_version") != "jacobian.lrat.rup/v1"
+            or payload.get("cnf", {}).get("cnf_artifact_uri") != claim["artifact_uri"]
+        ):
+            return _result(False, "unsupported or unbound LRAT artifact")
+        expected_cnf_binding = {
+            "binding_version": "1",
+            "cnf_artifact_uri": claim["artifact_uri"],
+            "cnf_object_digest": claim["object_digest"],
+            "cnf_payload_digest": claim["payload_digest"],
+            "variable_map_digest": claim["payload"]["variable_map_digest"],
+            "dimacs_digest": claim["payload"]["dimacs_digest"],
+            "projection_format": claim["payload"]["projection_format"],
+            "projection_version": claim["payload"]["projection_version"],
+            "variable_count": len(claim["payload"]["variables"]),
+            "clause_count": len(claim["payload"]["clauses"]),
+        }
+        if payload["cnf"] != expected_cnf_binding:
+            return _result(False, "LRAT source binding does not match exact CNF")
+        raw = base64.b64decode(payload["proof_base64"], validate=True)
+        if (
+            base64.b64encode(raw).decode("ascii") != payload["proof_base64"]
+            or _sha(raw) != payload.get("proof_digest")
+            or len(raw) != payload.get("proof_byte_count")
+        ):
+            return _result(False, "LRAT bytes do not match their binding")
+        expected_payload = {
+            "cnf_uri": claim["artifact_uri"],
+            "proof_uri": candidate["artifact_uri"],
+            "proof_digest": payload["proof_digest"],
+            "limits": payload["limits"],
+        }
+        envelope = certificate["payload"]
+        if (
+            not isinstance(envelope, dict)
+            or envelope.get("certificate_type") != "sat.lrat-proof"
+            or envelope.get("format_version") != "1"
+            or envelope.get("bindings") != bindings
+            or envelope.get("payload") != expected_payload
+            or envelope.get("payload_digest") != _sha(_json(expected_payload))
+        ):
+            return _result(False, "LRAT certificate is not exactly bound")
+        clauses, variable_count = _cnf(claim["payload"])
+        limits = dict(payload["limits"])
+        limits["variable_count"] = variable_count
+        accepted, detail = _replay(clauses, raw, limits)
+        return _result(
+            accepted, detail if accepted else detail + "; empty clause absent"
+        )
+    except NotImplementedError:
+        return _result(False, "unsupported LRAT feature: negative RAT hints")
+    except TimeoutError:
+        return _result(False, "LRAT replay timed out")
+    except (KeyError, TypeError, ValueError, OverflowError):
+        return _result(False, "malformed, rejected, or over-budget LRAT proof")

--- a/tests/integration/test_sat_lrat_verification.py
+++ b/tests/integration/test_sat_lrat_verification.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from jacobian.contracts.capabilities import (
+    CapabilityAssuranceLevel,
+    CapabilityMode,
+    CapabilityRequest,
+)
+from jacobian.contracts.results import ExecutionStatus
+from jacobian.kernel import JacobianKernel
+
+pytestmark = [pytest.mark.integration, pytest.mark.subprocess]
+
+
+def _verify(kernel: JacobianKernel, cnf_uri: str, proof: bytes, **extra: object):
+    return kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="sat.lrat.verify",
+            mode=CapabilityMode.VERIFY,
+            input={
+                "cnf_uri": cnf_uri,
+                "proof_base64": base64.b64encode(proof).decode("ascii"),
+                **extra,
+            },
+        )
+    )
+
+
+def test_rup_lrat_derives_empty_clause_and_binds_artifacts(tmp_path) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+    cnf = kernel.sat.put_cnf(variable_names=("x",), clauses=((-1,), (1,)))
+
+    result = _verify(kernel, cnf.artifact_uri, b"3 0 1 2 0\n")
+
+    assert result.output["status"] == "VERIFIED_UNSAT"
+    assert result.output["conclusion"] == "TRUE"
+    assert result.assurance.level is CapabilityAssuranceLevel.VERIFIED
+    assert result.output["verification_record_uri"] is not None
+    proof = kernel.store.get(result.output["proof_uri"])
+    assert proof.manifest.parents == (cnf.artifact_uri,)
+    assert (
+        proof.payload["cnf"]["variable_map_digest"]
+        == result.scope.parameters["variable_map_digest"]
+    )
+    assert (
+        proof.payload["cnf"]["dimacs_digest"]
+        == result.scope.parameters["dimacs_digest"]
+    )
+
+
+@pytest.mark.parametrize(
+    "proof",
+    (
+        b"3 0 1 0\n",  # no conflict
+        b"3 0 1 99 0\n",  # missing hint
+        b"3 1 0 1 2 0\n",  # only a nonempty derived clause
+        b"3 0 1 2",  # truncated framing
+    ),
+)
+def test_invalid_or_incomplete_lrat_never_proves_sat_or_unsat(tmp_path, proof) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+    cnf = kernel.sat.put_cnf(variable_names=("x",), clauses=((-1,), (1,)))
+
+    result = _verify(kernel, cnf.artifact_uri, proof)
+
+    assert result.output["status"] == "REJECTED"
+    assert result.output["conclusion"] == "UNKNOWN"
+    assert result.output["verification_record_uri"] is None
+
+
+def test_negative_rat_hint_is_explicitly_unsupported(tmp_path) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+    cnf = kernel.sat.put_cnf(variable_names=("x",), clauses=((-1,), (1,)))
+
+    result = _verify(kernel, cnf.artifact_uri, b"3 0 -1 2 0\n")
+
+    assert result.output["status"] == "UNSUPPORTED"
+    assert result.output["conclusion"] == "UNKNOWN"
+
+
+def test_timeout_and_cancellation_are_fail_closed(tmp_path) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+    cnf = kernel.sat.put_cnf(variable_names=("x",), clauses=((-1,), (1,)))
+
+    timed_out = _verify(
+        kernel,
+        cnf.artifact_uri,
+        b"3 0 1 2 0\n",
+        limits={"timeout_ms": 0},
+    )
+    cancelled = _verify(kernel, cnf.artifact_uri, b"3 0 1 2 0\n", cancelled=True)
+
+    assert timed_out.output["status"] == "TIMEOUT"
+    assert timed_out.output["conclusion"] == "UNKNOWN"
+    assert timed_out.execution.status is ExecutionStatus.TIMEOUT
+    assert cancelled.output["status"] == "CANCELLED"
+    assert cancelled.output["conclusion"] == "UNKNOWN"
+    assert cancelled.execution.status is ExecutionStatus.CANCELLED
+
+
+def test_capability_is_absent_without_operator_authorized_references(tmp_path) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=False)
+    ids = {item.capability_id for item in kernel.capabilities.catalog().capabilities}
+    assert "sat.lrat.verify" not in ids


### PR DESCRIPTION
Closes #98

## Summary
- adds independent `sat.lrat.verify` rather than extending or aliasing the DRAT verifier
- preserves exact ASCII LRAT bytes in a CNF-bound artifact with variable-map, DIMACS, digest, checker, certificate, and resource-limit bindings
- implements deterministic ordered RUP-hint replay for additions and deletions; negative RAT hints are explicitly `UNSUPPORTED` in v1
- fails closed on rejection, truncation, timeout, cancellation, malformed bindings, and unavailable authorization

## Verification boundary
Only the separately authorized `jacobian_checkers.sat_lrat:check_lrat` replay may return `VERIFIED_UNSAT`. Every other outcome is `UNKNOWN` and is not SAT evidence.

## Validation
- Ruff: passed
- mypy (161 source files): passed
- new LRAT integration suite: passed
- contract/checker/SAT regression selection: 280 passed before one unrelated pre-existing SMT checker environment failure (`test_checker_reconstructs_exact_inputs_and_uses_only_strict_flags`)
