### PR TITLE
docs(examples): cover rational and sequence operations

### DIFF
--- a/src/jacobian/domains/arithmetic/rationals.py
+++ b/src/jacobian/domains/arithmetic/rationals.py
@@ -44,6 +44,7 @@ RATIONAL_CAPABILITIES = (
         reciprocal,
         "rational",
         "exact",
+        invocation_examples=(example("reciprocal_two_thirds", "Compute the reciprocal of two thirds.", {"value": {"num": "2", "den": "3"}}),),
     ),
     arithmetic_operation(
         "rational.compute.negation",
@@ -54,6 +55,7 @@ RATIONAL_CAPABILITIES = (
         negation,
         "rational",
         "exact",
+        invocation_examples=(example("negation_two_thirds", "Negate two thirds.", {"value": {"num": "2", "den": "3"}}),),
     ),
     arithmetic_operation(
         "rational.compute.absolute_value",
@@ -64,6 +66,7 @@ RATIONAL_CAPABILITIES = (
         rational_absolute_value,
         "rational",
         "exact",
+        invocation_examples=(example("absolute_value_negative_three_halves", "Compute the absolute value of negative three halves.", {"value": {"num": "-3", "den": "2"}}),),
     ),
     arithmetic_operation(
         "rational.compute.sum",
@@ -91,6 +94,7 @@ RATIONAL_CAPABILITIES = (
         difference,
         "rational",
         "exact",
+        invocation_examples=(example("three_fourths_minus_one_sixth", "Subtract one sixth from three fourths.", {"left": {"num": "3", "den": "4"}, "right": {"num": "1", "den": "6"}}),),
     ),
     arithmetic_operation(
         "rational.compute.product",
@@ -101,6 +105,7 @@ RATIONAL_CAPABILITIES = (
         product,
         "rational",
         "exact",
+        invocation_examples=(example("two_thirds_times_three_fifths", "Multiply two thirds by three fifths.", {"left": {"num": "2", "den": "3"}, "right": {"num": "3", "den": "5"}}),),
     ),
     arithmetic_operation(
         "rational.compute.quotient",
@@ -111,6 +116,7 @@ RATIONAL_CAPABILITIES = (
         quotient,
         "rational",
         "exact",
+        invocation_examples=(example("three_fourths_divided_by_two_thirds", "Divide three fourths by two thirds.", {"left": {"num": "3", "den": "4"}, "right": {"num": "2", "den": "3"}}),),
     ),
     arithmetic_operation(
         "rational.compute.minimum",
@@ -121,6 +127,7 @@ RATIONAL_CAPABILITIES = (
         minimum,
         "rational",
         "order",
+        invocation_examples=(example("minimum_one_half_two_thirds", "Find the lesser of one half and two thirds.", {"left": {"num": "1", "den": "2"}, "right": {"num": "2", "den": "3"}}),),
     ),
     arithmetic_operation(
         "rational.compute.maximum",
@@ -131,6 +138,7 @@ RATIONAL_CAPABILITIES = (
         maximum,
         "rational",
         "order",
+        invocation_examples=(example("maximum_one_half_two_thirds", "Find the greater of one half and two thirds.", {"left": {"num": "1", "den": "2"}, "right": {"num": "2", "den": "3"}}),),
     ),
     arithmetic_operation(
         "rational.compute.floor",
@@ -141,6 +149,7 @@ RATIONAL_CAPABILITIES = (
         floor,
         "rational",
         "rounding",
+        invocation_examples=(example("floor_seven_thirds", "Compute the floor of seven thirds.", {"value": {"num": "7", "den": "3"}}),),
     ),
     arithmetic_operation(
         "rational.compute.ceiling",
@@ -151,6 +160,7 @@ RATIONAL_CAPABILITIES = (
         ceiling,
         "rational",
         "rounding",
+        invocation_examples=(example("ceiling_seven_thirds", "Compute the ceiling of seven thirds.", {"value": {"num": "7", "den": "3"}}),),
     ),
     arithmetic_operation(
         "rational.compute.continued_fraction",
@@ -178,6 +188,7 @@ RATIONAL_CAPABILITIES = (
         equal,
         "rational",
         "predicate",
+        invocation_examples=(example("equal_two_fourths_one_half", "Check equality of two equivalent rationals.", {"left": {"num": "2", "den": "4"}, "right": {"num": "1", "den": "2"}}),),
     ),
     arithmetic_operation(
         "rational.decide.less_than",
@@ -188,5 +199,6 @@ RATIONAL_CAPABILITIES = (
         less_than,
         "rational",
         "predicate",
+        invocation_examples=(example("less_than_one_half_two_thirds", "Check whether one half is less than two thirds.", {"left": {"num": "1", "den": "2"}, "right": {"num": "2", "den": "3"}}),),
     ),
 )

--- a/src/jacobian/domains/arithmetic/rationals.py
+++ b/src/jacobian/domains/arithmetic/rationals.py
@@ -44,7 +44,13 @@ RATIONAL_CAPABILITIES = (
         reciprocal,
         "rational",
         "exact",
-        invocation_examples=(example("reciprocal_two_thirds", "Compute the reciprocal of two thirds.", {"value": {"num": "2", "den": "3"}}),),
+        invocation_examples=(
+            example(
+                "reciprocal_two_thirds",
+                "Compute the reciprocal of two thirds.",
+                {"value": {"num": "2", "den": "3"}},
+            ),
+        ),
     ),
     arithmetic_operation(
         "rational.compute.negation",
@@ -55,7 +61,13 @@ RATIONAL_CAPABILITIES = (
         negation,
         "rational",
         "exact",
-        invocation_examples=(example("negation_two_thirds", "Negate two thirds.", {"value": {"num": "2", "den": "3"}}),),
+        invocation_examples=(
+            example(
+                "negation_two_thirds",
+                "Negate two thirds.",
+                {"value": {"num": "2", "den": "3"}},
+            ),
+        ),
     ),
     arithmetic_operation(
         "rational.compute.absolute_value",
@@ -66,7 +78,13 @@ RATIONAL_CAPABILITIES = (
         rational_absolute_value,
         "rational",
         "exact",
-        invocation_examples=(example("absolute_value_negative_three_halves", "Compute the absolute value of negative three halves.", {"value": {"num": "-3", "den": "2"}}),),
+        invocation_examples=(
+            example(
+                "absolute_value_negative_three_halves",
+                "Compute the absolute value of negative three halves.",
+                {"value": {"num": "-3", "den": "2"}},
+            ),
+        ),
     ),
     arithmetic_operation(
         "rational.compute.sum",
@@ -94,7 +112,13 @@ RATIONAL_CAPABILITIES = (
         difference,
         "rational",
         "exact",
-        invocation_examples=(example("three_fourths_minus_one_sixth", "Subtract one sixth from three fourths.", {"left": {"num": "3", "den": "4"}, "right": {"num": "1", "den": "6"}}),),
+        invocation_examples=(
+            example(
+                "three_fourths_minus_one_sixth",
+                "Subtract one sixth from three fourths.",
+                {"left": {"num": "3", "den": "4"}, "right": {"num": "1", "den": "6"}},
+            ),
+        ),
     ),
     arithmetic_operation(
         "rational.compute.product",
@@ -105,7 +129,13 @@ RATIONAL_CAPABILITIES = (
         product,
         "rational",
         "exact",
-        invocation_examples=(example("two_thirds_times_three_fifths", "Multiply two thirds by three fifths.", {"left": {"num": "2", "den": "3"}, "right": {"num": "3", "den": "5"}}),),
+        invocation_examples=(
+            example(
+                "two_thirds_times_three_fifths",
+                "Multiply two thirds by three fifths.",
+                {"left": {"num": "2", "den": "3"}, "right": {"num": "3", "den": "5"}},
+            ),
+        ),
     ),
     arithmetic_operation(
         "rational.compute.quotient",
@@ -116,7 +146,13 @@ RATIONAL_CAPABILITIES = (
         quotient,
         "rational",
         "exact",
-        invocation_examples=(example("three_fourths_divided_by_two_thirds", "Divide three fourths by two thirds.", {"left": {"num": "3", "den": "4"}, "right": {"num": "2", "den": "3"}}),),
+        invocation_examples=(
+            example(
+                "three_fourths_divided_by_two_thirds",
+                "Divide three fourths by two thirds.",
+                {"left": {"num": "3", "den": "4"}, "right": {"num": "2", "den": "3"}},
+            ),
+        ),
     ),
     arithmetic_operation(
         "rational.compute.minimum",
@@ -127,7 +163,13 @@ RATIONAL_CAPABILITIES = (
         minimum,
         "rational",
         "order",
-        invocation_examples=(example("minimum_one_half_two_thirds", "Find the lesser of one half and two thirds.", {"left": {"num": "1", "den": "2"}, "right": {"num": "2", "den": "3"}}),),
+        invocation_examples=(
+            example(
+                "minimum_one_half_two_thirds",
+                "Find the lesser of one half and two thirds.",
+                {"left": {"num": "1", "den": "2"}, "right": {"num": "2", "den": "3"}},
+            ),
+        ),
     ),
     arithmetic_operation(
         "rational.compute.maximum",
@@ -138,7 +180,13 @@ RATIONAL_CAPABILITIES = (
         maximum,
         "rational",
         "order",
-        invocation_examples=(example("maximum_one_half_two_thirds", "Find the greater of one half and two thirds.", {"left": {"num": "1", "den": "2"}, "right": {"num": "2", "den": "3"}}),),
+        invocation_examples=(
+            example(
+                "maximum_one_half_two_thirds",
+                "Find the greater of one half and two thirds.",
+                {"left": {"num": "1", "den": "2"}, "right": {"num": "2", "den": "3"}},
+            ),
+        ),
     ),
     arithmetic_operation(
         "rational.compute.floor",
@@ -149,7 +197,13 @@ RATIONAL_CAPABILITIES = (
         floor,
         "rational",
         "rounding",
-        invocation_examples=(example("floor_seven_thirds", "Compute the floor of seven thirds.", {"value": {"num": "7", "den": "3"}}),),
+        invocation_examples=(
+            example(
+                "floor_seven_thirds",
+                "Compute the floor of seven thirds.",
+                {"value": {"num": "7", "den": "3"}},
+            ),
+        ),
     ),
     arithmetic_operation(
         "rational.compute.ceiling",
@@ -160,7 +214,13 @@ RATIONAL_CAPABILITIES = (
         ceiling,
         "rational",
         "rounding",
-        invocation_examples=(example("ceiling_seven_thirds", "Compute the ceiling of seven thirds.", {"value": {"num": "7", "den": "3"}}),),
+        invocation_examples=(
+            example(
+                "ceiling_seven_thirds",
+                "Compute the ceiling of seven thirds.",
+                {"value": {"num": "7", "den": "3"}},
+            ),
+        ),
     ),
     arithmetic_operation(
         "rational.compute.continued_fraction",
@@ -188,7 +248,13 @@ RATIONAL_CAPABILITIES = (
         equal,
         "rational",
         "predicate",
-        invocation_examples=(example("equal_two_fourths_one_half", "Check equality of two equivalent rationals.", {"left": {"num": "2", "den": "4"}, "right": {"num": "1", "den": "2"}}),),
+        invocation_examples=(
+            example(
+                "equal_two_fourths_one_half",
+                "Check equality of two equivalent rationals.",
+                {"left": {"num": "2", "den": "4"}, "right": {"num": "1", "den": "2"}},
+            ),
+        ),
     ),
     arithmetic_operation(
         "rational.decide.less_than",
@@ -199,6 +265,12 @@ RATIONAL_CAPABILITIES = (
         less_than,
         "rational",
         "predicate",
-        invocation_examples=(example("less_than_one_half_two_thirds", "Check whether one half is less than two thirds.", {"left": {"num": "1", "den": "2"}, "right": {"num": "2", "den": "3"}}),),
+        invocation_examples=(
+            example(
+                "less_than_one_half_two_thirds",
+                "Check whether one half is less than two thirds.",
+                {"left": {"num": "1", "den": "2"}, "right": {"num": "2", "den": "3"}},
+            ),
+        ),
     ),
 )

--- a/src/jacobian/domains/sequences/predicates.py
+++ b/src/jacobian/domains/sequences/predicates.py
@@ -23,7 +23,13 @@ SEQUENCE_PREDICATE_CAPABILITIES = (
         decide_arithmetic,
         "sequence",
         "predicate",
-        invocation_examples=(example("arithmetic_sequence", "Recognize an arithmetic sequence.", {"values": ["3", "6", "9", "12"]}),),
+        invocation_examples=(
+            example(
+                "arithmetic_sequence",
+                "Recognize an arithmetic sequence.",
+                {"values": ["3", "6", "9", "12"]},
+            ),
+        ),
     ),
     sequence_operation(
         "sequence.decide.geometric",
@@ -51,7 +57,13 @@ SEQUENCE_PREDICATE_CAPABILITIES = (
         decide_nondecreasing,
         "sequence",
         "predicate",
-        invocation_examples=(example("nondecreasing_sequence", "Check nondecreasing order.", {"values": ["1", "1", "3", "5"]}),),
+        invocation_examples=(
+            example(
+                "nondecreasing_sequence",
+                "Check nondecreasing order.",
+                {"values": ["1", "1", "3", "5"]},
+            ),
+        ),
     ),
     sequence_operation(
         "sequence.decide.strictly_increasing",
@@ -62,6 +74,12 @@ SEQUENCE_PREDICATE_CAPABILITIES = (
         decide_strictly_increasing,
         "sequence",
         "predicate",
-        invocation_examples=(example("strictly_increasing_sequence", "Check strict increase.", {"values": ["1", "2", "4", "7"]}),),
+        invocation_examples=(
+            example(
+                "strictly_increasing_sequence",
+                "Check strict increase.",
+                {"values": ["1", "2", "4", "7"]},
+            ),
+        ),
     ),
 )

--- a/src/jacobian/domains/sequences/predicates.py
+++ b/src/jacobian/domains/sequences/predicates.py
@@ -23,6 +23,7 @@ SEQUENCE_PREDICATE_CAPABILITIES = (
         decide_arithmetic,
         "sequence",
         "predicate",
+        invocation_examples=(example("arithmetic_sequence", "Recognize an arithmetic sequence.", {"values": ["3", "6", "9", "12"]}),),
     ),
     sequence_operation(
         "sequence.decide.geometric",
@@ -50,6 +51,7 @@ SEQUENCE_PREDICATE_CAPABILITIES = (
         decide_nondecreasing,
         "sequence",
         "predicate",
+        invocation_examples=(example("nondecreasing_sequence", "Check nondecreasing order.", {"values": ["1", "1", "3", "5"]}),),
     ),
     sequence_operation(
         "sequence.decide.strictly_increasing",
@@ -60,5 +62,6 @@ SEQUENCE_PREDICATE_CAPABILITIES = (
         decide_strictly_increasing,
         "sequence",
         "predicate",
+        invocation_examples=(example("strictly_increasing_sequence", "Check strict increase.", {"values": ["1", "2", "4", "7"]}),),
     ),
 )

--- a/src/jacobian/domains/sequences/transforms.py
+++ b/src/jacobian/domains/sequences/transforms.py
@@ -32,7 +32,13 @@ SEQUENCE_TRANSFORM_CAPABILITIES = (
         prefix_sums,
         "sequence",
         "transform",
-        invocation_examples=(example("prefix_sums_1_2_3", "Compute prefix sums of 1, 2, and 3.", {"values": ["1", "2", "3"]}),),
+        invocation_examples=(
+            example(
+                "prefix_sums_1_2_3",
+                "Compute prefix sums of 1, 2, and 3.",
+                {"values": ["1", "2", "3"]},
+            ),
+        ),
     ),
     sequence_operation(
         "sequence.compute.first_differences",
@@ -60,7 +66,13 @@ SEQUENCE_TRANSFORM_CAPABILITIES = (
         prefix_products,
         "sequence",
         "transform",
-        invocation_examples=(example("prefix_products_2_3_4", "Compute prefix products of 2, 3, and 4.", {"values": ["2", "3", "4"]}),),
+        invocation_examples=(
+            example(
+                "prefix_products_2_3_4",
+                "Compute prefix products of 2, 3, and 4.",
+                {"values": ["2", "3", "4"]},
+            ),
+        ),
     ),
     sequence_operation(
         "sequence.compute.prefix_minima",
@@ -71,7 +83,13 @@ SEQUENCE_TRANSFORM_CAPABILITIES = (
         prefix_minima,
         "sequence",
         "transform",
-        invocation_examples=(example("prefix_minima_3_1_2", "Compute prefix minima of 3, 1, and 2.", {"values": ["3", "1", "2"]}),),
+        invocation_examples=(
+            example(
+                "prefix_minima_3_1_2",
+                "Compute prefix minima of 3, 1, and 2.",
+                {"values": ["3", "1", "2"]},
+            ),
+        ),
     ),
     sequence_operation(
         "sequence.compute.prefix_maxima",
@@ -82,7 +100,13 @@ SEQUENCE_TRANSFORM_CAPABILITIES = (
         prefix_maxima,
         "sequence",
         "transform",
-        invocation_examples=(example("prefix_maxima_1_3_2", "Compute prefix maxima of 1, 3, and 2.", {"values": ["1", "3", "2"]}),),
+        invocation_examples=(
+            example(
+                "prefix_maxima_1_3_2",
+                "Compute prefix maxima of 1, 3, and 2.",
+                {"values": ["1", "3", "2"]},
+            ),
+        ),
     ),
     sequence_operation(
         "sequence.compute.prefix_gcds",
@@ -110,7 +134,13 @@ SEQUENCE_TRANSFORM_CAPABILITIES = (
         prefix_lcms,
         "sequence",
         "divisibility",
-        invocation_examples=(example("prefix_lcms_2_3_4", "Compute prefix lcms of 2, 3, and 4.", {"values": ["2", "3", "4"]}),),
+        invocation_examples=(
+            example(
+                "prefix_lcms_2_3_4",
+                "Compute prefix lcms of 2, 3, and 4.",
+                {"values": ["2", "3", "4"]},
+            ),
+        ),
     ),
     sequence_operation(
         "sequence.compute.second_differences",
@@ -121,7 +151,13 @@ SEQUENCE_TRANSFORM_CAPABILITIES = (
         second_differences,
         "sequence",
         "transform",
-        invocation_examples=(example("second_differences_squares", "Compute second differences of consecutive squares.", {"values": ["1", "4", "9", "16"]}),),
+        invocation_examples=(
+            example(
+                "second_differences_squares",
+                "Compute second differences of consecutive squares.",
+                {"values": ["1", "4", "9", "16"]},
+            ),
+        ),
     ),
     sequence_operation(
         "sequence.transform.sorted_unique",
@@ -132,7 +168,13 @@ SEQUENCE_TRANSFORM_CAPABILITIES = (
         sorted_unique,
         "sequence",
         "transform",
-        invocation_examples=(example("sorted_unique_3_1_3_2", "Sort and deduplicate a sequence.", {"values": ["3", "1", "3", "2"]}),),
+        invocation_examples=(
+            example(
+                "sorted_unique_3_1_3_2",
+                "Sort and deduplicate a sequence.",
+                {"values": ["3", "1", "3", "2"]},
+            ),
+        ),
     ),
     sequence_operation(
         "sequence.transform.sort",
@@ -143,7 +185,11 @@ SEQUENCE_TRANSFORM_CAPABILITIES = (
         sort_sequence,
         "sequence",
         "transform",
-        invocation_examples=(example("sort_3_1_2", "Sort an integer sequence.", {"values": ["3", "1", "2"]}),),
+        invocation_examples=(
+            example(
+                "sort_3_1_2", "Sort an integer sequence.", {"values": ["3", "1", "2"]}
+            ),
+        ),
     ),
     sequence_operation(
         "sequence.transform.reverse",
@@ -154,7 +200,13 @@ SEQUENCE_TRANSFORM_CAPABILITIES = (
         reverse_sequence,
         "sequence",
         "transform",
-        invocation_examples=(example("reverse_1_2_3", "Reverse an integer sequence.", {"values": ["1", "2", "3"]}),),
+        invocation_examples=(
+            example(
+                "reverse_1_2_3",
+                "Reverse an integer sequence.",
+                {"values": ["1", "2", "3"]},
+            ),
+        ),
     ),
     sequence_operation(
         "sequence.transform.parities",
@@ -165,7 +217,13 @@ SEQUENCE_TRANSFORM_CAPABILITIES = (
         parities,
         "sequence",
         "transform",
-        invocation_examples=(example("parities_1_2_3", "Compute parities of 1, 2, and 3.", {"values": ["1", "2", "3"]}),),
+        invocation_examples=(
+            example(
+                "parities_1_2_3",
+                "Compute parities of 1, 2, and 3.",
+                {"values": ["1", "2", "3"]},
+            ),
+        ),
     ),
     sequence_operation(
         "sequence.transform.signs",
@@ -176,6 +234,12 @@ SEQUENCE_TRANSFORM_CAPABILITIES = (
         signs,
         "sequence",
         "transform",
-        invocation_examples=(example("signs_negative_zero_positive", "Compute signs of negative, zero, and positive values.", {"values": ["-2", "0", "5"]}),),
+        invocation_examples=(
+            example(
+                "signs_negative_zero_positive",
+                "Compute signs of negative, zero, and positive values.",
+                {"values": ["-2", "0", "5"]},
+            ),
+        ),
     ),
 )

--- a/src/jacobian/domains/sequences/transforms.py
+++ b/src/jacobian/domains/sequences/transforms.py
@@ -32,6 +32,7 @@ SEQUENCE_TRANSFORM_CAPABILITIES = (
         prefix_sums,
         "sequence",
         "transform",
+        invocation_examples=(example("prefix_sums_1_2_3", "Compute prefix sums of 1, 2, and 3.", {"values": ["1", "2", "3"]}),),
     ),
     sequence_operation(
         "sequence.compute.first_differences",
@@ -59,6 +60,7 @@ SEQUENCE_TRANSFORM_CAPABILITIES = (
         prefix_products,
         "sequence",
         "transform",
+        invocation_examples=(example("prefix_products_2_3_4", "Compute prefix products of 2, 3, and 4.", {"values": ["2", "3", "4"]}),),
     ),
     sequence_operation(
         "sequence.compute.prefix_minima",
@@ -69,6 +71,7 @@ SEQUENCE_TRANSFORM_CAPABILITIES = (
         prefix_minima,
         "sequence",
         "transform",
+        invocation_examples=(example("prefix_minima_3_1_2", "Compute prefix minima of 3, 1, and 2.", {"values": ["3", "1", "2"]}),),
     ),
     sequence_operation(
         "sequence.compute.prefix_maxima",
@@ -79,6 +82,7 @@ SEQUENCE_TRANSFORM_CAPABILITIES = (
         prefix_maxima,
         "sequence",
         "transform",
+        invocation_examples=(example("prefix_maxima_1_3_2", "Compute prefix maxima of 1, 3, and 2.", {"values": ["1", "3", "2"]}),),
     ),
     sequence_operation(
         "sequence.compute.prefix_gcds",
@@ -106,6 +110,7 @@ SEQUENCE_TRANSFORM_CAPABILITIES = (
         prefix_lcms,
         "sequence",
         "divisibility",
+        invocation_examples=(example("prefix_lcms_2_3_4", "Compute prefix lcms of 2, 3, and 4.", {"values": ["2", "3", "4"]}),),
     ),
     sequence_operation(
         "sequence.compute.second_differences",
@@ -116,6 +121,7 @@ SEQUENCE_TRANSFORM_CAPABILITIES = (
         second_differences,
         "sequence",
         "transform",
+        invocation_examples=(example("second_differences_squares", "Compute second differences of consecutive squares.", {"values": ["1", "4", "9", "16"]}),),
     ),
     sequence_operation(
         "sequence.transform.sorted_unique",
@@ -126,6 +132,7 @@ SEQUENCE_TRANSFORM_CAPABILITIES = (
         sorted_unique,
         "sequence",
         "transform",
+        invocation_examples=(example("sorted_unique_3_1_3_2", "Sort and deduplicate a sequence.", {"values": ["3", "1", "3", "2"]}),),
     ),
     sequence_operation(
         "sequence.transform.sort",
@@ -136,6 +143,7 @@ SEQUENCE_TRANSFORM_CAPABILITIES = (
         sort_sequence,
         "sequence",
         "transform",
+        invocation_examples=(example("sort_3_1_2", "Sort an integer sequence.", {"values": ["3", "1", "2"]}),),
     ),
     sequence_operation(
         "sequence.transform.reverse",
@@ -146,6 +154,7 @@ SEQUENCE_TRANSFORM_CAPABILITIES = (
         reverse_sequence,
         "sequence",
         "transform",
+        invocation_examples=(example("reverse_1_2_3", "Reverse an integer sequence.", {"values": ["1", "2", "3"]}),),
     ),
     sequence_operation(
         "sequence.transform.parities",
@@ -156,6 +165,7 @@ SEQUENCE_TRANSFORM_CAPABILITIES = (
         parities,
         "sequence",
         "transform",
+        invocation_examples=(example("parities_1_2_3", "Compute parities of 1, 2, and 3.", {"values": ["1", "2", "3"]}),),
     ),
     sequence_operation(
         "sequence.transform.signs",
@@ -166,5 +176,6 @@ SEQUENCE_TRANSFORM_CAPABILITIES = (
         signs,
         "sequence",
         "transform",
+        invocation_examples=(example("signs_negative_zero_positive", "Compute signs of negative, zero, and positive values.", {"values": ["-2", "0", "5"]}),),
     ),
 )


### PR DESCRIPTION
## Summary

Add concise invocation examples for 26 previously uncovered rational and integer-sequence capabilities.

## Scope

- Completes the uncovered rational arithmetic, order, rounding, and predicate operations.
- Covers sequence predicates and transforms.
- Reuses the existing `CapabilityInvocationExample` mechanism without schema or semantic changes.

## Validation

- Catalog registration validates all examples against canonical schemas.
- Coverage rises from 83 to 109 of 217 capabilities.
- Ruff and `git diff --check` pass locally.
- The current pytest environment cannot collect the repository suite because `timeout` and `z3` dependencies are unavailable.