### PR TITLE
fix(mcp): harden hosted MCP telemetry and graph verification

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -11,6 +11,10 @@
       "name": "AzureStorageKeyDetector"
     },
     {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
       "name": "BasicAuthDetector"
     },
     {
@@ -26,10 +30,8 @@
       "name": "GitLabTokenDetector"
     },
     {
-      "name": "Base64HighEntropyString"
-    },
-    {
-      "name": "HexHighEntropyString"
+      "name": "HexHighEntropyString",
+      "limit": 3.0
     },
     {
       "name": "IbmCloudIamDetector"
@@ -44,7 +46,8 @@
       "name": "JwtTokenDetector"
     },
     {
-      "name": "KeywordDetector"
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
     },
     {
       "name": "MailchimpDetector"
@@ -82,6 +85,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -102,6 +109,55 @@
       "pattern": []
     }
   ],
-  "results": {},
-  "generated_at": "2026-07-23T21:36:00Z"
+  "results": {
+    "docs/how-to/deploy-remote-mcp.md": [
+      {
+        "type": "Public IP (ipv4)",
+        "filename": "docs/how-to/deploy-remote-mcp.md",
+        "hashed_secret": "e562f69ec36e625116376f376d991e41613e9bf3",
+        "is_verified": false,
+        "line_number": 131
+      }
+    ],
+    "src/jacobian/provider_runtime.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/jacobian/provider_runtime.py",
+        "hashed_secret": "ee496eb00066978c8e6d17d39a8e0d244f4edb28",
+        "is_verified": false,
+        "line_number": 30
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/jacobian/provider_runtime.py",
+        "hashed_secret": "aba5514206f5fccaa765fd7986cc30cf20f2b565",
+        "is_verified": false,
+        "line_number": 35
+      },
+      {
+        "type": "Public IP (ipv4)",
+        "filename": "src/jacobian/provider_runtime.py",
+        "hashed_secret": "8de052f755916e8806e0131a106d7f48449333c0",
+        "is_verified": false,
+        "line_number": 54
+      }
+    ],
+    "tests/integration/infrastructure/test_mcp_adapter.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/integration/infrastructure/test_mcp_adapter.py",
+        "hashed_secret": "d188c04072e19678ed0333be9ed7cdc033ddf7a8",
+        "is_verified": false,
+        "line_number": 170
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/integration/infrastructure/test_mcp_adapter.py",
+        "hashed_secret": "f50968fac94142be96a69cf336f1632ede976f56",
+        "is_verified": false,
+        "line_number": 800
+      }
+    ]
+  },
+  "generated_at": "2026-07-28T09:44:12Z"
 }

--- a/deploy/caddy/Caddyfile
+++ b/deploy/caddy/Caddyfile
@@ -1,0 +1,56 @@
+{
+	admin 127.0.0.1:20243
+
+	# Runtime/module logs are separate from HTTP access logs. Reverse-proxy
+	# warnings can carry a structured request object, so redact both layers.
+	log default {
+		output stdout
+		format filter {
+			wrap json
+			fields {
+				request>headers>Authorization delete
+				request>headers>Cookie delete
+				request>headers>X-Openai-Session delete
+				request>headers>X-Openai-Subject delete
+				request>headers>Tailscale-User-Login delete
+				request>headers>Tailscale-User-Name delete
+				request>headers>Tailscale-User-Profile-Pic delete
+				request>headers>Traceparent hash
+				headers>Set-Cookie delete
+				response>headers>Set-Cookie delete
+			}
+		}
+	}
+}
+
+http://:8766 {
+	bind 127.0.0.1
+
+	@mcp path /mcp /mcp/*
+	handle @mcp {
+		reverse_proxy 127.0.0.1:8765 {
+			header_up Host 127.0.0.1:8765
+		}
+	}
+	handle {
+		respond 404
+	}
+
+	log {
+		output stdout
+		format filter {
+			wrap json
+			fields {
+				request>headers>Authorization delete
+				request>headers>Cookie delete
+				request>headers>X-Openai-Session delete
+				request>headers>X-Openai-Subject delete
+				request>headers>Tailscale-User-Login delete
+				request>headers>Tailscale-User-Name delete
+				request>headers>Tailscale-User-Profile-Pic delete
+				request>headers>Traceparent hash
+				resp_headers>Set-Cookie delete
+			}
+		}
+	}
+}

--- a/docs/how-to/deploy-remote-mcp.md
+++ b/docs/how-to/deploy-remote-mcp.md
@@ -59,10 +59,41 @@ For a disposable local transport test only:
 uv run jacobian-mcp \
   --transport streamable-http \
   --max-tenant-kernels 32 \
-  --allow-anonymous
+  --allow-anonymous \
+  --anonymous-tenant-id local-smoke-2026-07
 ```
 
-Do not expose anonymous mode to a network.
+`--anonymous-tenant-id` is fixed by the operator, never selected from a request.
+Give every independently operated anonymous test endpoint a different value so
+their workspaces, research episodes, and artifacts do not share one state
+directory. This is namespace isolation, not authentication: every caller that
+can reach the same endpoint still shares that endpoint's tenant. Do not expose
+anonymous mode to an untrusted network.
+
+## Filter reverse-proxy logs
+
+Access-log filtering does not cover a reverse proxy's own warning and error
+logs. Those records can include a structured copy of request headers when an
+upstream disconnects or times out. Configure both the proxy's global/runtime
+logger and its access logger.
+
+The checked-in [Caddyfile](../../deploy/caddy/Caddyfile) is the deployment
+baseline for the localhost ports used by the hosted test service. It deletes
+authorization, cookie, OpenAI session/subject, and Tailscale identity headers
+from both log paths. `Traceparent` is reduced to Caddy's eight-hex-character
+SHA-256 correlation digest; Jacobian emits the same digest in its bounded
+`MCP capability attempt` record.
+
+Validate and reload a copied configuration before changing live traffic:
+
+```sh
+caddy validate --config /etc/caddy-jacobian/Caddyfile --adapter caddyfile
+caddy reload --config /etc/caddy-jacobian/Caddyfile --adapter caddyfile
+```
+
+Do not enable Caddy's `debug` or `log_credentials` options on a hosted
+connector. Retention and downstream log aggregation must preserve the same
+field-deletion boundary.
 
 ## Warm the Mathlib profile when serving `lean.check`
 
@@ -120,3 +151,7 @@ subject to the same tenant-routing interface.
   larger searches instead of holding one HTTP request open.
 - Do not interpret HTTP success, solver completion, or an MCP response as a
   verified mathematical result.
+- Use the one-line `MCP capability attempt` records for operational counts.
+  Completed research episodes intentionally omit failed attempts, while the
+  attempt record distinguishes `COMPLETED`, `TIMEOUT`, `CANCELLED`, and `ERROR`
+  and retains only bounded status/provenance fields and argument digests.

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,6 +66,7 @@ expectations.
 - [Exact rational linear-system evidence](reference/linear-rational-solutions.md)
 - [Exact rational matrix determinants](reference/matrix-rational-determinant.md)
 - [Graph counterexample shrinking](reference/graph-counterexample-shrinking.md)
+- [Maximum-matching certificate and verification](reference/graph-maximum-matching.md)
 - [Integer matrix Hermite normal form](reference/matrix-hermite-normal-form.md)
 - [Typed polynomial expression normalization](reference/polynomial-expression-normalization.md)
 - [Polynomial-map inverse verification](reference/polynomial-map-inverse-verification.md)

--- a/docs/reference/graph-maximum-matching.md
+++ b/docs/reference/graph-maximum-matching.md
@@ -1,0 +1,105 @@
+# Maximum-matching certificate and verification
+
+[Documentation home](../index.md)
+
+`graph.invariant.maximum_matching.compute` version `2` returns a feasible
+matching together with a Tutte–Berge barrier certificate. The producer remains
+`COMPUTED`. An operator-authorized
+`graph.invariant.maximum_matching.verify` capability may promote the exact
+stored result to `VERIFIED` only after independent clean-process replay.
+
+## Exact claim and scope
+
+The verifier checks one claim:
+
+> The stored witness edges form a maximum-cardinality matching of the exact
+> stored finite simple undirected graph.
+
+The claim is bound to the producer input artifact, result artifact, graph
+semantics, result schema version, checker identity, and checker provider
+runtime. It does not certify a graph supplied directly by the caller, a
+different matching, or any theorem that uses the matching as an intermediate
+fact.
+
+The producer accepts at most 32 vertices and 496 edges. The independent checker
+uses only bounded standard-library graph traversal. It imports neither
+NetworkX, which constructs the matching and certificate, nor Python-FLINT,
+which serves unrelated polynomial and matrix checkers.
+
+## Producer certificate
+
+The result contains:
+
+- a canonical, vertex-disjoint edge witness;
+- its declared cardinality; and
+- a `TUTTE_BERGE_BARRIER` certificate containing a canonical vertex set
+  \(U\), the declared number of odd components of \(G-U\), and the resulting
+  upper bound.
+
+The NetworkX producer obtains a barrier through the Gallai–Edmonds
+decomposition. It computes
+
+\[
+D=\{v:\nu(G-v)=\nu(G)\},\qquad U=N(D)\setminus D.
+\]
+
+Certificate construction is untrusted. A failure to construct a valid
+certificate is an operation failure, not evidence that the matching is
+nonmaximum.
+
+## Verification obligation ledger
+
+| Obligation | Independent replay | Failure meaning |
+| --- | --- | --- |
+| Exact artifact binding | Recompute and compare claim, semantics, candidate, lineage, witness-envelope, and payload digests. | Reject this evidence; no mathematical conclusion. |
+| Graph validity | Parse the complete bounded simple graph; reject loops, duplicate undirected edges, undeclared endpoints, malformed vertices, and unsupported order. | Reject malformed or unsupported evidence. |
+| Matching feasibility | Require canonical witness edges, graph membership, vertex disjointness, and equality between witness length and declared cardinality. | Reject the candidate; no opposite claim follows. |
+| Certificate scope | Require one canonical barrier subset of the exact graph and the exact versioned certificate shape. | Reject the certificate. |
+| Odd-component count | Remove the barrier and independently enumerate connected components by breadth-first traversal; count components of odd order. | Reject a mismatched certificate. |
+| Tutte–Berge upper bound | Recompute \(b=(|V|+|U|-q(G-U))/2\), require integral parity, and require the declared upper bound and matching cardinality to equal \(b\). | Reject the optimality claim. |
+| Optimality conclusion | Combine the feasible matching lower bound with the independently checked Tutte–Berge upper bound. | Only equality permits acceptance. |
+| Authorization and runtime | Dispatch only the operator-authorized checker whose source digest, schemas, semantics, evidence format, and provider runtime match the record. | Unavailable, timeout, cancellation, or error remains non-conclusive. |
+
+The Tutte–Berge theorem gives
+
+\[
+\nu(G)=\frac{1}{2}\min_{U\subseteq V}
+\left(|V|+|U|-q(G-U)\right).
+\]
+
+Consequently any checked barrier supplies an upper bound, while the checked
+matching witness supplies a lower bound. Equality discharges the maximum
+cardinality obligation without replaying the producer's matching algorithm.
+
+## Adversarial matrix
+
+The checker tests include:
+
+- a feasible but nonmaximum matching;
+- a witness edge absent from the source graph;
+- intersecting, duplicated, reversed, or noncanonical witness edges;
+- a barrier vertex outside the source graph;
+- a mutated barrier, odd-component count, or upper bound;
+- source, candidate, semantics, claim-binding, or payload-digest substitution;
+- a valid certificate rebound to another graph or result; and
+- checker unavailability, timeout, cancellation, and unauthorized installation.
+
+Every rejection returns `UNKNOWN`; it never asserts that another matching is
+maximum.
+
+## Capability-development handoff
+
+`stage=implementation,status=complete`
+
+- Evidence: hosted OpenAI use exercised maximum matching repeatedly, while the
+  producer exposed only an unverified edge witness.
+- Availability delta: version `2` adds the certificate-bearing producer
+  contract and the domain-owned verification capability.
+- Assurance delta: producer output remains `COMPUTED`; only the independent,
+  operator-authorized clean-process checker can return `VERIFIED`.
+- Compatibility: the required certificate changes the result schema, so
+  version `1` artifacts are intentionally not accepted as version `2`
+  candidates.
+- Remaining proof obligation: comparative model-in-the-loop evaluation may
+  measure whether the verifier improves autonomous research outcomes; it is not
+  required to establish the local certificate theorem.

--- a/src/jacobian/adapters/mcp/remote.py
+++ b/src/jacobian/adapters/mcp/remote.py
@@ -79,15 +79,22 @@ class TenantKernelRouter:
         *,
         install_references: bool = True,
         allow_anonymous: bool = False,
+        anonymous_tenant_id: str = "anonymous",
         capability_adapter_entrypoints: tuple[str, ...] = (),
         capability_policy: CapabilityPolicy | None = None,
         max_tenant_kernels: int = DEFAULT_MAX_TENANT_KERNELS,
     ) -> None:
         if max_tenant_kernels < 1:
             raise ValueError("max_tenant_kernels must be positive")
+        if not _TENANT_PATTERN.fullmatch(anonymous_tenant_id):
+            raise ValueError(
+                "anonymous_tenant_id must start with a letter or digit, contain only "
+                "letters, digits, '.', '_', or '-', and be at most 128 characters"
+            )
         self.root = Path(root)
         self.install_references = install_references
         self.allow_anonymous = allow_anonymous
+        self.anonymous_tenant_id = anonymous_tenant_id
         self.capability_adapter_entrypoints = capability_adapter_entrypoints
         self.capability_policy = capability_policy
         self.max_tenant_kernels = max_tenant_kernels
@@ -102,7 +109,7 @@ class TenantKernelRouter:
                     "Authentication is required for this server. "
                     "Authenticate with a configured bearer token and retry."
                 )
-            tenant = "anonymous"
+            tenant = self.anonymous_tenant_id
         if not _TENANT_PATTERN.fullmatch(tenant):
             raise AuthenticationError(
                 "The authenticated subject cannot be used for tenant isolation. "

--- a/src/jacobian/adapters/mcp/server.py
+++ b/src/jacobian/adapters/mcp/server.py
@@ -87,6 +87,18 @@ _RELATED_CAPABILITIES: dict[str, tuple[tuple[str, str], ...]] = {
             "prefer named Boolean CNF for finite colorings and forbidden patterns",
         ),
     ),
+    "graph.invariant.maximum_matching.compute": (
+        (
+            "graph.invariant.maximum_matching.verify",
+            "independently replay the stored Tutte-Berge certificate",
+        ),
+    ),
+    "graph.invariant.maximum_matching.verify": (
+        (
+            "graph.invariant.maximum_matching.compute",
+            "produce a matching witness and Tutte-Berge certificate",
+        ),
+    ),
 }
 
 if TYPE_CHECKING:
@@ -255,6 +267,27 @@ def _argument_digest(arguments: dict[str, Any]) -> str:
     return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
 
 
+def _request_trace_digest(ctx: Any | None) -> tuple[str, str]:
+    """Return a bounded correlation digest without retaining caller identifiers."""
+
+    if ctx is None:
+        return "none", "none"
+    headers = getattr(ctx, "headers", None)
+    if headers is not None:
+        traceparent = headers.get("traceparent")
+        if isinstance(traceparent, str) and 0 < len(traceparent) <= 256:
+            digest = hashlib.sha256(traceparent.encode("utf-8")).hexdigest()[:8]
+            return digest, "traceparent"
+    try:
+        request_id = str(ctx.request_id)
+    except (AttributeError, TypeError, ValueError):
+        return "none", "none"
+    if not request_id or len(request_id) > 256:
+        return "none", "none"
+    digest = hashlib.sha256(request_id.encode("utf-8")).hexdigest()[:8]
+    return digest, "request_id"
+
+
 def _response_size(value: Any) -> int:
     try:
         if hasattr(value, "model_dump_json"):
@@ -269,6 +302,122 @@ def _response_size(value: Any) -> int:
         )
     except (TypeError, ValueError):
         return -1
+
+
+def _log_capability_attempt(
+    *,
+    capability_id: str,
+    mode: CapabilityMode,
+    started: float,
+    argument_digest: str,
+    trace_digest: str,
+    trace_source: str,
+    result: CapabilityResult | None = None,
+    execution_status: str | None = None,
+    diagnostic_codes: tuple[str, ...] = (),
+) -> None:
+    if result is not None:
+        execution_status = result.execution.status.value
+        diagnostic_codes = tuple(item.code for item in result.diagnostics)
+        capability_version = result.capability_version
+        assurance = result.assurance.level.value
+        operation_runtime_ms = result.execution.runtime_ms
+        response_bytes = _response_size(result)
+    else:
+        capability_version = "unknown"
+        assurance = "none"
+        operation_runtime_ms = None
+        response_bytes = 0
+    codes = ",".join(diagnostic_codes[:8]) or "none"
+    _LOGGER.info(
+        "MCP capability attempt trace_digest=%s trace_source=%s "
+        "capability_id=%s capability_version=%s mode=%s "
+        "execution_status=%s assurance=%s diagnostic_codes=%s "
+        "attempt_duration_ms=%.3f operation_runtime_ms=%s "
+        "response_bytes=%d argument_digest=%s",
+        trace_digest,
+        trace_source,
+        capability_id,
+        capability_version,
+        mode.value,
+        execution_status or "ERROR",
+        assurance,
+        codes,
+        (time.monotonic() - started) * 1000,
+        "none" if operation_runtime_ms is None else operation_runtime_ms,
+        response_bytes,
+        argument_digest,
+    )
+
+
+async def _invoke_capability_attempt(
+    kernel: Any,
+    *,
+    capability_id: str,
+    payload: dict[str, Any],
+    mode: CapabilityMode,
+    ctx: Any | None,
+) -> CapabilityResult:
+    started = time.monotonic()
+    argument_digest = _argument_digest(
+        {
+            "capability_id": capability_id,
+            "mode": mode.value,
+            "payload": payload,
+        }
+    )
+    trace_digest, trace_source = _request_trace_digest(ctx)
+    cancellation_event = threading.Event()
+    worker = asyncio.create_task(
+        asyncio.to_thread(
+            _invoke_capability_with_cancellation,
+            kernel,
+            CapabilityRequest(
+                capability_id=capability_id,
+                mode=mode,
+                input=payload,
+            ),
+            cancellation_event,
+        )
+    )
+    try:
+        result = await asyncio.shield(worker)
+    except asyncio.CancelledError:
+        cancellation_event.set()
+        worker.add_done_callback(_consume_cancelled_worker_result)
+        _log_capability_attempt(
+            capability_id=capability_id,
+            mode=mode,
+            started=started,
+            argument_digest=argument_digest,
+            trace_digest=trace_digest,
+            trace_source=trace_source,
+            execution_status="CANCELLED",
+            diagnostic_codes=("CLIENT_CANCELLED",),
+        )
+        raise
+    except Exception:
+        _log_capability_attempt(
+            capability_id=capability_id,
+            mode=mode,
+            started=started,
+            argument_digest=argument_digest,
+            trace_digest=trace_digest,
+            trace_source=trace_source,
+            execution_status="ERROR",
+            diagnostic_codes=("INVOCATION_EXCEPTION",),
+        )
+        raise
+    _log_capability_attempt(
+        capability_id=capability_id,
+        mode=mode,
+        started=started,
+        argument_digest=argument_digest,
+        trace_digest=trace_digest,
+        trace_source=trace_source,
+        result=result,
+    )
+    return result
 
 
 def _catalog_digest(
@@ -449,6 +598,7 @@ def create_server(
     install_references: bool = True,
     tenant_isolation: bool = False,
     allow_anonymous: bool = False,
+    anonymous_tenant_id: str = "anonymous",
     token_verifier: Any | None = None,
     auth: Any | None = None,
     capability_adapter_entrypoints: tuple[str, ...] = (),
@@ -541,6 +691,7 @@ def create_server(
             configured_root,
             install_references=install_references,
             allow_anonymous=allow_anonymous,
+            anonymous_tenant_id=anonymous_tenant_id,
             capability_adapter_entrypoints=capability_adapter_entrypoints,
             capability_policy=capability_policy,
             max_tenant_kernels=(
@@ -745,29 +896,13 @@ def create_server(
         ctx: Context[AppState, Any] | None = None,
     ) -> CapabilityResult:
         active_kernel = _kernel(ctx)
-        cancellation_event = threading.Event()
-        worker = asyncio.create_task(
-            asyncio.to_thread(
-                _invoke_capability_with_cancellation,
-                active_kernel,
-                CapabilityRequest(
-                    capability_id=capability_id,
-                    mode=mode,
-                    input=payload,
-                ),
-                cancellation_event,
-            )
+        return await _invoke_capability_attempt(
+            active_kernel,
+            capability_id=capability_id,
+            payload=payload,
+            mode=mode,
+            ctx=ctx,
         )
-        try:
-            return await asyncio.shield(worker)
-        except asyncio.CancelledError:
-            cancellation_event.set()
-            worker.add_done_callback(_consume_cancelled_worker_result)
-            _LOGGER.info(
-                "MCP capability invocation cancelled capability_id=%s",
-                capability_id,
-            )
-            raise
 
     @server.tool(
         name="workspace.open",
@@ -1441,6 +1576,14 @@ def main() -> None:
         help="development only: permit unauthenticated remote requests",
     )
     parser.add_argument(
+        "--anonymous-tenant-id",
+        default="anonymous",
+        help=(
+            "fixed operator-chosen tenant namespace for anonymous mode; use a "
+            "different value for each isolated test endpoint"
+        ),
+    )
+    parser.add_argument(
         "--capability-adapter",
         action="append",
         default=[],
@@ -1501,6 +1644,8 @@ def main() -> None:
     args = parser.parse_args()
     if args.max_tenant_kernels < 1:
         parser.error("--max-tenant-kernels must be positive")
+    if args.anonymous_tenant_id != "anonymous" and not args.allow_anonymous:
+        parser.error("--anonymous-tenant-id requires --allow-anonymous")
     args.path = args.path if args.path.startswith("/") else f"/{args.path}"
     capability_policy = CapabilityPolicy(
         profile=args.capability_policy_profile,
@@ -1514,7 +1659,11 @@ def main() -> None:
         denied_modes=frozenset(CapabilityMode(value) for value in args.deny_mode),
     )
     if args.transport == "stdio":
-        if args.auth_tokens_file is not None or args.allow_anonymous:
+        if (
+            args.auth_tokens_file is not None
+            or args.allow_anonymous
+            or args.anonymous_tenant_id != "anonymous"
+        ):
             parser.error("remote authentication options cannot be used with stdio")
         create_server(
             state_dir=args.state_dir,
@@ -1552,6 +1701,7 @@ def main() -> None:
         state_dir=args.state_dir,
         tenant_isolation=True,
         allow_anonymous=args.allow_anonymous,
+        anonymous_tenant_id=args.anonymous_tenant_id,
         token_verifier=token_verifier,
         auth=auth,
         capability_adapter_entrypoints=tuple(args.capability_adapter),

--- a/src/jacobian/checker_operations.py
+++ b/src/jacobian/checker_operations.py
@@ -17,17 +17,46 @@ class ExactReplayCheckerDeclaration:
     request_model: type[ContractModel]
     function: str
     format_id: str
+    entrypoint_module: str = "jacobian_checkers.exact_domain_operations"
+    replay_method: str = "Python-FLINT exact replay"
+    reason: str = (
+        "operator-authorized Python-FLINT exact replay independent of the "
+        "SymPy producer"
+    )
+    verification_capability_id: str | None = None
+    verification_title: str | None = None
+    verification_description: str | None = None
+    verification_tags: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         for field, value in {
             "capability_id": self.capability_id,
             "function": self.function,
             "format_id": self.format_id,
+            "entrypoint_module": self.entrypoint_module,
+            "replay_method": self.replay_method,
+            "reason": self.reason,
         }.items():
             if not value.strip():
                 raise ValueError(
                     f"exact replay checker declaration {field} must not be empty"
                 )
+        verification_fields = (
+            self.verification_capability_id,
+            self.verification_title,
+            self.verification_description,
+        )
+        if any(value is not None for value in verification_fields) and not all(
+            isinstance(value, str) and value.strip() for value in verification_fields
+        ):
+            raise ValueError(
+                "verification capability ID, title, and description must be "
+                "declared together"
+            )
+        if self.verification_tags and self.verification_capability_id is None:
+            raise ValueError(
+                "verification tags require verification capability metadata"
+            )
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/jacobian/contracts/graph_invariant_operations.py
+++ b/src/jacobian/contracts/graph_invariant_operations.py
@@ -78,14 +78,33 @@ class GraphSpanningTreeCountResult(ContractModel):
     connected: StrictBool
 
 
+class GraphTutteBergeCertificate(ContractModel):
+    certificate_schema_version: Literal["1"] = "1"
+    kind: Literal["TUTTE_BERGE_BARRIER"] = "TUTTE_BERGE_BARRIER"
+    barrier_vertices: tuple[GraphVertex, ...] = Field(max_length=32)
+    odd_component_count: StrictInt = Field(ge=0, le=32)
+    upper_bound: StrictInt = Field(ge=0, le=16)
+
+    @model_validator(mode="after")
+    def require_canonical_barrier(self) -> Self:
+        if tuple(sorted(self.barrier_vertices)) != self.barrier_vertices or len(
+            set(self.barrier_vertices)
+        ) != len(self.barrier_vertices):
+            raise ValueError("Tutte-Berge barrier vertices must be unique and sorted")
+        return self
+
+
 class GraphMaximumMatchingResult(ContractModel):
     maximum_matching_cardinality: StrictInt = Field(ge=0, le=16)
     witness_edges: tuple[tuple[GraphVertex, GraphVertex], ...]
+    certificate: GraphTutteBergeCertificate
 
     @model_validator(mode="after")
     def bind_witness(self) -> Self:
         if len(self.witness_edges) != self.maximum_matching_cardinality:
             raise ValueError("matching witness cardinality must match the result")
+        if self.certificate.upper_bound != self.maximum_matching_cardinality:
+            raise ValueError("Tutte-Berge upper bound must match the result")
         if (
             any(left >= right for left, right in self.witness_edges)
             or tuple(sorted(self.witness_edges)) != self.witness_edges

--- a/src/jacobian/domains/graph_optimization/checkers.py
+++ b/src/jacobian/domains/graph_optimization/checkers.py
@@ -1,7 +1,10 @@
 """Independent checker declarations owned by the graph-optimization domain."""
 
 from jacobian.checker_operations import ExactReplayCheckerDeclaration
+from jacobian.contracts.graph_invariant_operations import GraphInvariantRequest
 from jacobian.contracts.graph_optimization import GraphOptimizationRequest
+
+_GRAPH_ENTRYPOINT = "jacobian_checkers.graph_exact_operations"
 
 GRAPH_OPTIMIZATION_EXACT_REPLAY_CHECKERS = (
     ExactReplayCheckerDeclaration(
@@ -9,6 +12,44 @@ GRAPH_OPTIMIZATION_EXACT_REPLAY_CHECKERS = (
         GraphOptimizationRequest,
         "check_graph_induced_tree_maximum",
         "graph.induced-tree.maximum.exhaustive-replay",
+        entrypoint_module=_GRAPH_ENTRYPOINT,
+        replay_method="finite-subset exhaustive replay",
+        reason=(
+            "operator-authorized finite exhaustive checker independent of the "
+            "Z3 producer"
+        ),
+        verification_capability_id="graph.induced_tree.maximum.verify",
+        verification_title="Verify a maximum induced tree result",
+        verification_description=(
+            "Independently exhaust bounded vertex subsets to verify one stored "
+            "exact maximum induced-tree result and its graph binding."
+        ),
+        verification_tags=("verification", "exact", "graph", "induced-tree"),
+    ),
+    ExactReplayCheckerDeclaration(
+        "graph.invariant.maximum_matching.compute",
+        GraphInvariantRequest,
+        "check_graph_maximum_matching",
+        "graph.maximum-matching.tutte-berge-v1",
+        entrypoint_module=_GRAPH_ENTRYPOINT,
+        replay_method="Tutte-Berge barrier replay",
+        reason=(
+            "operator-authorized standard-library Tutte-Berge checker independent "
+            "of the NetworkX producer"
+        ),
+        verification_capability_id="graph.invariant.maximum_matching.verify",
+        verification_title="Verify a maximum matching result",
+        verification_description=(
+            "Independently verify matching feasibility and a Tutte-Berge upper-bound "
+            "certificate for one exact stored finite graph."
+        ),
+        verification_tags=(
+            "verification",
+            "exact",
+            "graph",
+            "matching",
+            "tutte-berge",
+        ),
     ),
 )
 

--- a/src/jacobian/domains/graph_optimization/invariant_bundle.py
+++ b/src/jacobian/domains/graph_optimization/invariant_bundle.py
@@ -73,5 +73,5 @@ GRAPH_INVARIANT_BUNDLE = DomainBundle(
     completeness_basis=(
         "maintained exact algorithms covered the complete finite graph"
     ),
-    assurance_basis=("NetworkX/SymPy/Z3 computation; no independent checker invoked"),
+    assurance_basis=("NetworkX/SymPy computation; no independent checker invoked"),
 )

--- a/src/jacobian/domains/graph_optimization/invariants.py
+++ b/src/jacobian/domains/graph_optimization/invariants.py
@@ -11,7 +11,10 @@ from typing import Any, cast
 import networkx as nx
 import sympy
 
-from jacobian.contracts.capabilities import CapabilityDiagnostic
+from jacobian.contracts.capabilities import (
+    CapabilityDiagnostic,
+    CapabilityInvocationExample,
+)
 from jacobian.contracts.graph_invariant_operations import (
     GraphCardinalityMaximumObligation,
     GraphCliqueNumberResult,
@@ -27,6 +30,7 @@ from jacobian.contracts.graph_invariant_operations import (
     GraphRadiusResult,
     GraphSpanningTreeCountResult,
     GraphTriangleCountResult,
+    GraphTutteBergeCertificate,
     GraphVertexConnectivityResult,
 )
 from jacobian.contracts.graph_optimization import (
@@ -35,6 +39,7 @@ from jacobian.contracts.graph_optimization import (
     OptimizationTermination,
 )
 from jacobian.contracts.results import ContractModel
+from jacobian.domains._examples import example
 from jacobian.domains.graph_optimization.operations import build_simple_graph
 from jacobian.operations import (
     BoundedSearchIncomplete,
@@ -65,6 +70,7 @@ def _computed[
     operation: Callable[[nx.Graph[str]], ResultT],
     *tags: str,
     version: str = "1",
+    invocation_examples: tuple[CapabilityInvocationExample, ...] = (),
 ) -> ComputedOperation[GraphInvariantRequest, ResultT]:
     def implementation(
         request: GraphInvariantRequest,
@@ -93,6 +99,7 @@ def _computed[
         tags=("graph", "invariant", *tags),
         invalid_request=_INVALID_REQUEST,
         version=version,
+        invocation_examples=invocation_examples,
     )
 
 
@@ -174,9 +181,35 @@ def _maximum_matching(graph: nx.Graph[str]) -> GraphMaximumMatchingResult:
             for left, right in raw
         )
     )
+    cardinality = len(edges)
+    exposed_vertices: set[str] = set()
+    for vertex in graph:
+        reduced = graph.copy()
+        reduced.remove_node(vertex)
+        if len(nx.max_weight_matching(reduced, maxcardinality=True)) == cardinality:
+            exposed_vertices.add(str(vertex))
+    barrier = tuple(
+        sorted(
+            {
+                str(neighbor)
+                for vertex in exposed_vertices
+                for neighbor in graph.neighbors(vertex)
+                if str(neighbor) not in exposed_vertices
+            }
+        )
+    )
+    reduced = graph.subgraph(set(graph) - set(barrier))
+    odd_component_count = sum(
+        len(component) % 2 for component in nx.connected_components(reduced)
+    )
     return GraphMaximumMatchingResult(
-        maximum_matching_cardinality=len(edges),
+        maximum_matching_cardinality=cardinality,
         witness_edges=edges,
+        certificate=GraphTutteBergeCertificate(
+            barrier_vertices=barrier,
+            odd_component_count=odd_component_count,
+            upper_bound=cardinality,
+        ),
     )
 
 
@@ -532,6 +565,24 @@ EXACT_GRAPH_INVARIANT_CAPABILITIES = (
         "matching",
         "maximum",
         "exact",
+        version="2",
+        invocation_examples=(
+            example(
+                "triangle_with_tail",
+                "Compute and certify a maximum matching of a triangle with one tail.",
+                {
+                    "graph": {
+                        "vertices": ["a", "b", "c", "d"],
+                        "edges": [
+                            ["a", "b"],
+                            ["a", "c"],
+                            ["b", "c"],
+                            ["c", "d"],
+                        ],
+                    }
+                },
+            ),
+        ),
     ),
 )
 

--- a/src/jacobian/exact_domain_checkers.py
+++ b/src/jacobian/exact_domain_checkers.py
@@ -102,20 +102,9 @@ def install_exact_domain_checkers(
     for installed, declaration in (
         *((polynomial, item) for item in POLYNOMIAL_EXACT_REPLAY_CHECKERS),
         *((matrix, item) for item in MATRIX_EXACT_REPLAY_CHECKERS),
-        *(
-            ()
-            if graph is None and graph_invariants is None
-            else tuple(
-                (
-                    _graph_declaration_bundle(
-                        item,
-                        graph=graph,
-                        graph_invariants=graph_invariants,
-                    ),
-                    item,
-                )
-                for item in GRAPH_OPTIMIZATION_EXACT_REPLAY_CHECKERS
-            )
+        *_available_graph_declaration_bundles(
+            graph=graph,
+            graph_invariants=graph_invariants,
         ),
     ):
         declarations_by_id[declaration.capability_id] = declaration
@@ -203,20 +192,15 @@ def install_exact_domain_verification(
         _installed_declaration(matrix, declaration, installation)
         for declaration in MATRIX_EXACT_REPLAY_CHECKERS
     )
-    graph_declarations = (
-        ()
-        if graph is None and graph_invariants is None
-        else tuple(
-            _installed_declaration(
-                _graph_declaration_bundle(
-                    declaration,
-                    graph=graph,
-                    graph_invariants=graph_invariants,
-                ),
-                declaration,
-                installation,
-            )
-            for declaration in GRAPH_OPTIMIZATION_EXACT_REPLAY_CHECKERS
+    graph_declarations = tuple(
+        _installed_declaration(
+            bundle,
+            declaration,
+            installation,
+        )
+        for bundle, declaration in _available_graph_declaration_bundles(
+            graph=graph,
+            graph_invariants=graph_invariants,
         )
     )
     graph_adapters: tuple[CapabilityAdapter, ...] = tuple(
@@ -294,22 +278,21 @@ def _verification_metadata(
     )
 
 
-def _graph_declaration_bundle(
-    declaration: ExactReplayCheckerDeclaration,
+def _available_graph_declaration_bundles(
     *,
     graph: InstalledDomainBundle | None,
     graph_invariants: InstalledDomainBundle | None,
-) -> InstalledDomainBundle:
-    bundle = (
-        graph_invariants
-        if declaration.capability_id.startswith("graph.invariant.")
-        else graph
-    )
-    if bundle is None:
-        raise ValueError(
-            f"missing installed domain bundle for {declaration.capability_id}"
+) -> tuple[tuple[InstalledDomainBundle, ExactReplayCheckerDeclaration], ...]:
+    available: list[tuple[InstalledDomainBundle, ExactReplayCheckerDeclaration]] = []
+    for declaration in GRAPH_OPTIMIZATION_EXACT_REPLAY_CHECKERS:
+        bundle = (
+            graph_invariants
+            if declaration.capability_id.startswith("graph.invariant.")
+            else graph
         )
-    return bundle
+        if bundle is not None:
+            available.append((bundle, declaration))
+    return tuple(available)
 
 
 def _installed_declaration(

--- a/src/jacobian/exact_domain_checkers.py
+++ b/src/jacobian/exact_domain_checkers.py
@@ -43,7 +43,10 @@ from jacobian.domains.graph_optimization.checkers import (
 from jacobian.domains.matrix_lattice.checkers import MATRIX_EXACT_REPLAY_CHECKERS
 from jacobian.domains.polynomial.checkers import POLYNOMIAL_EXACT_REPLAY_CHECKERS
 from jacobian.operation_installation import InstalledDomainBundle
-from jacobian.provider_runtime import exact_domain_checker_provider_runtime
+from jacobian.provider_runtime import (
+    exact_domain_checker_provider_runtime,
+    graph_exact_checker_provider_runtime,
+)
 from jacobian.registry import CheckerRegistry
 from jacobian.schema_registry import SchemaRegistry, SchemaRegistryError, model_schema
 from jacobian.store import ArtifactStore, StoredArtifact, StoreError
@@ -55,7 +58,7 @@ class ExactDomainCheckerInstallation:
     """Authorized checker identities keyed by producer capability ID."""
 
     checker_ids: dict[str, str | None]
-    provider_runtime: CapabilityProviderRuntime
+    provider_runtimes: dict[str, CapabilityProviderRuntime]
     witness_schema_uri: str | None = None
 
 
@@ -68,39 +71,58 @@ class _InstalledDeclaration:
     checker_id: str
 
 
+def _provider_runtime_key(declaration: ExactReplayCheckerDeclaration) -> str:
+    if declaration.entrypoint_module == "jacobian_checkers.exact_domain_operations":
+        return "python-flint"
+    if declaration.entrypoint_module == "jacobian_checkers.graph_exact_operations":
+        return "finite-graph"
+    raise ValueError(
+        "exact replay checker declaration uses an unsupported provider runtime"
+    )
+
+
 def install_exact_domain_checkers(
     checkers: CheckerRegistry,
     *,
     polynomial: InstalledDomainBundle,
     matrix: InstalledDomainBundle,
     graph: InstalledDomainBundle | None = None,
+    graph_invariants: InstalledDomainBundle | None = None,
     authorize: bool,
 ) -> ExactDomainCheckerInstallation:
     """Install independent exact replay against dynamically registered schemas."""
 
     installer = CheckerInstaller(checkers)
-    provider_runtime = exact_domain_checker_provider_runtime()
+    provider_runtimes = {
+        "python-flint": exact_domain_checker_provider_runtime(),
+        "finite-graph": graph_exact_checker_provider_runtime(),
+    }
     checker_ids: dict[str, str | None] = {}
+    declarations_by_id: dict[str, ExactReplayCheckerDeclaration] = {}
     for installed, declaration in (
         *((polynomial, item) for item in POLYNOMIAL_EXACT_REPLAY_CHECKERS),
         *((matrix, item) for item in MATRIX_EXACT_REPLAY_CHECKERS),
         *(
             ()
-            if graph is None
+            if graph is None and graph_invariants is None
             else tuple(
-                (graph, item) for item in GRAPH_OPTIMIZATION_EXACT_REPLAY_CHECKERS
+                (
+                    _graph_declaration_bundle(
+                        item,
+                        graph=graph,
+                        graph_invariants=graph_invariants,
+                    ),
+                    item,
+                )
+                for item in GRAPH_OPTIMIZATION_EXACT_REPLAY_CHECKERS
             )
         ),
     ):
-        is_graph_checker = declaration.capability_id.startswith("graph.")
+        declarations_by_id[declaration.capability_id] = declaration
+        runtime_key = _provider_runtime_key(declaration)
         operation = CheckerOperation(
-            name=(
-                f"{declaration.capability_id} independent "
-                + ("finite exhaustive replay" if is_graph_checker else "FLINT replay")
-            ),
-            entrypoint=(
-                f"jacobian_checkers.exact_domain_operations:{declaration.function}"
-            ),
+            name=f"{declaration.capability_id} independent {declaration.replay_method}",
+            entrypoint=(f"{declaration.entrypoint_module}:{declaration.function}"),
             evidence_kind=EvidenceKind.WITNESS,
             format_id=declaration.format_id,
             format_version="1",
@@ -109,29 +131,32 @@ def install_exact_domain_checkers(
             candidate_schema_uris=(
                 installed.result_schema_uris[declaration.capability_id],
             ),
-            reason=(
-                "operator-authorized finite exhaustive checker independent of "
-                "the Z3 producer"
-                if is_graph_checker
-                else (
-                    "operator-authorized Python-FLINT exact replay independent "
-                    "of the SymPy producer"
-                )
-            ),
-            provider_runtime=provider_runtime,
+            reason=declaration.reason,
+            provider_runtime=provider_runtimes[runtime_key],
         )
         checker_ids[declaration.capability_id] = installer.install(
             operation,
             authorize=authorize,
         ).checker_id
-    authorized_ids = tuple(
-        checker_id for checker_id in checker_ids.values() if checker_id is not None
-    )
+    authorized_ids = {
+        runtime_key: tuple(
+            checker_id
+            for capability_id, checker_id in checker_ids.items()
+            if checker_id is not None
+            and _provider_runtime_key(declarations_by_id[capability_id]) == runtime_key
+        )
+        for runtime_key in provider_runtimes
+    }
     return ExactDomainCheckerInstallation(
         checker_ids=checker_ids,
-        provider_runtime=exact_domain_checker_provider_runtime(
-            checker_ids=authorized_ids
-        ),
+        provider_runtimes={
+            "python-flint": exact_domain_checker_provider_runtime(
+                checker_ids=authorized_ids["python-flint"]
+            ),
+            "finite-graph": graph_exact_checker_provider_runtime(
+                checker_ids=authorized_ids["finite-graph"]
+            ),
+        },
     )
 
 
@@ -145,6 +170,7 @@ def install_exact_domain_verification(
     polynomial: InstalledDomainBundle,
     matrix: InstalledDomainBundle,
     graph: InstalledDomainBundle | None = None,
+    graph_invariants: InstalledDomainBundle | None = None,
     authorize: bool,
 ) -> tuple[tuple[CapabilityAdapter, ...], ExactDomainCheckerInstallation]:
     """Authorize exact replay and expose domain-owned verification capabilities."""
@@ -154,6 +180,7 @@ def install_exact_domain_verification(
         polynomial=polynomial,
         matrix=matrix,
         graph=graph,
+        graph_invariants=graph_invariants,
         authorize=authorize,
     )
     witness_schema_uri = schemas.register_model(
@@ -164,7 +191,7 @@ def install_exact_domain_verification(
     installation = ExactDomainCheckerInstallation(
         checker_ids=installed.checker_ids,
         witness_schema_uri=witness_schema_uri,
-        provider_runtime=installed.provider_runtime,
+        provider_runtimes=installed.provider_runtimes,
     )
     if not authorize:
         return (), installation
@@ -178,33 +205,35 @@ def install_exact_domain_verification(
     )
     graph_declarations = (
         ()
-        if graph is None
+        if graph is None and graph_invariants is None
         else tuple(
-            _installed_declaration(graph, declaration, installation)
+            _installed_declaration(
+                _graph_declaration_bundle(
+                    declaration,
+                    graph=graph,
+                    graph_invariants=graph_invariants,
+                ),
+                declaration,
+                installation,
+            )
             for declaration in GRAPH_OPTIMIZATION_EXACT_REPLAY_CHECKERS
         )
     )
-    graph_adapters: tuple[CapabilityAdapter, ...] = (
-        ()
-        if not graph_declarations
-        else (
-            ExactDomainResultVerificationAdapter(
-                capability_id="graph.induced_tree.maximum.verify",
-                title="Verify a maximum induced tree result",
-                description=(
-                    "Independently exhaust bounded vertex subsets to verify one "
-                    "stored exact maximum induced-tree result and its graph binding."
-                ),
-                tags=("verification", "exact", "graph", "induced-tree"),
-                store=store,
-                schemas=schemas,
-                artifacts=artifacts,
-                verification=verification,
-                declarations=graph_declarations,
-                witness_schema_uri=witness_schema_uri,
-                provider_runtime=installation.provider_runtime,
-            ),
+    graph_adapters: tuple[CapabilityAdapter, ...] = tuple(
+        ExactDomainResultVerificationAdapter(
+            capability_id=_verification_metadata(declaration)[0],
+            title=_verification_metadata(declaration)[1],
+            description=_verification_metadata(declaration)[2],
+            tags=declaration.declaration.verification_tags,
+            store=store,
+            schemas=schemas,
+            artifacts=artifacts,
+            verification=verification,
+            declarations=(declaration,),
+            witness_schema_uri=witness_schema_uri,
+            provider_runtime=installation.provider_runtimes["finite-graph"],
         )
+        for declaration in graph_declarations
     )
     return (
         (
@@ -222,7 +251,7 @@ def install_exact_domain_verification(
                 verification=verification,
                 declarations=polynomial_declarations,
                 witness_schema_uri=witness_schema_uri,
-                provider_runtime=installation.provider_runtime,
+                provider_runtime=installation.provider_runtimes["python-flint"],
             ),
             ExactDomainResultVerificationAdapter(
                 capability_id="matrix.result.verify",
@@ -238,12 +267,49 @@ def install_exact_domain_verification(
                 verification=verification,
                 declarations=matrix_declarations,
                 witness_schema_uri=witness_schema_uri,
-                provider_runtime=installation.provider_runtime,
+                provider_runtime=installation.provider_runtimes["python-flint"],
             ),
             *graph_adapters,
         ),
         installation,
     )
+
+
+def _verification_metadata(
+    installed: _InstalledDeclaration,
+) -> tuple[str, str, str]:
+    declaration = installed.declaration
+    if (
+        declaration.verification_capability_id is None
+        or declaration.verification_title is None
+        or declaration.verification_description is None
+    ):
+        raise ValueError(
+            "separately exposed exact replay requires verification metadata"
+        )
+    return (
+        declaration.verification_capability_id,
+        declaration.verification_title,
+        declaration.verification_description,
+    )
+
+
+def _graph_declaration_bundle(
+    declaration: ExactReplayCheckerDeclaration,
+    *,
+    graph: InstalledDomainBundle | None,
+    graph_invariants: InstalledDomainBundle | None,
+) -> InstalledDomainBundle:
+    bundle = (
+        graph_invariants
+        if declaration.capability_id.startswith("graph.invariant.")
+        else graph
+    )
+    if bundle is None:
+        raise ValueError(
+            f"missing installed domain bundle for {declaration.capability_id}"
+        )
+    return bundle
 
 
 def _installed_declaration(
@@ -268,7 +334,7 @@ class ExactDomainArtifactError(ValueError):
 
 
 class ExactDomainResultVerificationAdapter:
-    """Verify one stored exact producer result using independent FLINT replay."""
+    """Verify one stored exact producer result using independent bounded replay."""
 
     def __init__(
         self,
@@ -298,7 +364,7 @@ class ExactDomainResultVerificationAdapter:
             version="1",
             title=title,
             description=description,
-            provider="jacobian.exact-domain-checkers",
+            provider=provider_runtime.provider,
             provider_runtime=provider_runtime,
             modes=(CapabilityMode.VERIFY,),
             input_schema=model_schema(ExactDomainResultVerificationRequest),

--- a/src/jacobian/kernel.py
+++ b/src/jacobian/kernel.py
@@ -886,6 +886,7 @@ class JacobianKernel:
         polynomial = self.domain_bundles.get("polynomial")
         matrix = self.domain_bundles.get("matrix")
         graph = self.domain_bundles.get("graph_optimization")
+        graph_invariants = self.domain_bundles.get("graph_invariants")
         if polynomial is None or matrix is None:
             return
         adapters, self.exact_domain_checkers = install_exact_domain_verification(
@@ -897,6 +898,7 @@ class JacobianKernel:
             polynomial=polynomial,
             matrix=matrix,
             graph=graph,
+            graph_invariants=graph_invariants,
             authorize=authorize,
         )
         for adapter in adapters:

--- a/src/jacobian/provider_runtime.py
+++ b/src/jacobian/provider_runtime.py
@@ -1106,6 +1106,47 @@ def exact_domain_checker_provider_runtime(
     )
 
 
+def graph_exact_checker_provider_runtime(
+    *,
+    checker_ids: tuple[str, ...] = (),
+) -> CapabilityProviderRuntime:
+    """Bind the independent finite-graph checker source without FLINT."""
+
+    try:
+        version, _, license_files = _jacobian_identity()
+    except ProviderRuntimeError:
+        source = _unavailable_runtime(
+            provider="jacobian.graph-exact-checker-source",
+            install_tier=CapabilityInstallTier.T1,
+            license_id="MIT",
+            diagnostic="The finite-graph checker source could not be identified.",
+        )
+    else:
+        source = source_provider_runtime(
+            "jacobian.graph-exact-checker-source",
+            version=version,
+            entrypoint=(
+                "jacobian_checkers.graph_exact_operations:"
+                "check_graph_induced_tree_maximum"
+            ),
+            install_tier=CapabilityInstallTier.T1,
+            license_id="MIT",
+            license_files=license_files,
+            features=("clean-process-replay", "standard-library-only"),
+        )
+    return composite_provider_runtime(
+        "jacobian.graph-exact-checkers",
+        components=(source,),
+        features=(
+            "clean-process-replay",
+            "finite-subset-exhaustive-replay",
+            "tutte-berge-barrier-replay",
+            "standard-library-only",
+        ),
+        checker_ids=checker_ids,
+    )
+
+
 def python_flint_hnf_provider_runtime(
     *,
     refresh: bool = False,

--- a/src/jacobian_checkers/bound_artifacts.py
+++ b/src/jacobian_checkers/bound_artifacts.py
@@ -1,0 +1,143 @@
+"""Passive JSON binding checks shared by independent checker entrypoints."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Any
+
+_ARTIFACT_URI = re.compile(r"^artifact://sha256/[0-9a-f]{64}$")
+_DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
+_ARTIFACT_KEYS = {
+    "artifact_uri",
+    "object_digest",
+    "payload_digest",
+    "schema_uri",
+    "semantics_uri",
+    "parents",
+    "payload",
+}
+_BINDING_KEYS = {
+    "claim_digest",
+    "semantics_digest",
+    "candidate_digest",
+    "scope_digest",
+    "encoding_digest",
+}
+
+
+def _digest(value: object) -> str:
+    encoded = json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _artifact(value: object) -> dict[str, Any]:
+    if not isinstance(value, dict) or set(value) != _ARTIFACT_KEYS:
+        raise ValueError("artifact metadata is malformed")
+    if not all(
+        isinstance(value[key], str) and pattern.fullmatch(value[key]) is not None
+        for key, pattern in (
+            ("artifact_uri", _ARTIFACT_URI),
+            ("object_digest", _DIGEST),
+            ("payload_digest", _DIGEST),
+            ("schema_uri", _ARTIFACT_URI),
+            ("semantics_uri", _ARTIFACT_URI),
+        )
+    ):
+        raise ValueError("artifact identifiers are malformed")
+    parents = value["parents"]
+    if (
+        not isinstance(parents, list)
+        or len(parents) != len(set(parents))
+        or not all(
+            isinstance(parent, str) and _ARTIFACT_URI.fullmatch(parent)
+            for parent in parents
+        )
+    ):
+        raise ValueError("artifact lineage is malformed")
+    if value["payload_digest"] != _digest(value["payload"]):
+        raise ValueError("artifact payload digest does not match")
+    return value
+
+
+def bound_request(
+    request: object, *, operation_id: str, witness_format: str
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Validate exact artifact and evidence binding before mathematical replay."""
+
+    if not isinstance(request, dict) or set(request) != {
+        "request_version",
+        "claim",
+        "candidate",
+        "semantics",
+        "scope",
+        "witness",
+        "expected_bindings",
+    }:
+        raise ValueError("checker request is malformed")
+    if request["request_version"] != "1" or request["scope"] is not None:
+        raise ValueError("checker request version or scope is unsupported")
+    claim = _artifact(request["claim"])
+    candidate = _artifact(request["candidate"])
+    semantics = _artifact(request["semantics"])
+    witness = _artifact(request["witness"])
+    if (
+        len(candidate["parents"]) != 1
+        or candidate["parents"][0] != claim["artifact_uri"]
+    ):
+        raise ValueError("candidate is not bound to the input artifact")
+    if (
+        claim["semantics_uri"] != candidate["semantics_uri"]
+        or claim["semantics_uri"] != witness["semantics_uri"]
+    ):
+        raise ValueError("artifacts use different semantics")
+    bindings = request["expected_bindings"]
+    if (
+        not isinstance(bindings, dict)
+        or set(bindings) != _BINDING_KEYS
+        or bindings["scope_digest"] is not None
+        or bindings["encoding_digest"] is not None
+        or bindings["claim_digest"] != claim["object_digest"]
+        or bindings["candidate_digest"] != candidate["object_digest"]
+        or bindings["semantics_digest"] != semantics["object_digest"]
+        or semantics["artifact_uri"] != claim["semantics_uri"]
+    ):
+        raise ValueError("evidence bindings are malformed or mismatched")
+    envelope = witness["payload"]
+    if (
+        not isinstance(envelope, dict)
+        or set(envelope)
+        != {
+            "evidence_schema_version",
+            "witness_format",
+            "format_version",
+            "role",
+            "bindings",
+            "payload",
+        }
+        or envelope["evidence_schema_version"] != "1"
+        or envelope["witness_format"] != witness_format
+        or envelope["format_version"] != "1"
+        or envelope["role"] != "SUPPORTS_CLAIM"
+        or envelope["bindings"] != bindings
+        or envelope["payload"]
+        != {
+            "operation_id": operation_id,
+            "input_uri": claim["artifact_uri"],
+            "result_uri": candidate["artifact_uri"],
+        }
+        or len(witness["parents"]) != 2
+        or set(witness["parents"]) != {claim["artifact_uri"], candidate["artifact_uri"]}
+    ):
+        raise ValueError("witness is not exactly bound to the operation artifacts")
+    return claim["payload"], candidate["payload"]
+
+
+__all__ = ["bound_request"]

--- a/src/jacobian_checkers/exact_domain_operations.py
+++ b/src/jacobian_checkers/exact_domain_operations.py
@@ -6,36 +6,17 @@ SymPy nor Jacobian code; only passive JSON values cross the checker boundary.
 
 from __future__ import annotations
 
-import hashlib
-import json
 import re
 from collections.abc import Callable
 from fractions import Fraction
-from itertools import combinations
 from typing import Any
 
 import flint
 from flint import fmpq, fmpq_mat, fmpq_poly, fmpz_mat
 
-_ARTIFACT_URI = re.compile(r"^artifact://sha256/[0-9a-f]{64}$")
-_DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
+from jacobian_checkers.bound_artifacts import bound_request as _bound_request
+
 _INTEGER = re.compile(r"^-?(?:0|[1-9][0-9]*)$")
-_ARTIFACT_KEYS = {
-    "artifact_uri",
-    "object_digest",
-    "payload_digest",
-    "schema_uri",
-    "semantics_uri",
-    "parents",
-    "payload",
-}
-_BINDING_KEYS = {
-    "claim_digest",
-    "semantics_digest",
-    "candidate_digest",
-    "scope_digest",
-    "encoding_digest",
-}
 _PYTHON_FLINT_VERSION = "0.9.0"
 _FLINT_VERSION = "3.6.0"
 
@@ -60,117 +41,6 @@ def _accept(detail: str) -> dict[str, Any]:
         "coverage": "NOT_APPLICABLE",
         "detail": detail,
     }
-
-
-def _digest(value: object) -> str:
-    encoded = json.dumps(
-        value,
-        allow_nan=False,
-        ensure_ascii=False,
-        separators=(",", ":"),
-        sort_keys=True,
-    ).encode()
-    return "sha256:" + hashlib.sha256(encoded).hexdigest()
-
-
-def _artifact(value: object) -> dict[str, Any]:
-    if not isinstance(value, dict) or set(value) != _ARTIFACT_KEYS:
-        raise ValueError("artifact metadata is malformed")
-    if not all(
-        isinstance(value[key], str) and pattern.fullmatch(value[key]) is not None
-        for key, pattern in (
-            ("artifact_uri", _ARTIFACT_URI),
-            ("object_digest", _DIGEST),
-            ("payload_digest", _DIGEST),
-            ("schema_uri", _ARTIFACT_URI),
-            ("semantics_uri", _ARTIFACT_URI),
-        )
-    ):
-        raise ValueError("artifact identifiers are malformed")
-    parents = value["parents"]
-    if (
-        not isinstance(parents, list)
-        or len(parents) != len(set(parents))
-        or not all(
-            isinstance(parent, str) and _ARTIFACT_URI.fullmatch(parent)
-            for parent in parents
-        )
-    ):
-        raise ValueError("artifact lineage is malformed")
-    if value["payload_digest"] != _digest(value["payload"]):
-        raise ValueError("artifact payload digest does not match")
-    return value
-
-
-def _bound_request(
-    request: object, *, operation_id: str, witness_format: str
-) -> tuple[dict[str, Any], dict[str, Any]]:
-    if not isinstance(request, dict) or set(request) != {
-        "request_version",
-        "claim",
-        "candidate",
-        "semantics",
-        "scope",
-        "witness",
-        "expected_bindings",
-    }:
-        raise ValueError("checker request is malformed")
-    if request["request_version"] != "1" or request["scope"] is not None:
-        raise ValueError("checker request version or scope is unsupported")
-    claim = _artifact(request["claim"])
-    candidate = _artifact(request["candidate"])
-    semantics = _artifact(request["semantics"])
-    witness = _artifact(request["witness"])
-    if (
-        len(candidate["parents"]) != 1
-        or candidate["parents"][0] != claim["artifact_uri"]
-    ):
-        raise ValueError("candidate is not bound to the input artifact")
-    if (
-        claim["semantics_uri"] != candidate["semantics_uri"]
-        or claim["semantics_uri"] != witness["semantics_uri"]
-    ):
-        raise ValueError("artifacts use different semantics")
-    bindings = request["expected_bindings"]
-    if (
-        not isinstance(bindings, dict)
-        or set(bindings) != _BINDING_KEYS
-        or bindings["scope_digest"] is not None
-        or bindings["encoding_digest"] is not None
-        or bindings["claim_digest"] != claim["object_digest"]
-        or bindings["candidate_digest"] != candidate["object_digest"]
-        or bindings["semantics_digest"] != semantics["object_digest"]
-        or semantics["artifact_uri"] != claim["semantics_uri"]
-    ):
-        raise ValueError("evidence bindings are malformed or mismatched")
-    envelope = witness["payload"]
-    if (
-        not isinstance(envelope, dict)
-        or set(envelope)
-        != {
-            "evidence_schema_version",
-            "witness_format",
-            "format_version",
-            "role",
-            "bindings",
-            "payload",
-        }
-        or envelope["evidence_schema_version"] != "1"
-        or envelope["witness_format"] != witness_format
-        or envelope["format_version"] != "1"
-        or envelope["role"] != "SUPPORTS_CLAIM"
-        or envelope["bindings"] != bindings
-        or envelope["payload"]
-        != {
-            "operation_id": operation_id,
-            "input_uri": claim["artifact_uri"],
-            "result_uri": candidate["artifact_uri"],
-        }
-        or len(witness["parents"]) != 2
-        or set(witness["parents"]) != {claim["artifact_uri"], candidate["artifact_uri"]}
-    ):
-        raise ValueError("witness is not exactly bound to the operation artifacts")
-    return claim["payload"], candidate["payload"]
 
 
 def _integer(value: object) -> int:
@@ -311,11 +181,9 @@ def _run(
     operation_id: str,
     witness_format: str,
     replay: Callable[[dict[str, Any], dict[str, Any]], bool],
-    replay_method: str = "Python-FLINT replay",
-    requires_python_flint: bool = True,
 ) -> dict[str, Any]:
     try:
-        if requires_python_flint and (
+        if (
             flint.__version__ != _PYTHON_FLINT_VERSION
             or flint.__FLINT_VERSION__ != _FLINT_VERSION
         ):
@@ -327,9 +195,9 @@ def _run(
         )
         if not replay(source, result):
             return _reject(
-                f"declared result does not match independent {replay_method}"
+                "declared result does not match independent Python-FLINT replay"
             )
-        return _accept(f"independent {replay_method} accepted {operation_id}")
+        return _accept(f"independent Python-FLINT replay accepted {operation_id}")
     except (KeyError, TypeError, ValueError, ZeroDivisionError, OverflowError):
         return _reject("malformed, unsupported, or mismatched checker request")
 
@@ -641,115 +509,7 @@ def check_matrix_smith_normal_form(request: dict[str, Any]) -> dict[str, Any]:
     )
 
 
-def _induced_tree_maximum(
-    source: dict[str, Any],
-    result: dict[str, Any],
-) -> bool:
-    graph = source.get("graph")
-    if not isinstance(graph, dict):
-        raise ValueError("graph optimization input is malformed")
-    vertices = graph.get("vertices")
-    edges = graph.get("edges")
-    if (
-        graph.get("graph_schema_version") != "1"
-        or not isinstance(vertices, list)
-        or len(vertices) > 16
-        or not all(isinstance(vertex, str) and vertex for vertex in vertices)
-        or len(vertices) != len(set(vertices))
-        or not isinstance(edges, list)
-    ):
-        raise ValueError("graph lies outside the exhaustive checker scope")
-    vertex_set = set(vertices)
-    normalized_edges: set[tuple[str, str]] = set()
-    for edge in edges:
-        if (
-            not isinstance(edge, list)
-            or len(edge) != 2
-            or not all(isinstance(endpoint, str) for endpoint in edge)
-            or edge[0] == edge[1]
-            or edge[0] not in vertex_set
-            or edge[1] not in vertex_set
-        ):
-            raise ValueError("graph edge payload is malformed")
-        normalized_edges.add(tuple(sorted((edge[0], edge[1]))))
-    if len(normalized_edges) != len(edges):
-        raise ValueError("graph edge payload contains duplicates")
-
-    adjacency = {vertex: set[str]() for vertex in vertices}
-    for left, right in normalized_edges:
-        adjacency[left].add(right)
-        adjacency[right].add(left)
-
-    def is_induced_tree(candidate: tuple[str, ...]) -> bool:
-        if not candidate:
-            return False
-        selected = set(candidate)
-        edge_count = sum(
-            1
-            for left, right in normalized_edges
-            if left in selected and right in selected
-        )
-        if edge_count != len(candidate) - 1:
-            return False
-        reached = {candidate[0]}
-        frontier = [candidate[0]]
-        while frontier:
-            current = frontier.pop()
-            for neighbor in adjacency[current] & selected:
-                if neighbor not in reached:
-                    reached.add(neighbor)
-                    frontier.append(neighbor)
-        return len(reached) == len(candidate)
-
-    claimed = result.get("optimum_value")
-    witness = result.get("witness_vertices")
-    if (
-        result.get("status") != "EXACT"
-        or result.get("convention") != "NONEMPTY_CONNECTED_ACYCLIC_EMPTY_SOURCE_ZERO"
-        or type(claimed) is not int
-        or claimed < 0
-        or claimed > len(vertices)
-        or result.get("order") != len(vertices)
-        or result.get("incumbent_value") != claimed
-        or result.get("lower_bound") != claimed
-        or result.get("upper_bound") != claimed
-        or not isinstance(witness, list)
-        or len(witness) != claimed
-        or not all(isinstance(vertex, str) for vertex in witness)
-        or len(witness) != len(set(witness))
-        or any(vertex not in vertex_set for vertex in witness)
-    ):
-        return False
-    if claimed == 0:
-        if vertices or witness:
-            return False
-    elif not is_induced_tree(tuple(witness)):
-        return False
-
-    actual = 0
-    for cardinality in range(len(vertices), 0, -1):
-        if any(
-            is_induced_tree(candidate)
-            for candidate in combinations(vertices, cardinality)
-        ):
-            actual = cardinality
-            break
-    return actual == claimed
-
-
-def check_graph_induced_tree_maximum(request: dict[str, Any]) -> dict[str, Any]:
-    return _run(
-        request,
-        operation_id="graph.induced_tree.maximum.compute",
-        witness_format="graph.induced-tree.maximum.exhaustive-replay",
-        replay=_induced_tree_maximum,
-        replay_method="finite-subset exhaustive replay",
-        requires_python_flint=False,
-    )
-
-
 __all__ = [
-    "check_graph_induced_tree_maximum",
     "check_matrix_characteristic_polynomial",
     "check_matrix_nullspace",
     "check_matrix_rref",

--- a/src/jacobian_checkers/graph_exact_operations.py
+++ b/src/jacobian_checkers/graph_exact_operations.py
@@ -1,0 +1,292 @@
+"""Independent finite-graph replay with no producer or numeric-backend imports."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from itertools import combinations
+from typing import Any
+
+from jacobian_checkers.bound_artifacts import bound_request
+
+
+def _reject(detail: str) -> dict[str, Any]:
+    return {
+        "accepted": False,
+        "conclusion": "UNKNOWN",
+        "arithmetic": "EXACT_INTEGER",
+        "method": "DIRECT_WITNESS",
+        "coverage": "NOT_APPLICABLE",
+        "detail": detail,
+    }
+
+
+def _accept(detail: str) -> dict[str, Any]:
+    return {
+        "accepted": True,
+        "conclusion": "TRUE",
+        "arithmetic": "EXACT_INTEGER",
+        "method": "DIRECT_WITNESS",
+        "coverage": "NOT_APPLICABLE",
+        "detail": detail,
+    }
+
+
+def _run(
+    request: object,
+    *,
+    operation_id: str,
+    witness_format: str,
+    replay_method: str,
+    replay: Callable[[dict[str, Any], dict[str, Any]], bool],
+) -> dict[str, Any]:
+    try:
+        source, result = bound_request(
+            request,
+            operation_id=operation_id,
+            witness_format=witness_format,
+        )
+        if not replay(source, result):
+            return _reject(
+                f"declared result does not match independent {replay_method}"
+            )
+        return _accept(f"independent {replay_method} accepted {operation_id}")
+    except (KeyError, TypeError, ValueError, OverflowError):
+        return _reject("malformed, unsupported, or mismatched checker request")
+
+
+def _finite_simple_graph(
+    source: dict[str, Any],
+    *,
+    maximum_order: int,
+) -> tuple[tuple[str, ...], set[tuple[str, str]], dict[str, set[str]]]:
+    graph = source.get("graph")
+    if not isinstance(graph, dict) or set(graph) != {
+        "graph_schema_version",
+        "vertices",
+        "edges",
+    }:
+        raise ValueError("graph input is malformed")
+    vertices = graph["vertices"]
+    edges = graph["edges"]
+    if (
+        graph["graph_schema_version"] != "1"
+        or not isinstance(vertices, list)
+        or len(vertices) > maximum_order
+        or not all(
+            isinstance(vertex, str) and 0 < len(vertex) <= 256 for vertex in vertices
+        )
+        or len(vertices) != len(set(vertices))
+        or not isinstance(edges, list)
+        or len(edges) > len(vertices) * (len(vertices) - 1) // 2
+    ):
+        raise ValueError("graph lies outside the checker scope")
+    vertex_set = set(vertices)
+    normalized_edges: set[tuple[str, str]] = set()
+    for edge in edges:
+        if (
+            not isinstance(edge, list)
+            or len(edge) != 2
+            or not all(isinstance(endpoint, str) for endpoint in edge)
+            or edge[0] == edge[1]
+            or edge[0] not in vertex_set
+            or edge[1] not in vertex_set
+        ):
+            raise ValueError("graph edge payload is malformed")
+        normalized_edges.add(tuple(sorted((edge[0], edge[1]))))
+    if len(normalized_edges) != len(edges):
+        raise ValueError("graph edge payload contains duplicates")
+    adjacency = {vertex: set[str]() for vertex in vertices}
+    for left, right in normalized_edges:
+        adjacency[left].add(right)
+        adjacency[right].add(left)
+    return tuple(vertices), normalized_edges, adjacency
+
+
+def _induced_tree_maximum(
+    source: dict[str, Any],
+    result: dict[str, Any],
+) -> bool:
+    vertices, normalized_edges, adjacency = _finite_simple_graph(
+        source,
+        maximum_order=16,
+    )
+    vertex_set = set(vertices)
+
+    def is_induced_tree(candidate: tuple[str, ...]) -> bool:
+        if not candidate:
+            return False
+        selected = set(candidate)
+        edge_count = sum(
+            1
+            for left, right in normalized_edges
+            if left in selected and right in selected
+        )
+        if edge_count != len(candidate) - 1:
+            return False
+        reached = {candidate[0]}
+        frontier = [candidate[0]]
+        while frontier:
+            current = frontier.pop()
+            for neighbor in adjacency[current] & selected:
+                if neighbor not in reached:
+                    reached.add(neighbor)
+                    frontier.append(neighbor)
+        return len(reached) == len(candidate)
+
+    claimed = result.get("optimum_value")
+    witness = result.get("witness_vertices")
+    if (
+        result.get("status") != "EXACT"
+        or result.get("convention") != "NONEMPTY_CONNECTED_ACYCLIC_EMPTY_SOURCE_ZERO"
+        or type(claimed) is not int
+        or claimed < 0
+        or claimed > len(vertices)
+        or result.get("order") != len(vertices)
+        or result.get("incumbent_value") != claimed
+        or result.get("lower_bound") != claimed
+        or result.get("upper_bound") != claimed
+        or not isinstance(witness, list)
+        or len(witness) != claimed
+        or not all(isinstance(vertex, str) for vertex in witness)
+        or len(witness) != len(set(witness))
+        or any(vertex not in vertex_set for vertex in witness)
+    ):
+        return False
+    if claimed == 0:
+        if vertices or witness:
+            return False
+    elif not is_induced_tree(tuple(witness)):
+        return False
+
+    actual = 0
+    for cardinality in range(len(vertices), 0, -1):
+        if any(
+            is_induced_tree(candidate)
+            for candidate in combinations(vertices, cardinality)
+        ):
+            actual = cardinality
+            break
+    return actual == claimed
+
+
+def check_graph_induced_tree_maximum(request: dict[str, Any]) -> dict[str, Any]:
+    return _run(
+        request,
+        operation_id="graph.induced_tree.maximum.compute",
+        witness_format="graph.induced-tree.maximum.exhaustive-replay",
+        replay=_induced_tree_maximum,
+        replay_method="finite-subset exhaustive replay",
+    )
+
+
+def _maximum_matching(
+    source: dict[str, Any],
+    result: dict[str, Any],
+) -> bool:
+    vertices, normalized_edges, adjacency = _finite_simple_graph(
+        source,
+        maximum_order=32,
+    )
+    if set(result) != {
+        "maximum_matching_cardinality",
+        "witness_edges",
+        "certificate",
+    }:
+        return False
+    claimed = result["maximum_matching_cardinality"]
+    witness = result["witness_edges"]
+    if (
+        type(claimed) is not int
+        or claimed < 0
+        or claimed > len(vertices) // 2
+        or not isinstance(witness, list)
+        or len(witness) != claimed
+    ):
+        return False
+    parsed_witness: list[tuple[str, str]] = []
+    used_vertices: set[str] = set()
+    for edge in witness:
+        if (
+            not isinstance(edge, list)
+            or len(edge) != 2
+            or not all(isinstance(endpoint, str) for endpoint in edge)
+            or edge[0] >= edge[1]
+            or (edge[0], edge[1]) not in normalized_edges
+            or edge[0] in used_vertices
+            or edge[1] in used_vertices
+        ):
+            return False
+        parsed_witness.append((edge[0], edge[1]))
+        used_vertices.update(edge)
+    if parsed_witness != sorted(parsed_witness):
+        return False
+
+    certificate = result["certificate"]
+    if not isinstance(certificate, dict) or set(certificate) != {
+        "certificate_schema_version",
+        "kind",
+        "barrier_vertices",
+        "odd_component_count",
+        "upper_bound",
+    }:
+        return False
+    barrier = certificate["barrier_vertices"]
+    declared_odd_components = certificate["odd_component_count"]
+    declared_upper_bound = certificate["upper_bound"]
+    vertex_set = set(vertices)
+    if (
+        certificate["certificate_schema_version"] != "1"
+        or certificate["kind"] != "TUTTE_BERGE_BARRIER"
+        or not isinstance(barrier, list)
+        or not all(isinstance(vertex, str) for vertex in barrier)
+        or barrier != sorted(set(barrier))
+        or any(vertex not in vertex_set for vertex in barrier)
+        or type(declared_odd_components) is not int
+        or type(declared_upper_bound) is not int
+        or declared_odd_components < 0
+        or declared_upper_bound < 0
+    ):
+        return False
+
+    barrier_set = set(barrier)
+    unseen = vertex_set - barrier_set
+    odd_component_count = 0
+    while unseen:
+        first = min(unseen)
+        unseen.remove(first)
+        component = {first}
+        frontier = [first]
+        while frontier:
+            current = frontier.pop()
+            for neighbor in adjacency[current] - barrier_set:
+                if neighbor in unseen:
+                    unseen.remove(neighbor)
+                    component.add(neighbor)
+                    frontier.append(neighbor)
+        odd_component_count += len(component) % 2
+
+    numerator = len(vertices) + len(barrier) - odd_component_count
+    if numerator < 0 or numerator % 2:
+        return False
+    upper_bound = numerator // 2
+    return (
+        declared_odd_components == odd_component_count
+        and declared_upper_bound == upper_bound
+        and claimed == upper_bound
+    )
+
+
+def check_graph_maximum_matching(request: dict[str, Any]) -> dict[str, Any]:
+    return _run(
+        request,
+        operation_id="graph.invariant.maximum_matching.compute",
+        witness_format="graph.maximum-matching.tutte-berge-v1",
+        replay=_maximum_matching,
+        replay_method="Tutte-Berge barrier replay",
+    )
+
+
+__all__ = [
+    "check_graph_induced_tree_maximum",
+    "check_graph_maximum_matching",
+]

--- a/tests/checkers/test_exact_domain_operation_checkers.py
+++ b/tests/checkers/test_exact_domain_operation_checkers.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import copy
+import subprocess
+import sys
 from collections.abc import Callable
 from typing import Any
 
@@ -11,7 +13,6 @@ from tests.helpers.rationals import rational_payload as _q
 
 import jacobian_checkers.exact_domain_operations as checker_module
 from jacobian_checkers.exact_domain_operations import (
-    check_graph_induced_tree_maximum,
     check_matrix_characteristic_polynomial,
     check_matrix_nullspace,
     check_matrix_rref,
@@ -20,6 +21,10 @@ from jacobian_checkers.exact_domain_operations import (
     check_polynomial_gcd,
     check_polynomial_resultant,
     check_polynomial_square_free,
+)
+from jacobian_checkers.graph_exact_operations import (
+    check_graph_induced_tree_maximum,
+    check_graph_maximum_matching,
 )
 
 
@@ -293,6 +298,35 @@ _CASES: tuple[
             },
         ),
     ),
+    (
+        check_graph_maximum_matching,
+        _request(
+            "graph.invariant.maximum_matching.compute",
+            "graph.maximum-matching.tutte-berge-v1",
+            {
+                "graph": {
+                    "graph_schema_version": "1",
+                    "vertices": ["center", "x", "y", "z"],
+                    "edges": [
+                        ["center", "x"],
+                        ["center", "y"],
+                        ["center", "z"],
+                    ],
+                }
+            },
+            {
+                "maximum_matching_cardinality": 1,
+                "witness_edges": [["center", "x"]],
+                "certificate": {
+                    "certificate_schema_version": "1",
+                    "kind": "TUTTE_BERGE_BARRIER",
+                    "barrier_vertices": ["center"],
+                    "odd_component_count": 3,
+                    "upper_bound": 1,
+                },
+            },
+        ),
+    ),
 )
 
 
@@ -400,7 +434,7 @@ def test_exact_domain_checker_rejects_changed_flint_runtime(
 
 
 def test_graph_checker_reports_its_actual_exhaustive_replay_method() -> None:
-    checker, checker_request = _CASES[-1]
+    checker, checker_request = _CASES[-2]
 
     decision = checker(checker_request)
 
@@ -415,13 +449,85 @@ def test_graph_checker_reports_its_actual_exhaustive_replay_method() -> None:
 def test_graph_checker_does_not_require_the_unrelated_flint_runtime(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    checker, checker_request = _CASES[-1]
+    checker, checker_request = _CASES[-2]
     monkeypatch.setattr(checker_module.flint, "__version__", "unexpected")
 
     decision = checker(checker_request)
 
     assert decision["accepted"] is True
     assert decision["conclusion"] == "TRUE"
+
+
+def test_graph_checker_import_boundary_excludes_producer_and_flint_modules() -> None:
+    script = """
+import builtins
+real_import = builtins.__import__
+blocked = {"flint", "networkx", "sympy", "jacobian"}
+def guarded(name, *args, **kwargs):
+    if name.split(".", 1)[0] in blocked:
+        raise RuntimeError(f"forbidden checker import: {name}")
+    return real_import(name, *args, **kwargs)
+builtins.__import__ = guarded
+import jacobian_checkers.graph_exact_operations
+"""
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    (
+        lambda result: result.update(
+            {
+                "maximum_matching_cardinality": 0,
+                "witness_edges": [],
+                "certificate": {
+                    **result["certificate"],
+                    "upper_bound": 0,
+                },
+            }
+        ),
+        lambda result: result.update(witness_edges=[["x", "y"]]),
+        lambda result: result["certificate"].update(barrier_vertices=["outside"]),
+        lambda result: result["certificate"].update(odd_component_count=1),
+        lambda result: result["certificate"].update(upper_bound=0),
+    ),
+)
+def test_maximum_matching_checker_rejects_false_or_rebound_certificates(
+    mutate: Callable[[dict[str, Any]], object],
+) -> None:
+    checker, checker_request = _CASES[-1]
+    adversarial = copy.deepcopy(checker_request)
+    mutate(adversarial["candidate"]["payload"])
+    adversarial["candidate"]["payload_digest"] = _digest(
+        adversarial["candidate"]["payload"]
+    )
+
+    decision = checker(adversarial)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+def test_maximum_matching_checker_reports_tutte_berge_replay() -> None:
+    checker, checker_request = _CASES[-1]
+
+    decision = checker(checker_request)
+
+    assert decision["accepted"] is True
+    assert decision["detail"] == (
+        "independent Tutte-Berge barrier replay accepted "
+        "graph.invariant.maximum_matching.compute"
+    )
+    assert decision["arithmetic"] == "EXACT_INTEGER"
 
 
 def test_square_free_checker_normalizes_flint_factors_to_monic_contract() -> None:

--- a/tests/integration/domains/test_exact_domain_result_verification.py
+++ b/tests/integration/domains/test_exact_domain_result_verification.py
@@ -247,6 +247,86 @@ def test_induced_tree_result_is_domain_bound_and_independently_replayed(
     assert rejected.output["verification_record_uri"] is None
 
 
+def test_maximum_matching_result_uses_independent_tutte_berge_replay(
+    tmp_path: Path,
+) -> None:
+    kernel = JacobianKernel(tmp_path, install_references=True)
+    computed = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.invariant.maximum_matching.compute",
+            input={
+                "graph": {
+                    "vertices": ["center", "x", "y", "z"],
+                    "edges": [
+                        ["center", "x"],
+                        ["center", "y"],
+                        ["center", "z"],
+                    ],
+                }
+            },
+        )
+    )
+    result_uri = computed.artifact_uris[1]
+
+    verified = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.invariant.maximum_matching.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"result_uri": result_uri},
+        )
+    )
+
+    assert computed.capability_version == "2"
+    assert verified.execution.status is ExecutionStatus.COMPLETED
+    assert verified.output["status"] == "VERIFIED"
+    assert verified.output["operation_id"] == (
+        "graph.invariant.maximum_matching.compute"
+    )
+    assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED
+    assert verified.execution.detail == (
+        "independent Tutte-Berge barrier replay accepted "
+        "graph.invariant.maximum_matching.compute"
+    )
+    runtime = next(
+        descriptor.provider_runtime
+        for descriptor in kernel.capabilities.catalog().capabilities
+        if descriptor.capability_id == "graph.invariant.maximum_matching.verify"
+    )
+    assert runtime is not None
+    assert runtime.provider == "jacobian.graph-exact-checkers"
+    assert {
+        component["provider"] for component in runtime.configuration["components"]
+    } == {"jacobian.graph-exact-checker-source"}
+
+    result_artifact = kernel.store.get(result_uri)
+    false_result = kernel.artifacts.put(
+        schema_uri=result_artifact.manifest.schema_uri,
+        semantics_uri=result_artifact.manifest.semantics_uri,
+        parents=result_artifact.manifest.parents,
+        payload={
+            "maximum_matching_cardinality": 0,
+            "witness_edges": [],
+            "certificate": {
+                **result_artifact.payload["certificate"],
+                "upper_bound": 0,
+            },
+        },
+        summary="adversarial feasible but nonmaximum matching result",
+    )
+    rejected = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.invariant.maximum_matching.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"result_uri": false_result.artifact_uri},
+        )
+    )
+
+    assert rejected.execution.status is ExecutionStatus.COMPLETED
+    assert rejected.output["status"] == "REJECTED"
+    assert rejected.output["conclusion"] == "UNKNOWN"
+    assert rejected.output["verification_record_uri"] is None
+
+
 def test_operator_can_leave_exact_result_verification_unavailable(
     tmp_path: Path,
 ) -> None:

--- a/tests/integration/graph/test_graph_invariant_domain.py
+++ b/tests/integration/graph/test_graph_invariant_domain.py
@@ -75,6 +75,34 @@ def test_graph_invariant_family_boundaries_and_witnesses(tmp_path: Path) -> None
     assert matching.output["result"] == {
         "maximum_matching_cardinality": 2,
         "witness_edges": [["a", "b"], ["c", "d"]],
+        "certificate": {
+            "certificate_schema_version": "1",
+            "kind": "TUTTE_BERGE_BARRIER",
+            "barrier_vertices": [],
+            "odd_component_count": 0,
+            "upper_bound": 2,
+        },
+    }
+    assert matching.capability_version == "2"
+
+    star = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.invariant.maximum_matching.compute",
+            input={
+                "graph": _graph(
+                    ["center", "x", "y", "z"],
+                    [["center", "x"], ["center", "y"], ["center", "z"]],
+                )
+            },
+        )
+    )
+    assert star.output["result"]["maximum_matching_cardinality"] == 1
+    assert star.output["result"]["certificate"] == {
+        "certificate_schema_version": "1",
+        "kind": "TUTTE_BERGE_BARRIER",
+        "barrier_vertices": ["center"],
+        "odd_component_count": 3,
+        "upper_bound": 1,
     }
 
 

--- a/tests/integration/infrastructure/test_mcp_adapter.py
+++ b/tests/integration/infrastructure/test_mcp_adapter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
 import os
@@ -15,6 +16,7 @@ from jacobian.adapters.mcp.guidance import OPERATING_GUIDE
 from jacobian.adapters.mcp.server import (
     WORKSPACE_TOOL_NAMES,
     _public_tool_error,
+    _request_trace_digest,
     create_server,
 )
 from jacobian.capabilities import CapabilityPolicy
@@ -22,6 +24,22 @@ from jacobian.contracts.capabilities import CapabilityDescriptor
 
 CAPABILITY_TOOL_NAMES = {"capability.describe", "capability.invoke"}
 MCP_TOOL_NAMES = CAPABILITY_TOOL_NAMES | WORKSPACE_TOOL_NAMES
+
+
+def test_mcp_trace_correlation_hashes_headers_without_retaining_them() -> None:
+    traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+
+    class RequestContext:
+        def __init__(self) -> None:
+            self.headers = {"traceparent": traceparent}
+            self.request_id = "private-request-id"
+
+    digest, source = _request_trace_digest(RequestContext())
+
+    assert digest == hashlib.sha256(traceparent.encode()).hexdigest()[:8]
+    assert source == "traceparent"
+    assert traceparent not in digest
+    assert "private-request-id" not in digest
 
 
 def test_mcp_exposes_capability_and_workspace_tools_with_read_only_resources(
@@ -493,6 +511,22 @@ def test_mcp_describes_and_invokes_capabilities(tmp_path: Path) -> None:
             assert response["provider"] == contract["capability"]["provider"]
             assert response["provider_digest"] == runtime["digest"]
 
+            matching_description = await client.call_tool(
+                "capability.describe",
+                {"capability_id": ("graph.invariant.maximum_matching.compute")},
+            )
+            matching_contract = json.loads(matching_description.content[0].text)
+            assert matching_contract["capability"]["version"] == "2"
+            assert matching_contract["invocations"][0]["name"] == ("triangle_with_tail")
+            assert matching_contract["related_capabilities"] == [
+                {
+                    "capability_id": ("graph.invariant.maximum_matching.verify"),
+                    "relationship": (
+                        "independently replay the stored Tutte-Berge certificate"
+                    ),
+                }
+            ]
+
             unknown = await client.call_tool(
                 "capability.invoke",
                 {
@@ -733,6 +767,16 @@ def test_mcp_logs_bounded_tool_metrics_without_arguments(
                 "capability.describe",
                 {"query": "private-query-marker"},
             )
+            failed = await client.call_tool(
+                "capability.invoke",
+                {
+                    "capability_id": "missing.capability",
+                    "mode": "EXPLORE",
+                    "payload": {"private": "private-payload-marker"},
+                },
+            )
+            response = json.loads(failed.content[0].text)
+            assert response["execution"]["status"] == "ERROR"
 
     asyncio.run(scenario())
 
@@ -746,6 +790,17 @@ def test_mcp_logs_bounded_tool_metrics_without_arguments(
     assert "response_bytes=" in metric
     assert "argument_digest=sha256:" in metric
     assert "private-query-marker" not in metric
+    attempt = next(
+        message
+        for message in messages
+        if "MCP capability attempt" in message
+        and "capability_id=missing.capability" in message
+    )
+    assert "execution_status=ERROR" in attempt
+    assert "diagnostic_codes=UNKNOWN_CAPABILITY" in attempt
+    assert "trace_digest=" in attempt
+    assert "argument_digest=sha256:" in attempt
+    assert "private-payload-marker" not in attempt
 
 
 def test_mcp_tool_failures_return_safe_actionable_errors(tmp_path: Path) -> None:

--- a/tests/integration/infrastructure/test_remote_mcp.py
+++ b/tests/integration/infrastructure/test_remote_mcp.py
@@ -163,6 +163,34 @@ def test_tenant_router_isolates_artifact_stores(tmp_path: Path) -> None:
         beta.store.get(stored)
 
 
+def test_anonymous_tenant_namespace_is_fixed_by_the_operator(tmp_path: Path) -> None:
+    first = TenantKernelRouter(
+        tmp_path,
+        install_references=False,
+        allow_anonymous=True,
+        anonymous_tenant_id="test-endpoint-a",
+    )
+    second = TenantKernelRouter(
+        tmp_path,
+        install_references=False,
+        allow_anonymous=True,
+        anonymous_tenant_id="test-endpoint-b",
+    )
+
+    first_kernel = first.kernel_for(None)
+    second_kernel = second.kernel_for(None)
+
+    assert first_kernel.store.root != second_kernel.store.root
+    assert first.kernel_for(None) is first_kernel
+    with pytest.raises(ValueError, match="anonymous_tenant_id must start"):
+        TenantKernelRouter(
+            tmp_path,
+            install_references=False,
+            allow_anonymous=True,
+            anonymous_tenant_id="caller controlled",
+        )
+
+
 def test_tenant_router_isolates_epistemic_workspaces(tmp_path: Path) -> None:
     router = TenantKernelRouter(tmp_path, install_references=False)
     alpha = router.kernel_for("alpha")
@@ -220,6 +248,26 @@ def test_token_file_is_strict_and_remote_cli_fails_closed(
     )
     assert completed.returncode != 0
     assert "require --auth-tokens-file" in completed.stderr
+
+    named_without_anonymous = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "jacobian.adapters.mcp.server",
+            "--transport",
+            "streamable-http",
+            "--anonymous-tenant-id",
+            "test-endpoint-a",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert named_without_anonymous.returncode != 0
+    assert "--anonymous-tenant-id requires --allow-anonymous" in (
+        named_without_anonymous.stderr
+    )
 
 
 @pytest.mark.subprocess

--- a/tests/unit/test_exact_domain_checker_installation.py
+++ b/tests/unit/test_exact_domain_checker_installation.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 from tests.helpers.artifacts import artifact_uri as _uri
 
+from jacobian.contracts.graph_invariant_operations import GraphInvariantRequest
+from jacobian.contracts.graph_optimization import GraphOptimizationRequest
 from jacobian.contracts.matrix_operations import (
     IntegerMatrixRequest,
     RationalMatrixRequest,
@@ -54,6 +56,10 @@ def test_installer_authorizes_all_exact_domain_replays(tmp_path: Path) -> None:
         "matrix.characteristic_polynomial.compute",
         "matrix.normal_form.smith.compute",
     )
+    graph_ids = (
+        "graph.induced_tree.maximum.compute",
+        "graph.invariant.maximum_matching.compute",
+    )
     registry = CheckerRegistry(tmp_path / "checkers.sqlite3")
 
     installation = install_exact_domain_checkers(
@@ -77,17 +83,35 @@ def test_installer_authorizes_all_exact_domain_replays(tmp_path: Path) -> None:
             matrix_ids,
             character="f",
         ),
+        graph=_installed(
+            (GraphOptimizationRequest,),
+            (graph_ids[0],),
+            character="7",
+        ),
+        graph_invariants=_installed(
+            (GraphInvariantRequest,),
+            (graph_ids[1],),
+            character="8",
+        ),
         authorize=True,
     )
 
-    assert set(installation.checker_ids) == set(polynomial_ids + matrix_ids)
+    assert set(installation.checker_ids) == set(polynomial_ids + matrix_ids + graph_ids)
     assert all(installation.checker_ids.values())
-    for checker_id in installation.checker_ids.values():
+    for capability_id, checker_id in installation.checker_ids.items():
         assert checker_id is not None
         registration = registry.require_active(checker_id)
-        assert registration.entrypoint.startswith(
-            "jacobian_checkers.exact_domain_operations:"
+        expected_module = (
+            "jacobian_checkers.graph_exact_operations:"
+            if capability_id.startswith("graph.")
+            else "jacobian_checkers.exact_domain_operations:"
         )
+        assert registration.entrypoint.startswith(expected_module)
+    graph_runtime = installation.provider_runtimes["finite-graph"]
+    assert graph_runtime.provider == "jacobian.graph-exact-checkers"
+    assert {
+        component["provider"] for component in graph_runtime.configuration["components"]
+    } == {"jacobian.graph-exact-checker-source"}
 
 
 def test_installer_preserves_operator_control(tmp_path: Path) -> None:

--- a/tests/unit/test_exact_domain_checker_installation.py
+++ b/tests/unit/test_exact_domain_checker_installation.py
@@ -152,3 +152,76 @@ def test_installer_preserves_operator_control(tmp_path: Path) -> None:
     )
 
     assert set(installation.checker_ids.values()) == {None}
+
+
+def test_installer_skips_checkers_for_an_unavailable_graph_bundle(
+    tmp_path: Path,
+) -> None:
+    polynomial = _installed(
+        (
+            PolynomialGcdRequest,
+            PolynomialResultantRequest,
+            PolynomialDiscriminantRequest,
+            PolynomialSquareFreeRequest,
+        ),
+        (
+            "polynomial.compute.gcd",
+            "polynomial.compute.resultant",
+            "polynomial.compute.discriminant",
+            "polynomial.compute.square_free_decomposition",
+        ),
+        character="e",
+    )
+    matrix = _installed(
+        (
+            RationalMatrixRequest,
+            SquareRationalMatrixRequest,
+            IntegerMatrixRequest,
+        ),
+        (
+            "matrix.normal_form.rref.compute",
+            "matrix.nullspace.compute",
+            "matrix.characteristic_polynomial.compute",
+            "matrix.normal_form.smith.compute",
+        ),
+        character="f",
+    )
+    graph = _installed(
+        (GraphOptimizationRequest,),
+        ("graph.induced_tree.maximum.compute",),
+        character="7",
+    )
+    graph_invariants = _installed(
+        (GraphInvariantRequest,),
+        ("graph.invariant.maximum_matching.compute",),
+        character="8",
+    )
+
+    for name, optional_bundles, expected_graph_id in (
+        (
+            "optimization-only",
+            {"graph": graph},
+            "graph.induced_tree.maximum.compute",
+        ),
+        (
+            "invariants-only",
+            {"graph_invariants": graph_invariants},
+            "graph.invariant.maximum_matching.compute",
+        ),
+    ):
+        registry_path = tmp_path / name / "checkers.sqlite3"
+        registry_path.parent.mkdir()
+        installation = install_exact_domain_checkers(
+            CheckerRegistry(registry_path),
+            polynomial=polynomial,
+            matrix=matrix,
+            authorize=True,
+            **optional_bundles,
+        )
+
+        graph_ids = {
+            capability_id
+            for capability_id in installation.checker_ids
+            if capability_id.startswith("graph.")
+        }
+        assert graph_ids == {expected_graph_id}

--- a/tests/unit/test_graph_atlas.py
+++ b/tests/unit/test_graph_atlas.py
@@ -4,6 +4,7 @@ import networkx as nx
 import pytest
 
 import jacobian.graph_atlas as graph_atlas
+from jacobian.domains.graph_optimization.invariants import _maximum_matching
 
 
 def test_graph_atlas_is_built_once_and_cached_as_frozen_graphs(
@@ -27,3 +28,22 @@ def test_graph_atlas_is_built_once_and_cached_as_frozen_graphs(
     assert first is second
     assert len(first) == 1044
     assert all(nx.is_frozen(graph) for graph in first)
+
+
+def test_gallai_edmonds_barrier_certifies_every_graph_through_order_seven() -> None:
+    for indexed_graph in nx.graph_atlas_g():
+        graph = nx.relabel_nodes(
+            indexed_graph,
+            {vertex: str(vertex) for vertex in indexed_graph},
+        )
+        result = _maximum_matching(graph)
+        barrier = set(result.certificate.barrier_vertices)
+        reduced = graph.subgraph(set(graph) - barrier)
+        odd_component_count = sum(
+            len(component) % 2 for component in nx.connected_components(reduced)
+        )
+
+        assert result.certificate.odd_component_count == odd_component_count
+        assert 2 * result.maximum_matching_cardinality == (
+            len(graph) + len(barrier) - odd_component_count
+        )


### PR DESCRIPTION
## Summary

- isolate anonymous test deployments behind an operator-chosen tenant namespace, add bounded per-attempt MCP telemetry, and ship Caddy runtime/access-log redaction
- upgrade maximum matching to a versioned Tutte-Berge certificate and add an independent clean-process verifier
- split finite-graph verification from the Python-FLINT checker runtime, correct graph provenance, and document the verification obligation ledger and attack matrix

## Compatibility

`graph.invariant.maximum_matching.compute` is intentionally bumped to version 2. Its result now requires a `graph.maximum-matching.tutte-berge-v1` certificate, so version-1 result artifacts are not valid version-2 artifacts.

## Validation

- `make check` — 580 passed, lint passed
- `make test-checkers` — 234 passed
- `make test-mcp` — 19 passed
- focused exact-domain/graph/infrastructure tests — 12 passed
- graph-atlas certificate property test — passed for every atlas graph through order 7
- `uv run mypy` — 283 source files clean
- `uv run pre-commit run` — all hooks passed
- `caddy validate --config deploy/caddy/Caddyfile --adapter caddyfile` — valid
