### PR TITLE
docs(examples): cover combinatorics and finite sets

### DIFF
--- a/src/jacobian/domains/combinatorics/counting.py
+++ b/src/jacobian/domains/combinatorics/counting.py
@@ -33,9 +33,7 @@ COUNTING_CAPABILITIES = (
         factorial,
         "combinatorics",
         "counting",
-        invocation_examples=(
-            example("factorial_5", "Compute 5 factorial.", {"n": 5}),
-        ),
+        invocation_examples=(example("factorial_5", "Compute 5 factorial.", {"n": 5}),),
     ),
     combinatorics_operation(
         "combinatorics.compute.double_factorial",
@@ -103,7 +101,11 @@ COUNTING_CAPABILITIES = (
         "combinatorics",
         "counting",
         invocation_examples=(
-            example("permutations_5_2", "Count ordered selections of 2 from 5.", {"n": 5, "k": 2}),
+            example(
+                "permutations_5_2",
+                "Count ordered selections of 2 from 5.",
+                {"n": 5, "k": 2},
+            ),
         ),
     ),
     combinatorics_operation(
@@ -142,7 +144,11 @@ COUNTING_CAPABILITIES = (
         "combinatorics",
         "counting",
         invocation_examples=(
-            example("central_binomial_4", "Compute the central binomial coefficient for n=4.", {"n": 4}),
+            example(
+                "central_binomial_4",
+                "Compute the central binomial coefficient for n=4.",
+                {"n": 4},
+            ),
         ),
     ),
     combinatorics_operation(
@@ -155,7 +161,11 @@ COUNTING_CAPABILITIES = (
         "combinatorics",
         "counting",
         invocation_examples=(
-            example("compositions_5_2", "Count positive compositions of 5 into 2 parts.", {"n": 5, "k": 2}),
+            example(
+                "compositions_5_2",
+                "Count positive compositions of 5 into 2 parts.",
+                {"n": 5, "k": 2},
+            ),
         ),
     ),
 )

--- a/src/jacobian/domains/combinatorics/counting.py
+++ b/src/jacobian/domains/combinatorics/counting.py
@@ -33,6 +33,9 @@ COUNTING_CAPABILITIES = (
         factorial,
         "combinatorics",
         "counting",
+        invocation_examples=(
+            example("factorial_5", "Compute 5 factorial.", {"n": 5}),
+        ),
     ),
     combinatorics_operation(
         "combinatorics.compute.double_factorial",
@@ -43,6 +46,9 @@ COUNTING_CAPABILITIES = (
         double_factorial,
         "combinatorics",
         "counting",
+        invocation_examples=(
+            example("double_factorial_7", "Compute 7 double factorial.", {"n": 7}),
+        ),
     ),
     combinatorics_operation(
         "combinatorics.compute.derangements",
@@ -53,6 +59,9 @@ COUNTING_CAPABILITIES = (
         derangements,
         "combinatorics",
         "counting",
+        invocation_examples=(
+            example("derangements_4", "Count derangements of 4 objects.", {"n": 4}),
+        ),
     ),
     combinatorics_operation(
         "combinatorics.compute.binomial",
@@ -76,6 +85,13 @@ COUNTING_CAPABILITIES = (
         multinomial,
         "combinatorics",
         "counting",
+        invocation_examples=(
+            example(
+                "multinomial_2_1_2",
+                "Compute a multinomial coefficient for parts 2, 1, and 2.",
+                {"values": ["2", "1", "2"]},
+            ),
+        ),
     ),
     combinatorics_operation(
         "combinatorics.compute.permutations",
@@ -86,6 +102,9 @@ COUNTING_CAPABILITIES = (
         permutations,
         "combinatorics",
         "counting",
+        invocation_examples=(
+            example("permutations_5_2", "Count ordered selections of 2 from 5.", {"n": 5, "k": 2}),
+        ),
     ),
     combinatorics_operation(
         "combinatorics.compute.catalan",
@@ -96,6 +115,9 @@ COUNTING_CAPABILITIES = (
         catalan,
         "combinatorics",
         "counting",
+        invocation_examples=(
+            example("catalan_4", "Compute the fourth Catalan number.", {"n": 4}),
+        ),
     ),
     combinatorics_operation(
         "combinatorics.compute.motzkin",
@@ -106,6 +128,9 @@ COUNTING_CAPABILITIES = (
         motzkin,
         "combinatorics",
         "counting",
+        invocation_examples=(
+            example("motzkin_5", "Compute the fifth Motzkin number.", {"n": 5}),
+        ),
     ),
     combinatorics_operation(
         "combinatorics.compute.central_binomial",
@@ -116,6 +141,9 @@ COUNTING_CAPABILITIES = (
         central_binomial,
         "combinatorics",
         "counting",
+        invocation_examples=(
+            example("central_binomial_4", "Compute the central binomial coefficient for n=4.", {"n": 4}),
+        ),
     ),
     combinatorics_operation(
         "combinatorics.compute.compositions",
@@ -126,5 +154,8 @@ COUNTING_CAPABILITIES = (
         compositions,
         "combinatorics",
         "counting",
+        invocation_examples=(
+            example("compositions_5_2", "Count positive compositions of 5 into 2 parts.", {"n": 5, "k": 2}),
+        ),
     ),
 )

--- a/src/jacobian/domains/combinatorics/partitions.py
+++ b/src/jacobian/domains/combinatorics/partitions.py
@@ -29,6 +29,9 @@ PARTITION_CAPABILITIES = (
         stirling_first,
         "combinatorics",
         "partition",
+        invocation_examples=(
+            example("stirling_first_5_2", "Compute the unsigned Stirling number for n=5, k=2.", {"n": 5, "k": 2}),
+        ),
     ),
     combinatorics_operation(
         "combinatorics.compute.stirling_second",
@@ -39,6 +42,9 @@ PARTITION_CAPABILITIES = (
         stirling_second,
         "combinatorics",
         "partition",
+        invocation_examples=(
+            example("stirling_second_5_2", "Compute the Stirling number for n=5, k=2.", {"n": 5, "k": 2}),
+        ),
     ),
     combinatorics_operation(
         "combinatorics.compute.bell",
@@ -49,6 +55,9 @@ PARTITION_CAPABILITIES = (
         bell,
         "combinatorics",
         "partition",
+        invocation_examples=(
+            example("bell_5", "Compute the fifth Bell number.", {"n": 5}),
+        ),
     ),
     combinatorics_operation(
         "combinatorics.compute.partition_number",
@@ -59,6 +68,9 @@ PARTITION_CAPABILITIES = (
         partition_number,
         "combinatorics",
         "partition",
+        invocation_examples=(
+            example("partition_number_6", "Count the additive partitions of 6.", {"n": 6}),
+        ),
     ),
     combinatorics_operation(
         "combinatorics.enumerate.integer_partitions",

--- a/src/jacobian/domains/combinatorics/partitions.py
+++ b/src/jacobian/domains/combinatorics/partitions.py
@@ -30,7 +30,11 @@ PARTITION_CAPABILITIES = (
         "combinatorics",
         "partition",
         invocation_examples=(
-            example("stirling_first_5_2", "Compute the unsigned Stirling number for n=5, k=2.", {"n": 5, "k": 2}),
+            example(
+                "stirling_first_5_2",
+                "Compute the unsigned Stirling number for n=5, k=2.",
+                {"n": 5, "k": 2},
+            ),
         ),
     ),
     combinatorics_operation(
@@ -43,7 +47,11 @@ PARTITION_CAPABILITIES = (
         "combinatorics",
         "partition",
         invocation_examples=(
-            example("stirling_second_5_2", "Compute the Stirling number for n=5, k=2.", {"n": 5, "k": 2}),
+            example(
+                "stirling_second_5_2",
+                "Compute the Stirling number for n=5, k=2.",
+                {"n": 5, "k": 2},
+            ),
         ),
     ),
     combinatorics_operation(
@@ -69,7 +77,9 @@ PARTITION_CAPABILITIES = (
         "combinatorics",
         "partition",
         invocation_examples=(
-            example("partition_number_6", "Count the additive partitions of 6.", {"n": 6}),
+            example(
+                "partition_number_6", "Count the additive partitions of 6.", {"n": 6}
+            ),
         ),
     ),
     combinatorics_operation(

--- a/src/jacobian/domains/combinatorics/recurrence.py
+++ b/src/jacobian/domains/combinatorics/recurrence.py
@@ -28,6 +28,9 @@ RECURRENCE_CAPABILITIES = (
         fibonacci,
         "combinatorics",
         "sequence",
+        invocation_examples=(
+            example("fibonacci_10", "Compute the tenth Fibonacci number.", {"n": 10}),
+        ),
     ),
     combinatorics_operation(
         "combinatorics.compute.fibonacci_pair",
@@ -39,6 +42,9 @@ RECURRENCE_CAPABILITIES = (
         "combinatorics",
         "fibonacci",
         "recurrence-boundary",
+        invocation_examples=(
+            example("fibonacci_pair_8", "Return consecutive Fibonacci values at n=8.", {"n": 8}),
+        ),
     ),
     combinatorics_operation(
         "combinatorics.compute.lucas",
@@ -49,6 +55,9 @@ RECURRENCE_CAPABILITIES = (
         lucas,
         "combinatorics",
         "sequence",
+        invocation_examples=(
+            example("lucas_7", "Compute the seventh Lucas number.", {"n": 7}),
+        ),
     ),
     combinatorics_operation(
         "combinatorics.compute.bernoulli",

--- a/src/jacobian/domains/combinatorics/recurrence.py
+++ b/src/jacobian/domains/combinatorics/recurrence.py
@@ -43,7 +43,11 @@ RECURRENCE_CAPABILITIES = (
         "fibonacci",
         "recurrence-boundary",
         invocation_examples=(
-            example("fibonacci_pair_8", "Return consecutive Fibonacci values at n=8.", {"n": 8}),
+            example(
+                "fibonacci_pair_8",
+                "Return consecutive Fibonacci values at n=8.",
+                {"n": 8},
+            ),
         ),
     ),
     combinatorics_operation(

--- a/src/jacobian/domains/finite_sets/set_cardinality.py
+++ b/src/jacobian/domains/finite_sets/set_cardinality.py
@@ -4,6 +4,7 @@ from jacobian.contracts.finite_sets import (
     FiniteSetCardinalityResult,
     FiniteSetPairRequest,
 )
+from jacobian.domains._examples import example
 from jacobian.domains.finite_sets._support import finite_set_operation
 from jacobian.domains.finite_sets.operations import (
     intersection_cardinality,
@@ -21,6 +22,9 @@ SET_CARDINALITY_CAPABILITIES = (
         left_cardinality,
         "finite-set",
         "counting",
+        invocation_examples=(
+            example("left_cardinality_1_2_3", "Count elements in the left finite set.", {"left": {"elements": ["1", "2", "3"]}, "right": {"elements": ["2"]}}),
+        ),
     ),
     finite_set_operation(
         "finite_set.compute.intersection_cardinality",
@@ -31,6 +35,9 @@ SET_CARDINALITY_CAPABILITIES = (
         intersection_cardinality,
         "finite-set",
         "counting",
+        invocation_examples=(
+            example("intersection_cardinality_1_2_and_2_3", "Count common elements of two finite sets.", {"left": {"elements": ["1", "2"]}, "right": {"elements": ["2", "3"]}}),
+        ),
     ),
     finite_set_operation(
         "finite_set.compute.union_cardinality",
@@ -41,5 +48,8 @@ SET_CARDINALITY_CAPABILITIES = (
         union_cardinality,
         "finite-set",
         "counting",
+        invocation_examples=(
+            example("union_cardinality_1_2_and_2_3", "Count elements in the union of two finite sets.", {"left": {"elements": ["1", "2"]}, "right": {"elements": ["2", "3"]}}),
+        ),
     ),
 )

--- a/src/jacobian/domains/finite_sets/set_cardinality.py
+++ b/src/jacobian/domains/finite_sets/set_cardinality.py
@@ -23,7 +23,11 @@ SET_CARDINALITY_CAPABILITIES = (
         "finite-set",
         "counting",
         invocation_examples=(
-            example("left_cardinality_1_2_3", "Count elements in the left finite set.", {"left": {"elements": ["1", "2", "3"]}, "right": {"elements": ["2"]}}),
+            example(
+                "left_cardinality_1_2_3",
+                "Count elements in the left finite set.",
+                {"left": {"elements": ["1", "2", "3"]}, "right": {"elements": ["2"]}},
+            ),
         ),
     ),
     finite_set_operation(
@@ -36,7 +40,11 @@ SET_CARDINALITY_CAPABILITIES = (
         "finite-set",
         "counting",
         invocation_examples=(
-            example("intersection_cardinality_1_2_and_2_3", "Count common elements of two finite sets.", {"left": {"elements": ["1", "2"]}, "right": {"elements": ["2", "3"]}}),
+            example(
+                "intersection_cardinality_1_2_and_2_3",
+                "Count common elements of two finite sets.",
+                {"left": {"elements": ["1", "2"]}, "right": {"elements": ["2", "3"]}},
+            ),
         ),
     ),
     finite_set_operation(
@@ -49,7 +57,11 @@ SET_CARDINALITY_CAPABILITIES = (
         "finite-set",
         "counting",
         invocation_examples=(
-            example("union_cardinality_1_2_and_2_3", "Count elements in the union of two finite sets.", {"left": {"elements": ["1", "2"]}, "right": {"elements": ["2", "3"]}}),
+            example(
+                "union_cardinality_1_2_and_2_3",
+                "Count elements in the union of two finite sets.",
+                {"left": {"elements": ["1", "2"]}, "right": {"elements": ["2", "3"]}},
+            ),
         ),
     ),
 )

--- a/src/jacobian/domains/finite_sets/set_operations.py
+++ b/src/jacobian/domains/finite_sets/set_operations.py
@@ -40,6 +40,13 @@ SET_OPERATION_CAPABILITIES = (
         set_intersection,
         "finite-set",
         "exact",
+        invocation_examples=(
+            example(
+                "intersection_1_2_and_2_3",
+                "Intersect two finite sets.",
+                {"left": {"elements": ["1", "2"]}, "right": {"elements": ["2", "3"]}},
+            ),
+        ),
     ),
     finite_set_operation(
         "finite_set.compute.difference",
@@ -50,6 +57,13 @@ SET_OPERATION_CAPABILITIES = (
         set_difference,
         "finite-set",
         "exact",
+        invocation_examples=(
+            example(
+                "difference_1_2_minus_2_3",
+                "Subtract one finite set from another.",
+                {"left": {"elements": ["1", "2"]}, "right": {"elements": ["2", "3"]}},
+            ),
+        ),
     ),
     finite_set_operation(
         "finite_set.compute.symmetric_difference",

--- a/src/jacobian/domains/finite_sets/set_predicates.py
+++ b/src/jacobian/domains/finite_sets/set_predicates.py
@@ -23,7 +23,14 @@ SET_PREDICATE_CAPABILITIES = (
         "finite-set",
         "predicate",
         invocation_examples=(
-            example("subset_1_2_of_1_2_3", "Check a finite-set subset relation.", {"left": {"elements": ["1", "2"]}, "right": {"elements": ["1", "2", "3"]}}),
+            example(
+                "subset_1_2_of_1_2_3",
+                "Check a finite-set subset relation.",
+                {
+                    "left": {"elements": ["1", "2"]},
+                    "right": {"elements": ["1", "2", "3"]},
+                },
+            ),
         ),
     ),
     finite_set_operation(
@@ -36,7 +43,14 @@ SET_PREDICATE_CAPABILITIES = (
         "finite-set",
         "predicate",
         invocation_examples=(
-            example("proper_subset_1_2_of_1_2_3", "Check a proper finite-set subset relation.", {"left": {"elements": ["1", "2"]}, "right": {"elements": ["1", "2", "3"]}}),
+            example(
+                "proper_subset_1_2_of_1_2_3",
+                "Check a proper finite-set subset relation.",
+                {
+                    "left": {"elements": ["1", "2"]},
+                    "right": {"elements": ["1", "2", "3"]},
+                },
+            ),
         ),
     ),
     finite_set_operation(
@@ -49,7 +63,11 @@ SET_PREDICATE_CAPABILITIES = (
         "finite-set",
         "predicate",
         invocation_examples=(
-            example("disjoint_1_2_and_3_4", "Check whether two finite sets are disjoint.", {"left": {"elements": ["1", "2"]}, "right": {"elements": ["3", "4"]}}),
+            example(
+                "disjoint_1_2_and_3_4",
+                "Check whether two finite sets are disjoint.",
+                {"left": {"elements": ["1", "2"]}, "right": {"elements": ["3", "4"]}},
+            ),
         ),
     ),
 )

--- a/src/jacobian/domains/finite_sets/set_predicates.py
+++ b/src/jacobian/domains/finite_sets/set_predicates.py
@@ -4,6 +4,7 @@ from jacobian.contracts.finite_sets import (
     FiniteSetBooleanResult,
     FiniteSetPairRequest,
 )
+from jacobian.domains._examples import example
 from jacobian.domains.finite_sets._support import finite_set_operation
 from jacobian.domains.finite_sets.operations import (
     decide_disjoint,
@@ -21,6 +22,9 @@ SET_PREDICATE_CAPABILITIES = (
         decide_subset,
         "finite-set",
         "predicate",
+        invocation_examples=(
+            example("subset_1_2_of_1_2_3", "Check a finite-set subset relation.", {"left": {"elements": ["1", "2"]}, "right": {"elements": ["1", "2", "3"]}}),
+        ),
     ),
     finite_set_operation(
         "finite_set.decide.proper_subset",
@@ -31,6 +35,9 @@ SET_PREDICATE_CAPABILITIES = (
         decide_proper_subset,
         "finite-set",
         "predicate",
+        invocation_examples=(
+            example("proper_subset_1_2_of_1_2_3", "Check a proper finite-set subset relation.", {"left": {"elements": ["1", "2"]}, "right": {"elements": ["1", "2", "3"]}}),
+        ),
     ),
     finite_set_operation(
         "finite_set.decide.disjoint",
@@ -41,5 +48,8 @@ SET_PREDICATE_CAPABILITIES = (
         decide_disjoint,
         "finite-set",
         "predicate",
+        invocation_examples=(
+            example("disjoint_1_2_and_3_4", "Check whether two finite sets are disjoint.", {"left": {"elements": ["1", "2"]}, "right": {"elements": ["3", "4"]}}),
+        ),
     ),
 )


### PR DESCRIPTION
## Summary

Add concise, deterministic invocation examples for 24 previously uncovered combinatorics and finite-set capabilities.

## Scope

- Completes the remaining combinatorics counting, recurrence, and partition capabilities.
- Adds finite-set operation, cardinality, and predicate examples.
- Reuses the existing `CapabilityInvocationExample` mechanism.
- Does not change schemas or capability semantics.

## Validation

- Catalog registration validates all examples against their canonical schemas.
- 59 capabilities now expose schema-valid invocation examples (217 total).
- Ruff and `git diff --check` pass.
- Local pytest collection is blocked by the environment's missing `timeout` plugin and `z3` dependency; no assertions were changed or skipped.