### PR TITLE
Add automatic capability example coverage report

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PYTEST_ARGS ?=
 TESTS ?=
 EVAL_ARGS ?=
 
-.PHONY: help setup hooks fix lint lint-full typecheck test test-fast test-contracts test-checkers test-mcp test-storage test-lean test-failed test-durations build check check-static validate-full agent-eval
+.PHONY: help setup hooks fix lint lint-full typecheck test test-fast test-contracts test-checkers test-mcp test-storage test-lean test-failed test-durations example-coverage build check check-static validate-full agent-eval
 
 help: ## Show available developer commands.
 	@awk 'BEGIN {FS = ":.*## "; printf "Jacobian developer commands:\n\n"} /^[a-zA-Z_-]+:.*## / {printf "  %-18s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -68,6 +68,9 @@ test-durations: ## Refresh committed integration shard timings for pytest-split.
 		-m "(integration or end_to_end) and not lean_runtime" \
 		--store-durations --clean-durations --durations-path .test_durations \
 		$(PYTEST_ARGS)
+
+example-coverage: ## Generate capability invocation-example coverage reports.
+	$(UV_RUN) python scripts/capability_example_coverage.py
 
 build: ## Build Python source and wheel distributions.
 	uv build

--- a/docs/contributing/capability-example-coverage.md
+++ b/docs/contributing/capability-example-coverage.md
@@ -1,0 +1,35 @@
+# Capability example coverage report
+
+Generate the report from the installed catalog with:
+
+```sh
+make example-coverage
+```
+
+This writes JSON and Markdown files under `reports/` by default. Counts and
+capability IDs come from `JacobianKernel.capabilities.catalog()`; the report is
+not a second descriptor or example registry. Use `--json` and `--markdown` on
+the script to choose different output paths.
+
+## Interpretation
+
+- **Directly invocable** means the request schema does not contain artifact,
+  checker, proof-state, plugin, experiment, workspace, session, or URI inputs,
+  and the provider/capability is not runtime-labelled by the report heuristic.
+- **Artifact-dependent** identifies requests that need runtime artifacts or
+  URIs. These are not expected to have standalone examples without a stable
+  fixture.
+- **Runtime/plugin dependent** is a triage category for Lean, solver/backend,
+  plugin, or runtime-labelled providers, IDs, and tags; it is not an assurance
+  claim.
+- **Schema-valid** means each example input validates against its descriptor's
+  canonical input schema. It does not imply execution success or verification.
+- **Integration-test evidence** is best-effort text evidence from searching
+  `tests/integration` for the capability ID. Missing evidence needs review and
+  is not proof that no test exists.
+- **Known exclusions** are conservative artifact/runtime categories. The tool
+  does not generate examples or alter descriptors.
+
+Regenerate after changing capability registration, schemas, or invocation
+examples. The generated snapshot can be committed separately if maintainers
+want a versioned report; the source of truth remains the installed catalog.

--- a/scripts/capability_example_coverage.py
+++ b/scripts/capability_example_coverage.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Generate invocation-example coverage reports from the installed catalog."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+from jacobian.kernel import JacobianKernel
+
+_ARTIFACT_KEYS = re.compile(
+    r"(?:artifact|checker|proof[_-]?state|plugin|experiment|workspace|session|uri)",
+    re.IGNORECASE,
+)
+_RUNTIME_TERMS = re.compile(r"(?:lean|plugin|runtime|cvc5|cadical|drat|flint)", re.I)
+
+
+def _schema_contains(schema: Any, pattern: re.Pattern[str]) -> bool:
+    if isinstance(schema, dict):
+        return any(
+            (isinstance(key, str) and pattern.search(key))
+            or _schema_contains(value, pattern)
+            for key, value in schema.items()
+        )
+    if isinstance(schema, list):
+        return any(_schema_contains(value, pattern) for value in schema)
+    return False
+
+
+def _evidence(capability_id: str, root: Path) -> list[str]:
+    hits: list[str] = []
+    for path in sorted((root / "tests" / "integration").glob("test_*.py")):
+        try:
+            if capability_id in path.read_text(encoding="utf-8"):
+                hits.append(str(path.relative_to(root)))
+        except OSError:
+            continue
+    return hits
+
+
+def _row(descriptor: Any, root: Path) -> dict[str, Any]:
+    input_schema = descriptor.input_schema
+    artifact_dependent = _schema_contains(input_schema, _ARTIFACT_KEYS)
+    runtime_dependent = bool(
+        _RUNTIME_TERMS.search(descriptor.provider)
+        or _RUNTIME_TERMS.search(descriptor.capability_id)
+        or any(_RUNTIME_TERMS.search(tag) for tag in descriptor.tags)
+    )
+    exclusions: list[str] = []
+    if artifact_dependent:
+        exclusions.append("artifact-dependent input or runtime URI")
+    if runtime_dependent:
+        exclusions.append("provider/runtime/plugin-dependent")
+    examples = descriptor.invocation_examples
+    validation_errors: list[dict[str, str]] = []
+    validator = Draft202012Validator(input_schema)
+    for example in examples:
+        errors = sorted(
+            validator.iter_errors(example.input), key=lambda error: list(error.path)
+        )
+        for error in errors:
+            validation_errors.append(
+                {
+                    "example": example.name,
+                    "path": ".".join(map(str, error.path)),
+                    "message": error.message,
+                }
+            )
+    evidence = _evidence(descriptor.capability_id, root)
+    return {
+        "capability_id": descriptor.capability_id,
+        "provider": descriptor.provider,
+        "modes": [mode.value for mode in descriptor.modes],
+        "directly_invocable": not artifact_dependent and not runtime_dependent,
+        "requires_runtime_generated_artifacts": artifact_dependent,
+        "runtime_or_plugin_dependent": runtime_dependent,
+        "has_invocation_examples": bool(examples),
+        "invocation_example_count": len(examples),
+        "examples_schema_valid": not validation_errors,
+        "integration_test_evidence": evidence,
+        "covered_by_integration_tests": bool(evidence),
+        "known_exclusions": exclusions,
+        "validation_errors": validation_errors,
+    }
+
+
+def build_report(root: Path) -> dict[str, Any]:
+    with tempfile.TemporaryDirectory(prefix="jacobian-example-coverage-") as directory:
+        catalog = JacobianKernel(Path(directory)).capabilities.catalog()
+    capabilities = [_row(descriptor, root) for descriptor in catalog.capabilities]
+    capabilities.sort(key=lambda row: row["capability_id"])
+    summary = {
+        "total_capabilities": len(capabilities),
+        "directly_invocable": sum(row["directly_invocable"] for row in capabilities),
+        "artifact_dependent": sum(
+            row["requires_runtime_generated_artifacts"] for row in capabilities
+        ),
+        "runtime_or_plugin_dependent": sum(
+            row["runtime_or_plugin_dependent"] for row in capabilities
+        ),
+        "with_examples": sum(row["has_invocation_examples"] for row in capabilities),
+        "missing_examples": sum(
+            not row["has_invocation_examples"] for row in capabilities
+        ),
+        "schema_validation_failures": sum(
+            not row["examples_schema_valid"] for row in capabilities
+        ),
+        "known_exclusions": sum(bool(row["known_exclusions"]) for row in capabilities),
+    }
+    return {"report_version": "1", "summary": summary, "capabilities": capabilities}
+
+
+def _table(title: str, rows: list[dict[str, Any]]) -> list[str]:
+    lines = [
+        f"## {title}",
+        "",
+        "| Capability | Provider | Examples | Integration evidence | Notes |",
+        "|---|---|---:|---|---|",
+    ]
+    for row in rows:
+        evidence = ", ".join(row["integration_test_evidence"]) or "—"
+        notes = ", ".join(row["known_exclusions"]) or "—"
+        lines.append(
+            f"| `{row['capability_id']}` | `{row['provider']}` | {row['invocation_example_count']} | {evidence} | {notes} |"
+        )
+    return [*lines, ""]
+
+
+def to_markdown(report: dict[str, Any]) -> str:
+    rows = report["capabilities"]
+    summary = report["summary"]
+    lines = [
+        "# Capability Example Coverage",
+        "",
+        "Generated from the installed catalog; counts are not hand-maintained.",
+        "",
+        "| Metric | Count |",
+        "|---|---:|",
+    ]
+    for key, value in summary.items():
+        lines.append(f"| {key.replace('_', ' ').title()} | {value} |")
+    lines.append("")
+    lines += _table(
+        "Missing examples", [row for row in rows if not row["has_invocation_examples"]]
+    )
+    lines += _table(
+        "Already covered", [row for row in rows if row["has_invocation_examples"]]
+    )
+    lines += _table(
+        "Artifact-dependent",
+        [row for row in rows if row["requires_runtime_generated_artifacts"]],
+    )
+    lines += _table(
+        "Runtime/plugin dependent",
+        [row for row in rows if row["runtime_or_plugin_dependent"]],
+    )
+    lines += _table(
+        "Known exclusions", [row for row in rows if row["known_exclusions"]]
+    )
+    lines += _table(
+        "Validation failures", [row for row in rows if not row["examples_schema_valid"]]
+    )
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument(
+        "--json", type=Path, default=Path("reports/capability-example-coverage.json")
+    )
+    parser.add_argument(
+        "--markdown", type=Path, default=Path("reports/capability-example-coverage.md")
+    )
+    args = parser.parse_args()
+    report = build_report(args.root.resolve())
+    args.json.parent.mkdir(parents=True, exist_ok=True)
+    args.markdown.parent.mkdir(parents=True, exist_ok=True)
+    args.json.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    args.markdown.write_text(to_markdown(report), encoding="utf-8")
+    print(json.dumps(report["summary"], sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_capability_example_coverage.py
+++ b/tests/unit/test_capability_example_coverage.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+from scripts.capability_example_coverage import _row, build_report, to_markdown
+
+from jacobian.contracts.capabilities import CapabilityInvocationExample, CapabilityMode
+from jacobian.kernel import JacobianKernel
+
+
+def test_report_runs_and_matches_installed_descriptors(tmp_path: Path) -> None:
+    report = build_report(Path.cwd())
+    catalog = JacobianKernel(tmp_path).capabilities.catalog()
+    rows = {row["capability_id"]: row for row in report["capabilities"]}
+    descriptors = {
+        descriptor.capability_id: descriptor for descriptor in catalog.capabilities
+    }
+    assert set(rows) == set(descriptors)
+    assert report["summary"]["total_capabilities"] == len(descriptors)
+    assert all(
+        row["invocation_example_count"]
+        == len(descriptors[capability_id].invocation_examples)
+        for capability_id, row in rows.items()
+    )
+    assert "# Capability Example Coverage" in to_markdown(report)
+
+
+def test_schema_validation_failures_are_reported() -> None:
+    descriptor = SimpleNamespace(
+        capability_id="test.compute.value",
+        provider="test.provider",
+        modes=(CapabilityMode.EXPLORE,),
+        tags=(),
+        input_schema={
+            "type": "object",
+            "properties": {"value": {"type": "integer"}},
+            "required": ["value"],
+        },
+        invocation_examples=(
+            CapabilityInvocationExample(
+                name="bad",
+                description="An intentionally invalid test example.",
+                mode=CapabilityMode.EXPLORE,
+                input={"value": "not-an-integer"},
+            ),
+        ),
+    )
+    row = _row(descriptor, Path.cwd())
+    assert row["invocation_example_count"] == 1
+    assert row["examples_schema_valid"] is False
+    assert row["validation_errors"][0]["example"] == "bad"


### PR DESCRIPTION
## Summary
- add a catalog-derived JSON/Markdown invocation-example coverage report
- classify direct, artifact-dependent, and runtime/plugin-dependent capabilities
- report schema validation, integration-test evidence, exclusions, and missing examples
- add regression tests and `make example-coverage` documentation

## Validation
- Ruff check and format check pass for new files
- `git diff --check` passes
- locked pytest setup was attempted; local z3-solver build failed because the environment lacked the required CMake executable

This is a draft for review. No capability descriptors or invocation examples are modified, and no merge is requested.