### PR TITLE
docs: add Cursor Cloud environment setup notes to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,3 +94,36 @@ checker authorization out of plugins and search code.
   unrelated kernel startup and catalog entries remain available.
 - Keep `deep_review.md` local; it is ignored and is not design source material.
 - Keep worked cases in reference scenarios and benchmarks.
+
+## Cursor Cloud specific instructions
+
+This is a Python 3.12 project managed with `uv`; the base image ships Python 3.12
+and Node but not `uv`. The startup update script installs `uv` (to
+`~/.local/bin`, added to `PATH` via `.bashrc`/`.profile`) and runs
+`uv sync --locked --dev`, so dependencies (including the `flint`/`smt` dev-group
+backends `python-flint`, `cvc5`, `z3-solver`) are already installed when a
+session starts. Standard dev, test, lint, and build commands live in the
+`Makefile` (`make help`) and `CONTRIBUTING.md`; use those rather than duplicating
+them.
+
+Non-obvious caveats:
+
+- If a fresh non-login shell can't find `uv`, run `export PATH="$HOME/.local/bin:$PATH"`.
+- Optional backends are absent by default and their capabilities are correctly
+  omitted: `lean.check` prints `lean.check is not installed` on `init`/startup
+  (the pinned Lean 4.31.0 toolchain is not installed), and external solver
+  executables (`cadical`, `drat-trim`, `carcara`) are not on `PATH`. This does
+  not break the kernel, catalog, or the core test suites. Only install Lean/elan
+  or those executables when specifically exercising `lean_runtime` tests or SAT
+  proof-artifact capabilities.
+- `make test-fast` is the quick core loop; `make check` (lint + typecheck +
+  test-fast) is the pre-push gate. Never run bare `uv run pytest` across the whole
+  suite — it mixes `lean_runtime` tests into the xdist pool and pytest rejects it;
+  use the `make test-*` targets instead.
+- Quick end-to-end smoke of the product surface: `uv run jacobian --state-dir .jacobian init`
+  (CLI), or start the MCP server with
+  `uv run jacobian-mcp --transport streamable-http --host 127.0.0.1 --port 8000 --allow-anonymous`
+  (remote transports require `--allow-anonymous` or `--auth-tokens-file`; stdio is
+  the default transport). The runnable
+  `docs/tutorials/first-verified-result.md` script exercises the full
+  find-then-independently-verify flow.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the Cursor Cloud development environment for Jacobian, and records durable, non-obvious startup guidance for future cloud agents in `AGENTS.md`.

This is a Python 3.12 project managed with `uv`. The base VM ships Python 3.12 and Node but not `uv`, so the configured startup update script installs `uv` and runs `uv sync --locked --dev`.

## Update script (startup dependency refresh)

```sh
[ -x "$HOME/.local/bin/uv" ] || curl -LsSf https://astral.sh/uv/install.sh | sh
"$HOME/.local/bin/uv" sync --locked --dev
```

Minimal, idempotent, and self-healing (reinstalls `uv` only if the binary is absent). `python-flint`, `cvc5`, and `z3-solver` come in via the dev group, so exact-linear-algebra / SMT / SAT-via-Z3 capabilities work out of the box.

## Verification performed

| Step | Command | Result |
| --- | --- | --- |
| Install deps | `uv sync --locked --dev` | 101 packages installed |
| Lint | `make lint` | All checks passed; 486 files formatted |
| Typecheck | `make typecheck` | No issues in 283 source files |
| Tests | `make test-fast` | 593 passed, 3 deselected |
| Build | `make build` | sdist + wheel built |
| CLI | `uv run jacobian --state-dir .jacobian init` | State initialized, catalog printed |
| MCP server | `uv run jacobian-mcp --transport streamable-http --allow-anonymous` | Boots on `:8000`, responds to `initialize` |
| End-to-end | `docs/tutorials/first-verified-result.md` | `evaluation: FALSE HEURISTIC` → `verification: FALSE VERIFIED` |

The hello-world exercises the core find-then-independently-verify flow: search produces heuristic `FALSE`, then an authorized independent checker promotes it to `FALSE · VERIFIED` bound to a content-addressed witness artifact.

Optional backends (Lean toolchain, `cadical`/`drat-trim`/`carcara`) are intentionally absent; their capabilities are correctly omitted without affecting kernel startup or the core suites.

## Changes

- `AGENTS.md`: added a `## Cursor Cloud specific instructions` section with startup caveats (uv/PATH, absent optional backends, correct `make test-*` usage, smoke-test commands).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5dec12ad-02ef-432a-9b06-c40c6629f996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5dec12ad-02ef-432a-9b06-c40c6629f996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

