### PR TITLE
test: harden test boundaries and subprocess lifetimes

### DIFF
--- a/tests/reference/test_erdos_straus_plugin.py
+++ b/tests/reference/test_erdos_straus_plugin.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from jacobian.plugins.erdos_straus import (
     evaluate_capability,
     find_witness_capability,
@@ -66,22 +68,30 @@ def test_find_witness_returns_complete_exact_table() -> None:
     )
 
 
-def test_find_witness_rejects_wrong_role_or_range() -> None:
-    for request in (
-        {
-            "claim": _claim(),
-            "candidate": _candidate(),
-            "witness_role": "DEFEATS_CANDIDATE",
-        },
-        {
-            "claim": _claim(2, 100),
-            "candidate": _candidate(2, 99),
-            "witness_role": "SUPPORTS_CLAIM",
-        },
-    ):
-        try:
-            find_witness_capability(request)
-        except ValueError:
-            pass
-        else:
-            raise AssertionError("invalid witness request was accepted")
+@pytest.mark.parametrize(
+    ("witness_request", "message"),
+    (
+        (
+            {
+                "claim": _claim(),
+                "candidate": _candidate(),
+                "witness_role": "DEFEATS_CANDIDATE",
+            },
+            "supports only SUPPORTS_CLAIM witnesses",
+        ),
+        (
+            {
+                "claim": _claim(2, 100),
+                "candidate": _candidate(2, 99),
+                "witness_role": "SUPPORTS_CLAIM",
+            },
+            "candidate range must exactly match the claim range",
+        ),
+    ),
+)
+def test_find_witness_rejects_wrong_role_or_range(
+    witness_request: dict[str, object],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        find_witness_capability(witness_request)

--- a/tests/unit/test_ci_plan.py
+++ b/tests/unit/test_ci_plan.py
@@ -194,6 +194,7 @@ def test_ci_plan_fails_closed_outside_isolated_paths(
         check=True,
         capture_output=True,
         text=True,
+        timeout=30,
     )
 
     assert (
@@ -207,6 +208,7 @@ def test_full_override_expands_an_isolated_plan() -> None:
         check=True,
         capture_output=True,
         text=True,
+        timeout=30,
     )
 
     plan = dict(line.split("=", 1) for line in completed.stdout.splitlines())
@@ -220,6 +222,7 @@ def test_lean_override_only_adds_lean_to_an_isolated_plan() -> None:
         check=True,
         capture_output=True,
         text=True,
+        timeout=30,
     )
 
     plan = dict(line.split("=", 1) for line in completed.stdout.splitlines())
@@ -246,9 +249,10 @@ def test_ci_plan_output_is_internally_consistent(args: tuple[str, ...]) -> None:
         check=True,
         capture_output=True,
         text=True,
+        timeout=30,
     ).stdout
 
-    subprocess.run([VALIDATOR], input=plan, check=True, text=True)
+    subprocess.run([VALIDATOR], input=plan, check=True, text=True, timeout=30)
 
 
 @pytest.mark.parametrize(
@@ -289,6 +293,7 @@ def test_ci_plan_validator_rejects_malformed_or_incoherent_plans(plan: str) -> N
         input=plan,
         capture_output=True,
         text=True,
+        timeout=30,
     )
 
     assert completed.returncode != 0
@@ -301,6 +306,7 @@ def test_every_tracked_source_file_has_explicit_suite_ownership() -> None:
         check=True,
         capture_output=True,
         text=True,
+        timeout=30,
     ).stdout.splitlines()
 
     unowned = []

--- a/tests/unit/test_ci_test_timings.py
+++ b/tests/unit/test_ci_test_timings.py
@@ -21,6 +21,7 @@ def run_script(
         check=False,
         capture_output=True,
         text=True,
+        timeout=30,
     )
 
 

--- a/tests/unit/test_ci_timings.py
+++ b/tests/unit/test_ci_timings.py
@@ -50,6 +50,7 @@ def test_ci_timing_summary_reports_elapsed_and_runner_minutes(tmp_path: Path) ->
         check=True,
         capture_output=True,
         text=True,
+        timeout=30,
     )
 
     assert "Critical path (workflow elapsed) | 5.0 min" in completed.stdout

--- a/tests/unit/test_graph_oracle.py
+++ b/tests/unit/test_graph_oracle.py
@@ -52,6 +52,15 @@ def test_graph_oracle_rejects_wrong_exact_property() -> None:
         )
 
 
+def test_graph_oracle_accepts_maximum_independence_scope() -> None:
+    graph = {"vertices": [str(index) for index in range(18)], "edges": []}
+
+    properties = compute_properties(graph)
+
+    assert properties["order"] == 18
+    assert properties["independence_number"] == 18
+
+
 def test_graph_oracle_rejects_exponential_independence_scope() -> None:
     graph = {"vertices": [str(index) for index in range(19)], "edges": []}
 


### PR DESCRIPTION
## Problem

Several tests left their intended boundary or failure mode implicit. The graph oracle rejected inputs above its 18-vertex limit without proving that the limit itself remained accepted. The bounded Erdős–Straus witness test accepted any `ValueError`, and local CI utility subprocesses relied on the suite-level timeout instead of owning a shorter lifetime.

## Solution

- Add an acceptance case at the graph oracle maximum before the existing over-limit rejection case.
- Parameterize the invalid Erdős–Straus witness cases and match each expected rejection reason.
- Give every cited CI utility subprocess invocation a 30-second timeout, consistent with neighboring infrastructure tests.

## Testing

```sh
uv run pytest -n 0 -q tests/unit/test_ci_plan.py tests/unit/test_ci_timings.py tests/unit/test_ci_test_timings.py tests/reference/test_erdos_straus_plugin.py tests/unit/test_graph_oracle.py
uv run ruff check tests/unit/test_ci_plan.py tests/unit/test_ci_timings.py tests/unit/test_ci_test_timings.py tests/reference/test_erdos_straus_plugin.py tests/unit/test_graph_oracle.py
uv run ruff format --check tests/unit/test_ci_plan.py tests/unit/test_ci_timings.py tests/unit/test_ci_test_timings.py tests/reference/test_erdos_straus_plugin.py tests/unit/test_graph_oracle.py
```

The focused pytest run passed all 50 tests.

## Trust & Compatibility Impact

Test-only change. It does not alter the verification kernel, checker registry, artifact formats, or public API.

## Checklist

- [ ] Routine local validation passes (`make check`)
- [x] Relevant focused tests are listed above