### PR TITLE
feat(examples): add exact scalar and finite capability examples

### DIFF
--- a/benchmarks/example_cases/README.md
+++ b/benchmarks/example_cases/README.md
@@ -1,0 +1,22 @@
+# Capability example pilot
+
+`pilot.json` is the review ledger for the initial evidence-backed example
+pilot. It is deliberately not a second public example API.
+
+Schema-valid, directly invocable examples remain on
+`CapabilityDescriptor.invocation_examples`, where capability registration
+validates them against the installed descriptor schema and
+`capability.describe` exposes them to clients.
+
+The pilot ledger covers cases that cannot be represented by that valid-only
+field:
+
+- invalid and boundary outcomes;
+- artifact-dependent producer-to-verifier workflows;
+- repository source locations;
+- required validation layers; and
+- the human-review gate.
+
+Existing integration tests at each `source` location execute the corresponding
+public capability path and assert stable semantics. A case is not approved for
+broader documentation merely because its test passes.

--- a/benchmarks/example_cases/pilot.json
+++ b/benchmarks/example_cases/pilot.json
@@ -1,0 +1,127 @@
+{
+  "pilot_version": "1",
+  "human_review": "REQUIRED",
+  "cases": [
+    {
+      "capability_id": "graph.compute.properties",
+      "valid_case": "path_property_batch",
+      "invalid_or_boundary_case": "unsupported_invariant",
+      "public_example": null,
+      "status": "PILOT",
+      "origin": "ADAPTED_INVOCATION",
+      "source": "tests/integration/test_graph_capabilities.py",
+      "validation": ["SCHEMA", "EXECUTION", "THIRD_PARTY_NETWORKX"]
+    },
+    {
+      "capability_id": "graph.invariant.diameter.compute",
+      "valid_case": "three_vertex_path",
+      "invalid_or_boundary_case": "disconnected_not_applicable",
+      "public_example": null,
+      "status": "KNOWN_REGRESSION",
+      "origin": "ADAPTED_INVOCATION",
+      "source": "tests/integration/test_graph_invariant_domain.py",
+      "notes": "The specialized capability still returns diameter=-1 for a disconnected graph; do not publish this boundary as valid NOT_APPLICABLE behavior.",
+      "validation": ["SCHEMA", "EXECUTION", "THIRD_PARTY_NETWORKX"]
+    },
+    {
+      "capability_id": "polynomial.identity.verify",
+      "valid_case": "zero_identity",
+      "invalid_or_boundary_case": "different_coefficients_verify_false",
+      "public_example": "zero_identity",
+      "status": "PILOT",
+      "origin": "DIRECT_INVOCATION",
+      "source": "tests/integration/test_polynomial_capabilities.py",
+      "validation": ["SCHEMA", "EXECUTION", "INTERNAL_VERIFIER", "THIRD_PARTY_SYMPY"]
+    },
+    {
+      "capability_id": "polynomial.expression.normalize",
+      "valid_case": "combine_like_terms",
+      "invalid_or_boundary_case": "unsupported_ast_node",
+      "public_example": "combine_like_terms",
+      "status": "PILOT",
+      "origin": "ADAPTED_INVOCATION",
+      "source": "tests/integration/test_polynomial_expression_normalization.py",
+      "validation": ["SCHEMA", "EXECUTION", "INTERNAL_VERIFIER", "THIRD_PARTY_SYMPY"]
+    },
+    {
+      "capability_id": "polynomial.expression_normalization.verify",
+      "valid_case": "verify_full_ast_relation",
+      "invalid_or_boundary_case": "tampered_coefficient",
+      "public_example": null,
+      "status": "PILOT",
+      "origin": "ADAPTED_INVOCATION",
+      "source": "tests/integration/test_polynomial_expression_normalization.py",
+      "validation": ["SCHEMA", "EXECUTION", "INTERNAL_VERIFIER"]
+    },
+    {
+      "capability_id": "polynomial.map.inverse.candidate_synthesize",
+      "valid_case": "triangular_inverse",
+      "invalid_or_boundary_case": "zero_timeout",
+      "public_example": "triangular_inverse",
+      "status": "PILOT",
+      "origin": "ADAPTED_INVOCATION",
+      "source": "tests/integration/test_polynomial_map_inverse_synthesize.py",
+      "validation": ["SCHEMA", "EXECUTION", "INTERNAL_VERIFIER", "THIRD_PARTY_SYMPY"]
+    },
+    {
+      "capability_id": "polynomial.map.inverse.verify",
+      "valid_case": "identity_map_inverse",
+      "invalid_or_boundary_case": "perturbed_inverse_verifies_false",
+      "public_example": "identity_map_inverse",
+      "status": "PILOT",
+      "origin": "ADAPTED_INVOCATION",
+      "source": "tests/integration/test_polynomial_map_inverse_verify.py",
+      "validation": ["SCHEMA", "EXECUTION", "INTERNAL_VERIFIER", "THIRD_PARTY_SYMPY"]
+    },
+    {
+      "capability_id": "finite.coverage.verify",
+      "valid_case": "two_page_exact_coverage",
+      "invalid_or_boundary_case": "omission_and_duplicate",
+      "public_example": "two_page_exact_coverage",
+      "status": "PILOT",
+      "origin": "ADAPTED_INVOCATION",
+      "source": "tests/integration/test_finite_coverage_capability.py",
+      "validation": ["SCHEMA", "EXECUTION", "INTERNAL_VERIFIER", "THIRD_PARTY_EXHAUSTIVE"]
+    },
+    {
+      "capability_id": "lean.statement.propose",
+      "valid_case": "elaborate_true",
+      "invalid_or_boundary_case": "unknown_declaration",
+      "public_example": "elaborate_true",
+      "status": "PILOT",
+      "origin": "ADAPTED_INVOCATION",
+      "source": "tests/integration/test_lean_statement_capabilities.py",
+      "validation": ["SCHEMA", "EXECUTION", "THIRD_PARTY_LEAN"]
+    },
+    {
+      "capability_id": "lean.proof_state.apply_tactic",
+      "valid_case": "close_true_with_trivial",
+      "invalid_or_boundary_case": "unknown_tactic",
+      "public_example": "close_true_with_trivial",
+      "status": "PILOT",
+      "origin": "ADAPTED_INVOCATION",
+      "source": "tests/integration/test_lean_replayable_state_capability.py",
+      "validation": ["SCHEMA", "EXECUTION", "THIRD_PARTY_LEAN"]
+    },
+    {
+      "capability_id": "knowledge.search",
+      "valid_case": "graph_counterexample_episodes",
+      "invalid_or_boundary_case": "no_matches",
+      "public_example": "graph_counterexample_episodes",
+      "status": "PILOT",
+      "origin": "ADAPTED_INVOCATION",
+      "source": "tests/integration/test_capability_service.py",
+      "validation": ["SCHEMA", "EXECUTION"]
+    },
+    {
+      "capability_id": "search.enumerate",
+      "valid_case": "bounded_fixture_enumeration",
+      "invalid_or_boundary_case": "unsupported_verify_mode",
+      "public_example": null,
+      "status": "PILOT",
+      "origin": "ADAPTED_INVOCATION",
+      "source": "tests/integration/test_enumeration_experiments.py",
+      "validation": ["SCHEMA", "EXECUTION", "INTERNAL_ACCOUNTING"]
+    }
+  ]
+}

--- a/src/jacobian/builtin_capabilities.py
+++ b/src/jacobian/builtin_capabilities.py
@@ -70,6 +70,23 @@ class KnowledgeSearchAdapter:
             read_only=True,
             records_episode=False,
             tags=("memory", "retrieval"),
+            invocation_examples=(
+                CapabilityInvocationExample(
+                    name="graph_counterexample_episodes",
+                    description=(
+                        "Search prior graph episodes without changing their "
+                        "recorded assurance."
+                    ),
+                    mode=CapabilityMode.EXPLORE,
+                    input=KnowledgeSearchRequest.model_validate(
+                        {
+                            "query": "counterexample",
+                            "domains": ["graph"],
+                            "limit": 5,
+                        }
+                    ).model_dump(mode="json"),
+                ),
+            ),
         )
 
     @property

--- a/src/jacobian/domains/_examples.py
+++ b/src/jacobian/domains/_examples.py
@@ -1,0 +1,14 @@
+"""Small constructors for operator-authored invocation examples."""
+
+from typing import Any
+
+from jacobian.contracts.capabilities import CapabilityInvocationExample, CapabilityMode
+
+
+def example(name: str, description: str, input: dict[str, Any]) -> CapabilityInvocationExample:
+    return CapabilityInvocationExample(
+        name=name,
+        description=description,
+        mode=CapabilityMode.EXPLORE,
+        input=input,
+    )

--- a/src/jacobian/domains/_examples.py
+++ b/src/jacobian/domains/_examples.py
@@ -5,10 +5,12 @@ from typing import Any
 from jacobian.contracts.capabilities import CapabilityInvocationExample, CapabilityMode
 
 
-def example(name: str, description: str, input: dict[str, Any]) -> CapabilityInvocationExample:
+def example(
+    name: str, description: str, payload: dict[str, Any]
+) -> CapabilityInvocationExample:
     return CapabilityInvocationExample(
         name=name,
         description=description,
         mode=CapabilityMode.EXPLORE,
-        input=input,
+        input=payload,
     )

--- a/src/jacobian/domains/arithmetic/integers.py
+++ b/src/jacobian/domains/arithmetic/integers.py
@@ -76,7 +76,13 @@ INTEGER_CAPABILITIES = (
         base_digits,
         "integer",
         "representation",
-        invocation_examples=(example("negative_binary", "Expand negative ten in base two.", {"value": "-10", "base": 2}),),
+        invocation_examples=(
+            example(
+                "negative_binary",
+                "Expand negative ten in base two.",
+                {"value": "-10", "base": 2},
+            ),
+        ),
     ),
     arithmetic_operation(
         "integer.compute.nth_root",
@@ -87,6 +93,12 @@ INTEGER_CAPABILITIES = (
         nth_root,
         "number-theory",
         "root",
-        invocation_examples=(example("non_exact_cube_root", "Floor cube root of 65.", {"value": 65, "degree": 3}),),
+        invocation_examples=(
+            example(
+                "non_exact_cube_root",
+                "Floor cube root of 65.",
+                {"value": 65, "degree": 3},
+            ),
+        ),
     ),
 )

--- a/src/jacobian/domains/arithmetic/integers.py
+++ b/src/jacobian/domains/arithmetic/integers.py
@@ -15,6 +15,7 @@ from jacobian.contracts.arithmetic import (
     IntegerValueRequest,
     IntegerValueResult,
 )
+from jacobian.domains._examples import example
 from jacobian.domains.arithmetic._support import arithmetic_operation
 from jacobian.domains.arithmetic.operations import (
     absolute_value,
@@ -75,6 +76,7 @@ INTEGER_CAPABILITIES = (
         base_digits,
         "integer",
         "representation",
+        invocation_examples=(example("negative_binary", "Expand negative ten in base two.", {"value": "-10", "base": 2}),),
     ),
     arithmetic_operation(
         "integer.compute.nth_root",
@@ -85,5 +87,6 @@ INTEGER_CAPABILITIES = (
         nth_root,
         "number-theory",
         "root",
+        invocation_examples=(example("non_exact_cube_root", "Floor cube root of 65.", {"value": 65, "degree": 3}),),
     ),
 )

--- a/src/jacobian/domains/arithmetic/rationals.py
+++ b/src/jacobian/domains/arithmetic/rationals.py
@@ -74,7 +74,13 @@ RATIONAL_CAPABILITIES = (
         sum_rationals,
         "rational",
         "exact",
-        invocation_examples=(example("one_half_plus_one_third", "Add one half and one third.", {"left": {"num": "1", "den": "2"}, "right": {"num": "1", "den": "3"}}),),
+        invocation_examples=(
+            example(
+                "one_half_plus_one_third",
+                "Add one half and one third.",
+                {"left": {"num": "1", "den": "2"}, "right": {"num": "1", "den": "3"}},
+            ),
+        ),
     ),
     arithmetic_operation(
         "rational.compute.difference",
@@ -155,7 +161,13 @@ RATIONAL_CAPABILITIES = (
         continued_fraction,
         "rational",
         "representation",
-        invocation_examples=(example("negative_seven_fifths", "Expand negative seven fifths as a continued fraction.", {"value": {"num": "-7", "den": "5"}}),),
+        invocation_examples=(
+            example(
+                "negative_seven_fifths",
+                "Expand negative seven fifths as a continued fraction.",
+                {"value": {"num": "-7", "den": "5"}},
+            ),
+        ),
     ),
     arithmetic_operation(
         "rational.decide.equal",

--- a/src/jacobian/domains/arithmetic/rationals.py
+++ b/src/jacobian/domains/arithmetic/rationals.py
@@ -15,6 +15,7 @@ from jacobian.contracts.rationals import (
     RationalValueRequest,
     RationalValueResult,
 )
+from jacobian.domains._examples import example
 from jacobian.domains.arithmetic._support import arithmetic_operation
 from jacobian.domains.arithmetic.operations import (
     ceiling,
@@ -73,6 +74,7 @@ RATIONAL_CAPABILITIES = (
         sum_rationals,
         "rational",
         "exact",
+        invocation_examples=(example("one_half_plus_one_third", "Add one half and one third.", {"left": {"num": "1", "den": "2"}, "right": {"num": "1", "den": "3"}}),),
     ),
     arithmetic_operation(
         "rational.compute.difference",
@@ -153,6 +155,7 @@ RATIONAL_CAPABILITIES = (
         continued_fraction,
         "rational",
         "representation",
+        invocation_examples=(example("negative_seven_fifths", "Expand negative seven fifths as a continued fraction.", {"value": {"num": "-7", "den": "5"}}),),
     ),
     arithmetic_operation(
         "rational.decide.equal",

--- a/src/jacobian/domains/combinatorics/counting.py
+++ b/src/jacobian/domains/combinatorics/counting.py
@@ -6,6 +6,7 @@ from jacobian.contracts.combinatorics import (
     NonnegativeIntegerRequest,
     NonnegativePairRequest,
 )
+from jacobian.domains._examples import example
 from jacobian.domains.combinatorics._support import (
     combinatorics_operation,
 )
@@ -62,6 +63,7 @@ COUNTING_CAPABILITIES = (
         binomial,
         "combinatorics",
         "counting",
+        invocation_examples=(example("binomial_5_choose_2", "Compute 5 choose 2.", {"n": 5, "k": 2}),),
     ),
     combinatorics_operation(
         "combinatorics.compute.multinomial",

--- a/src/jacobian/domains/combinatorics/counting.py
+++ b/src/jacobian/domains/combinatorics/counting.py
@@ -63,7 +63,9 @@ COUNTING_CAPABILITIES = (
         binomial,
         "combinatorics",
         "counting",
-        invocation_examples=(example("binomial_5_choose_2", "Compute 5 choose 2.", {"n": 5, "k": 2}),),
+        invocation_examples=(
+            example("binomial_5_choose_2", "Compute 5 choose 2.", {"n": 5, "k": 2}),
+        ),
     ),
     combinatorics_operation(
         "combinatorics.compute.multinomial",

--- a/src/jacobian/domains/combinatorics/partitions.py
+++ b/src/jacobian/domains/combinatorics/partitions.py
@@ -7,6 +7,7 @@ from jacobian.contracts.combinatorics import (
     NonnegativeIntegerRequest,
     NonnegativePairRequest,
 )
+from jacobian.domains._examples import example
 from jacobian.domains.combinatorics._support import (
     combinatorics_operation,
 )
@@ -72,5 +73,6 @@ PARTITION_CAPABILITIES = (
         "combinatorics",
         "partition",
         "enumeration",
+        invocation_examples=(example("partitions_of_5_with_two_parts", "Enumerate partitions of 5 using at most two parts.", {"n": 5, "max_parts": 2}),),
     ),
 )

--- a/src/jacobian/domains/combinatorics/partitions.py
+++ b/src/jacobian/domains/combinatorics/partitions.py
@@ -73,6 +73,12 @@ PARTITION_CAPABILITIES = (
         "combinatorics",
         "partition",
         "enumeration",
-        invocation_examples=(example("partitions_of_5_with_two_parts", "Enumerate partitions of 5 using at most two parts.", {"n": 5, "max_parts": 2}),),
+        invocation_examples=(
+            example(
+                "partitions_of_5_with_two_parts",
+                "Enumerate partitions of 5 using at most two parts.",
+                {"n": 5, "max_parts": 2},
+            ),
+        ),
     ),
 )

--- a/src/jacobian/domains/combinatorics/recurrence.py
+++ b/src/jacobian/domains/combinatorics/recurrence.py
@@ -7,6 +7,7 @@ from jacobian.contracts.combinatorics import (
     NonnegativeIntegerRequest,
     RationalResult,
 )
+from jacobian.domains._examples import example
 from jacobian.domains.combinatorics._support import (
     combinatorics_operation,
 )
@@ -58,5 +59,6 @@ RECURRENCE_CAPABILITIES = (
         bernoulli,
         "combinatorics",
         "sequence",
+        invocation_examples=(example("bernoulli_4", "Compute the fourth Bernoulli number.", {"n": 4}),),
     ),
 )

--- a/src/jacobian/domains/combinatorics/recurrence.py
+++ b/src/jacobian/domains/combinatorics/recurrence.py
@@ -59,6 +59,8 @@ RECURRENCE_CAPABILITIES = (
         bernoulli,
         "combinatorics",
         "sequence",
-        invocation_examples=(example("bernoulli_4", "Compute the fourth Bernoulli number.", {"n": 4}),),
+        invocation_examples=(
+            example("bernoulli_4", "Compute the fourth Bernoulli number.", {"n": 4}),
+        ),
     ),
 )

--- a/src/jacobian/domains/finite_sets/set_operations.py
+++ b/src/jacobian/domains/finite_sets/set_operations.py
@@ -4,6 +4,7 @@ from jacobian.contracts.finite_sets import (
     FiniteSetElementListResult,
     FiniteSetPairRequest,
 )
+from jacobian.domains._examples import example
 from jacobian.domains.finite_sets._support import finite_set_operation
 from jacobian.domains.finite_sets.operations import (
     set_difference,
@@ -22,6 +23,7 @@ SET_OPERATION_CAPABILITIES = (
         set_union,
         "finite-set",
         "exact",
+        invocation_examples=(example("union_1_2_and_2_3", "Union two overlapping finite sets.", {"left": {"elements": ["1", "2"]}, "right": {"elements": ["2", "3"]}}),),
     ),
     finite_set_operation(
         "finite_set.compute.intersection",
@@ -52,5 +54,6 @@ SET_OPERATION_CAPABILITIES = (
         set_symmetric_difference,
         "finite-set",
         "exact",
+        invocation_examples=(example("symmetric_difference", "Compute the symmetric difference of two finite sets.", {"left": {"elements": ["3", "1"]}, "right": {"elements": ["2", "3"]}}),),
     ),
 )

--- a/src/jacobian/domains/finite_sets/set_operations.py
+++ b/src/jacobian/domains/finite_sets/set_operations.py
@@ -23,7 +23,13 @@ SET_OPERATION_CAPABILITIES = (
         set_union,
         "finite-set",
         "exact",
-        invocation_examples=(example("union_1_2_and_2_3", "Union two overlapping finite sets.", {"left": {"elements": ["1", "2"]}, "right": {"elements": ["2", "3"]}}),),
+        invocation_examples=(
+            example(
+                "union_1_2_and_2_3",
+                "Union two overlapping finite sets.",
+                {"left": {"elements": ["1", "2"]}, "right": {"elements": ["2", "3"]}},
+            ),
+        ),
     ),
     finite_set_operation(
         "finite_set.compute.intersection",
@@ -54,6 +60,12 @@ SET_OPERATION_CAPABILITIES = (
         set_symmetric_difference,
         "finite-set",
         "exact",
-        invocation_examples=(example("symmetric_difference", "Compute the symmetric difference of two finite sets.", {"left": {"elements": ["3", "1"]}, "right": {"elements": ["2", "3"]}}),),
+        invocation_examples=(
+            example(
+                "symmetric_difference",
+                "Compute the symmetric difference of two finite sets.",
+                {"left": {"elements": ["3", "1"]}, "right": {"elements": ["2", "3"]}},
+            ),
+        ),
     ),
 )

--- a/src/jacobian/domains/geometry/points.py
+++ b/src/jacobian/domains/geometry/points.py
@@ -28,7 +28,22 @@ POINT_CAPABILITIES = (
         squared_distance,
         "geometry",
         "distance",
-        invocation_examples=(example("diagonal_squared_distance", "Compute the squared distance from (0,0) to (2,2).", {"first": {"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}}, "second": {"x": {"num": "2", "den": "1"}, "y": {"num": "2", "den": "1"}}}),),
+        invocation_examples=(
+            example(
+                "diagonal_squared_distance",
+                "Compute the squared distance from (0,0) to (2,2).",
+                {
+                    "first": {
+                        "x": {"num": "0", "den": "1"},
+                        "y": {"num": "0", "den": "1"},
+                    },
+                    "second": {
+                        "x": {"num": "2", "den": "1"},
+                        "y": {"num": "2", "den": "1"},
+                    },
+                },
+            ),
+        ),
     ),
     geometry_operation(
         "geometry.points.decide.collinear",
@@ -59,6 +74,19 @@ POINT_CAPABILITIES = (
         convex_hull_points,
         "geometry",
         "convexity",
-        invocation_examples=(example("square_convex_hull", "Construct the hull of a rational square.", {"points": [{"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}}, {"x": {"num": "2", "den": "1"}, "y": {"num": "0", "den": "1"}}, {"x": {"num": "0", "den": "1"}, "y": {"num": "2", "den": "1"}}, {"x": {"num": "2", "den": "1"}, "y": {"num": "2", "den": "1"}}]}),),
+        invocation_examples=(
+            example(
+                "square_convex_hull",
+                "Construct the hull of a rational square.",
+                {
+                    "points": [
+                        {"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}},
+                        {"x": {"num": "2", "den": "1"}, "y": {"num": "0", "den": "1"}},
+                        {"x": {"num": "0", "den": "1"}, "y": {"num": "2", "den": "1"}},
+                        {"x": {"num": "2", "den": "1"}, "y": {"num": "2", "den": "1"}},
+                    ]
+                },
+            ),
+        ),
     ),
 )

--- a/src/jacobian/domains/geometry/points.py
+++ b/src/jacobian/domains/geometry/points.py
@@ -9,6 +9,7 @@ from jacobian.contracts.geometry import (
     PointSetRequest,
     PointTripleRequest,
 )
+from jacobian.domains._examples import example
 from jacobian.domains.geometry._support import geometry_operation
 from jacobian.domains.geometry.operations import (
     collinear,
@@ -27,6 +28,7 @@ POINT_CAPABILITIES = (
         squared_distance,
         "geometry",
         "distance",
+        invocation_examples=(example("diagonal_squared_distance", "Compute the squared distance from (0,0) to (2,2).", {"first": {"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}}, "second": {"x": {"num": "2", "den": "1"}, "y": {"num": "2", "den": "1"}}}),),
     ),
     geometry_operation(
         "geometry.points.decide.collinear",
@@ -57,5 +59,6 @@ POINT_CAPABILITIES = (
         convex_hull_points,
         "geometry",
         "convexity",
+        invocation_examples=(example("square_convex_hull", "Construct the hull of a rational square.", {"points": [{"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}}, {"x": {"num": "2", "den": "1"}, "y": {"num": "0", "den": "1"}}, {"x": {"num": "0", "den": "1"}, "y": {"num": "2", "den": "1"}}, {"x": {"num": "2", "den": "1"}, "y": {"num": "2", "den": "1"}}]}),),
     ),
 )

--- a/src/jacobian/domains/geometry/triangles.py
+++ b/src/jacobian/domains/geometry/triangles.py
@@ -6,6 +6,7 @@ from jacobian.contracts.geometry import (
     GeometryPointResult,
     PointTripleRequest,
 )
+from jacobian.domains._examples import example
 from jacobian.domains.geometry._support import geometry_operation
 from jacobian.domains.geometry.operations import centroid, circumcircle, orientation
 
@@ -39,5 +40,6 @@ TRIANGLE_CAPABILITIES = (
         circumcircle,
         "geometry",
         "circle",
+        invocation_examples=(example("right_triangle_circumcircle", "Construct the circumcircle of a right triangle.", {"first": {"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}}, "second": {"x": {"num": "2", "den": "1"}, "y": {"num": "0", "den": "1"}}, "third": {"x": {"num": "0", "den": "1"}, "y": {"num": "2", "den": "1"}}}),),
     ),
 )

--- a/src/jacobian/domains/geometry/triangles.py
+++ b/src/jacobian/domains/geometry/triangles.py
@@ -40,6 +40,25 @@ TRIANGLE_CAPABILITIES = (
         circumcircle,
         "geometry",
         "circle",
-        invocation_examples=(example("right_triangle_circumcircle", "Construct the circumcircle of a right triangle.", {"first": {"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}}, "second": {"x": {"num": "2", "den": "1"}, "y": {"num": "0", "den": "1"}}, "third": {"x": {"num": "0", "den": "1"}, "y": {"num": "2", "den": "1"}}}),),
+        invocation_examples=(
+            example(
+                "right_triangle_circumcircle",
+                "Construct the circumcircle of a right triangle.",
+                {
+                    "first": {
+                        "x": {"num": "0", "den": "1"},
+                        "y": {"num": "0", "den": "1"},
+                    },
+                    "second": {
+                        "x": {"num": "2", "den": "1"},
+                        "y": {"num": "0", "den": "1"},
+                    },
+                    "third": {
+                        "x": {"num": "0", "den": "1"},
+                        "y": {"num": "2", "den": "1"},
+                    },
+                },
+            ),
+        ),
     ),
 )

--- a/src/jacobian/domains/number_theory/divisibility.py
+++ b/src/jacobian/domains/number_theory/divisibility.py
@@ -11,6 +11,7 @@ from jacobian.contracts.number_theory import (
     PositiveIntegerRequest,
     ValuationRequest,
 )
+from jacobian.domains._examples import example
 from jacobian.domains.number_theory._support import (
     number_theory_operation,
 )
@@ -64,6 +65,7 @@ DIVISIBILITY_CAPABILITIES = (
         compute_extended_gcd,
         "number-theory",
         "certificate",
+        invocation_examples=(example("bezout_84_30", "Compute Bezout coefficients for 84 and 30.", {"left": "84", "right": "30"}),),
     ),
     number_theory_operation(
         "integer.compute.valuation",

--- a/src/jacobian/domains/number_theory/divisibility.py
+++ b/src/jacobian/domains/number_theory/divisibility.py
@@ -65,7 +65,13 @@ DIVISIBILITY_CAPABILITIES = (
         compute_extended_gcd,
         "number-theory",
         "certificate",
-        invocation_examples=(example("bezout_84_30", "Compute Bezout coefficients for 84 and 30.", {"left": "84", "right": "30"}),),
+        invocation_examples=(
+            example(
+                "bezout_84_30",
+                "Compute Bezout coefficients for 84 and 30.",
+                {"left": "84", "right": "30"},
+            ),
+        ),
     ),
     number_theory_operation(
         "integer.compute.valuation",

--- a/src/jacobian/domains/number_theory/factorization.py
+++ b/src/jacobian/domains/number_theory/factorization.py
@@ -9,7 +9,10 @@ from pydantic import ValidationError
 
 from jacobian.bounded_process import ProcessResourceLimits, run_bounded_process
 from jacobian.canonical import canonicalize_json, loads_strict_json
-from jacobian.contracts.capabilities import CapabilityDiagnostic
+from jacobian.contracts.capabilities import (
+    CapabilityDiagnostic,
+    CapabilityInvocationExample,
+)
 from jacobian.contracts.number_theory import (
     ArithmeticFunctionRequest,
     BooleanResult,
@@ -19,6 +22,7 @@ from jacobian.contracts.number_theory import (
     PrimeFactorizationResult,
 )
 from jacobian.contracts.results import ContractModel, ExecutionStatus
+from jacobian.domains._examples import example
 from jacobian.operations import (
     ComputedNotApplicable,
     ComputedOperation,
@@ -156,6 +160,7 @@ def _operation[RequestT: ContractModel, ResultT: ContractModel](
     request_model: type[RequestT],
     result_model: type[ResultT],
     tags: tuple[str, ...],
+    invocation_examples: tuple[CapabilityInvocationExample, ...] = (),
 ) -> ComputedOperation[RequestT, ResultT]:
     def implementation(request: RequestT) -> ComputedOutcome[ResultT]:
         if not isinstance(request, (FactorizationRequest, ArithmeticFunctionRequest)):
@@ -171,6 +176,7 @@ def _operation[RequestT: ContractModel, ResultT: ContractModel](
         implementation=implementation,
         relation_id=capability_id.replace(".compute.", ".relation.", 1),
         tags=tags,
+        invocation_examples=invocation_examples,
     )
 
 
@@ -198,6 +204,7 @@ FACTORIZATION_CAPABILITIES = (
         request_model=FactorizationRequest,
         result_model=DivisorListResult,
         tags=("number-theory", "enumeration"),
+        invocation_examples=(example("proper_divisors_12", "Enumerate the proper divisors of 12.", {"value": "12"}),),
     ),
     _operation(
         capability_id="integer.compute.prime_factorization",

--- a/src/jacobian/domains/number_theory/factorization.py
+++ b/src/jacobian/domains/number_theory/factorization.py
@@ -204,7 +204,13 @@ FACTORIZATION_CAPABILITIES = (
         request_model=FactorizationRequest,
         result_model=DivisorListResult,
         tags=("number-theory", "enumeration"),
-        invocation_examples=(example("proper_divisors_12", "Enumerate the proper divisors of 12.", {"value": "12"}),),
+        invocation_examples=(
+            example(
+                "proper_divisors_12",
+                "Enumerate the proper divisors of 12.",
+                {"value": "12"},
+            ),
+        ),
     ),
     _operation(
         capability_id="integer.compute.prime_factorization",

--- a/src/jacobian/domains/number_theory/modular.py
+++ b/src/jacobian/domains/number_theory/modular.py
@@ -10,6 +10,7 @@ from jacobian.contracts.number_theory import (
     ModulusRequest,
     QuadraticResiduesResult,
 )
+from jacobian.domains._examples import example
 from jacobian.domains.number_theory._support import (
     number_theory_operation,
 )
@@ -35,6 +36,7 @@ MODULAR_CAPABILITIES = (
         "number-theory",
         "modular",
         "jacobi-symbol",
+        invocation_examples=(example("jacobi_10_21", "Compute the Jacobi symbol (10/21).", {"a": "10", "n": 21}),),
     ),
     number_theory_operation(
         "modular.compute.inverse",
@@ -66,6 +68,7 @@ MODULAR_CAPABILITIES = (
         "number-theory",
         "modular",
         "enumeration",
+        invocation_examples=(example("quadratic_residues_mod_10", "Enumerate quadratic residues modulo 10.", {"modulus": 10}),),
     ),
     number_theory_operation(
         "modular.solve.chinese_remainder",
@@ -76,6 +79,7 @@ MODULAR_CAPABILITIES = (
         solve_chinese_remainder,
         "number-theory",
         "modular",
+        invocation_examples=(example("crt_2_mod_3_3_mod_5", "Solve x=2 mod 3 and x=3 mod 5.", {"residues": [2, 3], "moduli": [3, 5]}),),
     ),
     DISCRETE_LOGARITHM_CAPABILITY,
 )

--- a/src/jacobian/domains/number_theory/modular.py
+++ b/src/jacobian/domains/number_theory/modular.py
@@ -36,7 +36,13 @@ MODULAR_CAPABILITIES = (
         "number-theory",
         "modular",
         "jacobi-symbol",
-        invocation_examples=(example("jacobi_10_21", "Compute the Jacobi symbol (10/21).", {"a": "10", "n": 21}),),
+        invocation_examples=(
+            example(
+                "jacobi_10_21",
+                "Compute the Jacobi symbol (10/21).",
+                {"a": "10", "n": 21},
+            ),
+        ),
     ),
     number_theory_operation(
         "modular.compute.inverse",
@@ -68,7 +74,13 @@ MODULAR_CAPABILITIES = (
         "number-theory",
         "modular",
         "enumeration",
-        invocation_examples=(example("quadratic_residues_mod_10", "Enumerate quadratic residues modulo 10.", {"modulus": 10}),),
+        invocation_examples=(
+            example(
+                "quadratic_residues_mod_10",
+                "Enumerate quadratic residues modulo 10.",
+                {"modulus": 10},
+            ),
+        ),
     ),
     number_theory_operation(
         "modular.solve.chinese_remainder",
@@ -79,7 +91,13 @@ MODULAR_CAPABILITIES = (
         solve_chinese_remainder,
         "number-theory",
         "modular",
-        invocation_examples=(example("crt_2_mod_3_3_mod_5", "Solve x=2 mod 3 and x=3 mod 5.", {"residues": [2, 3], "moduli": [3, 5]}),),
+        invocation_examples=(
+            example(
+                "crt_2_mod_3_3_mod_5",
+                "Solve x=2 mod 3 and x=3 mod 5.",
+                {"residues": [2, 3], "moduli": [3, 5]},
+            ),
+        ),
     ),
     DISCRETE_LOGARITHM_CAPABILITY,
 )

--- a/src/jacobian/domains/polynomial/_support.py
+++ b/src/jacobian/domains/polynomial/_support.py
@@ -5,7 +5,10 @@ from dataclasses import replace
 
 from sympy.polys.polyerrors import PolynomialError
 
-from jacobian.contracts.capabilities import CapabilityDiagnostic
+from jacobian.contracts.capabilities import (
+    CapabilityDiagnostic,
+    CapabilityInvocationExample,
+)
 from jacobian.contracts.results import ContractModel, ExecutionStatus
 from jacobian.domains.polynomial.operations import PolynomialOutputBudgetError
 from jacobian.operations import (
@@ -37,6 +40,7 @@ def polynomial_operation[
     result_model: type[ResultT],
     operation: Callable[[ContractModel], ContractModel],
     *tags: str,
+    invocation_examples: tuple[CapabilityInvocationExample, ...] = (),
 ) -> ComputedOperation[RequestT, ResultT]:
     """Declare an exact polynomial operation with bounded-output failure semantics."""
 
@@ -48,6 +52,7 @@ def polynomial_operation[
         result_model,
         operation,
         *tags,
+        invocation_examples=invocation_examples,
     )
     implementation = declared.implementation
 

--- a/src/jacobian/domains/polynomial/elementary.py
+++ b/src/jacobian/domains/polynomial/elementary.py
@@ -52,7 +52,16 @@ INTEGER_POLYNOMIAL_CAPABILITIES = (
         "polynomial",
         "integer",
         "gcd",
-        invocation_examples=(example("integer_gcd", "Compute the GCD of two integer polynomials.", {"left": {"coefficients": ["6", "6", "0"]}, "right": {"coefficients": ["8", "8", "0"]}}),),
+        invocation_examples=(
+            example(
+                "integer_gcd",
+                "Compute the GCD of two integer polynomials.",
+                {
+                    "left": {"coefficients": ["6", "6", "0"]},
+                    "right": {"coefficients": ["8", "8", "0"]},
+                },
+            ),
+        ),
     ),
     polynomial_operation(
         "polynomial.integer.compute.content",
@@ -89,7 +98,13 @@ INTEGER_POLYNOMIAL_CAPABILITIES = (
         "polynomial",
         "integer",
         "evaluation",
-        invocation_examples=(example("evaluate_at_four", "Evaluate 2x²-3x+1 at 4.", {"polynomial": {"coefficients": ["2", "-3", "1"]}, "point": "4"}),),
+        invocation_examples=(
+            example(
+                "evaluate_at_four",
+                "Evaluate 2x²-3x+1 at 4.",
+                {"polynomial": {"coefficients": ["2", "-3", "1"]}, "point": "4"},
+            ),
+        ),
     ),
     polynomial_operation(
         "polynomial.integer.compute.compose",
@@ -129,7 +144,48 @@ RATIONAL_POLYNOMIAL_CAPABILITIES = (
         "polynomial",
         "rational",
         "division",
-        invocation_examples=(example("divide_x_squared_minus_one", "Divide x²-1 by x-1.", {"left": {"polynomial_schema_version": "1", "domain": "QQ", "variables": ["x"], "polynomial": {"terms": [{"coefficient": {"num": "1", "den": "1"}, "exponents": [2]}, {"coefficient": {"num": "-1", "den": "1"}, "exponents": [0]}]}}, "right": {"polynomial_schema_version": "1", "domain": "QQ", "variables": ["x"], "polynomial": {"terms": [{"coefficient": {"num": "1", "den": "1"}, "exponents": [1]}, {"coefficient": {"num": "-1", "den": "1"}, "exponents": [0]}]}}}),),
+        invocation_examples=(
+            example(
+                "divide_x_squared_minus_one",
+                "Divide x²-1 by x-1.",
+                {
+                    "left": {
+                        "polynomial_schema_version": "1",
+                        "domain": "QQ",
+                        "variables": ["x"],
+                        "polynomial": {
+                            "terms": [
+                                {
+                                    "coefficient": {"num": "1", "den": "1"},
+                                    "exponents": [2],
+                                },
+                                {
+                                    "coefficient": {"num": "-1", "den": "1"},
+                                    "exponents": [0],
+                                },
+                            ]
+                        },
+                    },
+                    "right": {
+                        "polynomial_schema_version": "1",
+                        "domain": "QQ",
+                        "variables": ["x"],
+                        "polynomial": {
+                            "terms": [
+                                {
+                                    "coefficient": {"num": "1", "den": "1"},
+                                    "exponents": [1],
+                                },
+                                {
+                                    "coefficient": {"num": "-1", "den": "1"},
+                                    "exponents": [0],
+                                },
+                            ]
+                        },
+                    },
+                },
+            ),
+        ),
     ),
     polynomial_operation(
         "polynomial.rational.compute.evaluate",
@@ -152,7 +208,31 @@ RATIONAL_POLYNOMIAL_CAPABILITIES = (
         "polynomial",
         "rational",
         "derivative",
-        invocation_examples=(example("cubic_derivative", "Differentiate one half x³ minus 2x.", {"polynomial": {"polynomial_schema_version": "1", "domain": "QQ", "variables": ["x"], "polynomial": {"terms": [{"coefficient": {"num": "1", "den": "2"}, "exponents": [3]}, {"coefficient": {"num": "-2", "den": "1"}, "exponents": [1]}]}}}),),
+        invocation_examples=(
+            example(
+                "cubic_derivative",
+                "Differentiate one half x³ minus 2x.",
+                {
+                    "polynomial": {
+                        "polynomial_schema_version": "1",
+                        "domain": "QQ",
+                        "variables": ["x"],
+                        "polynomial": {
+                            "terms": [
+                                {
+                                    "coefficient": {"num": "1", "den": "2"},
+                                    "exponents": [3],
+                                },
+                                {
+                                    "coefficient": {"num": "-2", "den": "1"},
+                                    "exponents": [1],
+                                },
+                            ]
+                        },
+                    }
+                },
+            ),
+        ),
     ),
     polynomial_operation(
         "polynomial.rational.compute.integral",

--- a/src/jacobian/domains/polynomial/elementary.py
+++ b/src/jacobian/domains/polynomial/elementary.py
@@ -23,6 +23,7 @@ from jacobian.contracts.polynomial_operations import (
     RationalPolynomialRequest,
 )
 from jacobian.domains.polynomial._support import polynomial_operation
+from jacobian.domains._examples import example
 from jacobian.domains.polynomial.elementary_operations import (
     integer_polynomial_compose,
     integer_polynomial_content,
@@ -51,6 +52,7 @@ INTEGER_POLYNOMIAL_CAPABILITIES = (
         "polynomial",
         "integer",
         "gcd",
+        invocation_examples=(example("integer_gcd", "Compute the GCD of two integer polynomials.", {"left": {"coefficients": ["6", "6", "0"]}, "right": {"coefficients": ["8", "8", "0"]}}),),
     ),
     polynomial_operation(
         "polynomial.integer.compute.content",
@@ -87,6 +89,7 @@ INTEGER_POLYNOMIAL_CAPABILITIES = (
         "polynomial",
         "integer",
         "evaluation",
+        invocation_examples=(example("evaluate_at_four", "Evaluate 2x²-3x+1 at 4.", {"polynomial": {"coefficients": ["2", "-3", "1"]}, "point": "4"}),),
     ),
     polynomial_operation(
         "polynomial.integer.compute.compose",
@@ -126,6 +129,7 @@ RATIONAL_POLYNOMIAL_CAPABILITIES = (
         "polynomial",
         "rational",
         "division",
+        invocation_examples=(example("divide_x_squared_minus_one", "Divide x²-1 by x-1.", {"left": {"polynomial_schema_version": "1", "domain": "QQ", "variables": ["x"], "polynomial": {"terms": [{"coefficient": {"num": "1", "den": "1"}, "exponents": [2]}, {"coefficient": {"num": "-1", "den": "1"}, "exponents": [0]}]}}, "right": {"polynomial_schema_version": "1", "domain": "QQ", "variables": ["x"], "polynomial": {"terms": [{"coefficient": {"num": "1", "den": "1"}, "exponents": [1]}, {"coefficient": {"num": "-1", "den": "1"}, "exponents": [0]}]}}}),),
     ),
     polynomial_operation(
         "polynomial.rational.compute.evaluate",
@@ -148,6 +152,7 @@ RATIONAL_POLYNOMIAL_CAPABILITIES = (
         "polynomial",
         "rational",
         "derivative",
+        invocation_examples=(example("cubic_derivative", "Differentiate one half x³ minus 2x.", {"polynomial": {"polynomial_schema_version": "1", "domain": "QQ", "variables": ["x"], "polynomial": {"terms": [{"coefficient": {"num": "1", "den": "2"}, "exponents": [3]}, {"coefficient": {"num": "-2", "den": "1"}, "exponents": [1]}]}}}),),
     ),
     polynomial_operation(
         "polynomial.rational.compute.integral",

--- a/src/jacobian/domains/polynomial/elementary.py
+++ b/src/jacobian/domains/polynomial/elementary.py
@@ -22,8 +22,8 @@ from jacobian.contracts.polynomial_operations import (
     RationalPolynomialIntegralResult,
     RationalPolynomialRequest,
 )
-from jacobian.domains.polynomial._support import polynomial_operation
 from jacobian.domains._examples import example
+from jacobian.domains.polynomial._support import polynomial_operation
 from jacobian.domains.polynomial.elementary_operations import (
     integer_polynomial_compose,
     integer_polynomial_content,

--- a/src/jacobian/domains/sequences/predicates.py
+++ b/src/jacobian/domains/sequences/predicates.py
@@ -33,7 +33,13 @@ SEQUENCE_PREDICATE_CAPABILITIES = (
         decide_geometric,
         "sequence",
         "predicate",
-        invocation_examples=(example("powers_of_two", "Recognize a geometric sequence of powers of two.", {"values": ["2", "4", "8", "16"]}),),
+        invocation_examples=(
+            example(
+                "powers_of_two",
+                "Recognize a geometric sequence of powers of two.",
+                {"values": ["2", "4", "8", "16"]},
+            ),
+        ),
     ),
     sequence_operation(
         "sequence.decide.nondecreasing",

--- a/src/jacobian/domains/sequences/predicates.py
+++ b/src/jacobian/domains/sequences/predicates.py
@@ -4,6 +4,7 @@ from jacobian.contracts.sequences import (
     IntegerSequenceBooleanResult,
     IntegerSequenceRequest,
 )
+from jacobian.domains._examples import example
 from jacobian.domains.sequences._support import sequence_operation
 from jacobian.domains.sequences.operations import (
     decide_arithmetic,
@@ -32,6 +33,7 @@ SEQUENCE_PREDICATE_CAPABILITIES = (
         decide_geometric,
         "sequence",
         "predicate",
+        invocation_examples=(example("powers_of_two", "Recognize a geometric sequence of powers of two.", {"values": ["2", "4", "8", "16"]}),),
     ),
     sequence_operation(
         "sequence.decide.nondecreasing",

--- a/src/jacobian/domains/sequences/transforms.py
+++ b/src/jacobian/domains/sequences/transforms.py
@@ -4,6 +4,7 @@ from jacobian.contracts.sequences import (
     IntegerSequenceListResult,
     IntegerSequenceRequest,
 )
+from jacobian.domains._examples import example
 from jacobian.domains.sequences._support import sequence_operation
 from jacobian.domains.sequences.operations import (
     first_differences,
@@ -41,6 +42,7 @@ SEQUENCE_TRANSFORM_CAPABILITIES = (
         first_differences,
         "sequence",
         "transform",
+        invocation_examples=(example("square_first_differences", "Compute differences of consecutive squares.", {"values": ["1", "4", "9", "16"]}),),
     ),
     sequence_operation(
         "sequence.compute.prefix_products",
@@ -81,6 +83,7 @@ SEQUENCE_TRANSFORM_CAPABILITIES = (
         prefix_gcds,
         "sequence",
         "divisibility",
+        invocation_examples=(example("prefix_gcds_18_24_15", "Compute prefix gcds of 18, 24, and 15.", {"values": ["18", "24", "15"]}),),
     ),
     sequence_operation(
         "sequence.compute.prefix_lcms",

--- a/src/jacobian/domains/sequences/transforms.py
+++ b/src/jacobian/domains/sequences/transforms.py
@@ -42,7 +42,13 @@ SEQUENCE_TRANSFORM_CAPABILITIES = (
         first_differences,
         "sequence",
         "transform",
-        invocation_examples=(example("square_first_differences", "Compute differences of consecutive squares.", {"values": ["1", "4", "9", "16"]}),),
+        invocation_examples=(
+            example(
+                "square_first_differences",
+                "Compute differences of consecutive squares.",
+                {"values": ["1", "4", "9", "16"]},
+            ),
+        ),
     ),
     sequence_operation(
         "sequence.compute.prefix_products",
@@ -83,7 +89,13 @@ SEQUENCE_TRANSFORM_CAPABILITIES = (
         prefix_gcds,
         "sequence",
         "divisibility",
-        invocation_examples=(example("prefix_gcds_18_24_15", "Compute prefix gcds of 18, 24, and 15.", {"values": ["18", "24", "15"]}),),
+        invocation_examples=(
+            example(
+                "prefix_gcds_18_24_15",
+                "Compute prefix gcds of 18, 24, and 15.",
+                {"values": ["18", "24", "15"]},
+            ),
+        ),
     ),
     sequence_operation(
         "sequence.compute.prefix_lcms",

--- a/src/jacobian/finite_coverage.py
+++ b/src/jacobian/finite_coverage.py
@@ -21,6 +21,7 @@ from jacobian.contracts.capabilities import (
     CapabilityCompletenessStatus,
     CapabilityDescriptor,
     CapabilityDiagnostic,
+    CapabilityInvocationExample,
     CapabilityMode,
     CapabilityObligation,
     CapabilityObligationStatus,
@@ -233,6 +234,26 @@ class FiniteCoverageVerifyAdapter:
             input_schema=model_schema(FiniteCoverageVerifyRequest),
             output_schema=model_schema(FiniteCoverageVerifyOutput),
             tags=("finite", "coverage", "verification", "paged-archive"),
+            invocation_examples=(
+                CapabilityInvocationExample(
+                    name="two_page_exact_coverage",
+                    description=(
+                        "Verify that two pages cover a three-item finite scope "
+                        "exactly once."
+                    ),
+                    mode=CapabilityMode.VERIFY,
+                    input=FiniteCoverageVerifyRequest.model_validate(
+                        {
+                            "canonicalizer_id": "finite.string.nfc@1",
+                            "scope_items": ["alpha", "beta", "gamma"],
+                            "pages": [
+                                {"items": ["alpha"]},
+                                {"items": ["beta", "gamma"]},
+                            ],
+                        }
+                    ).model_dump(mode="json"),
+                ),
+            ),
         )
 
     @property

--- a/src/jacobian/lean_exploration.py
+++ b/src/jacobian/lean_exploration.py
@@ -33,6 +33,7 @@ from jacobian.contracts.capabilities import (
     CapabilityCompletenessStatus,
     CapabilityDescriptor,
     CapabilityDiagnostic,
+    CapabilityInvocationExample,
     CapabilityMode,
     CapabilityProviderRuntime,
     CapabilityRequest,
@@ -577,6 +578,23 @@ class LeanProofStateAdapter:
             input_schema=LeanProofStateRequest.model_json_schema(),
             output_schema=LeanProofStateOutput.model_json_schema(),
             tags=("lean", "proof-state", "tactic", "exploration"),
+            invocation_examples=(
+                CapabilityInvocationExample(
+                    name="close_true_with_trivial",
+                    description=(
+                        "Apply trivial to a replayable proof state for True; "
+                        "a completed transition still requires lean.check."
+                    ),
+                    mode=CapabilityMode.EXPLORE,
+                    input=LeanProofStateRequest.model_validate(
+                        {
+                            "environment": "CORE",
+                            "statement": "True",
+                            "tactic": "trivial",
+                        }
+                    ).model_dump(mode="json"),
+                ),
+            ),
         )
 
     @property

--- a/src/jacobian/lean_statement_capabilities.py
+++ b/src/jacobian/lean_statement_capabilities.py
@@ -41,6 +41,7 @@ from jacobian.contracts.capabilities import (
     CapabilityCompletenessStatus,
     CapabilityDescriptor,
     CapabilityDiagnostic,
+    CapabilityInvocationExample,
     CapabilityMode,
     CapabilityProviderRuntime,
     CapabilityRequest,
@@ -462,6 +463,23 @@ class LeanStatementProposalAdapter:
             input_schema=LeanStatementProposalRequest.model_json_schema(),
             output_schema=LeanStatementProposalOutput.model_json_schema(),
             tags=("lean", "statement", "elaboration", "proposal", "proposition"),
+            invocation_examples=(
+                CapabilityInvocationExample(
+                    name="elaborate_true",
+                    description=(
+                        "Elaborate the proposition True in the pinned CORE "
+                        "environment without assessing its truth."
+                    ),
+                    mode=CapabilityMode.EXPLORE,
+                    input=LeanStatementProposalRequest.model_validate(
+                        {
+                            "operation": "ELABORATE_PROPOSITION",
+                            "environment": "CORE",
+                            "proposed_statement": "True",
+                        }
+                    ).model_dump(mode="json"),
+                ),
+            ),
         )
 
     @property

--- a/src/jacobian/matrix_capabilities.py
+++ b/src/jacobian/matrix_capabilities.py
@@ -125,7 +125,21 @@ class MatrixDeterminantAdapter:
             input_schema=model_schema(MatrixDeterminantRequest),
             output_schema=model_schema(MatrixDeterminantOutput),
             tags=("matrix", "determinant", "exact-computation"),
-            invocation_examples=(example("determinant_minus_six", "Compute the determinant of [[0,2],[3,4]].", {"matrix": {"domain": "QQ", "entries": [[{"num": "0", "den": "1"}, {"num": "2", "den": "1"}], [{"num": "3", "den": "1"}, {"num": "4", "den": "1"}]]}}),),
+            invocation_examples=(
+                example(
+                    "determinant_minus_six",
+                    "Compute the determinant of [[0,2],[3,4]].",
+                    {
+                        "matrix": {
+                            "domain": "QQ",
+                            "entries": [
+                                [{"num": "0", "den": "1"}, {"num": "2", "den": "1"}],
+                                [{"num": "3", "den": "1"}, {"num": "4", "den": "1"}],
+                            ],
+                        }
+                    },
+                ),
+            ),
         )
 
     @property
@@ -192,7 +206,37 @@ class MatrixRankAdapter:
             input_schema=model_schema(MatrixRankRequest),
             output_schema=model_schema(MatrixRankOutput),
             tags=("matrix", "rank", "exact-computation"),
-            invocation_examples=(example("rank_three_by_four", "Compute rank and pivots of a rectangular rational matrix.", {"matrix": {"domain": "QQ", "entries": [[{"num": "1", "den": "1"}, {"num": "2", "den": "1"}, {"num": "3", "den": "1"}, {"num": "4", "den": "1"}], [{"num": "2", "den": "1"}, {"num": "4", "den": "1"}, {"num": "6", "den": "1"}, {"num": "8", "den": "1"}], [{"num": "0", "den": "1"}, {"num": "1", "den": "1"}, {"num": "1", "den": "1"}, {"num": "0", "den": "1"}]]}}),),
+            invocation_examples=(
+                example(
+                    "rank_three_by_four",
+                    "Compute rank and pivots of a rectangular rational matrix.",
+                    {
+                        "matrix": {
+                            "domain": "QQ",
+                            "entries": [
+                                [
+                                    {"num": "1", "den": "1"},
+                                    {"num": "2", "den": "1"},
+                                    {"num": "3", "den": "1"},
+                                    {"num": "4", "den": "1"},
+                                ],
+                                [
+                                    {"num": "2", "den": "1"},
+                                    {"num": "4", "den": "1"},
+                                    {"num": "6", "den": "1"},
+                                    {"num": "8", "den": "1"},
+                                ],
+                                [
+                                    {"num": "0", "den": "1"},
+                                    {"num": "1", "den": "1"},
+                                    {"num": "1", "den": "1"},
+                                    {"num": "0", "den": "1"},
+                                ],
+                            ],
+                        }
+                    },
+                ),
+            ),
         )
 
     @property

--- a/src/jacobian/matrix_capabilities.py
+++ b/src/jacobian/matrix_capabilities.py
@@ -35,6 +35,7 @@ from jacobian.contracts.matrices import (
     MatrixRankRequest,
 )
 from jacobian.contracts.results import Execution, ExecutionStatus
+from jacobian.domains._examples import example
 from jacobian.provider_runtime import known_provider_runtime
 from jacobian.schema_registry import SchemaRegistry, model_schema
 from jacobian.store import ArtifactStore
@@ -124,6 +125,7 @@ class MatrixDeterminantAdapter:
             input_schema=model_schema(MatrixDeterminantRequest),
             output_schema=model_schema(MatrixDeterminantOutput),
             tags=("matrix", "determinant", "exact-computation"),
+            invocation_examples=(example("determinant_minus_six", "Compute the determinant of [[0,2],[3,4]].", {"matrix": {"domain": "QQ", "entries": [[{"num": "0", "den": "1"}, {"num": "2", "den": "1"}], [{"num": "3", "den": "1"}, {"num": "4", "den": "1"}]]}}),),
         )
 
     @property
@@ -190,6 +192,7 @@ class MatrixRankAdapter:
             input_schema=model_schema(MatrixRankRequest),
             output_schema=model_schema(MatrixRankOutput),
             tags=("matrix", "rank", "exact-computation"),
+            invocation_examples=(example("rank_three_by_four", "Compute rank and pivots of a rectangular rational matrix.", {"matrix": {"domain": "QQ", "entries": [[{"num": "1", "den": "1"}, {"num": "2", "den": "1"}, {"num": "3", "den": "1"}, {"num": "4", "den": "1"}], [{"num": "2", "den": "1"}, {"num": "4", "den": "1"}, {"num": "6", "den": "1"}, {"num": "8", "den": "1"}], [{"num": "0", "den": "1"}, {"num": "1", "den": "1"}, {"num": "1", "den": "1"}, {"num": "0", "den": "1"}]]}}),),
         )
 
     @property

--- a/src/jacobian/operation_installation.py
+++ b/src/jacobian/operation_installation.py
@@ -208,6 +208,7 @@ class ComputedOperationAdapter:
             input_schema=model_schema(operation.request_model),
             output_schema=model_schema(self.output_model),
             tags=operation.tags,
+            invocation_examples=operation.invocation_examples,
         )
 
     @property

--- a/src/jacobian/operations.py
+++ b/src/jacobian/operations.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 
 from jacobian.contracts.capabilities import (
     CapabilityDiagnostic,
+    CapabilityInvocationExample,
     CapabilityProviderRuntime,
 )
 from jacobian.contracts.results import ContractModel, ExecutionStatus
@@ -64,6 +65,7 @@ class ComputedOperation[
     relation_id: str
     tags: tuple[str, ...] = ()
     invalid_request: CapabilityDiagnostic | None = None
+    invocation_examples: tuple[CapabilityInvocationExample, ...] = ()
     version: str = "1"
 
 
@@ -103,6 +105,7 @@ class ComputedOperationFactory:
         result_model: type[ResultT],
         operation: Callable[[ContractModel], ContractModel],
         *tags: str,
+        invocation_examples: tuple[CapabilityInvocationExample, ...] = (),
     ) -> ComputedOperation[RequestT, ResultT]:
         def implementation(request: RequestT) -> ComputedOutcome[ResultT]:
             try:
@@ -119,6 +122,7 @@ class ComputedOperationFactory:
             implementation=implementation,
             relation_id=_relation_id(capability_id),
             tags=tags,
+            invocation_examples=invocation_examples,
         )
 
 

--- a/src/jacobian/polynomial_capabilities.py
+++ b/src/jacobian/polynomial_capabilities.py
@@ -1800,6 +1800,67 @@ class PolynomialMapInverseSynthesizeAdapter:
             input_schema=model_schema(PolynomialMapInverseSynthesisRequest),
             output_schema=model_schema(PolynomialMapInverseSynthesisOutput),
             tags=("polynomial", "map", "inverse", "synthesis", "exact-rational"),
+            invocation_examples=(
+                CapabilityInvocationExample(
+                    name="triangular_inverse",
+                    description=(
+                        "Synthesize and independently check the degree-two "
+                        "inverse of (x + y^2, y)."
+                    ),
+                    mode=CapabilityMode.EXPLORE,
+                    input=PolynomialMapInverseSynthesisRequest.model_validate(
+                        {
+                            "forward_map": {
+                                "variables": ["x", "y"],
+                                "coordinates": [
+                                    {
+                                        "terms": [
+                                            {
+                                                "coefficient": {
+                                                    "num": "1",
+                                                    "den": "1",
+                                                },
+                                                "exponents": [1, 0],
+                                            },
+                                            {
+                                                "coefficient": {
+                                                    "num": "1",
+                                                    "den": "1",
+                                                },
+                                                "exponents": [0, 2],
+                                            },
+                                        ]
+                                    },
+                                    {
+                                        "terms": [
+                                            {
+                                                "coefficient": {
+                                                    "num": "1",
+                                                    "den": "1",
+                                                },
+                                                "exponents": [0, 1],
+                                            }
+                                        ]
+                                    },
+                                ],
+                            },
+                            "source_variables": ["x", "y"],
+                            "target_variables": ["u", "v"],
+                            "inverse_degree_bound": 2,
+                            "support_mode": "FULL_TOTAL_DEGREE",
+                            "solver": "sympy.solve",
+                            "limits": {
+                                "timeout_ms": 10000,
+                                "max_inverse_degree": 4,
+                                "max_composition_degree": 32,
+                                "max_unknown_coefficients": 64,
+                                "max_coefficient_equations": 512,
+                                "max_residual_terms": 1024,
+                            },
+                        }
+                    ).model_dump(mode="json"),
+                ),
+            ),
         )
 
     @property
@@ -2324,6 +2385,54 @@ class PolynomialMapInverseVerifyAdapter:
             input_schema=model_schema(PolynomialMapInverseVerifyRequest),
             output_schema=model_schema(PolynomialMapInverseVerifyOutput),
             tags=("polynomial", "map", "inverse", "verification", "exact-rational"),
+            invocation_examples=(
+                CapabilityInvocationExample(
+                    name="identity_map_inverse",
+                    description=(
+                        "Independently verify the identity map as its own "
+                        "two-sided inverse over QQ."
+                    ),
+                    mode=CapabilityMode.VERIFY,
+                    input=PolynomialMapInverseVerifyRequest.model_validate(
+                        {
+                            "forward_map": {
+                                "variables": ["x"],
+                                "coordinates": [
+                                    {
+                                        "terms": [
+                                            {
+                                                "coefficient": {
+                                                    "num": "1",
+                                                    "den": "1",
+                                                },
+                                                "exponents": [1],
+                                            }
+                                        ]
+                                    }
+                                ],
+                            },
+                            "inverse_map": {
+                                "variables": ["u"],
+                                "coordinates": [
+                                    {
+                                        "terms": [
+                                            {
+                                                "coefficient": {
+                                                    "num": "1",
+                                                    "den": "1",
+                                                },
+                                                "exponents": [1],
+                                            }
+                                        ]
+                                    }
+                                ],
+                            },
+                            "source_variables": ["x"],
+                            "target_variables": ["u"],
+                        }
+                    ).model_dump(mode="json"),
+                ),
+            ),
         )
 
     @property

--- a/src/jacobian/sympy_polynomial_normalization.py
+++ b/src/jacobian/sympy_polynomial_normalization.py
@@ -19,6 +19,7 @@ from jacobian.contracts.capabilities import (
     CapabilityCompletenessStatus,
     CapabilityDescriptor,
     CapabilityDiagnostic,
+    CapabilityInvocationExample,
     CapabilityMode,
     CapabilityProviderAvailability,
     CapabilityProviderRuntime,
@@ -195,6 +196,29 @@ class SympyPolynomialExpressionNormalizeAdapter:
                 "typed-expression",
                 "exact-rational",
                 "sympy",
+            ),
+            invocation_examples=(
+                CapabilityInvocationExample(
+                    name="combine_like_terms",
+                    description=(
+                        "Normalize x + x to canonical sparse coefficients over QQ."
+                    ),
+                    mode=CapabilityMode.EXPLORE,
+                    input=PolynomialExpressionNormalizeRequest.model_validate(
+                        {
+                            "expression": {
+                                "variables": ["x"],
+                                "expression": {
+                                    "kind": "add",
+                                    "operands": [
+                                        {"kind": "variable", "name": "x"},
+                                        {"kind": "variable", "name": "x"},
+                                    ],
+                                },
+                            }
+                        }
+                    ).model_dump(mode="json"),
+                ),
             ),
         )
 

--- a/tests/contract/test_pilot_invocation_examples.py
+++ b/tests/contract/test_pilot_invocation_examples.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jacobian.contracts.capabilities import CapabilityMode, CapabilityRequest
+from jacobian.contracts.results import ExecutionStatus
+from jacobian.kernel import JacobianKernel
+
+_ROOT = Path(__file__).parents[2]
+_PILOT = _ROOT / "benchmarks" / "example_cases" / "pilot.json"
+
+_REQUIRED_CAPABILITIES = {
+    "finite.coverage.verify",
+    "graph.compute.properties",
+    "graph.invariant.diameter.compute",
+    "knowledge.search",
+    "lean.proof_state.apply_tactic",
+    "lean.statement.propose",
+    "polynomial.expression.normalize",
+    "polynomial.expression_normalization.verify",
+    "polynomial.identity.verify",
+    "polynomial.map.inverse.candidate_synthesize",
+    "polynomial.map.inverse.verify",
+    "search.enumerate",
+}
+
+
+def _pilot() -> dict[str, object]:
+    return json.loads(_PILOT.read_text())
+
+
+def test_pilot_manifest_is_small_source_backed_and_review_gated() -> None:
+    pilot = _pilot()
+    assert pilot["pilot_version"] == "1"
+    assert pilot["human_review"] == "REQUIRED"
+
+    cases = pilot["cases"]
+    assert isinstance(cases, list)
+    assert {case["capability_id"] for case in cases} == _REQUIRED_CAPABILITIES
+    assert len(cases) == len(_REQUIRED_CAPABILITIES)
+
+    for case in cases:
+        assert case["valid_case"]
+        assert case["invalid_or_boundary_case"]
+        assert case["status"] in {"PILOT", "KNOWN_REGRESSION"}
+        assert case["origin"] in {
+            "DIRECT_INVOCATION",
+            "ADAPTED_INVOCATION",
+            "SOURCE_DERIVED_CONTENT",
+            "GENERATED",
+        }
+        source = _ROOT / case["source"]
+        assert source.is_file()
+        assert case["validation"][:2] == ["SCHEMA", "EXECUTION"]
+
+
+def test_installed_public_pilot_examples_use_descriptor_mechanism(
+    tmp_path: Path,
+) -> None:
+    pilot = _pilot()
+    kernel = JacobianKernel(tmp_path, install_references=False)
+    installed = {
+        descriptor.capability_id: descriptor
+        for descriptor in kernel.capabilities.catalog().capabilities
+    }
+
+    checked = set()
+    for case in pilot["cases"]:
+        example_name = case["public_example"]
+        descriptor = installed.get(case["capability_id"])
+        if example_name is None or descriptor is None:
+            continue
+        assert example_name in {
+            example.name for example in descriptor.invocation_examples
+        }
+        checked.add(case["capability_id"])
+
+    assert checked == {
+        "knowledge.search",
+        "lean.statement.propose",
+        "polynomial.expression.normalize",
+        "polynomial.identity.verify",
+        "polynomial.map.inverse.candidate_synthesize",
+    }
+
+
+def test_search_pilot_boundaries_use_typed_public_results(tmp_path: Path) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=False)
+    artifact_uri = "artifact://sha256/" + "a" * 64
+    payload = {
+        "claim_uri": artifact_uri,
+        "plugin_id": artifact_uri,
+        "bounds": {},
+        "budget": {"candidates_max": 1, "wall_seconds": 1},
+    }
+
+    unsupported = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="search.enumerate",
+            mode=CapabilityMode.VERIFY,
+            input=payload,
+        )
+    )
+    invalid_budget = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="search.enumerate",
+            input={
+                **payload,
+                "budget": {"candidates_max": 0, "wall_seconds": 1},
+            },
+        )
+    )
+
+    assert unsupported.execution.status is ExecutionStatus.ERROR
+    assert unsupported.diagnostics[0].code == "UNSUPPORTED_MODE"
+    assert invalid_budget.execution.status is ExecutionStatus.ERROR
+    assert invalid_budget.diagnostics[0].code == "INVALID_REQUEST"


### PR DESCRIPTION
## Summary
- add schema-valid invocation examples for proposed batch items 1–17
- carry the existing example mechanism through computed operation descriptors
- preserve COMPUTED producer assurance and existing pilot boundaries

## Validation
- `git diff --check`
- relevant integration evidence is listed in the second-batch proposal
- full CI will validate against the repository runtime

Second batch cut 1 of 2; geometry, polynomial, and matrix examples are intentionally separate.