### PR TITLE
fix(tests): repair test-suite infra honesty and scheduled-lane DX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
       - if: needs.plan.outputs.run-security == 'true'
         run: make security-audit
 
-  validate-agents-md:
+  validate-built-package:
     name: Validate Built Package
     needs: [plan, build]
     if: needs.plan.outputs.run-build == 'true'
@@ -791,7 +791,7 @@ jobs:
       - plan
       - lint
       - security-audit
-      - validate-agents-md
+      - validate-built-package
       - core-test
       - integration-test
       - compatibility-test

--- a/.github/workflows/scheduled-validation.yml
+++ b/.github/workflows/scheduled-validation.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   stress:
-    name: Stress property and stateful tests
+    name: Stress property tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -23,8 +23,8 @@ jobs:
         with:
           python-version: "3.12"
       - run: >-
-          uv run --locked --with pytest-repeat==0.9.4 pytest
-          -m "(property or stateful) and not lean_runtime"
+          uv run --locked pytest
+          -m "property and not lean_runtime"
           --count=3
           --durations=20
 
@@ -42,7 +42,7 @@ jobs:
         with:
           python-version: "3.12"
       - run: >-
-          uv run --locked --with pytest-randomly==4.1.0 pytest
+          uv run --locked pytest
           -m "not lean_runtime"
           --randomly-seed=${{ matrix.seed }}
           --durations=20

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,0 +1,13 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "^https?://"
+    },
+    {
+      "pattern": "^mailto:"
+    }
+  ],
+  "retryOn429": true,
+  "timeout": "10s",
+  "aliveStatusCodes": [200, 206]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,9 +143,11 @@ For documentation-only changes, run:
 ```sh
 git diff --check
 git diff -- AGENTS.md README.md CONTRIBUTING.md docs/
+make docs-linkcheck
 ```
 
-Verify every relative Markdown link before submitting the change.
+Verify every relative Markdown link before submitting the change
+(`make docs-linkcheck` checks project Markdown offline).
 
 ## Releases
 
@@ -170,7 +172,10 @@ Test directories define semantic ownership: `tests/unit`, `tests/contract`,
 `tests/integration` and `tests/end_to_end` form the integration suite. Use
 `make test-core` and `make test-integration` as the canonical entry points.
 Markers describe runtime traits such as `lean_runtime`, `slow`, `subprocess`, or
-`external_backend`; they do not duplicate directory ownership.
+`external_backend`; they do not duplicate directory ownership. Reproduce the
+scheduled validation lanes locally with `make test-stress` and
+`make test-ordering PYTEST_ARGS=--randomly-seed=17` (locked `pytest-repeat` and
+`pytest-randomly` are part of the dev environment).
 
 CI change impact is declared in `.github/ci-impact.json`. Its matching rules are
 additive, so a path may require several suites. Integration timing history is a

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ INTEGRATION_TEST_PATHS := tests/integration tests/end_to_end
 RUFF_PATHS := src tests benchmarks
 PYTEST_XDIST_ARGS := -n auto --maxprocesses=4 --dist=worksteal
 
-.PHONY: help setup hooks fix lint lint-full security-audit typecheck test test-fast test-core test-integration test-contracts test-checkers test-mcp test-storage test-lean test-failed duplicate-code npm-test todo-check coverage build check precommit check-static validate-full agent-eval bench-core
+.PHONY: help setup hooks fix lint lint-full security-audit typecheck test test-fast test-core test-integration test-contracts test-checkers test-mcp test-storage test-lean test-failed test-stress test-ordering duplicate-code npm-test todo-check coverage build check precommit check-static validate-full agent-eval bench-core clean docs-linkcheck
 
 help: ## Show available developer commands.
 	@awk 'BEGIN {FS = ":.*## "; printf "Jacobian developer commands:\n\n"} /^[a-zA-Z_-]+:.*## / {printf "  %-18s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -80,6 +80,12 @@ test-lean: ## Run pinned Lean tests serially; narrow with TESTS=... and PYTEST_A
 test-failed: ## Re-run failures from the previous pytest invocation.
 	$(UV_RUN) pytest $(PYTEST_XDIST_ARGS) --lf -m "not lean_runtime" $(PYTEST_ARGS)
 
+test-stress: ## Reproduce scheduled property stress (pytest-repeat --count=3).
+	$(UV_RUN) pytest -m "property and not lean_runtime" --count=3 $(PYTEST_ARGS)
+
+test-ordering: ## Reproduce scheduled ordering with PYTEST_ARGS=--randomly-seed=N.
+	$(UV_RUN) pytest -m "not lean_runtime" $(PYTEST_ARGS)
+
 duplicate-code: ## Run the CI duplicate-code detector locally.
 	npx --yes jscpd@5.0.12 --config .jscpd.json .
 
@@ -118,3 +124,14 @@ agent-eval: ## Plan a local agent eval; execution requires explicit EVAL_ARGS.
 
 bench-core: ## Run the core performance benchmark script.
 	$(UV_RUN) python benchmarks/benchmark_core.py
+
+clean: ## Remove local caches, build outputs, and coverage artifacts.
+	rm -rf .pytest_cache .mypy_cache .ruff_cache dist build htmlcov
+	rm -f .coverage .coverage.*
+	find src tests benchmarks -type d -name '__pycache__' -prune -exec rm -rf {} +
+	find . -maxdepth 2 -type d -name '*.egg-info' -prune -exec rm -rf {} +
+
+docs-linkcheck: ## Check relative Markdown links in project docs.
+	npx --yes markdown-link-check@3.15.0 \
+		--config .markdown-link-check.json -q \
+		README.md AGENTS.md CONTRIBUTING.md docs

--- a/docs/contributing/test-suite-cost-audit.md
+++ b/docs/contributing/test-suite-cost-audit.md
@@ -145,8 +145,8 @@ Source-to-suite impact is declared in `.github/ci-impact.json` and tested
 against tracked source files. Unknown paths still fail closed. Each CI run
 reports workflow elapsed time (the observable critical path), summed runner
 minutes, and its longest job, making both reviewer latency and compute growth
-visible. Scheduled lanes exercise repeated property/stateful tests, alternate
-orders, optional providers, and the core performance benchmark outside the
+visible. Scheduled lanes exercise repeated property tests, alternate orders,
+optional providers, and the core performance benchmark outside the
 pull-request critical path.
 
 Do not run the complete non-Lean and Lean suites repeatedly during

--- a/docs/reference/testing-strategy.md
+++ b/docs/reference/testing-strategy.md
@@ -64,9 +64,13 @@ make test-checkers
 make test-mcp PYTEST_ARGS="-k authentication"
 make test-storage PYTEST_ARGS="-k workspace"
 make test-lean TESTS=tests/integration/lean/test_lean.py PYTEST_ARGS="-k induction"
+make test-stress
+make test-ordering PYTEST_ARGS=--randomly-seed=17
 make check
 make check-static
 make validate-full
+make docs-linkcheck
+make clean
 ```
 
 `make test-fast` collects only unit, contract, checker, and reference
@@ -76,6 +80,9 @@ seeded stores. Avoid inventing layer-marker filters; directory Make targets own
 suite selection.
 Named contract, checker, MCP, and storage targets
 make common affected areas discoverable without adding another test runner.
+`make test-stress` and `make test-ordering` reproduce the scheduled validation
+property-repeat and ordering-seed lanes using locked `pytest-repeat` and
+`pytest-randomly`.
 `make check` combines fast Ruff, strict typing, and non-integration test
 feedback as the routine local pre-push gate. Developers should push after it and
 let CI own dependency and dead-code analysis, package builds, and exhaustive
@@ -91,7 +98,7 @@ wait on isolated subprocesses. Bare `pytest` stays single-process so focused
 debugging and Lean reproduction do not accidentally start a worker pool. `make test-failed` is the failure-recovery
 shortcut. Use `PYTEST_ARGS="-n 0"` for debugger-friendly, single-process
 execution and `PYTEST_ARGS="--durations=25"` when investigating regressions. A
-120-second per-test backstop prevents local deadlocks from hanging indefinitely
+60-second per-test backstop prevents local deadlocks from hanging indefinitely
 and is disabled automatically by pytest-timeout while debugging. Parallel
 workers retain separate `tmp_path` roots; tests that add shared external state
 must coordinate it explicitly.
@@ -165,9 +172,9 @@ matrices are conditional. Maintainer-applied `ci:full` and `ci:lean` labels can
 force all lanes or add Lean respectively; label events re-trigger CI so the
 override applies without an extra push. Overrides are additive only and
 cannot weaken the plan selected from changed paths. A scheduled validation
-workflow separately exercises repeated property/stateful stress, alternate
-ordering seeds, optional providers, and the core performance benchmark outside
-the pull-request critical path.
+workflow separately exercises repeated property stress, alternate ordering
+seeds, optional providers, and the core performance benchmark outside the
+pull-request critical path.
 
 The build lane produces the source distribution and wheel once. Its dependent
 package-validation job downloads that artifact and exercises both installed
@@ -606,18 +613,20 @@ tests/
 ```
 
 Package-local tests are appropriate for focused behavior. Cross-package trust
-tests live in the top-level groups above. Runtime pytest markers currently in
-use are:
+tests live in the top-level groups above. Runtime pytest markers currently in use are:
 
 ```text
 external_backend
 lean_runtime
 slow
 property
-stateful
-benchmark
-agent_eval
+subprocess
+conformance
+differential
 ```
+
+Reserved markers declared for future or out-of-suite selection (no routine
+tests use them yet) are `stateful`, `benchmark`, and `agent_eval`.
 
 Layer markers such as `integration` or `end_to_end` are intentionally not used;
 select those suites by directory through Make targets.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,8 @@ dev = [
     "pyperf>=2.9,<3",
     "pytest>=8.3,<10",
     "pytest-cov>=6,<8",
+    "pytest-randomly==4.1.0",
+    "pytest-repeat==0.9.4",
     "pytest-rerunfailures>=14,<17",
     "pytest-split==0.11.0",
     "pytest-timeout>=2.4,<3",
@@ -63,7 +65,7 @@ packages = ["src/jacobian", "src/jacobian_checkers"]
 [tool.pytest.ini_options]
 addopts = "-ra --strict-config --strict-markers"
 testpaths = ["tests"]
-timeout = 120
+timeout = 60
 markers = [
     "property: property-based invariant tests",
     "stateful: persistent lifecycle state-machine tests",

--- a/tests/contract/test_canonical_json.py
+++ b/tests/contract/test_canonical_json.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import pytest
-from hypothesis import given
+from hypothesis import given, settings
 from hypothesis import strategies as st
 from pydantic import ValidationError
 
@@ -95,6 +95,7 @@ def test_nesting_beyond_the_configured_limit_is_rejected() -> None:
 
 
 @pytest.mark.property
+@settings(max_examples=100)
 @given(
     numerator=st.integers(min_value=-(10**100), max_value=10**100),
     denominator=st.integers(min_value=1, max_value=10**50),

--- a/tests/integration/graph/test_finite_graph_optimization.py
+++ b/tests/integration/graph/test_finite_graph_optimization.py
@@ -87,6 +87,13 @@ def _edge_subsets(graph: nx.Graph[str]):
 
 
 def _brute_force_optimum(capability_id: str, graph: nx.Graph[str]) -> int:
+    assert len(graph) <= 6, (
+        f"brute-force oracle is exponential; got {len(graph)} vertices (max 6)"
+    )
+    assert graph.number_of_edges() <= 10, (
+        "brute-force oracle is exponential; "
+        f"got {graph.number_of_edges()} edges (max 10)"
+    )
     if capability_id == "graph.domination.minimum.compute":
         return min(
             len(subset)

--- a/tests/integration/graph/test_graph_counterexample_shrinking.py
+++ b/tests/integration/graph/test_graph_counterexample_shrinking.py
@@ -4,8 +4,6 @@ import shutil
 from pathlib import Path
 from typing import Any
 
-import pytest
-
 from jacobian.contracts.capabilities import (
     CapabilityAssuranceLevel,
     CapabilityCompletenessStatus,
@@ -157,7 +155,6 @@ def test_graph_counterexample_shrink_rejects_unrelated_reducer_edits(
     assert "exact single-vertex deletion" in result.output["attempts"][0]["detail"]
 
 
-@pytest.mark.slow
 def test_graph_counterexample_shrink_order_is_deterministic(
     tmp_path: Path, kernel_store_template_with_references: Path
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -514,6 +514,8 @@ dev = [
     { name = "pyperf" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-randomly" },
+    { name = "pytest-repeat" },
     { name = "pytest-rerunfailures" },
     { name = "pytest-split" },
     { name = "pytest-timeout" },
@@ -553,6 +555,8 @@ dev = [
     { name = "pyperf", specifier = ">=2.9,<3" },
     { name = "pytest", specifier = ">=8.3,<10" },
     { name = "pytest-cov", specifier = ">=6,<8" },
+    { name = "pytest-randomly", specifier = "==4.1.0" },
+    { name = "pytest-repeat", specifier = "==0.9.4" },
     { name = "pytest-rerunfailures", specifier = ">=14,<17" },
     { name = "pytest-split", specifier = "==0.11.0" },
     { name = "pytest-timeout", specifier = ">=2.4,<3" },
@@ -1141,6 +1145,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-randomly"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/b3/36192dacc0f470ac2cc516f73e01739c9a48a8224f76beada4f85e1c8a89/pytest_randomly-4.1.0.tar.gz", hash = "sha256:47f1d9746c3bc3efabd53ae1ebfb8bb385cf3d4df4b505b6d58d9c97a3dfe70f", size = 14302, upload-time = "2026-04-20T13:01:51.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/db/2df9a1fca597a273f957a559c20c2d95d629928384507b2afa43ba6909d1/pytest_randomly-4.1.0-py3-none-any.whl", hash = "sha256:f55e89e53367b090c0c053697d7f9d77595543d0e0516c93978b50c0f6b252f9", size = 8353, upload-time = "2026-04-20T13:01:50.382Z" },
+]
+
+[[package]]
+name = "pytest-repeat"
+version = "0.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/d4/69e9dbb9b8266df0b157c72be32083403c412990af15c7c15f7a3fd1b142/pytest_repeat-0.9.4.tar.gz", hash = "sha256:d92ac14dfaa6ffcfe6917e5d16f0c9bc82380c135b03c2a5f412d2637f224485", size = 6488, upload-time = "2025-04-07T14:59:53.077Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/d4/8b706b81b07b43081bd68a2c0359fe895b74bf664b20aca8005d2bb3be71/pytest_repeat-0.9.4-py3-none-any.whl", hash = "sha256:c1738b4e412a6f3b3b9e0b8b29fcd7a423e50f87381ad9307ef6f5a8601139f3", size = 4180, upload-time = "2025-04-07T14:59:51.492Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Rename the stale `validate-agents-md` CI job to `validate-built-package`, make scheduled stress property-only (no phantom `stateful` lane), and lock `pytest-repeat` / `pytest-randomly` so scheduled validation is reproducible locally.
- Guard the graph brute-force oracle size, pin Hypothesis `max_examples=100`, drop the dead integration `@pytest.mark.slow`, and tighten the pytest timeout to 60s.
- Add `make clean`, `make docs-linkcheck`, `make test-stress`, and `make test-ordering`, with CONTRIBUTING / testing-strategy updates.

## Test plan
- [x] `uv run pytest -m "property and not lean_runtime" --collect-only -q` → 1 test
- [x] `make test-stress PYTEST_ARGS='--collect-only -q'` → 3 repeats
- [x] `pytest` on canonical JSON property + finite graph optimization → 39 passed
- [x] `make clean` and `make docs-linkcheck` succeed
- [x] `rg validate-agents-md` empty; ruff clean on touched tests
- [ ] CI green on this PR