### PR TITLE
feat(examples): add geometry polynomial and matrix capability examples

### DIFF
--- a/src/jacobian/domains/geometry/points.py
+++ b/src/jacobian/domains/geometry/points.py
@@ -9,6 +9,7 @@ from jacobian.contracts.geometry import (
     PointSetRequest,
     PointTripleRequest,
 )
+from jacobian.domains._examples import example
 from jacobian.domains.geometry._support import geometry_operation
 from jacobian.domains.geometry.operations import (
     collinear,
@@ -27,6 +28,7 @@ POINT_CAPABILITIES = (
         squared_distance,
         "geometry",
         "distance",
+        invocation_examples=(example("diagonal_squared_distance", "Compute the squared distance from (0,0) to (2,2).", {"first": {"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}}, "second": {"x": {"num": "2", "den": "1"}, "y": {"num": "2", "den": "1"}}}),),
     ),
     geometry_operation(
         "geometry.points.decide.collinear",
@@ -57,5 +59,6 @@ POINT_CAPABILITIES = (
         convex_hull_points,
         "geometry",
         "convexity",
+        invocation_examples=(example("square_convex_hull", "Construct the hull of a rational square.", {"points": [{"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}}, {"x": {"num": "2", "den": "1"}, "y": {"num": "0", "den": "1"}}, {"x": {"num": "0", "den": "1"}, "y": {"num": "2", "den": "1"}}, {"x": {"num": "2", "den": "1"}, "y": {"num": "2", "den": "1"}}]}),),
     ),
 )

--- a/src/jacobian/domains/geometry/triangles.py
+++ b/src/jacobian/domains/geometry/triangles.py
@@ -6,6 +6,7 @@ from jacobian.contracts.geometry import (
     GeometryPointResult,
     PointTripleRequest,
 )
+from jacobian.domains._examples import example
 from jacobian.domains.geometry._support import geometry_operation
 from jacobian.domains.geometry.operations import centroid, circumcircle, orientation
 
@@ -39,5 +40,6 @@ TRIANGLE_CAPABILITIES = (
         circumcircle,
         "geometry",
         "circle",
+        invocation_examples=(example("right_triangle_circumcircle", "Construct the circumcircle of a right triangle.", {"first": {"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}}, "second": {"x": {"num": "2", "den": "1"}, "y": {"num": "0", "den": "1"}}, "third": {"x": {"num": "0", "den": "1"}, "y": {"num": "2", "den": "1"}}}),),
     ),
 )

--- a/src/jacobian/domains/polynomial/elementary.py
+++ b/src/jacobian/domains/polynomial/elementary.py
@@ -23,6 +23,7 @@ from jacobian.contracts.polynomial_operations import (
     RationalPolynomialRequest,
 )
 from jacobian.domains.polynomial._support import polynomial_operation
+from jacobian.domains._examples import example
 from jacobian.domains.polynomial.elementary_operations import (
     integer_polynomial_compose,
     integer_polynomial_content,
@@ -51,6 +52,7 @@ INTEGER_POLYNOMIAL_CAPABILITIES = (
         "polynomial",
         "integer",
         "gcd",
+        invocation_examples=(example("integer_gcd", "Compute the GCD of two integer polynomials.", {"left": {"coefficients": ["6", "6", "0"]}, "right": {"coefficients": ["8", "8", "0"]}}),),
     ),
     polynomial_operation(
         "polynomial.integer.compute.content",
@@ -87,6 +89,7 @@ INTEGER_POLYNOMIAL_CAPABILITIES = (
         "polynomial",
         "integer",
         "evaluation",
+        invocation_examples=(example("evaluate_at_four", "Evaluate 2x²-3x+1 at 4.", {"polynomial": {"coefficients": ["2", "-3", "1"]}, "point": "4"}),),
     ),
     polynomial_operation(
         "polynomial.integer.compute.compose",
@@ -126,6 +129,7 @@ RATIONAL_POLYNOMIAL_CAPABILITIES = (
         "polynomial",
         "rational",
         "division",
+        invocation_examples=(example("divide_x_squared_minus_one", "Divide x²-1 by x-1.", {"left": {"polynomial_schema_version": "1", "domain": "QQ", "variables": ["x"], "polynomial": {"terms": [{"coefficient": {"num": "1", "den": "1"}, "exponents": [2]}, {"coefficient": {"num": "-1", "den": "1"}, "exponents": [0]}]}}, "right": {"polynomial_schema_version": "1", "domain": "QQ", "variables": ["x"], "polynomial": {"terms": [{"coefficient": {"num": "1", "den": "1"}, "exponents": [1]}, {"coefficient": {"num": "-1", "den": "1"}, "exponents": [0]}]}}}),),
     ),
     polynomial_operation(
         "polynomial.rational.compute.evaluate",
@@ -148,6 +152,7 @@ RATIONAL_POLYNOMIAL_CAPABILITIES = (
         "polynomial",
         "rational",
         "derivative",
+        invocation_examples=(example("cubic_derivative", "Differentiate one half x³ minus 2x.", {"polynomial": {"polynomial_schema_version": "1", "domain": "QQ", "variables": ["x"], "polynomial": {"terms": [{"coefficient": {"num": "1", "den": "2"}, "exponents": [3]}, {"coefficient": {"num": "-2", "den": "1"}, "exponents": [1]}]}}}),),
     ),
     polynomial_operation(
         "polynomial.rational.compute.integral",

--- a/src/jacobian/matrix_capabilities.py
+++ b/src/jacobian/matrix_capabilities.py
@@ -35,6 +35,7 @@ from jacobian.contracts.matrices import (
     MatrixRankRequest,
 )
 from jacobian.contracts.results import Execution, ExecutionStatus
+from jacobian.domains._examples import example
 from jacobian.provider_runtime import known_provider_runtime
 from jacobian.schema_registry import SchemaRegistry, model_schema
 from jacobian.store import ArtifactStore
@@ -124,6 +125,7 @@ class MatrixDeterminantAdapter:
             input_schema=model_schema(MatrixDeterminantRequest),
             output_schema=model_schema(MatrixDeterminantOutput),
             tags=("matrix", "determinant", "exact-computation"),
+            invocation_examples=(example("determinant_minus_six", "Compute the determinant of [[0,2],[3,4]].", {"matrix": {"domain": "QQ", "entries": [[{"num": "0", "den": "1"}, {"num": "2", "den": "1"}], [{"num": "3", "den": "1"}, {"num": "4", "den": "1"}]]}}),),
         )
 
     @property
@@ -190,6 +192,7 @@ class MatrixRankAdapter:
             input_schema=model_schema(MatrixRankRequest),
             output_schema=model_schema(MatrixRankOutput),
             tags=("matrix", "rank", "exact-computation"),
+            invocation_examples=(example("rank_three_by_four", "Compute rank and pivots of a rectangular rational matrix.", {"matrix": {"domain": "QQ", "entries": [[{"num": "1", "den": "1"}, {"num": "2", "den": "1"}, {"num": "3", "den": "1"}, {"num": "4", "den": "1"}], [{"num": "2", "den": "1"}, {"num": "4", "den": "1"}, {"num": "6", "den": "1"}, {"num": "8", "den": "1"}], [{"num": "0", "den": "1"}, {"num": "1", "den": "1"}, {"num": "1", "den": "1"}, {"num": "0", "den": "1"}]]}}),),
         )
 
     @property


### PR DESCRIPTION
## Summary
- add schema-valid invocation examples for proposed batch items 18–26
- cover geometry, elementary polynomial, determinant, and rank producers
- preserve COMPUTED assurance and avoid implying verification

## Validation
- `git diff --check`
- examples are grounded in the listed geometry, polynomial, and matrix integration tests
- full CI will validate schema and execution compatibility

This is the second review cut and depends on the exact scalar/finite example PR.