### PR TITLE
fix(lean): parse Lean 4.31 proposition elaboration output

### DIFF
--- a/src/jacobian/lean_statement_capabilities.py
+++ b/src/jacobian/lean_statement_capabilities.py
@@ -111,6 +111,10 @@ _DIRECT_ELABORATION_OPTIONS = (
     LeanElaborationOption(name="pp.universes", value="true"),
 )
 _LEAN_NAME = re.compile(r"\b[A-Za-z_][A-Za-z0-9_']*(?:\.[A-Za-z0-9_']+)*\b")
+_LEAN_MESSAGE_KIND = re.compile(
+    r"(?:^|:\s*)(error|warning|info)(?:\([^)]*\))?:",
+    re.IGNORECASE,
+)
 _LEAN_KEYWORDS = frozenset(
     {
         "Prop",
@@ -185,7 +189,9 @@ def _elaborate_proposition(
     )
     output = _execute_lean_source(source, timeout_seconds=timeout_seconds)
     messages = tuple(_parse_lean_messages(output))
-    errors = tuple(message for message in messages if "error:" in message.lower())
+    errors = tuple(
+        message for message in messages if _lean_message_severity(message) == "ERROR"
+    )
     expression = None if errors else _parse_elaborated_expression(output)
     if not errors and expression is None:
         errors = ("error: Lean did not emit the elaborated proposition",)
@@ -237,7 +243,9 @@ def _run_lean_source(
 ) -> _ElaborationResult:
     output = _execute_lean_source(source, timeout_seconds=timeout_seconds)
     messages = _parse_lean_messages(output)
-    errors = tuple(m for m in messages if "error:" in m.lower())
+    errors = tuple(
+        message for message in messages if _lean_message_severity(message) == "ERROR"
+    )
     elaborates = len(errors) == 0
     return _ElaborationResult(
         elaborates=elaborates,
@@ -269,10 +277,17 @@ def _execute_lean_source(source: str, *, timeout_seconds: int) -> str:
 
 
 def _parse_elaborated_expression(output: str) -> str | None:
-    match = re.search(r"\binfo:\s*(.+?)\s*:\s*Prop(?:\s|$)", output, re.DOTALL)
-    if match is None:
+    diagnostic_match = re.search(
+        r"\binfo:\s*(.+?)\s*:\s*Prop(?:\s|$)", output, re.DOTALL
+    )
+    if diagnostic_match is not None:
+        return " ".join(diagnostic_match.group(1).split())
+    # Lean's command-line frontend emits successful ``#check`` output as the
+    # bare ``<expression> : Prop`` line.  It does not add an ``info:`` prefix.
+    plain_match = re.fullmatch(r"\s*(.+?)\s*:\s*Prop\s*", output, re.DOTALL)
+    if plain_match is None:
         return None
-    return " ".join(match.group(1).split())
+    return " ".join(plain_match.group(1).split())
 
 
 def _parse_lean_messages(output: str) -> list[str]:
@@ -282,23 +297,40 @@ def _parse_lean_messages(output: str) -> list[str]:
         if not stripped:
             continue
         if re.match(
-            r"^.*:\d+:\d+:\s*(error|warning|info):", stripped
-        ) or stripped.lower().startswith(("error:", "warning:", "info:")):
+            r"^.*:\d+:\d+:\s*(error|warning|info)(?:\([^)]*\))?:",
+            stripped,
+            re.IGNORECASE,
+        ) or re.match(
+            r"^(error|warning|info)(?:\([^)]*\))?:",
+            stripped,
+            re.IGNORECASE,
+        ):
             messages.append(stripped)
     return messages
+
+
+def _lean_message_severity(
+    message: str,
+) -> Literal["ERROR", "WARNING", "INFO"]:
+    match = _LEAN_MESSAGE_KIND.search(message)
+    if match is None:
+        return "INFO"
+    kind = match.group(1).lower()
+    if kind == "error":
+        return "ERROR"
+    if kind == "warning":
+        return "WARNING"
+    return "INFO"
 
 
 def _diagnostics(messages: tuple[str, ...]) -> tuple[LeanElaborationDiagnostic, ...]:
     diagnostics: list[LeanElaborationDiagnostic] = []
     for message in messages:
-        lowered = message.lower()
-        severity: Literal["ERROR", "WARNING", "INFO"] = (
-            "ERROR"
-            if "error:" in lowered
-            else ("WARNING" if "warning:" in lowered else "INFO")
-        )
         diagnostics.append(
-            LeanElaborationDiagnostic(severity=severity, message=message)
+            LeanElaborationDiagnostic(
+                severity=_lean_message_severity(message),
+                message=message,
+            )
         )
     return tuple(diagnostics)
 

--- a/tests/integration/test_lean_statement_capabilities.py
+++ b/tests/integration/test_lean_statement_capabilities.py
@@ -241,6 +241,46 @@ def test_direct_elaboration_parser_preserves_multiline_core_expression() -> None
     )
 
 
+def test_direct_elaboration_parser_accepts_plain_lean_check_output() -> None:
+    assert lean_statements._parse_elaborated_expression("True : Prop\n") == "True"
+
+
+@pytest.mark.skipif(not LEAN_AVAILABLE, reason="Lean is not installed")
+def test_direct_elaboration_core_runtime_matrix() -> None:
+    successful_cases = (
+        ("True", "True"),
+        ("False", "False"),
+        ("1 = 1", "@Eq"),
+        ("∀ n : Nat, n = n", "∀"),
+    )
+    for statement, expected_fragment in successful_cases:
+        result = lean_statements._elaborate_proposition(statement)
+        assert result.elaborates is True
+        assert result.errors == ()
+        assert result.elaborated_expression is not None
+        assert expected_fragment in result.elaborated_expression
+
+    failed_cases = (
+        ("NotARealTypeXYZ", "unknown identifier"),
+        ("∀ n : Nat,", "unexpected token"),
+    )
+    for statement, expected_diagnostic in failed_cases:
+        result = lean_statements._elaborate_proposition(statement)
+        assert result.elaborates is False
+        assert result.elaborated_expression is None
+        assert any(expected_diagnostic in error.lower() for error in result.errors)
+
+
+def test_direct_elaboration_parser_preserves_coded_lean_error() -> None:
+    output = (
+        "fixture.lean:4:8: error(lean.unknownIdentifier): "
+        "Unknown identifier `NotARealTypeXYZ`\n"
+    )
+
+    assert lean_statements._parse_lean_messages(output) == [output.strip()]
+    assert lean_statements._lean_message_severity(output) == "ERROR"
+
+
 # ---------------------------------------------------------------------------
 # lean.statement.compare
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix `lean.statement.propose` direct proposition elaboration under Lean 4.31 without changing its public contract or assurance boundary.

## Root cause

Lean 4.31 emits successful `#check` output as bare `<expression> : Prop`, while the adapter only accepted output carrying an `info:` prefix. It also failed to recognize coded diagnostics such as `error(lean.unknownIdentifier):`, replacing useful name-resolution errors with a generic extraction failure.

## Changes

- accept both bare and diagnostic-prefixed proposition output;
- recognize coded Lean error, warning, and info diagnostics;
- preserve distinct name-resolution and malformed-syntax failures;
- add real-runtime regression coverage for `True`, `False`, equality, quantified propositions, an unknown identifier, and malformed syntax;
- preserve `COMPUTED`, `UNVERIFIED`, and `truth_status = NOT_ASSESSED` semantics.

## Sanity audit

- Exact diff: 2 files, 86 insertions, 14 deletions.
- All three newly added regression tests fail against `origin/main` and pass with this patch.
- Focused contract/integration validation: 35 passed.
- Broader non-Lean suite: 529 passed, 2 skipped; one unrelated SMT checker test failed identically on both baseline and patched code.
- Ruff, formatting, and `git diff --check` passed.

## Validation

```text
PATH=<Lean-4.31-bin> .venv/bin/python -m pytest -n 0 \
  tests/contract/test_lean_statement_contracts.py \
  tests/integration/test_lean_statement_capabilities.py -q
# 35 passed

.venv/bin/ruff check \
  src/jacobian/lean_statement_capabilities.py \
  tests/integration/test_lean_statement_capabilities.py
# All checks passed
```

MATHLIB remains explicitly unsupported by this capability version; callers should continue using CORE or `lean.check` as documented.