### PR TITLE
fix(mcp): preserve fail-closed outcomes across checker and MCP boundaries

### DIFF
--- a/src/jacobian/adapters/mcp/remote.py
+++ b/src/jacobian/adapters/mcp/remote.py
@@ -56,11 +56,15 @@ class StaticTokenVerifier:
             raise ValueError("tenant IDs in the token file must be unique")
         if len({grant.token for grant in grants}) != len(grants):
             raise ValueError("bearer tokens in the token file must be unique")
-        self._grants = grants
+        self._grants = tuple(
+            (hashlib.sha256(grant.token.encode("utf-8")).digest(), grant)
+            for grant in grants
+        )
 
     async def verify_token(self, token: str) -> AccessToken | None:
-        for grant in self._grants:
-            if hmac.compare_digest(token, grant.token):
+        token_digest = hashlib.sha256(token.encode("utf-8")).digest()
+        for grant_digest, grant in self._grants:
+            if hmac.compare_digest(token_digest, grant_digest):
                 return AccessToken(
                     token=token,
                     client_id=f"jacobian-tenant:{grant.tenant_id}",

--- a/src/jacobian/plugin_execution.py
+++ b/src/jacobian/plugin_execution.py
@@ -101,10 +101,6 @@ class PluginExecutor:
             limit=self.max_diagnostic_bytes,
         )
         if completed.timed_out:
-            diagnostics = _bounded_text(
-                completed.stderr,
-                limit=self.max_diagnostic_bytes,
-            )
             return PluginExecutionResult(
                 status=ExecutionStatus.TIMEOUT,
                 output=None,

--- a/src/jacobian/verification.py
+++ b/src/jacobian/verification.py
@@ -64,6 +64,10 @@ class CheckerExecutionError(RuntimeError):
     """An authorized checker failed operationally."""
 
 
+class CheckerExecutionCancelledError(CheckerExecutionError):
+    """An authorized checker was cancelled by its caller."""
+
+
 _CHECKER_OUTPUT_TOO_LARGE = (
     "The checker returned too much data. Retry with a smaller input "
     "and inspect the local checker log if the limit is reached again."
@@ -92,6 +96,7 @@ _CHECKER_TIMEOUT = (
     "The checker did not finish within the allowed time. "
     "Retry with a smaller input and inspect the local checker log if it times out again."
 )
+_CHECKER_CANCELLED = "The checker was cancelled before returning a decision."
 
 
 def _digest_bytes(data: bytes) -> str:
@@ -253,6 +258,8 @@ class VerificationService:
                 cmd=[sys.executable, "-m", "jacobian.checker_worker", entrypoint],
                 timeout=effective_timeout,
             )
+        if completed.cancelled:
+            raise CheckerExecutionCancelledError(_CHECKER_CANCELLED)
         if completed.stdout_exceeded:
             raise CheckerExecutionError(_CHECKER_OUTPUT_TOO_LARGE)
         if completed.stderr_exceeded:
@@ -520,6 +527,12 @@ class VerificationService:
             return self._operational_failure(
                 status=ExecutionStatus.TIMEOUT,
                 detail=_CHECKER_TIMEOUT,
+                started=started,
+            )
+        except CheckerExecutionCancelledError as exc:
+            return self._operational_failure(
+                status=ExecutionStatus.CANCELLED,
+                detail=str(exc),
                 started=started,
             )
         except CheckerExecutableChangedError as exc:
@@ -807,6 +820,12 @@ class VerificationService:
                 detail=_CHECKER_TIMEOUT,
                 started=started,
             )
+        except CheckerExecutionCancelledError as exc:
+            return self._operational_failure(
+                status=ExecutionStatus.CANCELLED,
+                detail=str(exc),
+                started=started,
+            )
         except CheckerExecutableChangedError as exc:
             return self._operational_failure(
                 status=ExecutionStatus.ERROR,
@@ -1008,6 +1027,12 @@ class VerificationService:
                 detail=_CHECKER_TIMEOUT,
                 started=started,
             )
+        except CheckerExecutionCancelledError as exc:
+            return self._operational_failure(
+                status=ExecutionStatus.CANCELLED,
+                detail=str(exc),
+                started=started,
+            )
         except CheckerExecutableChangedError as exc:
             return self._operational_failure(
                 status=ExecutionStatus.ERROR,
@@ -1199,6 +1224,12 @@ class VerificationService:
             return self._operational_failure(
                 status=ExecutionStatus.TIMEOUT,
                 detail=_CHECKER_TIMEOUT,
+                started=started,
+            )
+        except CheckerExecutionCancelledError as exc:
+            return self._operational_failure(
+                status=ExecutionStatus.CANCELLED,
+                detail=str(exc),
                 started=started,
             )
         except CheckerExecutableChangedError as exc:

--- a/src/jacobian_checkers/sat.py
+++ b/src/jacobian_checkers/sat.py
@@ -681,6 +681,10 @@ def check_unsat_proof(request: dict[str, Any]) -> dict[str, Any]:
                 f"{len(clauses)} canonical clauses"
             ),
         }
+    except subprocess.TimeoutExpired:
+        return _reject_proof(
+            "DRAT_TIMEOUT: DRAT-trim did not finish; no proof conclusion is available"
+        )
     except (KeyError, OSError, TypeError, ValueError, OverflowError):
         return _reject_proof("malformed or unauthorized SAT proof checker request")
 

--- a/src/jacobian_checkers/smt.py
+++ b/src/jacobian_checkers/smt.py
@@ -621,5 +621,9 @@ def check_unsat_proof(request: dict[str, Any]) -> dict[str, Any]:
                 "against the full bound QF_UF query"
             ),
         }
+    except subprocess.TimeoutExpired:
+        return _reject(
+            "CARCARA_TIMEOUT: Carcara did not finish; no proof conclusion is available"
+        )
     except (KeyError, OSError, TypeError, ValueError, OverflowError):
         return _reject("malformed or unauthorized SMT proof checker request")

--- a/tests/checkers/test_erdos_straus_checker.py
+++ b/tests/checkers/test_erdos_straus_checker.py
@@ -106,3 +106,21 @@ def test_checker_rejects_range_substitution() -> None:
     request["candidate"]["payload"]["upper_bound"] = 5
 
     assert check_decomposition_table(request)["accepted"] is False
+
+
+def test_checker_rejects_binding_substitution() -> None:
+    request = _request(
+        [
+            {"n": 2, "x": 1, "y": 2, "z": 2},
+            {"n": 3, "x": 1, "y": 4, "z": 12},
+            {"n": 4, "x": 2, "y": 3, "z": 6},
+        ]
+    )
+    rebound = dict(request["witness"]["payload"]["bindings"])
+    rebound["candidate_digest"] = "sha256:" + "9" * 64
+    request["witness"]["payload"]["bindings"] = rebound
+
+    decision = check_decomposition_table(request)
+
+    assert decision["accepted"] is False
+    assert "bindings" in decision["detail"]

--- a/tests/checkers/test_finite_partition_checker.py
+++ b/tests/checkers/test_finite_partition_checker.py
@@ -100,3 +100,35 @@ def test_finite_partition_checker_rejects_unbound_relationship_metadata() -> Non
 
     assert decision["accepted"] is False
     assert "relationship metadata" in decision["detail"]
+
+
+def test_finite_partition_checker_rejects_binding_substitution() -> None:
+    request = _request(
+        cases=[
+            {"case_id": "left", "members": ["a", "b"]},
+            {"case_id": "right", "members": ["c", "d"]},
+        ]
+    )
+    rebound = dict(request["certificate"]["payload"]["bindings"])
+    rebound["scope_digest"] = "sha256:" + "9" * 64
+    request["certificate"]["payload"]["bindings"] = rebound
+
+    decision = check_partition(request)
+
+    assert decision["accepted"] is False
+    assert "bindings" in decision["detail"]
+
+
+def test_finite_partition_checker_rejects_unknown_format() -> None:
+    request = _request(
+        cases=[
+            {"case_id": "left", "members": ["a", "b"]},
+            {"case_id": "right", "members": ["c", "d"]},
+        ]
+    )
+    request["certificate"]["payload"]["format_version"] = "2"
+
+    decision = check_partition(request)
+
+    assert decision["accepted"] is False
+    assert "format" in decision["detail"]

--- a/tests/checkers/test_graph_checkers.py
+++ b/tests/checkers/test_graph_checkers.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
 from jacobian_checkers.graph_paths import (
     check_odd_cycle,
     check_path_enumeration,
@@ -47,6 +52,52 @@ def test_two_coloring_checker_rejects_boolean_colors() -> None:
     )
 
     assert decision["accepted"] is False
+
+
+@pytest.mark.parametrize(
+    ("checker", "vertices", "arcs", "witness_format", "role", "payload"),
+    [
+        (
+            check_odd_cycle,
+            ["a", "b", "c"],
+            [["a", "b"], ["b", "c"], ["c", "a"]],
+            "graph.odd_cycle",
+            "DEFEATS_CANDIDATE",
+            {"cycle": ["a", "b", "c"]},
+        ),
+        (
+            check_two_coloring,
+            ["a", "b"],
+            [["a", "b"]],
+            "graph.2coloring",
+            "SUPPORTS_CLAIM",
+            {"coloring": {"a": 0, "b": 1}},
+        ),
+    ],
+)
+def test_graph_witness_checkers_reject_binding_substitution(
+    checker: Callable[[dict[str, Any]], dict[str, Any]],
+    vertices: list[str],
+    arcs: list[list[str]],
+    witness_format: str,
+    role: str,
+    payload: dict[str, Any],
+) -> None:
+    request = _graph_witness_request(
+        vertices=vertices,
+        arcs=arcs,
+        witness_format=witness_format,
+        role=role,
+        payload=payload,
+    )
+    rebound = dict(request["witness"]["payload"]["bindings"])
+    rebound["candidate_digest"] = "sha256:" + "9" * 64
+    request["witness"]["payload"]["bindings"] = rebound
+
+    decision = checker(request)
+
+    assert decision["accepted"] is False
+    assert "bindings" in decision["detail"]
 
 
 def test_path_enumeration_continues_through_intermediate_terminal() -> None:

--- a/tests/checkers/test_lean4_checker.py
+++ b/tests/checkers/test_lean4_checker.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import subprocess
+from copy import deepcopy
+from typing import Any
+
+import pytest
+
+from jacobian_checkers.lean4 import (
+    LEAN_COMMIT,
+    LEAN_VERSION,
+    check_kernel_certificate,
+)
+
+
+def _request() -> dict[str, Any]:
+    bindings = {
+        "claim_digest": "sha256:" + "a" * 64,
+        "semantics_digest": "sha256:" + "b" * 64,
+        "candidate_digest": "sha256:" + "c" * 64,
+        "scope_digest": None,
+        "encoding_digest": None,
+    }
+    statement = "True"
+    proof = "by trivial"
+    return {
+        "request_version": "1",
+        "claim": {
+            "payload": {
+                "statement": statement,
+                "environment": "CORE",
+                "allowed_axioms": [],
+            }
+        },
+        "candidate": {
+            "payload": {
+                "statement": statement,
+                "proof": proof,
+                "environment": "CORE",
+            }
+        },
+        "certificate": {
+            "payload": {
+                "certificate_type": "lean4.kernel",
+                "format_version": "1",
+                "bindings": deepcopy(bindings),
+                "payload": {
+                    "statement": statement,
+                    "proof": proof,
+                    "environment": "CORE",
+                    "allowed_axioms": [],
+                    "declaration_name": "jacobian_theorem",
+                    "lean_version": LEAN_VERSION,
+                    "lean_commit": LEAN_COMMIT,
+                    "import_name": None,
+                    "mathlib_commit": None,
+                },
+            }
+        },
+        "expected_bindings": bindings,
+    }
+
+
+def test_lean_checker_accepts_exact_bound_core_proof(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "jacobian_checkers.lean4._run_lean",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess(
+            args=("lean",),
+            returncode=0,
+            stdout="'jacobian_theorem' does not depend on any axioms",
+            stderr="",
+        ),
+    )
+
+    decision = check_kernel_certificate(_request())
+
+    assert decision["accepted"] is True
+    assert decision["conclusion"] == "TRUE"
+    assert decision["method"] == "CHECKED_CERTIFICATE"
+
+
+@pytest.mark.parametrize("mutation", ["bindings", "format", "forbidden_proof"])
+def test_lean_checker_rejects_unbound_or_unsupported_certificates(
+    mutation: str,
+) -> None:
+    request = _request()
+    certificate = request["certificate"]["payload"]
+    if mutation == "bindings":
+        certificate["bindings"]["candidate_digest"] = "sha256:" + "9" * 64
+    elif mutation == "format":
+        certificate["format_version"] = "2"
+    else:
+        certificate["payload"]["proof"] = "by sorry"
+        request["candidate"]["payload"]["proof"] = "by sorry"
+
+    decision = check_kernel_certificate(request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+def test_lean_checker_timeout_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def timed_out(*_args: object, **_kwargs: object) -> object:
+        raise subprocess.TimeoutExpired(cmd=("lean",), timeout=1)
+
+    monkeypatch.setattr("jacobian_checkers.lean4._run_lean", timed_out)
+
+    decision = check_kernel_certificate(_request())
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"

--- a/tests/checkers/test_sat_unsat_proof_checker.py
+++ b/tests/checkers/test_sat_unsat_proof_checker.py
@@ -357,3 +357,22 @@ def test_missing_runtime_authorization_is_rejected(
 
     assert decision["accepted"] is False
     assert decision["conclusion"] == "UNKNOWN"
+
+
+def test_drat_timeout_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    proof_request_factory: ProofRequestFactory,
+) -> None:
+    executable, marker = _fake_checker(
+        tmp_path,
+        "import time\ntime.sleep(5)",
+    )
+    _install_runtime_environment(monkeypatch, executable)
+    monkeypatch.setattr("jacobian_checkers.sat.DRAT_TRIM_TIMEOUT_SECONDS", 0.1)
+
+    decision = check_unsat_proof(proof_request_factory(_DEFAULT_PROOF))
+
+    assert marker.read_text(encoding="utf-8") == "called"
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"

--- a/tests/checkers/test_smt_unsat_proof_checker.py
+++ b/tests/checkers/test_smt_unsat_proof_checker.py
@@ -343,3 +343,22 @@ def test_excessive_output_and_runtime_mutation_fail_closed(
 
     assert mutated_decision["accepted"] is False
     assert mutated_decision["conclusion"] == "UNKNOWN"
+
+
+def test_carcara_timeout_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    proof_request_factory: ProofRequestFactory,
+) -> None:
+    executable, marker = _fake_checker(
+        tmp_path,
+        "import time\ntime.sleep(5)",
+    )
+    _install_runtime_environment(monkeypatch, executable)
+    monkeypatch.setattr("jacobian_checkers.smt.CARCARA_TIMEOUT_SECONDS", 0.1)
+
+    decision = check_unsat_proof(proof_request_factory())
+
+    assert marker.read_text(encoding="utf-8") == "called"
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"

--- a/tests/contract/test_checker_dependency_boundary.py
+++ b/tests/contract/test_checker_dependency_boundary.py
@@ -16,10 +16,12 @@ _FORBIDDEN_PREFIXES = (
 
 @pytest.mark.conformance
 def test_independent_checkers_do_not_import_search_implementations() -> None:
-    checker_root = Path("src/jacobian_checkers")
+    checker_root = Path(__file__).parents[2] / "src" / "jacobian_checkers"
+    source_paths = sorted(checker_root.glob("*.py"))
+    assert source_paths, f"no checker sources found below {checker_root}"
     violations: list[str] = []
 
-    for source_path in sorted(checker_root.glob("*.py")):
+    for source_path in source_paths:
         tree = ast.parse(source_path.read_text(encoding="utf-8"))
         for node in ast.walk(tree):
             imported: tuple[str, ...] = ()

--- a/tests/fixtures/plugin_functions.py
+++ b/tests/fixtures/plugin_functions.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import copy
 import os
+import pathlib
 import subprocess
 import sys
 import time
@@ -43,12 +44,15 @@ def emit_large_diagnostic(_request: dict[str, Any]) -> dict[str, Any]:
 
 def spawn_delayed_child(request: dict[str, Any]) -> dict[str, Any]:
     marker = request["marker"]
+    started_marker = request["started_marker"]
+    delay_seconds = request.get("delay_seconds", 1)
     script = (
         "import pathlib,time;"
-        "time.sleep(1);"
+        f"time.sleep({delay_seconds!r});"
         f"pathlib.Path({marker!r}).write_text('survived', encoding='utf-8')"
     )
     subprocess.Popen([sys.executable, "-c", script])
+    pathlib.Path(started_marker).write_text("started", encoding="utf-8")
     time.sleep(60)
     return {"unreachable": True}
 

--- a/tests/integration/infrastructure/test_mcp_adapter.py
+++ b/tests/integration/infrastructure/test_mcp_adapter.py
@@ -311,6 +311,8 @@ def test_mcp_workspace_schema_aliases_and_fail_closed_round_trip(
                 },
             )
             assert rejected_result.is_error is True
+            rejected = json.loads(rejected_result.content[0].text)
+            assert rejected["error"]["code"] == "INVALID_INPUT"
 
             second_problem_result = await client.call_tool(
                 "workspace.write",
@@ -330,6 +332,8 @@ def test_mcp_workspace_schema_aliases_and_fail_closed_round_trip(
                 },
             )
             assert second_problem_result.is_error is True
+            second_problem = json.loads(second_problem_result.content[0].text)
+            assert second_problem["error"]["code"] == "INVALID_INPUT"
 
             unchanged_result = await client.call_tool(
                 "workspace.query",
@@ -406,6 +410,8 @@ def test_mcp_workspace_schema_aliases_and_fail_closed_round_trip(
                 },
             )
             assert conflicting_mark_result.is_error is True
+            conflicting_mark = json.loads(conflicting_mark_result.content[0].text)
+            assert conflicting_mark["error"]["code"] == "INVALID_INPUT"
 
             mark_result = await client.call_tool(
                 "workspace.write",
@@ -488,7 +494,9 @@ def test_mcp_describes_and_invokes_capabilities(tmp_path: Path) -> None:
             )
             unknown_result = json.loads(unknown.content[0].text)
             assert unknown.is_error is False
+            assert unknown_result["execution"]["status"] == "ERROR"
             assert unknown_result["output"]["error"]["code"] == "UNKNOWN_CAPABILITY"
+            assert unknown_result["assurance"]["level"] != "VERIFIED"
 
     asyncio.run(scenario())
 
@@ -527,6 +535,7 @@ def test_mcp_no_retrieval_policy_is_operator_bound_and_fail_closed(
             result = json.loads(denied.content[0].text)
             assert result["execution"]["status"] == "ERROR"
             assert result["output"]["error"]["code"] == "CAPABILITY_POLICY_DENIED"
+            assert result["assurance"]["level"] != "VERIFIED"
             assert result["diagnostics"][0]["details"] == {
                 "policy_profile": "COMPUTE_VERIFY_NO_RETRIEVAL",
                 "policy_digest": policy.digest,

--- a/tests/integration/infrastructure/test_plugin_execution.py
+++ b/tests/integration/infrastructure/test_plugin_execution.py
@@ -115,14 +115,20 @@ def test_plugin_diagnostic_limit_fails_closed() -> None:
 
 def test_plugin_timeout_kills_descendant_processes(tmp_path: Path) -> None:
     marker = tmp_path / "descendant-survived"
+    started_marker = tmp_path / "descendant-started"
 
     result = PluginExecutor().run(
         entrypoint="tests.fixtures.plugin_functions:spawn_delayed_child",
-        request={"marker": str(marker)},
-        timeout_seconds=0.2,
+        request={
+            "marker": str(marker),
+            "started_marker": str(started_marker),
+            "delay_seconds": 3,
+        },
+        timeout_seconds=2,
     )
     time.sleep(1.2)
 
+    assert started_marker.read_text(encoding="utf-8") == "started"
     assert result.status.value == "TIMEOUT"
     assert not marker.exists()
 
@@ -133,7 +139,7 @@ def test_plugin_success_kills_descendant_holding_output_pipes(tmp_path: Path) ->
 
     result = PluginExecutor().run(
         entrypoint="tests.fixtures.plugin_functions:spawn_child_then_return",
-        request={"marker": str(marker), "delay_seconds": 3},
+        request={"marker": str(marker)},
         timeout_seconds=2,
     )
     elapsed = time.monotonic() - start

--- a/tests/integration/infrastructure/test_pytest_execution_policy.py
+++ b/tests/integration/infrastructure/test_pytest_execution_policy.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-PROJECT_ROOT = Path(__file__).parents[2]
+PROJECT_ROOT = Path(__file__).parents[3]
 
 
 def test_parallel_pytest_rejects_selected_lean_runtime_tests() -> None:
@@ -24,6 +24,7 @@ def test_parallel_pytest_rejects_selected_lean_runtime_tests() -> None:
         cwd=PROJECT_ROOT,
         capture_output=True,
         text=True,
+        timeout=30,
     )
 
     assert completed.returncode == 4

--- a/tests/integration/infrastructure/test_remote_mcp.py
+++ b/tests/integration/infrastructure/test_remote_mcp.py
@@ -5,10 +5,14 @@ import json
 import socket
 import subprocess
 import sys
+import threading
 import time
 from pathlib import Path
 
 import pytest
+from mcp.server.auth.settings import AuthSettings
+from pydantic import AnyHttpUrl
+from uvicorn import Config, Server
 
 from jacobian.adapters.mcp.remote import (
     StaticTokenGrant,
@@ -17,6 +21,7 @@ from jacobian.adapters.mcp.remote import (
     TenantKernelRouter,
     load_static_token_file,
 )
+from jacobian.adapters.mcp.server import create_server
 from jacobian.contracts.workspaces import (
     WorkspaceOpenRequest,
     WorkspaceQueryRequest,
@@ -37,10 +42,14 @@ def test_static_tokens_bind_distinct_authenticated_subjects() -> None:
     alpha = asyncio.run(verifier.verify_token("a" * 32))
     beta = asyncio.run(verifier.verify_token("b" * 32))
     unknown = asyncio.run(verifier.verify_token("c" * 32))
+    empty = asyncio.run(verifier.verify_token(""))
+    oversized = asyncio.run(verifier.verify_token("c" * 4096))
 
     assert alpha is not None and alpha.subject == "alpha"
     assert beta is not None and beta.subject == "beta"
     assert unknown is None
+    assert empty is None
+    assert oversized is None
 
 
 def test_remote_configuration_errors_name_the_rule_and_recovery(
@@ -233,49 +242,73 @@ def test_authenticated_streamable_http_isolates_tenant_memory(
                 "tokens": [
                     {"tenant_id": "alpha", "token": "a" * 32},
                     {"tenant_id": "beta", "token": "b" * 32},
+                    {
+                        "tenant_id": "wrong-scope",
+                        "token": "s" * 32,
+                        "scopes": ["jacobian:other"],
+                    },
                 ]
             }
         ),
         encoding="utf-8",
     )
-    with socket.socket() as reserved:
-        reserved.bind(("127.0.0.1", 0))
-        port = int(reserved.getsockname()[1])
-    process = subprocess.Popen(
-        [
-            sys.executable,
-            "-m",
-            "jacobian.adapters.mcp.server",
-            "--transport",
-            "streamable-http",
-            "--host",
-            "127.0.0.1",
-            "--port",
-            str(port),
-            "--state-dir",
-            str(tmp_path / "state"),
-            "--auth-tokens-file",
-            str(token_file),
-            "--public-base-url",
-            f"http://127.0.0.1:{port}",
-            "--capability-adapter",
-            "tests.fixtures.capability_functions:create_adapter",
-        ],
-        cwd=Path.cwd(),
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
-    try:
-        _wait_for_port(port, process)
-        asyncio.run(_remote_tenant_scenario(port))
-    finally:
-        process.terminate()
+    with socket.socket() as listener:
+        listener.bind(("127.0.0.1", 0))
+        listener.listen()
+        port = int(listener.getsockname()[1])
+        public_base_url = f"http://127.0.0.1:{port}"
+        mcp_server = create_server(
+            tmp_path / "state",
+            tenant_isolation=True,
+            allow_anonymous=False,
+            token_verifier=StaticTokenVerifier(load_static_token_file(token_file)),
+            auth=AuthSettings(
+                issuer_url=AnyHttpUrl(public_base_url),
+                resource_server_url=AnyHttpUrl(f"{public_base_url}/mcp"),
+                required_scopes=["jacobian:use"],
+            ),
+            capability_adapter_entrypoints=(
+                "tests.fixtures.capability_functions:create_adapter",
+            ),
+        )
+        http_server = Server(
+            Config(
+                mcp_server.streamable_http_app(),
+                host="127.0.0.1",
+                port=port,
+                log_level="warning",
+            )
+        )
+        server_thread = threading.Thread(
+            target=http_server.run,
+            kwargs={"sockets": [listener]},
+            daemon=True,
+        )
+        server_thread.start()
         try:
-            process.wait(timeout=10)
-        except subprocess.TimeoutExpired:
-            process.kill()
-            process.wait(timeout=5)
+            _wait_for_server(http_server, server_thread)
+            asyncio.run(_remote_auth_rejections(port))
+            asyncio.run(_remote_tenant_scenario(port))
+        finally:
+            http_server.should_exit = True
+            server_thread.join(timeout=10)
+            assert not server_thread.is_alive()
+
+
+async def _remote_auth_rejections(port: int) -> None:
+    import httpx2
+
+    url = f"http://127.0.0.1:{port}/mcp"
+    async with httpx2.AsyncClient() as client:
+        unauthenticated = await client.post(url, json={})
+        wrong_scope = await client.post(
+            url,
+            json={},
+            headers={"Authorization": f"Bearer {'s' * 32}"},
+        )
+
+    assert unauthenticated.status_code == 401
+    assert wrong_scope.status_code == 403
 
 
 async def _remote_tenant_scenario(port: int) -> None:
@@ -327,15 +360,15 @@ async def _remote_tenant_scenario(port: int) -> None:
     assert await invoke("b" * 32, create=False) == 0
 
 
-def _wait_for_port(port: int, process: subprocess.Popen[str]) -> None:
+def _wait_for_server(
+    http_server: Server,
+    server_thread: threading.Thread,
+) -> None:
     deadline = time.monotonic() + 20
     while time.monotonic() < deadline:
-        if process.poll() is not None:
-            stderr = process.stderr.read() if process.stderr is not None else ""
-            raise AssertionError(f"remote MCP server exited early: {stderr}")
-        try:
-            with socket.create_connection(("127.0.0.1", port), timeout=0.2):
-                return
-        except OSError:
-            time.sleep(0.1)
+        if not server_thread.is_alive():
+            raise AssertionError("remote MCP server exited early")
+        if http_server.started:
+            return
+        time.sleep(0.1)
     raise AssertionError("remote MCP server did not start")

--- a/tests/integration/infrastructure/test_worker_error_protocol.py
+++ b/tests/integration/infrastructure/test_worker_error_protocol.py
@@ -44,6 +44,7 @@ def test_source_changes_cross_worker_boundary_as_typed_codes(
         input=b"{}",
         capture_output=True,
         check=False,
+        timeout=10,
     )
     response = loads_strict_json(completed.stdout)
 
@@ -83,6 +84,7 @@ def test_worker_code_cannot_self_report_a_source_change(
         input=b"{}",
         capture_output=True,
         check=False,
+        timeout=10,
     )
     response = loads_strict_json(completed.stdout)
 

--- a/tests/integration/workflow/test_certificate_verification.py
+++ b/tests/integration/workflow/test_certificate_verification.py
@@ -1,21 +1,22 @@
 from __future__ import annotations
 
 import hashlib
+from copy import deepcopy
 from pathlib import Path
 
 import pytest
 
 from jacobian.canonical import canonicalize_json, loads_strict_json
 from jacobian.contracts.evidence import CertificateEnvelope, EvidenceBindings
-from jacobian.contracts.results import Conclusion, Verification
+from jacobian.contracts.results import Conclusion, ExecutionStatus, Verification
 from jacobian.registry import CheckerRegistry
 from jacobian.store import ArtifactStore
 from jacobian.verification import VerificationService
 
 
-@pytest.mark.subprocess
-@pytest.mark.conformance
-def test_complete_path_enumeration_certificate_is_verified(tmp_path: Path) -> None:
+def _certificate_case(
+    tmp_path: Path,
+) -> tuple[ArtifactStore, VerificationService, str]:
     store = ArtifactStore(tmp_path)
     claim_schema = store.register_descriptor(
         kind="schema",
@@ -123,10 +124,70 @@ def test_complete_path_enumeration_certificate_is_verified(tmp_path: Path) -> No
         candidate_schema_uris=(candidate_schema,),
     )
 
-    result = VerificationService(store, registry).verify_certificate(
-        certificate_uri=certificate_artifact.artifact_uri
+    return (
+        store,
+        VerificationService(store, registry),
+        certificate_artifact.artifact_uri,
     )
+
+
+@pytest.mark.subprocess
+@pytest.mark.conformance
+def test_complete_path_enumeration_certificate_is_verified(tmp_path: Path) -> None:
+    _, service, certificate_uri = _certificate_case(tmp_path)
+
+    result = service.verify_certificate(certificate_uri=certificate_uri)
 
     assert result.conclusion is Conclusion.FALSE
     assert result.assurance.verification is Verification.VERIFIED
     assert result.assurance.coverage.value == "EXHAUSTIVE"
+
+
+def test_certificate_binding_substitution_is_rejected(tmp_path: Path) -> None:
+    store, service, certificate_uri = _certificate_case(tmp_path)
+    original = store.get(certificate_uri)
+    payload = deepcopy(original.payload)
+    payload["bindings"]["candidate_digest"] = "sha256:" + "9" * 64
+    rebound = store.put(
+        schema_uri=original.manifest.schema_uri,
+        semantics_uri=original.manifest.semantics_uri,
+        payload=payload,
+        parents=original.manifest.parents,
+    )
+
+    result = service.verify_certificate(certificate_uri=rebound.artifact_uri)
+
+    assert result.conclusion is Conclusion.UNKNOWN
+    assert result.assurance.verification is Verification.UNVERIFIED
+    assert result.verification_record_uri is None
+
+
+def test_certificate_without_bound_parents_is_rejected(tmp_path: Path) -> None:
+    store, service, certificate_uri = _certificate_case(tmp_path)
+    original = store.get(certificate_uri)
+    unbound = store.put(
+        schema_uri=original.manifest.schema_uri,
+        semantics_uri=original.manifest.semantics_uri,
+        payload=original.payload,
+    )
+
+    result = service.verify_certificate(certificate_uri=unbound.artifact_uri)
+
+    assert result.conclusion is Conclusion.UNKNOWN
+    assert result.assurance.verification is Verification.UNVERIFIED
+    assert result.verification_record_uri is None
+
+
+def test_corrupt_certificate_payload_is_an_operational_failure(
+    tmp_path: Path,
+) -> None:
+    store, service, certificate_uri = _certificate_case(tmp_path)
+    certificate = store.get(certificate_uri)
+    store._blob_path(certificate.manifest.payload_digest).write_bytes(b"corrupt")
+
+    result = service.verify_certificate(certificate_uri=certificate_uri)
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.conclusion is Conclusion.UNKNOWN
+    assert result.assurance.verification is Verification.UNVERIFIED
+    assert result.verification_record_uri is None

--- a/tests/integration/workflow/test_search_orchestration.py
+++ b/tests/integration/workflow/test_search_orchestration.py
@@ -245,7 +245,7 @@ def test_checkpoint_persistence_is_included_in_wall_accounting(
 
     def delayed_put(**kwargs: object) -> object:
         nonlocal current_time
-        if kwargs.get("summary") == "immutable search checkpoint":
+        if kwargs.get("schema_uri") == kernel.search.checkpoint_schema_uri:
             current_time += 1
         return original_put(**kwargs)
 
@@ -262,7 +262,7 @@ def test_checkpoint_persistence_is_included_in_wall_accounting(
     snapshot = kernel.search.wait(handle.experiment_uri, timeout_seconds=30)
 
     assert snapshot.state is ExperimentState.COMPLETED
-    assert snapshot.accounting.wall_time_ms == 1_000
+    assert snapshot.accounting.wall_time_ms >= 1_000
 
 
 def test_checkpoint_persistence_cannot_complete_past_wall_budget(
@@ -279,7 +279,7 @@ def test_checkpoint_persistence_cannot_complete_past_wall_budget(
 
     def delayed_put(**kwargs: object) -> object:
         nonlocal current_time
-        if kwargs.get("summary") == "immutable search checkpoint":
+        if kwargs.get("schema_uri") == kernel.search.checkpoint_schema_uri:
             current_time += 5.1
         return original_put(**kwargs)
 

--- a/tests/integration/workflow/test_verification_workflow.py
+++ b/tests/integration/workflow/test_verification_workflow.py
@@ -48,7 +48,7 @@ def _invoke(
     )
 
 
-def test_atomic_capability_catalog_exposes_only_composable_operations(
+def test_atomic_capability_catalog_includes_required_and_excludes_composite_operations(
     tmp_path: Path,
 ) -> None:
     kernel = JacobianKernel(tmp_path)

--- a/tests/integration/workflow/test_witness_verification.py
+++ b/tests/integration/workflow/test_witness_verification.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import pytest
 
+from jacobian.bounded_process import BoundedProcessResult
 from jacobian.canonical import canonicalize_json, loads_strict_json
 from jacobian.contracts.checkers import CheckerDecision
 from jacobian.contracts.evidence import EvidenceBindings, WitnessEnvelope
@@ -13,6 +14,7 @@ from jacobian.contracts.results import (
     Arithmetic,
     Conclusion,
     Coverage,
+    ExecutionStatus,
     Method,
     Verification,
 )
@@ -126,6 +128,62 @@ def _graph_case(
         witness.artifact_uri,
         candidate_schema,
     )
+
+
+@pytest.mark.parametrize(
+    ("stopped", "expected_status"),
+    [
+        (
+            BoundedProcessResult(
+                returncode=-9,
+                stdout=b"",
+                stderr=b"",
+                stdout_exceeded=False,
+                stderr_exceeded=False,
+                timed_out=True,
+                cancelled=False,
+            ),
+            ExecutionStatus.TIMEOUT,
+        ),
+        (
+            BoundedProcessResult(
+                returncode=-9,
+                stdout=b"",
+                stderr=b"",
+                stdout_exceeded=False,
+                stderr_exceeded=False,
+                timed_out=False,
+                cancelled=True,
+            ),
+            ExecutionStatus.CANCELLED,
+        ),
+    ],
+)
+def test_checker_timeout_and_cancellation_are_non_conclusions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    stopped: BoundedProcessResult,
+    expected_status: ExecutionStatus,
+) -> None:
+    _, service, checker_id, claim_uri, candidate_uri, witness_uri, _ = _graph_case(
+        tmp_path
+    )
+    monkeypatch.setattr(
+        "jacobian.verification.run_bounded_process",
+        lambda *_args, **_kwargs: stopped,
+    )
+
+    result = service.verify_witness(
+        claim_uri=claim_uri,
+        candidate_uri=candidate_uri,
+        witness_uri=witness_uri,
+        checker_id=checker_id,
+    )
+
+    assert result.execution.status is expected_status
+    assert result.conclusion is Conclusion.UNKNOWN
+    assert result.assurance.verification is Verification.UNVERIFIED
+    assert result.verification_record_uri is None
 
 
 @pytest.mark.subprocess

--- a/tests/unit/test_bounded_process.py
+++ b/tests/unit/test_bounded_process.py
@@ -141,13 +141,13 @@ def test_detached_descendant_with_inherited_pipe_fails_closed() -> None:
             (
                 "import subprocess, sys; "
                 "subprocess.Popen("
-                "[sys.executable, '-c', 'import time; time.sleep(1)'], "
+                "[sys.executable, '-c', 'import time; time.sleep(5)'], "
                 "stdout=sys.stdout, stderr=sys.stderr, start_new_session=True); "
                 "print('worker complete', flush=True)"
             ),
         ],
         input_bytes=b"",
-        timeout_seconds=0.2,
+        timeout_seconds=2,
         environment=dict(os.environ),
         stdout_limit=4096,
         stderr_limit=4096,
@@ -155,40 +155,3 @@ def test_detached_descendant_with_inherited_pipe_fails_closed() -> None:
 
     assert completed.returncode == 0
     assert completed.timed_out
-
-
-@pytest.mark.skipif(
-    os.name != "posix",
-    reason="process-group descendant cleanup is exercised on POSIX",
-)
-def test_clean_exit_with_in_group_descendant_does_not_false_timeout() -> None:
-    """A clean worker exit must not be reported as timed out.
-
-    Regression test: a worker that exits normally while a descendant inherited
-    the stdout pipe (but remains in the process group) should not trigger a
-    false ``timed_out`` flag. The process-group kill closes the descendant's
-    pipe, allowing the reader to drain the already-buffered output and exit.
-    """
-    completed = run_bounded_process(
-        [
-            sys.executable,
-            "-c",
-            (
-                "import subprocess, sys; "
-                "subprocess.Popen("
-                "[sys.executable, '-c', 'import time; time.sleep(30)'], "
-                "stdout=sys.stdout, stderr=sys.stderr); "
-                "print('worker complete', flush=True)"
-            ),
-        ],
-        input_bytes=b"",
-        timeout_seconds=0.5,
-        environment=dict(os.environ),
-        stdout_limit=4096,
-        stderr_limit=4096,
-    )
-
-    assert completed.returncode == 0
-    assert not completed.timed_out
-    assert completed.stdout == b"worker complete\n"
-    assert completed.stderr == b""


### PR DESCRIPTION
## Problem

Several verification and isolation tests could pass without exercising the claimed boundary, while checker cancellation was normalized as a generic operational error. Direct SAT and SMT checker timeouts could also escape their fail-closed response path. Adjacent MCP tests left authentication, scope, status, and assurance invariants under-specified.

## Solution

Preserve checker cancellation as `CANCELLED` and keep timeout/cancellation results `UNKNOWN` and `UNVERIFIED`. Direct DRAT-trim and Carcara timeouts now return rejected checker decisions rather than propagating `TimeoutExpired`.

Harden the regression coverage around those boundaries:

- use explicit child-process readiness signals and pre-bound server sockets instead of timing and port-reservation races;
- compare bearer-token SHA-256 digests so comparisons have fixed length while leaving scope policy in MCP authorization middleware;
- add binding, format, timeout, certificate-corruption, authentication, and assurance-negative tests across graph, SAT, SMT, Lean, workflow, and MCP paths;
- remove a duplicate bounded-process test, add worker subprocess timeouts, make the checker dependency test root-independent, and move pytest execution-policy coverage to integration infrastructure.

No artifact format, checker authorization policy, or public request contract changes.

## Testing

```sh
uv run --locked ruff check . --exclude test_suite_audit_report.md
uv run --locked ruff format --check . --exclude test_suite_audit_report.md
uv run pytest -n 0 'tests/integration/workflow/test_witness_verification.py::test_checker_timeout_and_cancellation_are_non_conclusions'
```

Ruff passed. The focused changed-area suite accounted for 133 passing tests: 131 passed in the combined run, then the two corrected timeout/cancellation parameterizations passed independently.

The canonical core command reached 574 passing tests, then `tests/reference/test_reference_claim_schemas.py::test_path_closure_claim_requires_simple_path_semantics` timed out after 120 seconds in untouched Pydantic/JSON Schema generation. The isolated rerun timed out at the same kernel initialization boundary.

## Trust & Compatibility Impact

This changes verification-kernel failure normalization: caller cancellation is now reported as `CANCELLED` instead of `ERROR`; both remain non-conclusions with `UNKNOWN` completeness and `UNVERIFIED` assurance. SAT and SMT external-checker timeouts now fail closed through their normal rejected-decision protocol. MCP token matching changes internally to fixed-length digests; token-file and authorization behavior remain compatible.

Suggested review order: `verification.py` and direct checker timeout handling, MCP authentication/server changes, then the regression-test hardening commits.

## Checklist
- [ ] Routine local validation passes (`make check`)
- [x] Relevant focused tests are listed above
