### PR TITLE
fix(ci): repair CI plan bugs and tighten developer/test DX

### DIFF
--- a/.github/actions/setup-lean/action.yml
+++ b/.github/actions/setup-lean/action.yml
@@ -34,7 +34,7 @@ runs:
           echo "| Toolchain and Mathlib cache | $duration |"
         } >> "$GITHUB_STEP_SUMMARY"
     - name: Set up Python
-      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: "3.12"
     - name: Set up uv

--- a/.github/ci-config.json
+++ b/.github/ci-config.json
@@ -1,0 +1,3 @@
+{
+  "integration_shard_count": 4
+}

--- a/.github/ci-impact.json
+++ b/.github/ci-impact.json
@@ -85,8 +85,23 @@
     },
     {
       "name": "repository-policy",
-      "patterns": ["AGENTS.md", ".pre-commit-config.yaml", ".jscpd.json"],
+      "patterns": [
+        "AGENTS.md",
+        "CONTRIBUTING.md",
+        ".pre-commit-config.yaml",
+        ".jscpd.json"
+      ],
       "suites": ["core", "integration", "lean", "npm", "static", "build", "security", "duplicate"]
+    },
+    {
+      "name": "test-support",
+      "patterns": ["tests/helpers/**", "tests/conftest.py"],
+      "suites": ["core", "integration", "static"]
+    },
+    {
+      "name": "benchmarks",
+      "patterns": ["benchmarks/**"],
+      "suites": ["core", "integration", "static", "build"]
     }
   ],
   "fallback": {

--- a/.github/ci-impact.json
+++ b/.github/ci-impact.json
@@ -28,11 +28,7 @@
     },
     {
       "name": "lean-python-tests",
-      "patterns": [
-        "tests/integration/lean/test_lean.py",
-        "tests/integration/lean/test_lean_proof_edit.py",
-        "tests/integration/lean/test_lean_exploration_capabilities.py"
-      ],
+      "patterns": ["tests/integration/lean/**"],
       "suites": ["lean", "static"]
     },
     {
@@ -80,6 +76,7 @@
         ".github/scripts/**",
         ".github/workflows/**",
         ".github/ci-impact.json",
+        ".github/ci-config.json",
         "pyproject.toml",
         "uv.lock",
         "Makefile"

--- a/.github/scripts/manage-test-timings
+++ b/.github/scripts/manage-test-timings
@@ -15,6 +15,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+ROOT = Path(__file__).resolve().parents[2]
+CONFIG = ROOT / ".github" / "ci-config.json"
 ARTIFACT_NAME = "integration-test-durations"
 ARTIFACT_FILE = "integration-test-durations.json"
 MAX_BYTES = 5 * 1024 * 1024
@@ -22,6 +24,14 @@ MAX_ENTRIES = 10_000
 MAX_CANDIDATES = 5
 HTTP_TIMEOUT_SECONDS = 10
 TEST_ROOTS = ("tests/integration/", "tests/end_to_end/")
+
+
+def integration_shard_count() -> int:
+    payload = json.loads(CONFIG.read_text(encoding="utf-8"))
+    count = payload.get("integration_shard_count")
+    if not isinstance(count, int) or isinstance(count, bool) or count < 1:
+        raise ValueError("integration_shard_count must be a positive integer")
+    return count
 
 
 def warning(message: str) -> None:
@@ -114,7 +124,7 @@ def artifact_durations(
     if (
         payload.get("version") != 1
         or payload.get("suite") != "integration"
-        or payload.get("shard_count") != 4
+        or payload.get("shard_count") != integration_shard_count()
     ):
         raise ValueError("timing artifact metadata is incompatible")
     return validate_durations(payload.get("durations"), ARTIFACT_FILE)
@@ -179,8 +189,11 @@ def merge(
     python_version: str,
     pytest_split_version: str,
 ) -> None:
-    if len(inputs) != 4:
-        raise ValueError(f"expected 4 shard timing files, received {len(inputs)}")
+    shard_count = integration_shard_count()
+    if len(inputs) != shard_count:
+        raise ValueError(
+            f"expected {shard_count} shard timing files, received {len(inputs)}"
+        )
     merged: dict[str, float] = {}
     for path in inputs:
         payload = load_json_bytes(path.read_bytes(), str(path))
@@ -197,7 +210,7 @@ def merge(
         "source_sha": source_sha,
         "generated_at": datetime.now(UTC).isoformat(),
         "python_version": python_version,
-        "shard_count": 4,
+        "shard_count": shard_count,
         "pytest_split_version": pytest_split_version,
         "durations": dict(sorted(merged.items())),
     }

--- a/.github/scripts/validate-ci-plan
+++ b/.github/scripts/validate-ci-plan
@@ -18,6 +18,9 @@ BOOLEAN_KEYS = (
     "run-security",
     "run-duplicate",
 )
+FUNCTIONAL_KEYS = tuple(
+    key for key in BOOLEAN_KEYS if key not in {"run-coverage", "run-compatibility"}
+)
 CLASSIFICATIONS = {
     "docs",
     "npm",
@@ -32,6 +35,82 @@ CLASSIFICATIONS = {
 
 def fail(message: str) -> None:
     raise SystemExit(message)
+
+
+def _enabled(plan: dict[str, str], *keys: str) -> bool:
+    return all(plan[key] == "true" for key in keys)
+
+
+def _only_enabled(plan: dict[str, str], *allowed: str) -> bool:
+    allowed_set = set(allowed)
+    return all(
+        (plan[key] == "true") == (key in allowed_set) for key in BOOLEAN_KEYS
+    )
+
+
+def _validate_classification(plan: dict[str, str]) -> None:
+    classification = plan["classification"]
+    if classification == "docs":
+        if any(plan[key] == "true" for key in BOOLEAN_KEYS):
+            fail("docs CI must disable every lane")
+        return
+    if classification == "npm":
+        if not _only_enabled(plan, "run-npm"):
+            fail("npm CI must enable only run-npm")
+        return
+    if classification == "lean":
+        if not _only_enabled(plan, "run-lean"):
+            fail("lean CI must enable only run-lean")
+        return
+    if classification == "python-core":
+        if plan["run-core"] != "true" or plan["run-python"] != "true":
+            fail("python-core CI must enable run-core and run-python")
+        for key in (
+            "run-integration",
+            "run-coverage",
+            "run-compatibility",
+            "run-lean",
+            "run-npm",
+            "run-build",
+            "run-security",
+            "run-duplicate",
+        ):
+            if plan[key] == "true":
+                fail(f"python-core CI must disable {key}")
+        return
+    if classification == "python-integration":
+        if plan["run-integration"] != "true" or plan["run-python"] != "true":
+            fail("python-integration CI must enable run-integration and run-python")
+        for key in (
+            "run-core",
+            "run-coverage",
+            "run-compatibility",
+            "run-lean",
+            "run-npm",
+            "run-build",
+            "run-security",
+            "run-duplicate",
+        ):
+            if plan[key] == "true":
+                fail(f"python-integration CI must disable {key}")
+        return
+    if classification == "full":
+        if any(plan[key] != "true" for key in FUNCTIONAL_KEYS):
+            fail("full CI must enable every functional lane")
+        if plan["run-coverage"] == "true" or plan["run-compatibility"] == "true":
+            fail("full CI must leave coverage and compatibility to exhaustive")
+        return
+    if classification == "selective":
+        if not any(plan[key] == "true" for key in FUNCTIONAL_KEYS):
+            fail("selective CI must enable at least one functional lane")
+        if _enabled(plan, *FUNCTIONAL_KEYS) and not (
+            plan["run-coverage"] == "true" or plan["run-compatibility"] == "true"
+        ):
+            fail("selective CI must not match the full functional lane set")
+        return
+    if classification == "exhaustive":
+        return
+    fail(f"unhandled CI classification: {classification}")
 
 
 def main() -> None:
@@ -67,6 +146,7 @@ def main() -> None:
             fail("exhaustive CI must enable every lane")
     elif plan["run-coverage"] == "true" or plan["run-compatibility"] == "true":
         fail("coverage and compatibility are exhaustive-only lanes")
+    _validate_classification(plan)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,28 @@ jobs:
       run-build: ${{ steps.classify.outputs.run-build }}
       run-security: ${{ steps.classify.outputs.run-security }}
       run-duplicate: ${{ steps.classify.outputs.run-duplicate }}
+      integration-shard-count: ${{ steps.shards.outputs.integration-shard-count }}
+      integration-shards: ${{ steps.shards.outputs.integration-shards }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
+      - id: shards
+        name: Load integration shard configuration
+        run: |
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          from pathlib import Path
+
+          count = json.loads(Path(".github/ci-config.json").read_text(encoding="utf-8"))[
+              "integration_shard_count"
+          ]
+          if not isinstance(count, int) or isinstance(count, bool) or count < 1:
+              raise SystemExit("integration_shard_count must be a positive integer")
+          print(f"integration-shard-count={count}")
+          print(f"integration-shards={json.dumps(list(range(1, count + 1)))}")
+          PY
       - name: Prepare integration timing hint
         env:
           GH_TOKEN: ${{ github.token }}
@@ -106,7 +123,17 @@ jobs:
           PLAN_RESULT: ${{ needs.plan.result }}
           RUN_STATIC: ${{ needs.plan.outputs.run-static }}
         run: |
-          test "$PLAN_RESULT" = "success"
+          case "$PLAN_RESULT" in
+            success) ;;
+            cancelled)
+              echo "Upstream plan was cancelled; treating gate as non-failure"
+              exit 0
+              ;;
+            *)
+              echo "Upstream plan did not succeed: $PLAN_RESULT"
+              exit 1
+              ;;
+          esac
           case "$RUN_STATIC" in
             true|false) ;;
             *) exit 1 ;;
@@ -219,7 +246,7 @@ jobs:
 
   integration-test:
     name: >-
-      Tests (integration ${{ matrix.shard }} of 4,
+      Tests (integration ${{ matrix.shard }} of ${{ needs.plan.outputs.integration-shard-count }},
       Python 3.12)
     needs: plan
     if: needs.plan.outputs.run-integration == 'true'
@@ -228,7 +255,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: ${{ fromJSON(needs.plan.outputs.integration-shards) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Download integration timing hint
@@ -242,7 +269,7 @@ jobs:
       - run: make test-integration
         env:
           PYTEST_ARGS: >-
-            --splits 4
+            --splits ${{ needs.plan.outputs.integration-shard-count }}
             --group ${{ matrix.shard }}
             --splitting-algorithm least_duration
             --durations-path .ci/test-durations.json
@@ -280,7 +307,7 @@ jobs:
   publish-test-durations:
     name: Publish integration test durations
     if: github.ref == 'refs/heads/main'
-    needs: integration-test
+    needs: [plan, integration-test]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -291,16 +318,19 @@ jobs:
           pattern: integration-duration-shard-*
           path: .ci/shards
       - name: Merge shard timings
-        run: >-
-          .github/scripts/manage-test-timings merge
-          --input .ci/shards/integration-duration-shard-1/test-durations.json
-          --input .ci/shards/integration-duration-shard-2/test-durations.json
-          --input .ci/shards/integration-duration-shard-3/test-durations.json
-          --input .ci/shards/integration-duration-shard-4/test-durations.json
-          --output .ci/integration-test-durations.json
-          --source-sha "${{ github.sha }}"
-          --python-version "3.12"
-          --pytest-split-version "0.11.0"
+        env:
+          SHARD_COUNT: ${{ needs.plan.outputs.integration-shard-count }}
+        run: |
+          inputs=()
+          for shard in $(seq 1 "$SHARD_COUNT"); do
+            inputs+=(--input ".ci/shards/integration-duration-shard-${shard}/test-durations.json")
+          done
+          .github/scripts/manage-test-timings merge \
+            "${inputs[@]}" \
+            --output .ci/integration-test-durations.json \
+            --source-sha "${{ github.sha }}" \
+            --python-version "3.12" \
+            --pytest-split-version "0.11.0"
       - name: Publish timing hint
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -351,7 +381,17 @@ jobs:
           INTEGRATION_RESULT: ${{ needs.integration-test.result }}
           COMPATIBILITY_RESULT: ${{ needs.compatibility-test.result }}
         run: |
-          test "$PLAN_RESULT" = "success"
+          case "$PLAN_RESULT" in
+            success) ;;
+            cancelled)
+              echo "Upstream plan was cancelled; treating gate as non-failure"
+              exit 0
+              ;;
+            *)
+              echo "Upstream plan did not succeed: $PLAN_RESULT"
+              exit 1
+              ;;
+          esac
           case "$RUN_PYTHON" in
             true|false) ;;
             *) exit 1 ;;
@@ -407,7 +447,17 @@ jobs:
           RUN_LEAN: ${{ needs.plan.outputs.run-lean }}
           LEAN_RESULT: ${{ needs.lean-test-run.result }}
         run: |
-          test "$PLAN_RESULT" = "success"
+          case "$PLAN_RESULT" in
+            success) ;;
+            cancelled)
+              echo "Upstream plan was cancelled; treating gate as non-failure"
+              exit 0
+              ;;
+            *)
+              echo "Upstream plan did not succeed: $PLAN_RESULT"
+              exit 1
+              ;;
+          esac
           case "$RUN_LEAN" in
             true) test "$LEAN_RESULT" = "success" ;;
             false) test "$LEAN_RESULT" = "skipped" ;;
@@ -431,7 +481,17 @@ jobs:
           CORE_RESULT: ${{ needs.core-test.result }}
           INTEGRATION_RESULT: ${{ needs.integration-test.result }}
         run: |
-          test "$PLAN_RESULT" = "success"
+          case "$PLAN_RESULT" in
+            success) ;;
+            cancelled)
+              echo "Upstream plan was cancelled; treating gate as non-failure"
+              exit 0
+              ;;
+            *)
+              echo "Upstream plan did not succeed: $PLAN_RESULT"
+              exit 1
+              ;;
+          esac
           case "$RUN_COVERAGE" in
             true|false) ;;
             *) exit 1 ;;
@@ -491,23 +551,29 @@ jobs:
             echo "Duplicate code detection via jscpd (threshold 10)."
           } > coverage-summary.md
           jq -n --rawfile body coverage-summary.md '{body: $body}' > coverage-comment.json
-          mapfile -t comment_ids < <(
+          list_coverage_comments() {
             gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" --paginate \
               --jq '.[] | select(.user.login == "github-actions[bot]") | select((.body | contains("<!-- jacobian-coverage-report -->")) or (.body | startswith("## Coverage Report"))) | .id'
-          )
+          }
+          mapfile -t comment_ids < <(list_coverage_comments)
           if [ "${#comment_ids[@]}" -eq 0 ]; then
             gh api --method POST \
               "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
               --input coverage-comment.json
-          else
-            gh api --method PATCH \
-              "repos/$GITHUB_REPOSITORY/issues/comments/${comment_ids[0]}" \
-              --input coverage-comment.json
-            for duplicate_id in "${comment_ids[@]:1}"; do
-              gh api --method DELETE \
-                "repos/$GITHUB_REPOSITORY/issues/comments/$duplicate_id"
-            done
+            # Heal TOCTOU races where a concurrent run also created a comment.
+            mapfile -t comment_ids < <(list_coverage_comments)
           fi
+          if [ "${#comment_ids[@]}" -eq 0 ]; then
+            echo "failed to create or locate coverage comment" >&2
+            exit 1
+          fi
+          gh api --method PATCH \
+            "repos/$GITHUB_REPOSITORY/issues/comments/${comment_ids[0]}" \
+            --input coverage-comment.json
+          for duplicate_id in "${comment_ids[@]:1}"; do
+            gh api --method DELETE \
+              "repos/$GITHUB_REPOSITORY/issues/comments/$duplicate_id"
+          done
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -529,7 +595,17 @@ jobs:
           PLAN_RESULT: ${{ needs.plan.result }}
           RUN_DUPLICATE: ${{ needs.plan.outputs.run-duplicate }}
         run: |
-          test "$PLAN_RESULT" = "success"
+          case "$PLAN_RESULT" in
+            success) ;;
+            cancelled)
+              echo "Upstream plan was cancelled; treating gate as non-failure"
+              exit 0
+              ;;
+            *)
+              echo "Upstream plan did not succeed: $PLAN_RESULT"
+              exit 1
+              ;;
+          esac
           case "$RUN_DUPLICATE" in
             true|false) ;;
             *) exit 1 ;;
@@ -555,7 +631,17 @@ jobs:
           PLAN_RESULT: ${{ needs.plan.result }}
           RUN_NPM: ${{ needs.plan.outputs.run-npm }}
         run: |
-          test "$PLAN_RESULT" = "success"
+          case "$PLAN_RESULT" in
+            success) ;;
+            cancelled)
+              echo "Upstream plan was cancelled; treating gate as non-failure"
+              exit 0
+              ;;
+            *)
+              echo "Upstream plan did not succeed: $PLAN_RESULT"
+              exit 1
+              ;;
+          esac
           case "$RUN_NPM" in
             true|false) ;;
             *) exit 1 ;;
@@ -586,7 +672,17 @@ jobs:
           PLAN_RESULT: ${{ needs.plan.result }}
           RUN_BUILD: ${{ needs.plan.outputs.run-build }}
         run: |
-          test "$PLAN_RESULT" = "success"
+          case "$PLAN_RESULT" in
+            success) ;;
+            cancelled)
+              echo "Upstream plan was cancelled; treating gate as non-failure"
+              exit 0
+              ;;
+            *)
+              echo "Upstream plan did not succeed: $PLAN_RESULT"
+              exit 1
+              ;;
+          esac
           case "$RUN_BUILD" in
             true|false) ;;
             *) exit 1 ;;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   merge_group:
     types: [checks_requested]
 
@@ -140,6 +141,8 @@ jobs:
           esac
       - if: needs.plan.outputs.run-static == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - if: needs.plan.outputs.run-static == 'true'
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -157,35 +160,55 @@ jobs:
         run: make lint-full
       - if: needs.plan.outputs.run-static == 'true'
         run: make typecheck
-      - name: Check TODO comments reference issues
-        if: needs.plan.outputs.run-static == 'true'
-        run: |
-          violations="$(rg --pcre2 -n 'TODO(?!\(#\d+\))' --type py src/ tests/ || true)"
-          if [ -n "$violations" ]; then
-            echo "::error::TODOs must reference an issue: TODO(#123)"
-            echo "$violations"
-            exit 1
-          fi
+      - if: needs.plan.outputs.run-static == 'true'
+        run: make todo-check
 
   security-audit:
     name: Security Audit
     needs: plan
-    if: needs.plan.outputs.run-security == 'true'
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      - name: Require a valid security-audit plan
+        env:
+          PLAN_RESULT: ${{ needs.plan.result }}
+          RUN_SECURITY: ${{ needs.plan.outputs.run-security }}
+        run: |
+          case "$PLAN_RESULT" in
+            success) ;;
+            cancelled)
+              echo "Upstream plan was cancelled; treating gate as non-failure"
+              exit 0
+              ;;
+            *)
+              echo "Upstream plan did not succeed: $PLAN_RESULT"
+              exit 1
+              ;;
+          esac
+          case "$RUN_SECURITY" in
+            true|false) ;;
+            *) exit 1 ;;
+          esac
+      - if: needs.plan.outputs.run-security == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - if: needs.plan.outputs.run-security == 'true'
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
-      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+      - if: needs.plan.outputs.run-security == 'true'
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
           cache-dependency-glob: |
             pyproject.toml
             uv.lock
-      - run: uv sync --locked --dev
-      - run: make security-audit
+      - if: needs.plan.outputs.run-security == 'true'
+        run: uv sync --locked --dev
+      - if: needs.plan.outputs.run-security == 'true'
+        run: make security-audit
 
   validate-agents-md:
     name: Validate Built Package
@@ -217,6 +240,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-python-tests
         with:
           python-version: "3.12"
@@ -258,6 +283,8 @@ jobs:
         shard: ${{ fromJSON(needs.plan.outputs.integration-shards) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Download integration timing hint
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -312,6 +339,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Download shard timings
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -347,6 +376,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-python-tests
         with:
           python-version: "3.13"
@@ -420,6 +451,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Prepare Lean test environment
         uses: ./.github/actions/setup-lean
       - name: Run Lean tests
@@ -478,6 +511,8 @@ jobs:
         env:
           PLAN_RESULT: ${{ needs.plan.result }}
           RUN_COVERAGE: ${{ needs.plan.outputs.run-coverage }}
+          RUN_CORE: ${{ needs.plan.outputs.run-core }}
+          RUN_INTEGRATION: ${{ needs.plan.outputs.run-integration }}
           CORE_RESULT: ${{ needs.core-test.result }}
           INTEGRATION_RESULT: ${{ needs.integration-test.result }}
         run: |
@@ -496,12 +531,24 @@ jobs:
             true|false) ;;
             *) exit 1 ;;
           esac
+          case "$RUN_CORE" in
+            true) test "$CORE_RESULT" = "success" ;;
+            false) test "$CORE_RESULT" = "skipped" ;;
+            *) exit 1 ;;
+          esac
+          case "$RUN_INTEGRATION" in
+            true) test "$INTEGRATION_RESULT" = "success" ;;
+            false) test "$INTEGRATION_RESULT" = "skipped" ;;
+            *) exit 1 ;;
+          esac
           if [ "$RUN_COVERAGE" = "true" ]; then
             test "$CORE_RESULT" = "success"
             test "$INTEGRATION_RESULT" = "success"
           fi
       - if: needs.plan.outputs.run-coverage == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - if: needs.plan.outputs.run-coverage == 'true'
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -612,6 +659,8 @@ jobs:
           esac
       - if: needs.plan.outputs.run-duplicate == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - if: needs.plan.outputs.run-duplicate == 'true'
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -648,6 +697,8 @@ jobs:
           esac
       - if: needs.plan.outputs.run-npm == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - if: needs.plan.outputs.run-npm == 'true'
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -689,6 +740,8 @@ jobs:
           esac
       - if: needs.plan.outputs.run-build == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - if: needs.plan.outputs.run-build == 'true'
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:

--- a/.github/workflows/python-debug.yml
+++ b/.github/workflows/python-debug.yml
@@ -34,19 +34,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      - uses: ./.github/actions/setup-python-tests
         with:
           python-version: ${{ inputs.python-version }}
-      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
-        with:
-          enable-cache: true
-          cache-dependency-glob: |
-            pyproject.toml
-            uv.lock
-      - run: uv sync --locked --dev
       - name: Run focused Python test
         env:
           TEST_SELECTOR: ${{ inputs.pytest-selector }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,8 @@ Non-obvious caveats:
 - `make test-fast` is the quick core loop; `make check` (lint + typecheck +
   test-fast) is the pre-push gate. Never run bare `uv run pytest` across the whole
   suite — it mixes `lean_runtime` tests into the xdist pool and pytest rejects it;
-  use the `make test-*` targets instead.
+  use the `make test-*` targets instead. Parallel xdist is enabled by Make
+  targets (`test`, `test-core`, `test-integration`), not by global pytest addopts.
 - Quick end-to-end smoke of the product surface: `uv run jacobian --state-dir .jacobian init`
   (CLI), or start the MCP server with
   `uv run jacobian-mcp --transport streamable-http --host 127.0.0.1 --port 8000 --allow-anonymous`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,18 +23,21 @@ make setup
 make test-fast
 ```
 
-`make test-fast` is the short non-integration feedback loop; it excludes tests
-explicitly marked `slow`. Run `make check` before pushing; it performs fast
-Ruff, strict typing, and non-integration test checks. Push after that check and
-let CI own dependency and dead-code analysis, package builds, the full Python
-matrix, integration, end-to-end, coverage, and real-Lean validation.
-`make check-static` reproduces the
-CI-owned static and package checks when a focused change needs them.
-`make validate-full` is the broadest local Python, Lean, static, and package
-validation target. It does not reproduce CI's Python 3.13 compatibility,
-combined coverage, security, duplicate-code, or npm lanes. Run `make help` for
-focused commands. The measured costs and reasoning behind these lanes are
-recorded in the
+`make test-fast` is the short sequential non-integration feedback loop; it
+excludes tests explicitly marked `slow`. `make test-core` runs the same core
+directories with default xdist parallelism and includes `slow` cases; CI's core
+lane uses that target. Run `make check` before pushing; it performs fast Ruff,
+strict typing, and `test-fast`. Push after that check and let CI own
+path-planned validation: static analysis, package builds, planned Python lanes,
+and Lean/npm/security/duplicate-code when the impact manifest selects them.
+Coverage and Python 3.13 compatibility run only on exhaustive plans (merge
+queue and `main`). `make check-static` reproduces CI's static checks plus a
+local package build when a focused change needs them. `make validate-full` is
+the broadest local Python, Lean, static, and package validation target. It does
+not reproduce CI's Python 3.13 compatibility, combined coverage, security,
+duplicate-code, or npm lanes (`make security-audit`, `make duplicate-code`, and
+`make npm-test` cover those locally). Run `make help` for focused commands. The
+measured costs and reasoning behind these lanes are recorded in the
 [test-suite cost audit](docs/contributing/test-suite-cost-audit.md).
 Tests can be narrowed without learning another wrapper:
 
@@ -48,8 +51,10 @@ make test-storage PYTEST_ARGS="-k workspace"
 make test-lean TESTS=tests/integration/lean/test_lean.py PYTEST_ARGS="-k induction"
 ```
 
-Run `make hooks` once to install the repository's formatting, syntax, secret,
-and large-file checks plus the `make check` pre-push gate. Hooks remain
+Run `make hooks` once to install commit-time formatting, syntax, secret,
+large-file, dead-code, and actionlint hooks plus the `make check` pre-push
+gate. Commit hooks are a narrower hygiene pass than `make check` (which adds
+mypy and `test-fast`); pre-push is the routine correctness gate. Hooks remain
 bypassable for exceptional cases with Git's standard `--no-verify` option.
 `make fix` applies Ruff's safe lint fixes followed by formatting. `make
 precommit` applies those fixes and then runs the routine handoff checks.
@@ -75,28 +80,32 @@ Python and Lean lanes. Unknown paths fail closed to all functional lanes.
 Required status contexts still complete after checking the plan when their
 expensive validation is intentionally omitted.
 Maintainers can add the `ci:full` label to force every lane or `ci:lean` to
-add real-Lean validation to an otherwise isolated plan. These overrides only
-add work; labels cannot reduce the fail-closed path classification.
+add real-Lean validation to an otherwise isolated plan. Label changes re-trigger
+CI so the override applies without an extra push. These overrides only add work;
+labels cannot reduce the fail-closed path classification.
 Pull requests run the canonical Python version. Merge-queue groups and pushes
 to `main` additionally run supported-version compatibility and combined
 coverage as exhaustive gates. Successful `main` runs publish fresh integration
 shard timings. Timing history is not committed, and missing or invalid history
 falls back to equal-weight sharding.
 
-For a quick local feedback loop, skip the integration and end-to-end layers:
+Keep the local edit loop on directory-owned Make targets rather than inventing
+marker filters:
 
 ```sh
-uv run pytest -m "not integration and not end_to_end"
+make test-fast
+make test-core
+make test TESTS=tests/integration/infrastructure/test_mcp_adapter.py
 ```
 
-Pytest assigns these layer markers from the test directories, so new
-integration tests join the right loop without repeated file-level boilerplate.
+Ownership is by test directory, not by `integration` / `end_to_end` markers.
 Tests marked `lean_runtime` run serially through `make test-lean`; keep them out
 of the normal xdist pool because Mathlib processes can retain several
 gigabytes. CI installs the pinned Lean toolchain and Mathlib cache in a
 dedicated pair of serial lanes on separate runners.
-Use `uv run pytest --lf` after a failure, `uv run pytest -n 0` while debugging,
-and `make check` before pushing. Use `make test-lean TESTS=path/to/test.py` for
+Use `uv run --locked pytest --lf` after a failure, `uv run --locked pytest -n 0`
+while debugging, and `make check` before pushing. Use
+`make test-lean TESTS=path/to/test.py` for
 a deliberately focused local Lean reproduction, or dispatch the remote Lean
 debug workflow from GitHub Actions when local Lean is impractical. Use
 `make test-lean PYTEST_ARGS=--lf` to rerun a failed Lean-runtime test.
@@ -143,8 +152,8 @@ Verify every relative Markdown link before submitting the change.
 The manifest-driven Release Please configuration keeps the Python and npm
 package versions synchronized. CI tests and packs the npm launcher
 independently, then publishes both distributions after a release is created.
-The `jacobian` package on npm must authorize `.github/workflows/ci.yml` as its
-trusted GitHub Actions publisher, using the `npm` environment; releases use
+The `jacobian` package on npm must authorize `.github/workflows/release.yml` as
+its trusted GitHub Actions publisher, using the `npm` environment; releases use
 OIDC rather than a long-lived npm token.
 
 ## Pull requests

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,9 @@ EVAL_ARGS ?=
 CORE_TEST_PATHS := tests/unit tests/contract tests/checkers tests/reference
 INTEGRATION_TEST_PATHS := tests/integration tests/end_to_end
 RUFF_PATHS := src tests benchmarks
+PYTEST_XDIST_ARGS := -n auto --maxprocesses=4 --dist=worksteal
 
-.PHONY: help setup hooks fix lint lint-full security-audit typecheck test test-fast test-core test-integration test-contracts test-checkers test-mcp test-storage test-lean test-failed duplicate-code npm-test build check precommit check-static validate-full agent-eval
+.PHONY: help setup hooks fix lint lint-full security-audit typecheck test test-fast test-core test-integration test-contracts test-checkers test-mcp test-storage test-lean test-failed duplicate-code npm-test todo-check coverage build check precommit check-static validate-full agent-eval bench-core
 
 help: ## Show available developer commands.
 	@awk 'BEGIN {FS = ":.*## "; printf "Jacobian developer commands:\n\n"} /^[a-zA-Z_-]+:.*## / {printf "  %-18s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -39,18 +40,18 @@ typecheck: ## Run strict static type checking.
 	$(UV_RUN) mypy
 
 test: ## Run tests; narrow with TESTS=... and PYTEST_ARGS=....
-	$(UV_RUN) pytest -m "not lean_runtime" $(TESTS) $(PYTEST_ARGS)
+	$(UV_RUN) pytest $(PYTEST_XDIST_ARGS) -m "not lean_runtime" $(TESTS) $(PYTEST_ARGS)
 
 test-fast: ## Sequential core edit loop (unit/contract/checkers/reference, no xdist).
 	$(UV_RUN) pytest -n 0 -m "not lean_runtime and not slow" \
 		$(if $(TESTS),$(TESTS),$(CORE_TEST_PATHS)) $(PYTEST_ARGS)
 
 test-core: ## Parallel core suites (same paths as test-fast, uses xdist by default).
-	$(UV_RUN) pytest -m "not lean_runtime" \
+	$(UV_RUN) pytest $(PYTEST_XDIST_ARGS) -m "not lean_runtime" \
 		$(if $(TESTS),$(TESTS),$(CORE_TEST_PATHS)) $(PYTEST_ARGS)
 
 test-integration: ## Run the directory-owned integration suites.
-	$(UV_RUN) pytest -m "not lean_runtime" \
+	$(UV_RUN) pytest $(PYTEST_XDIST_ARGS) -m "not lean_runtime" \
 		$(if $(TESTS),$(TESTS),$(INTEGRATION_TEST_PATHS)) $(PYTEST_ARGS)
 
 test-contracts: ## Run contract tests.
@@ -77,7 +78,7 @@ test-lean: ## Run pinned Lean tests serially; narrow with TESTS=... and PYTEST_A
 	$(UV_RUN) pytest -n 0 -m lean_runtime $(TESTS) $(PYTEST_ARGS)
 
 test-failed: ## Re-run failures from the previous pytest invocation.
-	$(UV_RUN) pytest --lf -m "not lean_runtime" $(PYTEST_ARGS)
+	$(UV_RUN) pytest $(PYTEST_XDIST_ARGS) --lf -m "not lean_runtime" $(PYTEST_ARGS)
 
 duplicate-code: ## Run the CI duplicate-code detector locally.
 	npx --yes jscpd@5.0.12 --config .jscpd.json .
@@ -85,6 +86,19 @@ duplicate-code: ## Run the CI duplicate-code detector locally.
 npm-test: ## Run the npm package tests and dry-run pack.
 	npm test --prefix npm
 	npm pack --dry-run --prefix npm
+
+todo-check: ## Fail on TODO comments that do not reference an issue.
+	@violations="$$(rg --pcre2 -n 'TODO(?!\(#\d+\))' --type py src/ tests/ || true)"; \
+	if [ -n "$$violations" ]; then \
+	  printf '%s\n' "$$violations"; \
+	  echo "TODO comments must reference an issue, e.g. TODO(#123)." >&2; \
+	  exit 1; \
+	fi
+
+coverage: ## Combine coverage data files and enforce the repository threshold.
+	$(UV_RUN) coverage combine
+	$(UV_RUN) coverage report --fail-under=50
+	$(UV_RUN) coverage xml
 
 build: ## Build Python source and wheel distributions.
 	uv build
@@ -95,9 +109,12 @@ precommit: ## Fix and run every routine local handoff check.
 	$(MAKE) fix
 	$(MAKE) check
 
-check-static: lint-full typecheck build ## Run CI-owned static and package checks locally.
+check-static: lint-full typecheck todo-check build ## Run CI-owned static checks plus a local package build.
 
 validate-full: lint-full typecheck test test-lean build ## Run broad local validation (slow; omits security/duplicate/npm CI lanes).
 
 agent-eval: ## Plan a local agent eval; execution requires explicit EVAL_ARGS.
 	$(UV_RUN) python benchmarks/agent_ab.py $(EVAL_ARGS)
+
+bench-core: ## Run the core performance benchmark script.
+	$(UV_RUN) python benchmarks/benchmark_core.py

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ CORE_TEST_PATHS := tests/unit tests/contract tests/checkers tests/reference
 INTEGRATION_TEST_PATHS := tests/integration tests/end_to_end
 RUFF_PATHS := src tests benchmarks
 
-.PHONY: help setup hooks fix lint lint-full typecheck test test-fast test-core test-integration test-contracts test-checkers test-mcp test-storage test-lean test-failed build check precommit check-static validate-full agent-eval
+.PHONY: help setup hooks fix lint lint-full security-audit typecheck test test-fast test-core test-integration test-contracts test-checkers test-mcp test-storage test-lean test-failed duplicate-code npm-test build check precommit check-static validate-full agent-eval
 
 help: ## Show available developer commands.
 	@awk 'BEGIN {FS = ":.*## "; printf "Jacobian developer commands:\n\n"} /^[a-zA-Z_-]+:.*## / {printf "  %-18s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -41,11 +41,11 @@ typecheck: ## Run strict static type checking.
 test: ## Run tests; narrow with TESTS=... and PYTEST_ARGS=....
 	$(UV_RUN) pytest -m "not lean_runtime" $(TESTS) $(PYTEST_ARGS)
 
-test-fast: ## Run the sequential core feedback loop.
+test-fast: ## Sequential core edit loop (unit/contract/checkers/reference, no xdist).
 	$(UV_RUN) pytest -n 0 -m "not lean_runtime and not slow" \
 		$(if $(TESTS),$(TESTS),$(CORE_TEST_PATHS)) $(PYTEST_ARGS)
 
-test-core: ## Run the directory-owned core suites.
+test-core: ## Parallel core suites (same paths as test-fast, uses xdist by default).
 	$(UV_RUN) pytest -m "not lean_runtime" \
 		$(if $(TESTS),$(TESTS),$(CORE_TEST_PATHS)) $(PYTEST_ARGS)
 
@@ -79,6 +79,13 @@ test-lean: ## Run pinned Lean tests serially; narrow with TESTS=... and PYTEST_A
 test-failed: ## Re-run failures from the previous pytest invocation.
 	$(UV_RUN) pytest --lf -m "not lean_runtime" $(PYTEST_ARGS)
 
+duplicate-code: ## Run the CI duplicate-code detector locally.
+	npx --yes jscpd@5.0.12 --config .jscpd.json .
+
+npm-test: ## Run the npm package tests and dry-run pack.
+	npm test --prefix npm
+	npm pack --dry-run --prefix npm
+
 build: ## Build Python source and wheel distributions.
 	uv build
 
@@ -90,7 +97,7 @@ precommit: ## Fix and run every routine local handoff check.
 
 check-static: lint-full typecheck build ## Run CI-owned static and package checks locally.
 
-validate-full: lint-full typecheck test test-lean build ## Run broad local validation (slow and exceptional; not every CI lane).
+validate-full: lint-full typecheck test test-lean build ## Run broad local validation (slow; omits security/duplicate/npm CI lanes).
 
 agent-eval: ## Plan a local agent eval; execution requires explicit EVAL_ARGS.
 	$(UV_RUN) python benchmarks/agent_ab.py $(EVAL_ARGS)

--- a/docs/contributing/test-suite-cost-audit.md
+++ b/docs/contributing/test-suite-cost-audit.md
@@ -177,6 +177,13 @@ of multi-second kernel startups. Modules that need authorized references opt
 into `initialized_kernel_store_with_references` instead of rebuilding that
 install on every case.
 
+Attaching `JacobianKernel(tmp_path)` after the store fixture is intentional, not
+a double bootstrap: the session template pays fresh construction once per worker,
+`copytree` seeds each test root in milliseconds, and attach reuses content-
+addressed descriptors in well under a second. Prefer the `kernel` /
+`kernel_with_references` fixtures for that attach step; do not remove the store
+fixtures to "avoid double construction."
+
 Suite infrastructure checks for the store templates themselves also live under
 `tests/integration/`: building and freezing those snapshots is multi-second
 setup work and must not run in the routine fast lane.

--- a/docs/reference/testing-strategy.md
+++ b/docs/reference/testing-strategy.md
@@ -76,11 +76,11 @@ independent checker tests. Suite fixture infrastructure that builds and freezes
 kernel store templates lives under `tests/integration/` for the same reason.
 Named contract, checker, MCP, and storage targets
 make common affected areas discoverable without adding another test runner.
-`make check` combines fast Ruff and non-integration test feedback as the
-routine local pre-push gate. Developers should push after it and let CI own
-dependency and dead-code analysis, strict typing, package builds, and
-exhaustive validation. `make check-static` reproduces those CI-owned static
-and package checks when relevant.
+`make check` combines fast Ruff, strict typing, and non-integration test
+feedback as the routine local pre-push gate. Developers should push after it and
+let CI own dependency and dead-code analysis, package builds, and exhaustive
+validation. `make check-static` reproduces those CI-owned static and package
+checks when relevant.
 `make validate-full` is the broad local Python, Lean, static, and package
 escape hatch, not a routine handoff requirement. It does not reproduce CI's
 Python 3.13 compatibility, combined coverage, security, duplicate-code, or npm
@@ -97,8 +97,11 @@ Workflow tests that repeatedly construct the kernel may opt into
 `initialized_kernel_store`. Each xdist worker builds the core descriptor store
 once, then the fixture physically copies that snapshot into the test's own
 `tmp_path` before construction. SQLite metadata and blobs remain isolated per
-test; no kernel service, process, or mutable database is shared. Tests that need
-authorized reference plugins and checkers may instead opt into
+test; no kernel service, process, or mutable database is shared. Prefer the
+function-scoped `kernel` fixture (or `kernel_with_references`) when a test only
+needs to attach to that seeded root; keep explicit `JacobianKernel(tmp_path)`
+for restart, sibling-root, or bootstrap cases. Tests that need authorized
+reference plugins and checkers may instead opt into
 `initialized_kernel_store_with_references`, which copies a second immutable
 session snapshot that already includes those installs. Tests whose subject is
 fresh-store bootstrap, quota accounting, migration, or descriptor installation

--- a/docs/reference/testing-strategy.md
+++ b/docs/reference/testing-strategy.md
@@ -70,10 +70,10 @@ make validate-full
 ```
 
 `make test-fast` collects only unit, contract, checker, and reference
-directories, then excludes integration-marked cases. Avoiding collection of
-integration and end-to-end modules keeps the loop short without dropping
-independent checker tests. Suite fixture infrastructure that builds and freezes
-kernel store templates lives under `tests/integration/` for the same reason.
+directories and excludes `slow` cases under a single process. Prefer the
+function-scoped `kernel` / `kernel_with_references` fixtures when attaching to
+seeded stores. Avoid inventing layer-marker filters; directory Make targets own
+suite selection.
 Named contract, checker, MCP, and storage targets
 make common affected areas discoverable without adding another test runner.
 `make check` combines fast Ruff, strict typing, and non-integration test
@@ -84,9 +84,11 @@ checks when relevant.
 `make validate-full` is the broad local Python, Lean, static, and package
 escape hatch, not a routine handoff requirement. It does not reproduce CI's
 Python 3.13 compatibility, combined coverage, security, duplicate-code, or npm
-lanes. The full Python suite uses `pytest-xdist` work stealing and
+lanes. The full Python suite opts into `pytest-xdist` through Make targets
+(`make test`, `make test-core`, `make test-integration`) with work stealing and
 at most four workers because test durations vary substantially and many tests
-wait on isolated subprocesses. `make test-failed` is the failure-recovery
+wait on isolated subprocesses. Bare `pytest` stays single-process so focused
+debugging and Lean reproduction do not accidentally start a worker pool. `make test-failed` is the failure-recovery
 shortcut. Use `PYTEST_ARGS="-n 0"` for debugger-friendly, single-process
 execution and `PYTEST_ARGS="--durations=25"` when investigating regressions. A
 120-second per-test backstop prevents local deadlocks from hanging indefinitely
@@ -140,10 +142,12 @@ environment for focused reproduction when local Lean is impractical.
 The Python Debug workflow provides the same focused remote reproduction for
 one ordinary pytest file or node on either supported Python version.
 When coverage is enabled for an exhaustive plan, the Python 3.12 core lane and
-three integration partitions write raw coverage data; a dependent job combines
-all four files before enforcing the repository threshold and producing the XML
-report. Coverage.py's subprocess patch includes plugin and checker workers so
-clean-process execution is not misreported as uncovered.
+each integration shard write raw coverage data; a dependent job combines the
+core file plus every shard file before enforcing the repository threshold and
+producing the XML report. The shard count is owned by
+[`.github/ci-config.json`](../../.github/ci-config.json). Coverage.py's
+subprocess patch includes plugin and checker workers so clean-process execution
+is not misreported as uncovered.
 Measured costs and lane policy are recorded in the
 [test-suite cost audit](../contributing/test-suite-cost-audit.md).
 
@@ -158,7 +162,8 @@ lanes. Merge-queue checks and pushes to `main` always use the exhaustive plan,
 which also enables coverage and the second Python version. Stable aggregate
 Python and Lean jobs preserve required status semantics when their underlying
 matrices are conditional. Maintainer-applied `ci:full` and `ci:lean` labels can
-force all lanes or add Lean respectively. Overrides are additive only and
+force all lanes or add Lean respectively; label events re-trigger CI so the
+override applies without an extra push. Overrides are additive only and
 cannot weaken the plan selected from changed paths. A scheduled validation
 workflow separately exercises repeated property/stateful stress, alternate
 ordering seeds, optional providers, and the core performance benchmark outside
@@ -586,37 +591,36 @@ already happens to pass it.
 
 ## Test organization
 
-An initial layout may use:
+Directory ownership is the source of truth:
 
 ```text
 tests/
+    unit/
     contract/
-    property/
-    stateful/
+    checkers/
+    reference/
     integration/
-    subprocess/
-    conformance/
-    differential/
+    end_to_end/
+    helpers/
     fixtures/
 ```
 
 Package-local tests are appropriate for focused behavior. Cross-package trust
-tests live in the top-level groups above. Suggested pytest markers are:
+tests live in the top-level groups above. Runtime pytest markers currently in
+use are:
 
 ```text
-contract
+external_backend
+lean_runtime
+slow
 property
 stateful
-integration
-subprocess
-conformance
-differential
-external_backend
-slow
 benchmark
 agent_eval
 ```
 
+Layer markers such as `integration` or `end_to_end` are intentionally not used;
+select those suites by directory through Make targets.
 Markers are selection tools, not excuses for leaving required tests out of
 release validation.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ dev = [
 packages = ["src/jacobian", "src/jacobian_checkers"]
 
 [tool.pytest.ini_options]
-addopts = "-ra --strict-config --strict-markers -n auto --maxprocesses=4 --dist=worksteal"
+addopts = "-ra --strict-config --strict-markers"
 testpaths = ["tests"]
 timeout = 120
 markers = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """Suite-wide pytest conventions."""
 
 import gc
+import os
 import shutil
 import sqlite3
 from pathlib import Path
@@ -118,18 +119,27 @@ def pytest_collection_modifyitems(
     config: pytest.Config,
     items: list[pytest.Item],
 ) -> None:
-    """Reject unsafe parallel Lean execution."""
+    """Reject unsafe parallel Lean execution on controllers and xdist workers."""
 
     workers = config.getoption("numprocesses", default=None)
-    if workers in (None, 0, "0"):
+    under_xdist = hasattr(config, "workerinput") or bool(
+        os.environ.get("PYTEST_XDIST_WORKER")
+    )
+    parallel = under_xdist or workers not in (None, 0, "0")
+    if not parallel:
         return
     lean_items = [
         item.nodeid for item in items if item.get_closest_marker("lean_runtime")
     ]
-    if lean_items:
-        sample = ", ".join(lean_items[:3])
-        raise pytest.UsageError(
-            "Lean runtime tests cannot run under pytest-xdist. "
-            "Use `make test` for the non-Lean suite or `make test-lean` "
-            f"for serial Lean validation. Selected Lean tests include: {sample}"
-        )
+    if not lean_items:
+        return
+    sample = ", ".join(lean_items[:3])
+    message = (
+        "Lean runtime tests cannot run under pytest-xdist. "
+        "Use `make test` for the non-Lean suite or `make test-lean` "
+        f"for serial Lean validation. Selected Lean tests include: {sample}"
+    )
+    if under_xdist:
+        # UsageError on workers only kills the worker; exit so the controller fails closed.
+        pytest.exit(message, returncode=4)
+    raise pytest.UsageError(message)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,6 +96,23 @@ def initialized_kernel_store_with_references(
     )
 
 
+@pytest.fixture
+def kernel(tmp_path: Path, initialized_kernel_store: None) -> JacobianKernel:
+    """Attach a kernel to a per-test copy of the core descriptor snapshot."""
+
+    return JacobianKernel(tmp_path)
+
+
+@pytest.fixture
+def kernel_with_references(
+    tmp_path: Path,
+    initialized_kernel_store_with_references: None,
+) -> JacobianKernel:
+    """Attach a kernel to a per-test copy that already has authorized references."""
+
+    return JacobianKernel(tmp_path, install_references=True)
+
+
 @pytest.hookimpl(trylast=True)
 def pytest_collection_modifyitems(
     config: pytest.Config,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,6 +101,7 @@ def initialized_kernel_store_with_references(
 def kernel(tmp_path: Path, initialized_kernel_store: None) -> JacobianKernel:
     """Attach a kernel to a per-test copy of the core descriptor snapshot."""
 
+    _ = initialized_kernel_store
     return JacobianKernel(tmp_path)
 
 
@@ -111,6 +112,7 @@ def kernel_with_references(
 ) -> JacobianKernel:
     """Attach a kernel to a per-test copy that already has authorized references."""
 
+    _ = initialized_kernel_store_with_references
     return JacobianKernel(tmp_path, install_references=True)
 
 

--- a/tests/helpers/capabilities.py
+++ b/tests/helpers/capabilities.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Any
+
+from jacobian.contracts.capabilities import (
+    CapabilityMode,
+    CapabilityRequest,
+    CapabilityResult,
+)
+from jacobian.kernel import JacobianKernel
+
+
+def invoke_capability(
+    kernel: JacobianKernel,
+    capability_id: str,
+    payload: dict[str, Any],
+    *,
+    mode: CapabilityMode = CapabilityMode.EXPLORE,
+) -> CapabilityResult:
+    """Invoke one capability through the public request envelope."""
+
+    return kernel.capabilities.invoke(
+        CapabilityRequest(capability_id=capability_id, mode=mode, input=payload)
+    )

--- a/tests/helpers/installations.py
+++ b/tests/helpers/installations.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from jacobian.artifacts import ArtifactService
+from jacobian.registry import CheckerRegistry
+from jacobian.schema_registry import SchemaRegistry
+from jacobian.store import ArtifactStore
+from jacobian.verification import VerificationService
+
+
+def install_capability_bundle(
+    tmp_path: Path,
+    installer: Callable[..., tuple[Any, Any]],
+) -> tuple[Any, Any, ArtifactStore]:
+    """Build a minimal store and install one capability bundle for focused tests."""
+
+    store = ArtifactStore(tmp_path / "store")
+    schemas = SchemaRegistry(store)
+    artifacts = ArtifactService(store, schemas)
+    checkers = CheckerRegistry(tmp_path / "checkers.sqlite3")
+    verification = VerificationService(store, checkers)
+    adapters, installed = installer(
+        store,
+        schemas,
+        artifacts,
+        verification,
+        checkers,
+        authorize_checker=True,
+    )
+    return adapters, installed, store

--- a/tests/integration/agent/test_agent_benchmark.py
+++ b/tests/integration/agent/test_agent_benchmark.py
@@ -6,12 +6,9 @@ from pathlib import Path
 
 import pytest
 from benchmarks import agent_mcp as benchmark
+from tests.helpers.capabilities import invoke_capability as _invoke
 
-from jacobian.contracts.capabilities import (
-    CapabilityMode,
-    CapabilityRequest,
-    CapabilityResult,
-)
+from jacobian.contracts.capabilities import CapabilityMode, CapabilityRequest
 from jacobian.contracts.evidence import WitnessRole
 from jacobian.kernel import JacobianKernel
 
@@ -25,18 +22,6 @@ def _feedback() -> dict[str, list[str]]:
         "domain_knowledge_gaps": [],
         "suggested_improvements": [],
     }
-
-
-def _invoke(
-    kernel: JacobianKernel,
-    capability_id: str,
-    payload: dict[str, object],
-    *,
-    mode: CapabilityMode = CapabilityMode.EXPLORE,
-) -> CapabilityResult:
-    return kernel.capabilities.invoke(
-        CapabilityRequest(capability_id=capability_id, mode=mode, input=payload)
-    )
 
 
 def test_graph_capability_scorer_checks_multi_call_artifacts(

--- a/tests/integration/domains/test_sequence_differences.py
+++ b/tests/integration/domains/test_sequence_differences.py
@@ -1,12 +1,8 @@
-from pathlib import Path
-
 import pytest
 
 from jacobian.contracts.capabilities import CapabilityRequest
 from jacobian.contracts.results import ExecutionStatus
 from jacobian.kernel import JacobianKernel
-
-pytestmark = pytest.mark.usefixtures("initialized_kernel_store")
 
 
 @pytest.mark.parametrize(
@@ -18,12 +14,10 @@ pytestmark = pytest.mark.usefixtures("initialized_kernel_store")
     ),
 )
 def test_finite_differences_return_natural_empty_result(
-    tmp_path: Path,
+    kernel: JacobianKernel,
     capability_id: str,
     values: list[str],
 ) -> None:
-    kernel = JacobianKernel(tmp_path)
-
     result = kernel.capabilities.invoke(
         CapabilityRequest(
             capability_id=capability_id,

--- a/tests/integration/infrastructure/_workspace_support.py
+++ b/tests/integration/infrastructure/_workspace_support.py
@@ -1,14 +1,10 @@
 from __future__ import annotations
 
-import pytest
-
 from jacobian.contracts.workspaces import (
     WorkspaceOpenRequest,
     WorkspaceOpenResult,
 )
 from jacobian.kernel import JacobianKernel
-
-pytestmark = pytest.mark.usefixtures("initialized_kernel_store")
 
 
 def _open(

--- a/tests/integration/infrastructure/test_pytest_execution_policy.py
+++ b/tests/integration/infrastructure/test_pytest_execution_policy.py
@@ -30,3 +30,36 @@ def test_parallel_pytest_rejects_selected_lean_runtime_tests() -> None:
     assert completed.returncode == 4
     assert "Lean runtime tests cannot run under pytest-xdist" in completed.stderr
     assert "make test-lean" in completed.stderr
+
+
+def test_parallel_pytest_rejects_lean_runtime_execution_under_xdist_workers() -> None:
+    """xdist workers clear numprocesses; the guard must still fail closed there."""
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-q",
+            "-n",
+            "2",
+            "tests/integration/lean/test_lean.py::test_mathlib_warmup_starts_only_once",
+        ],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    combined = f"{completed.stdout}\n{completed.stderr}"
+    assert completed.returncode != 0
+    assert "passed" not in completed.stdout
+    assert (
+        "no tests ran" in combined
+        or "Lean runtime tests cannot run under pytest-xdist" in combined
+    )
+    assert (
+        "make test-lean" in combined
+        or "lean_runtime" in combined.lower()
+        or "test_lean.py" in combined
+    )

--- a/tests/integration/lean/test_lean.py
+++ b/tests/integration/lean/test_lean.py
@@ -58,9 +58,14 @@ pytestmark = [
 
 def test_core_declaration_catalog_matches_a_fresh_scan_and_detects_tampering(
     tmp_path: Path,
+    kernel_store_template_with_references: Path,
 ) -> None:
-    indexed_kernel = JacobianKernel(tmp_path / "indexed", install_references=True)
-    fresh_kernel = JacobianKernel(tmp_path / "fresh", install_references=True)
+    indexed_root = tmp_path / "indexed"
+    fresh_root = tmp_path / "fresh"
+    shutil.copytree(kernel_store_template_with_references, indexed_root)
+    shutil.copytree(kernel_store_template_with_references, fresh_root)
+    indexed_kernel = JacobianKernel(indexed_root, install_references=True)
+    fresh_kernel = JacobianKernel(fresh_root, install_references=True)
     indexed = indexed_kernel.lean_declarations
     fresh = fresh_kernel.lean_declarations
     assert indexed is not None

--- a/tests/integration/matrix/test_linear_rational_inconsistency.py
+++ b/tests/integration/matrix/test_linear_rational_inconsistency.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from tests.helpers.capabilities import invoke_capability as _invoke
 from tests.helpers.rationals import rational_payload as _q
 
 from jacobian.bounded_process import BoundedProcessResult
@@ -12,8 +13,6 @@ from jacobian.contracts.capabilities import (
     CapabilityCompletenessStatus,
     CapabilityMode,
     CapabilityProviderAvailability,
-    CapabilityRequest,
-    CapabilityResult,
 )
 from jacobian.contracts.results import ExecutionStatus
 from jacobian.kernel import JacobianKernel
@@ -32,22 +31,6 @@ def _system(coefficients: list[list[int]], rhs: list[int]) -> dict[str, Any]:
         },
         "rhs": [_q(value) for value in rhs],
     }
-
-
-def _invoke(
-    kernel: JacobianKernel,
-    capability_id: str,
-    payload: dict[str, Any],
-    *,
-    mode: CapabilityMode,
-) -> CapabilityResult:
-    return kernel.capabilities.invoke(
-        CapabilityRequest(
-            capability_id=capability_id,
-            mode=mode,
-            input=payload,
-        )
-    )
 
 
 def _kernel_with_checker(root: Path) -> JacobianKernel:

--- a/tests/integration/matrix/test_linear_rational_solution.py
+++ b/tests/integration/matrix/test_linear_rational_solution.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from tests.helpers.capabilities import invoke_capability as _invoke
 from tests.helpers.rationals import rational_payload as _q
 
 import jacobian.provider_runtime as provider_runtime
@@ -19,8 +20,6 @@ from jacobian.contracts.capabilities import (
     CapabilityProviderAvailability,
     CapabilityProviderDigestKind,
     CapabilityProviderRuntime,
-    CapabilityRequest,
-    CapabilityResult,
 )
 from jacobian.contracts.results import ExecutionStatus
 from jacobian.kernel import JacobianKernel
@@ -44,22 +43,6 @@ def _system(
         },
         "rhs": [wire(value) for value in rhs],
     }
-
-
-def _invoke(
-    kernel: JacobianKernel,
-    capability_id: str,
-    payload: dict[str, Any],
-    *,
-    mode: CapabilityMode,
-) -> CapabilityResult:
-    return kernel.capabilities.invoke(
-        CapabilityRequest(
-            capability_id=capability_id,
-            mode=mode,
-            input=payload,
-        )
-    )
 
 
 def _kernel_with_linear_checker(root: Path) -> JacobianKernel:

--- a/tests/integration/matrix/test_matrix_hermite_normal_form.py
+++ b/tests/integration/matrix/test_matrix_hermite_normal_form.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from tests.helpers.capabilities import invoke_capability as _invoke
 
 import jacobian.provider_runtime as provider_runtime
 from jacobian.bounded_process import BoundedProcessResult
@@ -15,8 +16,6 @@ from jacobian.contracts.capabilities import (
     CapabilityInstallTier,
     CapabilityMode,
     CapabilityProviderAvailability,
-    CapabilityRequest,
-    CapabilityResult,
 )
 from jacobian.contracts.results import ExecutionStatus
 from jacobian.kernel import JacobianKernel
@@ -29,22 +28,6 @@ pytestmark = pytest.mark.usefixtures("initialized_kernel_store")
 
 def _matrix(entries: list[list[int | str]]) -> dict[str, Any]:
     return {"entries": [[str(value) for value in row] for row in entries]}
-
-
-def _invoke(
-    kernel: JacobianKernel,
-    capability_id: str,
-    payload: dict[str, Any],
-    *,
-    mode: CapabilityMode,
-) -> CapabilityResult:
-    return kernel.capabilities.invoke(
-        CapabilityRequest(
-            capability_id=capability_id,
-            mode=mode,
-            input=payload,
-        )
-    )
 
 
 def _kernel_with_checker(root: Path) -> JacobianKernel:

--- a/tests/integration/polynomial/test_polynomial_expression_normalization.py
+++ b/tests/integration/polynomial/test_polynomial_expression_normalization.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from tests.helpers.capabilities import invoke_capability as _invoke
 from tests.helpers.rationals import rational_payload as _q
 
 import jacobian.provider_runtime as provider_runtime
@@ -16,8 +17,6 @@ from jacobian.contracts.capabilities import (
     CapabilityInstallTier,
     CapabilityMode,
     CapabilityProviderAvailability,
-    CapabilityRequest,
-    CapabilityResult,
 )
 from jacobian.contracts.results import ExecutionStatus
 from jacobian.kernel import JacobianKernel
@@ -41,22 +40,6 @@ def _expression(
         "variables": variables or ["x", "y"],
         "expression": node,
     }
-
-
-def _invoke(
-    kernel: JacobianKernel,
-    capability_id: str,
-    payload: dict[str, Any],
-    *,
-    mode: CapabilityMode,
-) -> CapabilityResult:
-    return kernel.capabilities.invoke(
-        CapabilityRequest(
-            capability_id=capability_id,
-            mode=mode,
-            input=payload,
-        )
-    )
 
 
 def _kernel_with_checker(root: Path) -> JacobianKernel:

--- a/tests/integration/polynomial/test_polynomial_factor.py
+++ b/tests/integration/polynomial/test_polynomial_factor.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
 
-from pathlib import Path
-
-import pytest
 from tests.helpers.polynomials import univariate_term as _term
 
 from jacobian.contracts.capabilities import (
@@ -11,13 +8,10 @@ from jacobian.contracts.capabilities import (
 )
 from jacobian.kernel import JacobianKernel
 
-pytestmark = pytest.mark.usefixtures("initialized_kernel_store")
-
 
 def test_factor_compute_preserves_multiplicity_and_reconstructs_exactly(
-    tmp_path: Path,
+    kernel: JacobianKernel,
 ) -> None:
-    kernel = JacobianKernel(tmp_path)
     polynomial = {
         "terms": [
             _term(1, 2),
@@ -51,10 +45,8 @@ def test_factor_compute_preserves_multiplicity_and_reconstructs_exactly(
 
 
 def test_factor_compute_handles_zero_as_a_coefficient_not_a_unit(
-    tmp_path: Path,
+    kernel: JacobianKernel,
 ) -> None:
-    kernel = JacobianKernel(tmp_path)
-
     result = kernel.capabilities.invoke(
         CapabilityRequest(
             capability_id="polynomial.factor.compute",
@@ -70,9 +62,8 @@ def test_factor_compute_handles_zero_as_a_coefficient_not_a_unit(
 
 
 def test_factor_compute_preserves_rational_coefficient_and_irreducible_factor(
-    tmp_path: Path,
+    kernel: JacobianKernel,
 ) -> None:
-    kernel = JacobianKernel(tmp_path)
     polynomial = {
         "terms": [
             {

--- a/tests/integration/polynomial/test_polynomial_interval_capabilities.py
+++ b/tests/integration/polynomial/test_polynomial_interval_capabilities.py
@@ -4,9 +4,9 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from tests.helpers.installations import install_capability_bundle
 from tests.helpers.polynomials import univariate_term as _term
 
-from jacobian.artifacts import ArtifactService
 from jacobian.capabilities import CapabilityInvocationError
 from jacobian.contracts.capabilities import (
     CapabilityAssuranceLevel,
@@ -18,10 +18,6 @@ from jacobian.contracts.results import ExecutionStatus
 from jacobian.polynomial_interval_capabilities import (
     install_polynomial_interval_capabilities,
 )
-from jacobian.registry import CheckerRegistry
-from jacobian.schema_registry import SchemaRegistry
-from jacobian.store import ArtifactStore
-from jacobian.verification import VerificationService
 
 
 def _polynomial(variable: str, terms: list[dict[str, Any]]) -> dict[str, Any]:
@@ -43,20 +39,10 @@ def _interval(lo: str, hi: str) -> dict[str, Any]:
 
 @pytest.fixture()
 def installation(tmp_path: Path):
-    store = ArtifactStore(tmp_path / "store")
-    schemas = SchemaRegistry(store)
-    artifacts = ArtifactService(store, schemas)
-    checkers = CheckerRegistry(tmp_path / "checkers.sqlite3")
-    verification = VerificationService(store, checkers)
-    adapters, installed = install_polynomial_interval_capabilities(
-        store,
-        schemas,
-        artifacts,
-        verification,
-        checkers,
-        authorize_checker=True,
+    return install_capability_bundle(
+        tmp_path,
+        install_polynomial_interval_capabilities,
     )
-    return adapters, installed, store
 
 
 def test_enclose_capability_computes_a_valid_bernstein_enclosure(

--- a/tests/integration/polynomial/test_polynomial_operation_bundle.py
+++ b/tests/integration/polynomial/test_polynomial_operation_bundle.py
@@ -2,12 +2,11 @@ from pathlib import Path
 from typing import Any, cast
 
 import pytest
+from tests.helpers.capabilities import invoke_capability as _invoke
 
 from jacobian.bounded_process import BoundedProcessResult
 from jacobian.contracts.capabilities import (
     CapabilityAssuranceLevel,
-    CapabilityRequest,
-    CapabilityResult,
 )
 from jacobian.contracts.results import ExecutionStatus
 from jacobian.kernel import JacobianKernel
@@ -35,16 +34,6 @@ def _polynomial(
             ]
         },
     }
-
-
-def _invoke(
-    kernel: JacobianKernel,
-    capability_id: str,
-    payload: dict[str, object],
-) -> CapabilityResult:
-    return kernel.capabilities.invoke(
-        CapabilityRequest(capability_id=capability_id, input=payload)
-    )
 
 
 def test_polynomial_bundle_installs_and_computes_exact_invariants(

--- a/tests/integration/polynomial/test_polynomial_positivity_capabilities.py
+++ b/tests/integration/polynomial/test_polynomial_positivity_capabilities.py
@@ -5,9 +5,9 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from tests.helpers.installations import install_capability_bundle
 from tests.helpers.polynomials import univariate_term as _term
 
-from jacobian.artifacts import ArtifactService
 from jacobian.contracts.capabilities import (
     CapabilityAssuranceLevel,
     CapabilityMode,
@@ -18,10 +18,6 @@ from jacobian.contracts.results import ExecutionStatus
 from jacobian.polynomial_positivity_capabilities import (
     install_polynomial_positivity_capabilities,
 )
-from jacobian.registry import CheckerRegistry
-from jacobian.schema_registry import SchemaRegistry
-from jacobian.store import ArtifactStore
-from jacobian.verification import VerificationService
 from jacobian_checkers.polynomial_positivity import check_positivity
 
 # ---------------------------------------------------------------------------
@@ -268,20 +264,10 @@ def test_checker_rejects_noncanonical_rational() -> None:
 
 @pytest.fixture()
 def installation(tmp_path: Path):
-    store = ArtifactStore(tmp_path / "store")
-    schemas = SchemaRegistry(store)
-    artifacts = ArtifactService(store, schemas)
-    checkers = CheckerRegistry(tmp_path / "checkers.sqlite3")
-    verification = VerificationService(store, checkers)
-    adapters, installed = install_polynomial_positivity_capabilities(
-        store,
-        schemas,
-        artifacts,
-        verification,
-        checkers,
-        authorize_checker=True,
+    return install_capability_bundle(
+        tmp_path,
+        install_polynomial_positivity_capabilities,
     )
-    return adapters, installed, store
 
 
 def test_decide_capability_finds_positive_linear(installation) -> None:

--- a/tests/integration/sat_smt/test_carcara.py
+++ b/tests/integration/sat_smt/test_carcara.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
 
 import pytest
@@ -17,21 +18,22 @@ from jacobian.provider_runtime import carcara_provider_runtime
 
 pytestmark = [
     pytest.mark.external_backend,
-    pytest.mark.usefixtures("initialized_kernel_store_with_references"),
 ]
 
 _FIXTURES = Path(__file__).parents[2] / "fixtures" / "smt"
 
 
 @pytest.fixture(scope="module")
-def kernel(tmp_path_factory: pytest.TempPathFactory) -> JacobianKernel:
+def kernel(
+    tmp_path_factory: pytest.TempPathFactory,
+    kernel_store_template_with_references: Path,
+) -> JacobianKernel:
     runtime = carcara_provider_runtime()
     if runtime.availability is not CapabilityProviderAvailability.AVAILABLE:
         pytest.skip("the exact operator-provenanced Carcara runtime is unavailable")
-    installed = JacobianKernel(
-        tmp_path_factory.mktemp("carcara-kernel"),
-        install_references=True,
-    )
+    root = tmp_path_factory.mktemp("carcara-kernel")
+    shutil.copytree(kernel_store_template_with_references, root, dirs_exist_ok=True)
+    installed = JacobianKernel(root, install_references=True)
     assert installed.carcara_runtime == runtime
     return installed
 

--- a/tests/integration/sat_smt/test_sat_unsat_proof_external_backend.py
+++ b/tests/integration/sat_smt/test_sat_unsat_proof_external_backend.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from tests.helpers.capabilities import invoke_capability as _invoke
 
 from jacobian.contracts.capabilities import (
     CapabilityAssuranceLevel,
     CapabilityMode,
-    CapabilityRequest,
 )
 from jacobian.contracts.results import ExecutionStatus
 from jacobian.contracts.sat import SatProofArtifact
@@ -23,22 +23,6 @@ pytestmark = [
     pytest.mark.external_backend,
     pytest.mark.usefixtures("initialized_kernel_store_with_references"),
 ]
-
-
-def _invoke(
-    kernel: JacobianKernel,
-    capability_id: str,
-    payload: dict[str, object],
-    *,
-    mode: CapabilityMode,
-):
-    return kernel.capabilities.invoke(
-        CapabilityRequest(
-            capability_id=capability_id,
-            mode=mode,
-            input=payload,
-        )
-    )
 
 
 def test_cadical_text_proof_replays_in_pinned_drat_trim(

--- a/tests/integration/workflow/test_verification_workflow.py
+++ b/tests/integration/workflow/test_verification_workflow.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from tests.helpers.capabilities import invoke_capability as _invoke
 
 from jacobian.contracts.capabilities import (
     CapabilityAssuranceLevel,
     CapabilityCompletenessStatus,
     CapabilityMode,
-    CapabilityRequest,
 )
 from jacobian.contracts.evidence import WitnessRole
 from jacobian.contracts.results import Conclusion, Verification
@@ -34,18 +34,6 @@ def _claim(
         "required_capabilities": capabilities,
         "correspondence_status": "HUMAN_REVIEWED",
     }
-
-
-def _invoke(
-    kernel: JacobianKernel,
-    capability_id: str,
-    payload: dict[str, object],
-    *,
-    mode: CapabilityMode = CapabilityMode.EXPLORE,
-):
-    return kernel.capabilities.invoke(
-        CapabilityRequest(capability_id=capability_id, mode=mode, input=payload)
-    )
 
 
 def test_atomic_capability_catalog_includes_required_and_excludes_composite_operations(

--- a/tests/unit/test_ci_plan.py
+++ b/tests/unit/test_ci_plan.py
@@ -114,9 +114,20 @@ def _expected_plan(classification: str, *enabled: str) -> dict[str, str]:
         (
             ("tests/integration/lean/test_lean_replayable_state_capability.py",),
             _expected_plan(
-                "python-integration",
+                "selective",
                 "run-python",
                 "run-integration",
+                "run-lean",
+                "run-static",
+            ),
+        ),
+        (
+            ("tests/integration/lean/test_lean_statement_capabilities.py",),
+            _expected_plan(
+                "selective",
+                "run-python",
+                "run-integration",
+                "run-lean",
                 "run-static",
             ),
         ),
@@ -279,8 +290,36 @@ def test_ci_plan_output_is_internally_consistent(args: tuple[str, ...]) -> None:
         "run-duplicate=false\n",
         "classification=docs\n"
         "run-python=false\n"
+        "run-core=false\n"
+        "run-integration=false\n"
+        "run-coverage=false\n"
+        "run-compatibility=false\n"
         "run-lean=false\n"
         "run-npm=true\n"
+        "run-static=false\n"
+        "run-build=false\n"
+        "run-security=false\n"
+        "run-duplicate=false\n",
+        "classification=docs\n"
+        "run-python=true\n"
+        "run-core=true\n"
+        "run-integration=false\n"
+        "run-coverage=false\n"
+        "run-compatibility=false\n"
+        "run-lean=false\n"
+        "run-npm=false\n"
+        "run-static=false\n"
+        "run-build=false\n"
+        "run-security=false\n"
+        "run-duplicate=false\n",
+        "classification=lean\n"
+        "run-python=true\n"
+        "run-core=true\n"
+        "run-integration=false\n"
+        "run-coverage=false\n"
+        "run-compatibility=false\n"
+        "run-lean=false\n"
+        "run-npm=false\n"
         "run-static=false\n"
         "run-build=false\n"
         "run-security=false\n"
@@ -297,6 +336,27 @@ def test_ci_plan_validator_rejects_malformed_or_incoherent_plans(plan: str) -> N
     )
 
     assert completed.returncode != 0
+
+
+def test_every_lean_python_test_enables_the_lean_lane() -> None:
+    lean_tests = sorted(
+        path.as_posix()
+        for path in (Path(__file__).parents[2] / "tests" / "integration" / "lean").glob(
+            "test_*.py"
+        )
+    )
+    assert lean_tests
+
+    for lean_test in lean_tests:
+        completed = subprocess.run(
+            [PLANNER, lean_test],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        plan = dict(line.split("=", 1) for line in completed.stdout.splitlines())
+        assert plan["run-lean"] == "true", lean_test
 
 
 def test_every_tracked_source_file_has_explicit_suite_ownership() -> None:

--- a/tests/unit/test_ci_plan.py
+++ b/tests/unit/test_ci_plan.py
@@ -194,6 +194,41 @@ def _expected_plan(classification: str, *enabled: str) -> dict[str, str]:
             (".github/workflows/ci.yml",),
             _expected_plan("full", *FUNCTIONAL_KEYS),
         ),
+        (
+            ("CONTRIBUTING.md",),
+            _expected_plan("full", *FUNCTIONAL_KEYS),
+        ),
+        (
+            ("tests/helpers/capabilities.py",),
+            _expected_plan(
+                "selective",
+                "run-python",
+                "run-core",
+                "run-integration",
+                "run-static",
+            ),
+        ),
+        (
+            ("tests/conftest.py",),
+            _expected_plan(
+                "selective",
+                "run-python",
+                "run-core",
+                "run-integration",
+                "run-static",
+            ),
+        ),
+        (
+            ("benchmarks/benchmark_core.py",),
+            _expected_plan(
+                "selective",
+                "run-python",
+                "run-core",
+                "run-integration",
+                "run-static",
+                "run-build",
+            ),
+        ),
     ],
 )
 def test_ci_plan_fails_closed_outside_isolated_paths(

--- a/tests/unit/test_ci_test_timings.py
+++ b/tests/unit/test_ci_test_timings.py
@@ -8,6 +8,13 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / ".github" / "scripts" / "manage-test-timings"
+CI_CONFIG = ROOT / ".github" / "ci-config.json"
+
+
+def shard_count() -> int:
+    return int(
+        json.loads(CI_CONFIG.read_text(encoding="utf-8"))["integration_shard_count"]
+    )
 
 
 def run_script(
@@ -41,8 +48,9 @@ def test_prepare_falls_back_to_equal_weighting_without_github_context(
 
 
 def test_merge_publishes_versioned_metadata_and_all_shards(tmp_path: Path) -> None:
+    count = shard_count()
     inputs: list[str] = []
-    for shard in range(1, 5):
+    for shard in range(1, count + 1):
         path = tmp_path / f"shard-{shard}.json"
         path.write_text(
             json.dumps({f"tests/integration/test_{shard}.py::test_case": shard}),
@@ -68,13 +76,14 @@ def test_merge_publishes_versioned_metadata_and_all_shards(tmp_path: Path) -> No
     payload = json.loads(output.read_text(encoding="utf-8"))
     assert payload["version"] == 1
     assert payload["suite"] == "integration"
-    assert payload["shard_count"] == 4
-    assert len(payload["durations"]) == 4
+    assert payload["shard_count"] == count
+    assert len(payload["durations"]) == count
 
 
 def test_merge_rejects_duplicate_node_ids(tmp_path: Path) -> None:
+    count = shard_count()
     inputs: list[str] = []
-    for shard in range(1, 5):
+    for shard in range(1, count + 1):
         path = tmp_path / f"shard-{shard}.json"
         path.write_text(
             json.dumps(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

A deeper audit of CI, fixtures, hooks, and docs found additional fail-closed and DX bugs beyond the first pass—most critically, Lean tests could still execute under xdist workers because workers clear `numprocesses`, so the suite guard was a no-op during real runs. Docs also taught a marker filter that selects the entire suite, and several CI/developer workflows silently drifted from intended behavior.

## Solution

### Critical / high
- Fail closed on Lean under xdist for both controllers and workers; cover with an execution-path regression test
- Remove global `-n auto` from pytest addopts; Make targets (`test`, `test-core`, `test-integration`, `test-failed`) opt into xdist
- Fix Python Debug to use `setup-python-tests` (honors 3.13) and checkout v7
- Re-trigger CI on `labeled`/`unlabeled` so `ci:full` / `ci:lean` apply without a push
- Coverage gate now requires planned core/integration outcomes even when coverage is off
- Security-audit uses the same always-on plan gate pattern as sibling lanes
- Seed Carcara/Lean sibling roots from the reference template instead of wasting the module fixture

### Ownership / Makefile / docs
- `CONTRIBUTING.md` is repository-policy (no longer docs-only)
- Explicit ownership for `tests/helpers/**`, `tests/conftest.py`, `benchmarks/**`
- Add `todo-check`, `coverage`, `bench-core`; wire CI static TODO check through Make
- Correct npm trusted-publisher workflow docs (`release.yml`)
- Replace the false `not integration and not end_to_end` recipe with directory Make targets
- Refresh testing-strategy organization/coverage/label wording; clarify pre-commit vs `make check`

### From the first commit on this branch
Lean path glob, classification validation, cancelled-plan gates, shard SSOT, setup-lean v7, coverage comment TOCTOU heal, kernel fixtures, shared test helpers.

## Testing

```sh
make check
make todo-check
uv run pytest -n 0 \
  tests/integration/infrastructure/test_pytest_execution_policy.py \
  tests/unit/test_ci_plan.py \
  tests/unit/test_ci_test_timings.py
```

## Trust & Compatibility Impact

No verification-kernel, checker-registry, artifact-format, or public-API changes. CI planning, pytest execution policy, docs, and test helpers only.

## Checklist
- [x] Routine local validation passes (`make check`)
- [x] Relevant focused tests are listed above

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08057a55-c351-4bf6-a25c-322886cb240b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08057a55-c351-4bf6-a25c-322886cb240b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

