### PR TITLE
test: fix zero-coefficient mutation and add obstruction coverage

### DIFF
--- a/tests/checkers/test_exact_domain_operation_checkers.py
+++ b/tests/checkers/test_exact_domain_operation_checkers.py
@@ -296,7 +296,10 @@ _CASES: tuple[
 def _mutate_numeric_leaf(value: object) -> bool:
     if isinstance(value, dict):
         if set(value) == {"num", "den"}:
-            value["num"] = str(int(value["num"]) + 1)
+            mutated = int(value["num"]) + 1
+            if mutated == 0:
+                mutated = 1
+            value["num"] = str(mutated)
             return True
         return any(_mutate_numeric_leaf(item) for item in value.values())
     if isinstance(value, list):
@@ -304,7 +307,10 @@ def _mutate_numeric_leaf(value: object) -> bool:
             if _mutate_numeric_leaf(item):
                 return True
             if isinstance(item, str) and item.lstrip("-").isdigit():
-                value[index] = str(int(item) + 1)
+                mutated = int(item) + 1
+                if mutated == 0:
+                    mutated = 1
+                value[index] = str(mutated)
                 return True
     return False
 

--- a/tests/checkers/test_graph_degree_sequence_checker.py
+++ b/tests/checkers/test_graph_degree_sequence_checker.py
@@ -171,3 +171,131 @@ def test_checker_rejects_fabricated_erdos_gallai_obstruction() -> None:
 
     assert decision["accepted"] is False
     assert decision["conclusion"] == "UNKNOWN"
+
+
+def test_checker_accepts_max_degree_obstruction() -> None:
+    """A degree exceeding the simple-graph maximum is a valid non-graphical obstruction."""
+    obstruction = {
+        "kind": "MAX_DEGREE",
+        "index": 0,
+        "degree": 4,
+        "order": 4,
+    }
+    request = _request(
+        sequence=[4, 1, 1, 0],
+        candidate={
+            "result_schema_version": "1",
+            "degree_sequence": [4, 1, 1, 0],
+            "conclusion": "NON_GRAPHICAL",
+            "graph_uri": None,
+            "graph": None,
+            "obstruction": obstruction,
+        },
+        certificate_payload={
+            "method": "MAX_DEGREE_OBSTRUCTION",
+            "degree_sequence": [4, 1, 1, 0],
+            "conclusion": "NON_GRAPHICAL",
+            "graph_uri": None,
+            "obstruction": obstruction,
+        },
+    )
+
+    decision = check_degree_sequence(request)
+
+    assert decision["accepted"] is True
+    assert decision["conclusion"] == "FALSE"
+
+
+def test_checker_rejects_fabricated_max_degree_obstruction() -> None:
+    """A MAX_DEGREE obstruction whose degree does not exceed the maximum is fabricated."""
+    obstruction = {
+        "kind": "MAX_DEGREE",
+        "index": 0,
+        "degree": 3,
+        "order": 4,
+    }
+    request = _request(
+        sequence=[3, 1, 1, 0],
+        candidate={
+            "result_schema_version": "1",
+            "degree_sequence": [3, 1, 1, 0],
+            "conclusion": "NON_GRAPHICAL",
+            "graph_uri": None,
+            "graph": None,
+            "obstruction": obstruction,
+        },
+        certificate_payload={
+            "method": "MAX_DEGREE_OBSTRUCTION",
+            "degree_sequence": [3, 1, 1, 0],
+            "conclusion": "NON_GRAPHICAL",
+            "graph_uri": None,
+            "obstruction": obstruction,
+        },
+    )
+
+    decision = check_degree_sequence(request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+def test_checker_accepts_odd_sum_obstruction() -> None:
+    """An odd degree sum is a valid non-graphical obstruction."""
+    obstruction = {
+        "kind": "ODD_SUM",
+        "degree_sum": 7,
+    }
+    request = _request(
+        sequence=[3, 2, 1, 1],
+        candidate={
+            "result_schema_version": "1",
+            "degree_sequence": [3, 2, 1, 1],
+            "conclusion": "NON_GRAPHICAL",
+            "graph_uri": None,
+            "graph": None,
+            "obstruction": obstruction,
+        },
+        certificate_payload={
+            "method": "ODD_SUM_OBSTRUCTION",
+            "degree_sequence": [3, 2, 1, 1],
+            "conclusion": "NON_GRAPHICAL",
+            "graph_uri": None,
+            "obstruction": obstruction,
+        },
+    )
+
+    decision = check_degree_sequence(request)
+
+    assert decision["accepted"] is True
+    assert decision["conclusion"] == "FALSE"
+
+
+def test_checker_rejects_fabricated_odd_sum_obstruction() -> None:
+    """An ODD_SUM obstruction whose sum is even is fabricated."""
+    obstruction = {
+        "kind": "ODD_SUM",
+        "degree_sum": 6,
+    }
+    request = _request(
+        sequence=[3, 1, 1, 1],
+        candidate={
+            "result_schema_version": "1",
+            "degree_sequence": [3, 1, 1, 1],
+            "conclusion": "NON_GRAPHICAL",
+            "graph_uri": None,
+            "graph": None,
+            "obstruction": obstruction,
+        },
+        certificate_payload={
+            "method": "ODD_SUM_OBSTRUCTION",
+            "degree_sequence": [3, 1, 1, 1],
+            "conclusion": "NON_GRAPHICAL",
+            "graph_uri": None,
+            "obstruction": obstruction,
+        },
+    )
+
+    decision = check_degree_sequence(request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"


### PR DESCRIPTION
## Summary

Fixes two issues found during a fixture-by-fixture audit of the test suite.

### 1. `_mutate_numeric_leaf` could mutate a rational coefficient to zero

**File:** `tests/checkers/test_exact_domain_operation_checkers.py`

The mutation helper walked the payload in DFS order and incremented the first `{"num","den"}` dict's `num` by 1. When the first coefficient encountered was `{"num":"-1","den":"1"}` (as in the GCD case `gcd = x − 1`), the increment produced `{"num":"0","den":"1"}` — a **zero coefficient in a sparse term**, which the checker rejects as non-canonical rather than as a tampered value. The mutation test therefore passed for the wrong reason and would not detect a regression that only rejects zero coefficients.

**Fix:** Guard the increment so the mutated numerator is never zero.

### 2. `MAX_DEGREE` and `ODD_SUM` obstruction branches were untested

**File:** `tests/checkers/test_graph_degree_sequence_checker.py`

The degree-sequence checker has three obstruction branches (`ERDOS_GALLAI`, `MAX_DEGREE`, `ODD_SUM`), but the test suite only exercised `ERDOS_GALLAI` and the graphical case. The `MAX_DEGREE` and `ODD_SUM` branches were completely untested, leaving two rejection paths without coverage.

**Fix:** Added four tests:
- `test_checker_accepts_max_degree_obstruction` — valid `MAX_DEGREE` obstruction accepted as FALSE
- `test_checker_rejects_fabricated_max_degree_obstruction` — `MAX_DEGREE` obstruction with degree below maximum is rejected
- `test_checker_accepts_odd_sum_obstruction` — valid `ODD_SUM` obstruction accepted as FALSE
- `test_checker_rejects_fabricated_odd_sum_obstruction` — `ODD_SUM` obstruction with even sum is rejected

## Validation

- `tests/checkers` + `tests/unit`: 313 passed, no regressions.
- All mathematical claims in checker tests verified by hand against source implementations.

---