### PR TITLE
docs(examples): cover integer number theory

### DIFF
--- a/src/jacobian/domains/arithmetic/integers.py
+++ b/src/jacobian/domains/arithmetic/integers.py
@@ -36,6 +36,7 @@ INTEGER_CAPABILITIES = (
         absolute_value,
         "integer",
         "exact",
+        invocation_examples=(example("absolute_value_negative_42", "Compute the absolute value of -42.", {"value": "-42"}),),
     ),
     arithmetic_operation(
         "integer.compute.sign",
@@ -46,6 +47,7 @@ INTEGER_CAPABILITIES = (
         sign,
         "integer",
         "exact",
+        invocation_examples=(example("sign_negative_42", "Compute the sign of -42.", {"value": "-42"}),),
     ),
     arithmetic_operation(
         "integer.compute.decimal_digit_sum",
@@ -56,6 +58,7 @@ INTEGER_CAPABILITIES = (
         decimal_digit_sum,
         "integer",
         "representation",
+        invocation_examples=(example("decimal_digit_sum_12345", "Sum the decimal digits of 12345.", {"value": "12345"}),),
     ),
     arithmetic_operation(
         "integer.compute.decimal_digit_count",
@@ -66,6 +69,7 @@ INTEGER_CAPABILITIES = (
         decimal_digit_count,
         "integer",
         "representation",
+        invocation_examples=(example("decimal_digit_count_12345", "Count the decimal digits of 12345.", {"value": "12345"}),),
     ),
     arithmetic_operation(
         "integer.transform.base_digits",

--- a/src/jacobian/domains/arithmetic/integers.py
+++ b/src/jacobian/domains/arithmetic/integers.py
@@ -36,7 +36,13 @@ INTEGER_CAPABILITIES = (
         absolute_value,
         "integer",
         "exact",
-        invocation_examples=(example("absolute_value_negative_42", "Compute the absolute value of -42.", {"value": "-42"}),),
+        invocation_examples=(
+            example(
+                "absolute_value_negative_42",
+                "Compute the absolute value of -42.",
+                {"value": "-42"},
+            ),
+        ),
     ),
     arithmetic_operation(
         "integer.compute.sign",
@@ -47,7 +53,9 @@ INTEGER_CAPABILITIES = (
         sign,
         "integer",
         "exact",
-        invocation_examples=(example("sign_negative_42", "Compute the sign of -42.", {"value": "-42"}),),
+        invocation_examples=(
+            example("sign_negative_42", "Compute the sign of -42.", {"value": "-42"}),
+        ),
     ),
     arithmetic_operation(
         "integer.compute.decimal_digit_sum",
@@ -58,7 +66,13 @@ INTEGER_CAPABILITIES = (
         decimal_digit_sum,
         "integer",
         "representation",
-        invocation_examples=(example("decimal_digit_sum_12345", "Sum the decimal digits of 12345.", {"value": "12345"}),),
+        invocation_examples=(
+            example(
+                "decimal_digit_sum_12345",
+                "Sum the decimal digits of 12345.",
+                {"value": "12345"},
+            ),
+        ),
     ),
     arithmetic_operation(
         "integer.compute.decimal_digit_count",
@@ -69,7 +83,13 @@ INTEGER_CAPABILITIES = (
         decimal_digit_count,
         "integer",
         "representation",
-        invocation_examples=(example("decimal_digit_count_12345", "Count the decimal digits of 12345.", {"value": "12345"}),),
+        invocation_examples=(
+            example(
+                "decimal_digit_count_12345",
+                "Count the decimal digits of 12345.",
+                {"value": "12345"},
+            ),
+        ),
     ),
     arithmetic_operation(
         "integer.transform.base_digits",

--- a/src/jacobian/domains/number_theory/divisibility.py
+++ b/src/jacobian/domains/number_theory/divisibility.py
@@ -45,7 +45,9 @@ DIVISIBILITY_CAPABILITIES = (
         compute_gcd,
         "number-theory",
         "divisibility",
-        invocation_examples=(example("gcd_84_30", "Compute gcd(84, 30).", {"left": "84", "right": "30"}),),
+        invocation_examples=(
+            example("gcd_84_30", "Compute gcd(84, 30).", {"left": "84", "right": "30"}),
+        ),
     ),
     number_theory_operation(
         "integer.compute.lcm",
@@ -56,7 +58,9 @@ DIVISIBILITY_CAPABILITIES = (
         compute_lcm,
         "number-theory",
         "divisibility",
-        invocation_examples=(example("lcm_12_18", "Compute lcm(12, 18).", {"left": "12", "right": "18"}),),
+        invocation_examples=(
+            example("lcm_12_18", "Compute lcm(12, 18).", {"left": "12", "right": "18"}),
+        ),
     ),
     number_theory_operation(
         "integer.compute.extended_gcd",
@@ -84,7 +88,13 @@ DIVISIBILITY_CAPABILITIES = (
         compute_valuation,
         "number-theory",
         "valuation",
-        invocation_examples=(example("valuation_40_at_2", "Compute the 2-adic valuation of 40.", {"value": "40", "prime": "2"}),),
+        invocation_examples=(
+            example(
+                "valuation_40_at_2",
+                "Compute the 2-adic valuation of 40.",
+                {"value": "40", "prime": "2"},
+            ),
+        ),
     ),
     number_theory_operation(
         "integer.compute.divisor_count",
@@ -95,7 +105,11 @@ DIVISIBILITY_CAPABILITIES = (
         compute_divisor_count,
         "number-theory",
         "divisibility",
-        invocation_examples=(example("divisor_count_36", "Count the positive divisors of 36.", {"n": 36}),),
+        invocation_examples=(
+            example(
+                "divisor_count_36", "Count the positive divisors of 36.", {"n": 36}
+            ),
+        ),
     ),
     number_theory_operation(
         "integer.compute.divisor_sum",
@@ -106,7 +120,9 @@ DIVISIBILITY_CAPABILITIES = (
         compute_divisor_sum,
         "number-theory",
         "divisibility",
-        invocation_examples=(example("divisor_sum_12", "Sum the positive divisors of 12.", {"n": 12}),),
+        invocation_examples=(
+            example("divisor_sum_12", "Sum the positive divisors of 12.", {"n": 12}),
+        ),
     ),
     number_theory_operation(
         "integer.compute.aliquot_sum",
@@ -117,7 +133,9 @@ DIVISIBILITY_CAPABILITIES = (
         compute_aliquot_sum,
         "number-theory",
         "divisibility",
-        invocation_examples=(example("aliquot_sum_12", "Compute the aliquot sum of 12.", {"n": 12}),),
+        invocation_examples=(
+            example("aliquot_sum_12", "Compute the aliquot sum of 12.", {"n": 12}),
+        ),
     ),
     number_theory_operation(
         "integer.decide.coprime",
@@ -128,7 +146,13 @@ DIVISIBILITY_CAPABILITIES = (
         decide_coprime,
         "number-theory",
         "predicate",
-        invocation_examples=(example("coprime_14_25", "Check whether 14 and 25 are coprime.", {"left": "14", "right": "25"}),),
+        invocation_examples=(
+            example(
+                "coprime_14_25",
+                "Check whether 14 and 25 are coprime.",
+                {"left": "14", "right": "25"},
+            ),
+        ),
     ),
     number_theory_operation(
         "integer.decide.divides",
@@ -139,7 +163,13 @@ DIVISIBILITY_CAPABILITIES = (
         decide_divides,
         "number-theory",
         "predicate",
-        invocation_examples=(example("divides_6_42", "Check whether 6 divides 42.", {"divisor": "6", "dividend": "42"}),),
+        invocation_examples=(
+            example(
+                "divides_6_42",
+                "Check whether 6 divides 42.",
+                {"divisor": "6", "dividend": "42"},
+            ),
+        ),
     ),
     number_theory_operation(
         "integer.decide.even",
@@ -150,7 +180,9 @@ DIVISIBILITY_CAPABILITIES = (
         decide_even,
         "integer",
         "predicate",
-        invocation_examples=(example("even_42", "Check whether 42 is even.", {"value": "42"}),),
+        invocation_examples=(
+            example("even_42", "Check whether 42 is even.", {"value": "42"}),
+        ),
     ),
     number_theory_operation(
         "integer.decide.odd",
@@ -161,7 +193,9 @@ DIVISIBILITY_CAPABILITIES = (
         decide_odd,
         "integer",
         "predicate",
-        invocation_examples=(example("odd_41", "Check whether 41 is odd.", {"value": "41"}),),
+        invocation_examples=(
+            example("odd_41", "Check whether 41 is odd.", {"value": "41"}),
+        ),
     ),
     number_theory_operation(
         "integer.decide.square",
@@ -172,7 +206,9 @@ DIVISIBILITY_CAPABILITIES = (
         decide_square,
         "number-theory",
         "predicate",
-        invocation_examples=(example("square_144", "Check whether 144 is a perfect square.", {"n": 144}),),
+        invocation_examples=(
+            example("square_144", "Check whether 144 is a perfect square.", {"n": 144}),
+        ),
     ),
     number_theory_operation(
         "integer.decide.perfect",
@@ -183,7 +219,9 @@ DIVISIBILITY_CAPABILITIES = (
         decide_perfect,
         "number-theory",
         "predicate",
-        invocation_examples=(example("perfect_28", "Check whether 28 is perfect.", {"n": 28}),),
+        invocation_examples=(
+            example("perfect_28", "Check whether 28 is perfect.", {"n": 28}),
+        ),
     ),
     number_theory_operation(
         "integer.decide.abundant",
@@ -194,7 +232,9 @@ DIVISIBILITY_CAPABILITIES = (
         decide_abundant,
         "number-theory",
         "predicate",
-        invocation_examples=(example("abundant_12", "Check whether 12 is abundant.", {"n": 12}),),
+        invocation_examples=(
+            example("abundant_12", "Check whether 12 is abundant.", {"n": 12}),
+        ),
     ),
     number_theory_operation(
         "integer.decide.deficient",
@@ -205,6 +245,8 @@ DIVISIBILITY_CAPABILITIES = (
         decide_deficient,
         "number-theory",
         "predicate",
-        invocation_examples=(example("deficient_10", "Check whether 10 is deficient.", {"n": 10}),),
+        invocation_examples=(
+            example("deficient_10", "Check whether 10 is deficient.", {"n": 10}),
+        ),
     ),
 )

--- a/src/jacobian/domains/number_theory/divisibility.py
+++ b/src/jacobian/domains/number_theory/divisibility.py
@@ -45,6 +45,7 @@ DIVISIBILITY_CAPABILITIES = (
         compute_gcd,
         "number-theory",
         "divisibility",
+        invocation_examples=(example("gcd_84_30", "Compute gcd(84, 30).", {"left": "84", "right": "30"}),),
     ),
     number_theory_operation(
         "integer.compute.lcm",
@@ -55,6 +56,7 @@ DIVISIBILITY_CAPABILITIES = (
         compute_lcm,
         "number-theory",
         "divisibility",
+        invocation_examples=(example("lcm_12_18", "Compute lcm(12, 18).", {"left": "12", "right": "18"}),),
     ),
     number_theory_operation(
         "integer.compute.extended_gcd",
@@ -82,6 +84,7 @@ DIVISIBILITY_CAPABILITIES = (
         compute_valuation,
         "number-theory",
         "valuation",
+        invocation_examples=(example("valuation_40_at_2", "Compute the 2-adic valuation of 40.", {"value": "40", "prime": "2"}),),
     ),
     number_theory_operation(
         "integer.compute.divisor_count",
@@ -92,6 +95,7 @@ DIVISIBILITY_CAPABILITIES = (
         compute_divisor_count,
         "number-theory",
         "divisibility",
+        invocation_examples=(example("divisor_count_36", "Count the positive divisors of 36.", {"n": 36}),),
     ),
     number_theory_operation(
         "integer.compute.divisor_sum",
@@ -102,6 +106,7 @@ DIVISIBILITY_CAPABILITIES = (
         compute_divisor_sum,
         "number-theory",
         "divisibility",
+        invocation_examples=(example("divisor_sum_12", "Sum the positive divisors of 12.", {"n": 12}),),
     ),
     number_theory_operation(
         "integer.compute.aliquot_sum",
@@ -112,6 +117,7 @@ DIVISIBILITY_CAPABILITIES = (
         compute_aliquot_sum,
         "number-theory",
         "divisibility",
+        invocation_examples=(example("aliquot_sum_12", "Compute the aliquot sum of 12.", {"n": 12}),),
     ),
     number_theory_operation(
         "integer.decide.coprime",
@@ -122,6 +128,7 @@ DIVISIBILITY_CAPABILITIES = (
         decide_coprime,
         "number-theory",
         "predicate",
+        invocation_examples=(example("coprime_14_25", "Check whether 14 and 25 are coprime.", {"left": "14", "right": "25"}),),
     ),
     number_theory_operation(
         "integer.decide.divides",
@@ -132,6 +139,7 @@ DIVISIBILITY_CAPABILITIES = (
         decide_divides,
         "number-theory",
         "predicate",
+        invocation_examples=(example("divides_6_42", "Check whether 6 divides 42.", {"divisor": "6", "dividend": "42"}),),
     ),
     number_theory_operation(
         "integer.decide.even",
@@ -142,6 +150,7 @@ DIVISIBILITY_CAPABILITIES = (
         decide_even,
         "integer",
         "predicate",
+        invocation_examples=(example("even_42", "Check whether 42 is even.", {"value": "42"}),),
     ),
     number_theory_operation(
         "integer.decide.odd",
@@ -152,6 +161,7 @@ DIVISIBILITY_CAPABILITIES = (
         decide_odd,
         "integer",
         "predicate",
+        invocation_examples=(example("odd_41", "Check whether 41 is odd.", {"value": "41"}),),
     ),
     number_theory_operation(
         "integer.decide.square",
@@ -162,6 +172,7 @@ DIVISIBILITY_CAPABILITIES = (
         decide_square,
         "number-theory",
         "predicate",
+        invocation_examples=(example("square_144", "Check whether 144 is a perfect square.", {"n": 144}),),
     ),
     number_theory_operation(
         "integer.decide.perfect",
@@ -172,6 +183,7 @@ DIVISIBILITY_CAPABILITIES = (
         decide_perfect,
         "number-theory",
         "predicate",
+        invocation_examples=(example("perfect_28", "Check whether 28 is perfect.", {"n": 28}),),
     ),
     number_theory_operation(
         "integer.decide.abundant",
@@ -182,6 +194,7 @@ DIVISIBILITY_CAPABILITIES = (
         decide_abundant,
         "number-theory",
         "predicate",
+        invocation_examples=(example("abundant_12", "Check whether 12 is abundant.", {"n": 12}),),
     ),
     number_theory_operation(
         "integer.decide.deficient",
@@ -192,5 +205,6 @@ DIVISIBILITY_CAPABILITIES = (
         decide_deficient,
         "number-theory",
         "predicate",
+        invocation_examples=(example("deficient_10", "Check whether 10 is deficient.", {"n": 10}),),
     ),
 )

--- a/src/jacobian/domains/number_theory/factorization.py
+++ b/src/jacobian/domains/number_theory/factorization.py
@@ -192,6 +192,7 @@ FACTORIZATION_CAPABILITIES = (
         request_model=FactorizationRequest,
         result_model=DivisorListResult,
         tags=("number-theory", "enumeration"),
+        invocation_examples=(example("divisors_12", "Enumerate the positive divisors of 12.", {"value": "12"}),),
     ),
     _operation(
         capability_id="integer.compute.proper_divisors",
@@ -223,6 +224,7 @@ FACTORIZATION_CAPABILITIES = (
         request_model=FactorizationRequest,
         result_model=PrimeFactorizationResult,
         tags=("number-theory", "factorization"),
+        invocation_examples=(example("prime_factorization_360", "Factor 360 into prime powers.", {"value": "360"}),),
     ),
     _operation(
         capability_id="integer.decide.squarefree",
@@ -235,6 +237,7 @@ FACTORIZATION_CAPABILITIES = (
         request_model=ArithmeticFunctionRequest,
         result_model=BooleanResult,
         tags=("number-theory", "predicate"),
+        invocation_examples=(example("squarefree_30", "Check whether 30 is square-free.", {"n": 30}),),
     ),
     _operation(
         capability_id="integer.compute.radical",
@@ -247,5 +250,6 @@ FACTORIZATION_CAPABILITIES = (
         request_model=ArithmeticFunctionRequest,
         result_model=IntegerValueResult,
         tags=("number-theory", "arithmetic-function"),
+        invocation_examples=(example("radical_360", "Compute the radical of 360.", {"n": 360}),),
     ),
 )

--- a/src/jacobian/domains/number_theory/factorization.py
+++ b/src/jacobian/domains/number_theory/factorization.py
@@ -192,7 +192,11 @@ FACTORIZATION_CAPABILITIES = (
         request_model=FactorizationRequest,
         result_model=DivisorListResult,
         tags=("number-theory", "enumeration"),
-        invocation_examples=(example("divisors_12", "Enumerate the positive divisors of 12.", {"value": "12"}),),
+        invocation_examples=(
+            example(
+                "divisors_12", "Enumerate the positive divisors of 12.", {"value": "12"}
+            ),
+        ),
     ),
     _operation(
         capability_id="integer.compute.proper_divisors",
@@ -224,7 +228,13 @@ FACTORIZATION_CAPABILITIES = (
         request_model=FactorizationRequest,
         result_model=PrimeFactorizationResult,
         tags=("number-theory", "factorization"),
-        invocation_examples=(example("prime_factorization_360", "Factor 360 into prime powers.", {"value": "360"}),),
+        invocation_examples=(
+            example(
+                "prime_factorization_360",
+                "Factor 360 into prime powers.",
+                {"value": "360"},
+            ),
+        ),
     ),
     _operation(
         capability_id="integer.decide.squarefree",
@@ -237,7 +247,9 @@ FACTORIZATION_CAPABILITIES = (
         request_model=ArithmeticFunctionRequest,
         result_model=BooleanResult,
         tags=("number-theory", "predicate"),
-        invocation_examples=(example("squarefree_30", "Check whether 30 is square-free.", {"n": 30}),),
+        invocation_examples=(
+            example("squarefree_30", "Check whether 30 is square-free.", {"n": 30}),
+        ),
     ),
     _operation(
         capability_id="integer.compute.radical",
@@ -250,6 +262,8 @@ FACTORIZATION_CAPABILITIES = (
         request_model=ArithmeticFunctionRequest,
         result_model=IntegerValueResult,
         tags=("number-theory", "arithmetic-function"),
-        invocation_examples=(example("radical_360", "Compute the radical of 360.", {"n": 360}),),
+        invocation_examples=(
+            example("radical_360", "Compute the radical of 360.", {"n": 360}),
+        ),
     ),
 )

--- a/src/jacobian/domains/number_theory/modular.py
+++ b/src/jacobian/domains/number_theory/modular.py
@@ -53,6 +53,7 @@ MODULAR_CAPABILITIES = (
         compute_modular_inverse,
         "number-theory",
         "modular",
+        invocation_examples=(example("inverse_3_mod_11", "Compute the inverse of 3 modulo 11.", {"value": "3", "modulus": 11}),),
     ),
     number_theory_operation(
         "modular.compute.multiplicative_order",
@@ -63,6 +64,7 @@ MODULAR_CAPABILITIES = (
         compute_multiplicative_order,
         "number-theory",
         "modular",
+        invocation_examples=(example("multiplicative_order_2_mod_7", "Compute the multiplicative order of 2 modulo 7.", {"value": "2", "modulus": 7}),),
     ),
     number_theory_operation(
         "modular.enumerate.quadratic_residues",

--- a/src/jacobian/domains/number_theory/modular.py
+++ b/src/jacobian/domains/number_theory/modular.py
@@ -53,7 +53,13 @@ MODULAR_CAPABILITIES = (
         compute_modular_inverse,
         "number-theory",
         "modular",
-        invocation_examples=(example("inverse_3_mod_11", "Compute the inverse of 3 modulo 11.", {"value": "3", "modulus": 11}),),
+        invocation_examples=(
+            example(
+                "inverse_3_mod_11",
+                "Compute the inverse of 3 modulo 11.",
+                {"value": "3", "modulus": 11},
+            ),
+        ),
     ),
     number_theory_operation(
         "modular.compute.multiplicative_order",
@@ -64,7 +70,13 @@ MODULAR_CAPABILITIES = (
         compute_multiplicative_order,
         "number-theory",
         "modular",
-        invocation_examples=(example("multiplicative_order_2_mod_7", "Compute the multiplicative order of 2 modulo 7.", {"value": "2", "modulus": 7}),),
+        invocation_examples=(
+            example(
+                "multiplicative_order_2_mod_7",
+                "Compute the multiplicative order of 2 modulo 7.",
+                {"value": "2", "modulus": 7},
+            ),
+        ),
     ),
     number_theory_operation(
         "modular.enumerate.quadratic_residues",


### PR DESCRIPTION
## Summary

Add concise, deterministic invocation examples for 24 previously uncovered integer arithmetic and number-theory capabilities.

## Scope

- Covers integer arithmetic representations and predicates.
- Covers gcd/lcm, divisibility, divisor functions, factorization, and modular operations.
- Reuses the existing `CapabilityInvocationExample` mechanism.
- Does not change schemas or capability semantics.

## Validation

- Local catalog registration validates all examples against canonical schemas.
- Coverage rises from 59 to 83 of 217 capabilities.
- Ruff and `git diff --check` pass locally.
- The available pytest environment cannot collect the repository suite because the `timeout` plugin and `z3` dependency are unavailable.