### PR TITLE
refactor(tests): reorganize test suite ownership and CI scheduling

### DIFF
--- a/.github/actions/setup-lean/action.yml
+++ b/.github/actions/setup-lean/action.yml
@@ -46,7 +46,7 @@ runs:
           uv.lock
     - name: Install Python dependencies
       shell: bash
-      run: uv sync --frozen --dev
+      run: uv sync --locked --dev
     - name: Build Lean exploration runtime
       shell: bash
       working-directory: lean

--- a/.github/actions/setup-python-tests/action.yml
+++ b/.github/actions/setup-python-tests/action.yml
@@ -21,7 +21,7 @@ runs:
       shell: bash
       env:
         UV_PYTHON: ${{ inputs.python-version }}
-      run: uv sync --frozen --dev
+      run: uv sync --locked --dev
     - name: Require the requested Python version
       shell: bash
       env:

--- a/.github/ci-impact.json
+++ b/.github/ci-impact.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": 2,
   "suites": [
     "core",
     "integration",
@@ -12,22 +12,22 @@
   ],
   "rules": [
     {
-      "owner": "documentation",
+      "name": "documentation",
       "patterns": ["docs/**", "*.md", ".github/ISSUE_TEMPLATE/**", ".github/CODEOWNERS"],
       "suites": []
     },
     {
-      "owner": "npm-package",
+      "name": "npm-package",
       "patterns": ["npm/**"],
       "suites": ["npm"]
     },
     {
-      "owner": "lean-runtime",
+      "name": "lean-runtime",
       "patterns": ["lean/**"],
       "suites": ["lean"]
     },
     {
-      "owner": "lean-python-tests",
+      "name": "lean-python-tests",
       "patterns": [
         "tests/integration/test_lean.py",
         "tests/integration/test_lean_proof_edit.py",
@@ -36,17 +36,17 @@
       "suites": ["lean", "static"]
     },
     {
-      "owner": "python-core-tests",
+      "name": "python-core-tests",
       "patterns": ["tests/unit/**", "tests/contract/**", "tests/checkers/**", "tests/reference/**"],
       "suites": ["core", "static"]
     },
     {
-      "owner": "python-integration-tests",
+      "name": "python-integration-tests",
       "patterns": ["tests/integration/**", "tests/end_to_end/**"],
       "suites": ["integration", "static"]
     },
     {
-      "owner": "verification-boundary",
+      "name": "verification-boundary",
       "patterns": [
         "src/jacobian/kernel.py",
         "src/jacobian/contracts/**",
@@ -59,33 +59,41 @@
       "suites": ["core", "integration", "lean", "npm", "static", "build", "security", "duplicate"]
     },
     {
-      "owner": "lean-python-adapter",
+      "name": "lean-python-adapter",
       "patterns": ["src/jacobian/lean*.py", "src/jacobian/**/*lean*.py"],
       "suites": ["core", "integration", "lean", "static", "build"]
     },
     {
-      "owner": "npm-facing-adapter",
+      "name": "npm-facing-adapter",
       "patterns": ["src/jacobian/adapters/mcp/**"],
       "suites": ["core", "integration", "npm", "static", "build"]
     },
     {
-      "owner": "python-source",
+      "name": "python-source",
       "patterns": ["src/jacobian/**", "src/jacobian_checkers/**"],
       "suites": ["core", "integration", "static", "build"]
     },
     {
-      "owner": "ci-and-packaging",
-      "patterns": [".github/**", "pyproject.toml", "uv.lock", "Makefile"],
+      "name": "ci-and-packaging",
+      "patterns": [
+        ".github/actions/**",
+        ".github/scripts/**",
+        ".github/workflows/**",
+        ".github/ci-impact.json",
+        "pyproject.toml",
+        "uv.lock",
+        "Makefile"
+      ],
       "suites": ["core", "integration", "lean", "npm", "static", "build", "security", "duplicate"]
     },
     {
-      "owner": "repository-policy",
+      "name": "repository-policy",
       "patterns": ["AGENTS.md", ".pre-commit-config.yaml", ".jscpd.json"],
       "suites": ["core", "integration", "lean", "npm", "static", "build", "security", "duplicate"]
     }
   ],
   "fallback": {
-    "owner": "unclassified-fail-closed",
+    "name": "unclassified-fail-closed",
     "suites": ["core", "integration", "lean", "npm", "static", "build", "security", "duplicate"]
   }
 }

--- a/.github/scripts/classify-ci-paths
+++ b/.github/scripts/classify-ci-paths
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Map changed repository paths to CI suites using the ownership manifest."""
+"""Map changed repository paths to suites using the CI impact manifest."""
 
 from __future__ import annotations
 
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any
 
 ROOT = Path(__file__).resolve().parents[2]
-MANIFEST = ROOT / ".github" / "ci-ownership.json"
+MANIFEST = ROOT / ".github" / "ci-impact.json"
 
 
 def load_manifest() -> dict[str, Any]:
@@ -18,12 +18,18 @@ def load_manifest() -> dict[str, Any]:
         return json.load(handle)
 
 
-def suites_for_path(path: str, manifest: dict[str, Any]) -> tuple[str, set[str]]:
+def suites_for_path(path: str, manifest: dict[str, Any]) -> tuple[set[str], set[str]]:
+    matching_rules: list[dict[str, Any]] = []
     for rule in manifest["rules"]:
         if any(fnmatchcase(path, pattern) for pattern in rule["patterns"]):
-            return rule["owner"], set(rule["suites"])
+            matching_rules.append(rule)
+    if matching_rules:
+        return (
+            {str(rule["name"]) for rule in matching_rules},
+            {str(suite) for rule in matching_rules for suite in rule["suites"]},
+        )
     fallback = manifest["fallback"]
-    return fallback["owner"], set(fallback["suites"])
+    return {str(fallback["name"])}, set(fallback["suites"])
 
 
 def classify(paths: list[str], *, exhaustive: bool, force_lean: bool) -> dict[str, str]:
@@ -37,8 +43,8 @@ def classify(paths: list[str], *, exhaustive: bool, force_lean: bool) -> dict[st
         suites = all_suites
     else:
         for path in paths:
-            owner, owned_suites = suites_for_path(path, manifest)
-            owners.add(owner)
+            path_owners, owned_suites = suites_for_path(path, manifest)
+            owners.update(path_owners)
             suites.update(owned_suites)
 
     if force_lean:

--- a/.github/scripts/manage-test-timings
+++ b/.github/scripts/manage-test-timings
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Prepare and merge non-authoritative pytest-split timing artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import math
+import os
+import sys
+import urllib.request
+import zipfile
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+ARTIFACT_NAME = "integration-test-durations"
+ARTIFACT_FILE = "integration-test-durations.json"
+MAX_BYTES = 5 * 1024 * 1024
+MAX_ENTRIES = 10_000
+MAX_CANDIDATES = 5
+HTTP_TIMEOUT_SECONDS = 10
+TEST_ROOTS = ("tests/integration/", "tests/end_to_end/")
+
+
+def warning(message: str) -> None:
+    print(f"::warning::{message}", file=sys.stderr)
+
+
+def load_json_bytes(payload: bytes, source: str) -> Any:
+    if len(payload) > MAX_BYTES:
+        raise ValueError(f"{source} exceeds {MAX_BYTES} bytes")
+    return json.loads(payload)
+
+
+def validate_durations(value: Any, source: str) -> dict[str, float]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{source} must contain a JSON object")
+    if len(value) > MAX_ENTRIES:
+        raise ValueError(f"{source} exceeds {MAX_ENTRIES} timing entries")
+
+    durations: dict[str, float] = {}
+    for nodeid, duration in value.items():
+        if not isinstance(nodeid, str) or not nodeid.startswith(TEST_ROOTS):
+            raise ValueError(f"{source} contains an invalid test node id: {nodeid!r}")
+        if isinstance(duration, bool) or not isinstance(duration, (int, float)):
+            raise ValueError(f"{source} contains a non-numeric duration for {nodeid}")
+        seconds = float(duration)
+        if not math.isfinite(seconds) or seconds < 0:
+            raise ValueError(f"{source} contains an invalid duration for {nodeid}")
+        durations[nodeid] = seconds
+    return durations
+
+
+def api_json(url: str, token: str) -> Any:
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+        return load_json_bytes(response.read(MAX_BYTES + 1), url)
+
+
+def download(url: str, token: str) -> bytes:
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+        return response.read(MAX_BYTES + 1)
+
+
+def write_durations(path: Path, durations: dict[str, float]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(durations, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def artifact_durations(
+    artifact: dict[str, Any],
+    *,
+    api: str,
+    repository: str,
+    token: str,
+) -> dict[str, float] | None:
+    run = api_json(
+        f"{api}/repos/{repository}/actions/runs/{artifact['workflow_run']['id']}",
+        token,
+    )
+    if run.get("head_branch") != "main" or run.get("conclusion") != "success":
+        return None
+
+    archive = download(artifact["archive_download_url"], token)
+    if len(archive) > MAX_BYTES:
+        raise ValueError("timing artifact archive is too large")
+    with zipfile.ZipFile(io.BytesIO(archive)) as bundle:
+        member = bundle.getinfo(ARTIFACT_FILE)
+        if member.file_size > MAX_BYTES:
+            raise ValueError("timing artifact payload is too large")
+        payload = load_json_bytes(bundle.read(member), ARTIFACT_FILE)
+    if not isinstance(payload, dict):
+        raise ValueError("timing artifact payload must be a JSON object")
+    if (
+        payload.get("version") != 1
+        or payload.get("suite") != "integration"
+        or payload.get("shard_count") != 4
+    ):
+        raise ValueError("timing artifact metadata is incompatible")
+    return validate_durations(payload.get("durations"), ARTIFACT_FILE)
+
+
+def prepare(output: Path) -> None:
+    try:
+        repository = os.environ["GITHUB_REPOSITORY"]
+        token = os.environ["GH_TOKEN"]
+        api = os.environ.get("GITHUB_API_URL", "https://api.github.com")
+        listing = api_json(
+            f"{api}/repos/{repository}/actions/artifacts"
+            f"?name={ARTIFACT_NAME}&per_page={MAX_CANDIDATES}",
+            token,
+        )
+        artifacts = sorted(
+            [artifact for artifact in listing["artifacts"] if not artifact["expired"]],
+            key=lambda candidate: candidate["created_at"],
+            reverse=True,
+        )[:MAX_CANDIDATES]
+        durations = None
+        for artifact in artifacts:
+            try:
+                durations = artifact_durations(
+                    artifact,
+                    api=api,
+                    repository=repository,
+                    token=token,
+                )
+            except (
+                IndexError,
+                KeyError,
+                OSError,
+                TypeError,
+                ValueError,
+                zipfile.BadZipFile,
+            ):
+                continue
+            if durations is not None:
+                break
+        if durations is None:
+            raise ValueError(
+                "no valid successful main-branch timing artifact is available"
+            )
+    except (
+        IndexError,
+        KeyError,
+        OSError,
+        TypeError,
+        ValueError,
+        zipfile.BadZipFile,
+    ) as exc:
+        warning(f"{exc}; integration shards will use equal weighting")
+        durations = {}
+    write_durations(output, durations)
+
+
+def merge(
+    inputs: list[Path],
+    output: Path,
+    source_sha: str,
+    python_version: str,
+    pytest_split_version: str,
+) -> None:
+    if len(inputs) != 4:
+        raise ValueError(f"expected 4 shard timing files, received {len(inputs)}")
+    merged: dict[str, float] = {}
+    for path in inputs:
+        payload = load_json_bytes(path.read_bytes(), str(path))
+        durations = validate_durations(payload, str(path))
+        duplicates = merged.keys() & durations.keys()
+        if duplicates:
+            duplicate = min(duplicates)
+            raise ValueError(f"duplicate timing entry across shards: {duplicate}")
+        merged.update(durations)
+
+    envelope = {
+        "version": 1,
+        "suite": "integration",
+        "source_sha": source_sha,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "python_version": python_version,
+        "shard_count": 4,
+        "pytest_split_version": pytest_split_version,
+        "durations": dict(sorted(merged.items())),
+    }
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(envelope, indent=2) + "\n", encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    prepare_parser = subparsers.add_parser("prepare")
+    prepare_parser.add_argument("--output", type=Path, required=True)
+
+    merge_parser = subparsers.add_parser("merge")
+    merge_parser.add_argument("--input", action="append", type=Path, required=True)
+    merge_parser.add_argument("--output", type=Path, required=True)
+    merge_parser.add_argument("--source-sha", required=True)
+    merge_parser.add_argument("--python-version", required=True)
+    merge_parser.add_argument("--pytest-split-version", required=True)
+
+    args = parser.parse_args()
+    if args.command == "prepare":
+        prepare(args.output)
+    else:
+        merge(
+            args.input,
+            args.output,
+            args.source_sha,
+            args.python_version,
+            args.pytest_split_version,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/summarize-ci-timings
+++ b/.github/scripts/summarize-ci-timings
@@ -77,9 +77,9 @@ def render(payload: Any) -> str:
         if skew_ratio >= 1.5:
             lines.extend(
                 (
-                    "Integration shards differ by at least 1.5x. Refresh committed "
-                    "timings with `make test-durations` when the suite shape changes "
-                    "substantially.",
+                    "Integration shards differ by at least 1.5x. The next successful "
+                    "main-branch integration run will publish fresh timings; until "
+                    "then, shards fall back to equal weighting.",
                     "",
                 )
             )

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
     name: Plan CI
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      actions: read
+      contents: read
     outputs:
       classification: ${{ steps.classify.outputs.classification }}
       run-python: ${{ steps.classify.outputs.run-python }}
@@ -38,6 +41,19 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+      - name: Prepare integration timing hint
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          .github/scripts/manage-test-timings prepare
+          --output .ci/test-durations.json
+      - name: Share integration timing hint
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: integration-test-durations-input
+          path: .ci/test-durations.json
+          include-hidden-files: true
+          retention-days: 1
       - id: classify
         name: Classify changed paths
         env:
@@ -109,7 +125,7 @@ jobs:
             pyproject.toml
             uv.lock
       - if: needs.plan.outputs.run-static == 'true'
-        run: uv sync --frozen --dev
+        run: uv sync --locked --dev
       - if: needs.plan.outputs.run-static == 'true'
         run: make lint-full
       - if: needs.plan.outputs.run-static == 'true'
@@ -141,7 +157,7 @@ jobs:
           cache-dependency-glob: |
             pyproject.toml
             uv.lock
-      - run: uv sync --frozen --dev
+      - run: uv sync --locked --dev
       - run: make security-audit
 
   validate-agents-md:
@@ -177,12 +193,12 @@ jobs:
       - uses: ./.github/actions/setup-python-tests
         with:
           python-version: "3.12"
-      - run: >-
-          uv run --frozen pytest
-          -m "not integration and not end_to_end and not lean_runtime"
-          --junitxml=pytest.xml
-          ${{ needs.plan.outputs.run-coverage == 'true' && '--cov --cov-report= --cov-fail-under=0' || '' }}
-          --durations=10
+      - run: make test-core
+        env:
+          PYTEST_ARGS: >-
+            --junitxml=pytest.xml
+            ${{ needs.plan.outputs.run-coverage == 'true' && '--cov --cov-report= --cov-fail-under=0' || '' }}
+            --durations=10
       - if: ${{ !cancelled() }}
         run: uv cache prune --ci
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -203,7 +219,7 @@ jobs:
 
   integration-test:
     name: >-
-      Tests (integration ${{ matrix.shard }} of 3,
+      Tests (integration ${{ matrix.shard }} of 4,
       Python 3.12)
     needs: plan
     if: needs.plan.outputs.run-integration == 'true'
@@ -212,22 +228,36 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3]
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Download integration timing hint
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        with:
+          name: integration-test-durations-input
+          path: .ci
       - uses: ./.github/actions/setup-python-tests
         with:
           python-version: "3.12"
-      - run: >-
-          uv run --frozen pytest
-          -m "(integration or end_to_end) and not lean_runtime"
-          --splits 3
-          --group ${{ matrix.shard }}
-          --splitting-algorithm least_duration
-          --durations-path .test_durations
-          --junitxml=pytest.xml
-          ${{ needs.plan.outputs.run-coverage == 'true' && '--cov --cov-report= --cov-fail-under=0' || '' }}
-          --durations=10
+      - run: make test-integration
+        env:
+          PYTEST_ARGS: >-
+            --splits 4
+            --group ${{ matrix.shard }}
+            --splitting-algorithm least_duration
+            --durations-path .ci/test-durations.json
+            --store-durations
+            --clean-durations
+            --junitxml=pytest.xml
+            ${{ needs.plan.outputs.run-coverage == 'true' && '--cov --cov-report= --cov-fail-under=0' || '' }}
+            --durations=10
+      - name: Upload integration shard timings
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: integration-duration-shard-${{ matrix.shard }}
+          path: .ci/test-durations.json
+          include-hidden-files: true
+          retention-days: 1
       - if: ${{ !cancelled() }}
         run: uv cache prune --ci
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -247,6 +277,38 @@ jobs:
           path: .coverage.integration-${{ matrix.shard }}
           include-hidden-files: true
 
+  publish-test-durations:
+    name: Publish integration test durations
+    if: github.ref == 'refs/heads/main'
+    needs: integration-test
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Download shard timings
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        with:
+          pattern: integration-duration-shard-*
+          path: .ci/shards
+      - name: Merge shard timings
+        run: >-
+          .github/scripts/manage-test-timings merge
+          --input .ci/shards/integration-duration-shard-1/test-durations.json
+          --input .ci/shards/integration-duration-shard-2/test-durations.json
+          --input .ci/shards/integration-duration-shard-3/test-durations.json
+          --input .ci/shards/integration-duration-shard-4/test-durations.json
+          --output .ci/integration-test-durations.json
+          --source-sha "${{ github.sha }}"
+          --python-version "3.12"
+          --pytest-split-version "0.11.0"
+      - name: Publish timing hint
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: integration-test-durations
+          path: .ci/integration-test-durations.json
+          include-hidden-files: true
+          retention-days: 90
+
   compatibility-test:
     name: Exhaustive compatibility (Python 3.13)
     needs: plan
@@ -258,11 +320,9 @@ jobs:
       - uses: ./.github/actions/setup-python-tests
         with:
           python-version: "3.13"
-      - run: >-
-          uv run --frozen pytest
-          -m "not lean_runtime"
-          --junitxml=pytest.xml
-          --durations=10
+      - run: make test
+        env:
+          PYTEST_ARGS: --junitxml=pytest.xml --durations=10
       - if: ${{ !cancelled() }}
         run: uv cache prune --ci
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -394,7 +454,7 @@ jobs:
             pyproject.toml
             uv.lock
       - if: needs.plan.outputs.run-coverage == 'true'
-        run: uv sync --frozen --dev
+        run: uv sync --locked --dev
       - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         if: needs.plan.outputs.run-coverage == 'true'
         with:
@@ -402,12 +462,12 @@ jobs:
           path: coverage-data
           merge-multiple: true
       - if: needs.plan.outputs.run-coverage == 'true'
-        run: uv run --frozen coverage combine coverage-data
+        run: uv run --locked coverage combine coverage-data
       - if: needs.plan.outputs.run-coverage == 'true'
-        run: uv run --frozen coverage report --fail-under=50 | tee coverage-report.txt
+        run: uv run --locked coverage report --fail-under=50 | tee coverage-report.txt
         shell: bash -o pipefail {0}
       - if: needs.plan.outputs.run-coverage == 'true'
-        run: uv run --frozen coverage xml
+        run: uv run --locked coverage xml
       - name: Post coverage summary to PR
         if: >-
           needs.plan.outputs.run-coverage == 'true' &&

--- a/.github/workflows/lean-debug.yml
+++ b/.github/workflows/lean-debug.yml
@@ -45,7 +45,7 @@ jobs:
 
           started=$SECONDS
           set +e
-          uv run --frozen pytest "${args[@]}"
+          uv run --locked pytest "${args[@]}"
           status=$?
           set -e
           echo "| Selected Lean tests | $((SECONDS - started)) |" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/python-debug.yml
+++ b/.github/workflows/python-debug.yml
@@ -46,7 +46,7 @@ jobs:
           cache-dependency-glob: |
             pyproject.toml
             uv.lock
-      - run: uv sync --frozen --dev
+      - run: uv sync --locked --dev
       - name: Run focused Python test
         env:
           TEST_SELECTOR: ${{ inputs.pytest-selector }}
@@ -56,4 +56,4 @@ jobs:
           if [ -n "$TEST_KEYWORD" ]; then
             args+=(-k "$TEST_KEYWORD")
           fi
-          uv run --frozen pytest "${args[@]}"
+          uv run --locked pytest "${args[@]}"

--- a/.github/workflows/scheduled-validation.yml
+++ b/.github/workflows/scheduled-validation.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           python-version: "3.12"
       - run: >-
-          uv run --frozen --with pytest-repeat==0.9.4 pytest
+          uv run --locked --with pytest-repeat==0.9.4 pytest
           -m "(property or stateful) and not lean_runtime"
           --count=3
           --durations=20
@@ -42,7 +42,7 @@ jobs:
         with:
           python-version: "3.12"
       - run: >-
-          uv run --frozen --with pytest-randomly==4.1.0 pytest
+          uv run --locked --with pytest-randomly==4.1.0 pytest
           -m "not lean_runtime"
           --randomly-seed=${{ matrix.seed }}
           --durations=20
@@ -57,7 +57,7 @@ jobs:
         with:
           python-version: "3.12"
       - run: >-
-          uv run --frozen pytest
+          uv run --locked pytest
           -n 0
           -m "external_backend and not lean_runtime"
           --durations=20
@@ -72,7 +72,7 @@ jobs:
         with:
           python-version: "3.12"
       - run: >-
-          uv run --frozen python benchmarks/benchmark_core.py
+          uv run --locked python benchmarks/benchmark_core.py
           --fast
           --output benchmark.json
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ Thumbs.db
 # Python development artifacts
 .coverage
 .coverage.*
+.test_durations*
+.ci/*duration*.json
 coverage.json
 coverage.xml
 .hypothesis/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,8 +64,8 @@ dispatched Python Debug and Lean Debug workflows reproduce one pytest file or
 node in a prepared remote environment when the relevant local runtime is
 impractical.
 
-CI classifies pull requests through the tested source-to-suite ownership
-manifest in `.github/ci-ownership.json`. Documentation-only changes skip
+CI classifies pull requests through the tested source-to-suite impact
+manifest in `.github/ci-impact.json`. Documentation-only changes skip
 Python, npm, Lean, static, package, security, and duplicate-code lanes.
 Documentation plus npm or npm-only changes run npm packaging without the
 Python and Lean lanes. Unknown paths fail closed to all functional lanes.
@@ -76,10 +76,9 @@ add real-Lean validation to an otherwise isolated plan. These overrides only
 add work; labels cannot reduce the fail-closed path classification.
 Pull requests run the canonical Python version. Merge-queue groups and pushes
 to `main` additionally run supported-version compatibility and combined
-coverage as exhaustive gates. Refresh committed integration shard timings with
-`make test-durations` after substantial suite-shape changes.
-When integration timings materially change, run `make test-durations` and
-commit the refreshed `.test_durations` file with the affected tests.
+coverage as exhaustive gates. Successful `main` runs publish fresh integration
+shard timings. Timing history is not committed, and missing or invalid history
+falls back to equal-weight sharding.
 
 For a quick local feedback loop, skip the integration and end-to-end layers:
 
@@ -151,3 +150,17 @@ Keep each change focused on one outcome. Explain the problem, the resulting
 behavior or contract, any compatibility impact, and the validation performed.
 Link a relevant issue when one exists. Include screenshots only when rendered
 layout or diagrams materially change.
+
+## Test ownership and selection
+
+Test directories define semantic ownership: `tests/unit`, `tests/contract`,
+`tests/checkers`, and `tests/reference` form the core suite, while
+`tests/integration` and `tests/end_to_end` form the integration suite. Use
+`make test-core` and `make test-integration` as the canonical entry points.
+Markers describe runtime traits such as `lean_runtime`, `slow`, `subprocess`, or
+`external_backend`; they do not duplicate directory ownership.
+
+CI change impact is declared in `.github/ci-impact.json`. Its matching rules are
+additive, so a path may require several suites. Integration timing history is a
+scheduling hint produced by successful `main` runs; it is not committed state,
+and missing or invalid history falls back to equal-weight sharding.

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
 .DEFAULT_GOAL := help
 
-UV_RUN := uv run --frozen
+UV_RUN := uv run --locked
 PYTEST_ARGS ?=
 TESTS ?=
 EVAL_ARGS ?=
+CORE_TEST_PATHS := tests/unit tests/contract tests/checkers tests/reference
+INTEGRATION_TEST_PATHS := tests/integration tests/end_to_end
 
-.PHONY: help setup hooks fix lint lint-full typecheck test test-fast test-contracts test-checkers test-mcp test-storage test-lean test-failed test-durations build check check-static validate-full agent-eval
+.PHONY: help setup hooks fix lint lint-full typecheck test test-fast test-core test-integration test-contracts test-checkers test-mcp test-storage test-lean test-failed build check check-static validate-full agent-eval
 
 help: ## Show available developer commands.
 	@awk 'BEGIN {FS = ":.*## "; printf "Jacobian developer commands:\n\n"} /^[a-zA-Z_-]+:.*## / {printf "  %-18s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -37,9 +39,17 @@ typecheck: ## Run strict static type checking.
 test: ## Run tests; narrow with TESTS=... and PYTEST_ARGS=....
 	$(UV_RUN) pytest -m "not lean_runtime" $(TESTS) $(PYTEST_ARGS)
 
-test-fast: ## Run the sequential non-integration feedback loop.
-	$(UV_RUN) pytest -n 0 -m "not integration and not end_to_end and not lean_runtime" \
-		tests/unit tests/contract tests/checkers tests/reference $(PYTEST_ARGS)
+test-fast: ## Run the sequential core feedback loop.
+	$(UV_RUN) pytest -n 0 -m "not lean_runtime" \
+		$(if $(TESTS),$(TESTS),$(CORE_TEST_PATHS)) $(PYTEST_ARGS)
+
+test-core: ## Run the directory-owned core suites.
+	$(UV_RUN) pytest -m "not lean_runtime" \
+		$(if $(TESTS),$(TESTS),$(CORE_TEST_PATHS)) $(PYTEST_ARGS)
+
+test-integration: ## Run the directory-owned integration suites.
+	$(UV_RUN) pytest -m "not lean_runtime" \
+		$(if $(TESTS),$(TESTS),$(INTEGRATION_TEST_PATHS)) $(PYTEST_ARGS)
 
 test-contracts: ## Run contract tests.
 	$(UV_RUN) pytest -n 0 tests/contract $(PYTEST_ARGS)
@@ -62,12 +72,6 @@ test-lean: ## Run pinned Lean tests serially; narrow with TESTS=... and PYTEST_A
 
 test-failed: ## Re-run failures from the previous pytest invocation.
 	$(UV_RUN) pytest --lf -m "not lean_runtime" $(PYTEST_ARGS)
-
-test-durations: ## Refresh committed integration shard timings for pytest-split.
-	$(UV_RUN) pytest \
-		-m "(integration or end_to_end) and not lean_runtime" \
-		--store-durations --clean-durations --durations-path .test_durations \
-		$(PYTEST_ARGS)
 
 build: ## Build Python source and wheel distributions.
 	uv build

--- a/docs/contributing/test-suite-cost-audit.md
+++ b/docs/contributing/test-suite-cost-audit.md
@@ -1,5 +1,9 @@
 # Test-suite cost audit
 
+> **Historical baseline.** Counts and timings below describe the audit snapshot,
+> not current mutable scheduling state. CI timing hints now come from successful
+> `main` artifacts and may be absent without affecting test selection.
+
 [Documentation home](../index.md)
 
 This audit records the 2026-07-26 local measurements used to restore a short
@@ -121,7 +125,7 @@ and Lean debug workflows provide
 remote reproduction without rerunning unrelated matrices. On the measured
 host, the resulting `make check` completed 256 selected tests in 8.36 seconds.
 
-Source-to-suite ownership is declared in `.github/ci-ownership.json` and tested
+Source-to-suite impact is declared in `.github/ci-impact.json` and tested
 against tracked source files. Unknown paths still fail closed. Each CI run
 reports workflow elapsed time (the observable critical path), summed runner
 minutes, and its longest job, making both reviewer latency and compute growth
@@ -140,11 +144,10 @@ parallel and were not on the measured critical path. Consolidating them would
 increase workflow coupling without materially shortening feedback, so this
 audit leaves them unchanged.
 
-Committed `.test_durations` feeds `pytest-split`'s least-duration algorithm for
-the three integration shards. Refresh with `make test-durations` after large
-suite-shape changes; CI metrics report max/min shard skew and remind
-maintainers when it exceeds 1.5x. Unknown tests receive the recorded average
-duration until the next refresh.
+An ephemeral timing artifact feeds `pytest-split`'s least-duration algorithm
+for the four integration shards. Successful `main` runs publish fresh history;
+missing or invalid history falls back to equal weighting. CI metrics report
+max/min shard skew and flag ratios above 1.5x.
 
 Do not stack a local duration refresh, full integration profiling, and focused
 module debugging on the same host at once. That contention recreates the

--- a/docs/reference/testing-strategy.md
+++ b/docs/reference/testing-strategy.md
@@ -2,6 +2,29 @@
 
 [Documentation home](../index.md)
 
+## Ownership model
+
+The suite separates five concerns that previously overlapped:
+
+| Concern | Authority |
+| --- | --- |
+| Semantic ownership | Test directories |
+| Runtime traits | Pytest markers |
+| Change impact | `.github/ci-impact.json` |
+| Canonical execution | Make targets |
+| Shard scheduling | Ephemeral integration timing artifact |
+
+A test's directory answers what kind of behavior it owns. A marker answers how
+that test must run. The CI impact manifest maps changed paths to every affected
+suite, with additive matches and a fail-closed fallback. Make targets keep local
+and hosted execution aligned. Timing data affects scheduling only: successful
+`main` runs publish it, consumers validate it, and any absence or corruption
+falls back to equal weighting without changing which tests run.
+
+The canonical local commands are `make test-core`, `make test-integration`,
+`make test-lean`, and `make test`. `make test-fast` is the sequential core
+feedback loop.
+
 ## Purpose
 
 Jacobian is a mathematical capability toolbox with a fail-closed verification
@@ -41,7 +64,6 @@ make test-checkers
 make test-mcp PYTEST_ARGS="-k authentication"
 make test-storage PYTEST_ARGS="-k workspace"
 make test-lean TESTS=tests/integration/test_lean.py PYTEST_ARGS="-k induction"
-make test-durations
 make check
 make check-static
 make validate-full
@@ -87,10 +109,10 @@ expanding the fast loop.
 Pull-request CI divides the non-Lean suite into two semantic lanes on the
 canonical Python version. The `core` lane contains unit, contract, checker, and
 reference tests. The `integration` lane contains integration and end-to-end
-tests, split across three runners with committed `pytest-split` timings
-(`.test_durations`, algorithm `least_duration`). Refresh those timings with
-`make test-durations` after substantial suite-shape changes; unknown tests
-receive the recorded average duration. Each shard then uses xdist's live
+tests, split across four runners with an ephemeral `pytest-split` timing
+artifact (algorithm `least_duration`). Successful `main` runs publish fresh
+history; missing or invalid history falls back to equal weighting. Each shard
+then uses xdist's live
 `worksteal` scheduler with at most four workers. Merge-queue groups and pushes
 to `main` additionally run the second supported Python version as an exhaustive
 compatibility lane and enable combined coverage. A shared test setup action
@@ -123,7 +145,7 @@ Measured costs and lane policy are recorded in the
 [test-suite cost audit](../contributing/test-suite-cost-audit.md).
 
 For pull requests, a tested path planner reads
-[`.github/ci-ownership.json`](../../.github/ci-ownership.json) and makes
+[`.github/ci-impact.json`](../../.github/ci-impact.json) and makes
 independent core Python, integration Python, Lean, npm, static, build,
 security, and duplicate-code decisions. Documentation-only and npm-only changes
 stay narrow. Ordinary capability source stays on core + integration + static +

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,11 +65,8 @@ addopts = "-ra --strict-config --strict-markers -n auto --maxprocesses=4 --dist=
 testpaths = ["tests"]
 timeout = 120
 markers = [
-    "contract: public wire and Python contract tests",
     "property: property-based invariant tests",
     "stateful: persistent lifecycle state-machine tests",
-    "integration: real filesystem, SQLite, or process-boundary tests",
-    "end_to_end: complete user-visible research-kernel workflows",
     "subprocess: clean-process replay tests",
     "conformance: normative release conformance cases",
     "differential: independent implementation comparisons",

--- a/tests/checkers/test_erdos_straus_checker.py
+++ b/tests/checkers/test_erdos_straus_checker.py
@@ -50,7 +50,6 @@ def _request(
     }
 
 
-@pytest.mark.contract
 def test_checker_accepts_complete_exact_table() -> None:
     decision = check_decomposition_table(
         _request(
@@ -67,7 +66,6 @@ def test_checker_accepts_complete_exact_table() -> None:
     assert decision["coverage"] == "EXHAUSTIVE"
 
 
-@pytest.mark.contract
 @pytest.mark.parametrize(
     "table",
     [
@@ -97,7 +95,6 @@ def test_checker_rejects_incomplete_invalid_or_duplicate_table(
     assert decision["conclusion"] == "UNKNOWN"
 
 
-@pytest.mark.contract
 def test_checker_rejects_range_substitution() -> None:
     request = _request(
         [

--- a/tests/checkers/test_graph_checkers.py
+++ b/tests/checkers/test_graph_checkers.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import pytest
-
 from jacobian_checkers.graph_paths import (
     check_odd_cycle,
     check_path_enumeration,
@@ -9,7 +7,6 @@ from jacobian_checkers.graph_paths import (
 )
 
 
-@pytest.mark.contract
 def test_odd_cycle_checker_rejects_even_cycle() -> None:
     decision = check_odd_cycle(
         _graph_witness_request(
@@ -24,7 +21,6 @@ def test_odd_cycle_checker_rejects_even_cycle() -> None:
     assert decision["accepted"] is False
 
 
-@pytest.mark.contract
 def test_two_coloring_checker_requires_every_vertex() -> None:
     decision = check_two_coloring(
         _graph_witness_request(
@@ -39,7 +35,6 @@ def test_two_coloring_checker_requires_every_vertex() -> None:
     assert decision["accepted"] is False
 
 
-@pytest.mark.contract
 def test_two_coloring_checker_rejects_boolean_colors() -> None:
     decision = check_two_coloring(
         _graph_witness_request(
@@ -54,7 +49,6 @@ def test_two_coloring_checker_rejects_boolean_colors() -> None:
     assert decision["accepted"] is False
 
 
-@pytest.mark.contract
 def test_path_enumeration_continues_through_intermediate_terminal() -> None:
     bindings = {
         "claim_digest": "sha256:" + "a" * 64,

--- a/tests/checkers/test_matrix_checkers.py
+++ b/tests/checkers/test_matrix_checkers.py
@@ -10,7 +10,6 @@ from jacobian_checkers.matrices import (
 )
 
 
-@pytest.mark.contract
 def test_kernel_checker_accepts_exact_nonzero_vector() -> None:
     decision = check_kernel_vector(
         _witness_request(
@@ -30,7 +29,6 @@ def test_kernel_checker_accepts_exact_nonzero_vector() -> None:
     assert decision["conclusion"] == "FALSE"
 
 
-@pytest.mark.contract
 def test_kernel_checker_rejects_zero_vector() -> None:
     decision = check_kernel_vector(
         _witness_request(
@@ -49,7 +47,6 @@ def test_kernel_checker_rejects_zero_vector() -> None:
     assert decision["accepted"] is False
 
 
-@pytest.mark.contract
 def test_maxdet_checker_replays_all_512_matrices() -> None:
     bindings = {
         "claim_digest": "sha256:" + "a" * 64,
@@ -102,7 +99,6 @@ def test_maxdet_checker_replays_all_512_matrices() -> None:
     assert decision["coverage"] == "EXHAUSTIVE"
 
 
-@pytest.mark.contract
 def test_maximizer_witness_checker_replays_scope() -> None:
     bindings = {
         "claim_digest": "sha256:" + "a" * 64,
@@ -152,7 +148,6 @@ def test_maximizer_witness_checker_replays_scope() -> None:
     assert decision["coverage"] == "EXHAUSTIVE"
 
 
-@pytest.mark.contract
 def test_maximizer_witness_checker_accepts_an_alternative_bound_maximizer() -> None:
     bindings = _bindings()
     proposed = {
@@ -180,7 +175,6 @@ def test_maximizer_witness_checker_accepts_an_alternative_bound_maximizer() -> N
     assert decision["conclusion"] == "TRUE"
 
 
-@pytest.mark.contract
 def test_maximizer_witness_checker_rejects_nonmaximal_bound_candidate() -> None:
     bindings = {
         "claim_digest": "sha256:" + "a" * 64,
@@ -234,7 +228,6 @@ def test_maximizer_witness_checker_rejects_nonmaximal_bound_candidate() -> None:
     assert decision["accepted"] is False
 
 
-@pytest.mark.contract
 def test_maximizer_witness_checker_replays_all_65536_matrices() -> None:
     matrix = {
         "rows": 4,
@@ -261,7 +254,6 @@ def test_maximizer_witness_checker_replays_all_65536_matrices() -> None:
     assert decision["detail"] == "replayed all 65536 matrices in the declared scope"
 
 
-@pytest.mark.contract
 def test_maximizer_witness_checker_rejects_over_budget_before_enumeration(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,11 +9,6 @@ import pytest
 
 from jacobian.kernel import JacobianKernel
 
-_LAYER_MARKERS = {
-    "integration": pytest.mark.integration,
-    "end_to_end": pytest.mark.end_to_end,
-}
-
 
 def _freeze_kernel_store(root: Path) -> None:
     """Checkpoint the template database and remove its volatile WAL files."""
@@ -104,23 +99,7 @@ def pytest_collection_modifyitems(
     config: pytest.Config,
     items: list[pytest.Item],
 ) -> None:
-    """Keep layer markers aligned and reject unsafe parallel Lean execution."""
-
-    tests_root = Path(__file__).parent
-    for item in items:
-        try:
-            layer = Path(item.path).relative_to(tests_root).parts[0]
-        except ValueError:
-            msg = (
-                f"test {item.nodeid} is not under {tests_root}; "
-                "layer markers cannot be assigned safely"
-            )
-            raise pytest.UsageError(msg) from None
-        except IndexError:
-            continue
-        marker = _LAYER_MARKERS.get(layer)
-        if marker is not None:
-            item.add_marker(marker)
+    """Reject unsafe parallel Lean execution."""
 
     workers = config.getoption("numprocesses", default=None)
     if workers in (None, 0, "0"):

--- a/tests/contract/test_canonical_json.py
+++ b/tests/contract/test_canonical_json.py
@@ -13,7 +13,6 @@ from jacobian.canonical import (
 from jacobian.contracts.exact import CanonicalRational
 
 
-@pytest.mark.contract
 def test_equivalent_rationals_have_identical_canonical_bytes() -> None:
     first = canonicalize_json({"weight": {"num": "2", "den": "4"}})
     second = canonicalize_json({"weight": {"num": "1", "den": "2"}})
@@ -21,7 +20,6 @@ def test_equivalent_rationals_have_identical_canonical_bytes() -> None:
     assert first == second == b'{"weight":{"den":"2","num":"1"}}'
 
 
-@pytest.mark.contract
 @pytest.mark.parametrize(
     "value",
     [
@@ -35,7 +33,6 @@ def test_ambiguous_or_inexact_json_is_rejected(value: object) -> None:
         canonicalize_json(value)
 
 
-@pytest.mark.contract
 @pytest.mark.parametrize(
     ("value", "message"),
     [
@@ -59,20 +56,17 @@ def test_canonical_errors_preserve_only_repair_relevant_context(
     assert "tuple" not in str(raised.value)
 
 
-@pytest.mark.contract
 def test_canonical_rational_wire_model_rejects_unreduced_input() -> None:
     with pytest.raises(ValidationError):
         CanonicalRational.model_validate({"num": "2", "den": "4"})
 
 
-@pytest.mark.contract
 def test_num_den_is_a_reserved_exact_rational_shape() -> None:
     assert canonicalize_json({"num": "2", "den": "4"}) == canonicalize_json(
         {"num": "1", "den": "2"}
     )
 
 
-@pytest.mark.contract
 def test_num_den_schema_property_map_is_regular_json() -> None:
     encoded = canonicalize_json(
         {
@@ -84,7 +78,6 @@ def test_num_den_schema_property_map_is_regular_json() -> None:
     assert encoded == b'{"den":{"type":"string"},"num":{"type":"string"}}'
 
 
-@pytest.mark.contract
 def test_unicode_bom_and_non_json_tuples_are_rejected() -> None:
     with pytest.raises(CanonicalizationError):
         canonicalize_json(b'\xef\xbb\xbf{"value":1}')
@@ -92,7 +85,6 @@ def test_unicode_bom_and_non_json_tuples_are_rejected() -> None:
         canonicalize_json({"value": (1, 2)})
 
 
-@pytest.mark.contract
 @pytest.mark.conformance
 def test_nesting_beyond_the_configured_limit_is_rejected() -> None:
     with pytest.raises(CanonicalizationError, match="depth"):
@@ -102,7 +94,6 @@ def test_nesting_beyond_the_configured_limit_is_rejected() -> None:
         )
 
 
-@pytest.mark.contract
 @pytest.mark.property
 @given(
     numerator=st.integers(min_value=-(10**100), max_value=10**100),

--- a/tests/contract/test_capability_contracts.py
+++ b/tests/contract/test_capability_contracts.py
@@ -21,7 +21,6 @@ from jacobian.contracts.results import Execution, ExecutionStatus
 RECORD_URI = "artifact://sha256/" + "a" * 64
 
 
-@pytest.mark.contract
 def test_explore_lane_cannot_claim_verified_assurance() -> None:
     with pytest.raises(ValidationError, match="exploration lane"):
         CapabilityResult(
@@ -37,7 +36,6 @@ def test_explore_lane_cannot_claim_verified_assurance() -> None:
         )
 
 
-@pytest.mark.contract
 def test_nonverified_assurance_cannot_smuggle_a_record_uri() -> None:
     with pytest.raises(ValidationError, match="only verified"):
         CapabilityAssurance(
@@ -47,7 +45,6 @@ def test_nonverified_assurance_cannot_smuggle_a_record_uri() -> None:
         )
 
 
-@pytest.mark.contract
 def test_complete_result_requires_an_explicit_scope() -> None:
     with pytest.raises(
         ValidationError, match="complete result requires explicit scope"
@@ -69,7 +66,6 @@ def test_complete_result_requires_an_explicit_scope() -> None:
         )
 
 
-@pytest.mark.contract
 def test_failed_execution_cannot_claim_completeness() -> None:
     with pytest.raises(ValidationError, match="failed execution cannot be complete"):
         CapabilityResult(
@@ -93,7 +89,6 @@ def test_failed_execution_cannot_claim_completeness() -> None:
         )
 
 
-@pytest.mark.contract
 def test_verified_relationship_must_use_result_checker_record() -> None:
     other_record = "artifact://sha256/" + "b" * 64
     with pytest.raises(
@@ -122,7 +117,6 @@ def test_verified_relationship_must_use_result_checker_record() -> None:
         )
 
 
-@pytest.mark.contract
 def test_discharged_obligation_requires_verified_result() -> None:
     with pytest.raises(
         ValidationError,

--- a/tests/contract/test_checker_dependency_boundary.py
+++ b/tests/contract/test_checker_dependency_boundary.py
@@ -14,7 +14,6 @@ _FORBIDDEN_PREFIXES = (
 )
 
 
-@pytest.mark.contract
 @pytest.mark.conformance
 def test_independent_checkers_do_not_import_search_implementations() -> None:
     checker_root = Path("src/jacobian_checkers")

--- a/tests/contract/test_evidence_contracts.py
+++ b/tests/contract/test_evidence_contracts.py
@@ -9,7 +9,6 @@ from jacobian.canonical import canonicalize_json
 from jacobian.contracts.evidence import CertificateEnvelope
 
 
-@pytest.mark.contract
 @pytest.mark.conformance
 def test_certificate_payload_must_match_its_declared_digest() -> None:
     original_payload = {"rows": [{"candidate": "0", "value": "1"}]}

--- a/tests/contract/test_graph_shrinking_contracts.py
+++ b/tests/contract/test_graph_shrinking_contracts.py
@@ -13,7 +13,6 @@ _ARTIFACT_URI = "artifact://sha256/" + "1" * 64
 _CHECKER_URI = "checker://sha256/" + "2" * 64
 
 
-@pytest.mark.contract
 def test_graph_shrink_request_requires_a_registered_checker_and_reducer() -> None:
     with pytest.raises(ValidationError):
         GraphCounterexampleShrinkRequest(
@@ -25,7 +24,6 @@ def test_graph_shrink_request_requires_a_registered_checker_and_reducer() -> Non
         )
 
 
-@pytest.mark.contract
 def test_graph_shrink_contract_cannot_claim_unchecked_local_minimality() -> None:
     with pytest.raises(ValidationError):
         GraphLocalMinimalityScope(
@@ -37,7 +35,6 @@ def test_graph_shrink_contract_cannot_claim_unchecked_local_minimality() -> None
         )
 
 
-@pytest.mark.contract
 def test_accepted_graph_reduction_requires_verification_record() -> None:
     with pytest.raises(ValidationError):
         GraphReductionAttempt(

--- a/tests/contract/test_lean_replayable_state_contracts.py
+++ b/tests/contract/test_lean_replayable_state_contracts.py
@@ -12,7 +12,6 @@ STATE_URI = "artifact://sha256/" + "a" * 64
 DIGEST = "sha256:" + "b" * 64
 
 
-@pytest.mark.contract
 def test_state_request_accepts_uri_without_replacement_source() -> None:
     request = LeanProofStateRequest(state_uri=STATE_URI, tactic="constructor")
 
@@ -20,7 +19,6 @@ def test_state_request_accepts_uri_without_replacement_source() -> None:
     assert request.proof_prefix == ()
 
 
-@pytest.mark.contract
 def test_state_request_rejects_uri_with_replacement_prefix() -> None:
     with pytest.raises(ValidationError, match="cannot be combined"):
         LeanProofStateRequest(
@@ -30,7 +28,6 @@ def test_state_request_rejects_uri_with_replacement_prefix() -> None:
         )
 
 
-@pytest.mark.contract
 def test_state_artifact_binds_completion_to_normalized_goals() -> None:
     with pytest.raises(ValidationError, match="completion"):
         LeanProofStateArtifact(

--- a/tests/contract/test_lean_statement_contracts.py
+++ b/tests/contract/test_lean_statement_contracts.py
@@ -21,7 +21,6 @@ DIGEST = "sha256:" + "b" * 64
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.contract
 def test_proposal_request_rejects_multiline_statement() -> None:
     with pytest.raises(ValidationError, match="one Lean expression"):
         LeanStatementProposalRequest(
@@ -30,7 +29,6 @@ def test_proposal_request_rejects_multiline_statement() -> None:
         )
 
 
-@pytest.mark.contract
 def test_proposal_request_rejects_declaration_syntax() -> None:
     with pytest.raises(ValidationError, match=":="):
         LeanStatementProposalRequest(
@@ -39,7 +37,6 @@ def test_proposal_request_rejects_declaration_syntax() -> None:
         )
 
 
-@pytest.mark.contract
 def test_proposal_request_accepts_valid_input() -> None:
     req = LeanStatementProposalRequest(
         informal_claim="one plus one equals two",
@@ -50,7 +47,6 @@ def test_proposal_request_accepts_valid_input() -> None:
     assert req.source_locator == "https://example.com/claim"
 
 
-@pytest.mark.contract
 def test_direct_elaboration_does_not_require_informal_claim() -> None:
     request = LeanStatementProposalRequest(
         operation="ELABORATE_PROPOSITION",
@@ -60,7 +56,6 @@ def test_direct_elaboration_does_not_require_informal_claim() -> None:
     assert request.informal_claim is None
 
 
-@pytest.mark.contract
 def test_direct_elaboration_rejects_informal_claim() -> None:
     with pytest.raises(ValidationError, match="must be omitted"):
         LeanStatementProposalRequest(
@@ -75,7 +70,6 @@ def test_direct_elaboration_rejects_informal_claim() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.contract
 def test_proposal_artifact_requires_sorry_when_elaborates() -> None:
     with pytest.raises(ValidationError, match="at least one sorry"):
         LeanStatementProposalArtifact(
@@ -92,7 +86,6 @@ def test_proposal_artifact_requires_sorry_when_elaborates() -> None:
         )
 
 
-@pytest.mark.contract
 def test_proposal_artifact_accepts_non_elaborating_with_zero_sorry() -> None:
     artifact = LeanStatementProposalArtifact(
         environment="CORE",
@@ -110,7 +103,6 @@ def test_proposal_artifact_accepts_non_elaborating_with_zero_sorry() -> None:
     assert artifact.sorry_count == 0
 
 
-@pytest.mark.contract
 def test_direct_elaboration_artifact_requires_expression_on_success() -> None:
     with pytest.raises(ValidationError, match="return an expression"):
         LeanStatementProposalArtifact(
@@ -132,7 +124,6 @@ def test_direct_elaboration_artifact_requires_expression_on_success() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.contract
 def test_comparison_request_rejects_multiline_statement_a() -> None:
     with pytest.raises(ValidationError, match="statement_a"):
         LeanStatementComparisonRequest(
@@ -141,7 +132,6 @@ def test_comparison_request_rejects_multiline_statement_a() -> None:
         )
 
 
-@pytest.mark.contract
 def test_comparison_request_rejects_declaration_in_statement_b() -> None:
     with pytest.raises(ValidationError, match="statement_b"):
         LeanStatementComparisonRequest(
@@ -150,7 +140,6 @@ def test_comparison_request_rejects_declaration_in_statement_b() -> None:
         )
 
 
-@pytest.mark.contract
 def test_comparison_request_accepts_axiom_sets() -> None:
     req = LeanStatementComparisonRequest(
         statement_a="True",
@@ -166,7 +155,6 @@ def test_comparison_request_accepts_axiom_sets() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.contract
 def test_comparison_artifact_rejects_both_elaborate_without_check() -> None:
     with pytest.raises(ValidationError, match="both_elaborate"):
         LeanStatementComparisonArtifact(
@@ -186,7 +174,6 @@ def test_comparison_artifact_rejects_both_elaborate_without_check() -> None:
         )
 
 
-@pytest.mark.contract
 def test_comparison_artifact_accepts_no_elaboration_when_unchecked() -> None:
     artifact = LeanStatementComparisonArtifact(
         environment="CORE",

--- a/tests/contract/test_plugin_manifest.py
+++ b/tests/contract/test_plugin_manifest.py
@@ -6,7 +6,6 @@ from pydantic import ValidationError
 from jacobian.contracts.plugins import PluginManifest
 
 
-@pytest.mark.contract
 @pytest.mark.conformance
 def test_plugin_manifest_cannot_declare_trusted_checkers() -> None:
     digest = "a" * 64

--- a/tests/contract/test_result_envelope.py
+++ b/tests/contract/test_result_envelope.py
@@ -7,7 +7,6 @@ from jacobian.contracts.checkers import CheckerDecision
 from jacobian.contracts.results import ResultEnvelope, validate_result_envelope
 
 
-@pytest.mark.contract
 def test_timeout_cannot_carry_a_verified_false_conclusion() -> None:
     with pytest.raises(ValidationError):
         ResultEnvelope.model_validate(
@@ -29,7 +28,6 @@ def test_timeout_cannot_carry_a_verified_false_conclusion() -> None:
         )
 
 
-@pytest.mark.contract
 def test_timeout_is_represented_as_unknown_unverified_execution() -> None:
     result = ResultEnvelope.model_validate(
         {
@@ -49,7 +47,6 @@ def test_timeout_is_represented_as_unknown_unverified_execution() -> None:
     assert result.model_dump(mode="json")["execution"]["status"] == "TIMEOUT"
 
 
-@pytest.mark.contract
 @pytest.mark.parametrize(
     ("conclusion", "arithmetic", "method", "coverage"),
     [
@@ -77,7 +74,6 @@ def test_verified_result_rejects_non_replayable_assurance(
         )
 
 
-@pytest.mark.contract
 def test_verified_result_requires_claim_and_semantics_bindings() -> None:
     for missing in ("claim_digest", "semantics_digest"):
         payload = _verified_result()
@@ -86,7 +82,6 @@ def test_verified_result_requires_claim_and_semantics_bindings() -> None:
             ResultEnvelope.model_validate(payload)
 
 
-@pytest.mark.contract
 @pytest.mark.parametrize("method", ["DIRECT_WITNESS", "EXHAUSTIVE_FINITE"])
 def test_verified_result_requires_candidate_binding(method: str) -> None:
     payload = _verified_result(
@@ -99,7 +94,6 @@ def test_verified_result_requires_candidate_binding(method: str) -> None:
         ResultEnvelope.model_validate(payload)
 
 
-@pytest.mark.contract
 @pytest.mark.parametrize(
     ("arithmetic", "coverage"),
     [
@@ -133,7 +127,6 @@ def test_checked_certificates_support_non_rational_proof_mechanisms(
     assert decision.accepted is True
 
 
-@pytest.mark.contract
 def test_trust_boundary_revalidates_model_construct_instances() -> None:
     malformed = ResultEnvelope.model_construct(
         **_verified_result(
@@ -146,7 +139,6 @@ def test_trust_boundary_revalidates_model_construct_instances() -> None:
         validate_result_envelope(malformed)
 
 
-@pytest.mark.contract
 def test_checker_relationship_requires_exact_artifact_endpoints() -> None:
     decision = {
         "accepted": True,

--- a/tests/contract/test_sat_contracts.py
+++ b/tests/contract/test_sat_contracts.py
@@ -57,7 +57,6 @@ def _binding(*, variable_count: int = 2) -> SatCnfBinding:
     )
 
 
-@pytest.mark.contract
 def test_cnf_canonicalization_normalizes_map_literals_clauses_and_tautologies() -> None:
     first = canonicalize_cnf(
         variable_names=("b", "a"),
@@ -79,7 +78,6 @@ def test_cnf_canonicalization_normalizes_map_literals_clauses_and_tautologies() 
     assert first.dimacs_digest.startswith("sha256:")
 
 
-@pytest.mark.contract
 @pytest.mark.parametrize(
     ("mutation", "message"),
     (
@@ -116,7 +114,6 @@ def test_canonical_cnf_rejects_noncanonical_or_misbound_payloads(
         CanonicalCnf.model_validate(payload)
 
 
-@pytest.mark.contract
 def test_cnf_canonicalization_rejects_invalid_variable_maps_and_literals() -> None:
     with pytest.raises(ValueError, match="variable names must be unique"):
         canonicalize_cnf(variable_names=("x", "x"), clauses=((1,),))
@@ -126,7 +123,6 @@ def test_cnf_canonicalization_rejects_invalid_variable_maps_and_literals() -> No
         canonicalize_cnf(variable_names=("x",), clauses=((2,),))
 
 
-@pytest.mark.contract
 def test_assignment_is_total_strict_and_cannot_claim_verification() -> None:
     assignment = SatAssignmentArtifact(
         cnf=_binding(),
@@ -152,7 +148,6 @@ def test_assignment_is_total_strict_and_cannot_claim_verification() -> None:
         SatAssignmentArtifact.model_validate(payload)
 
 
-@pytest.mark.contract
 def test_assignment_and_proof_require_an_available_exact_producer() -> None:
     unavailable = _producer().model_copy(
         update={
@@ -184,7 +179,6 @@ def test_assignment_and_proof_require_an_available_exact_producer() -> None:
         SatProofArtifact.model_validate(proof)
 
 
-@pytest.mark.contract
 def test_proof_preserves_exact_bytes_and_rejects_digest_or_encoding_mutation() -> None:
     proof = SatProofArtifact.from_bytes(
         cnf=_binding(),
@@ -208,7 +202,6 @@ def test_proof_preserves_exact_bytes_and_rejects_digest_or_encoding_mutation() -
         SatProofArtifact.model_validate(payload)
 
 
-@pytest.mark.contract
 def test_binding_and_budget_fields_are_required_and_fail_closed() -> None:
     assignment = SatAssignmentArtifact(
         cnf=_binding(),
@@ -235,7 +228,6 @@ def test_binding_and_budget_fields_are_required_and_fail_closed() -> None:
         SatAssignmentArtifact.model_validate(assignment)
 
 
-@pytest.mark.contract
 def test_exploration_request_exposes_only_enforced_budget_fields() -> None:
     request = SatExplorationRequest.model_validate(
         {
@@ -270,7 +262,6 @@ def test_exploration_request_exposes_only_enforced_budget_fields() -> None:
         )
 
 
-@pytest.mark.contract
 def test_exploration_outputs_never_project_a_solver_status_as_a_conclusion() -> None:
     model = SatModelFindOutput(
         status="NO_ASSIGNMENT_PRODUCED",

--- a/tests/contract/test_schema_registry.py
+++ b/tests/contract/test_schema_registry.py
@@ -30,7 +30,6 @@ class _OrderedPair(BaseModel):
         return self
 
 
-@pytest.mark.contract
 def test_cached_model_schema_returns_independent_copies(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -50,7 +49,6 @@ def test_cached_model_schema_returns_independent_copies(
     assert second["title"] == "_CachedSchemaModel"
 
 
-@pytest.mark.contract
 def test_external_dynamic_reference_is_rejected(tmp_path: Path) -> None:
     registry = SchemaRegistry(ArtifactStore(tmp_path))
 
@@ -62,7 +60,6 @@ def test_external_dynamic_reference_is_rejected(tmp_path: Path) -> None:
         )
 
 
-@pytest.mark.contract
 def test_schema_validator_cache_is_bound_to_canonical_schema(
     tmp_path: Path,
 ) -> None:
@@ -83,7 +80,6 @@ def test_schema_validator_cache_is_bound_to_canonical_schema(
         registry.validate(string_schema, {"value": 1})
 
 
-@pytest.mark.contract
 def test_model_backed_schema_applies_cross_field_contracts(
     tmp_path: Path,
 ) -> None:

--- a/tests/contract/test_v02_discovery_contracts.py
+++ b/tests/contract/test_v02_discovery_contracts.py
@@ -14,7 +14,6 @@ from jacobian.contracts.polytope import (
 )
 
 
-@pytest.mark.contract
 def test_incomplete_enumeration_page_requires_a_progress_cursor() -> None:
     with pytest.raises(ValidationError, match="next_cursor"):
         PluginEnumerationPage(
@@ -24,7 +23,6 @@ def test_incomplete_enumeration_page_requires_a_progress_cursor() -> None:
         )
 
 
-@pytest.mark.contract
 def test_complete_enumeration_page_rejects_a_cursor() -> None:
     with pytest.raises(ValidationError, match="cannot carry next_cursor"):
         PluginEnumerationPage(
@@ -35,7 +33,6 @@ def test_complete_enumeration_page_rejects_a_cursor() -> None:
         )
 
 
-@pytest.mark.contract
 def test_polytope_inputs_require_canonical_exact_rationals() -> None:
     with pytest.raises(ValidationError, match="reduced"):
         FiniteGeneratorSet(
@@ -44,7 +41,6 @@ def test_polytope_inputs_require_canonical_exact_rationals() -> None:
         )
 
 
-@pytest.mark.contract
 def test_polytope_projection_rejects_duplicate_coordinates() -> None:
     with pytest.raises(ValidationError, match="unique"):
         PolytopeSeparateRequest(
@@ -54,7 +50,6 @@ def test_polytope_projection_rejects_duplicate_coordinates() -> None:
         )
 
 
-@pytest.mark.contract
 def test_exhaustive_snapshot_requires_complete_enumerator_report() -> None:
     with pytest.raises(ValidationError, match="complete enumerator"):
         ExperimentSnapshot(
@@ -79,7 +74,6 @@ def test_exhaustive_snapshot_requires_complete_enumerator_report() -> None:
         )
 
 
-@pytest.mark.contract
 def test_terminal_experiment_state_requires_its_matching_stop_reason() -> None:
     with pytest.raises(ValidationError, match="state and stop reason disagree"):
         ExperimentSnapshot(

--- a/tests/contract/test_witness_and_shrink_results.py
+++ b/tests/contract/test_witness_and_shrink_results.py
@@ -40,7 +40,6 @@ def _verified_result(*, evidence_uri: str) -> dict[str, object]:
     }
 
 
-@pytest.mark.contract
 def test_none_certified_requires_the_named_certificate_to_be_verified() -> None:
     named_certificate = _uri("f")
     other_evidence = _uri("1")
@@ -58,7 +57,6 @@ def test_none_certified_requires_the_named_certificate_to_be_verified() -> None:
         )
 
 
-@pytest.mark.contract
 def test_plugin_may_only_propose_none_certified_with_a_certificate() -> None:
     with pytest.raises(ValidationError):
         PluginWitnessResponse.model_validate(
@@ -80,7 +78,6 @@ def test_plugin_may_only_propose_none_certified_with_a_certificate() -> None:
     assert proposed.certificate_uri == _uri("7")
 
 
-@pytest.mark.contract
 @pytest.mark.parametrize("minimality", ["ONE_STEP", "BOUNDED_GLOBAL", "PROVED_GLOBAL"])
 def test_v01_rejects_unsupported_minimality_claims(minimality: str) -> None:
     final_target = _uri("5")

--- a/tests/end_to_end/test_capability_round_trips.py
+++ b/tests/end_to_end/test_capability_round_trips.py
@@ -12,7 +12,6 @@ from mcp import Client
 from jacobian.adapters.mcp.server import create_server
 
 pytestmark = [
-    pytest.mark.end_to_end,
     pytest.mark.usefixtures("initialized_kernel_store_with_references"),
 ]
 

--- a/tests/end_to_end/test_reference_kernel.py
+++ b/tests/end_to_end/test_reference_kernel.py
@@ -18,7 +18,6 @@ from jacobian.kernel import JacobianKernel
 pytestmark = pytest.mark.usefixtures("initialized_kernel_store_with_references")
 
 
-@pytest.mark.end_to_end
 def test_graph_search_witness_and_independent_replay(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path, install_references=True)
     reference = kernel.references["graph_paths"]
@@ -120,7 +119,6 @@ def test_graph_search_witness_and_independent_replay(tmp_path: Path) -> None:
     assert replayed["assurance"]["verification"] == "VERIFIED"
 
 
-@pytest.mark.end_to_end
 def test_matrix_kernel_witness_and_independent_replay(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path, install_references=True)
     reference = kernel.references["matrices"]
@@ -172,7 +170,6 @@ def test_matrix_kernel_witness_and_independent_replay(tmp_path: Path) -> None:
     assert verified.assurance.verification.value == "VERIFIED"
 
 
-@pytest.mark.end_to_end
 def test_erdos_straus_range_witness_and_independent_replay(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path, install_references=True)
     reference = kernel.references["erdos_straus"]
@@ -221,7 +218,6 @@ def test_erdos_straus_range_witness_and_independent_replay(tmp_path: Path) -> No
     assert verified.assurance.verification.value == "VERIFIED"
 
 
-@pytest.mark.end_to_end
 def test_matrix_maxdet_certificate_replays_full_scope(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path, install_references=True)
     reference = kernel.references["matrices"]
@@ -314,7 +310,6 @@ def test_matrix_maxdet_certificate_replays_full_scope(tmp_path: Path) -> None:
     assert verified.assurance.verification.value == "VERIFIED"
 
 
-@pytest.mark.end_to_end
 def test_graph_counterexample_shrinks_to_the_odd_cycle(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path, install_references=True)
     reference = kernel.references["graph_paths"]

--- a/tests/integration/test_agent_ab_benchmark.py
+++ b/tests/integration/test_agent_ab_benchmark.py
@@ -24,8 +24,6 @@ from jacobian.contracts.sat import SatResourceBudget
 from jacobian.contracts.smt import SmtResourceBudget
 from jacobian.kernel import JacobianKernel
 
-pytestmark = pytest.mark.integration
-
 
 def _kernel_from_template(
     tmp_path: Path,

--- a/tests/integration/test_agent_benchmark.py
+++ b/tests/integration/test_agent_benchmark.py
@@ -39,7 +39,6 @@ def _invoke(
     )
 
 
-@pytest.mark.integration
 def test_graph_capability_scorer_checks_multi_call_artifacts(
     tmp_path: Path,
 ) -> None:
@@ -494,7 +493,6 @@ def test_known_answer_scorer_accepts_verified_positive_witness(
     assert score["passed"] is True
 
 
-@pytest.mark.integration
 @pytest.mark.skipif(
     shutil.which("lean") is None,
     reason="Lean is not installed",

--- a/tests/integration/test_artifact_service.py
+++ b/tests/integration/test_artifact_service.py
@@ -9,8 +9,6 @@ from jacobian.schema_registry import SchemaRegistry
 from jacobian.store import ArtifactStore
 
 
-@pytest.mark.integration
-@pytest.mark.contract
 def test_artifact_put_validates_against_registered_json_schema(
     tmp_path: Path,
 ) -> None:
@@ -54,7 +52,6 @@ def test_artifact_put_validates_against_registered_json_schema(
     assert store.get(artifact.artifact_uri).payload == {"value": 1}
 
 
-@pytest.mark.integration
 def test_artifact_put_distinguishes_duplicate_parents_from_missing_descriptors(
     tmp_path: Path,
 ) -> None:

--- a/tests/integration/test_artifact_store.py
+++ b/tests/integration/test_artifact_store.py
@@ -22,7 +22,6 @@ from jacobian.store import (
 )
 
 
-@pytest.mark.integration
 @pytest.mark.conformance
 def test_artifact_identity_uses_canonical_payload_schema_and_semantics(
     tmp_path: Path,
@@ -92,7 +91,6 @@ def test_artifact_identity_uses_canonical_payload_schema_and_semantics(
     assert store.get(first.artifact_uri).payload == {"weight": {"den": "2", "num": "1"}}
 
 
-@pytest.mark.integration
 @pytest.mark.conformance
 def test_modified_blob_is_rejected_on_read(tmp_path: Path) -> None:
     store = ArtifactStore(tmp_path)
@@ -125,7 +123,6 @@ def test_modified_blob_is_rejected_on_read(tmp_path: Path) -> None:
         store.get(artifact.artifact_uri)
 
 
-@pytest.mark.integration
 @pytest.mark.conformance
 @pytest.mark.parametrize("column", ["manifest_digest", "summary"])
 def test_modified_artifact_metadata_is_rejected_on_read(
@@ -179,7 +176,6 @@ def test_modified_artifact_metadata_is_rejected_on_read(
         store.get(artifact.artifact_uri)
 
 
-@pytest.mark.integration
 @pytest.mark.conformance
 @pytest.mark.parametrize("missing_reference", ["parent", "schema", "semantics"])
 def test_missing_reference_metadata_is_rejected_on_read(
@@ -226,7 +222,6 @@ def test_missing_reference_metadata_is_rejected_on_read(
         store.get(child.artifact_uri)
 
 
-@pytest.mark.integration
 @pytest.mark.conformance
 def test_over_limit_artifact_leaves_no_partial_metadata(tmp_path: Path) -> None:
     store = ArtifactStore(
@@ -267,7 +262,6 @@ def test_over_limit_artifact_leaves_no_partial_metadata(tmp_path: Path) -> None:
     assert blobs_after == blobs_before
 
 
-@pytest.mark.integration
 @pytest.mark.conformance
 def test_concurrent_blob_commits_cannot_oversubscribe_quota(
     tmp_path: Path,
@@ -325,7 +319,6 @@ def test_concurrent_blob_commits_cannot_oversubscribe_quota(
     assert sum(isinstance(outcome, StoreLimitError) for outcome in outcomes) == 1
 
 
-@pytest.mark.integration
 def test_blob_writes_do_not_rescan_the_blob_tree(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -339,7 +332,6 @@ def test_blob_writes_do_not_rescan_the_blob_tree(
     store._write_blob(b"constant-time quota accounting")
 
 
-@pytest.mark.integration
 def test_store_open_reconciles_stale_quota_metadata(tmp_path: Path) -> None:
     store = ArtifactStore(tmp_path)
     committed = store._blob_bytes_committed()
@@ -353,7 +345,6 @@ def test_store_open_reconciles_stale_quota_metadata(tmp_path: Path) -> None:
     assert reopened._blob_bytes_committed() == committed
 
 
-@pytest.mark.integration
 def test_store_open_migrates_legacy_quota_metadata(tmp_path: Path) -> None:
     tmp_path.mkdir(parents=True, exist_ok=True)
     database = tmp_path / "metadata.sqlite3"
@@ -386,7 +377,6 @@ def test_store_open_migrates_legacy_quota_metadata(tmp_path: Path) -> None:
     assert store._blob_bytes_committed() == 0
 
 
-@pytest.mark.integration
 def test_concurrent_store_open_migrates_legacy_quota_metadata_once(
     tmp_path: Path,
 ) -> None:
@@ -427,7 +417,6 @@ ArtifactStore(sys.argv[1])
     assert columns.count("reconciliation_required") == 1
 
 
-@pytest.mark.integration
 def test_store_open_recovers_process_death_before_blob_publication(
     tmp_path: Path,
 ) -> None:
@@ -461,7 +450,6 @@ store._write_blob(b"reserved-but-unpublished")
     assert not tuple((tmp_path / "blobs" / "sha256").glob("*/*"))
 
 
-@pytest.mark.integration
 def test_store_open_recovers_process_death_after_blob_publication(
     tmp_path: Path,
 ) -> None:
@@ -491,7 +479,6 @@ store._write_blob(sys.argv[2].encode("ascii"))
     assert reopened._read_blob(digest) == data
 
 
-@pytest.mark.integration
 @pytest.mark.skipif(
     os.name == "nt",
     reason="Windows revalidates blob accounting on every store open",
@@ -515,7 +502,6 @@ def test_clean_store_open_does_not_scan_the_blob_tree(
     assert reopened._blob_path(digest).is_file()
 
 
-@pytest.mark.integration
 def test_duplicate_put_rechecks_a_changed_blob(tmp_path: Path) -> None:
     store = ArtifactStore(tmp_path)
     original = b"original"
@@ -526,7 +512,6 @@ def test_duplicate_put_rechecks_a_changed_blob(tmp_path: Path) -> None:
         store._write_blob(original)
 
 
-@pytest.mark.integration
 def test_failed_blob_publication_releases_quota_reservation(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -545,7 +530,6 @@ def test_failed_blob_publication_releases_quota_reservation(
     assert store._blob_bytes_committed() == committed
 
 
-@pytest.mark.integration
 def test_cross_process_blob_writes_cannot_oversubscribe_quota(
     tmp_path: Path,
 ) -> None:
@@ -579,7 +563,6 @@ else:
     ]
 
 
-@pytest.mark.integration
 @pytest.mark.conformance
 def test_store_keeps_filesystem_paths_local(
     tmp_path: Path,

--- a/tests/integration/test_cadical_capabilities.py
+++ b/tests/integration/test_cadical_capabilities.py
@@ -20,7 +20,6 @@ from jacobian.kernel import JacobianKernel
 from jacobian.provider_runtime import cadical_provider_runtime
 
 pytestmark = [
-    pytest.mark.integration,
     pytest.mark.usefixtures("initialized_kernel_store_with_references"),
 ]
 

--- a/tests/integration/test_cadical_external_backend.py
+++ b/tests/integration/test_cadical_external_backend.py
@@ -11,7 +11,6 @@ from jacobian.kernel import JacobianKernel
 from jacobian.provider_runtime import CADICAL_VERSION, cadical_provider_runtime
 
 pytestmark = [
-    pytest.mark.integration,
     pytest.mark.external_backend,
     pytest.mark.skipif(
         shutil.which("cadical") is None,

--- a/tests/integration/test_capability_service.py
+++ b/tests/integration/test_capability_service.py
@@ -290,7 +290,6 @@ class MisboundVerifiedAdapter:
         )
 
 
-@pytest.mark.integration
 def test_external_adapter_invocation_is_recorded_and_retrievable(
     tmp_path: Path,
 ) -> None:
@@ -314,7 +313,6 @@ def test_external_adapter_invocation_is_recorded_and_retrievable(
     assert [hit.episode_uri for hit in hits] == [result.episode_uri]
 
 
-@pytest.mark.integration
 def test_installed_capability_discovery_is_compact_deterministic_and_transparent(
     tmp_path: Path,
 ) -> None:
@@ -387,7 +385,6 @@ def test_installed_capability_discovery_is_compact_deterministic_and_transparent
     assert "fixture_graph" in first.available_domains
 
 
-@pytest.mark.integration
 def test_capability_registration_rejects_an_invalid_invocation_example(
     tmp_path: Path,
 ) -> None:
@@ -423,7 +420,6 @@ def test_capability_registration_rejects_an_invalid_invocation_example(
         kernel.register_capability(adapter)
 
 
-@pytest.mark.integration
 def test_knowledge_search_filters_episode_domain_tags_and_failures(
     tmp_path: Path,
 ) -> None:
@@ -492,7 +488,6 @@ def test_knowledge_search_filters_episode_domain_tags_and_failures(
     assert result.output["index_snapshot"].startswith("sha256:")
 
 
-@pytest.mark.integration
 def test_knowledge_search_reports_snapshot_bounded_partial_results(
     tmp_path: Path,
 ) -> None:
@@ -528,7 +523,6 @@ def test_knowledge_search_reports_snapshot_bounded_partial_results(
     assert result.output["completeness"] == "PARTIAL"
 
 
-@pytest.mark.integration
 def test_unknown_capability_returns_an_actionable_result(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path)
 
@@ -550,7 +544,6 @@ def test_unknown_capability_returns_an_actionable_result(tmp_path: Path) -> None
     assert result.output["available_capability_ids"]
 
 
-@pytest.mark.integration
 def test_unsupported_capability_mode_lists_available_modes(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path)
     kernel.register_capability(ComputedAdapter())
@@ -569,7 +562,6 @@ def test_unsupported_capability_mode_lists_available_modes(tmp_path: Path) -> No
     assert result.output["available_modes"] == ["EXPLORE"]
 
 
-@pytest.mark.integration
 def test_invalid_capability_input_does_not_echo_payload(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path)
     kernel.register_capability(ComputedAdapter())
@@ -597,7 +589,6 @@ def test_invalid_capability_input_does_not_echo_payload(tmp_path: Path) -> None:
     assert "fixture-secret-value" not in repr(diagnostic)
 
 
-@pytest.mark.integration
 def test_adapter_failure_does_not_expose_internal_exception_text(
     tmp_path: Path,
 ) -> None:
@@ -624,7 +615,6 @@ def test_adapter_failure_does_not_expose_internal_exception_text(
     assert "RuntimeError" not in result.execution.detail
 
 
-@pytest.mark.integration
 def test_adapter_cannot_forge_provider_provenance(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path)
     kernel.register_capability(ForgedProviderAdapter())
@@ -641,7 +631,6 @@ def test_adapter_cannot_forge_provider_provenance(tmp_path: Path) -> None:
         )
 
 
-@pytest.mark.integration
 def test_external_adapter_loads_from_an_operator_entrypoint(tmp_path: Path) -> None:
     kernel = JacobianKernel(
         tmp_path,
@@ -660,7 +649,6 @@ def test_external_adapter_loads_from_an_operator_entrypoint(tmp_path: Path) -> N
     assert result.output == {"value": 5}
 
 
-@pytest.mark.integration
 def test_adapter_cannot_promote_without_a_local_verification_record(
     tmp_path: Path,
 ) -> None:
@@ -677,7 +665,6 @@ def test_adapter_cannot_promote_without_a_local_verification_record(
         )
 
 
-@pytest.mark.integration
 def test_first_class_relationship_endpoints_must_be_exposed(
     tmp_path: Path,
 ) -> None:
@@ -693,7 +680,6 @@ def test_first_class_relationship_endpoints_must_be_exposed(
         )
 
 
-@pytest.mark.integration
 def test_verified_relationship_must_match_checker_selected_endpoints(
     tmp_path: Path,
 ) -> None:
@@ -734,7 +720,6 @@ def test_verified_relationship_must_match_checker_selected_endpoints(
         )
 
 
-@pytest.mark.integration
 def test_verified_relationship_must_match_checker_selected_obligation(
     tmp_path: Path,
 ) -> None:
@@ -773,7 +758,6 @@ def test_verified_relationship_must_match_checker_selected_obligation(
         )
 
 
-@pytest.mark.integration
 @pytest.mark.lean_runtime
 @pytest.mark.skipif(
     shutil.which("lean") is None,
@@ -799,7 +783,6 @@ def test_lean_capability_returns_bound_verified_result(tmp_path: Path) -> None:
     assert result.output["conclusion"] == "TRUE"
 
 
-@pytest.mark.integration
 @pytest.mark.lean_runtime
 @pytest.mark.skipif(
     shutil.which("lean") is None,

--- a/tests/integration/test_certificate_verification.py
+++ b/tests/integration/test_certificate_verification.py
@@ -13,7 +13,6 @@ from jacobian.store import ArtifactStore
 from jacobian.verification import VerificationService
 
 
-@pytest.mark.integration
 @pytest.mark.subprocess
 @pytest.mark.conformance
 def test_complete_path_enumeration_certificate_is_verified(tmp_path: Path) -> None:

--- a/tests/integration/test_checker_registry.py
+++ b/tests/integration/test_checker_registry.py
@@ -30,7 +30,6 @@ CLAIM_SCHEMA_A = "artifact://sha256/" + "a" * 64
 CLAIM_SCHEMA_B = "artifact://sha256/" + "b" * 64
 
 
-@pytest.mark.integration
 def test_checker_selection_errors_explain_recovery(tmp_path: Path) -> None:
     registry = CheckerRegistry(ArtifactStore(tmp_path).db_path)
     selection = {
@@ -67,7 +66,6 @@ def test_checker_selection_errors_explain_recovery(tmp_path: Path) -> None:
         registry.select_compatible(**selection)
 
 
-@pytest.mark.integration
 @pytest.mark.conformance
 def test_revoked_checker_cannot_authorize_new_verification(tmp_path: Path) -> None:
     store = ArtifactStore(tmp_path)
@@ -98,7 +96,6 @@ def test_revoked_checker_cannot_authorize_new_verification(tmp_path: Path) -> No
     ]
 
 
-@pytest.mark.integration
 def test_concurrent_duplicate_authorize_is_serialized(tmp_path: Path) -> None:
     registry = CheckerRegistry(ArtifactStore(tmp_path).db_path)
     barrier = threading.Barrier(8)
@@ -136,7 +133,6 @@ def test_concurrent_duplicate_authorize_is_serialized(tmp_path: Path) -> None:
     ] == ["AUTHORIZED"]
 
 
-@pytest.mark.integration
 @pytest.mark.conformance
 @pytest.mark.parametrize("corruption", ["registration", "digest_column"])
 def test_checker_registry_rejects_identity_metadata_corruption(
@@ -182,7 +178,6 @@ def test_checker_registry_rejects_identity_metadata_corruption(
         registry.get(checker.checker_id)
 
 
-@pytest.mark.integration
 @pytest.mark.conformance
 @pytest.mark.parametrize(
     ("evidence_kind", "claim_schemas", "semantics", "candidate_schemas", "targets"),
@@ -224,7 +219,6 @@ def test_checker_authorization_requires_explicit_compatibility_scope(
         )
 
 
-@pytest.mark.integration
 @pytest.mark.conformance
 def test_checker_registry_binds_external_runtime_identity(tmp_path: Path) -> None:
     executable = tmp_path / "external-checker"
@@ -265,7 +259,6 @@ def test_checker_registry_binds_external_runtime_identity(tmp_path: Path) -> Non
         registry.require_active(checker.checker_id)
 
 
-@pytest.mark.integration
 @pytest.mark.conformance
 def test_checker_registry_authorizes_python_distribution_runtime(
     tmp_path: Path,

--- a/tests/integration/test_chromatic_number.py
+++ b/tests/integration/test_chromatic_number.py
@@ -16,8 +16,6 @@ from jacobian.contracts.capabilities import (
 from jacobian.contracts.results import ExecutionStatus
 from jacobian.kernel import JacobianKernel
 
-pytestmark = pytest.mark.integration
-
 
 def _invoke(
     kernel: JacobianKernel,

--- a/tests/integration/test_claim_decomposition.py
+++ b/tests/integration/test_claim_decomposition.py
@@ -48,7 +48,6 @@ def _invoke(kernel: JacobianKernel, capability_id: str, source_uri: str):
     )
 
 
-@pytest.mark.integration
 def test_conjunction_split_preserves_order_grouping_and_reconstructs(
     tmp_path: Path,
 ) -> None:
@@ -83,7 +82,6 @@ def test_conjunction_split_preserves_order_grouping_and_reconstructs(
     )
 
 
-@pytest.mark.integration
 def test_conjunction_split_preserves_duplicate_subtrees_as_occurrences(
     tmp_path: Path,
 ) -> None:
@@ -102,7 +100,6 @@ def test_conjunction_split_preserves_duplicate_subtrees_as_occurrences(
     ]
 
 
-@pytest.mark.integration
 def test_implication_obligations_are_directional_and_reconstruct(
     tmp_path: Path,
 ) -> None:
@@ -130,7 +127,6 @@ def test_implication_obligations_are_directional_and_reconstruct(
     assert reconstruct(record) == root
 
 
-@pytest.mark.integration
 def test_reconstruction_rejects_tampered_ordered_child(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path)
     root = LogicalClaimNode(
@@ -149,7 +145,6 @@ def test_reconstruction_rejects_tampered_ordered_child(tmp_path: Path) -> None:
         reconstruct(tampered)
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize(
     ("capability_id", "connective"),
     [

--- a/tests/integration/test_claim_validation.py
+++ b/tests/integration/test_claim_validation.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from jacobian.artifacts import ArtifactService
 from jacobian.claims import ClaimValidationService
 from jacobian.contracts.claims import ClaimSpec
@@ -13,8 +11,6 @@ from jacobian.schema_registry import SchemaRegistry
 from jacobian.store import ArtifactStore
 
 
-@pytest.mark.integration
-@pytest.mark.contract
 def test_claim_validation_rejects_missing_plugin_capability(tmp_path: Path) -> None:
     store = ArtifactStore(tmp_path)
     schemas = SchemaRegistry(store)

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -11,7 +11,6 @@ from jacobian.kernel import JacobianKernel
 from jacobian.store import StoreLimitError
 
 
-@pytest.mark.integration
 def test_cli_init_reports_reference_domains_and_polytope_formats(
     tmp_path: Path,
 ) -> None:
@@ -45,7 +44,6 @@ def test_cli_init_reports_reference_domains_and_polytope_formats(
     assert catalog["lean4"]["profiles"]["MATHLIB"]["checker_timeout_seconds"] == 225
 
 
-@pytest.mark.integration
 def test_cli_help_exposes_v02_operations() -> None:
     result = CliRunner().invoke(app, ["--help"])
 
@@ -69,7 +67,6 @@ def test_cli_help_exposes_v02_operations() -> None:
         assert command in result.stdout
 
 
-@pytest.mark.integration
 def test_cli_measures_exact_provider_without_implicit_cold_install(
     tmp_path: Path,
 ) -> None:
@@ -94,7 +91,6 @@ def test_cli_measures_exact_provider_without_implicit_cold_install(
     assert measurement["reproduction_case"]["status"] == "COMPLETED"
 
 
-@pytest.mark.integration
 def test_cli_missing_input_file_returns_an_actionable_json_error(
     tmp_path: Path,
 ) -> None:
@@ -125,7 +121,6 @@ def test_cli_missing_input_file_returns_an_actionable_json_error(
     assert str(missing) not in result.stderr
 
 
-@pytest.mark.integration
 def test_cli_invalid_json_returns_an_actionable_json_error(tmp_path: Path) -> None:
     payload = tmp_path / "payload.json"
     payload.write_text('{"value": NaN}', encoding="utf-8")
@@ -158,7 +153,6 @@ def test_cli_invalid_json_returns_an_actionable_json_error(tmp_path: Path) -> No
     assert "Traceback" not in result.stderr
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize(
     ("as_directory", "expected_code"),
     [
@@ -210,7 +204,6 @@ def test_cli_storage_limit_has_a_capacity_recovery_action() -> None:
     assert "fixture" not in str(error)
 
 
-@pytest.mark.integration
 @pytest.mark.usefixtures("initialized_kernel_store_with_references")
 def test_cli_enumeration_completes_before_the_local_process_exits(
     tmp_path: Path,

--- a/tests/integration/test_conjecture_workflows.py
+++ b/tests/integration/test_conjecture_workflows.py
@@ -28,7 +28,6 @@ from jacobian.contracts.search import SearchBudget
 from jacobian.kernel import JacobianKernel
 
 pytestmark = [
-    pytest.mark.integration,
     pytest.mark.conformance,
     pytest.mark.usefixtures("initialized_kernel_store"),
 ]

--- a/tests/integration/test_enumeration_experiments.py
+++ b/tests/integration/test_enumeration_experiments.py
@@ -123,7 +123,6 @@ def _matrix_claim_for_plugin(
     return claim.artifact_uri
 
 
-@pytest.mark.integration
 def test_unknown_experiment_error_explains_recovery(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
@@ -141,7 +140,6 @@ def test_unknown_experiment_error_explains_recovery(
     assert missing_uri in caplog.text
 
 
-@pytest.mark.integration
 def test_graph_enumeration_deduplicates_isomorphic_candidates(
     tmp_path: Path,
 ) -> None:
@@ -202,7 +200,6 @@ def test_graph_enumeration_deduplicates_isomorphic_candidates(
         }
 
 
-@pytest.mark.integration
 def test_experiment_metadata_uses_registered_schema_validation(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -263,7 +260,6 @@ def test_experiment_metadata_uses_registered_schema_validation(
     assert kernel.references["matrices"].semantics_uri in validated_semantics_uris
 
 
-@pytest.mark.integration
 def test_matrix_enumeration_uses_the_same_experiment_contract(
     tmp_path: Path,
 ) -> None:
@@ -300,7 +296,6 @@ def test_matrix_enumeration_uses_the_same_experiment_contract(
     assert snapshot.verification.value == "UNVERIFIED"
 
 
-@pytest.mark.integration
 def test_enumeration_pages_respect_evaluator_batch_limit(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path, install_references=True)
     kernel.evaluation.max_batch_size = 2
@@ -341,7 +336,6 @@ def test_enumeration_pages_respect_evaluator_batch_limit(tmp_path: Path) -> None
     assert snapshot.archive_page_uris[0] in second_page.manifest.parents
 
 
-@pytest.mark.integration
 def test_cancellation_never_becomes_an_exhaustive_conclusion(
     tmp_path: Path,
 ) -> None:
@@ -379,7 +373,6 @@ def test_cancellation_never_becomes_an_exhaustive_conclusion(
     assert snapshot.archive_uri is not None
 
 
-@pytest.mark.integration
 def test_candidate_limit_never_becomes_exhaustive_coverage(
     tmp_path: Path,
 ) -> None:
@@ -416,7 +409,6 @@ def test_candidate_limit_never_becomes_exhaustive_coverage(
     assert snapshot.accounting.raw_candidates == 2
 
 
-@pytest.mark.integration
 def test_quotient_search_requires_a_domain_canonicalizer(
     tmp_path: Path,
 ) -> None:
@@ -444,7 +436,6 @@ def test_quotient_search_requires_a_domain_canonicalizer(
         )
 
 
-@pytest.mark.integration
 def test_cancelling_a_terminal_experiment_does_not_change_it(
     tmp_path: Path,
 ) -> None:
@@ -480,7 +471,6 @@ def test_cancelling_a_terminal_experiment_does_not_change_it(
     assert after == completed
 
 
-@pytest.mark.integration
 def test_enumerator_candidate_is_validated_before_archival(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path, install_references=True)
     plugin_id = _install_matrix_enumerator_plugin(
@@ -517,7 +507,6 @@ def test_enumerator_candidate_is_validated_before_archival(tmp_path: Path) -> No
     assert snapshot.archive_page_uris == ()
 
 
-@pytest.mark.integration
 @pytest.mark.subprocess
 def test_enumerator_timeout_remains_a_bounded_nonconclusion(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path, install_references=True)
@@ -560,7 +549,6 @@ def test_enumerator_timeout_remains_a_bounded_nonconclusion(tmp_path: Path) -> N
     assert snapshot.accounting.raw_candidates == 0
 
 
-@pytest.mark.integration
 @pytest.mark.subprocess
 def test_evaluator_timeout_prevents_complete_enumeration_result(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path, install_references=True)
@@ -598,7 +586,6 @@ def test_evaluator_timeout_prevents_complete_enumeration_result(tmp_path: Path) 
     assert snapshot.verification.value == "UNVERIFIED"
 
 
-@pytest.mark.integration
 def test_rejected_evaluation_batch_fails_enumeration(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -649,7 +636,6 @@ def test_rejected_evaluation_batch_fails_enumeration(
     assert "simulated incomplete evaluation" not in snapshot.detail
 
 
-@pytest.mark.integration
 def test_terminal_archive_failure_marks_enumeration_error(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -703,7 +689,6 @@ def test_terminal_archive_failure_marks_enumeration_error(
     assert "fixture archive failure" in caplog.text
 
 
-@pytest.mark.integration
 @pytest.mark.subprocess
 def test_interrupted_experiment_is_recovered_as_an_error(tmp_path: Path) -> None:
     script = """
@@ -764,7 +749,6 @@ os._exit(0)
     assert "ended before completion" in recovered.detail
 
 
-@pytest.mark.integration
 def test_corrupt_enumeration_snapshot_does_not_block_other_recovery(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/integration/test_evaluation.py
+++ b/tests/integration/test_evaluation.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from jacobian.artifacts import ArtifactService
 from jacobian.claims import ClaimValidationService
 from jacobian.contracts.claims import ClaimSpec
@@ -15,8 +13,6 @@ from jacobian.schema_registry import SchemaRegistry
 from jacobian.store import ArtifactStore
 
 
-@pytest.mark.integration
-@pytest.mark.contract
 def test_exact_exhaustive_evaluation_remains_unverified(tmp_path: Path) -> None:
     service, claim_uri, candidate_uri, plugin_id = _evaluation_fixture(tmp_path)
 

--- a/tests/integration/test_finite_graph_optimization.py
+++ b/tests/integration/test_finite_graph_optimization.py
@@ -19,7 +19,6 @@ from jacobian.contracts.results import ExecutionStatus
 from jacobian.kernel import JacobianKernel
 
 pytestmark = [
-    pytest.mark.integration,
     pytest.mark.usefixtures("initialized_kernel_store"),
 ]
 

--- a/tests/integration/test_geometry_verification.py
+++ b/tests/integration/test_geometry_verification.py
@@ -82,7 +82,6 @@ def test_geometry_checker_availability_does_not_grant_authority(
     assert installation.checker_id is None
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize(
     ("operation_id", "payload"),
     [
@@ -130,7 +129,6 @@ def test_selected_geometry_results_verify_through_public_dispatch(
     assert verified.assurance.verification_record_uri is not None
 
 
-@pytest.mark.integration
 def test_mutated_geometry_candidate_is_rejected_without_false_conclusion(
     tmp_path: Path,
 ) -> None:

--- a/tests/integration/test_graph_capabilities.py
+++ b/tests/integration/test_graph_capabilities.py
@@ -17,7 +17,6 @@ from jacobian.kernel import JacobianKernel
 pytestmark = pytest.mark.usefixtures("initialized_kernel_store_with_references")
 
 
-@pytest.mark.integration
 def test_explicit_graph_construction_canonicalizes_and_feeds_graph_capabilities(
     tmp_path: Path,
 ) -> None:
@@ -57,7 +56,6 @@ def test_explicit_graph_construction_canonicalizes_and_feeds_graph_capabilities(
     assert properties.output["properties"]["tree"]["value"] is True
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize(
     "input_payload",
     [
@@ -86,7 +84,6 @@ def test_explicit_graph_construction_fails_before_artifact_writes(
     assert result.diagnostics[0].details["validation_errors"]
 
 
-@pytest.mark.integration
 def test_graph_atlas_search_is_bounded_complete_and_replayable(
     tmp_path: Path,
 ) -> None:
@@ -134,7 +131,6 @@ def test_graph_atlas_search_is_bounded_complete_and_replayable(
     assert scope.payload["enumerated_count"] > 0
 
 
-@pytest.mark.integration
 def test_graph_atlas_search_reports_no_match_without_a_truth_claim(
     tmp_path: Path,
 ) -> None:
@@ -161,7 +157,6 @@ def test_graph_atlas_search_reports_no_match_without_a_truth_claim(
     assert "conclusion" not in result.output
 
 
-@pytest.mark.integration
 def test_graph_capabilities_return_actionable_parameter_and_artifact_errors(
     tmp_path: Path,
 ) -> None:
@@ -198,7 +193,6 @@ def test_graph_capabilities_return_actionable_parameter_and_artifact_errors(
     assert missing_graph.episode_uri is None
 
 
-@pytest.mark.integration
 def test_graph_property_batch_materializes_exact_computed_artifact(
     tmp_path: Path,
 ) -> None:
@@ -305,7 +299,6 @@ def test_graph_property_batch_materializes_exact_computed_artifact(
         assert invariant_artifact.payload["result"] == binding["result"]
 
 
-@pytest.mark.integration
 def test_graph_counterexample_invariant_batch_reproduces_path_five(
     tmp_path: Path,
 ) -> None:
@@ -360,7 +353,6 @@ def test_graph_counterexample_invariant_batch_reproduces_path_five(
     assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
 
 
-@pytest.mark.integration
 def test_graph_invariant_batch_preserves_unsupported_and_not_applicable_results(
     tmp_path: Path,
 ) -> None:
@@ -436,7 +428,6 @@ def test_graph_invariant_batch_preserves_unsupported_and_not_applicable_results(
     assert "made_up_invariant" not in result.output["supported_invariants"]
 
 
-@pytest.mark.integration
 def test_graph_invariant_registry_is_fixed_and_discoverable(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path)
     descriptor = next(

--- a/tests/integration/test_graph_coloring_encoding.py
+++ b/tests/integration/test_graph_coloring_encoding.py
@@ -15,7 +15,6 @@ from jacobian.contracts.results import ExecutionStatus
 from jacobian.kernel import JacobianKernel
 
 pytestmark = [
-    pytest.mark.integration,
     pytest.mark.usefixtures("initialized_kernel_store_with_references"),
 ]
 

--- a/tests/integration/test_graph_composition.py
+++ b/tests/integration/test_graph_composition.py
@@ -43,7 +43,6 @@ def _atlas_graph_uri(kernel: JacobianKernel, order: int, limit: int = 2) -> list
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.integration
 def test_compose_complement_returns_computed_graph_artifact(
     tmp_path: Path,
 ) -> None:
@@ -101,7 +100,6 @@ def test_compose_complement_returns_computed_graph_artifact(
     assert result.output["composition_artifact_uri"] in result.artifact_uris
 
 
-@pytest.mark.integration
 def test_compose_disjoint_union_combines_two_graphs(tmp_path: Path) -> None:
     kernel = _kernel_with_composition(tmp_path)
     graph_uris = _atlas_graph_uri(kernel, order=3, limit=2)
@@ -133,7 +131,6 @@ def test_compose_disjoint_union_combines_two_graphs(tmp_path: Path) -> None:
     assert right_uri in rel.target_artifact_uris
 
 
-@pytest.mark.integration
 def test_compose_join_adds_all_cross_edges(tmp_path: Path) -> None:
     kernel = _kernel_with_composition(tmp_path)
     graph_uris = _atlas_graph_uri(kernel, order=3, limit=2)
@@ -160,7 +157,6 @@ def test_compose_join_adds_all_cross_edges(tmp_path: Path) -> None:
     assert composition.payload["backend"] == "networkx.join"
 
 
-@pytest.mark.integration
 def test_compose_lexicographic_product_doubles_vertex_count(tmp_path: Path) -> None:
     kernel = _kernel_with_composition(tmp_path)
     graph_uris = _atlas_graph_uri(kernel, order=3, limit=2)
@@ -185,7 +181,6 @@ def test_compose_lexicographic_product_doubles_vertex_count(tmp_path: Path) -> N
     assert composition.payload["backend"] == "networkx.lexicographic_product"
 
 
-@pytest.mark.integration
 def test_compose_rejects_missing_right_graph_for_binary_operation(
     tmp_path: Path,
 ) -> None:
@@ -208,7 +203,6 @@ def test_compose_rejects_missing_right_graph_for_binary_operation(
     assert result.diagnostics[0].code == "INVALID_COMPOSITION_REQUEST"
 
 
-@pytest.mark.integration
 def test_compose_rejects_right_graph_for_unary_complement(
     tmp_path: Path,
 ) -> None:
@@ -232,7 +226,6 @@ def test_compose_rejects_right_graph_for_unary_complement(
     assert result.diagnostics[0].code == "INVALID_COMPOSITION_REQUEST"
 
 
-@pytest.mark.integration
 def test_compose_rejects_nonexistent_graph_artifact(tmp_path: Path) -> None:
     kernel = _kernel_with_composition(tmp_path)
     fake_uri = "artifact://sha256/" + "0" * 64
@@ -257,7 +250,6 @@ def test_compose_rejects_nonexistent_graph_artifact(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.integration
 def test_enumerate_returns_complete_atlas_catalog_with_boundary(
     tmp_path: Path,
 ) -> None:
@@ -317,7 +309,6 @@ def test_enumerate_returns_complete_atlas_catalog_with_boundary(
         assert entry["graph_uri"] in result.artifact_uris
 
 
-@pytest.mark.integration
 def test_enumerate_paginates_with_limit_and_offset(tmp_path: Path) -> None:
     kernel = _kernel_with_composition(tmp_path)
 
@@ -348,7 +339,6 @@ def test_enumerate_paginates_with_limit_and_offset(tmp_path: Path) -> None:
     assert first_uris.isdisjoint(second_uris)
 
 
-@pytest.mark.integration
 def test_enumerate_rejects_order_outside_backend_boundary(
     tmp_path: Path,
 ) -> None:
@@ -366,7 +356,6 @@ def test_enumerate_rejects_order_outside_backend_boundary(
     assert result.diagnostics[0].code == "INVALID_REQUEST"
 
 
-@pytest.mark.integration
 def test_enumerate_order_zero_returns_single_empty_graph(tmp_path: Path) -> None:
     kernel = _kernel_with_composition(tmp_path)
 

--- a/tests/integration/test_graph_counterexample_shrinking.py
+++ b/tests/integration/test_graph_counterexample_shrinking.py
@@ -15,11 +15,7 @@ from jacobian.contracts.results import ExecutionStatus
 from jacobian.kernel import JacobianKernel
 from jacobian.plugin_execution import PluginExecutionResult
 
-pytestmark = pytest.mark.integration
 
-
-@pytest.mark.integration
-@pytest.mark.contract
 def test_graph_counterexample_shrink_records_verified_steps_and_exact_local_scope(
     tmp_path: Path,
     kernel_store_template_with_references: Path,
@@ -64,8 +60,6 @@ def test_graph_counterexample_shrink_records_verified_steps_and_exact_local_scop
     assert trace.payload["local_minimality_scope"] == scope
 
 
-@pytest.mark.integration
-@pytest.mark.contract
 def test_graph_counterexample_shrink_budget_reports_only_tested_scope(
     tmp_path: Path,
     kernel_store_template_with_references: Path,
@@ -83,8 +77,6 @@ def test_graph_counterexample_shrink_budget_reports_only_tested_scope(
     assert scope["untested_vertex_deletions"] or scope["untested_edge_deletions"]
 
 
-@pytest.mark.integration
-@pytest.mark.contract
 def test_graph_counterexample_shrink_timeout_returns_incumbent_without_minimality(
     tmp_path: Path,
     kernel_store_template_with_references: Path,
@@ -103,8 +95,6 @@ def test_graph_counterexample_shrink_timeout_returns_incumbent_without_minimalit
     assert result.assurance.level is CapabilityAssuranceLevel.HEURISTIC
 
 
-@pytest.mark.integration
-@pytest.mark.contract
 def test_graph_counterexample_shrink_requires_compatible_registered_checker(
     tmp_path: Path,
     kernel_store_template_with_references: Path,
@@ -132,8 +122,6 @@ def test_graph_counterexample_shrink_requires_compatible_registered_checker(
     assert result.diagnostics[0].code == "GRAPH_PROPERTY_CHECKER_INVALID"
 
 
-@pytest.mark.integration
-@pytest.mark.contract
 def test_graph_counterexample_shrink_fails_closed_on_tampered_graph(
     tmp_path: Path,
     kernel_store_template_with_references: Path,
@@ -151,8 +139,6 @@ def test_graph_counterexample_shrink_fails_closed_on_tampered_graph(
     assert result.diagnostics[0].code == "GRAPH_SHRINK_INPUT_INVALID"
 
 
-@pytest.mark.integration
-@pytest.mark.contract
 def test_graph_counterexample_shrink_rejects_unrelated_reducer_edits(
     tmp_path: Path,
     kernel_store_template_with_references: Path,
@@ -171,8 +157,6 @@ def test_graph_counterexample_shrink_rejects_unrelated_reducer_edits(
     assert "exact single-vertex deletion" in result.output["attempts"][0]["detail"]
 
 
-@pytest.mark.integration
-@pytest.mark.contract
 @pytest.mark.slow
 def test_graph_counterexample_shrink_order_is_deterministic(
     tmp_path: Path, kernel_store_template_with_references: Path

--- a/tests/integration/test_graph_isomorphism.py
+++ b/tests/integration/test_graph_isomorphism.py
@@ -55,7 +55,6 @@ def _input(
     }
 
 
-@pytest.mark.integration
 def test_graph_isomorphism_verifies_a_valid_bijection(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path, install_references=True)
 
@@ -81,7 +80,6 @@ def test_graph_isomorphism_verifies_a_valid_bijection(tmp_path: Path) -> None:
     assert result.output["verification_record_uri"] in result.artifact_uris
 
 
-@pytest.mark.integration
 def test_graph_isomorphism_verifies_a_negative_result(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path, install_references=True)
 
@@ -102,7 +100,6 @@ def test_graph_isomorphism_verifies_a_negative_result(tmp_path: Path) -> None:
     )
 
 
-@pytest.mark.integration
 def test_graph_isomorphism_keeps_checker_rejection_unknown(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path, install_references=True)
     checker_id = kernel.graph_isomorphism.checker_id
@@ -129,7 +126,6 @@ def test_graph_isomorphism_keeps_checker_rejection_unknown(tmp_path: Path) -> No
     )
 
 
-@pytest.mark.integration
 def test_graph_isomorphism_accepts_graph_atlas_artifact_handoff(
     tmp_path: Path,
 ) -> None:
@@ -170,7 +166,6 @@ def test_graph_isomorphism_accepts_graph_atlas_artifact_handoff(
     )
 
 
-@pytest.mark.integration
 def test_graph_isomorphism_accepts_valid_unsorted_graph_artifacts(
     tmp_path: Path,
 ) -> None:
@@ -204,7 +199,6 @@ def test_graph_isomorphism_accepts_valid_unsorted_graph_artifacts(
     assert right_graph_uri in record.manifest.parents
 
 
-@pytest.mark.integration
 def test_graph_isomorphism_rejects_incompatible_graph_artifact(
     tmp_path: Path,
 ) -> None:

--- a/tests/integration/test_graph_neighborhood_independence.py
+++ b/tests/integration/test_graph_neighborhood_independence.py
@@ -47,7 +47,6 @@ def _wowii_200_graph() -> dict[str, object]:
     }
 
 
-@pytest.mark.integration
 def test_neighborhood_independence_reproduces_wowii_200_invariant(
     tmp_path: Path,
 ) -> None:

--- a/tests/integration/test_lean.py
+++ b/tests/integration/test_lean.py
@@ -49,7 +49,6 @@ MATHLIB_OLEAN = (
 )
 
 pytestmark = [
-    pytest.mark.integration,
     pytest.mark.external_backend,
     pytest.mark.lean_runtime,
     pytest.mark.skipif(shutil.which("lean") is None, reason="Lean is not installed"),

--- a/tests/integration/test_lean_exploration_capabilities.py
+++ b/tests/integration/test_lean_exploration_capabilities.py
@@ -12,7 +12,6 @@ from jacobian.contracts.capabilities import (
 from jacobian.kernel import JacobianKernel
 
 pytestmark = [
-    pytest.mark.integration,
     pytest.mark.external_backend,
     pytest.mark.lean_runtime,
     pytest.mark.skipif(shutil.which("lean") is None, reason="Lean is not installed"),

--- a/tests/integration/test_lean_proof_edit.py
+++ b/tests/integration/test_lean_proof_edit.py
@@ -14,7 +14,6 @@ from jacobian.contracts.capabilities import (
 from jacobian.kernel import JacobianKernel
 
 pytestmark = [
-    pytest.mark.integration,
     pytest.mark.external_backend,
     pytest.mark.lean_runtime,
     pytest.mark.skipif(shutil.which("lean") is None, reason="Lean is not installed"),

--- a/tests/integration/test_lean_replayable_state_capability.py
+++ b/tests/integration/test_lean_replayable_state_capability.py
@@ -20,8 +20,6 @@ from jacobian.references import LeanCheckerInstallation
 from jacobian.schema_registry import SchemaRegistry
 from jacobian.store import ArtifactStore
 
-pytestmark = pytest.mark.integration
-
 _ReplResponses = tuple[dict[str, object], dict[str, object], dict[str, object]]
 
 

--- a/tests/integration/test_lean_statement_capabilities.py
+++ b/tests/integration/test_lean_statement_capabilities.py
@@ -27,8 +27,6 @@ from jacobian.store import ArtifactStore
 
 LEAN_AVAILABLE = shutil.which("lean") is not None
 
-pytestmark = [pytest.mark.integration]
-
 
 # ---------------------------------------------------------------------------
 # Fixtures.

--- a/tests/integration/test_matrix_capabilities.py
+++ b/tests/integration/test_matrix_capabilities.py
@@ -67,7 +67,6 @@ def _kernel_with_determinant_checker(root: Path) -> JacobianKernel:
     return kernel
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize(
     ("rows", "expected"),
     [
@@ -106,7 +105,6 @@ def test_matrix_determinant_compute_is_exact_and_unverified(
     assert determinant_artifact.payload["backend_version"] == sympy.__version__
 
 
-@pytest.mark.integration
 def test_matrix_determinant_verify_independently_recomputes_exact_value(
     tmp_path: Path,
 ) -> None:
@@ -141,7 +139,6 @@ def test_matrix_determinant_verify_independently_recomputes_exact_value(
     assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED
 
 
-@pytest.mark.integration
 def test_matrix_determinant_verify_rejects_wrong_bound_value(tmp_path: Path) -> None:
     kernel = _kernel_with_determinant_checker(tmp_path)
     computed = kernel.capabilities.invoke(
@@ -177,7 +174,6 @@ def test_matrix_determinant_verify_rejects_wrong_bound_value(tmp_path: Path) -> 
     assert rejected.assurance.level is not CapabilityAssuranceLevel.VERIFIED
 
 
-@pytest.mark.integration
 def test_matrix_determinant_verify_timeout_is_not_a_conclusion(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -212,7 +208,6 @@ def test_matrix_determinant_verify_timeout_is_not_a_conclusion(
     assert timed_out.assurance.level is not CapabilityAssuranceLevel.VERIFIED
 
 
-@pytest.mark.integration
 def test_matrix_rank_compute_returns_rectangular_pivot_evidence(
     tmp_path: Path,
 ) -> None:
@@ -244,7 +239,6 @@ def test_matrix_rank_compute_returns_rectangular_pivot_evidence(
     assert rank_artifact.payload["backend_version"] == sympy.__version__
 
 
-@pytest.mark.integration
 def test_matrix_determinant_rejects_rectangular_input(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path)
 
@@ -259,7 +253,6 @@ def test_matrix_determinant_rejects_rectangular_input(tmp_path: Path) -> None:
     assert result.diagnostics[0].code == "INVALID_EXACT_MATRIX_REQUEST"
 
 
-@pytest.mark.integration
 @pytest.mark.differential
 def test_matrix_determinant_matches_independent_bounded_oracle(
     tmp_path: Path,
@@ -288,7 +281,6 @@ def test_matrix_determinant_matches_independent_bounded_oracle(
             )
 
 
-@pytest.mark.integration
 def test_matrix_capabilities_report_sympy_provider_identity(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path)
     descriptors = {

--- a/tests/integration/test_matrix_rank_verification.py
+++ b/tests/integration/test_matrix_rank_verification.py
@@ -27,7 +27,6 @@ def _matrix() -> dict[str, object]:
     }
 
 
-@pytest.mark.integration
 def test_matrix_rank_verify_independently_recomputes_rank(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path, install_references=True)
     computed = kernel.capabilities.invoke(
@@ -47,7 +46,6 @@ def test_matrix_rank_verify_independently_recomputes_rank(tmp_path: Path) -> Non
     assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED
 
 
-@pytest.mark.integration
 def test_matrix_rank_verify_rejects_wrong_rank(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path, install_references=True)
     computed = kernel.capabilities.invoke(

--- a/tests/integration/test_mcp_adapter.py
+++ b/tests/integration/test_mcp_adapter.py
@@ -23,7 +23,6 @@ CAPABILITY_TOOL_NAMES = {"capability.describe", "capability.invoke"}
 MCP_TOOL_NAMES = CAPABILITY_TOOL_NAMES | WORKSPACE_TOOL_NAMES
 
 
-@pytest.mark.integration
 def test_mcp_exposes_capability_and_workspace_tools_with_read_only_resources(
     tmp_path: Path,
 ) -> None:
@@ -150,7 +149,6 @@ def test_mcp_exposes_capability_and_workspace_tools_with_read_only_resources(
     asyncio.run(scenario())
 
 
-@pytest.mark.integration
 def test_mcp_workspace_schema_aliases_and_fail_closed_round_trip(
     tmp_path: Path,
 ) -> None:
@@ -451,7 +449,6 @@ def test_mcp_workspace_schema_aliases_and_fail_closed_round_trip(
     asyncio.run(scenario())
 
 
-@pytest.mark.integration
 def test_mcp_describes_and_invokes_capabilities(tmp_path: Path) -> None:
     async def scenario() -> None:
         from mcp import Client
@@ -496,7 +493,6 @@ def test_mcp_describes_and_invokes_capabilities(tmp_path: Path) -> None:
     asyncio.run(scenario())
 
 
-@pytest.mark.integration
 def test_mcp_no_retrieval_policy_is_operator_bound_and_fail_closed(
     tmp_path: Path,
 ) -> None:
@@ -541,7 +537,6 @@ def test_mcp_no_retrieval_policy_is_operator_bound_and_fail_closed(
     asyncio.run(scenario())
 
 
-@pytest.mark.integration
 def test_mcp_compact_capability_index_is_searchable_and_paginated(
     tmp_path: Path,
 ) -> None:
@@ -664,7 +659,6 @@ def test_mcp_compact_capability_index_is_searchable_and_paginated(
     asyncio.run(scenario())
 
 
-@pytest.mark.integration
 def test_mcp_logs_bounded_tool_metrics_without_arguments(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
@@ -694,7 +688,6 @@ def test_mcp_logs_bounded_tool_metrics_without_arguments(
     assert "private-query-marker" not in metric
 
 
-@pytest.mark.integration
 def test_mcp_tool_failures_return_safe_actionable_errors(tmp_path: Path) -> None:
     async def scenario() -> None:
         from mcp import Client
@@ -713,7 +706,6 @@ def test_mcp_tool_failures_return_safe_actionable_errors(tmp_path: Path) -> None
     assert internal["error"]["code"] == "OPERATION_FAILED"
 
 
-@pytest.mark.integration
 def test_mcp_protocol_and_authentication_errors_remain_distinct(tmp_path: Path) -> None:
     from mcp.shared.exceptions import MCPError
 
@@ -744,7 +736,6 @@ def test_mcp_protocol_and_authentication_errors_remain_distinct(tmp_path: Path) 
     asyncio.run(scenario())
 
 
-@pytest.mark.integration
 @pytest.mark.subprocess
 def test_mcp_stdio_entrypoint_exposes_capability_and_workspace_tools(
     tmp_path: Path,
@@ -770,7 +761,6 @@ def test_mcp_stdio_entrypoint_exposes_capability_and_workspace_tools(
     asyncio.run(scenario())
 
 
-@pytest.mark.integration
 @pytest.mark.subprocess
 def test_mcp_entrypoint_has_nonstarting_help() -> None:
     completed = subprocess.run(

--- a/tests/integration/test_mcp_agent_surface.py
+++ b/tests/integration/test_mcp_agent_surface.py
@@ -6,7 +6,6 @@ import json
 from pathlib import Path
 from typing import Any
 
-import pytest
 from mcp import Client
 
 from jacobian.adapters.mcp.server import create_server
@@ -91,7 +90,6 @@ async def _capture_surface(state_dir: Path) -> dict[str, Any]:
         }
 
 
-@pytest.mark.integration
 def test_complete_agent_facing_mcp_surface_matches_snapshot(tmp_path: Path) -> None:
     actual = asyncio.run(_capture_surface(tmp_path))
     canonical = json.dumps(

--- a/tests/integration/test_optional_provider_startup.py
+++ b/tests/integration/test_optional_provider_startup.py
@@ -4,10 +4,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-import pytest
-
-pytestmark = pytest.mark.integration
-
 
 def test_kernel_starts_and_exposes_unrelated_capabilities_without_flint(
     tmp_path: Path,

--- a/tests/integration/test_plugin_execution.py
+++ b/tests/integration/test_plugin_execution.py
@@ -10,7 +10,6 @@ import pytest
 from jacobian.plugin_execution import PluginExecutor
 
 
-@pytest.mark.integration
 def test_plugin_executor_returns_only_canonical_result() -> None:
     result = PluginExecutor().run(
         entrypoint="tests.fixtures.plugin_functions:echo",
@@ -23,7 +22,6 @@ def test_plugin_executor_returns_only_canonical_result() -> None:
     assert "untrusted plugin diagnostic" in result.diagnostics
 
 
-@pytest.mark.integration
 def test_plugin_executor_rejects_changed_implementation_digest() -> None:
     result = PluginExecutor().run(
         entrypoint="tests.fixtures.plugin_functions:echo",
@@ -40,7 +38,6 @@ def test_plugin_executor_rejects_changed_implementation_digest() -> None:
     )
 
 
-@pytest.mark.integration
 def test_plugin_executor_does_not_expose_untrusted_exception_text() -> None:
     result = PluginExecutor().run(
         entrypoint="tests.fixtures.plugin_functions:propose_declared_failure",
@@ -57,7 +54,6 @@ def test_plugin_executor_does_not_expose_untrusted_exception_text() -> None:
     assert "fixture" not in result.detail
 
 
-@pytest.mark.integration
 def test_module_import_diagnostics_do_not_corrupt_worker_protocol() -> None:
     result = PluginExecutor().run(
         entrypoint="tests.fixtures.noisy_module:echo",
@@ -70,7 +66,6 @@ def test_module_import_diagnostics_do_not_corrupt_worker_protocol() -> None:
     assert "module import diagnostic" in result.diagnostics
 
 
-@pytest.mark.integration
 def test_plugin_timeout_has_no_mathematical_output() -> None:
     result = PluginExecutor().run(
         entrypoint="tests.fixtures.plugin_functions:wait_forever",
@@ -86,7 +81,6 @@ def test_plugin_timeout_has_no_mathematical_output() -> None:
     )
 
 
-@pytest.mark.integration
 def test_plugin_unreadable_response_explains_recovery() -> None:
     result = PluginExecutor().run(
         entrypoint="tests.fixtures.plugin_functions:exit_without_response",
@@ -102,7 +96,6 @@ def test_plugin_unreadable_response_explains_recovery() -> None:
     )
 
 
-@pytest.mark.integration
 def test_plugin_diagnostic_limit_fails_closed() -> None:
     start = time.monotonic()
     result = PluginExecutor(max_diagnostic_bytes=32).run(
@@ -120,7 +113,6 @@ def test_plugin_diagnostic_limit_fails_closed() -> None:
     )
 
 
-@pytest.mark.integration
 def test_plugin_timeout_kills_descendant_processes(tmp_path: Path) -> None:
     marker = tmp_path / "descendant-survived"
 
@@ -135,7 +127,6 @@ def test_plugin_timeout_kills_descendant_processes(tmp_path: Path) -> None:
     assert not marker.exists()
 
 
-@pytest.mark.integration
 def test_plugin_success_kills_descendant_holding_output_pipes(tmp_path: Path) -> None:
     marker = tmp_path / "pipe-holder-survived"
     start = time.monotonic()
@@ -154,7 +145,6 @@ def test_plugin_success_kills_descendant_holding_output_pipes(tmp_path: Path) ->
     assert not marker.exists()
 
 
-@pytest.mark.integration
 def test_plugin_success_still_kills_detached_descendants(tmp_path: Path) -> None:
     marker = tmp_path / "detached-descendant-survived"
 
@@ -169,7 +159,6 @@ def test_plugin_success_still_kills_detached_descendants(tmp_path: Path) -> None
     assert not marker.exists()
 
 
-@pytest.mark.integration
 def test_plugin_worker_does_not_inherit_parent_secrets(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -186,7 +175,6 @@ def test_plugin_worker_does_not_inherit_parent_secrets(
     assert result.output == {"secret": None, "https_proxy": None}
 
 
-@pytest.mark.integration
 def test_plugin_worker_rejects_bytecode_modules(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/integration/test_plugin_registry_snapshots.py
+++ b/tests/integration/test_plugin_registry_snapshots.py
@@ -203,7 +203,6 @@ def _install_external_plugin(
     )
 
 
-@pytest.mark.integration
 @pytest.mark.conformance
 def test_registry_snapshot_binds_contract_source_runtime_and_platform(
     tmp_path: Path,
@@ -254,7 +253,6 @@ def test_registry_snapshot_binds_contract_source_runtime_and_platform(
     assert marker.exists()
 
 
-@pytest.mark.integration
 def test_registry_snapshot_fails_closed_on_runtime_mismatch(
     tmp_path: Path,
     plugin_kernel: JacobianKernel,
@@ -275,7 +273,6 @@ def test_registry_snapshot_fails_closed_on_runtime_mismatch(
         kernel.plugins.resolve(plugin_id, CapabilityName.EVALUATOR)
 
 
-@pytest.mark.integration
 @pytest.mark.subprocess
 def test_external_plugin_passes_the_generic_conformance_kit(
     tmp_path: Path,

--- a/tests/integration/test_polynomial_capabilities.py
+++ b/tests/integration/test_polynomial_capabilities.py
@@ -94,7 +94,6 @@ def _identity_input(
     }
 
 
-@pytest.mark.integration
 def test_polynomial_identity_descriptor_example_is_directly_invocable(
     tmp_path: Path,
 ) -> None:
@@ -117,7 +116,6 @@ def test_polynomial_identity_descriptor_example_is_directly_invocable(
     assert result.assurance.level is CapabilityAssuranceLevel.VERIFIED
 
 
-@pytest.mark.integration
 def test_polynomial_identity_verifies_equal_coefficients(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path, install_references=True)
 
@@ -169,7 +167,6 @@ def test_polynomial_identity_verifies_equal_coefficients(tmp_path: Path) -> None
     assert rejected.verification_record_uri is None
 
 
-@pytest.mark.integration
 def test_polynomial_identity_verifies_a_difference(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path, install_references=True)
 
@@ -191,7 +188,6 @@ def test_polynomial_identity_verifies_a_difference(tmp_path: Path) -> None:
     assert record.payload["relation_id"] is None
 
 
-@pytest.mark.integration
 def test_polynomial_identity_preserves_checker_rejection_as_unknown(
     tmp_path: Path,
 ) -> None:
@@ -216,7 +212,6 @@ def test_polynomial_identity_preserves_checker_rejection_as_unknown(
     assert result.relationships == ()
 
 
-@pytest.mark.integration
 def test_jacobian_canonically_omits_zero_partial_derivatives(
     tmp_path: Path,
 ) -> None:
@@ -251,7 +246,6 @@ def test_jacobian_canonically_omits_zero_partial_derivatives(
     }
 
 
-@pytest.mark.integration
 def test_jacobian_represents_derived_exponents_above_the_source_limit(
     tmp_path: Path,
 ) -> None:
@@ -296,7 +290,6 @@ def test_jacobian_represents_derived_exponents_above_the_source_limit(
     assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED
 
 
-@pytest.mark.integration
 def test_polynomial_jacobian_and_collision_reproduce_public_counterexample(
     tmp_path: Path,
 ) -> None:
@@ -412,7 +405,6 @@ def test_polynomial_jacobian_and_collision_reproduce_public_counterexample(
     assert verified.output["verification_record_uri"]
 
 
-@pytest.mark.integration
 def test_collision_checker_rejects_a_forged_image(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path, install_references=True)
     polynomial_map = _jacobian_counterexample_map()
@@ -487,7 +479,6 @@ def test_collision_checker_rejects_a_forged_image(tmp_path: Path) -> None:
     assert rejected.output["verification_record_uri"] is None
 
 
-@pytest.mark.integration
 def test_collision_comparison_does_not_promote_forged_evaluations(
     tmp_path: Path,
 ) -> None:
@@ -552,7 +543,6 @@ def test_collision_comparison_does_not_promote_forged_evaluations(
     assert rejected.assurance.level is CapabilityAssuranceLevel.HEURISTIC
 
 
-@pytest.mark.integration
 def test_noncollision_is_computed_evidence_without_witness_or_conclusion(
     tmp_path: Path,
 ) -> None:
@@ -594,7 +584,6 @@ def test_noncollision_is_computed_evidence_without_witness_or_conclusion(
     assert "conclusion" not in result.output
 
 
-@pytest.mark.integration
 def test_collision_rejects_evaluations_from_different_maps(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path)
     x = symbols("x")
@@ -637,7 +626,6 @@ def test_collision_rejects_evaluations_from_different_maps(tmp_path: Path) -> No
     assert result.diagnostics[0].code == "POLYNOMIAL_EVALUATION_MAP_MISMATCH"
 
 
-@pytest.mark.integration
 def test_collision_validates_evaluation_dimensions_before_artifact_writes(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -695,7 +683,6 @@ def test_collision_validates_evaluation_dimensions_before_artifact_writes(
     assert artifact_put_calls == 0
 
 
-@pytest.mark.integration
 def test_polynomial_map_evaluation_is_exact_and_materialized(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path)
     polynomial_map = _jacobian_counterexample_map()
@@ -721,7 +708,6 @@ def test_polynomial_map_evaluation_is_exact_and_materialized(tmp_path: Path) -> 
     assert result.completeness.status is CapabilityCompletenessStatus.COMPLETE
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize(
     ("capability_id", "payload", "diagnostic_code"),
     [

--- a/tests/integration/test_polynomial_collision_search.py
+++ b/tests/integration/test_polynomial_collision_search.py
@@ -42,7 +42,6 @@ def _request(exponent: int) -> CapabilityRequest:
     )
 
 
-@pytest.mark.integration
 def test_collision_search_returns_first_deterministic_candidate(
     tmp_path: Path,
 ) -> None:
@@ -62,7 +61,6 @@ def test_collision_search_returns_first_deterministic_candidate(
     assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
 
 
-@pytest.mark.integration
 def test_collision_search_reports_partial_grid_after_early_collision(
     tmp_path: Path,
 ) -> None:
@@ -108,7 +106,6 @@ def test_collision_search_reports_partial_grid_after_early_collision(
     assert relationship_artifacts <= set(result.artifact_uris)
 
 
-@pytest.mark.integration
 def test_collision_search_reports_exact_completed_not_found_scope(
     tmp_path: Path,
 ) -> None:
@@ -131,7 +128,6 @@ def test_collision_search_reports_exact_completed_not_found_scope(
     )
 
 
-@pytest.mark.integration
 def test_collision_search_validates_grid_bound_before_artifact_writes(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/integration/test_polynomial_collision_verify.py
+++ b/tests/integration/test_polynomial_collision_verify.py
@@ -45,7 +45,6 @@ def _request(image: int) -> CapabilityRequest:
     )
 
 
-@pytest.mark.integration
 def test_direct_collision_verifier_promotes_only_independent_replay(
     tmp_path: Path,
 ) -> None:
@@ -80,7 +79,6 @@ def test_direct_collision_verifier_promotes_only_independent_replay(
     assert relationship.obligation_uris == ()
 
 
-@pytest.mark.integration
 def test_direct_collision_verifier_fails_closed_for_wrong_image(
     tmp_path: Path,
 ) -> None:

--- a/tests/integration/test_polynomial_factor.py
+++ b/tests/integration/test_polynomial_factor.py
@@ -20,7 +20,6 @@ def _term(coefficient: int, exponent: int) -> dict[str, object]:
     }
 
 
-@pytest.mark.integration
 def test_factor_compute_preserves_multiplicity_and_reconstructs_exactly(
     tmp_path: Path,
 ) -> None:
@@ -57,7 +56,6 @@ def test_factor_compute_preserves_multiplicity_and_reconstructs_exactly(
     assert source.manifest.semantics_uri != factorization.manifest.semantics_uri
 
 
-@pytest.mark.integration
 def test_factor_compute_handles_zero_as_a_coefficient_not_a_unit(
     tmp_path: Path,
 ) -> None:
@@ -77,7 +75,6 @@ def test_factor_compute_handles_zero_as_a_coefficient_not_a_unit(
     assert result.output["irreducibility_verification"] == "UNVERIFIED"
 
 
-@pytest.mark.integration
 def test_factor_compute_preserves_rational_coefficient_and_irreducible_factor(
     tmp_path: Path,
 ) -> None:

--- a/tests/integration/test_polynomial_interval_capabilities.py
+++ b/tests/integration/test_polynomial_interval_capabilities.py
@@ -65,7 +65,6 @@ def installation(tmp_path: Path):
     return adapters, installed, store
 
 
-@pytest.mark.integration
 def test_enclose_capability_computes_a_valid_bernstein_enclosure(
     installation,
 ) -> None:
@@ -103,7 +102,6 @@ def test_enclose_capability_computes_a_valid_bernstein_enclosure(
     assert result.relationships[0].status is CapabilityRelationshipStatus.PROPOSED
 
 
-@pytest.mark.integration
 def test_enclose_capability_handles_a_quadratic_on_a_shifted_interval(
     installation,
 ) -> None:
@@ -134,7 +132,6 @@ def test_enclose_capability_handles_a_quadratic_on_a_shifted_interval(
     assert result.output["range_exactness"] == "ENCLOSURE_VALID_NOT_EXACT"
 
 
-@pytest.mark.integration
 def test_verify_capability_confirms_a_valid_enclosure(installation) -> None:
     adapters, _installed, _store = installation
     enclose, verify = adapters
@@ -179,7 +176,6 @@ def test_verify_capability_confirms_a_valid_enclosure(installation) -> None:
     assert result.relationships[0].status is CapabilityRelationshipStatus.VERIFIED
 
 
-@pytest.mark.integration
 def test_verify_capability_rejects_a_false_enclosure(installation) -> None:
     adapters, _installed, _store = installation
     _enclose, verify = adapters
@@ -211,7 +207,6 @@ def test_verify_capability_rejects_a_false_enclosure(installation) -> None:
     assert result.relationships == ()
 
 
-@pytest.mark.integration
 def test_enclose_capability_rejects_a_degenerate_interval(installation) -> None:
     adapters, _installed, _store = installation
     enclose, _verify = adapters

--- a/tests/integration/test_polynomial_map_inverse_synthesize.py
+++ b/tests/integration/test_polynomial_map_inverse_synthesize.py
@@ -65,7 +65,6 @@ def _request(
     )
 
 
-@pytest.mark.integration
 def test_triangular_automorphism_is_found_and_verified(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path, install_references=True)
     result = kernel.capabilities.invoke(_request(degree=2))
@@ -89,7 +88,6 @@ def test_triangular_automorphism_is_found_and_verified(tmp_path: Path) -> None:
     ]
 
 
-@pytest.mark.integration
 def test_degree_below_required_returns_bounded_no_candidate(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path, install_references=True)
     result = kernel.capabilities.invoke(_request(degree=1))
@@ -99,7 +97,6 @@ def test_degree_below_required_returns_bounded_no_candidate(tmp_path: Path) -> N
     assert result.output["noninvertibility_proved"] is False
 
 
-@pytest.mark.integration
 def test_redundant_explicit_ansatz_is_underdetermined(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path, install_references=True)
     identity = {
@@ -136,7 +133,6 @@ def test_redundant_explicit_ansatz_is_underdetermined(tmp_path: Path) -> None:
     assert "free parameters" in result.output["verification_failure"]
 
 
-@pytest.mark.integration
 def test_zero_timeout_and_unknown_budget_are_explicit(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path, install_references=True)
 
@@ -148,7 +144,6 @@ def test_zero_timeout_and_unknown_budget_are_explicit(tmp_path: Path) -> None:
     assert exhausted.output["status"] == "BUDGET_EXHAUSTED"
 
 
-@pytest.mark.integration
 def test_unknown_solver_is_unsupported_without_truth_claim(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path, install_references=True)
     payload = deepcopy(_request(degree=2).input)
@@ -166,7 +161,6 @@ def test_unknown_solver_is_unsupported_without_truth_claim(tmp_path: Path) -> No
     assert result.output["noninvertibility_proved"] is False
 
 
-@pytest.mark.integration
 def test_full_support_and_coefficient_order_are_deterministic(
     tmp_path: Path,
 ) -> None:
@@ -197,7 +191,6 @@ def test_full_support_and_coefficient_order_are_deterministic(
     ]
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize(
     "mutation",
     ["variable_order", "coefficient_domain"],
@@ -221,7 +214,6 @@ def test_ring_mismatches_fail_closed(tmp_path: Path, mutation: str) -> None:
     assert result.artifact_uris == ()
 
 
-@pytest.mark.integration
 def test_corrupted_found_candidate_does_not_verify(
     tmp_path: Path,
 ) -> None:

--- a/tests/integration/test_polynomial_map_inverse_verify.py
+++ b/tests/integration/test_polynomial_map_inverse_verify.py
@@ -87,7 +87,6 @@ def _checker_request(kernel: JacobianKernel, output: dict[str, Any]) -> dict[str
     }
 
 
-@pytest.mark.integration
 def test_two_sided_triangular_inverse_is_verified(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path, install_references=True)
     forward, inverse = _triangular_maps()
@@ -108,7 +107,6 @@ def test_two_sided_triangular_inverse_is_verified(tmp_path: Path) -> None:
     assert residuals["forward_after_inverse"] == [{"terms": []}, {"terms": []}]
 
 
-@pytest.mark.integration
 def test_overlapping_variable_names_use_simultaneous_composition(
     tmp_path: Path,
 ) -> None:
@@ -150,7 +148,6 @@ def test_overlapping_variable_names_use_simultaneous_composition(
     assert result.assurance.level is CapabilityAssuranceLevel.VERIFIED
 
 
-@pytest.mark.integration
 def test_unrepresentable_composition_is_rejected_before_artifacts(
     tmp_path: Path,
 ) -> None:
@@ -179,7 +176,6 @@ def test_unrepresentable_composition_is_rejected_before_artifacts(
     assert result.artifact_uris == ()
 
 
-@pytest.mark.integration
 def test_perturbed_inverse_coefficient_is_verified_false(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path, install_references=True)
     forward, inverse = _triangular_maps()
@@ -195,7 +191,6 @@ def test_perturbed_inverse_coefficient_is_verified_false(tmp_path: Path) -> None
     assert any(item["terms"] for item in residuals["forward_after_inverse"])
 
 
-@pytest.mark.integration
 def test_checker_rejects_residual_coefficient_tampering(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path, install_references=True)
     forward, inverse = _triangular_maps()
@@ -211,7 +206,6 @@ def test_checker_rejects_residual_coefficient_tampering(tmp_path: Path) -> None:
     assert decision["conclusion"] == Conclusion.UNKNOWN.value
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize(
     ("zero_direction", "nonzero_direction"),
     (
@@ -239,7 +233,6 @@ def test_one_declared_identity_direction_never_verifies(
     assert decision["conclusion"] == Conclusion.UNKNOWN.value
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize("tamper", ("domain", "source_order", "target_order"))
 def test_checker_rejects_domain_and_order_substitution(
     tmp_path: Path, tamper: str
@@ -261,7 +254,6 @@ def test_checker_rejects_domain_and_order_substitution(
     assert decision["conclusion"] == Conclusion.UNKNOWN.value
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize("source", ("scope", "inverse"))
 def test_checker_rejects_source_map_coefficient_tampering(
     tmp_path: Path, source: str
@@ -283,7 +275,6 @@ def test_checker_rejects_source_map_coefficient_tampering(
     assert decision["conclusion"] == Conclusion.UNKNOWN.value
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize(
     "family",
     (

--- a/tests/integration/test_polynomial_positivity_capabilities.py
+++ b/tests/integration/test_polynomial_positivity_capabilities.py
@@ -290,7 +290,6 @@ def installation(tmp_path: Path):
     return adapters, installed, store
 
 
-@pytest.mark.integration
 def test_decide_capability_finds_positive_linear(installation) -> None:
     adapters, _installed, _store = installation
     decide, _verify = adapters
@@ -322,7 +321,6 @@ def test_decide_capability_finds_positive_linear(installation) -> None:
     )
 
 
-@pytest.mark.integration
 def test_decide_capability_detects_root_in_interval(installation) -> None:
     adapters, _installed, _store = installation
     decide, _verify = adapters
@@ -346,7 +344,6 @@ def test_decide_capability_detects_root_in_interval(installation) -> None:
     assert result.output["sign_changes_at_hi"] == 0
 
 
-@pytest.mark.integration
 def test_decide_capability_detects_endpoint_root(installation) -> None:
     adapters, _installed, _store = installation
     decide, _verify = adapters
@@ -368,7 +365,6 @@ def test_decide_capability_detects_endpoint_root(installation) -> None:
     assert result.output["endpoint_root"] is True
 
 
-@pytest.mark.integration
 def test_verify_capability_confirms_positive_decision(installation) -> None:
     adapters, _installed, _store = installation
     decide, verify = adapters
@@ -414,7 +410,6 @@ def test_verify_capability_confirms_positive_decision(installation) -> None:
     assert result.relationships[0].status is CapabilityRelationshipStatus.VERIFIED
 
 
-@pytest.mark.integration
 def test_verify_capability_refutes_false_positive_claim(installation) -> None:
     adapters, _installed, _store = installation
     _decide, verify = adapters

--- a/tests/integration/test_polynomial_system_capabilities.py
+++ b/tests/integration/test_polynomial_system_capabilities.py
@@ -39,7 +39,6 @@ def _input(value: int) -> dict[str, Any]:
     }
 
 
-@pytest.mark.integration
 def test_solution_capability_verifies_valid_assignment(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path, install_references=True)
 
@@ -80,7 +79,6 @@ def test_solution_capability_verifies_valid_assignment(tmp_path: Path) -> None:
     assert record.payload["obligation_uri"] is None
 
 
-@pytest.mark.integration
 def test_solution_capability_verifies_invalid_assignment(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path, install_references=True)
 
@@ -104,7 +102,6 @@ def test_solution_capability_verifies_invalid_assignment(tmp_path: Path) -> None
     assert record.payload["obligation_uri"] is None
 
 
-@pytest.mark.integration
 def test_solution_capability_keeps_checker_failure_unknown(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -132,7 +129,6 @@ def test_solution_capability_keeps_checker_failure_unknown(
     assert result.relationships == ()
 
 
-@pytest.mark.integration
 def test_solution_capability_rejects_dimension_mismatch_before_artifact_writes(
     tmp_path: Path,
 ) -> None:
@@ -164,7 +160,6 @@ def test_solution_capability_rejects_dimension_mismatch_before_artifact_writes(
     assert before == after
 
 
-@pytest.mark.integration
 def test_solution_capability_is_only_available_with_checker(
     tmp_path: Path,
 ) -> None:

--- a/tests/integration/test_polynomial_system_search.py
+++ b/tests/integration/test_polynomial_system_search.py
@@ -32,7 +32,6 @@ def _request(constant: int) -> CapabilityRequest:
     )
 
 
-@pytest.mark.integration
 def test_rational_solution_search_returns_first_exact_candidate(tmp_path: Path) -> None:
     result = JacobianKernel(tmp_path, install_references=True).capabilities.invoke(
         _request(1)
@@ -43,7 +42,6 @@ def test_rational_solution_search_returns_first_exact_candidate(tmp_path: Path) 
     assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
 
 
-@pytest.mark.integration
 def test_rational_solution_search_reports_completed_bounded_absence(
     tmp_path: Path,
 ) -> None:

--- a/tests/integration/test_polytope_separation.py
+++ b/tests/integration/test_polytope_separation.py
@@ -52,7 +52,6 @@ def _simplex(
     return point_artifact.artifact_uri, generators.artifact_uri
 
 
-@pytest.mark.integration
 def test_backend_failure_keeps_provider_detail_local(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -87,7 +86,6 @@ def test_backend_failure_keeps_provider_detail_local(
     assert "internal-id=secret" in caplog.text
 
 
-@pytest.mark.integration
 @pytest.mark.subprocess
 def test_exact_membership_witness_is_independently_replayed(
     tmp_path: Path,
@@ -122,7 +120,6 @@ def test_exact_membership_witness_is_independently_replayed(
     assert verified.verification_record_uri is not None
 
 
-@pytest.mark.integration
 @pytest.mark.subprocess
 def test_exact_separator_is_generated_then_independently_checked(
     tmp_path: Path,
@@ -162,7 +159,6 @@ def test_exact_separator_is_generated_then_independently_checked(
     assert verified.assurance.verification.value == "VERIFIED"
 
 
-@pytest.mark.integration
 @pytest.mark.subprocess
 def test_separator_payload_tampering_fails_closed(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path, install_references=True)
@@ -201,7 +197,6 @@ def test_separator_payload_tampering_fails_closed(tmp_path: Path) -> None:
     assert result.verification_record_uri is None
 
 
-@pytest.mark.integration
 def test_projection_is_explicit_and_bound_to_derived_artifacts(
     tmp_path: Path,
 ) -> None:

--- a/tests/integration/test_remote_mcp.py
+++ b/tests/integration/test_remote_mcp.py
@@ -26,7 +26,6 @@ from jacobian.store import ArtifactNotFoundError
 from jacobian.workspaces import WorkspaceNotFoundError
 
 
-@pytest.mark.integration
 def test_static_tokens_bind_distinct_authenticated_subjects() -> None:
     verifier = StaticTokenVerifier(
         (
@@ -44,7 +43,6 @@ def test_static_tokens_bind_distinct_authenticated_subjects() -> None:
     assert unknown is None
 
 
-@pytest.mark.integration
 def test_remote_configuration_errors_name_the_rule_and_recovery(
     tmp_path: Path,
 ) -> None:
@@ -142,7 +140,6 @@ def test_remote_configuration_errors_name_the_rule_and_recovery(
         load_static_token_file(token_file)
 
 
-@pytest.mark.integration
 def test_tenant_router_isolates_artifact_stores(tmp_path: Path) -> None:
     router = TenantKernelRouter(
         tmp_path,
@@ -166,7 +163,6 @@ def test_tenant_router_isolates_artifact_stores(tmp_path: Path) -> None:
         beta.store.get(stored)
 
 
-@pytest.mark.integration
 def test_tenant_router_isolates_epistemic_workspaces(tmp_path: Path) -> None:
     router = TenantKernelRouter(tmp_path, install_references=False)
     alpha = router.kernel_for("alpha")
@@ -189,7 +185,6 @@ def test_tenant_router_isolates_epistemic_workspaces(tmp_path: Path) -> None:
         )
 
 
-@pytest.mark.integration
 def test_token_file_is_strict_and_remote_cli_fails_closed(
     tmp_path: Path,
 ) -> None:
@@ -227,7 +222,6 @@ def test_token_file_is_strict_and_remote_cli_fails_closed(
     assert "require --auth-tokens-file" in completed.stderr
 
 
-@pytest.mark.integration
 @pytest.mark.subprocess
 def test_authenticated_streamable_http_isolates_tenant_memory(
     tmp_path: Path,

--- a/tests/integration/test_sat_artifacts.py
+++ b/tests/integration/test_sat_artifacts.py
@@ -39,8 +39,6 @@ def _producer() -> CapabilityProviderRuntime:
     )
 
 
-@pytest.mark.integration
-@pytest.mark.contract
 def test_sat_service_materializes_one_identity_for_equivalent_cnf_input(
     tmp_path: Path,
 ) -> None:
@@ -63,8 +61,6 @@ def test_sat_service_materializes_one_identity_for_equivalent_cnf_input(
     assert stored.manifest.semantics_uri == kernel.sat.installation.semantics_uri
 
 
-@pytest.mark.integration
-@pytest.mark.contract
 def test_sat_cnf_materialization_capability_exposes_reusable_identity(
     tmp_path: Path,
 ) -> None:
@@ -126,8 +122,6 @@ def test_sat_materialization_makes_lexicographic_name_order_explicit(
     assert resolved.cnf.to_dimacs_bytes() == b"p cnf 3 3\n1 0\n2 0\n-3 0\n"
 
 
-@pytest.mark.integration
-@pytest.mark.contract
 def test_sat_cnf_materialization_validates_before_artifact_write(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -157,8 +151,6 @@ def test_sat_cnf_materialization_validates_before_artifact_write(
     assert result.diagnostics[0].code == "INVALID_CNF"
 
 
-@pytest.mark.integration
-@pytest.mark.contract
 def test_model_backed_schema_rejects_noncanonical_generic_artifact_put(
     tmp_path: Path,
 ) -> None:
@@ -186,8 +178,6 @@ def test_model_backed_schema_rejects_noncanonical_generic_artifact_put(
         )
 
 
-@pytest.mark.integration
-@pytest.mark.contract
 def test_assignment_and_raw_proof_bind_exact_cnf_identity_and_lineage(
     tmp_path: Path,
 ) -> None:
@@ -233,8 +223,6 @@ def test_assignment_and_raw_proof_bind_exact_cnf_identity_and_lineage(
     assert proof.raw_bytes() == b"d -1 2 0\n0\n"
 
 
-@pytest.mark.integration
-@pytest.mark.contract
 def test_sat_service_rejects_a_non_cnf_source_before_writing_evidence(
     tmp_path: Path,
 ) -> None:

--- a/tests/integration/test_sat_assignment_verification.py
+++ b/tests/integration/test_sat_assignment_verification.py
@@ -67,7 +67,6 @@ def _verify(kernel: JacobianKernel, assignment_uri: str):
     )
 
 
-@pytest.mark.integration
 @pytest.mark.subprocess
 def test_sat_assignment_is_verified_by_an_authorized_clean_process(
     tmp_path: Path,
@@ -109,7 +108,6 @@ def test_sat_assignment_is_verified_by_an_authorized_clean_process(
     }
 
 
-@pytest.mark.integration
 @pytest.mark.subprocess
 def test_unsatisfying_assignment_is_rejected_without_an_opposite_conclusion(
     tmp_path: Path,
@@ -127,7 +125,6 @@ def test_unsatisfying_assignment_is_rejected_without_an_opposite_conclusion(
     assert result.assurance.verification_record_uri is None
 
 
-@pytest.mark.integration
 def test_sat_assignment_verify_requires_operator_authorized_checker(
     tmp_path: Path,
 ) -> None:
@@ -140,7 +137,6 @@ def test_sat_assignment_verify_requires_operator_authorized_checker(
     }
 
 
-@pytest.mark.integration
 def test_misbound_assignment_artifact_fails_before_checker_dispatch(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -173,7 +169,6 @@ def test_misbound_assignment_artifact_fails_before_checker_dispatch(
     assert called is False
 
 
-@pytest.mark.integration
 def test_checker_timeout_cannot_create_a_sat_conclusion(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -194,7 +189,6 @@ def test_checker_timeout_cannot_create_a_sat_conclusion(
     assert result.assurance.verification_record_uri is None
 
 
-@pytest.mark.integration
 def test_checker_error_cannot_create_a_sat_conclusion(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/integration/test_sat_lrat_verification.py
+++ b/tests/integration/test_sat_lrat_verification.py
@@ -13,7 +13,6 @@ from jacobian.contracts.results import ExecutionStatus
 from jacobian.kernel import JacobianKernel
 
 pytestmark = [
-    pytest.mark.integration,
     pytest.mark.subprocess,
     pytest.mark.usefixtures("initialized_kernel_store_with_references"),
 ]

--- a/tests/integration/test_sat_unsat_proof_external_backend.py
+++ b/tests/integration/test_sat_unsat_proof_external_backend.py
@@ -20,7 +20,6 @@ from jacobian.provider_runtime import (
 )
 
 pytestmark = [
-    pytest.mark.integration,
     pytest.mark.external_backend,
     pytest.mark.usefixtures("initialized_kernel_store_with_references"),
 ]

--- a/tests/integration/test_sat_unsat_proof_verification.py
+++ b/tests/integration/test_sat_unsat_proof_verification.py
@@ -26,7 +26,6 @@ from jacobian.provider_runtime import drat_trim_provider_runtime
 from jacobian.verification import CheckerExecutionError, _environment_digest
 
 pytestmark = [
-    pytest.mark.integration,
     pytest.mark.usefixtures("initialized_kernel_store_with_references"),
 ]
 

--- a/tests/integration/test_search_orchestration.py
+++ b/tests/integration/test_search_orchestration.py
@@ -133,7 +133,6 @@ def _request(
     )
 
 
-@pytest.mark.integration
 def test_search_run_checkpoints_strategy_neutral_lineage(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path)
     claim_uri, plugin_id = _install_search_plugin(kernel)
@@ -177,7 +176,6 @@ def test_search_run_checkpoints_strategy_neutral_lineage(tmp_path: Path) -> None
     assert proposer_event.payload["output_digest"].startswith("sha256:")
 
 
-@pytest.mark.integration
 def test_resume_rejects_archive_page_rebound_to_another_plugin(
     tmp_path: Path,
 ) -> None:
@@ -233,7 +231,6 @@ def test_resume_rejects_archive_page_rebound_to_another_plugin(
     assert "archive page identity does not match the search" in recovered.detail
 
 
-@pytest.mark.integration
 def test_checkpoint_persistence_is_included_in_wall_accounting(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -268,7 +265,6 @@ def test_checkpoint_persistence_is_included_in_wall_accounting(
     assert snapshot.accounting.wall_time_ms == 1_000
 
 
-@pytest.mark.integration
 def test_checkpoint_persistence_cannot_complete_past_wall_budget(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -306,7 +302,6 @@ def test_checkpoint_persistence_cannot_complete_past_wall_budget(
     assert snapshot.accounting.wall_time_ms >= 5_000
 
 
-@pytest.mark.integration
 def test_concurrent_retries_create_one_search_invocation(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -341,7 +336,6 @@ def test_concurrent_retries_create_one_search_invocation(
     assert event_types.count("REQUEST_REUSED") == 8
 
 
-@pytest.mark.integration
 def test_search_lifecycle_events_are_append_only(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path)
     claim_uri, plugin_id = _install_search_plugin(kernel)
@@ -375,7 +369,6 @@ def test_search_lifecycle_events_are_append_only(tmp_path: Path) -> None:
         )
 
 
-@pytest.mark.integration
 def test_idempotency_key_cannot_be_rebound(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path)
     claim_uri, plugin_id = _install_search_plugin(kernel)
@@ -402,7 +395,6 @@ def test_idempotency_key_cannot_be_rebound(tmp_path: Path) -> None:
         )
 
 
-@pytest.mark.integration
 def test_search_pauses_and_resumes_without_duplicate_lineage(
     tmp_path: Path,
 ) -> None:
@@ -438,7 +430,6 @@ def test_search_pauses_and_resumes_without_duplicate_lineage(
     assert len(set(completed.archive_page_uris)) == 4
 
 
-@pytest.mark.integration
 def test_interrupted_search_recovers_from_checkpoint_without_chat_state(
     tmp_path: Path,
 ) -> None:
@@ -498,7 +489,6 @@ def test_interrupted_search_recovers_from_checkpoint_without_chat_state(
     assert len(set(completed.archive_page_uris)) == 4
 
 
-@pytest.mark.integration
 def test_interrupted_cancellation_remains_cancelled_after_recovery(
     tmp_path: Path,
 ) -> None:
@@ -560,7 +550,6 @@ def test_interrupted_cancellation_remains_cancelled_after_recovery(
     ]
 
 
-@pytest.mark.integration
 def test_corrupt_snapshot_is_quarantined_without_blocking_recovery(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -654,7 +643,6 @@ def test_corrupt_snapshot_is_quarantined_without_blocking_recovery(
     )
 
 
-@pytest.mark.integration
 @pytest.mark.subprocess
 def test_proposer_timeout_fails_closed(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path)
@@ -687,7 +675,6 @@ def test_proposer_timeout_fails_closed(tmp_path: Path) -> None:
     assert snapshot.archive_page_uris == ()
 
 
-@pytest.mark.integration
 def test_malformed_proposal_fails_without_evidence_promotion(
     tmp_path: Path,
 ) -> None:
@@ -716,7 +703,6 @@ def test_malformed_proposal_fails_without_evidence_promotion(
     assert snapshot.archive_page_uris == ()
 
 
-@pytest.mark.integration
 @pytest.mark.subprocess
 def test_partial_iteration_accounting_survives_malformed_candidate(
     tmp_path: Path,
@@ -745,7 +731,6 @@ def test_partial_iteration_accounting_survives_malformed_candidate(
     assert snapshot.accounting.evaluated_candidates == 0
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize(
     ("entrypoint", "detail", "case_id"),
     [
@@ -793,7 +778,6 @@ def test_search_plugin_failures_remain_operational(
     assert snapshot.archive_page_uris == ()
 
 
-@pytest.mark.integration
 def test_terminal_archive_failure_marks_search_error(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -827,7 +811,6 @@ def test_terminal_archive_failure_marks_search_error(
     assert "fixture archive failure" in caplog.text
 
 
-@pytest.mark.integration
 def test_plugin_cannot_widen_operator_batch_policy(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path)
     kernel.search.max_batch_size = 1
@@ -854,7 +837,6 @@ def test_plugin_cannot_widen_operator_batch_policy(tmp_path: Path) -> None:
     assert snapshot.accounting.proposed_candidates == 0
 
 
-@pytest.mark.integration
 def test_search_batch_respects_evaluator_limit(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path)
     kernel.evaluation.max_batch_size = 2
@@ -877,7 +859,6 @@ def test_search_batch_respects_evaluator_limit(tmp_path: Path) -> None:
     assert snapshot.accounting.iterations == 2
 
 
-@pytest.mark.integration
 def test_search_batch_respects_archive_parent_limit(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path)
     claim_uri, plugin_id = _install_search_plugin(kernel)
@@ -901,7 +882,6 @@ def test_search_batch_respects_archive_parent_limit(tmp_path: Path) -> None:
         assert len(kernel.store.get(page_uri).manifest.parents) <= 6
 
 
-@pytest.mark.integration
 def test_refiner_cannot_claim_verification(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path)
     claim_uri, plugin_id = _install_search_plugin(
@@ -928,7 +908,6 @@ def test_refiner_cannot_claim_verification(tmp_path: Path) -> None:
     assert snapshot.archive_page_uris == ()
 
 
-@pytest.mark.integration
 @pytest.mark.subprocess
 @pytest.mark.conformance
 def test_verified_counterexample_feedback_reaches_refiner(
@@ -985,7 +964,6 @@ def test_verified_counterexample_feedback_reaches_refiner(
     )
 
 
-@pytest.mark.integration
 @pytest.mark.subprocess
 @pytest.mark.conformance
 def test_supporting_checker_decision_is_not_counted_as_counterexample(

--- a/tests/integration/test_shrinking.py
+++ b/tests/integration/test_shrinking.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from jacobian.artifacts import ArtifactService
 from jacobian.claims import ClaimValidationService
 from jacobian.contracts.claims import ClaimSpec
@@ -17,8 +15,6 @@ from jacobian.store import ArtifactStore
 from jacobian.verification import VerificationService
 
 
-@pytest.mark.integration
-@pytest.mark.contract
 def test_shrinker_rejects_nonpreserving_step_without_trusting_reducer_completeness(
     tmp_path: Path,
 ) -> None:
@@ -49,8 +45,6 @@ def test_shrinker_rejects_nonpreserving_step_without_trusting_reducer_completene
     assert result.result.assurance.verification.value == "VERIFIED"
 
 
-@pytest.mark.integration
-@pytest.mark.contract
 def test_shrinker_rejects_non_improving_proposal(tmp_path: Path) -> None:
     (
         service,
@@ -83,8 +77,6 @@ def test_shrinker_rejects_non_improving_proposal(tmp_path: Path) -> None:
     assert "strictly improve" in result.steps[0].detail
 
 
-@pytest.mark.integration
-@pytest.mark.contract
 def test_shrinker_does_not_trust_empty_reducer_response_for_minimality(
     tmp_path: Path,
 ) -> None:
@@ -118,8 +110,6 @@ def test_shrinker_does_not_trust_empty_reducer_response_for_minimality(
     assert result.minimality.value == "NONE"
 
 
-@pytest.mark.integration
-@pytest.mark.contract
 def test_shrinker_does_not_treat_checker_error_as_boundary_rejection(
     tmp_path: Path,
 ) -> None:

--- a/tests/integration/test_smt_unsat_proof_verification.py
+++ b/tests/integration/test_smt_unsat_proof_verification.py
@@ -26,7 +26,6 @@ from jacobian.provider_runtime import carcara_provider_runtime
 from jacobian.verification import CheckerExecutionError, _environment_digest
 
 pytestmark = [
-    pytest.mark.integration,
     pytest.mark.usefixtures("initialized_kernel_store_with_references"),
 ]
 

--- a/tests/integration/test_structure_canonicalization.py
+++ b/tests/integration/test_structure_canonicalization.py
@@ -9,7 +9,6 @@ from jacobian.kernel import JacobianKernel
 pytestmark = pytest.mark.usefixtures("initialized_kernel_store_with_references")
 
 
-@pytest.mark.integration
 def test_isomorphic_graphs_share_one_canonical_object(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path, install_references=True)
     reference = kernel.references["graph_paths"]
@@ -46,7 +45,6 @@ def test_isomorphic_graphs_share_one_canonical_object(tmp_path: Path) -> None:
     assert first_result.result.assurance.verification.value == "UNVERIFIED"
 
 
-@pytest.mark.integration
 def test_nonisomorphic_graphs_have_distinct_canonical_keys(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path, install_references=True)
     reference = kernel.references["graph_paths"]

--- a/tests/integration/test_suite_fixtures.py
+++ b/tests/integration/test_suite_fixtures.py
@@ -6,13 +6,10 @@ import sqlite3
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
-import pytest
 from tests.conftest import _freeze_kernel_store
 
 from jacobian.kernel import JacobianKernel
 from jacobian.store import ArtifactStore
-
-pytestmark = pytest.mark.integration
 
 
 def _copy_and_check_store(

--- a/tests/integration/test_transformations.py
+++ b/tests/integration/test_transformations.py
@@ -9,7 +9,6 @@ from jacobian.kernel import JacobianKernel
 pytestmark = pytest.mark.usefixtures("initialized_kernel_store_with_references")
 
 
-@pytest.mark.integration
 @pytest.mark.subprocess
 def test_matrix_representation_change_is_independently_verified(
     tmp_path: Path,
@@ -48,7 +47,6 @@ def test_matrix_representation_change_is_independently_verified(
     )
 
 
-@pytest.mark.integration
 def test_transformation_target_rebinding_fails_closed(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path, install_references=True)
     reference = kernel.references["matrices"]
@@ -96,7 +94,6 @@ def test_transformation_target_rebinding_fails_closed(tmp_path: Path) -> None:
     assert result.verification_record_uri is None
 
 
-@pytest.mark.integration
 def test_transformation_relation_rebinding_fails_closed(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path, install_references=True)
     reference = kernel.references["matrices"]
@@ -135,7 +132,6 @@ def test_transformation_relation_rebinding_fails_closed(tmp_path: Path) -> None:
     assert result.verification_record_uri is None
 
 
-@pytest.mark.integration
 def test_transformation_obligation_tampering_fails_closed(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path, install_references=True)
     reference = kernel.references["matrices"]

--- a/tests/integration/test_universal_algebra_capabilities.py
+++ b/tests/integration/test_universal_algebra_capabilities.py
@@ -60,7 +60,6 @@ def _left_projection_problem() -> dict[str, object]:
     }
 
 
-@pytest.mark.integration
 def test_countermodel_descriptor_publishes_a_model_valid_invocation_example(
     tmp_path: Path,
 ) -> None:
@@ -79,7 +78,6 @@ def test_countermodel_descriptor_publishes_a_model_valid_invocation_example(
     assert validated.target_law.law_id == "associative"
 
 
-@pytest.mark.integration
 def test_evaluate_laws_returns_exact_truth_and_counterexample(
     tmp_path: Path,
 ) -> None:
@@ -137,7 +135,6 @@ def test_evaluate_laws_returns_exact_truth_and_counterexample(
     assert verified.output["verification_record_uri"]
 
 
-@pytest.mark.integration
 def test_complete_request_validation_precedes_artifact_writes(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -167,7 +164,6 @@ def test_complete_request_validation_precedes_artifact_writes(
     assert artifact_put_calls == 0
 
 
-@pytest.mark.integration
 def test_countermodel_search_composes_with_independent_law_replay(
     tmp_path: Path,
 ) -> None:
@@ -218,7 +214,6 @@ def test_countermodel_search_composes_with_independent_law_replay(
     assert verified.output["conclusion"] == Conclusion.TRUE.value
 
 
-@pytest.mark.integration
 def test_countermodel_search_reports_fixed_order_no_witness_without_conclusion(
     tmp_path: Path,
 ) -> None:
@@ -243,7 +238,6 @@ def test_countermodel_search_reports_fixed_order_no_witness_without_conclusion(
     assert "conclusion" not in search.output
 
 
-@pytest.mark.integration
 def test_countermodel_request_validation_precedes_artifact_writes(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -278,7 +272,6 @@ def test_countermodel_request_validation_precedes_artifact_writes(
     assert artifact_put_calls == 0
 
 
-@pytest.mark.integration
 def test_finite_magma_table_enumeration_is_exact_and_canonical(
     tmp_path: Path,
 ) -> None:
@@ -308,7 +301,6 @@ def test_finite_magma_table_enumeration_is_exact_and_canonical(
     assert set(enumeration.manifest.parents) == set(result.output["table_uris"])
 
 
-@pytest.mark.integration
 def test_finite_magma_table_enumeration_handles_order_one(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path)
 
@@ -324,7 +316,6 @@ def test_finite_magma_table_enumeration_handles_order_one(tmp_path: Path) -> Non
     assert table.payload["table"] == [[0]]
 
 
-@pytest.mark.integration
 def test_finite_magma_table_enumeration_rejects_unsupported_order_before_writes(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/integration/test_validated_analysis_domain.py
+++ b/tests/integration/test_validated_analysis_domain.py
@@ -27,8 +27,6 @@ from jacobian.operation_installation import OperationInstaller
 from jacobian.schema_registry import SchemaRegistry
 from jacobian.store import ArtifactStore
 
-pytestmark = pytest.mark.integration
-
 
 def _rational(num: int, den: int = 1) -> dict[str, str]:
     return {"num": str(num), "den": str(den)}

--- a/tests/integration/test_witness_search.py
+++ b/tests/integration/test_witness_search.py
@@ -31,8 +31,6 @@ from jacobian.verification import VerificationService
 from jacobian.witnesses import WitnessSearchService
 
 
-@pytest.mark.integration
-@pytest.mark.contract
 def test_witness_search_stores_bound_unverified_evidence(tmp_path: Path) -> None:
     service, store, claim_uri, candidate_uri, plugin_id = _witness_fixture(tmp_path)
 
@@ -55,8 +53,6 @@ def test_witness_search_stores_bound_unverified_evidence(tmp_path: Path) -> None
     )
 
 
-@pytest.mark.integration
-@pytest.mark.contract
 @pytest.mark.parametrize(
     ("certificate_conclusion", "expected_status"),
     [

--- a/tests/integration/test_witness_verification.py
+++ b/tests/integration/test_witness_verification.py
@@ -128,7 +128,6 @@ def _graph_case(
     )
 
 
-@pytest.mark.integration
 @pytest.mark.subprocess
 def test_checker_failure_does_not_expose_internal_exception_text(
     tmp_path: Path,
@@ -156,7 +155,6 @@ def test_checker_failure_does_not_expose_internal_exception_text(
     assert "secret" not in result.execution.detail
 
 
-@pytest.mark.integration
 @pytest.mark.subprocess
 @pytest.mark.parametrize(
     ("checker_entrypoint", "expected_detail"),
@@ -194,7 +192,6 @@ def test_invalid_checker_responses_explain_recovery(
     assert result.execution.detail == expected_detail
 
 
-@pytest.mark.integration
 @pytest.mark.subprocess
 def test_checker_output_limit_explains_recovery(tmp_path: Path) -> None:
     _, service, checker_id, claim_uri, candidate_uri, witness_uri, _ = _graph_case(
@@ -216,7 +213,6 @@ def test_checker_output_limit_explains_recovery(tmp_path: Path) -> None:
     )
 
 
-@pytest.mark.integration
 @pytest.mark.subprocess
 def test_checker_diagnostic_limit_explains_recovery(tmp_path: Path) -> None:
     _, service, checker_id, claim_uri, candidate_uri, witness_uri, _ = _graph_case(
@@ -239,7 +235,6 @@ def test_checker_diagnostic_limit_explains_recovery(tmp_path: Path) -> None:
     )
 
 
-@pytest.mark.integration
 def test_missing_verification_artifact_is_rejected_with_recovery(
     tmp_path: Path,
 ) -> None:
@@ -263,7 +258,6 @@ def test_missing_verification_artifact_is_rejected_with_recovery(
     assert result.assurance.verification is Verification.UNVERIFIED
 
 
-@pytest.mark.integration
 def test_corrupt_verification_artifact_is_an_operational_failure(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
@@ -293,7 +287,6 @@ def test_corrupt_verification_artifact_is_an_operational_failure(
     assert "blob digest mismatch" in caplog.text
 
 
-@pytest.mark.integration
 @pytest.mark.subprocess
 @pytest.mark.conformance
 def test_omitted_path_witness_is_independently_verified(tmp_path: Path) -> None:
@@ -313,7 +306,6 @@ def test_omitted_path_witness_is_independently_verified(tmp_path: Path) -> None:
     assert result.verification_record_uri is not None
 
 
-@pytest.mark.integration
 def test_witness_checker_cannot_certify_artifacts_outside_its_request(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -364,7 +356,6 @@ def test_witness_checker_cannot_certify_artifacts_outside_its_request(
         assert "outside its verification request" in result.input.errors[0]
 
 
-@pytest.mark.integration
 @pytest.mark.subprocess
 @pytest.mark.conformance
 def test_valid_witness_rebound_to_another_candidate_is_rejected(
@@ -408,7 +399,6 @@ def test_valid_witness_rebound_to_another_candidate_is_rejected(
     )
 
 
-@pytest.mark.integration
 @pytest.mark.subprocess
 @pytest.mark.conformance
 def test_witness_without_bound_artifact_parents_is_rejected(
@@ -443,7 +433,6 @@ def test_witness_without_bound_artifact_parents_is_rejected(
     assert result.input.status.value == "REJECTED"
 
 
-@pytest.mark.integration
 @pytest.mark.subprocess
 @pytest.mark.conformance
 def test_schema_label_cannot_authorize_an_invalid_candidate(tmp_path: Path) -> None:
@@ -476,7 +465,6 @@ def test_schema_label_cannot_authorize_an_invalid_candidate(tmp_path: Path) -> N
     assert result.input.status.value == "REJECTED"
 
 
-@pytest.mark.integration
 @pytest.mark.subprocess
 @pytest.mark.conformance
 def test_revocation_during_checker_execution_prevents_commit(

--- a/tests/integration/test_worker_error_protocol.py
+++ b/tests/integration/test_worker_error_protocol.py
@@ -11,7 +11,6 @@ from jacobian.plugin_execution import _plugin_failure_detail
 from jacobian.verification import _checker_failure_detail
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize(
     ("module", "entrypoint", "public_detail"),
     [
@@ -56,7 +55,6 @@ def test_source_changes_cross_worker_boundary_as_typed_codes(
         assert _checker_failure_detail(response) == public_detail
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize(
     ("module", "entrypoint"),
     [

--- a/tests/integration/test_workspaces.py
+++ b/tests/integration/test_workspaces.py
@@ -50,7 +50,6 @@ def _open(
     )
 
 
-@pytest.mark.integration
 def test_workspace_open_is_idempotent_and_restart_replays_revision(
     tmp_path: Path,
 ) -> None:
@@ -90,7 +89,6 @@ def test_workspace_open_is_idempotent_and_restart_replays_revision(
     assert "retrieval does not promote" in resume.warning
 
 
-@pytest.mark.integration
 def test_workspace_write_cannot_add_a_second_problem(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path)
     opened = _open(kernel, key="workspace-open-single-problem-001")
@@ -156,7 +154,6 @@ def test_workspace_write_cannot_add_a_second_problem(tmp_path: Path) -> None:
     assert resumed.resume.problem.card_id == opened.problem_card_id
 
 
-@pytest.mark.integration
 def test_workspace_write_builds_resume_frontier_and_attempt_views(
     tmp_path: Path,
 ) -> None:
@@ -279,7 +276,6 @@ def test_workspace_write_builds_resume_frontier_and_attempt_views(
     assert [item.attempt_id for item in attempts.attempts] == [written.id_map["T1"]]
 
 
-@pytest.mark.integration
 def test_workspace_rejects_stale_base_without_partial_index_writes(
     tmp_path: Path,
 ) -> None:
@@ -355,7 +351,6 @@ def test_workspace_rejects_stale_base_without_partial_index_writes(
         )
 
 
-@pytest.mark.integration
 def test_workspace_rejects_idempotency_rebinding_and_invalid_references(
     tmp_path: Path,
 ) -> None:
@@ -417,109 +412,6 @@ def test_workspace_rejects_idempotency_rebinding_and_invalid_references(
         )
 
 
-def test_workspace_drafts_do_not_accept_caller_controlled_verification() -> None:
-    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
-        WorkspaceFindingDraft.model_validate(
-            {
-                "client_ref": "L1",
-                "kind": "CLAIM",
-                "title": "Forged",
-                "body": "Caller attempts to self-promote this claim.",
-                "verification": "VERIFIED",
-            }
-        )
-
-
-def test_workspace_drafts_normalize_unambiguous_operational_aliases() -> None:
-    goal = WorkspaceFindingDraft.model_validate(
-        {
-            "client_ref": "G1",
-            "kind": "OPEN_GOAL",
-            "title": "Finish the proof",
-            "body": "This remains agent-authored and unverified.",
-        }
-    )
-    attempt = WorkspaceAttemptDraft.model_validate(
-        {
-            "client_ref": "T1",
-            "target_ref": "G1",
-            "method": "direct",
-            "outcome": "SUCCEEDED",
-            "summary": "The operational attempt finished.",
-        }
-    )
-    mark = WorkspaceMarkDraft.model_validate(
-        {
-            "client_ref": "M1",
-            "target_ref": "G1",
-            "state": "CLOSED",
-            "summary": "The agent explicitly closed this work item.",
-        }
-    )
-
-    assert goal.kind is WorkspaceFindingKind.GOAL
-    assert attempt.outcome is WorkspaceAttemptOutcome.COMPLETED
-    assert mark.reason == "The agent explicitly closed this work item."
-    assert goal.model_dump(mode="json")["kind"] == "GOAL"
-    assert attempt.model_dump(mode="json")["outcome"] == "COMPLETED"
-    assert set(mark.model_dump(mode="json")) == {
-        "client_ref",
-        "target_ref",
-        "state",
-        "reason",
-        "superseded_by_ref",
-    }
-
-
-def test_workspace_finding_kind_accepts_a_generic_finding_card() -> None:
-    finding = WorkspaceFindingDraft(
-        client_ref="F1",
-        kind="FINDING",
-        title="Recorded observation",
-        body="This is a generic agent-authored observation.",
-    )
-
-    assert finding.kind is WorkspaceFindingKind.FINDING
-
-
-def test_workspace_focus_requires_an_explicit_update() -> None:
-    with pytest.raises(
-        ValidationError,
-        match="focus update requires active_ref, pinned_refs, or clear=true",
-    ):
-        WorkspaceFocusDraft()
-
-    with pytest.raises(
-        ValidationError,
-        match="focus clear cannot be combined",
-    ):
-        WorkspaceFocusDraft(active_ref="G1", clear=True)
-
-
-def test_workspace_focus_rejects_attempt_and_scratch_client_refs() -> None:
-    with pytest.raises(
-        ValidationError,
-        match="focus references must identify finding cards",
-    ):
-        WorkspaceWriteRequest(
-            idempotency_key="workspace-write-focus-kind-001",
-            workspace_id="workspace://00000000000000000000000000000000",
-            branch_id="branch://00000000000000000000000000000000",
-            base_revision="revision://00000000000000000000000000000000",
-            attempts=(
-                WorkspaceAttemptDraft(
-                    client_ref="T1",
-                    target_ref="card://00000000000000000000000000000000",
-                    method="direct",
-                    outcome=WorkspaceAttemptOutcome.BLOCKED,
-                    summary="This attempt cannot be focused directly.",
-                ),
-            ),
-            focus=WorkspaceFocusDraft(pinned_refs=("T1",)),
-        )
-
-
-@pytest.mark.integration
 def test_workspace_focus_clear_is_explicit_and_resumable(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path)
     opened = _open(kernel, key="workspace-open-focus-clear-001")
@@ -547,7 +439,6 @@ def test_workspace_focus_clear_is_explicit_and_resumable(tmp_path: Path) -> None
     assert resume.resume.pinned_items == ()
 
 
-@pytest.mark.integration
 def test_workspace_marks_close_goals_and_propagate_staleness(
     tmp_path: Path,
 ) -> None:
@@ -751,7 +642,6 @@ def test_workspace_marks_close_goals_and_propagate_staleness(
     assert replayed == context
 
 
-@pytest.mark.integration
 def test_workspace_supersession_and_reactivation_are_explicit(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -860,7 +750,6 @@ def test_workspace_supersession_and_reactivation_are_explicit(
     assert after.context.dependencies[0].superseded_by_id is None
 
 
-@pytest.mark.integration
 def test_workspace_query_uses_one_revision_snapshot(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -930,7 +819,6 @@ def test_workspace_query_uses_one_revision_snapshot(
     ]
 
 
-@pytest.mark.integration
 def test_workspace_recent_views_follow_acceptance_order(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1022,7 +910,6 @@ def test_workspace_recent_views_follow_acceptance_order(
     ]
 
 
-@pytest.mark.integration
 def test_workspace_context_handles_a_deep_dependency_chain(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path)
     opened = _open(kernel, key="workspace-open-deep-context-001")
@@ -1077,7 +964,6 @@ def test_workspace_context_handles_a_deep_dependency_chain(tmp_path: Path) -> No
     assert len(context.context.dependencies) == 1
 
 
-@pytest.mark.integration
 def test_workspace_supersession_handles_a_deep_chain(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path)
     opened = _open(kernel, key="workspace-open-deep-supersession-001")
@@ -1146,67 +1032,6 @@ def test_workspace_supersession_handles_a_deep_chain(tmp_path: Path) -> None:
     assert context.context.target.superseded_by_id == card_ids[1]
 
 
-def test_workspace_mark_contracts_fail_closed() -> None:
-    with pytest.raises(
-        ValidationError,
-        match="cannot provide both reason and summary",
-    ):
-        WorkspaceMarkDraft.model_validate(
-            {
-                "client_ref": "M1",
-                "target_ref": "card://00000000000000000000000000000000",
-                "state": "CLOSED",
-                "reason": "Canonical reason.",
-                "summary": "Conflicting alias.",
-            }
-        )
-
-    with pytest.raises(
-        ValidationError,
-        match="SUPERSEDED marks require superseded_by_ref",
-    ):
-        WorkspaceMarkDraft(
-            client_ref="M1",
-            target_ref="card://00000000000000000000000000000000",
-            state=WorkspaceCardState.SUPERSEDED,
-            reason="Missing replacement.",
-        )
-
-    with pytest.raises(
-        ValidationError,
-        match="only SUPERSEDED marks may carry superseded_by_ref",
-    ):
-        WorkspaceMarkDraft(
-            client_ref="M1",
-            target_ref="card://00000000000000000000000000000000",
-            state=WorkspaceCardState.ACTIVE,
-            superseded_by_ref="card://11111111111111111111111111111111",
-            reason="An active mark cannot silently replace a card.",
-        )
-
-    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
-        WorkspaceMarkDraft.model_validate(
-            {
-                "client_ref": "M1",
-                "target_ref": "card://00000000000000000000000000000000",
-                "state": "CLOSED",
-                "reason": "Caller attempts to self-promote the mark.",
-                "verification": "VERIFIED",
-            }
-        )
-
-    with pytest.raises(
-        ValidationError,
-        match="target_card_id is required for the CONTEXT view",
-    ):
-        WorkspaceQueryRequest(
-            workspace_id="workspace://00000000000000000000000000000000",
-            branch_id="branch://00000000000000000000000000000000",
-            view=WorkspaceQueryView.CONTEXT,
-        )
-
-
-@pytest.mark.integration
 def test_workspace_context_truncation_and_stale_roots_are_deterministic(
     tmp_path: Path,
 ) -> None:
@@ -1308,7 +1133,6 @@ def test_workspace_context_truncation_and_stale_roots_are_deterministic(
     )
 
 
-@pytest.mark.integration
 def test_workspace_invalid_marks_leave_no_partial_state(tmp_path: Path) -> None:
     kernel = JacobianKernel(tmp_path)
     opened = _open(kernel, key="workspace-open-invalid-mark-001")
@@ -1433,7 +1257,6 @@ def test_workspace_invalid_marks_leave_no_partial_state(tmp_path: Path) -> None:
     assert mark_count == 1
 
 
-@pytest.mark.integration
 def test_workspace_invalidating_mark_requires_explicit_reactivation(
     tmp_path: Path,
 ) -> None:
@@ -1514,7 +1337,6 @@ def test_workspace_invalidating_mark_requires_explicit_reactivation(
     assert unchanged.context.dependencies[0].state is WorkspaceCardState.RETRACTED
 
 
-@pytest.mark.integration
 def test_workspace_archiving_is_organizational_not_invalidation(
     tmp_path: Path,
 ) -> None:

--- a/tests/reference/test_reference_claim_schemas.py
+++ b/tests/reference/test_reference_claim_schemas.py
@@ -8,8 +8,6 @@ from jacobian.artifacts import ArtifactValidationError
 from jacobian.kernel import JacobianKernel
 
 pytestmark = [
-    pytest.mark.contract,
-    pytest.mark.integration,
     pytest.mark.usefixtures("initialized_kernel_store_with_references"),
 ]
 

--- a/tests/unit/test_ci_plan.py
+++ b/tests/unit/test_ci_plan.py
@@ -9,7 +9,7 @@ import pytest
 
 PLANNER = Path(__file__).parents[2] / ".github" / "scripts" / "classify-ci-paths"
 VALIDATOR = Path(__file__).parents[2] / ".github" / "scripts" / "validate-ci-plan"
-OWNERSHIP = Path(__file__).parents[2] / ".github" / "ci-ownership.json"
+OWNERSHIP = Path(__file__).parents[2] / ".github" / "ci-impact.json"
 
 BOOLEAN_KEYS = (
     "run-python",
@@ -102,6 +102,8 @@ def _expected_plan(classification: str, *enabled: str) -> dict[str, str]:
             ("tests/integration/test_lean.py",),
             _expected_plan(
                 "selective",
+                "run-python",
+                "run-integration",
                 "run-lean",
                 "run-static",
             ),
@@ -313,7 +315,11 @@ def test_every_tracked_source_file_has_explicit_suite_ownership() -> None:
 def test_ownership_manifest_names_only_supported_suites() -> None:
     manifest = json.loads(OWNERSHIP.read_text(encoding="utf-8"))
     suites = set(manifest["suites"])
+    rule_names = [rule["name"] for rule in manifest["rules"]]
 
+    assert manifest["version"] == 2
     assert len(suites) == len(manifest["suites"])
+    assert len(rule_names) == len(set(rule_names))
     assert all(set(rule["suites"]) <= suites for rule in manifest["rules"])
+    assert manifest["fallback"]["name"] == "unclassified-fail-closed"
     assert set(manifest["fallback"]["suites"]) == suites

--- a/tests/unit/test_ci_test_timings.py
+++ b/tests/unit/test_ci_test_timings.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / ".github" / "scripts" / "manage-test-timings"
+
+
+def run_script(
+    *args: str,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        cwd=ROOT,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_prepare_falls_back_to_equal_weighting_without_github_context(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "durations.json"
+    env = os.environ.copy()
+    env.pop("GITHUB_REPOSITORY", None)
+    env.pop("GH_TOKEN", None)
+
+    result = run_script("prepare", "--output", str(output), env=env)
+
+    assert result.returncode == 0
+    assert json.loads(output.read_text(encoding="utf-8")) == {}
+    assert "equal weighting" in result.stderr
+
+
+def test_merge_publishes_versioned_metadata_and_all_shards(tmp_path: Path) -> None:
+    inputs: list[str] = []
+    for shard in range(1, 5):
+        path = tmp_path / f"shard-{shard}.json"
+        path.write_text(
+            json.dumps({f"tests/integration/test_{shard}.py::test_case": shard}),
+            encoding="utf-8",
+        )
+        inputs.extend(["--input", str(path)])
+    output = tmp_path / "integration-test-durations.json"
+
+    result = run_script(
+        "merge",
+        *inputs,
+        "--output",
+        str(output),
+        "--source-sha",
+        "a" * 40,
+        "--python-version",
+        "3.12",
+        "--pytest-split-version",
+        "0.11.0",
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["version"] == 1
+    assert payload["suite"] == "integration"
+    assert payload["shard_count"] == 4
+    assert len(payload["durations"]) == 4
+
+
+def test_merge_rejects_duplicate_node_ids(tmp_path: Path) -> None:
+    inputs: list[str] = []
+    for shard in range(1, 5):
+        path = tmp_path / f"shard-{shard}.json"
+        path.write_text(
+            json.dumps({"tests/integration/test_shared.py::test_case": shard}),
+            encoding="utf-8",
+        )
+        inputs.extend(["--input", str(path)])
+
+    result = run_script(
+        "merge",
+        *inputs,
+        "--output",
+        str(tmp_path / "output.json"),
+        "--source-sha",
+        "a" * 40,
+        "--python-version",
+        "3.12",
+        "--pytest-split-version",
+        "0.11.0",
+    )
+
+    assert result.returncode != 0
+    assert "duplicate timing entry" in result.stderr

--- a/tests/unit/test_ci_timings.py
+++ b/tests/unit/test_ci_timings.py
@@ -16,19 +16,24 @@ def test_ci_timing_summary_reports_elapsed_and_runner_minutes(tmp_path: Path) ->
                 "completed_at": "2026-07-27T10:02:00Z",
             },
             {
-                "name": "Tests (integration 1 of 3, Python 3.12)",
+                "name": "Tests (integration 1 of 4, Python 3.12)",
                 "started_at": "2026-07-27T10:01:00Z",
                 "completed_at": "2026-07-27T10:05:00Z",
             },
             {
-                "name": "Tests (integration 2 of 3, Python 3.12)",
+                "name": "Tests (integration 2 of 4, Python 3.12)",
                 "started_at": "2026-07-27T10:01:00Z",
                 "completed_at": "2026-07-27T10:03:00Z",
             },
             {
-                "name": "Tests (integration 3 of 3, Python 3.12)",
+                "name": "Tests (integration 3 of 4, Python 3.12)",
                 "started_at": "2026-07-27T10:01:00Z",
                 "completed_at": "2026-07-27T10:03:30Z",
+            },
+            {
+                "name": "Tests (integration 4 of 4, Python 3.12)",
+                "started_at": "2026-07-27T10:01:00Z",
+                "completed_at": "2026-07-27T10:03:00Z",
             },
             {
                 "name": "CI Metrics",
@@ -48,7 +53,7 @@ def test_ci_timing_summary_reports_elapsed_and_runner_minutes(tmp_path: Path) ->
     )
 
     assert "Critical path (workflow elapsed) | 5.0 min" in completed.stdout
-    assert "Total runner time | 10.5 min" in completed.stdout
-    assert "Tests (integration 1 of 3, Python 3.12) (4.0 min)" in completed.stdout
+    assert "Total runner time | 12.5 min" in completed.stdout
+    assert "Tests (integration 1 of 4, Python 3.12) (4.0 min)" in completed.stdout
     assert "Integration shard skew (max/min) | 2.00x" in completed.stdout
-    assert "make test-durations" in completed.stdout
+    assert "equal weighting" in completed.stdout

--- a/tests/unit/test_test_suite_ownership.py
+++ b/tests/unit/test_test_suite_ownership.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+TEST_ROOTS = {
+    "unit",
+    "contract",
+    "checkers",
+    "reference",
+    "integration",
+    "end_to_end",
+}
+LAYER_MARKERS = {"contract", "integration", "end_to_end"}
+
+
+def test_every_test_module_has_semantic_directory_ownership() -> None:
+    unowned = [
+        str(path.relative_to(ROOT))
+        for path in (ROOT / "tests").rglob("test_*.py")
+        if path.relative_to(ROOT / "tests").parts[0] not in TEST_ROOTS
+    ]
+
+    assert unowned == []
+
+
+def test_layer_ownership_is_not_duplicated_in_markers() -> None:
+    violations: list[str] = []
+    for path in (ROOT / "tests").rglob("test_*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Attribute):
+                continue
+            if (
+                isinstance(node.value, ast.Attribute)
+                and isinstance(node.value.value, ast.Name)
+                and node.value.value.id == "pytest"
+                and node.value.attr == "mark"
+                and node.attr in LAYER_MARKERS
+            ):
+                violations.append(f"{path.relative_to(ROOT)}:{node.lineno}")
+
+    assert violations == []

--- a/tests/unit/test_workspace_contract_models.py
+++ b/tests/unit/test_workspace_contract_models.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.contracts.workspaces import (
+    WorkspaceAttemptDraft,
+    WorkspaceAttemptOutcome,
+    WorkspaceCardState,
+    WorkspaceFindingDraft,
+    WorkspaceFindingKind,
+    WorkspaceFocusDraft,
+    WorkspaceMarkDraft,
+    WorkspaceQueryRequest,
+    WorkspaceQueryView,
+    WorkspaceWriteRequest,
+)
+
+
+def test_workspace_drafts_do_not_accept_caller_controlled_verification() -> None:
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        WorkspaceFindingDraft.model_validate(
+            {
+                "client_ref": "L1",
+                "kind": "CLAIM",
+                "title": "Forged",
+                "body": "Caller attempts to self-promote this claim.",
+                "verification": "VERIFIED",
+            }
+        )
+
+
+def test_workspace_drafts_normalize_unambiguous_operational_aliases() -> None:
+    goal = WorkspaceFindingDraft.model_validate(
+        {
+            "client_ref": "G1",
+            "kind": "OPEN_GOAL",
+            "title": "Finish the proof",
+            "body": "This remains agent-authored and unverified.",
+        }
+    )
+    attempt = WorkspaceAttemptDraft.model_validate(
+        {
+            "client_ref": "T1",
+            "target_ref": "G1",
+            "method": "direct",
+            "outcome": "SUCCEEDED",
+            "summary": "The operational attempt finished.",
+        }
+    )
+    mark = WorkspaceMarkDraft.model_validate(
+        {
+            "client_ref": "M1",
+            "target_ref": "G1",
+            "state": "CLOSED",
+            "summary": "The agent explicitly closed this work item.",
+        }
+    )
+
+    assert goal.kind is WorkspaceFindingKind.GOAL
+    assert attempt.outcome is WorkspaceAttemptOutcome.COMPLETED
+    assert mark.reason == "The agent explicitly closed this work item."
+    assert goal.model_dump(mode="json")["kind"] == "GOAL"
+    assert attempt.model_dump(mode="json")["outcome"] == "COMPLETED"
+    assert set(mark.model_dump(mode="json")) == {
+        "client_ref",
+        "target_ref",
+        "state",
+        "reason",
+        "superseded_by_ref",
+    }
+
+
+def test_workspace_finding_kind_accepts_a_generic_finding_card() -> None:
+    finding = WorkspaceFindingDraft(
+        client_ref="F1",
+        kind="FINDING",
+        title="Recorded observation",
+        body="This is a generic agent-authored observation.",
+    )
+
+    assert finding.kind is WorkspaceFindingKind.FINDING
+
+
+def test_workspace_focus_requires_an_explicit_update() -> None:
+    with pytest.raises(
+        ValidationError,
+        match="focus update requires active_ref, pinned_refs, or clear=true",
+    ):
+        WorkspaceFocusDraft()
+
+    with pytest.raises(
+        ValidationError,
+        match="focus clear cannot be combined",
+    ):
+        WorkspaceFocusDraft(active_ref="G1", clear=True)
+
+
+def test_workspace_focus_rejects_attempt_and_scratch_client_refs() -> None:
+    with pytest.raises(
+        ValidationError,
+        match="focus references must identify finding cards",
+    ):
+        WorkspaceWriteRequest(
+            idempotency_key="workspace-write-focus-kind-001",
+            workspace_id="workspace://00000000000000000000000000000000",
+            branch_id="branch://00000000000000000000000000000000",
+            base_revision="revision://00000000000000000000000000000000",
+            attempts=(
+                WorkspaceAttemptDraft(
+                    client_ref="T1",
+                    target_ref="card://00000000000000000000000000000000",
+                    method="direct",
+                    outcome=WorkspaceAttemptOutcome.BLOCKED,
+                    summary="This attempt cannot be focused directly.",
+                ),
+            ),
+            focus=WorkspaceFocusDraft(pinned_refs=("T1",)),
+        )
+
+
+def test_workspace_mark_contracts_fail_closed() -> None:
+    with pytest.raises(
+        ValidationError,
+        match="cannot provide both reason and summary",
+    ):
+        WorkspaceMarkDraft.model_validate(
+            {
+                "client_ref": "M1",
+                "target_ref": "card://00000000000000000000000000000000",
+                "state": "CLOSED",
+                "reason": "Canonical reason.",
+                "summary": "Conflicting alias.",
+            }
+        )
+
+    with pytest.raises(
+        ValidationError,
+        match="SUPERSEDED marks require superseded_by_ref",
+    ):
+        WorkspaceMarkDraft(
+            client_ref="M1",
+            target_ref="card://00000000000000000000000000000000",
+            state=WorkspaceCardState.SUPERSEDED,
+            reason="Missing replacement.",
+        )
+
+    with pytest.raises(
+        ValidationError,
+        match="only SUPERSEDED marks may carry superseded_by_ref",
+    ):
+        WorkspaceMarkDraft(
+            client_ref="M1",
+            target_ref="card://00000000000000000000000000000000",
+            state=WorkspaceCardState.ACTIVE,
+            superseded_by_ref="card://11111111111111111111111111111111",
+            reason="An active mark cannot silently replace a card.",
+        )
+
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        WorkspaceMarkDraft.model_validate(
+            {
+                "client_ref": "M1",
+                "target_ref": "card://00000000000000000000000000000000",
+                "state": "CLOSED",
+                "reason": "Caller attempts to self-promote the mark.",
+                "verification": "VERIFIED",
+            }
+        )
+
+    with pytest.raises(
+        ValidationError,
+        match="target_card_id is required for the CONTEXT view",
+    ):
+        WorkspaceQueryRequest(
+            workspace_id="workspace://00000000000000000000000000000000",
+            branch_id="branch://00000000000000000000000000000000",
+            view=WorkspaceQueryView.CONTEXT,
+        )


### PR DESCRIPTION
## Problem

Test suite ownership was represented in several competing places: directory names, layer markers, collection-time marker inference, CI path rules, Make commands, and a committed duration cache. That made selection order-dependent and turned scheduling data into mutable repository state.

## Solution

- Make test directories the authority for semantic ownership and retain markers only for runtime traits.
- Add canonical `make test-core` and `make test-integration` entry points used by CI.
- Replace first-match CI ownership rules with additive change-impact rules in `.github/ci-impact.json`.
- Replace committed integration timings with validated artifacts from successful `main` runs. Missing or invalid history falls back to equal-weight sharding.
- Expand integration execution from three to four shards.
- Move six pure workspace contract-model tests from integration to unit ownership.

The large test-file portion of the diff is mechanical marker removal. A normalized AST comparison confirmed that all pre-existing test bodies were preserved except the two CI tests intentionally updated for the new contracts.

Suggested review order:

1. `Makefile`, `pyproject.toml`, and `tests/conftest.py`
2. `.github/ci-impact.json` and `.github/scripts/classify-ci-paths`
3. `.github/scripts/manage-test-timings` and `.github/workflows/ci.yml`
4. Mechanical marker removals and documentation

## Testing

```sh
uv run --locked pytest -n 0 tests/unit/test_ci_plan.py tests/unit/test_ci_timings.py tests/unit/test_ci_test_timings.py tests/unit/test_test_suite_ownership.py tests/unit/test_workspace_contract_models.py
# 49 passed

make lint
# passed

make typecheck
# Success: no issues found in 279 source files

make test-core PYTEST_ARGS='--collect-only -q'
# 559 tests collected

make test-integration PYTEST_ARGS='--collect-only -qq'
# 681 tests collected
```

All GitHub workflow and local-action YAML files also parsed successfully.

## Trust & Compatibility Impact

No verification-kernel, checker-registry, artifact-format, or public product API behavior changes. Test selection remains fail-closed for unknown paths. Timing history affects shard scheduling only and cannot suppress tests.

The first run without a valid successful-`main` timing artifact uses equal weighting; that run then publishes the timing hint for subsequent runs.

## Checklist
- [ ] Routine local validation passes (`make check`)
- [x] Relevant focused tests are listed above
