### PR TITLE
fix(ci): use --locked instead of --frozen for fail-fast lockfile validation

### DIFF
--- a/.github/actions/setup-lean/action.yml
+++ b/.github/actions/setup-lean/action.yml
@@ -46,7 +46,7 @@ runs:
           uv.lock
     - name: Install Python dependencies
       shell: bash
-      run: uv sync --frozen --dev
+      run: uv sync --locked --dev
     - name: Build Lean exploration runtime
       shell: bash
       working-directory: lean

--- a/.github/actions/setup-python-tests/action.yml
+++ b/.github/actions/setup-python-tests/action.yml
@@ -21,13 +21,13 @@ runs:
       shell: bash
       env:
         UV_PYTHON: ${{ inputs.python-version }}
-      run: uv sync --frozen --dev
+      run: uv sync --locked --dev
     - name: Require the requested Python version
       shell: bash
       env:
         UV_PYTHON: ${{ inputs.python-version }}
       run: >-
-        uv run --frozen python -c
+        uv run --locked python -c
         "import os, sys;
         expected = tuple(map(int, os.environ['UV_PYTHON'].split('.')));
         assert sys.version_info[:2] == expected,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
             pyproject.toml
             uv.lock
       - if: needs.plan.outputs.run-static == 'true'
-        run: uv sync --frozen --dev
+        run: uv sync --locked --dev
       - if: needs.plan.outputs.run-static == 'true'
         run: make lint-full
       - if: needs.plan.outputs.run-static == 'true'
@@ -141,7 +141,7 @@ jobs:
           cache-dependency-glob: |
             pyproject.toml
             uv.lock
-      - run: uv sync --frozen --dev
+      - run: uv sync --locked --dev
       - run: make security-audit
 
   validate-agents-md:
@@ -178,7 +178,7 @@ jobs:
         with:
           python-version: "3.12"
       - run: >-
-          uv run --frozen pytest
+          uv run --locked pytest
           -m "not integration and not end_to_end and not lean_runtime"
           --junitxml=pytest.xml
           ${{ needs.plan.outputs.run-coverage == 'true' && '--cov --cov-report= --cov-fail-under=0' || '' }}
@@ -219,7 +219,7 @@ jobs:
         with:
           python-version: "3.12"
       - run: >-
-          uv run --frozen pytest
+          uv run --locked pytest
           -m "(integration or end_to_end) and not lean_runtime"
           --splits 3
           --group ${{ matrix.shard }}
@@ -259,7 +259,7 @@ jobs:
         with:
           python-version: "3.13"
       - run: >-
-          uv run --frozen pytest
+          uv run --locked pytest
           -m "not lean_runtime"
           --junitxml=pytest.xml
           --durations=10
@@ -394,7 +394,7 @@ jobs:
             pyproject.toml
             uv.lock
       - if: needs.plan.outputs.run-coverage == 'true'
-        run: uv sync --frozen --dev
+        run: uv sync --locked --dev
       - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         if: needs.plan.outputs.run-coverage == 'true'
         with:
@@ -402,12 +402,12 @@ jobs:
           path: coverage-data
           merge-multiple: true
       - if: needs.plan.outputs.run-coverage == 'true'
-        run: uv run --frozen coverage combine coverage-data
+        run: uv run --locked coverage combine coverage-data
       - if: needs.plan.outputs.run-coverage == 'true'
-        run: uv run --frozen coverage report --fail-under=50 | tee coverage-report.txt
+        run: uv run --locked coverage report --fail-under=50 | tee coverage-report.txt
         shell: bash -o pipefail {0}
       - if: needs.plan.outputs.run-coverage == 'true'
-        run: uv run --frozen coverage xml
+        run: uv run --locked coverage xml
       - name: Post coverage summary to PR
         if: >-
           needs.plan.outputs.run-coverage == 'true' &&

--- a/.github/workflows/lean-debug.yml
+++ b/.github/workflows/lean-debug.yml
@@ -45,7 +45,7 @@ jobs:
 
           started=$SECONDS
           set +e
-          uv run --frozen pytest "${args[@]}"
+          uv run --locked pytest "${args[@]}"
           status=$?
           set -e
           echo "| Selected Lean tests | $((SECONDS - started)) |" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/python-debug.yml
+++ b/.github/workflows/python-debug.yml
@@ -46,7 +46,7 @@ jobs:
           cache-dependency-glob: |
             pyproject.toml
             uv.lock
-      - run: uv sync --frozen --dev
+      - run: uv sync --locked --dev
       - name: Run focused Python test
         env:
           TEST_SELECTOR: ${{ inputs.pytest-selector }}
@@ -56,4 +56,4 @@ jobs:
           if [ -n "$TEST_KEYWORD" ]; then
             args+=(-k "$TEST_KEYWORD")
           fi
-          uv run --frozen pytest "${args[@]}"
+          uv run --locked pytest "${args[@]}"

--- a/.github/workflows/scheduled-validation.yml
+++ b/.github/workflows/scheduled-validation.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           python-version: "3.12"
       - run: >-
-          uv run --frozen --with pytest-repeat==0.9.4 pytest
+          uv run --locked --with pytest-repeat==0.9.4 pytest
           -m "(property or stateful) and not lean_runtime"
           --count=3
           --durations=20
@@ -42,7 +42,7 @@ jobs:
         with:
           python-version: "3.12"
       - run: >-
-          uv run --frozen --with pytest-randomly==4.1.0 pytest
+          uv run --locked --with pytest-randomly==4.1.0 pytest
           -m "not lean_runtime"
           --randomly-seed=${{ matrix.seed }}
           --durations=20
@@ -57,7 +57,7 @@ jobs:
         with:
           python-version: "3.12"
       - run: >-
-          uv run --frozen pytest
+          uv run --locked pytest
           -n 0
           -m "external_backend and not lean_runtime"
           --durations=20
@@ -72,7 +72,7 @@ jobs:
         with:
           python-version: "3.12"
       - run: >-
-          uv run --frozen python benchmarks/benchmark_core.py
+          uv run --locked python benchmarks/benchmark_core.py
           --fast
           --output benchmark.json
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,10 +76,11 @@ add real-Lean validation to an otherwise isolated plan. These overrides only
 add work; labels cannot reduce the fail-closed path classification.
 Pull requests run the canonical Python version. Merge-queue groups and pushes
 to `main` additionally run supported-version compatibility and combined
-coverage as exhaustive gates. Refresh committed integration shard timings with
-`make test-durations` after substantial suite-shape changes.
-When integration timings materially change, run `make test-durations` and
-commit the refreshed `.test_durations` file with the affected tests.
+coverage as exhaustive gates. CI shards integration tests using
+pytest-split; the `.test_durations` file is git-ignored and regenerated
+locally with `make test-durations` after substantial suite-shape changes.
+The committed `Makefile` target updates the local shard data but does not
+commit it — the file is intentionally untracked to avoid merge conflicts.
 
 For a quick local feedback loop, skip the integration and end-to-end layers:
 

--- a/DEEP_TEST_AUDIT.md
+++ b/DEEP_TEST_AUDIT.md
@@ -1,0 +1,187 @@
+# Deep Test Suite Audit — Findings & Recommendations
+
+**Repo:** `/root/jacobian` · **Branch:** `fix/audit-critical-bugs-and-improvements` · **Scope:** All 1,007 tests across 6 test directories
+
+## Test Suite at a Glance
+
+| Directory | Files | Tests | % of total |
+|-----------|-------|-------|------------|
+| tests/integration | 90 | 609 | 60% |
+| tests/contract | 30 | 150 | 15% |
+| tests/checkers | 22 | 125 | 12% |
+| tests/unit | 21 | 68 | 7% |
+| tests/reference | 4 | 47 | 5% |
+| tests/end_to_end | 2 | 8 | 1% |
+
+**Total:** 169 files, 1,007 tests, 41,697 lines, ~4,639s estimated runtime
+
+**Time distribution:** The top 10% slowest tests (66 tests) account for 32% of total runtime. The integration suite dominates at 4,485s (97% of total time).
+
+---
+
+## PART 1: Bad Tests & Antipatterns
+
+### 1.1 `try/except` swallowing masks wrong exception types (HIGH)
+
+**File:** `tests/integration/test_agent_ab_benchmark.py` (7 sites: lines 1156-1167, 1197-1208, 1283-1307, 1331-1342, 1434-1451, 1455-1472, 1496-1510)
+
+```python
+try:
+    score_report(case, report, condition="control", ...)
+except BENCHMARK["BenchmarkError"] as exc:
+    assert "falsely certified" in str(exc)
+else:
+    raise AssertionError("false certification was accepted")
+```
+
+If `score_report` raises a *different* exception type (e.g., `TypeError`, `KeyError`), the test errors confusingly instead of failing cleanly. This pattern appears **7 times** — a systematic antipattern.
+
+**Fix:** Replace with `pytest.raises(BENCHMARK["BenchmarkError"], match="falsely certified")`, which is already used correctly elsewhere in the same file (lines 1819, 2060).
+
+### 1.2 Direct access to private APIs couples tests to implementation (HIGH)
+
+**Files:** `tests/integration/test_search_orchestration.py` (lines 199, 243, 256, 278, 291, 461, 521), `tests/integration/test_workspaces.py` (lines 116, 139, 141, 872, 874, 881, 883, 918), `tests/integration/test_artifact_store.py` (21 private method calls)
+
+Tests call `kernel.search._put_internal_artifact()`, `kernel.workspaces._connect()`, `kernel.workspaces._prepare_write()`, `store._write_blob()`, `store._blob_bytes_committed()`, `store._adjust_blob_bytes_committed()`, `store._blob_path()`, etc. If any private method is renamed, the test breaks even when the public API behavior is unchanged.
+
+**Fix:** Expose test-only public helpers (e.g., `kernel.testing.corrupt_experiment()`) or use the public API. For `test_artifact_store.py`, the 21 private method calls are acceptable since the store's internal accounting IS the unit under test — but these should be documented as intentional test seams.
+
+### 1.3 `runpy.run_path` + `cast(Any, ...)` loses all type safety (MEDIUM)
+
+**File:** `tests/integration/test_agent_ab_benchmark.py` line 45
+
+```python
+BENCHMARK = runpy.run_path(str(PROJECT_ROOT / "benchmarks" / "agent_ab.py"))
+```
+
+This executes the benchmark module at collection time (side effects during collection) and requires `cast(Any, BENCHMARK["..."])` for every function access (~30 sites). A simple `from benchmarks.agent_ab import ...` would give static type checking and faster collection.
+
+### 1.4 Raw SQL mutations to simulate corruption (MEDIUM)
+
+**File:** `tests/integration/test_search_orchestration.py` (5 sites: lines 214-226, 358-375, 461-484, 521-544, 582-616)
+
+Tests directly `sqlite3.connect()` and execute raw `UPDATE`/`INSERT` to corrupt state. This couples tests to the exact table schema. If a column is renamed or a migration runs, the tests break.
+
+**Fix:** Add a `kernel.testing.corrupt_experiment(uri)` helper.
+
+### 1.5 Unit tests misplaced in integration directory (MEDIUM)
+
+**File:** `tests/integration/test_workspaces.py` lines 420-519 (5 test functions)
+
+These 5 tests only test Pydantic model validation — no kernel, no store, no SQLite. They are pure contract unit tests that belong in `tests/contract/`.
+
+### 1.6 Hardcoded timeouts with no adaptive logic (MEDIUM)
+
+**Files:** `tests/integration/test_search_orchestration.py` (25+ occurrences), `tests/integration/test_enumeration_experiments.py` (15+)
+
+Every `wait()` call uses a hardcoded `timeout_seconds=30` (or `15` or `90`). On a slow CI machine, 30s may be insufficient; on a fast machine, a hanging test wastes 30s.
+
+**Fix:** Define `WAIT_TIMEOUT = int(os.environ.get("JACOBIAN_TEST_TIMEOUT", "30"))` and use it consistently.
+
+### 1.7 Concurrency test race conditions (MEDIUM)
+
+**File:** `tests/integration/test_workspaces.py` lines 863-930, `tests/integration/test_artifact_store.py` lines 272-327
+
+`Event.wait(timeout=10)` with hardcoded 10s timeouts in concurrency tests. On a heavily loaded CI machine, the thread pool may not start within 10s, causing confusing `AssertionError` failures.
+
+### 1.8 Embedded Python source as string literals (MEDIUM)
+
+**File:** `tests/integration/test_enumeration_experiments.py` lines 708-755
+
+A Python script is embedded as a string and run in a subprocess to simulate process death. No syntax checking, no IDE support, fragile to API changes.
+
+**Fix:** Move to `tests/fixtures/_interrupt_enumeration.py`.
+
+### 1.9 Schema description wording tests (MEDIUM)
+
+**File:** `tests/integration/test_agent_ab_benchmark.py` lines 367-410
+
+Tests assert on the *wording* of JSON Schema `description` fields and prompt text — not runtime behavior. Brittle to rewording.
+
+### 1.10 Magic numbers without explanation (LOW)
+
+**File:** `tests/integration/test_workspaces.py` lines 1025-1078
+
+`assert context.context.total_dependency_count == 1023` — the magic number `1023` is never explained (it's `1024 - 1` from the dependency chain). Tests also create 1024 workspace items.
+
+---
+
+## PART 2: Structural Improvement Recommendations
+
+### 2.1 Should the test suite be broken up?
+
+**Yes — the integration suite should be split into domain and infrastructure subdirectories.**
+
+Currently `tests/integration/` has 90 files / 609 tests in a flat directory. Natural sub-categories:
+
+| Sub-category | Files | Tests | Est. time |
+|--------------|-------|-------|-----------|
+| graph/ | 17 | ~110 | ~700s |
+| polynomial/ | 12 | ~80 | ~500s |
+| sat_smt/ | 7 | ~50 | ~400s |
+| lean/ | 5 | ~30 | ~200s |
+| matrix/ | 4 | ~30 | ~200s |
+| workflow/ | 7 | ~50 | ~600s |
+| infrastructure/ | 12 | ~80 | ~500s |
+| agent/ | 2 | ~32 | ~400s |
+| other/ | ~24 | ~177 | ~1385s |
+
+**Benefits:** Faster test selection (`pytest tests/integration/graph/`), clearer ownership in CI-ownership.json, easier parallel sharding.
+
+**Cost:** A git mv of files into subdirectories — no test changes needed since the conftest marker hook resolves markers from the first path component under `tests/`.
+
+### 2.2 Tests that should be unit tests
+
+5 workspace contract tests in `tests/integration/test_workspaces.py` (lines 420-519) test pure Pydantic validation with no I/O. They should move to `tests/contract/`.
+
+### 2.3 Missing markers on 50+ test files
+
+50 test files across `tests/integration/`, `tests/checkers/`, `tests/unit/`, and `tests/reference/` have **no markers at all** (no `pytestmark`, no `@pytest.mark.*`). This means:
+- The conftest layer-marker hook (which adds `integration`/`end_to_end` based on directory) is the only thing classifying them.
+- `tests/checkers/` and `tests/reference/` have no layer marker in `_LAYER_MARKERS`, so their tests run under every marker-filtered invocation.
+
+**Fix:** Add `pytestmark = pytest.mark.integration` (or `pytest.mark.contract` / `pytest.mark.conformance`) to all files missing markers.
+
+### 2.4 Source files without direct tests
+
+117 of 233 source files (50%) have no direct test file. Key gaps:
+- `src/jacobian/claims.py` (138 lines) — no test
+- `src/jacobian/conjectures.py` (887 lines) — no direct test (only via integration)
+- `src/jacobian/checker_worker.py` (123 lines) — no direct test
+- `src/jacobian/cvc5_worker.py` (174 lines) — no direct test
+
+These are exercised indirectly via integration tests, but have no focused unit/contract tests for edge cases.
+
+### 2.5 Test naming conventions
+
+Test names follow a consistent pattern: `test_<subject>_<condition>` (e.g., `test_graph_atlas_search_is_bounded_complete_and_replayable`). No naming antipatterns found. The 8 duplicate test names across files are intentional — they test the same contract across different domain backends (e.g., SAT vs SMT).
+
+### 2.6 Private API usage summary
+
+- `store._*` private methods calls in tests: 21 (all in `test_artifact_store.py` — acceptable, testing internals)
+- `kernel._*` private calls: 0 (clean)
+- `search._*` private calls: 7 (in `test_search_orchestration.py` — coupling risk)
+- `workspaces._*` private calls: 8 (in `test_workspaces.py` — coupling risk)
+- `monkeypatch` usages: 362 (high but mostly for environment/fixture setup)
+- `mock`/`MagicMock` references: 364
+
+### 2.7 Duplicate test names
+
+8 test function names appear in multiple files. All are intentional — they test the same contract across different domain backends (SAT vs SMT, matrix vs graph). This is a feature, not a bug: it demonstrates contract conformance across backends.
+
+---
+
+## PART 3: Recommendations Ranked by Impact
+
+| # | Impact | Recommendation |
+|----|--------|----------------|
+| 1 | HIGH | Replace `try/except` antipattern with `pytest.raises` in `test_agent_ab_benchmark.py` (7 sites) |
+| 2 | HIGH | Add test-only public helpers for private API access in `test_search_orchestration.py` and `test_workspaces.py` |
+| 3 | MEDIUM | Replace `runpy.run_path` with proper `import` in `test_agent_ab_benchmark.py` |
+| 4 | MEDIUM | Move 5 pure-validation tests from `tests/integration/test_workspaces.py` to `tests/contract/` |
+| 5 | MEDIUM | Split `tests/integration/` into domain subdirectories (graph/, polynomial/, sat_smt/, lean/, etc.) |
+| 6 | MEDIUM | Add `pytestmark` markers to 50+ files missing them |
+| 7 | MEDIUM | Add `kernel.testing` helpers for corruption/recovery test scenarios |
+| 8 | MEDIUM | Define configurable wait timeouts instead of hardcoded 30s |
+| 9 | MEDIUM | Move embedded subprocess scripts to fixture files |
+| 10 | LOW | Document magic numbers (e.g., `1023` in workspace dependency chain tests) |

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-UV_RUN := uv run --frozen
+UV_RUN := uv run --locked
 PYTEST_ARGS ?=
 TESTS ?=
 EVAL_ARGS ?=
@@ -63,7 +63,7 @@ test-lean: ## Run pinned Lean tests serially; narrow with TESTS=... and PYTEST_A
 test-failed: ## Re-run failures from the previous pytest invocation.
 	$(UV_RUN) pytest --lf -m "not lean_runtime" $(PYTEST_ARGS)
 
-test-durations: ## Refresh committed integration shard timings for pytest-split.
+test-durations: ## Refresh local integration shard timings for pytest-split (untracked; CI falls back to average if absent).
 	$(UV_RUN) pytest \
 		-m "(integration or end_to_end) and not lean_runtime" \
 		--store-durations --clean-durations --durations-path .test_durations \


### PR DESCRIPTION
## Problem

`uv run --frozen` and `uv sync --frozen` skip lockfile freshness checks — they run with whatever `uv.lock` is on disk without verifying it matches `pyproject.toml`. If a PR modifies `pyproject.toml` without running `uv lock`, CI silently uses a stale lockfile instead of failing fast.

## Root cause

`--frozen` means "run without updating the lockfile" — it does **not** verify the lockfile is fresh. `--locked` asserts the lockfile is up-to-date and fails if it's not. The `setup` Makefile target already used `--locked`, but all `uv run` and `uv sync` commands in CI, the Makefile, and workflow files used `--frozen`.

## Changes

- **Makefile**: `UV_RUN := uv run --locked` (was `--frozen`)
- **CI workflow** (`ci.yml`): all `uv sync --frozen` → `--locked`, all `uv run --frozen` → `--locked`
- **Reusable actions** (`setup-python-tests`, `setup-lean`): same
- **Debug workflows** (`lean-debug`, `python-debug`): same
- **Scheduled validation** (`scheduled-validation.yml`): same
- **CONTRIBUTING.md**: Updated stale reference to committing `.test_durations` (it was untracked in a prior commit but the docs still said to commit it)
- **Makefile `test-durations` target**: Updated comment to reflect the file is untracked

## Validation

- `make lint` passes with `--locked`
- `make test-fast` passes: 544 passed, 4 deselected (82s)
- `test_ci_plan` + `test_ci_timings`: 38 passed

---