### PR TITLE
test: align Lean assurance expectation with current contract

### DIFF
--- a/tests/integration/test_lean_statement_capabilities.py
+++ b/tests/integration/test_lean_statement_capabilities.py
@@ -76,7 +76,7 @@ def test_propose_elaborates_valid_statement(tmp_path: Path) -> None:
     assert result.output["verification"] == "UNVERIFIED"
     assert result.output["proposal_uri"] in result.artifact_uris
     assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
-    assert "does not certify" in result.assurance.basis
+    assert "does not establish truth" in result.assurance.basis
 
 
 @pytest.mark.skipif(not LEAN_AVAILABLE, reason="Lean is not installed")


### PR DESCRIPTION
## Problem

The Lean statement integration test still expects the former assurance phrase
`does not certify`. The capability now describes the narrower trust boundary as
`does not establish truth, theoremhood, or semantic intent`, so the test fails
when the Lean-backed case runs.

## Solution

Assert the current semantic guarantee, `does not establish truth`. This keeps
the regression check focused on the supported assurance contract without
coupling it to the complete explanatory sentence.

## Testing

```sh
uv run pytest -q -n 0 tests/integration/test_lean_statement_capabilities.py
# 13 passed
```

## Trust & Compatibility Impact

Test-only. This does not change the verification kernel, checker registry,
artifact format, capability behavior, or public API.

## Checklist

- [ ] Routine local validation passes (`make check`)
- [x] Relevant focused tests are listed above
