### PR TITLE
docs(examples): cover geometry and graph invariants

### DIFF
--- a/src/jacobian/domains/geometry/lines.py
+++ b/src/jacobian/domains/geometry/lines.py
@@ -7,6 +7,7 @@ from jacobian.contracts.geometry import (
     LinePairRequest,
     PointLineRequest,
 )
+from jacobian.domains._examples import example
 from jacobian.domains.geometry._support import geometry_operation
 from jacobian.domains.geometry.operations import (
     line_intersection,
@@ -24,6 +25,7 @@ LINE_CAPABILITIES = (
         line_predicate(lambda first, second: bool(first.is_parallel(second))),
         "geometry",
         "line",
+        invocation_examples=(example("parallel_horizontal_lines", "Check two horizontal parallel lines.", {"first_line": {"first": {"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}}, "second": {"x": {"num": "1", "den": "1"}, "y": {"num": "0", "den": "1"}}}, "second_line": {"first": {"x": {"num": "0", "den": "1"}, "y": {"num": "1", "den": "1"}}, "second": {"x": {"num": "1", "den": "1"}, "y": {"num": "1", "den": "1"}}}}),),
     ),
     geometry_operation(
         "geometry.lines.decide.perpendicular",
@@ -34,6 +36,7 @@ LINE_CAPABILITIES = (
         line_predicate(lambda first, second: bool(first.is_perpendicular(second))),
         "geometry",
         "line",
+        invocation_examples=(example("perpendicular_axes", "Check perpendicular coordinate axes.", {"first_line": {"first": {"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}}, "second": {"x": {"num": "1", "den": "1"}, "y": {"num": "0", "den": "1"}}}, "second_line": {"first": {"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}}, "second": {"x": {"num": "0", "den": "1"}, "y": {"num": "1", "den": "1"}}}}),),
     ),
     geometry_operation(
         "geometry.lines.compute.intersection",
@@ -44,6 +47,7 @@ LINE_CAPABILITIES = (
         line_intersection,
         "geometry",
         "intersection",
+        invocation_examples=(example("crossing_diagonals", "Intersect two crossing lines.", {"first_line": {"first": {"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}}, "second": {"x": {"num": "2", "den": "1"}, "y": {"num": "2", "den": "1"}}}, "second_line": {"first": {"x": {"num": "0", "den": "1"}, "y": {"num": "2", "den": "1"}}, "second": {"x": {"num": "2", "den": "1"}, "y": {"num": "0", "den": "1"}}}}),),
     ),
     geometry_operation(
         "geometry.line.compute.projection",
@@ -54,5 +58,6 @@ LINE_CAPABILITIES = (
         projection,
         "geometry",
         "construction",
+        invocation_examples=(example("projection_to_x_axis", "Project (1,2) onto the x-axis.", {"point": {"x": {"num": "1", "den": "1"}, "y": {"num": "2", "den": "1"}}, "line": {"first": {"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}}, "second": {"x": {"num": "1", "den": "1"}, "y": {"num": "0", "den": "1"}}}}),),
     ),
 )

--- a/src/jacobian/domains/geometry/lines.py
+++ b/src/jacobian/domains/geometry/lines.py
@@ -25,7 +25,34 @@ LINE_CAPABILITIES = (
         line_predicate(lambda first, second: bool(first.is_parallel(second))),
         "geometry",
         "line",
-        invocation_examples=(example("parallel_horizontal_lines", "Check two horizontal parallel lines.", {"first_line": {"first": {"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}}, "second": {"x": {"num": "1", "den": "1"}, "y": {"num": "0", "den": "1"}}}, "second_line": {"first": {"x": {"num": "0", "den": "1"}, "y": {"num": "1", "den": "1"}}, "second": {"x": {"num": "1", "den": "1"}, "y": {"num": "1", "den": "1"}}}}),),
+        invocation_examples=(
+            example(
+                "parallel_horizontal_lines",
+                "Check two horizontal parallel lines.",
+                {
+                    "first_line": {
+                        "first": {
+                            "x": {"num": "0", "den": "1"},
+                            "y": {"num": "0", "den": "1"},
+                        },
+                        "second": {
+                            "x": {"num": "1", "den": "1"},
+                            "y": {"num": "0", "den": "1"},
+                        },
+                    },
+                    "second_line": {
+                        "first": {
+                            "x": {"num": "0", "den": "1"},
+                            "y": {"num": "1", "den": "1"},
+                        },
+                        "second": {
+                            "x": {"num": "1", "den": "1"},
+                            "y": {"num": "1", "den": "1"},
+                        },
+                    },
+                },
+            ),
+        ),
     ),
     geometry_operation(
         "geometry.lines.decide.perpendicular",
@@ -36,7 +63,34 @@ LINE_CAPABILITIES = (
         line_predicate(lambda first, second: bool(first.is_perpendicular(second))),
         "geometry",
         "line",
-        invocation_examples=(example("perpendicular_axes", "Check perpendicular coordinate axes.", {"first_line": {"first": {"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}}, "second": {"x": {"num": "1", "den": "1"}, "y": {"num": "0", "den": "1"}}}, "second_line": {"first": {"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}}, "second": {"x": {"num": "0", "den": "1"}, "y": {"num": "1", "den": "1"}}}}),),
+        invocation_examples=(
+            example(
+                "perpendicular_axes",
+                "Check perpendicular coordinate axes.",
+                {
+                    "first_line": {
+                        "first": {
+                            "x": {"num": "0", "den": "1"},
+                            "y": {"num": "0", "den": "1"},
+                        },
+                        "second": {
+                            "x": {"num": "1", "den": "1"},
+                            "y": {"num": "0", "den": "1"},
+                        },
+                    },
+                    "second_line": {
+                        "first": {
+                            "x": {"num": "0", "den": "1"},
+                            "y": {"num": "0", "den": "1"},
+                        },
+                        "second": {
+                            "x": {"num": "0", "den": "1"},
+                            "y": {"num": "1", "den": "1"},
+                        },
+                    },
+                },
+            ),
+        ),
     ),
     geometry_operation(
         "geometry.lines.compute.intersection",
@@ -47,7 +101,34 @@ LINE_CAPABILITIES = (
         line_intersection,
         "geometry",
         "intersection",
-        invocation_examples=(example("crossing_diagonals", "Intersect two crossing lines.", {"first_line": {"first": {"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}}, "second": {"x": {"num": "2", "den": "1"}, "y": {"num": "2", "den": "1"}}}, "second_line": {"first": {"x": {"num": "0", "den": "1"}, "y": {"num": "2", "den": "1"}}, "second": {"x": {"num": "2", "den": "1"}, "y": {"num": "0", "den": "1"}}}}),),
+        invocation_examples=(
+            example(
+                "crossing_diagonals",
+                "Intersect two crossing lines.",
+                {
+                    "first_line": {
+                        "first": {
+                            "x": {"num": "0", "den": "1"},
+                            "y": {"num": "0", "den": "1"},
+                        },
+                        "second": {
+                            "x": {"num": "2", "den": "1"},
+                            "y": {"num": "2", "den": "1"},
+                        },
+                    },
+                    "second_line": {
+                        "first": {
+                            "x": {"num": "0", "den": "1"},
+                            "y": {"num": "2", "den": "1"},
+                        },
+                        "second": {
+                            "x": {"num": "2", "den": "1"},
+                            "y": {"num": "0", "den": "1"},
+                        },
+                    },
+                },
+            ),
+        ),
     ),
     geometry_operation(
         "geometry.line.compute.projection",
@@ -58,6 +139,27 @@ LINE_CAPABILITIES = (
         projection,
         "geometry",
         "construction",
-        invocation_examples=(example("projection_to_x_axis", "Project (1,2) onto the x-axis.", {"point": {"x": {"num": "1", "den": "1"}, "y": {"num": "2", "den": "1"}}, "line": {"first": {"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}}, "second": {"x": {"num": "1", "den": "1"}, "y": {"num": "0", "den": "1"}}}}),),
+        invocation_examples=(
+            example(
+                "projection_to_x_axis",
+                "Project (1,2) onto the x-axis.",
+                {
+                    "point": {
+                        "x": {"num": "1", "den": "1"},
+                        "y": {"num": "2", "den": "1"},
+                    },
+                    "line": {
+                        "first": {
+                            "x": {"num": "0", "den": "1"},
+                            "y": {"num": "0", "den": "1"},
+                        },
+                        "second": {
+                            "x": {"num": "1", "den": "1"},
+                            "y": {"num": "0", "den": "1"},
+                        },
+                    },
+                },
+            ),
+        ),
     ),
 )

--- a/src/jacobian/domains/geometry/points.py
+++ b/src/jacobian/domains/geometry/points.py
@@ -54,6 +54,7 @@ POINT_CAPABILITIES = (
         collinear,
         "geometry",
         "incidence",
+        invocation_examples=(example("collinear_x_axis", "Check three points on the x-axis.", {"first": {"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}}, "second": {"x": {"num": "1", "den": "1"}, "y": {"num": "0", "den": "1"}}, "third": {"x": {"num": "2", "den": "1"}, "y": {"num": "0", "den": "1"}}}),),
     ),
     geometry_operation(
         "geometry.points.decide.concyclic",
@@ -64,6 +65,7 @@ POINT_CAPABILITIES = (
         concyclic,
         "geometry",
         "circle",
+        invocation_examples=(example("unit_circle_points", "Check four points on the unit circle.", {"first": {"x": {"num": "1", "den": "1"}, "y": {"num": "0", "den": "1"}}, "second": {"x": {"num": "0", "den": "1"}, "y": {"num": "1", "den": "1"}}, "third": {"x": {"num": "-1", "den": "1"}, "y": {"num": "0", "den": "1"}}, "fourth": {"x": {"num": "0", "den": "1"}, "y": {"num": "-1", "den": "1"}}}),),
     ),
     geometry_operation(
         "geometry.points.compute.convex_hull",

--- a/src/jacobian/domains/geometry/points.py
+++ b/src/jacobian/domains/geometry/points.py
@@ -54,7 +54,26 @@ POINT_CAPABILITIES = (
         collinear,
         "geometry",
         "incidence",
-        invocation_examples=(example("collinear_x_axis", "Check three points on the x-axis.", {"first": {"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}}, "second": {"x": {"num": "1", "den": "1"}, "y": {"num": "0", "den": "1"}}, "third": {"x": {"num": "2", "den": "1"}, "y": {"num": "0", "den": "1"}}}),),
+        invocation_examples=(
+            example(
+                "collinear_x_axis",
+                "Check three points on the x-axis.",
+                {
+                    "first": {
+                        "x": {"num": "0", "den": "1"},
+                        "y": {"num": "0", "den": "1"},
+                    },
+                    "second": {
+                        "x": {"num": "1", "den": "1"},
+                        "y": {"num": "0", "den": "1"},
+                    },
+                    "third": {
+                        "x": {"num": "2", "den": "1"},
+                        "y": {"num": "0", "den": "1"},
+                    },
+                },
+            ),
+        ),
     ),
     geometry_operation(
         "geometry.points.decide.concyclic",
@@ -65,7 +84,30 @@ POINT_CAPABILITIES = (
         concyclic,
         "geometry",
         "circle",
-        invocation_examples=(example("unit_circle_points", "Check four points on the unit circle.", {"first": {"x": {"num": "1", "den": "1"}, "y": {"num": "0", "den": "1"}}, "second": {"x": {"num": "0", "den": "1"}, "y": {"num": "1", "den": "1"}}, "third": {"x": {"num": "-1", "den": "1"}, "y": {"num": "0", "den": "1"}}, "fourth": {"x": {"num": "0", "den": "1"}, "y": {"num": "-1", "den": "1"}}}),),
+        invocation_examples=(
+            example(
+                "unit_circle_points",
+                "Check four points on the unit circle.",
+                {
+                    "first": {
+                        "x": {"num": "1", "den": "1"},
+                        "y": {"num": "0", "den": "1"},
+                    },
+                    "second": {
+                        "x": {"num": "0", "den": "1"},
+                        "y": {"num": "1", "den": "1"},
+                    },
+                    "third": {
+                        "x": {"num": "-1", "den": "1"},
+                        "y": {"num": "0", "den": "1"},
+                    },
+                    "fourth": {
+                        "x": {"num": "0", "den": "1"},
+                        "y": {"num": "-1", "den": "1"},
+                    },
+                },
+            ),
+        ),
     ),
     geometry_operation(
         "geometry.points.compute.convex_hull",

--- a/src/jacobian/domains/geometry/polygons.py
+++ b/src/jacobian/domains/geometry/polygons.py
@@ -15,6 +15,19 @@ POLYGON_CAPABILITIES = (
         signed_area,
         "geometry",
         "polygon",
-        invocation_examples=(example("unit_square_signed_area", "Compute the signed area of a unit square.", {"points": [{"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}}, {"x": {"num": "1", "den": "1"}, "y": {"num": "0", "den": "1"}}, {"x": {"num": "1", "den": "1"}, "y": {"num": "1", "den": "1"}}, {"x": {"num": "0", "den": "1"}, "y": {"num": "1", "den": "1"}}]}),),
+        invocation_examples=(
+            example(
+                "unit_square_signed_area",
+                "Compute the signed area of a unit square.",
+                {
+                    "points": [
+                        {"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}},
+                        {"x": {"num": "1", "den": "1"}, "y": {"num": "0", "den": "1"}},
+                        {"x": {"num": "1", "den": "1"}, "y": {"num": "1", "den": "1"}},
+                        {"x": {"num": "0", "den": "1"}, "y": {"num": "1", "den": "1"}},
+                    ]
+                },
+            ),
+        ),
     ),
 )

--- a/src/jacobian/domains/geometry/polygons.py
+++ b/src/jacobian/domains/geometry/polygons.py
@@ -1,6 +1,7 @@
 """Polygon-owned exact geometry capabilities."""
 
 from jacobian.contracts.geometry import GeometryRationalResult, PolygonRequest
+from jacobian.domains._examples import example
 from jacobian.domains.geometry._support import geometry_operation
 from jacobian.domains.geometry.operations import signed_area
 
@@ -14,5 +15,6 @@ POLYGON_CAPABILITIES = (
         signed_area,
         "geometry",
         "polygon",
+        invocation_examples=(example("unit_square_signed_area", "Compute the signed area of a unit square.", {"points": [{"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}}, {"x": {"num": "1", "den": "1"}, "y": {"num": "0", "den": "1"}}, {"x": {"num": "1", "den": "1"}, "y": {"num": "1", "den": "1"}}, {"x": {"num": "0", "den": "1"}, "y": {"num": "1", "den": "1"}}]}),),
     ),
 )

--- a/src/jacobian/domains/geometry/segments.py
+++ b/src/jacobian/domains/geometry/segments.py
@@ -1,6 +1,7 @@
 """Segment-owned exact geometry capabilities."""
 
 from jacobian.contracts.geometry import GeometryPointResult, PointPairRequest
+from jacobian.domains._examples import example
 from jacobian.domains.geometry._support import geometry_operation
 from jacobian.domains.geometry.operations import midpoint
 
@@ -14,5 +15,6 @@ SEGMENT_CAPABILITIES = (
         midpoint,
         "geometry",
         "construction",
+        invocation_examples=(example("segment_midpoint", "Construct the midpoint of a unit segment.", {"first": {"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}}, "second": {"x": {"num": "2", "den": "1"}, "y": {"num": "2", "den": "1"}}}),),
     ),
 )

--- a/src/jacobian/domains/geometry/segments.py
+++ b/src/jacobian/domains/geometry/segments.py
@@ -15,6 +15,21 @@ SEGMENT_CAPABILITIES = (
         midpoint,
         "geometry",
         "construction",
-        invocation_examples=(example("segment_midpoint", "Construct the midpoint of a unit segment.", {"first": {"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}}, "second": {"x": {"num": "1", "den": "1"}, "y": {"num": "0", "den": "1"}}}),),
+        invocation_examples=(
+            example(
+                "segment_midpoint",
+                "Construct the midpoint of a unit segment.",
+                {
+                    "first": {
+                        "x": {"num": "0", "den": "1"},
+                        "y": {"num": "0", "den": "1"},
+                    },
+                    "second": {
+                        "x": {"num": "1", "den": "1"},
+                        "y": {"num": "0", "den": "1"},
+                    },
+                },
+            ),
+        ),
     ),
 )

--- a/src/jacobian/domains/geometry/segments.py
+++ b/src/jacobian/domains/geometry/segments.py
@@ -15,6 +15,6 @@ SEGMENT_CAPABILITIES = (
         midpoint,
         "geometry",
         "construction",
-        invocation_examples=(example("segment_midpoint", "Construct the midpoint of a unit segment.", {"first": {"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}}, "second": {"x": {"num": "2", "den": "1"}, "y": {"num": "2", "den": "1"}}}),),
+        invocation_examples=(example("segment_midpoint", "Construct the midpoint of a unit segment.", {"first": {"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}}, "second": {"x": {"num": "1", "den": "1"}, "y": {"num": "0", "den": "1"}}}),),
     ),
 )

--- a/src/jacobian/domains/geometry/triangles.py
+++ b/src/jacobian/domains/geometry/triangles.py
@@ -20,6 +20,7 @@ TRIANGLE_CAPABILITIES = (
         orientation,
         "geometry",
         "orientation",
+        invocation_examples=(example("counterclockwise_triangle", "Compute orientation of a counterclockwise triangle.", {"first": {"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}}, "second": {"x": {"num": "1", "den": "1"}, "y": {"num": "0", "den": "1"}}, "third": {"x": {"num": "0", "den": "1"}, "y": {"num": "1", "den": "1"}}}),),
     ),
     geometry_operation(
         "geometry.triangle.compute.centroid",
@@ -30,6 +31,7 @@ TRIANGLE_CAPABILITIES = (
         centroid,
         "geometry",
         "construction",
+        invocation_examples=(example("right_triangle_centroid", "Construct the centroid of a right triangle.", {"first": {"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}}, "second": {"x": {"num": "2", "den": "1"}, "y": {"num": "0", "den": "1"}}, "third": {"x": {"num": "0", "den": "1"}, "y": {"num": "2", "den": "1"}}}),),
     ),
     geometry_operation(
         "geometry.triangle.compute.circumcircle",

--- a/src/jacobian/domains/geometry/triangles.py
+++ b/src/jacobian/domains/geometry/triangles.py
@@ -20,7 +20,26 @@ TRIANGLE_CAPABILITIES = (
         orientation,
         "geometry",
         "orientation",
-        invocation_examples=(example("counterclockwise_triangle", "Compute orientation of a counterclockwise triangle.", {"first": {"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}}, "second": {"x": {"num": "1", "den": "1"}, "y": {"num": "0", "den": "1"}}, "third": {"x": {"num": "0", "den": "1"}, "y": {"num": "1", "den": "1"}}}),),
+        invocation_examples=(
+            example(
+                "counterclockwise_triangle",
+                "Compute orientation of a counterclockwise triangle.",
+                {
+                    "first": {
+                        "x": {"num": "0", "den": "1"},
+                        "y": {"num": "0", "den": "1"},
+                    },
+                    "second": {
+                        "x": {"num": "1", "den": "1"},
+                        "y": {"num": "0", "den": "1"},
+                    },
+                    "third": {
+                        "x": {"num": "0", "den": "1"},
+                        "y": {"num": "1", "den": "1"},
+                    },
+                },
+            ),
+        ),
     ),
     geometry_operation(
         "geometry.triangle.compute.centroid",
@@ -31,7 +50,26 @@ TRIANGLE_CAPABILITIES = (
         centroid,
         "geometry",
         "construction",
-        invocation_examples=(example("right_triangle_centroid", "Construct the centroid of a right triangle.", {"first": {"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}}, "second": {"x": {"num": "2", "den": "1"}, "y": {"num": "0", "den": "1"}}, "third": {"x": {"num": "0", "den": "1"}, "y": {"num": "2", "den": "1"}}}),),
+        invocation_examples=(
+            example(
+                "right_triangle_centroid",
+                "Construct the centroid of a right triangle.",
+                {
+                    "first": {
+                        "x": {"num": "0", "den": "1"},
+                        "y": {"num": "0", "den": "1"},
+                    },
+                    "second": {
+                        "x": {"num": "2", "den": "1"},
+                        "y": {"num": "0", "den": "1"},
+                    },
+                    "third": {
+                        "x": {"num": "0", "den": "1"},
+                        "y": {"num": "2", "den": "1"},
+                    },
+                },
+            ),
+        ),
     ),
     geometry_operation(
         "geometry.triangle.compute.circumcircle",

--- a/src/jacobian/domains/graph_optimization/invariants.py
+++ b/src/jacobian/domains/graph_optimization/invariants.py
@@ -479,7 +479,18 @@ EXACT_GRAPH_INVARIANT_CAPABILITIES = (
         _triangle_count,
         "triangle",
         "exact",
-        invocation_examples=(example("triangle_graph", "Count triangles in a three-cycle.", {"graph": {"vertices": ["a", "b", "c"], "edges": [["a", "b"], ["b", "c"], ["a", "c"]]}}),),
+        invocation_examples=(
+            example(
+                "triangle_graph",
+                "Count triangles in a three-cycle.",
+                {
+                    "graph": {
+                        "vertices": ["a", "b", "c"],
+                        "edges": [["a", "b"], ["b", "c"], ["a", "c"]],
+                    }
+                },
+            ),
+        ),
     ),
     _computed(
         "graph.invariant.radius.compute",
@@ -490,7 +501,18 @@ EXACT_GRAPH_INVARIANT_CAPABILITIES = (
         "radius",
         "exact",
         version="2",
-        invocation_examples=(example("path_three_radius", "Compute the radius of a three-vertex path.", {"graph": {"vertices": ["a", "b", "c"], "edges": [["a", "b"], ["b", "c"]]}}),),
+        invocation_examples=(
+            example(
+                "path_three_radius",
+                "Compute the radius of a three-vertex path.",
+                {
+                    "graph": {
+                        "vertices": ["a", "b", "c"],
+                        "edges": [["a", "b"], ["b", "c"]],
+                    }
+                },
+            ),
+        ),
     ),
     ComputedOperation(
         capability_id="graph.k_core.compute",
@@ -502,7 +524,19 @@ EXACT_GRAPH_INVARIANT_CAPABILITIES = (
         relation_id="graph.relation.k-core-of",
         tags=("graph", "invariant", "k-core", "exact"),
         invalid_request=_INVALID_REQUEST,
-        invocation_examples=(example("triangle_two_core", "Compute the 2-core of a triangle.", {"graph": {"vertices": ["a", "b", "c"], "edges": [["a", "b"], ["b", "c"], ["a", "c"]]}, "k": 2}),),
+        invocation_examples=(
+            example(
+                "triangle_two_core",
+                "Compute the 2-core of a triangle.",
+                {
+                    "graph": {
+                        "vertices": ["a", "b", "c"],
+                        "edges": [["a", "b"], ["b", "c"], ["a", "c"]],
+                    },
+                    "k": 2,
+                },
+            ),
+        ),
     ),
     _computed(
         "graph.invariant.girth.compute",
@@ -512,7 +546,18 @@ EXACT_GRAPH_INVARIANT_CAPABILITIES = (
         _girth,
         "girth",
         "exact",
-        invocation_examples=(example("triangle_girth", "Compute the girth of a triangle.", {"graph": {"vertices": ["a", "b", "c"], "edges": [["a", "b"], ["b", "c"], ["a", "c"]]}}),),
+        invocation_examples=(
+            example(
+                "triangle_girth",
+                "Compute the girth of a triangle.",
+                {
+                    "graph": {
+                        "vertices": ["a", "b", "c"],
+                        "edges": [["a", "b"], ["b", "c"], ["a", "c"]],
+                    }
+                },
+            ),
+        ),
     ),
     _computed(
         "graph.invariant.diameter.compute",
@@ -523,7 +568,18 @@ EXACT_GRAPH_INVARIANT_CAPABILITIES = (
         "diameter",
         "exact",
         version="2",
-        invocation_examples=(example("path_three_diameter", "Compute the diameter of a three-vertex path.", {"graph": {"vertices": ["a", "b", "c"], "edges": [["a", "b"], ["b", "c"]]}}),),
+        invocation_examples=(
+            example(
+                "path_three_diameter",
+                "Compute the diameter of a three-vertex path.",
+                {
+                    "graph": {
+                        "vertices": ["a", "b", "c"],
+                        "edges": [["a", "b"], ["b", "c"]],
+                    }
+                },
+            ),
+        ),
     ),
     _computed(
         "graph.invariant.edge_connectivity.compute",
@@ -533,7 +589,18 @@ EXACT_GRAPH_INVARIANT_CAPABILITIES = (
         _edge_connectivity,
         "edge-connectivity",
         "exact",
-        invocation_examples=(example("triangle_edge_connectivity", "Compute edge connectivity of a triangle.", {"graph": {"vertices": ["a", "b", "c"], "edges": [["a", "b"], ["b", "c"], ["a", "c"]]}}),),
+        invocation_examples=(
+            example(
+                "triangle_edge_connectivity",
+                "Compute edge connectivity of a triangle.",
+                {
+                    "graph": {
+                        "vertices": ["a", "b", "c"],
+                        "edges": [["a", "b"], ["b", "c"], ["a", "c"]],
+                    }
+                },
+            ),
+        ),
     ),
     _computed(
         "graph.invariant.vertex_connectivity.compute",
@@ -543,7 +610,18 @@ EXACT_GRAPH_INVARIANT_CAPABILITIES = (
         _vertex_connectivity,
         "vertex-connectivity",
         "exact",
-        invocation_examples=(example("triangle_vertex_connectivity", "Compute vertex connectivity of a triangle.", {"graph": {"vertices": ["a", "b", "c"], "edges": [["a", "b"], ["b", "c"], ["a", "c"]]}}),),
+        invocation_examples=(
+            example(
+                "triangle_vertex_connectivity",
+                "Compute vertex connectivity of a triangle.",
+                {
+                    "graph": {
+                        "vertices": ["a", "b", "c"],
+                        "edges": [["a", "b"], ["b", "c"], ["a", "c"]],
+                    }
+                },
+            ),
+        ),
     ),
     _computed(
         "graph.invariant.is_eulerian.compute",
@@ -553,7 +631,18 @@ EXACT_GRAPH_INVARIANT_CAPABILITIES = (
         _eulerian,
         "eulerian",
         "exact",
-        invocation_examples=(example("triangle_eulerian", "Decide whether a triangle has an Eulerian circuit.", {"graph": {"vertices": ["a", "b", "c"], "edges": [["a", "b"], ["b", "c"], ["a", "c"]]}}),),
+        invocation_examples=(
+            example(
+                "triangle_eulerian",
+                "Decide whether a triangle has an Eulerian circuit.",
+                {
+                    "graph": {
+                        "vertices": ["a", "b", "c"],
+                        "edges": [["a", "b"], ["b", "c"], ["a", "c"]],
+                    }
+                },
+            ),
+        ),
     ),
     _computed(
         "graph.invariant.spanning_tree_count.compute",
@@ -563,7 +652,18 @@ EXACT_GRAPH_INVARIANT_CAPABILITIES = (
         _spanning_tree_count,
         "spanning-tree",
         "exact",
-        invocation_examples=(example("triangle_spanning_trees", "Count spanning trees of a triangle.", {"graph": {"vertices": ["a", "b", "c"], "edges": [["a", "b"], ["b", "c"], ["a", "c"]]}}),),
+        invocation_examples=(
+            example(
+                "triangle_spanning_trees",
+                "Count spanning trees of a triangle.",
+                {
+                    "graph": {
+                        "vertices": ["a", "b", "c"],
+                        "edges": [["a", "b"], ["b", "c"], ["a", "c"]],
+                    }
+                },
+            ),
+        ),
     ),
     _computed(
         "graph.invariant.maximum_matching.compute",

--- a/src/jacobian/domains/graph_optimization/invariants.py
+++ b/src/jacobian/domains/graph_optimization/invariants.py
@@ -479,6 +479,7 @@ EXACT_GRAPH_INVARIANT_CAPABILITIES = (
         _triangle_count,
         "triangle",
         "exact",
+        invocation_examples=(example("triangle_graph", "Count triangles in a three-cycle.", {"graph": {"vertices": ["a", "b", "c"], "edges": [["a", "b"], ["b", "c"], ["a", "c"]]}}),),
     ),
     _computed(
         "graph.invariant.radius.compute",
@@ -489,6 +490,7 @@ EXACT_GRAPH_INVARIANT_CAPABILITIES = (
         "radius",
         "exact",
         version="2",
+        invocation_examples=(example("path_three_radius", "Compute the radius of a three-vertex path.", {"graph": {"vertices": ["a", "b", "c"], "edges": [["a", "b"], ["b", "c"]]}}),),
     ),
     ComputedOperation(
         capability_id="graph.k_core.compute",
@@ -500,6 +502,7 @@ EXACT_GRAPH_INVARIANT_CAPABILITIES = (
         relation_id="graph.relation.k-core-of",
         tags=("graph", "invariant", "k-core", "exact"),
         invalid_request=_INVALID_REQUEST,
+        invocation_examples=(example("triangle_two_core", "Compute the 2-core of a triangle.", {"graph": {"vertices": ["a", "b", "c"], "edges": [["a", "b"], ["b", "c"], ["a", "c"]]}, "k": 2}),),
     ),
     _computed(
         "graph.invariant.girth.compute",
@@ -509,6 +512,7 @@ EXACT_GRAPH_INVARIANT_CAPABILITIES = (
         _girth,
         "girth",
         "exact",
+        invocation_examples=(example("triangle_girth", "Compute the girth of a triangle.", {"graph": {"vertices": ["a", "b", "c"], "edges": [["a", "b"], ["b", "c"], ["a", "c"]]}}),),
     ),
     _computed(
         "graph.invariant.diameter.compute",
@@ -519,6 +523,7 @@ EXACT_GRAPH_INVARIANT_CAPABILITIES = (
         "diameter",
         "exact",
         version="2",
+        invocation_examples=(example("path_three_diameter", "Compute the diameter of a three-vertex path.", {"graph": {"vertices": ["a", "b", "c"], "edges": [["a", "b"], ["b", "c"]]}}),),
     ),
     _computed(
         "graph.invariant.edge_connectivity.compute",
@@ -528,6 +533,7 @@ EXACT_GRAPH_INVARIANT_CAPABILITIES = (
         _edge_connectivity,
         "edge-connectivity",
         "exact",
+        invocation_examples=(example("triangle_edge_connectivity", "Compute edge connectivity of a triangle.", {"graph": {"vertices": ["a", "b", "c"], "edges": [["a", "b"], ["b", "c"], ["a", "c"]]}}),),
     ),
     _computed(
         "graph.invariant.vertex_connectivity.compute",
@@ -537,6 +543,7 @@ EXACT_GRAPH_INVARIANT_CAPABILITIES = (
         _vertex_connectivity,
         "vertex-connectivity",
         "exact",
+        invocation_examples=(example("triangle_vertex_connectivity", "Compute vertex connectivity of a triangle.", {"graph": {"vertices": ["a", "b", "c"], "edges": [["a", "b"], ["b", "c"], ["a", "c"]]}}),),
     ),
     _computed(
         "graph.invariant.is_eulerian.compute",
@@ -546,6 +553,7 @@ EXACT_GRAPH_INVARIANT_CAPABILITIES = (
         _eulerian,
         "eulerian",
         "exact",
+        invocation_examples=(example("triangle_eulerian", "Decide whether a triangle has an Eulerian circuit.", {"graph": {"vertices": ["a", "b", "c"], "edges": [["a", "b"], ["b", "c"], ["a", "c"]]}}),),
     ),
     _computed(
         "graph.invariant.spanning_tree_count.compute",
@@ -555,6 +563,7 @@ EXACT_GRAPH_INVARIANT_CAPABILITIES = (
         _spanning_tree_count,
         "spanning-tree",
         "exact",
+        invocation_examples=(example("triangle_spanning_trees", "Count spanning trees of a triangle.", {"graph": {"vertices": ["a", "b", "c"], "edges": [["a", "b"], ["b", "c"], ["a", "c"]]}}),),
     ),
     _computed(
         "graph.invariant.maximum_matching.compute",

--- a/tests/integration/domains/test_geometry_capabilities.py
+++ b/tests/integration/domains/test_geometry_capabilities.py
@@ -23,6 +23,35 @@ PY = {"x": ZERO, "y": TWO}
 PXY = {"x": TWO, "y": TWO}
 
 
+def test_segment_midpoint_example_is_directly_invocable(kernel) -> None:
+    descriptor = next(
+        descriptor
+        for descriptor in kernel.capabilities.catalog().capabilities
+        if descriptor.capability_id == "geometry.segment.compute.midpoint"
+    )
+    example = descriptor.invocation_examples[0]
+
+    result = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id=descriptor.capability_id,
+            mode=example.mode,
+            input=example.input,
+        )
+    )
+
+    assert example.input == {
+        "first": {"x": ZERO, "y": ZERO},
+        "second": {"x": ONE, "y": ZERO},
+    }
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output["result"] == {
+        "point": {
+            "x": {"num": "1", "den": "2"},
+            "y": ZERO,
+        }
+    }
+
+
 def test_geometry_capabilities_are_distinct_and_every_contract_completes(
     kernel,
 ) -> None:


### PR DESCRIPTION
## Summary

Add schema-valid invocation examples for 19 previously uncovered geometry and graph-invariant capabilities.

## Scope

- Covers point, line, triangle, polygon, and segment geometry operations.
- Covers exact graph invariants including triangle count, radius, k-core, girth, diameter, connectivity, Eulerian status, and spanning-tree count.
- Reuses the existing invocation-example mechanism without changing schemas or semantics.

## Validation

- Catalog registration validates all examples against canonical schemas.
- Coverage rises from 109 to 128 of 217 capabilities.
- Ruff and `git diff --check` pass locally.
- Full pytest collection remains unavailable because this environment lacks the repository's `timeout` plugin and `z3` dependency.