### PR TITLE
fix(ci): stabilize release and integration shard gates

### DIFF
--- a/.github/ci-config.json
+++ b/.github/ci-config.json
@@ -1,5 +1,6 @@
 {
   "integration_shard_count": 4,
   "node_version_jscpd": "20",
-  "node_version_npm": "24"
+  "node_version_npm": "24",
+  "pytest_randomly_shard_seed": 0
 }

--- a/.github/scripts/manage-test-timings
+++ b/.github/scripts/manage-test-timings
@@ -41,6 +41,9 @@ def ci_config() -> dict[str, Any]:
         value = payload.get(key)
         if not isinstance(value, str) or not value:
             raise ValueError(f"{key} must be a non-empty string")
+    seed = payload.get("pytest_randomly_shard_seed")
+    if not isinstance(seed, int) or isinstance(seed, bool) or seed < 0:
+        raise ValueError("pytest_randomly_shard_seed must be a nonnegative integer")
     return payload
 
 
@@ -71,6 +74,7 @@ def emit_plan_outputs() -> None:
     print(f"integration-shards={json.dumps(list(range(1, count + 1)))}")
     print(f"node-version-jscpd={config['node_version_jscpd']}")
     print(f"node-version-npm={config['node_version_npm']}")
+    print(f"pytest-randomly-shard-seed={config['pytest_randomly_shard_seed']}")
     print(f"pytest-split-version={pytest_split_version()}")
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
       integration-shards: ${{ steps.shards.outputs.integration-shards }}
       node-version-jscpd: ${{ steps.shards.outputs.node-version-jscpd }}
       node-version-npm: ${{ steps.shards.outputs.node-version-npm }}
+      pytest-randomly-shard-seed: ${{ steps.shards.outputs.pytest-randomly-shard-seed }}
       pytest-split-version: ${{ steps.shards.outputs.pytest-split-version }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -291,6 +292,7 @@ jobs:
             --group ${{ matrix.shard }}
             --splitting-algorithm least_duration
             --durations-path .ci/test-durations.json
+            --randomly-seed ${{ needs.plan.outputs.pytest-randomly-shard-seed }}
             --store-durations
             --clean-durations
             --junitxml=pytest.xml

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -54,5 +54,6 @@ jobs:
           RELEASE_TAG: ${{ steps.release.outputs.tag_name }}
         run: >-
           gh workflow run release.yml
+          --repo "$GITHUB_REPOSITORY"
           --ref "$RELEASE_TAG"
           --field tag="$RELEASE_TAG"

--- a/docs/reference/testing-strategy.md
+++ b/docs/reference/testing-strategy.md
@@ -83,6 +83,11 @@ make common affected areas discoverable without adding another test runner.
 `make test-stress` and `make test-ordering` reproduce the scheduled validation
 property-repeat and ordering-seed lanes using locked `pytest-repeat` and
 `pytest-randomly`.
+CI integration shards use one fixed `pytest-randomly` seed from
+`.github/ci-config.json`. Every shard must collect tests in the same order
+before `pytest-split` partitions them; otherwise independently randomized
+collections can overlap or omit tests. The merged timing artifact rejects
+duplicate node IDs instead of concealing such an overlap.
 `make check` combines fast Ruff, strict typing, and non-integration test
 feedback as the routine local pre-push gate. Developers should push after it and
 let CI own dependency and dead-code analysis, package builds, and exhaustive

--- a/tests/unit/test_ci_test_timings.py
+++ b/tests/unit/test_ci_test_timings.py
@@ -122,6 +122,7 @@ def test_emit_plan_outputs_exposes_ci_config_ssot() -> None:
     outputs = plan_outputs()
     assert outputs["node-version-jscpd"] == "20"
     assert outputs["node-version-npm"] == "24"
+    assert outputs["pytest-randomly-shard-seed"] == "0"
     assert outputs["pytest-split-version"]
     assert (
         run_script("node-version", "npm").stdout.strip() == outputs["node-version-npm"]


### PR DESCRIPTION
## Summary

- pin one pytest-randomly seed across every pytest-split integration shard
- retain fail-closed duplicate timing detection and document why collection order must match
- make Release Please publishing dispatch repository-explicit when no checkout exists

## Validation

- `tests/unit/test_ci_test_timings.py`: 5 passed
- fixed-seed collect-only partition: 722 tests across 4 shards, 0 overlaps, 0 missing
- targeted Ruff, format, and mypy checks passed
- `make docs-linkcheck` passed
- public MCP frontier and broad smoke passed on deployed `410fa50`

## Release context

Main run 30378996189 failed because different pytest-randomly collection orders made pytest-split execute two node IDs in multiple shards. Release run 30378968675 created the GitHub release but could not dispatch `release.yml` because `gh workflow run` lacked `--repo` in a job without a checkout.