### PR TITLE
feat(examples): add evidence-backed capability example pilot

### DIFF
--- a/benchmarks/example_cases/README.md
+++ b/benchmarks/example_cases/README.md
@@ -1,0 +1,22 @@
+# Capability example pilot
+
+`pilot.json` is the review ledger for the initial evidence-backed example
+pilot. It is deliberately not a second public example API.
+
+Schema-valid, directly invocable examples remain on
+`CapabilityDescriptor.invocation_examples`, where capability registration
+validates them against the installed descriptor schema and
+`capability.describe` exposes them to clients.
+
+The pilot ledger covers cases that cannot be represented by that valid-only
+field:
+
+- invalid and boundary outcomes;
+- artifact-dependent producer-to-verifier workflows;
+- repository source locations;
+- required validation layers; and
+- the human-review gate.
+
+Existing integration tests at each `source` location execute the corresponding
+public capability path and assert stable semantics. A case is not approved for
+broader documentation merely because its test passes.

--- a/benchmarks/example_cases/pilot.json
+++ b/benchmarks/example_cases/pilot.json
@@ -1,0 +1,127 @@
+{
+  "pilot_version": "1",
+  "human_review": "REQUIRED",
+  "cases": [
+    {
+      "capability_id": "graph.compute.properties",
+      "valid_case": "path_property_batch",
+      "invalid_or_boundary_case": "unsupported_invariant",
+      "public_example": null,
+      "status": "PILOT",
+      "origin": "ADAPTED_INVOCATION",
+      "source": "tests/integration/test_graph_capabilities.py",
+      "validation": ["SCHEMA", "EXECUTION", "THIRD_PARTY_NETWORKX"]
+    },
+    {
+      "capability_id": "graph.invariant.diameter.compute",
+      "valid_case": "three_vertex_path",
+      "invalid_or_boundary_case": "disconnected_not_applicable",
+      "public_example": null,
+      "status": "KNOWN_REGRESSION",
+      "origin": "ADAPTED_INVOCATION",
+      "source": "tests/integration/test_graph_invariant_domain.py",
+      "notes": "The specialized capability still returns diameter=-1 for a disconnected graph; do not publish this boundary as valid NOT_APPLICABLE behavior.",
+      "validation": ["SCHEMA", "EXECUTION", "THIRD_PARTY_NETWORKX"]
+    },
+    {
+      "capability_id": "polynomial.identity.verify",
+      "valid_case": "zero_identity",
+      "invalid_or_boundary_case": "different_coefficients_verify_false",
+      "public_example": "zero_identity",
+      "status": "PILOT",
+      "origin": "DIRECT_INVOCATION",
+      "source": "tests/integration/test_polynomial_capabilities.py",
+      "validation": ["SCHEMA", "EXECUTION", "INTERNAL_VERIFIER", "THIRD_PARTY_SYMPY"]
+    },
+    {
+      "capability_id": "polynomial.expression.normalize",
+      "valid_case": "combine_like_terms",
+      "invalid_or_boundary_case": "unsupported_ast_node",
+      "public_example": "combine_like_terms",
+      "status": "PILOT",
+      "origin": "ADAPTED_INVOCATION",
+      "source": "tests/integration/test_polynomial_expression_normalization.py",
+      "validation": ["SCHEMA", "EXECUTION", "INTERNAL_VERIFIER", "THIRD_PARTY_SYMPY"]
+    },
+    {
+      "capability_id": "polynomial.expression_normalization.verify",
+      "valid_case": "verify_full_ast_relation",
+      "invalid_or_boundary_case": "tampered_coefficient",
+      "public_example": null,
+      "status": "PILOT",
+      "origin": "ADAPTED_INVOCATION",
+      "source": "tests/integration/test_polynomial_expression_normalization.py",
+      "validation": ["SCHEMA", "EXECUTION", "INTERNAL_VERIFIER"]
+    },
+    {
+      "capability_id": "polynomial.map.inverse.candidate_synthesize",
+      "valid_case": "triangular_inverse",
+      "invalid_or_boundary_case": "zero_timeout",
+      "public_example": "triangular_inverse",
+      "status": "PILOT",
+      "origin": "ADAPTED_INVOCATION",
+      "source": "tests/integration/test_polynomial_map_inverse_synthesize.py",
+      "validation": ["SCHEMA", "EXECUTION", "INTERNAL_VERIFIER", "THIRD_PARTY_SYMPY"]
+    },
+    {
+      "capability_id": "polynomial.map.inverse.verify",
+      "valid_case": "identity_map_inverse",
+      "invalid_or_boundary_case": "perturbed_inverse_verifies_false",
+      "public_example": "identity_map_inverse",
+      "status": "PILOT",
+      "origin": "ADAPTED_INVOCATION",
+      "source": "tests/integration/test_polynomial_map_inverse_verify.py",
+      "validation": ["SCHEMA", "EXECUTION", "INTERNAL_VERIFIER", "THIRD_PARTY_SYMPY"]
+    },
+    {
+      "capability_id": "finite.coverage.verify",
+      "valid_case": "two_page_exact_coverage",
+      "invalid_or_boundary_case": "omission_and_duplicate",
+      "public_example": "two_page_exact_coverage",
+      "status": "PILOT",
+      "origin": "ADAPTED_INVOCATION",
+      "source": "tests/integration/test_finite_coverage_capability.py",
+      "validation": ["SCHEMA", "EXECUTION", "INTERNAL_VERIFIER", "THIRD_PARTY_EXHAUSTIVE"]
+    },
+    {
+      "capability_id": "lean.statement.propose",
+      "valid_case": "elaborate_true",
+      "invalid_or_boundary_case": "unknown_declaration",
+      "public_example": "elaborate_true",
+      "status": "PILOT",
+      "origin": "ADAPTED_INVOCATION",
+      "source": "tests/integration/test_lean_statement_capabilities.py",
+      "validation": ["SCHEMA", "EXECUTION", "THIRD_PARTY_LEAN"]
+    },
+    {
+      "capability_id": "lean.proof_state.apply_tactic",
+      "valid_case": "close_true_with_trivial",
+      "invalid_or_boundary_case": "unknown_tactic",
+      "public_example": "close_true_with_trivial",
+      "status": "PILOT",
+      "origin": "ADAPTED_INVOCATION",
+      "source": "tests/integration/test_lean_replayable_state_capability.py",
+      "validation": ["SCHEMA", "EXECUTION", "THIRD_PARTY_LEAN"]
+    },
+    {
+      "capability_id": "knowledge.search",
+      "valid_case": "graph_counterexample_episodes",
+      "invalid_or_boundary_case": "no_matches",
+      "public_example": "graph_counterexample_episodes",
+      "status": "PILOT",
+      "origin": "ADAPTED_INVOCATION",
+      "source": "tests/integration/test_capability_service.py",
+      "validation": ["SCHEMA", "EXECUTION"]
+    },
+    {
+      "capability_id": "search.enumerate",
+      "valid_case": "bounded_fixture_enumeration",
+      "invalid_or_boundary_case": "unsupported_verify_mode",
+      "public_example": null,
+      "status": "PILOT",
+      "origin": "ADAPTED_INVOCATION",
+      "source": "tests/integration/test_enumeration_experiments.py",
+      "validation": ["SCHEMA", "EXECUTION", "INTERNAL_ACCOUNTING"]
+    }
+  ]
+}

--- a/src/jacobian/builtin_capabilities.py
+++ b/src/jacobian/builtin_capabilities.py
@@ -70,6 +70,23 @@ class KnowledgeSearchAdapter:
             read_only=True,
             records_episode=False,
             tags=("memory", "retrieval"),
+            invocation_examples=(
+                CapabilityInvocationExample(
+                    name="graph_counterexample_episodes",
+                    description=(
+                        "Search prior graph episodes without changing their "
+                        "recorded assurance."
+                    ),
+                    mode=CapabilityMode.EXPLORE,
+                    input=KnowledgeSearchRequest.model_validate(
+                        {
+                            "query": "counterexample",
+                            "domains": ["graph"],
+                            "limit": 5,
+                        }
+                    ).model_dump(mode="json"),
+                ),
+            ),
         )
 
     @property

--- a/src/jacobian/finite_coverage.py
+++ b/src/jacobian/finite_coverage.py
@@ -21,6 +21,7 @@ from jacobian.contracts.capabilities import (
     CapabilityCompletenessStatus,
     CapabilityDescriptor,
     CapabilityDiagnostic,
+    CapabilityInvocationExample,
     CapabilityMode,
     CapabilityObligation,
     CapabilityObligationStatus,
@@ -233,6 +234,26 @@ class FiniteCoverageVerifyAdapter:
             input_schema=model_schema(FiniteCoverageVerifyRequest),
             output_schema=model_schema(FiniteCoverageVerifyOutput),
             tags=("finite", "coverage", "verification", "paged-archive"),
+            invocation_examples=(
+                CapabilityInvocationExample(
+                    name="two_page_exact_coverage",
+                    description=(
+                        "Verify that two pages cover a three-item finite scope "
+                        "exactly once."
+                    ),
+                    mode=CapabilityMode.VERIFY,
+                    input=FiniteCoverageVerifyRequest.model_validate(
+                        {
+                            "canonicalizer_id": "finite.string.nfc@1",
+                            "scope_items": ["alpha", "beta", "gamma"],
+                            "pages": [
+                                {"items": ["alpha"]},
+                                {"items": ["beta", "gamma"]},
+                            ],
+                        }
+                    ).model_dump(mode="json"),
+                ),
+            ),
         )
 
     @property

--- a/src/jacobian/lean_exploration.py
+++ b/src/jacobian/lean_exploration.py
@@ -33,6 +33,7 @@ from jacobian.contracts.capabilities import (
     CapabilityCompletenessStatus,
     CapabilityDescriptor,
     CapabilityDiagnostic,
+    CapabilityInvocationExample,
     CapabilityMode,
     CapabilityProviderRuntime,
     CapabilityRequest,
@@ -577,6 +578,23 @@ class LeanProofStateAdapter:
             input_schema=LeanProofStateRequest.model_json_schema(),
             output_schema=LeanProofStateOutput.model_json_schema(),
             tags=("lean", "proof-state", "tactic", "exploration"),
+            invocation_examples=(
+                CapabilityInvocationExample(
+                    name="close_true_with_trivial",
+                    description=(
+                        "Apply trivial to a replayable proof state for True; "
+                        "a completed transition still requires lean.check."
+                    ),
+                    mode=CapabilityMode.EXPLORE,
+                    input=LeanProofStateRequest.model_validate(
+                        {
+                            "environment": "CORE",
+                            "statement": "True",
+                            "tactic": "trivial",
+                        }
+                    ).model_dump(mode="json"),
+                ),
+            ),
         )
 
     @property

--- a/src/jacobian/lean_statement_capabilities.py
+++ b/src/jacobian/lean_statement_capabilities.py
@@ -41,6 +41,7 @@ from jacobian.contracts.capabilities import (
     CapabilityCompletenessStatus,
     CapabilityDescriptor,
     CapabilityDiagnostic,
+    CapabilityInvocationExample,
     CapabilityMode,
     CapabilityProviderRuntime,
     CapabilityRequest,
@@ -462,6 +463,23 @@ class LeanStatementProposalAdapter:
             input_schema=LeanStatementProposalRequest.model_json_schema(),
             output_schema=LeanStatementProposalOutput.model_json_schema(),
             tags=("lean", "statement", "elaboration", "proposal", "proposition"),
+            invocation_examples=(
+                CapabilityInvocationExample(
+                    name="elaborate_true",
+                    description=(
+                        "Elaborate the proposition True in the pinned CORE "
+                        "environment without assessing its truth."
+                    ),
+                    mode=CapabilityMode.EXPLORE,
+                    input=LeanStatementProposalRequest.model_validate(
+                        {
+                            "operation": "ELABORATE_PROPOSITION",
+                            "environment": "CORE",
+                            "proposed_statement": "True",
+                        }
+                    ).model_dump(mode="json"),
+                ),
+            ),
         )
 
     @property

--- a/src/jacobian/polynomial_capabilities.py
+++ b/src/jacobian/polynomial_capabilities.py
@@ -1800,6 +1800,67 @@ class PolynomialMapInverseSynthesizeAdapter:
             input_schema=model_schema(PolynomialMapInverseSynthesisRequest),
             output_schema=model_schema(PolynomialMapInverseSynthesisOutput),
             tags=("polynomial", "map", "inverse", "synthesis", "exact-rational"),
+            invocation_examples=(
+                CapabilityInvocationExample(
+                    name="triangular_inverse",
+                    description=(
+                        "Synthesize and independently check the degree-two "
+                        "inverse of (x + y^2, y)."
+                    ),
+                    mode=CapabilityMode.EXPLORE,
+                    input=PolynomialMapInverseSynthesisRequest.model_validate(
+                        {
+                            "forward_map": {
+                                "variables": ["x", "y"],
+                                "coordinates": [
+                                    {
+                                        "terms": [
+                                            {
+                                                "coefficient": {
+                                                    "num": "1",
+                                                    "den": "1",
+                                                },
+                                                "exponents": [1, 0],
+                                            },
+                                            {
+                                                "coefficient": {
+                                                    "num": "1",
+                                                    "den": "1",
+                                                },
+                                                "exponents": [0, 2],
+                                            },
+                                        ]
+                                    },
+                                    {
+                                        "terms": [
+                                            {
+                                                "coefficient": {
+                                                    "num": "1",
+                                                    "den": "1",
+                                                },
+                                                "exponents": [0, 1],
+                                            }
+                                        ]
+                                    },
+                                ],
+                            },
+                            "source_variables": ["x", "y"],
+                            "target_variables": ["u", "v"],
+                            "inverse_degree_bound": 2,
+                            "support_mode": "FULL_TOTAL_DEGREE",
+                            "solver": "sympy.solve",
+                            "limits": {
+                                "timeout_ms": 10000,
+                                "max_inverse_degree": 4,
+                                "max_composition_degree": 32,
+                                "max_unknown_coefficients": 64,
+                                "max_coefficient_equations": 512,
+                                "max_residual_terms": 1024,
+                            },
+                        }
+                    ).model_dump(mode="json"),
+                ),
+            ),
         )
 
     @property
@@ -2324,6 +2385,54 @@ class PolynomialMapInverseVerifyAdapter:
             input_schema=model_schema(PolynomialMapInverseVerifyRequest),
             output_schema=model_schema(PolynomialMapInverseVerifyOutput),
             tags=("polynomial", "map", "inverse", "verification", "exact-rational"),
+            invocation_examples=(
+                CapabilityInvocationExample(
+                    name="identity_map_inverse",
+                    description=(
+                        "Independently verify the identity map as its own "
+                        "two-sided inverse over QQ."
+                    ),
+                    mode=CapabilityMode.VERIFY,
+                    input=PolynomialMapInverseVerifyRequest.model_validate(
+                        {
+                            "forward_map": {
+                                "variables": ["x"],
+                                "coordinates": [
+                                    {
+                                        "terms": [
+                                            {
+                                                "coefficient": {
+                                                    "num": "1",
+                                                    "den": "1",
+                                                },
+                                                "exponents": [1],
+                                            }
+                                        ]
+                                    }
+                                ],
+                            },
+                            "inverse_map": {
+                                "variables": ["u"],
+                                "coordinates": [
+                                    {
+                                        "terms": [
+                                            {
+                                                "coefficient": {
+                                                    "num": "1",
+                                                    "den": "1",
+                                                },
+                                                "exponents": [1],
+                                            }
+                                        ]
+                                    }
+                                ],
+                            },
+                            "source_variables": ["x"],
+                            "target_variables": ["u"],
+                        }
+                    ).model_dump(mode="json"),
+                ),
+            ),
         )
 
     @property

--- a/src/jacobian/sympy_polynomial_normalization.py
+++ b/src/jacobian/sympy_polynomial_normalization.py
@@ -19,6 +19,7 @@ from jacobian.contracts.capabilities import (
     CapabilityCompletenessStatus,
     CapabilityDescriptor,
     CapabilityDiagnostic,
+    CapabilityInvocationExample,
     CapabilityMode,
     CapabilityProviderAvailability,
     CapabilityProviderRuntime,
@@ -195,6 +196,29 @@ class SympyPolynomialExpressionNormalizeAdapter:
                 "typed-expression",
                 "exact-rational",
                 "sympy",
+            ),
+            invocation_examples=(
+                CapabilityInvocationExample(
+                    name="combine_like_terms",
+                    description=(
+                        "Normalize x + x to canonical sparse coefficients over QQ."
+                    ),
+                    mode=CapabilityMode.EXPLORE,
+                    input=PolynomialExpressionNormalizeRequest.model_validate(
+                        {
+                            "expression": {
+                                "variables": ["x"],
+                                "expression": {
+                                    "kind": "add",
+                                    "operands": [
+                                        {"kind": "variable", "name": "x"},
+                                        {"kind": "variable", "name": "x"},
+                                    ],
+                                },
+                            }
+                        }
+                    ).model_dump(mode="json"),
+                ),
             ),
         )
 

--- a/tests/contract/test_pilot_invocation_examples.py
+++ b/tests/contract/test_pilot_invocation_examples.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jacobian.contracts.capabilities import CapabilityMode, CapabilityRequest
+from jacobian.contracts.results import ExecutionStatus
+from jacobian.kernel import JacobianKernel
+
+_ROOT = Path(__file__).parents[2]
+_PILOT = _ROOT / "benchmarks" / "example_cases" / "pilot.json"
+
+_REQUIRED_CAPABILITIES = {
+    "finite.coverage.verify",
+    "graph.compute.properties",
+    "graph.invariant.diameter.compute",
+    "knowledge.search",
+    "lean.proof_state.apply_tactic",
+    "lean.statement.propose",
+    "polynomial.expression.normalize",
+    "polynomial.expression_normalization.verify",
+    "polynomial.identity.verify",
+    "polynomial.map.inverse.candidate_synthesize",
+    "polynomial.map.inverse.verify",
+    "search.enumerate",
+}
+
+
+def _pilot() -> dict[str, object]:
+    return json.loads(_PILOT.read_text())
+
+
+def test_pilot_manifest_is_small_source_backed_and_review_gated() -> None:
+    pilot = _pilot()
+    assert pilot["pilot_version"] == "1"
+    assert pilot["human_review"] == "REQUIRED"
+
+    cases = pilot["cases"]
+    assert isinstance(cases, list)
+    assert {case["capability_id"] for case in cases} == _REQUIRED_CAPABILITIES
+    assert len(cases) == len(_REQUIRED_CAPABILITIES)
+
+    for case in cases:
+        assert case["valid_case"]
+        assert case["invalid_or_boundary_case"]
+        assert case["status"] in {"PILOT", "KNOWN_REGRESSION"}
+        assert case["origin"] in {
+            "DIRECT_INVOCATION",
+            "ADAPTED_INVOCATION",
+            "SOURCE_DERIVED_CONTENT",
+            "GENERATED",
+        }
+        source = _ROOT / case["source"]
+        assert source.is_file()
+        assert case["validation"][:2] == ["SCHEMA", "EXECUTION"]
+
+
+def test_installed_public_pilot_examples_use_descriptor_mechanism(
+    tmp_path: Path,
+) -> None:
+    pilot = _pilot()
+    kernel = JacobianKernel(tmp_path, install_references=False)
+    installed = {
+        descriptor.capability_id: descriptor
+        for descriptor in kernel.capabilities.catalog().capabilities
+    }
+
+    checked = set()
+    for case in pilot["cases"]:
+        example_name = case["public_example"]
+        descriptor = installed.get(case["capability_id"])
+        if example_name is None or descriptor is None:
+            continue
+        assert example_name in {
+            example.name for example in descriptor.invocation_examples
+        }
+        checked.add(case["capability_id"])
+
+    assert checked == {
+        "knowledge.search",
+        "lean.statement.propose",
+        "polynomial.expression.normalize",
+        "polynomial.identity.verify",
+        "polynomial.map.inverse.candidate_synthesize",
+    }
+
+
+def test_search_pilot_boundaries_use_typed_public_results(tmp_path: Path) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=False)
+    artifact_uri = "artifact://sha256/" + "a" * 64
+    payload = {
+        "claim_uri": artifact_uri,
+        "plugin_id": artifact_uri,
+        "bounds": {},
+        "budget": {"candidates_max": 1, "wall_seconds": 1},
+    }
+
+    unsupported = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="search.enumerate",
+            mode=CapabilityMode.VERIFY,
+            input=payload,
+        )
+    )
+    invalid_budget = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="search.enumerate",
+            input={
+                **payload,
+                "budget": {"candidates_max": 0, "wall_seconds": 1},
+            },
+        )
+    )
+
+    assert unsupported.execution.status is ExecutionStatus.ERROR
+    assert unsupported.diagnostics[0].code == "UNSUPPORTED_MODE"
+    assert invalid_budget.execution.status is ExecutionStatus.ERROR
+    assert invalid_budget.diagnostics[0].code == "INVALID_REQUEST"


### PR DESCRIPTION
## What changed

- add schema-valid pilot examples through the existing `CapabilityDescriptor.invocation_examples` mechanism for directly invocable knowledge, Lean, polynomial, and finite-coverage capabilities
- add a small 12-capability pilot ledger for source locations, invalid/boundary coverage, validation layers, and human-review status
- keep artifact-dependent workflows out of the public valid-only descriptor field
- record the disconnected specialized-diameter sentinel as a known regression instead of presenting it as valid `NOT_APPLICABLE` behavior
- add contract coverage for pilot scope, descriptor example reuse, and typed `search.enumerate` boundary results

## Why

The installed catalog currently exposes very few examples. This pilot exercises a representative producer/verifier/search set without introducing a competing public example format or attempting repository-wide rollout.

## Impact

Exact `capability.describe` responses expose additional schema-validated valid examples. Invalid and artifact-dependent cases remain an internal review ledger backed by existing integration tests. All entries remain human-review gated.

## Validation

- Ruff check and format check on changed Python files
- `tests/contract/test_pilot_invocation_examples.py`: 3 passed
- capability discovery and invalid invocation-example registration: 2 passed
- graph and finite pilot cases: 4 passed
- polynomial normalization, inverse synthesis/verification, and knowledge search: 5 passed
- polynomial descriptor example direct invocation: 1 passed
- Lean adapter contract tests: 2 passed
- `git diff --check`

The local environment did not run the real pinned Lean runtime lane. The repository-pinned optional `python-flint==0.9.0` was installed to run reference-enabled fixtures.