### PR TITLE
fix(runtime): batch kernel bootstrap registration and restore fast local checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,3 +34,12 @@ repos:
     rev: v1.7.12
     hooks:
       - id: actionlint
+
+  - repo: local
+    hooks:
+      - id: jacobian-pre-push
+        name: Jacobian pre-push checks
+        entry: make check
+        language: system
+        pass_filenames: false
+        stages: [pre-push]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,11 +23,12 @@ make setup
 make test-fast
 ```
 
-`make test-fast` is the short non-integration feedback loop. Run `make check`
-before pushing; it performs fast Ruff and non-integration test checks. Push
-after that check and let CI own dependency and dead-code analysis, strict
-typing, package builds, the full Python matrix, integration, end-to-end,
-coverage, and real-Lean validation. `make check-static` reproduces the
+`make test-fast` is the short non-integration feedback loop; it excludes tests
+explicitly marked `slow`. Run `make check` before pushing; it performs fast
+Ruff, strict typing, and non-integration test checks. Push after that check and
+let CI own dependency and dead-code analysis, package builds, the full Python
+matrix, integration, end-to-end, coverage, and real-Lean validation.
+`make check-static` reproduces the
 CI-owned static and package checks when a focused change needs them.
 `make validate-full` is the broadest local Python, Lean, static, and package
 validation target. It does not reproduce CI's Python 3.13 compatibility,
@@ -48,8 +49,10 @@ make test-lean TESTS=tests/integration/lean/test_lean.py PYTEST_ARGS="-k inducti
 ```
 
 Run `make hooks` once to install the repository's formatting, syntax, secret,
-and large-file checks. `make fix` applies Ruff's safe lint fixes followed by
-formatting.
+and large-file checks plus the `make check` pre-push gate. Hooks remain
+bypassable for exceptional cases with Git's standard `--no-verify` option.
+`make fix` applies Ruff's safe lint fixes followed by formatting. `make
+precommit` applies those fixes and then runs the routine handoff checks.
 
 On macOS, read the
 [Z3 installation note](README.md#macos-and-z3) before troubleshooting a

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,9 @@ TESTS ?=
 EVAL_ARGS ?=
 CORE_TEST_PATHS := tests/unit tests/contract tests/checkers tests/reference
 INTEGRATION_TEST_PATHS := tests/integration tests/end_to_end
+RUFF_PATHS := src tests benchmarks
 
-.PHONY: help setup hooks fix lint lint-full typecheck test test-fast test-core test-integration test-contracts test-checkers test-mcp test-storage test-lean test-failed build check check-static validate-full agent-eval
+.PHONY: help setup hooks fix lint lint-full typecheck test test-fast test-core test-integration test-contracts test-checkers test-mcp test-storage test-lean test-failed build check precommit check-static validate-full agent-eval
 
 help: ## Show available developer commands.
 	@awk 'BEGIN {FS = ":.*## "; printf "Jacobian developer commands:\n\n"} /^[a-zA-Z_-]+:.*## / {printf "  %-18s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -17,14 +18,15 @@ setup: ## Install the locked development environment.
 
 hooks: setup ## Install pre-commit hooks.
 	$(UV_RUN) pre-commit install --install-hooks
+	$(UV_RUN) pre-commit install --hook-type pre-push
 
 fix: ## Apply Ruff fixes and formatting.
-	$(UV_RUN) ruff check --fix .
-	$(UV_RUN) ruff format .
+	$(UV_RUN) ruff check --fix $(RUFF_PATHS)
+	$(UV_RUN) ruff format $(RUFF_PATHS)
 
 lint: ## Run the fast Ruff lint and format checks.
-	$(UV_RUN) ruff check .
-	$(UV_RUN) ruff format --check .
+	$(UV_RUN) ruff check $(RUFF_PATHS)
+	$(UV_RUN) ruff format --check $(RUFF_PATHS)
 
 lint-full: lint ## Add dependency and dead-code checks.
 	$(UV_RUN) deptry .
@@ -40,7 +42,7 @@ test: ## Run tests; narrow with TESTS=... and PYTEST_ARGS=....
 	$(UV_RUN) pytest -m "not lean_runtime" $(TESTS) $(PYTEST_ARGS)
 
 test-fast: ## Run the sequential core feedback loop.
-	$(UV_RUN) pytest -n 0 -m "not lean_runtime" \
+	$(UV_RUN) pytest -n 0 -m "not lean_runtime and not slow" \
 		$(if $(TESTS),$(TESTS),$(CORE_TEST_PATHS)) $(PYTEST_ARGS)
 
 test-core: ## Run the directory-owned core suites.
@@ -80,7 +82,11 @@ test-failed: ## Re-run failures from the previous pytest invocation.
 build: ## Build Python source and wheel distributions.
 	uv build
 
-check: lint test-fast ## Run the fast routine local handoff checks.
+check: lint typecheck test-fast ## Run the fast routine local handoff checks.
+
+precommit: ## Fix and run every routine local handoff check.
+	$(MAKE) fix
+	$(MAKE) check
 
 check-static: lint-full typecheck build ## Run CI-owned static and package checks locally.
 

--- a/docs/contributing/test-suite-cost-audit.md
+++ b/docs/contributing/test-suite-cost-audit.md
@@ -10,6 +10,22 @@ This audit records the 2026-07-26 local measurements used to restore a short
 edit-test loop without weakening Jacobian's verification boundary. Timings are
 machine-local observations, not performance gates.
 
+## 2026-07-28 bootstrap follow-up
+
+A later profile found that kernel construction had regressed to 31.6 seconds
+for a fresh core store. The main costs were repeated JSON Schema metaschema
+validation and one durable SQLite transaction per descriptor. Bootstrap now
+reuses exact-schema validation within the process and installs the capability
+portfolio through one store-owned transaction. Ordinary artifact writes retain
+their existing durability boundary.
+
+On the same local host, fresh core construction fell from 31.6 to 13.0 seconds.
+Attaching to a copied core snapshot took 0.79 seconds, and adding authorized
+references to a copied core snapshot took 3.68 seconds. `make test-fast` fell
+from 237.91 seconds wall time to 56.55 seconds while selecting 591 tests; three
+exhaustive cases were explicitly marked `slow` and excluded from that lane.
+These are single-host observations, not timing gates.
+
 ## Measured lanes
 
 | Lane | Selected tests | Observed wall time | Purpose |
@@ -68,8 +84,8 @@ make validate-full
 
 `make test-fast` is the normal edit loop. Use focused integration tests while
 changing stores, adapters, plugins, subprocesses, or checker execution.
-`make check` combines fast Ruff checks with that loop. Dependency and
-dead-code analysis, strict typing, and package builds remain available through
+`make check` combines fast Ruff checks, strict typing, and that loop.
+Dependency and dead-code analysis and package builds remain available through
 `make check-static` but are CI-owned rather than routine local handoff work.
 `make test` runs the complete non-Lean suite, and `make test-lean` keeps the
 memory-heavy backend serial. Neither is a routine pre-push requirement; CI

--- a/src/jacobian/capabilities.py
+++ b/src/jacobian/capabilities.py
@@ -38,6 +38,7 @@ from jacobian.contracts.memory import ResearchEpisode
 from jacobian.contracts.results import Coverage, Execution, ExecutionStatus
 from jacobian.contracts.verification import VerificationRecord
 from jacobian.memory import ResearchMemory
+from jacobian.schema_validation import check_draft202012_schema
 from jacobian.store import ArtifactStore, StoreError
 
 if TYPE_CHECKING:
@@ -738,11 +739,11 @@ def load_capability_adapter(
     return cast(CapabilityAdapter, adapter)
 
 
-@lru_cache(maxsize=256)
+@lru_cache(maxsize=1024)
 def _compiled_validator(canonical_schema: bytes) -> Draft202012Validator:
     normalized = loads_strict_json(canonical_schema)
     try:
-        Draft202012Validator.check_schema(normalized)
+        check_draft202012_schema(canonical_schema)
     except SchemaError as exc:
         raise CapabilityError("capability JSON Schema is invalid") from exc
     return Draft202012Validator(normalized)

--- a/src/jacobian/kernel.py
+++ b/src/jacobian/kernel.py
@@ -217,10 +217,27 @@ class JacobianKernel:
         capability_exclusions: frozenset[str] = frozenset(),
         capability_policy: CapabilityPolicy | None = None,
     ) -> None:
+        self.store = ArtifactStore(root)
+        self._initialize(
+            install_references=install_references,
+            capability_adapter_entrypoints=capability_adapter_entrypoints,
+            capability_exclusions=capability_exclusions,
+            capability_policy=capability_policy,
+        )
+
+    def _initialize(
+        self,
+        *,
+        install_references: bool,
+        capability_adapter_entrypoints: tuple[str, ...],
+        capability_exclusions: frozenset[str],
+        capability_policy: CapabilityPolicy | None,
+    ) -> None:
+        """Assemble foundational services, then install the portfolio atomically."""
+
         # Construction-time exclusions support controlled portfolio ablations.
         # They are not a runtime authorization or access-control mechanism.
         self._capability_exclusions = capability_exclusions
-        self.store = ArtifactStore(root)
         self.schemas = SchemaRegistry(self.store)
         self.artifacts = ArtifactService(self.store, self.schemas)
         self.operation_installer = OperationInstaller(
@@ -261,7 +278,7 @@ class JacobianKernel:
         self.memory = ResearchMemory(self.store, self.schemas)
         self.workspaces = WorkspaceService(self.store, self.schemas)
         self.plugins = PluginRegistry(self.store)
-        self.checkers = CheckerRegistry(self.store.db_path)
+        self.checkers = CheckerRegistry(self.store)
         self.claims = ClaimValidationService(
             self.store,
             self.schemas,
@@ -368,6 +385,22 @@ class JacobianKernel:
             self.memory,
             policy=capability_policy,
         )
+        with self.checkers.policy_transaction(), self.store.transaction():
+            self._install_capability_portfolio(
+                install_references=install_references,
+                capability_adapter_entrypoints=capability_adapter_entrypoints,
+                claim_decomposition_adapters=claim_decomposition_adapters,
+            )
+
+    def _install_capability_portfolio(
+        self,
+        *,
+        install_references: bool,
+        capability_adapter_entrypoints: tuple[str, ...],
+        claim_decomposition_adapters: tuple[CapabilityAdapter, ...],
+    ) -> None:
+        """Install capability descriptors and optional checker authority."""
+
         self.register_capability(SatCnfMaterializationAdapter(self.sat))
         self.sat_assignment_checker: SatAssignmentCheckerInstallation
         sat_assignment_adapter, self.sat_assignment_checker = (

--- a/src/jacobian/plugins/registry.py
+++ b/src/jacobian/plugins/registry.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import hashlib
 import logging
 import platform
-import sqlite3
 import sysconfig
 from dataclasses import dataclass
 
@@ -74,14 +73,8 @@ class PluginRegistry:
         )
         self._initialize_database()
 
-    def _connect(self) -> sqlite3.Connection:
-        connection = sqlite3.connect(self.store.db_path, timeout=30)
-        connection.row_factory = sqlite3.Row
-        connection.execute("PRAGMA foreign_keys = ON")
-        return connection
-
     def _initialize_database(self) -> None:
-        with self._connect() as connection:
+        with self.store.connection() as connection:
             connection.execute(
                 """
                 CREATE TABLE IF NOT EXISTS installed_plugins (
@@ -239,8 +232,9 @@ class PluginRegistry:
             summary="sealed plugin registry snapshot",
         )
 
-        with self._connect() as connection:
-            connection.execute("BEGIN IMMEDIATE")
+        with self.store.connection() as connection:
+            if not self.store.transaction_active:
+                connection.execute("BEGIN IMMEDIATE")
             connection.execute(
                 """
                 INSERT OR IGNORE INTO installed_plugins (
@@ -282,7 +276,7 @@ class PluginRegistry:
     def get(self, plugin_id: str) -> PluginManifest:
         """Return an installed manifest without resolving executable code."""
 
-        with self._connect() as connection:
+        with self.store.connection() as connection:
             installed = connection.execute(
                 "SELECT 1 FROM installed_plugins WHERE plugin_id = ?",
                 (plugin_id,),
@@ -301,7 +295,7 @@ class PluginRegistry:
     def snapshot_uri(self, plugin_id: str) -> str:
         """Return the immutable installation snapshot URI without importing code."""
 
-        with self._connect() as connection:
+        with self.store.connection() as connection:
             row = connection.execute(
                 """
                 SELECT registry_snapshot_uri

--- a/src/jacobian/registry.py
+++ b/src/jacobian/registry.py
@@ -6,6 +6,7 @@ import hashlib
 import logging
 import os
 import sqlite3
+import threading
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -23,6 +24,7 @@ from jacobian.provider_runtime import (
     ProviderRuntimeError,
     require_provider_runtime_unchanged,
 )
+from jacobian.store import ArtifactStore, transaction_active_for
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -45,6 +47,13 @@ class CheckerExecutableChangedError(CheckerRegistryError):
 
 class CheckerCompatibilityError(CheckerRegistryError):
     """The checker is not authorized for the requested evidence bindings."""
+
+
+class _PolicyLockState(threading.local):
+    """Per-thread nesting state for the cross-process policy lock."""
+
+    def __init__(self) -> None:
+        self.depth = 0
 
 
 def compute_entrypoint_digest(entrypoint: str) -> str:
@@ -77,22 +86,51 @@ def _require_runtime_unchanged(runtime: CapabilityProviderRuntime | None) -> Non
 class CheckerRegistry:
     """Persist operator authorization, compatibility, audit, and revocation."""
 
-    def __init__(self, database_path: str | Path) -> None:
-        self.database_path = Path(database_path)
+    def __init__(self, database: str | Path | ArtifactStore) -> None:
+        if isinstance(database, ArtifactStore):
+            self._store: ArtifactStore | None = database
+            self.database_path = database.db_path
+        else:
+            self._store = None
+            self.database_path = Path(database)
         self.policy_lock_path = self.database_path.with_name(
             self.database_path.name + ".checker-policy.lock"
         )
+        self._policy_lock_state = _PolicyLockState()
         self._initialize_database()
 
     @contextmanager
-    def _exclusive_policy_lock(self) -> Iterator[None]:
-        self.policy_lock_path.parent.mkdir(parents=True, exist_ok=True)
-        with self.policy_lock_path.open("a+b") as lock_file:
-            _lock_file(lock_file)
+    def policy_transaction(self) -> Iterator[None]:
+        """Hold checker policy authority across related durable writes."""
+
+        if self._policy_lock_state.depth:
+            self._policy_lock_state.depth += 1
             try:
                 yield
             finally:
+                self._policy_lock_state.depth -= 1
+            return
+        if transaction_active_for(self.database_path):
+            raise CheckerRegistryError(
+                "checker policy must be locked before the store transaction"
+            )
+
+        self.policy_lock_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.policy_lock_path.open("a+b") as lock_file:
+            _lock_file(lock_file)
+            self._policy_lock_state.depth = 1
+            try:
+                yield
+            finally:
+                self._policy_lock_state.depth = 0
                 _unlock_file(lock_file)
+
+    @contextmanager
+    def _policy_write_lock(self) -> Iterator[None]:
+        """Acquire policy before SQLite or reuse an existing outer lock."""
+
+        with self.policy_transaction():
+            yield
 
     @contextmanager
     def verification_guard(
@@ -103,7 +141,7 @@ class CheckerRegistry:
     ) -> Iterator[CheckerRegistration]:
         """Prevent revocation while a verified record is committed."""
 
-        with self._exclusive_policy_lock():
+        with self._policy_write_lock():
             registration = self.require_active(checker_id)
             if registration.executable_digest != expected_digest:
                 raise CheckerExecutableChangedError(
@@ -112,14 +150,24 @@ class CheckerRegistry:
                 )
             yield registration
 
-    def _connect(self) -> sqlite3.Connection:
+    @contextmanager
+    def _connection(self) -> Iterator[sqlite3.Connection]:
+        if self._store is not None:
+            with self._store.connection() as connection:
+                yield connection
+            return
+
         connection = sqlite3.connect(self.database_path, timeout=30)
         connection.row_factory = sqlite3.Row
         connection.execute("PRAGMA foreign_keys = ON")
-        return connection
+        try:
+            with connection:
+                yield connection
+        finally:
+            connection.close()
 
     def _initialize_database(self) -> None:
-        with self._connect() as connection:
+        with self._connection() as connection:
             connection.executescript(
                 """
                 CREATE TABLE IF NOT EXISTS checkers (
@@ -196,7 +244,7 @@ class CheckerRegistry:
             registration.model_dump(mode="json", exclude_none=True)
         )
 
-        with self._exclusive_policy_lock(), self._connect() as connection:
+        with self._policy_write_lock(), self._connection() as connection:
             existing = connection.execute(
                 """
                 SELECT registration_json, authorized, executable_digest
@@ -246,7 +294,7 @@ class CheckerRegistry:
     def get(self, checker_id: str) -> CheckerRegistration:
         """Return a checker registration, including its revocation state."""
 
-        with self._connect() as connection:
+        with self._connection() as connection:
             row = connection.execute(
                 """
                 SELECT registration_json, authorized, executable_digest
@@ -389,7 +437,7 @@ class CheckerRegistry:
     ) -> CheckerRegistration:
         """Select the unique active checker compatible with an evidence format."""
 
-        with self._connect() as connection:
+        with self._connection() as connection:
             rows = connection.execute(
                 "SELECT checker_id FROM checkers WHERE authorized = 1"
             ).fetchall()
@@ -427,7 +475,7 @@ class CheckerRegistry:
     def revoke(self, checker_id: str, *, reason: str) -> None:
         """Block new verification while preserving historical records."""
 
-        with self._exclusive_policy_lock(), self._connect() as connection:
+        with self._policy_write_lock(), self._connection() as connection:
             row = connection.execute(
                 "SELECT authorized FROM checkers WHERE checker_id = ?",
                 (checker_id,),
@@ -456,7 +504,7 @@ class CheckerRegistry:
     def audit_log(self, checker_id: str) -> tuple[CheckerAuditEvent, ...]:
         """Return ordered authorization and revocation events."""
 
-        with self._connect() as connection:
+        with self._connection() as connection:
             rows = connection.execute(
                 """
                 SELECT sequence, checker_id, action, reason, recorded_at

--- a/src/jacobian/schema_registry.py
+++ b/src/jacobian/schema_registry.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel
 from pydantic import ValidationError as PydanticValidationError
 
 from jacobian.canonical import canonicalize_json, loads_strict_json
+from jacobian.schema_validation import check_draft202012_schema
 from jacobian.store import ArtifactStore, StoreError
 
 
@@ -34,7 +35,7 @@ class SchemaValidationError(SchemaRegistryError):
         self.required_field = required_field
 
 
-@lru_cache(maxsize=128)
+@lru_cache(maxsize=1024)
 def _model_schema_bytes(model: type[BaseModel]) -> bytes:
     """Generate one canonical JSON Schema per Pydantic model and process."""
 
@@ -62,7 +63,7 @@ def _reject_external_references(value: Any) -> None:
             _reject_external_references(nested)
 
 
-@lru_cache(maxsize=128)
+@lru_cache(maxsize=1024)
 def _validated_schema(canonical_schema: bytes) -> Draft202012Validator:
     """Validate and compile one exact schema definition per process.
 
@@ -75,7 +76,7 @@ def _validated_schema(canonical_schema: bytes) -> Draft202012Validator:
     normalized = loads_strict_json(canonical_schema)
     _reject_external_references(normalized)
     try:
-        Draft202012Validator.check_schema(normalized)
+        check_draft202012_schema(canonical_schema)
     except SchemaError as exc:
         raise SchemaRegistryError("invalid Draft 2020-12 JSON Schema") from exc
     return Draft202012Validator(normalized, format_checker=FormatChecker())

--- a/src/jacobian/schema_validation.py
+++ b/src/jacobian/schema_validation.py
@@ -1,0 +1,24 @@
+"""Process-wide reuse for exact operator-installed JSON Schema checks."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+
+from jacobian.canonical import loads_strict_json
+
+_META_SCHEMA_VALIDATOR = Draft202012Validator(
+    schema=Draft202012Validator.META_SCHEMA,
+    format_checker=Draft202012Validator.FORMAT_CHECKER,
+)
+
+
+@lru_cache(maxsize=1024)
+def check_draft202012_schema(canonical_schema: bytes) -> None:
+    """Check one canonical schema once per process and bounded working set."""
+
+    schema = loads_strict_json(canonical_schema)
+    for error in _META_SCHEMA_VALIDATOR.iter_errors(schema):
+        raise SchemaError.create_from(error)

--- a/src/jacobian/store.py
+++ b/src/jacobian/store.py
@@ -7,6 +7,7 @@ import logging
 import os
 import sqlite3
 import tempfile
+import threading
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -70,6 +71,30 @@ class StoredArtifact:
     manifest: ArtifactManifest
     payload: Any
     canonical_bytes: bytes
+
+
+class _ConnectionState(threading.local):
+    """Per-thread ownership for one explicit store transaction."""
+
+    def __init__(self) -> None:
+        self.transaction: sqlite3.Connection | None = None
+        self.blob_lock_depth = 0
+
+
+class _ActiveTransactionPaths(threading.local):
+    """Database paths transaction-owned by the current thread."""
+
+    def __init__(self) -> None:
+        self.paths: set[Path] = set()
+
+
+_ACTIVE_TRANSACTION_PATHS = _ActiveTransactionPaths()
+
+
+def transaction_active_for(database_path: str | Path) -> bool:
+    """Whether this thread owns a store transaction for one database."""
+
+    return Path(database_path).resolve() in _ACTIVE_TRANSACTION_PATHS.paths
 
 
 def _sha256(data: bytes) -> str:
@@ -165,7 +190,9 @@ class ArtifactStore:
         self.staging_root = self.root / "staging"
         self.db_path = self.root / "metadata.sqlite3"
         self.blob_lock_path = self.root / ".blob-quota.lock"
+        self.transaction_recovery_path = self.root / ".transaction-recovery"
         self._validated_blobs: dict[str, tuple[int, int, int, int, int]] = {}
+        self._connection_state = _ConnectionState()
         self.blob_root.mkdir(parents=True, exist_ok=True)
         self.staging_root.mkdir(parents=True, exist_ok=True)
         self._initialize_database()
@@ -177,7 +204,14 @@ class ArtifactStore:
         return connection
 
     @contextmanager
-    def _connection(self) -> Iterator[sqlite3.Connection]:
+    def connection(self) -> Iterator[sqlite3.Connection]:
+        """Yield this thread's transaction connection or one owned connection."""
+
+        transaction = self._connection_state.transaction
+        if transaction is not None:
+            yield transaction
+            return
+
         connection = self._connect()
         try:
             with connection:
@@ -185,8 +219,73 @@ class ArtifactStore:
         finally:
             connection.close()
 
+    @property
+    def transaction_active(self) -> bool:
+        """Whether this thread is inside an explicit store transaction."""
+
+        return self._connection_state.transaction is not None
+
+    @contextmanager
+    def transaction(self) -> Iterator[None]:
+        """Commit related store operations through one SQLite transaction.
+
+        Blob publication remains content-addressed and durable. If metadata
+        rolls back, quota accounting is reconciled against the published blob
+        set before control returns to the caller.
+        """
+
+        if self._connection_state.transaction is not None:
+            raise StoreError("nested artifact store transactions are unsupported")
+
+        with self._exclusive_blob_lock():
+            self._write_transaction_recovery_marker()
+            connection = self._connect()
+            try:
+                connection.execute("BEGIN IMMEDIATE")
+                self._connection_state.transaction = connection
+                _ACTIVE_TRANSACTION_PATHS.paths.add(self.db_path)
+                yield
+                connection.commit()
+            except BaseException:
+                connection.rollback()
+                self._connection_state.transaction = None
+                _ACTIVE_TRANSACTION_PATHS.paths.discard(self.db_path)
+                connection.close()
+                try:
+                    self._reconcile_blob_quota(force=True)
+                except Exception:
+                    _LOGGER.exception(
+                        "failed to reconcile blob accounting after transaction rollback"
+                    )
+                raise
+            else:
+                self._connection_state.transaction = None
+                _ACTIVE_TRANSACTION_PATHS.paths.discard(self.db_path)
+                connection.close()
+                self._remove_transaction_recovery_marker()
+
+    def _sync_root_directory(self) -> None:
+        if os.name == "nt":  # pragma: no cover - Windows has no directory fsync
+            return
+        descriptor = os.open(self.root, os.O_RDONLY)
+        try:
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+
+    def _write_transaction_recovery_marker(self) -> None:
+        with self.transaction_recovery_path.open("wb") as marker:
+            marker.write(b"jacobian artifact transaction in progress\n")
+            marker.flush()
+            os.fsync(marker.fileno())
+        self._sync_root_directory()
+
+    def _remove_transaction_recovery_marker(self) -> None:
+        self.transaction_recovery_path.unlink(missing_ok=True)
+        self._sync_root_directory()
+
     def _initialize_database(self) -> None:
-        with self._exclusive_blob_lock(), self._connection() as connection:
+        with self._exclusive_blob_lock(), self.connection() as connection:
             connection.execute("PRAGMA journal_mode = WAL")
             connection.executescript(
                 """
@@ -281,11 +380,12 @@ class ArtifactStore:
                     total += after.st_size
         return total
 
-    def _reconcile_blob_quota(self) -> None:
+    def _reconcile_blob_quota(self, *, force: bool = False) -> None:
         """Recover quota accounting only after an interrupted blob mutation."""
 
         with self._exclusive_blob_lock():
-            with self._connection() as connection:
+            force = force or self.transaction_recovery_path.exists()
+            with self.connection() as connection:
                 row = connection.execute(
                     """
                     SELECT reconciliation_required
@@ -293,15 +393,24 @@ class ArtifactStore:
                     WHERE id = 0
                     """
                 ).fetchone()
+                if force:
+                    connection.execute(
+                        """
+                        UPDATE blob_quota
+                        SET reconciliation_required = 1
+                        WHERE id = 0
+                        """
+                    )
             if (
                 os.name != "nt"
+                and not force
                 and row is not None
                 and not bool(row["reconciliation_required"])
             ):
                 return
 
             total = self._scan_blob_bytes_committed()
-            with self._connection() as connection:
+            with self.connection() as connection:
                 connection.execute(
                     """
                     INSERT INTO blob_quota (
@@ -316,9 +425,11 @@ class ArtifactStore:
                     """,
                     (total,),
                 )
+            if self.transaction_recovery_path.exists():
+                self._remove_transaction_recovery_marker()
 
     def _blob_bytes_committed(self) -> int:
-        with self._connection() as connection:
+        with self.connection() as connection:
             row = connection.execute(
                 """
                 SELECT size_bytes, reconciliation_required
@@ -340,7 +451,7 @@ class ArtifactStore:
         *,
         reconciliation_required: bool,
     ) -> None:
-        with self._connection() as connection:
+        with self.connection() as connection:
             cursor = connection.execute(
                 """
                 UPDATE blob_quota
@@ -354,7 +465,7 @@ class ArtifactStore:
             raise ArtifactIntegrityError("artifact store quota metadata is invalid")
 
     def _mark_blob_quota_reconciled(self) -> None:
-        with self._connection() as connection:
+        with self.connection() as connection:
             cursor = connection.execute(
                 """
                 UPDATE blob_quota
@@ -369,11 +480,21 @@ class ArtifactStore:
     def _exclusive_blob_lock(self) -> Iterator[None]:
         """Serialize quota accounting and blob publication across processes."""
 
-        with self.blob_lock_path.open("a+b") as lock_file:
-            _lock_file(lock_file)
+        if self._connection_state.blob_lock_depth:
+            self._connection_state.blob_lock_depth += 1
             try:
                 yield
             finally:
+                self._connection_state.blob_lock_depth -= 1
+            return
+
+        with self.blob_lock_path.open("a+b") as lock_file:
+            _lock_file(lock_file)
+            self._connection_state.blob_lock_depth = 1
+            try:
+                yield
+            finally:
+                self._connection_state.blob_lock_depth = 0
                 _unlock_file(lock_file)
 
     def _write_blob(self, data: bytes) -> str:
@@ -494,7 +615,7 @@ class ArtifactStore:
         return digest
 
     def _artifact_exists(self, artifact_uri: str) -> bool:
-        with self._connection() as connection:
+        with self.connection() as connection:
             row = connection.execute(
                 "SELECT 1 FROM artifacts WHERE artifact_uri = ?",
                 (artifact_uri,),
@@ -634,7 +755,7 @@ class ArtifactStore:
         self._write_blob(canonical_bytes)
         self._write_blob(manifest_bytes)
 
-        with self._connection() as connection:
+        with self.connection() as connection:
             connection.execute(
                 """
                 INSERT OR IGNORE INTO artifacts (
@@ -692,7 +813,7 @@ class ArtifactStore:
 
         manifest_digest = _digest_from_uri(artifact_uri)
         committed_references: set[str] = set()
-        with self._connection() as connection:
+        with self.connection() as connection:
             row = connection.execute(
                 "SELECT * FROM artifacts WHERE artifact_uri = ?",
                 (artifact_uri,),
@@ -780,7 +901,7 @@ class ArtifactStore:
     def find_by_object_digest(self, object_digest: str) -> tuple[str, ...]:
         """Return every artifact URI carrying a mathematical object digest."""
 
-        with self._connection() as connection:
+        with self.connection() as connection:
             rows = connection.execute(
                 """
                 SELECT artifact_uri

--- a/tests/checkers/test_matrix_checkers.py
+++ b/tests/checkers/test_matrix_checkers.py
@@ -228,6 +228,7 @@ def test_maximizer_witness_checker_rejects_nonmaximal_bound_candidate() -> None:
     assert decision["accepted"] is False
 
 
+@pytest.mark.slow
 def test_maximizer_witness_checker_replays_all_65536_matrices() -> None:
     matrix = {
         "rows": 4,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,10 +60,12 @@ def kernel_store_template(tmp_path_factory: pytest.TempPathFactory) -> Path:
 @pytest.fixture(scope="session")
 def kernel_store_template_with_references(
     tmp_path_factory: pytest.TempPathFactory,
+    kernel_store_template: Path,
 ) -> Path:
     """Build an immutable store that already has authorized references installed."""
 
     template = tmp_path_factory.mktemp("kernel-store-template-with-references")
+    shutil.copytree(kernel_store_template, template, dirs_exist_ok=True)
     kernel = JacobianKernel(template, install_references=True)
     del kernel
     _freeze_kernel_store(template)

--- a/tests/contract/test_pilot_invocation_examples.py
+++ b/tests/contract/test_pilot_invocation_examples.py
@@ -3,12 +3,16 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from jacobian.contracts.capabilities import CapabilityMode, CapabilityRequest
 from jacobian.contracts.results import ExecutionStatus
 from jacobian.kernel import JacobianKernel
 
 _ROOT = Path(__file__).parents[2]
 _PILOT = _ROOT / "benchmarks" / "example_cases" / "pilot.json"
+
+pytestmark = pytest.mark.usefixtures("initialized_kernel_store")
 
 _REQUIRED_CAPABILITIES = {
     "finite.coverage.verify",

--- a/tests/integration/domains/test_domain_math_capabilities.py
+++ b/tests/integration/domains/test_domain_math_capabilities.py
@@ -1,11 +1,15 @@
 from pathlib import Path
 
+import pytest
+
 from jacobian.contracts.capabilities import (
     CapabilityAssuranceLevel,
     CapabilityRequest,
 )
 from jacobian.contracts.results import ExecutionStatus
 from jacobian.kernel import JacobianKernel
+
+pytestmark = pytest.mark.usefixtures("initialized_kernel_store")
 
 
 def test_representative_exact_domain_results(tmp_path: Path) -> None:

--- a/tests/integration/domains/test_exact_domain_result_verification.py
+++ b/tests/integration/domains/test_exact_domain_result_verification.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from tests.helpers.rationals import rational_payload as _q
 
 from jacobian.contracts.capabilities import (
@@ -12,6 +13,8 @@ from jacobian.contracts.capabilities import (
 from jacobian.contracts.results import ExecutionStatus
 from jacobian.exact_domain_checkers import install_exact_domain_verification
 from jacobian.kernel import JacobianKernel
+
+pytestmark = pytest.mark.usefixtures("initialized_kernel_store")
 
 
 def _poly(*coefficients_ascending: int) -> dict[str, object]:

--- a/tests/integration/domains/test_geometry_capabilities.py
+++ b/tests/integration/domains/test_geometry_capabilities.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from jacobian.contracts.capabilities import (
     CapabilityAssuranceLevel,
     CapabilityRequest,
@@ -16,6 +18,8 @@ from jacobian.contracts.geometry import (
 from jacobian.contracts.results import ExecutionStatus
 from jacobian.domains.geometry import GEOMETRY_BUNDLE
 from jacobian.kernel import JacobianKernel
+
+pytestmark = pytest.mark.usefixtures("initialized_kernel_store")
 
 ZERO = {"num": "0", "den": "1"}
 ONE = {"num": "1", "den": "1"}

--- a/tests/integration/domains/test_number_theory_combinatorics_migration.py
+++ b/tests/integration/domains/test_number_theory_combinatorics_migration.py
@@ -30,6 +30,8 @@ from jacobian.operation_installation import OperationInstaller
 from jacobian.schema_registry import SchemaRegistry
 from jacobian.store import ArtifactStore
 
+pytestmark = pytest.mark.usefixtures("initialized_kernel_store")
+
 
 def _service(tmp_path: Path) -> CapabilityService:
     store = ArtifactStore(tmp_path)

--- a/tests/integration/domains/test_sequence_differences.py
+++ b/tests/integration/domains/test_sequence_differences.py
@@ -6,6 +6,8 @@ from jacobian.contracts.capabilities import CapabilityRequest
 from jacobian.contracts.results import ExecutionStatus
 from jacobian.kernel import JacobianKernel
 
+pytestmark = pytest.mark.usefixtures("initialized_kernel_store")
+
 
 @pytest.mark.parametrize(
     ("capability_id", "values"),

--- a/tests/integration/graph/test_chromatic_number.py
+++ b/tests/integration/graph/test_chromatic_number.py
@@ -16,6 +16,8 @@ from jacobian.contracts.capabilities import (
 from jacobian.contracts.results import ExecutionStatus
 from jacobian.kernel import JacobianKernel
 
+pytestmark = pytest.mark.usefixtures("initialized_kernel_store")
+
 
 def _invoke(
     kernel: JacobianKernel,

--- a/tests/integration/graph/test_graph_invariant_domain.py
+++ b/tests/integration/graph/test_graph_invariant_domain.py
@@ -2,9 +2,13 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from jacobian.contracts.capabilities import CapabilityRequest
 from jacobian.contracts.results import ExecutionStatus
 from jacobian.kernel import JacobianKernel
+
+pytestmark = pytest.mark.usefixtures("initialized_kernel_store")
 
 
 def _graph(

--- a/tests/integration/infrastructure/test_artifact_store.py
+++ b/tests/integration/infrastructure/test_artifact_store.py
@@ -14,11 +14,112 @@ import pytest
 from jacobian.canonical import CanonicalizationError
 from jacobian.store import (
     ArtifactIntegrityError,
+    ArtifactNotFoundError,
     ArtifactStore,
     StoreError,
     StoreLimitError,
     StoreLimits,
 )
+
+
+def test_transaction_commits_multiple_descriptors_together(tmp_path: Path) -> None:
+    store = ArtifactStore(tmp_path)
+
+    with store.transaction():
+        first = store.register_descriptor(
+            kind="schema",
+            name="example.first",
+            version="1",
+            definition={"type": "object"},
+        )
+        second = store.register_descriptor(
+            kind="semantics",
+            name="example.second",
+            version="1",
+            definition={"description": "second"},
+        )
+
+    assert (
+        store.get_descriptor(first, expected_kind="schema")["name"] == "example.first"
+    )
+    assert (
+        store.get_descriptor(second, expected_kind="semantics")["name"]
+        == "example.second"
+    )
+    assert not store.transaction_recovery_path.exists()
+
+
+def test_transactions_serialize_across_store_instances(tmp_path: Path) -> None:
+    first = ArtifactStore(tmp_path)
+    second = ArtifactStore(tmp_path)
+    writer_started = threading.Event()
+    writer_entered = threading.Event()
+
+    def write_from_second_store() -> None:
+        writer_started.set()
+        with second.transaction():
+            writer_entered.set()
+            second.register_descriptor(
+                kind="schema",
+                name="example.concurrent",
+                version="1",
+                definition={"type": "object"},
+            )
+
+    writer = threading.Thread(target=write_from_second_store)
+    with first.transaction():
+        first.register_descriptor(
+            kind="schema",
+            name="example.serialized",
+            version="1",
+            definition={"type": "object"},
+        )
+        writer.start()
+        assert writer_started.wait(timeout=5)
+        assert not writer_entered.wait(timeout=0.1)
+
+    writer.join(timeout=5)
+    assert not writer.is_alive()
+    assert writer_entered.is_set()
+
+
+def test_transaction_rolls_back_metadata_and_recovers_blob_accounting(
+    tmp_path: Path,
+) -> None:
+    store = ArtifactStore(tmp_path)
+    descriptor_uri = ""
+
+    with pytest.raises(RuntimeError, match="abort bootstrap"), store.transaction():
+        descriptor_uri = store.register_descriptor(
+            kind="schema",
+            name="example.rolled-back",
+            version="1",
+            definition={"type": "object"},
+        )
+        raise RuntimeError("abort bootstrap")
+
+    with pytest.raises(ArtifactNotFoundError):
+        store.get_descriptor(descriptor_uri, expected_kind="schema")
+
+    stored_blob_bytes = sum(
+        blob.stat().st_size
+        for prefix in store.blob_root.iterdir()
+        if prefix.is_dir()
+        for blob in prefix.iterdir()
+        if blob.is_file()
+    )
+    assert store._blob_bytes_committed() == stored_blob_bytes
+
+    committed = store.register_descriptor(
+        kind="schema",
+        name="example.after-rollback",
+        version="1",
+        definition={"type": "object"},
+    )
+    assert (
+        store.get_descriptor(committed, expected_kind="schema")["name"]
+        == "example.after-rollback"
+    )
 
 
 @pytest.mark.conformance
@@ -482,6 +583,48 @@ store._write_blob(sys.argv[2].encode("ascii"))
 
     assert reopened._blob_bytes_committed() == len(data)
     assert reopened._read_blob(digest) == data
+
+
+def test_store_open_recovers_process_death_during_store_transaction(
+    tmp_path: Path,
+) -> None:
+    ArtifactStore(tmp_path)
+    script = """
+import os
+import sys
+from jacobian.store import ArtifactStore
+
+store = ArtifactStore(sys.argv[1])
+with store.transaction():
+    store.register_descriptor(
+        kind="schema",
+        name="crashed.transaction",
+        version="1",
+        definition={"type": "object", "description": "published before crash"},
+    )
+    os._exit(0)
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script, str(tmp_path)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert (tmp_path / ".transaction-recovery").is_file()
+
+    reopened = ArtifactStore(tmp_path)
+    stored_blob_bytes = sum(
+        blob.stat().st_size
+        for prefix in reopened.blob_root.iterdir()
+        if prefix.is_dir()
+        for blob in prefix.iterdir()
+        if blob.is_file()
+    )
+
+    assert reopened._blob_bytes_committed() == stored_blob_bytes
+    assert not reopened.transaction_recovery_path.exists()
 
 
 @pytest.mark.skipif(

--- a/tests/integration/infrastructure/test_checker_artifacts.py
+++ b/tests/integration/infrastructure/test_checker_artifacts.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from jacobian.checker_artifacts import put_witness_envelope
 from jacobian.contracts.capabilities import CapabilityRequest
 from jacobian.contracts.evidence import (
@@ -13,6 +15,8 @@ from jacobian.contracts.evidence import (
 )
 from jacobian.kernel import JacobianKernel
 from jacobian.store import StoredArtifact
+
+pytestmark = pytest.mark.usefixtures("initialized_kernel_store")
 
 
 def _witness_schema_uri(kernel: JacobianKernel) -> str:

--- a/tests/integration/infrastructure/test_checker_registry.py
+++ b/tests/integration/infrastructure/test_checker_registry.py
@@ -96,6 +96,59 @@ def test_revoked_checker_cannot_authorize_new_verification(tmp_path: Path) -> No
     ]
 
 
+def test_checker_policy_lock_must_precede_store_transaction(tmp_path: Path) -> None:
+    store = ArtifactStore(tmp_path)
+    registry = CheckerRegistry(store)
+    checker = registry.authorize(
+        name="reject-all-v1",
+        entrypoint="jacobian_checkers.reject:check",
+        evidence_kind="WITNESS",
+        format_id="example.witness",
+        format_version="1",
+        claim_schema_uris=(CLAIM_SCHEMA_A,),
+        semantics_uris=(CLAIM_SCHEMA_A,),
+        candidate_schema_uris=(CLAIM_SCHEMA_A,),
+    )
+
+    with (
+        store.transaction(),
+        pytest.raises(
+            CheckerRegistryError,
+            match="policy must be locked before the store transaction",
+        ),
+    ):
+        registry.revoke(checker.checker_id, reason="wrong lock order")
+
+    with (
+        store.transaction(),
+        pytest.raises(
+            CheckerRegistryError,
+            match="policy must be locked before the store transaction",
+        ),
+        registry.verification_guard(
+            checker.checker_id,
+            expected_digest=checker.executable_digest,
+        ),
+    ):
+        pass
+
+    path_backed_registry = CheckerRegistry(store.db_path)
+    with (
+        store.transaction(),
+        pytest.raises(
+            CheckerRegistryError,
+            match="policy must be locked before the store transaction",
+        ),
+    ):
+        path_backed_registry.revoke(checker.checker_id, reason="wrong legacy order")
+
+    with registry.policy_transaction(), store.transaction():
+        registry.revoke(checker.checker_id, reason="ordered policy change")
+
+    with pytest.raises(CheckerRevokedError):
+        registry.require_active(checker.checker_id)
+
+
 def test_concurrent_duplicate_authorize_is_serialized(tmp_path: Path) -> None:
     registry = CheckerRegistry(ArtifactStore(tmp_path).db_path)
     barrier = threading.Barrier(8)

--- a/tests/integration/infrastructure/test_operation_installation.py
+++ b/tests/integration/infrastructure/test_operation_installation.py
@@ -27,6 +27,8 @@ from jacobian.operations import (
 )
 from jacobian.provider_runtime import known_provider_runtime
 
+pytestmark = pytest.mark.usefixtures("initialized_kernel_store")
+
 
 class _SyntheticRequest(ContractModel):
     value: int = Field(ge=0, le=100)

--- a/tests/integration/matrix/test_matrix_capabilities.py
+++ b/tests/integration/matrix/test_matrix_capabilities.py
@@ -22,6 +22,8 @@ from jacobian.matrix_determinant_capabilities import (
     install_matrix_determinant_checker,
 )
 
+pytestmark = pytest.mark.usefixtures("initialized_kernel_store")
+
 
 def _rational(value: int | Fraction) -> dict[str, str]:
     exact = Fraction(value)

--- a/tests/integration/matrix/test_matrix_lattice_domain.py
+++ b/tests/integration/matrix/test_matrix_lattice_domain.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from pytest import MonkeyPatch
 from tests.helpers.rationals import rational_payload as _q
 
@@ -24,6 +25,8 @@ from jacobian.domains.matrix_lattice.lattice import reduce_lattice_basis
 from jacobian.domains.matrix_lattice.operations import compute_smith_normal_form
 from jacobian.kernel import JacobianKernel
 from jacobian.operations import ComputedSuccess, OperationExecutionFailure
+
+pytestmark = pytest.mark.usefixtures("initialized_kernel_store")
 
 
 def _qq(rows: list[list[int]]) -> dict[str, object]:

--- a/tests/integration/polynomial/test_elementary_polynomial_domain.py
+++ b/tests/integration/polynomial/test_elementary_polynomial_domain.py
@@ -1,8 +1,12 @@
 from pathlib import Path
 
+import pytest
+
 from jacobian.contracts.capabilities import CapabilityRequest
 from jacobian.contracts.results import ExecutionStatus
 from jacobian.kernel import JacobianKernel
+
+pytestmark = pytest.mark.usefixtures("initialized_kernel_store")
 
 
 def _polynomial(

--- a/tests/integration/polynomial/test_polynomial_operation_bundle.py
+++ b/tests/integration/polynomial/test_polynomial_operation_bundle.py
@@ -12,6 +12,8 @@ from jacobian.contracts.capabilities import (
 from jacobian.contracts.results import ExecutionStatus
 from jacobian.kernel import JacobianKernel
 
+pytestmark = pytest.mark.usefixtures("initialized_kernel_store")
+
 
 def _polynomial(
     variables: list[str],

--- a/tests/integration/sat_smt/test_cadical_external_backend.py
+++ b/tests/integration/sat_smt/test_cadical_external_backend.py
@@ -12,6 +12,7 @@ from jacobian.provider_runtime import CADICAL_VERSION, cadical_provider_runtime
 
 pytestmark = [
     pytest.mark.external_backend,
+    pytest.mark.usefixtures("initialized_kernel_store"),
     pytest.mark.skipif(
         shutil.which("cadical") is None,
         reason="CaDiCaL is not installed",

--- a/tests/reference/test_erdos_straus_plugin.py
+++ b/tests/reference/test_erdos_straus_plugin.py
@@ -32,6 +32,7 @@ def test_validate_bounded_range() -> None:
     assert validate_candidate(_candidate(2, 10_001))
 
 
+@pytest.mark.slow
 def test_evaluate_finds_every_decomposition_through_1000() -> None:
     response = evaluate_capability(
         {

--- a/tests/unit/test_graph_atlas.py
+++ b/tests/unit/test_graph_atlas.py
@@ -30,6 +30,7 @@ def test_graph_atlas_is_built_once_and_cached_as_frozen_graphs(
     assert all(nx.is_frozen(graph) for graph in first)
 
 
+@pytest.mark.slow
 def test_gallai_edmonds_barrier_certifies_every_graph_through_order_seven() -> None:
     for indexed_graph in nx.graph_atlas_g():
         graph = nx.relabel_nodes(


### PR DESCRIPTION
## Problem

`JacobianKernel` eagerly registered hundreds of schemas and capabilities with
one SQLite transaction and filesystem sync per artifact. A fresh core kernel
took 31.6 seconds locally, repeated test kernels dominated the development
loop, and `make test-fast` included several exhaustive cases.

The routine handoff path also omitted mypy, had no pre-push gate, and scanned
unrelated local Markdown notes through Ruff.

## Solution

- Cache exact Draft 2020-12 schema checks and compiled validators per process.
- Install the capability portfolio through one `BEGIN IMMEDIATE` store
  transaction while retaining normal durability for non-bootstrap writes.
- Preserve crash-safe blob quota accounting with a durable recovery marker.
- Establish checker-policy → blob-quota → SQLite lock ordering and reject
  reverse-order policy operations.
- Reuse the core fixture when building the reference template and seed the
  remaining ordinary integration callers from immutable templates.
- Mark the three exhaustive matrix, Erdős–Straus, and graph-atlas cases
  `slow`, and exclude that marker from `make test-fast`.
- Add mypy to `make check`, add `make precommit`, and install a `make check`
  pre-push hook.

Measured locally before the final concurrency hardening:

| Workload | Before | After |
| --- | ---: | ---: |
| Fresh core kernel | 31.6 s | 13.0 s |
| Copied core snapshot | ~4.1 s | 0.79 s |
| `make test-fast` wall time | 237.91 s | 56.55 s |

These are single-host observations, not timing gates.

## Testing

- `uv run --locked mypy` — 285 source files passed.
- `uv run --locked pytest -n 0 tests/integration/infrastructure/test_checker_registry.py -k policy_lock` — passed.
- `uv run --locked pytest -n 0 tests/integration/infrastructure/test_artifact_store.py -k 'transaction or process_death'` — 6 passed.
- `uv run --locked pre-commit validate-config .pre-commit-config.yaml` — passed.
- Earlier fast-lane run: 591 passed, 3 deselected in 52.10 seconds.
- Final `make check`: Ruff, formatting, and mypy passed; pytest reached
  589 passed and 3 deselected, with two existing 100 ms subprocess-timeout
  tests failing to create their marker files on the contended host.

## Trust & Compatibility Impact

Artifact formats and verification assurance semantics are unchanged. Bootstrap
metadata is now atomic. Blob accounting recovers after process death, and
checker authorization retains its cross-process exclusion guarantee through an
explicit lock order.

Suggested review order:

1. `src/jacobian/store.py` and its crash/concurrency tests.
2. `src/jacobian/registry.py` and checker lock-order tests.
3. `src/jacobian/kernel.py` and schema-validation caching.
4. Fixture, lane, and developer-workflow changes.

## Checklist

- [ ] Routine local validation passes (`make check`)
- [x] Relevant focused tests are listed above
