### PR TITLE
fix(process): harden bounded runtime and remove repeated math setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,10 +29,11 @@ after that check and let CI own dependency and dead-code analysis, strict
 typing, package builds, the full Python matrix, integration, end-to-end,
 coverage, and real-Lean validation. `make check-static` reproduces the
 CI-owned static and package checks when a focused change needs them.
-`make validate-full` is only for reproducing exhaustive CI validation locally
-when CI is unavailable or an environment-specific failure requires it. Run
-`make help` for focused commands. The measured costs and reasoning behind
-these lanes are recorded in the
+`make validate-full` is the broadest local Python, Lean, static, and package
+validation target. It does not reproduce CI's Python 3.13 compatibility,
+combined coverage, security, duplicate-code, or npm lanes. Run `make help` for
+focused commands. The measured costs and reasoning behind these lanes are
+recorded in the
 [test-suite cost audit](docs/contributing/test-suite-cost-audit.md).
 Tests can be narrowed without learning another wrapper:
 
@@ -55,12 +56,13 @@ On macOS, read the
 source-build failure from `uv sync --dev`.
 
 Use focused tests while implementing. Run `make check` before pushing and wait
-for green CI checks before merge. Run complete local validation only
-when changing CI itself, debugging an environment-specific failure, or when CI
-is unavailable; use `make validate-full` for that exceptional path. Report only
-checks that actually ran. The manually dispatched Python Debug and Lean Debug
-workflows reproduce one pytest file or node in a prepared remote environment
-when the relevant local runtime is impractical.
+for green CI checks before merge. Run broad local validation only when changing
+CI itself, debugging an environment-specific failure, or when CI is
+unavailable; use `make validate-full` for that exceptional path and rely on CI
+for its additional lanes. Report only checks that actually ran. The manually
+dispatched Python Debug and Lean Debug workflows reproduce one pytest file or
+node in a prepared remote environment when the relevant local runtime is
+impractical.
 
 CI classifies pull requests through the tested source-to-suite ownership
 manifest in `.github/ci-ownership.json`. Documentation-only changes skip

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY pyproject.toml uv.lock README.md ./
 COPY src ./src
 COPY lean ./lean
 
-RUN uv sync --locked --no-dev
+RUN uv sync --locked --no-dev --extra flint --extra smt
 
 EXPOSE 8000
 VOLUME ["/var/lib/jacobian"]

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ check: lint test-fast ## Run the fast routine local handoff checks.
 
 check-static: lint-full typecheck build ## Run CI-owned static and package checks locally.
 
-validate-full: lint-full typecheck test test-lean build ## Reproduce exhaustive CI validation locally (slow and exceptional).
+validate-full: lint-full typecheck test test-lean build ## Run broad local validation (slow and exceptional; not every CI lane).
 
 agent-eval: ## Plan a local agent eval; execution requires explicit EVAL_ARGS.
 	$(UV_RUN) python benchmarks/agent_ab.py $(EVAL_ARGS)

--- a/docs/contributing/test-suite-cost-audit.md
+++ b/docs/contributing/test-suite-cost-audit.md
@@ -70,10 +70,12 @@ dead-code analysis, strict typing, and package builds remain available through
 `make test` runs the complete non-Lean suite, and `make test-lean` keeps the
 memory-heavy backend serial. Neither is a routine pre-push requirement; CI
 owns exhaustive validation.
-`make validate-full` exists only to reproduce that exhaustive validation when
-CI is unavailable or an environment-specific failure requires it. Do not use
-unfiltered `uv run pytest` as the default handoff command because it mixes Lean
-into the general parallel pool.
+`make validate-full` combines the broad local Python, Lean, static, and package
+checks when CI is unavailable or an environment-specific failure requires it.
+Python 3.13 compatibility, combined coverage, security, duplicate-code, and npm
+validation remain separate CI lanes. Do not use unfiltered `uv run pytest` as
+the default handoff command because it mixes Lean into the general parallel
+pool.
 
 The Lean suite runs serially on one prepared runner. This avoids concurrent
 multi-gigabyte Mathlib processes, collects every `lean_runtime` test without a

--- a/docs/reference/testing-strategy.md
+++ b/docs/reference/testing-strategy.md
@@ -59,9 +59,10 @@ routine local pre-push gate. Developers should push after it and let CI own
 dependency and dead-code analysis, strict typing, package builds, and
 exhaustive validation. `make check-static` reproduces those CI-owned static
 and package checks when relevant.
-`make validate-full` is the local full-suite escape hatch for CI reproduction,
-not a routine handoff requirement. The full
-suite uses `pytest-xdist` work stealing and
+`make validate-full` is the broad local Python, Lean, static, and package
+escape hatch, not a routine handoff requirement. It does not reproduce CI's
+Python 3.13 compatibility, combined coverage, security, duplicate-code, or npm
+lanes. The full Python suite uses `pytest-xdist` work stealing and
 at most four workers because test durations vary substantially and many tests
 wait on isolated subprocesses. `make test-failed` is the failure-recovery
 shortcut. Use `PYTEST_ARGS="-n 0"` for debugger-friendly, single-process

--- a/src/jacobian/bounded_process.py
+++ b/src/jacobian/bounded_process.py
@@ -24,6 +24,7 @@ _CANCELLATION_EVENT: ContextVar[threading.Event | None] = ContextVar(
     "jacobian_bounded_process_cancellation_event",
     default=None,
 )
+_PIPE_DRAIN_GRACE_SECONDS = 0.5
 
 
 @dataclass(frozen=True, slots=True)
@@ -276,14 +277,18 @@ def run_bounded_process(
                 except subprocess.TimeoutExpired:
                     continue
         finally:
-            for reader in readers:
-                reader.join(timeout=max(0.0, deadline - time.monotonic()))
-            if any(reader.is_alive() for reader in readers):
-                # The immediate worker may have exited after spawning a
-                # descendant that inherited stdout or stderr.  In that case
-                # process.wait() succeeds while the pipes never reach EOF.
-                timed_out = True
+            # A clean worker may leave descendants holding inherited pipe
+            # handles. Terminate the process group before draining so those
+            # handles cannot turn successful completion into a false timeout.
             _kill_process_tree(process)
+            drain_deadline = time.monotonic() + _PIPE_DRAIN_GRACE_SECONDS
+            for reader in readers:
+                reader.join(timeout=max(0.0, drain_deadline - time.monotonic()))
+            if any(reader.is_alive() for reader in readers):
+                # A descendant may have escaped the worker process group while
+                # retaining a pipe. Fail closed instead of returning partial
+                # output as a successful worker completion.
+                timed_out = True
             process.stdout.close()
             process.stderr.close()
             for reader in readers:

--- a/src/jacobian/graph_atlas.py
+++ b/src/jacobian/graph_atlas.py
@@ -1,0 +1,26 @@
+"""Process-local immutable access to NetworkX Graph Atlas representatives."""
+
+from __future__ import annotations
+
+from functools import cache
+from typing import Any
+
+import networkx as nx
+
+_MAX_ATLAS_ORDER = 7
+
+
+@cache
+def _graph_atlas_by_order() -> tuple[tuple[nx.Graph[Any], ...], ...]:
+    grouped: list[list[nx.Graph[Any]]] = [[] for _ in range(_MAX_ATLAS_ORDER + 1)]
+    for graph in nx.graph_atlas_g():
+        grouped[graph.number_of_nodes()].append(nx.freeze(graph))
+    return tuple(tuple(graphs) for graphs in grouped)
+
+
+def graph_atlas_order(order: int) -> tuple[nx.Graph[Any], ...]:
+    """Return frozen atlas representatives of one supported order."""
+
+    if not 0 <= order <= _MAX_ATLAS_ORDER:
+        raise ValueError("Graph Atlas order must be between zero and seven")
+    return _graph_atlas_by_order()[order]

--- a/src/jacobian/graph_capabilities.py
+++ b/src/jacobian/graph_capabilities.py
@@ -56,6 +56,7 @@ from jacobian.contracts.graph_invariants import (
     GraphNeighborhoodIndependenceRequest,
 )
 from jacobian.contracts.results import Execution, ExecutionStatus
+from jacobian.graph_atlas import graph_atlas_order
 from jacobian.provider_runtime import known_provider_runtime
 from jacobian.registry import CheckerRegistry
 from jacobian.schema_registry import SchemaRegistry, model_schema
@@ -417,9 +418,7 @@ class GraphAtlasSearchAdapter:
         constraints = dict(request.input["constraints"])
         _validate_constraint_ranges(constraints)
         limit = int(request.input.get("limit", 10))
-        atlas_graphs = [
-            graph for graph in nx.graph_atlas_g() if graph.number_of_nodes() == order
-        ]
+        atlas_graphs = graph_atlas_order(order)
         scope = self.resources.artifacts.put(
             schema_uri=self.resources.scope_schema_uri,
             semantics_uri=self.resources.semantics_uri,

--- a/src/jacobian/graph_composition_capabilities.py
+++ b/src/jacobian/graph_composition_capabilities.py
@@ -51,6 +51,7 @@ from jacobian.contracts.graph_composition import (
     GraphEnumerationScopeArtifact,
 )
 from jacobian.contracts.results import Execution, ExecutionStatus
+from jacobian.graph_atlas import graph_atlas_order
 from jacobian.provider_runtime import known_provider_runtime
 from jacobian.schema_registry import SchemaRegistry, model_schema
 from jacobian.store import ArtifactStore, StoreError
@@ -451,9 +452,7 @@ class GraphEnumerateNonisomorphicAdapter:
         limit = validated.limit
         offset = validated.offset
 
-        atlas_graphs = [
-            graph for graph in nx.graph_atlas_g() if graph.number_of_nodes() == order
-        ]
+        atlas_graphs = graph_atlas_order(order)
         total_count = len(atlas_graphs)
         window = atlas_graphs[offset : offset + limit]
         truncated = (offset + limit) < total_count

--- a/src/jacobian/polynomial_capabilities.py
+++ b/src/jacobian/polynomial_capabilities.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import multiprocessing
 import time
+from collections.abc import Iterator
 from dataclasses import dataclass
 from fractions import Fraction
 from itertools import product
@@ -2099,19 +2100,29 @@ def _inverse_supports(
         return request.explicit_support
     dimension = len(request.target_variables)
     support = tuple(
-        sorted(
-            (
-                exponents
-                for exponents in product(
-                    range(request.inverse_degree_bound + 1),
-                    repeat=dimension,
-                )
-                if sum(exponents) <= request.inverse_degree_bound
-            ),
-            reverse=True,
+        _reverse_lex_degree_bounded_exponents(
+            dimension=dimension,
+            degree_bound=request.inverse_degree_bound,
         )
     )
     return tuple(support for _ in range(dimension))
+
+
+def _reverse_lex_degree_bounded_exponents(
+    *,
+    dimension: int,
+    degree_bound: int,
+) -> Iterator[tuple[int, ...]]:
+    if dimension == 1:
+        for exponent in range(degree_bound, -1, -1):
+            yield (exponent,)
+        return
+    for exponent in range(degree_bound, -1, -1):
+        for suffix in _reverse_lex_degree_bounded_exponents(
+            dimension=dimension - 1,
+            degree_bound=degree_bound - exponent,
+        ):
+            yield (exponent, *suffix)
 
 
 def _inverse_residual_term_bound(

--- a/src/jacobian/store.py
+++ b/src/jacobian/store.py
@@ -186,7 +186,7 @@ class ArtifactStore:
             connection.close()
 
     def _initialize_database(self) -> None:
-        with self._connection() as connection:
+        with self._exclusive_blob_lock(), self._connection() as connection:
             connection.execute("PRAGMA journal_mode = WAL")
             connection.executescript(
                 """
@@ -220,7 +220,6 @@ class ArtifactStore:
                 );
                 """
             )
-        with self._exclusive_blob_lock(), self._connection() as connection:
             quota_columns = {
                 str(row["name"])
                 for row in connection.execute("PRAGMA table_info(blob_quota)")

--- a/tests/integration/test_plugin_execution.py
+++ b/tests/integration/test_plugin_execution.py
@@ -136,7 +136,7 @@ def test_plugin_timeout_kills_descendant_processes(tmp_path: Path) -> None:
 
 
 @pytest.mark.integration
-def test_plugin_deadline_covers_descendant_held_output_pipes(tmp_path: Path) -> None:
+def test_plugin_success_kills_descendant_holding_output_pipes(tmp_path: Path) -> None:
     marker = tmp_path / "pipe-holder-survived"
     start = time.monotonic()
 
@@ -149,8 +149,8 @@ def test_plugin_deadline_covers_descendant_held_output_pipes(tmp_path: Path) -> 
     time.sleep(1.2)
 
     assert elapsed < 3
-    assert result.status.value == "TIMEOUT"
-    assert result.output is None
+    assert result.status.value == "COMPLETED"
+    assert result.output == {"worker": "returned"}
     assert not marker.exists()
 
 

--- a/tests/unit/test_atomic_capabilities.py
+++ b/tests/unit/test_atomic_capabilities.py
@@ -59,3 +59,43 @@ def test_failed_exhaustive_result_cannot_claim_complete_coverage(
 
     assert result.execution.status is ExecutionStatus.ERROR
     assert result.completeness.status is CapabilityCompletenessStatus.PARTIAL
+
+
+def test_exhaustive_result_without_scope_cannot_claim_complete_coverage(
+    tmp_path: Path,
+) -> None:
+    exhaustive = ResultEnvelope(
+        execution=Execution(status=ExecutionStatus.COMPLETED),
+        input=InputValidation(status=InputStatus.ACCEPTED),
+        conclusion=Conclusion.UNKNOWN,
+        assurance=Assurance(
+            arithmetic=Arithmetic.EXACT_INTEGER,
+            method=Method.EXHAUSTIVE_FINITE,
+            coverage=Coverage.EXHAUSTIVE,
+            verification=Verification.UNVERIFIED,
+        ),
+        claim_digest="sha256:" + "a" * 64,
+        semantics_digest="sha256:" + "b" * 64,
+        candidate_digest="sha256:" + "c" * 64,
+    )
+    adapter = AtomicServiceAdapter(
+        capability_id="test.explore.exhaustive",
+        title="Test exhaustive exploration",
+        description="Project one exhaustive result without a declared scope.",
+        modes=(CapabilityMode.EXPLORE,),
+        input_schema={"type": "object", "additionalProperties": False},
+        output_schema=ResultEnvelope.model_json_schema(),
+        invoke=lambda _payload: exhaustive,
+        store=ArtifactStore(tmp_path),
+    )
+
+    result = adapter.invoke(
+        CapabilityRequest(
+            capability_id="test.explore.exhaustive",
+            input={},
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.scope is None
+    assert result.completeness.status is CapabilityCompletenessStatus.PARTIAL

--- a/tests/unit/test_bounded_process.py
+++ b/tests/unit/test_bounded_process.py
@@ -97,3 +97,61 @@ def test_cancellation_stops_worker_before_its_wall_time_budget() -> None:
     assert completed.cancelled
     assert not completed.timed_out
     assert time.monotonic() - started < 3
+
+
+@pytest.mark.skipif(
+    os.name != "posix",
+    reason="process-group descendant cleanup is exercised on POSIX",
+)
+def test_clean_worker_exit_drains_pipes_inherited_by_descendants() -> None:
+    completed = run_bounded_process(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import subprocess, sys; "
+                "subprocess.Popen("
+                "[sys.executable, '-c', 'import time; time.sleep(30)'], "
+                "stdout=sys.stdout, stderr=sys.stderr); "
+                "print('worker complete', flush=True)"
+            ),
+        ],
+        input_bytes=b"",
+        timeout_seconds=0.5,
+        environment=dict(os.environ),
+        stdout_limit=4096,
+        stderr_limit=4096,
+    )
+
+    assert completed.returncode == 0
+    assert not completed.timed_out
+    assert completed.stdout == b"worker complete\n"
+    assert completed.stderr == b""
+
+
+@pytest.mark.skipif(
+    os.name != "posix",
+    reason="detached process groups are exercised on POSIX",
+)
+def test_detached_descendant_with_inherited_pipe_fails_closed() -> None:
+    completed = run_bounded_process(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import subprocess, sys; "
+                "subprocess.Popen("
+                "[sys.executable, '-c', 'import time; time.sleep(1)'], "
+                "stdout=sys.stdout, stderr=sys.stderr, start_new_session=True); "
+                "print('worker complete', flush=True)"
+            ),
+        ],
+        input_bytes=b"",
+        timeout_seconds=0.2,
+        environment=dict(os.environ),
+        stdout_limit=4096,
+        stderr_limit=4096,
+    )
+
+    assert completed.returncode == 0
+    assert completed.timed_out

--- a/tests/unit/test_graph_atlas.py
+++ b/tests/unit/test_graph_atlas.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import networkx as nx
+import pytest
+
+import jacobian.graph_atlas as graph_atlas
+
+
+def test_graph_atlas_is_built_once_and_cached_as_frozen_graphs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph_atlas._graph_atlas_by_order.cache_clear()
+    original = nx.graph_atlas_g
+    calls = 0
+
+    def counted_graph_atlas() -> list[nx.Graph[int]]:
+        nonlocal calls
+        calls += 1
+        return original()
+
+    monkeypatch.setattr(nx, "graph_atlas_g", counted_graph_atlas)
+
+    first = graph_atlas.graph_atlas_order(7)
+    second = graph_atlas.graph_atlas_order(7)
+
+    assert calls == 1
+    assert first is second
+    assert len(first) == 1044
+    assert all(nx.is_frozen(graph) for graph in first)


### PR DESCRIPTION
## Problem

A clean bounded worker could be reported as timed out when one of its descendants inherited stdout or stderr. The coordinator waited for pipe EOF before terminating the worker process group, so a successful parent exit could become `timed_out=True`; output retention was race-dependent.

The same audit found three smaller gaps:

- the production Docker sync excluded the `flint` and `smt` extras;
- both graph capability families rebuilt NetworkX's complete Graph Atlas on every invocation; and
- inverse synthesis generated the full exponent cube before filtering it to the declared total-degree support.

One completeness regression test also combined two guards, so it did not independently prove that exhaustive coverage without a declared scope remains partial. The `validate-full` help and documentation overstated which CI lanes it reproduces locally.

## Changes

- Terminate the bounded worker process group before draining captured pipes. A normal inherited-pipe descendant now closes cleanly without changing the successful parent result. A detached descendant that still holds a pipe after the drain grace remains a fail-closed timeout.
- Add separate regressions for ordinary and detached inherited-pipe descendants, plus a completed exhaustive result with no scope.
- Install the locked `flint` and `smt` extras in the production image.
- Build Graph Atlas once per process, freeze its representatives, group them by order, and share that cache between search and enumeration capabilities.
- Generate degree-bounded inverse monomials directly in the existing reverse-lexicographic order.
- Describe `make validate-full` as broad local Python, Lean, static, and package validation while leaving Python 3.13, combined coverage, security, duplicate-code, and npm validation to their CI lanes.

The patch intentionally leaves the existing 10,000-point polynomial grid guards unchanged. It also preserves per-candidate evaluator process isolation and duplicate-blob integrity validation; batching evaluators or bypassing blob reads would weaken current failure and trust boundaries.

## Evidence

On the base tree, a clean worker whose descendant inherited stdout reproduced `returncode=0` with `timed_out=True`. The final tree returns `returncode=0`, `timed_out=False`, and retains `b"worker-ok\n"`. The detached-process regression confirms an escaped descendant still fails closed.

Single-process timing smoke checks ran on a DO-Premium-AMD Linux host with Python 3.12 and the locked NetworkX version. The base implementation rebuilt the atlas in about 46.5 ms per call. The new immutable cache took 121.9 ms to populate once and 0.004 ms for a repeated order-7 lookup. Worst supported inverse-support generation produced the same 495 monomials in 0.35 ms, down from about 0.96 ms for product-and-filter enumeration. These are local smoke measurements, not cross-machine regression thresholds.

## Validation

```sh
uv run --frozen pytest -q -n 0 \
  tests/unit/test_bounded_process.py \
  tests/unit/test_atomic_capabilities.py \
  tests/unit/test_graph_atlas.py \
  tests/integration/test_polynomial_map_inverse_synthesize.py \
  tests/integration/test_graph_capabilities.py \
  tests/integration/test_graph_composition.py
# 34 passed

make check
# 532 passed, 4 deselected; Ruff lint and formatting passed

make check-static
# deptry, vulture, mypy, source build, and wheel build passed

uv run --frozen --isolated --no-dev --extra flint --extra smt \
  python -c 'import cvc5, flint; print(cvc5.__version__); print(flint.__version__)'
# 1.3.4
# 0.9.0
```

A Docker engine was unavailable locally, so the image itself was not built. The isolated production dependency selection above verifies the exact locked sync flags and imports; CI remains the image-level proof point.

## Compatibility

No capability ID, request schema, result schema, artifact identity, or verification authority changes. The Docker image gains two already-declared optional providers. Clean workers no longer become false timeouts; detached descendants with unclosed pipes still return timeout rather than partial success.

## Suggested review order

1. `bounded_process.py` and its inherited-pipe regressions.
2. Docker optional-provider selection and the independent completeness test.
3. Shared frozen Graph Atlas cache and direct inverse-support enumeration.
4. `validate-full` help and documentation wording.
