### PR TITLE
refactor: use typed graph invariant applicability

### DIFF
--- a/src/jacobian/contracts/graph_invariant_operations.py
+++ b/src/jacobian/contracts/graph_invariant_operations.py
@@ -31,13 +31,33 @@ class GraphGirthResult(ContractModel):
 
 
 class GraphDiameterResult(ContractModel):
-    diameter: StrictInt = Field(ge=-1, le=31)
+    status: Literal["COMPUTED", "NOT_APPLICABLE"]
+    diameter: StrictInt | None = Field(default=None, ge=0, le=31)
     connected: StrictBool
+    exactness: Literal["EXACT", "NOT_APPLICABLE"]
+    detail: str | None = Field(default=None, min_length=1, max_length=512)
 
     @model_validator(mode="after")
     def bind_connectivity(self) -> Self:
-        if self.connected == (self.diameter < 0):
-            raise ValueError("diameter -1 is reserved for disconnected graphs")
+        if self.status == "COMPUTED":
+            if (
+                self.diameter is None
+                or not self.connected
+                or self.exactness != "EXACT"
+                or self.detail is not None
+            ):
+                raise ValueError(
+                    "computed diameter requires an exact value on a connected graph"
+                )
+        elif (
+            self.diameter is not None
+            or self.connected
+            or self.exactness != "NOT_APPLICABLE"
+            or self.detail is None
+        ):
+            raise ValueError(
+                "inapplicable diameter requires no value and an explicit detail"
+            )
         return self
 
 
@@ -98,7 +118,34 @@ class GraphCoreResult(ContractModel):
 
 
 class GraphRadiusResult(ContractModel):
-    radius: StrictInt = Field(ge=0, le=31)
+    status: Literal["COMPUTED", "NOT_APPLICABLE"]
+    radius: StrictInt | None = Field(default=None, ge=0, le=31)
+    connected: StrictBool
+    exactness: Literal["EXACT", "NOT_APPLICABLE"]
+    detail: str | None = Field(default=None, min_length=1, max_length=512)
+
+    @model_validator(mode="after")
+    def bind_connectivity(self) -> Self:
+        if self.status == "COMPUTED":
+            if (
+                self.radius is None
+                or not self.connected
+                or self.exactness != "EXACT"
+                or self.detail is not None
+            ):
+                raise ValueError(
+                    "computed radius requires an exact value on a connected graph"
+                )
+        elif (
+            self.radius is not None
+            or self.connected
+            or self.exactness != "NOT_APPLICABLE"
+            or self.detail is None
+        ):
+            raise ValueError(
+                "inapplicable radius requires no value and an explicit detail"
+            )
+        return self
 
 
 class GraphCardinalityMaximumResult(ContractModel):

--- a/src/jacobian/domains/graph_optimization/invariants.py
+++ b/src/jacobian/domains/graph_optimization/invariants.py
@@ -64,6 +64,7 @@ def _computed[
     result_model: type[ResultT],
     operation: Callable[[nx.Graph[str]], ResultT],
     *tags: str,
+    version: str = "1",
 ) -> ComputedOperation[GraphInvariantRequest, ResultT]:
     def implementation(
         request: GraphInvariantRequest,
@@ -91,6 +92,7 @@ def _computed[
         relation_id=capability_id.removesuffix(".compute") + ".relation",
         tags=("graph", "invariant", *tags),
         invalid_request=_INVALID_REQUEST,
+        version=version,
     )
 
 
@@ -102,8 +104,18 @@ def _girth(graph: nx.Graph[str]) -> GraphGirthResult:
 
 def _diameter(graph: nx.Graph[str]) -> GraphDiameterResult:
     if not graph or not nx.is_connected(graph):
-        return GraphDiameterResult(diameter=-1, connected=False)
-    return GraphDiameterResult(diameter=int(nx.diameter(graph)), connected=True)
+        return GraphDiameterResult(
+            status="NOT_APPLICABLE",
+            connected=False,
+            exactness="NOT_APPLICABLE",
+            detail="diameter requires a nonempty connected graph",
+        )
+    return GraphDiameterResult(
+        status="COMPUTED",
+        diameter=int(nx.diameter(graph)),
+        connected=True,
+        exactness="EXACT",
+    )
 
 
 def _edge_connectivity(graph: nx.Graph[str]) -> GraphEdgeConnectivityResult:
@@ -174,11 +186,19 @@ def _triangle_count(graph: nx.Graph[str]) -> GraphTriangleCountResult:
 
 
 def _radius(graph: nx.Graph[str]) -> GraphRadiusResult:
-    if not graph:
-        return GraphRadiusResult(radius=0)
-    if not nx.is_connected(graph):
-        raise ValueError("radius requires a connected graph")
-    return GraphRadiusResult(radius=int(nx.radius(graph)))
+    if not graph or not nx.is_connected(graph):
+        return GraphRadiusResult(
+            status="NOT_APPLICABLE",
+            connected=False,
+            exactness="NOT_APPLICABLE",
+            detail="radius requires a nonempty connected graph",
+        )
+    return GraphRadiusResult(
+        status="COMPUTED",
+        radius=int(nx.radius(graph)),
+        connected=True,
+        exactness="EXACT",
+    )
 
 
 def _k_core_execute(
@@ -435,6 +455,7 @@ EXACT_GRAPH_INVARIANT_CAPABILITIES = (
         _radius,
         "radius",
         "exact",
+        version="2",
     ),
     ComputedOperation(
         capability_id="graph.k_core.compute",
@@ -464,6 +485,7 @@ EXACT_GRAPH_INVARIANT_CAPABILITIES = (
         _diameter,
         "diameter",
         "exact",
+        version="2",
     ),
     _computed(
         "graph.invariant.edge_connectivity.compute",

--- a/tests/integration/test_graph_capabilities.py
+++ b/tests/integration/test_graph_capabilities.py
@@ -312,7 +312,14 @@ def test_graph_invariant_batch_preserves_unsupported_and_not_applicable_results(
             capability_id="graph.compute.properties",
             input={
                 "graph_uri": searched.output["candidates"][0]["graph_uri"],
-                "properties": ["order", "diameter", "made_up_invariant"],
+                "properties": [
+                    "order",
+                    "diameter",
+                    "radius",
+                    "eccentricities",
+                    "average_eccentricity",
+                    "made_up_invariant",
+                ],
             },
         )
     )
@@ -331,11 +338,17 @@ def test_graph_invariant_batch_preserves_unsupported_and_not_applicable_results(
         "backend": "networkx",
         "detail": None,
     }
-    assert outcomes["diameter"]["status"] == "NOT_APPLICABLE"
-    assert outcomes["diameter"]["value"] is None
-    assert outcomes["diameter"]["exactness"] == "NOT_APPLICABLE"
-    assert outcomes["diameter"]["backend"] == "networkx"
-    assert outcomes["diameter"]["detail"]
+    for invariant in (
+        "diameter",
+        "radius",
+        "eccentricities",
+        "average_eccentricity",
+    ):
+        assert outcomes[invariant]["status"] == "NOT_APPLICABLE"
+        assert outcomes[invariant]["value"] is None
+        assert outcomes[invariant]["exactness"] == "NOT_APPLICABLE"
+        assert outcomes[invariant]["backend"] == "networkx"
+        assert outcomes[invariant]["detail"]
     assert outcomes["made_up_invariant"] == {
         "invariant": "made_up_invariant",
         "status": "UNSUPPORTED",

--- a/tests/integration/test_graph_invariant_domain.py
+++ b/tests/integration/test_graph_invariant_domain.py
@@ -29,7 +29,13 @@ def test_graph_invariant_family_boundaries_and_witnesses(tmp_path: Path) -> None
         (
             "graph.invariant.diameter.compute",
             triangle_tail,
-            {"diameter": 2, "connected": True},
+            {
+                "status": "COMPUTED",
+                "diameter": 2,
+                "connected": True,
+                "exactness": "EXACT",
+                "detail": None,
+            },
         ),
         (
             "graph.invariant.edge_connectivity.compute",
@@ -93,11 +99,55 @@ def test_disconnected_and_acyclic_graph_conventions(tmp_path: Path) -> None:
             input={"graph": graph},
         )
     )
-    assert diameter.output["result"] == {"diameter": -1, "connected": False}
+    assert diameter.execution.status is ExecutionStatus.COMPLETED
+    assert diameter.output["result"] == {
+        "status": "NOT_APPLICABLE",
+        "diameter": None,
+        "connected": False,
+        "exactness": "NOT_APPLICABLE",
+        "detail": "diameter requires a nonempty connected graph",
+    }
     assert girth.output["result"] == {"girth": 0, "has_cycle": False}
     assert trees.output["result"] == {
         "spanning_tree_count": 0,
         "connected": False,
+    }
+
+
+def test_radius_uses_explicit_not_applicable_for_disconnected_graph(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path)
+
+    connected = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.invariant.radius.compute",
+            input={"graph": _graph(["a", "b", "c"], [["a", "b"], ["b", "c"]])},
+        )
+    )
+    disconnected = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.invariant.radius.compute",
+            input={"graph": _graph(["a", "b", "c"], [["a", "b"]])},
+        )
+    )
+
+    assert connected.capability_version == "2"
+    assert disconnected.capability_version == "2"
+    assert connected.output["result"] == {
+        "status": "COMPUTED",
+        "radius": 1,
+        "connected": True,
+        "exactness": "EXACT",
+        "detail": None,
+    }
+    assert disconnected.execution.status is ExecutionStatus.COMPLETED
+    assert disconnected.output["result"] == {
+        "status": "NOT_APPLICABLE",
+        "radius": None,
+        "connected": False,
+        "exactness": "NOT_APPLICABLE",
+        "detail": "radius requires a nonempty connected graph",
     }
 
 

--- a/tests/integration/test_resource_atomic_capabilities.py
+++ b/tests/integration/test_resource_atomic_capabilities.py
@@ -141,12 +141,24 @@ def test_consolidated_domain_results_are_exact_computed_evidence(
                     "edges": [["a", "b"], ["b", "c"]],
                 }
             },
-            {"radius": 1},
+            {
+                "status": "COMPUTED",
+                "radius": 1,
+                "connected": True,
+                "exactness": "EXACT",
+                "detail": None,
+            },
         ),
         (
             "graph.invariant.radius.compute",
             {"graph": {"vertices": [], "edges": []}},
-            {"radius": 0},
+            {
+                "status": "NOT_APPLICABLE",
+                "radius": None,
+                "connected": False,
+                "exactness": "NOT_APPLICABLE",
+                "detail": "radius requires a nonempty connected graph",
+            },
         ),
         (
             "graph.k_core.compute",


### PR DESCRIPTION
## Motivation

Disconnected graph diameter used `-1` as an undefined-value sentinel, while the graph batch capability already exposed typed `NOT_APPLICABLE` results. Specialized radius used a third behavior by failing through a diagnostic.

## Root cause

The older specialized result contracts encoded connectedness preconditions through numeric values or exceptions instead of the typed invariant outcome introduced for graph batches.

## Implementation

- Replace the diameter sentinel with explicit `COMPUTED | NOT_APPLICABLE` status, exactness, nullable value, connectedness, and detail fields.
- Apply the same typed result contract to radius.
- Keep connected values exact and unchanged.
- Bump only the affected specialized capability versions to v2.
- Confirm batch diameter, radius, eccentricities, and average eccentricity all retain typed `NOT_APPLICABLE` behavior.
- Do not add unrelated graph algorithms.

## Files changed

- `src/jacobian/contracts/graph_invariant_operations.py`
- `src/jacobian/domains/graph_optimization/invariants.py`
- focused graph integration tests

## Regression tests

The new tests fail on the previous implementation:
- disconnected diameter returned `-1`;
- disconnected radius returned an execution error;
- connected specialized outputs lacked typed applicability metadata.

## Validation

- Focused graph regressions: 4 passed
- Broader graph suites: 10 passed, 1 deselected
- The deselected bounded NP-hard invariant test depends on the unavailable pinned Z3 provider and is unrelated to this change.
- Ruff check: passed
- Ruff format check: passed
- `git diff --check`: passed

## Backward compatibility

This is a deliberate v2 contract change for `graph.invariant.diameter.compute` and `graph.invariant.radius.compute`. Connected numeric values are unchanged but gain typed metadata. Disconnected diameter changes from `-1` to `null` with `status=NOT_APPLICABLE`; disconnected radius changes from an error to the same terminal typed outcome. Batch contracts are unchanged.

## Remaining risk

Consumers pinned to the v1 specialized result shape must migrate to the v2 status/value fields.