### PR TITLE
docs(examples): cover polynomial operations

### DIFF
--- a/src/jacobian/domains/polynomial/elementary.py
+++ b/src/jacobian/domains/polynomial/elementary.py
@@ -73,6 +73,7 @@ INTEGER_POLYNOMIAL_CAPABILITIES = (
         "polynomial",
         "integer",
         "content",
+        invocation_examples=(example("content_6x2_plus_9x", "Compute the coefficient content of 6x²+9x.", {"polynomial": {"coefficients": ["6", "9", "0"]}}),),
     ),
     polynomial_operation(
         "polynomial.integer.compute.primitive_part",
@@ -87,6 +88,7 @@ INTEGER_POLYNOMIAL_CAPABILITIES = (
         "polynomial",
         "integer",
         "primitive",
+        invocation_examples=(example("primitive_part_6x2_plus_9x", "Compute the primitive part of 6x²+9x.", {"polynomial": {"coefficients": ["6", "9", "0"]}}),),
     ),
     polynomial_operation(
         "polynomial.integer.compute.evaluate",
@@ -116,6 +118,7 @@ INTEGER_POLYNOMIAL_CAPABILITIES = (
         "polynomial",
         "integer",
         "composition",
+        invocation_examples=(example("compose_x_plus_one", "Compose x+1 with x².", {"outer": {"coefficient_order": "DESCENDING_DEGREE", "coefficients": ["1", "1"]}, "inner": {"coefficient_order": "DESCENDING_DEGREE", "coefficients": ["1", "0", "0"]}}),),
     ),
     polynomial_operation(
         "polynomial.integer.compute.shift",
@@ -127,6 +130,7 @@ INTEGER_POLYNOMIAL_CAPABILITIES = (
         "polynomial",
         "integer",
         "shift",
+        invocation_examples=(example("shift_x2_by_two", "Compute p(x+2) for p(x)=x².", {"polynomial": {"coefficient_order": "DESCENDING_DEGREE", "coefficients": ["1", "0", "0"]}, "shift": 2}),),
     ),
 )
 
@@ -197,6 +201,7 @@ RATIONAL_POLYNOMIAL_CAPABILITIES = (
         "polynomial",
         "rational",
         "evaluation",
+        invocation_examples=(example("rational_evaluate_x2_plus_one", "Evaluate x²+1 at 2.", {"polynomial": {"polynomial_schema_version": "1", "domain": "QQ", "variables": ["x"], "polynomial": {"terms": [{"coefficient": {"num": "1", "den": "1"}, "exponents": [2]}, {"coefficient": {"num": "1", "den": "1"}, "exponents": [0]}]}}, "point": {"num": "2", "den": "1"}}),),
     ),
     polynomial_operation(
         "polynomial.rational.compute.derivative",
@@ -247,6 +252,7 @@ RATIONAL_POLYNOMIAL_CAPABILITIES = (
         "polynomial",
         "rational",
         "integration",
+        invocation_examples=(example("integral_two_x", "Integrate 2x with zero constant.", {"polynomial": {"polynomial_schema_version": "1", "domain": "QQ", "variables": ["x"], "polynomial": {"terms": [{"coefficient": {"num": "2", "den": "1"}, "exponents": [1]}]}}}),),
     ),
     polynomial_operation(
         "polynomial.rational.compute.partial_fraction_decomposition",
@@ -261,6 +267,7 @@ RATIONAL_POLYNOMIAL_CAPABILITIES = (
         "polynomial",
         "rational-function",
         "partial-fraction",
+        invocation_examples=(example("partial_fraction_one_over_x2_minus_one", "Decompose 1/(x²-1) into partial fractions.", {"numerator": {"polynomial_schema_version": "1", "domain": "QQ", "variables": ["x"], "polynomial": {"terms": [{"coefficient": {"num": "1", "den": "1"}, "exponents": [0]}]}}, "denominator": {"polynomial_schema_version": "1", "domain": "QQ", "variables": ["x"], "polynomial": {"terms": [{"coefficient": {"num": "1", "den": "1"}, "exponents": [2]}, {"coefficient": {"num": "-1", "den": "1"}, "exponents": [0]}]}}}),),
     ),
 )
 

--- a/src/jacobian/domains/polynomial/elementary.py
+++ b/src/jacobian/domains/polynomial/elementary.py
@@ -73,7 +73,13 @@ INTEGER_POLYNOMIAL_CAPABILITIES = (
         "polynomial",
         "integer",
         "content",
-        invocation_examples=(example("content_6x2_plus_9x", "Compute the coefficient content of 6x²+9x.", {"polynomial": {"coefficients": ["6", "9", "0"]}}),),
+        invocation_examples=(
+            example(
+                "content_6x2_plus_9x",
+                "Compute the coefficient content of 6x²+9x.",
+                {"polynomial": {"coefficients": ["6", "9", "0"]}},
+            ),
+        ),
     ),
     polynomial_operation(
         "polynomial.integer.compute.primitive_part",
@@ -88,7 +94,13 @@ INTEGER_POLYNOMIAL_CAPABILITIES = (
         "polynomial",
         "integer",
         "primitive",
-        invocation_examples=(example("primitive_part_6x2_plus_9x", "Compute the primitive part of 6x²+9x.", {"polynomial": {"coefficients": ["6", "9", "0"]}}),),
+        invocation_examples=(
+            example(
+                "primitive_part_6x2_plus_9x",
+                "Compute the primitive part of 6x²+9x.",
+                {"polynomial": {"coefficients": ["6", "9", "0"]}},
+            ),
+        ),
     ),
     polynomial_operation(
         "polynomial.integer.compute.evaluate",
@@ -118,7 +130,22 @@ INTEGER_POLYNOMIAL_CAPABILITIES = (
         "polynomial",
         "integer",
         "composition",
-        invocation_examples=(example("compose_x_plus_one", "Compose x+1 with x².", {"outer": {"coefficient_order": "DESCENDING_DEGREE", "coefficients": ["1", "1"]}, "inner": {"coefficient_order": "DESCENDING_DEGREE", "coefficients": ["1", "0", "0"]}}),),
+        invocation_examples=(
+            example(
+                "compose_x_plus_one",
+                "Compose x+1 with x².",
+                {
+                    "outer": {
+                        "coefficient_order": "DESCENDING_DEGREE",
+                        "coefficients": ["1", "1"],
+                    },
+                    "inner": {
+                        "coefficient_order": "DESCENDING_DEGREE",
+                        "coefficients": ["1", "0", "0"],
+                    },
+                },
+            ),
+        ),
     ),
     polynomial_operation(
         "polynomial.integer.compute.shift",
@@ -130,7 +157,19 @@ INTEGER_POLYNOMIAL_CAPABILITIES = (
         "polynomial",
         "integer",
         "shift",
-        invocation_examples=(example("shift_x2_by_two", "Compute p(x+2) for p(x)=x².", {"polynomial": {"coefficient_order": "DESCENDING_DEGREE", "coefficients": ["1", "0", "0"]}, "shift": 2}),),
+        invocation_examples=(
+            example(
+                "shift_x2_by_two",
+                "Compute p(x+2) for p(x)=x².",
+                {
+                    "polynomial": {
+                        "coefficient_order": "DESCENDING_DEGREE",
+                        "coefficients": ["1", "0", "0"],
+                    },
+                    "shift": 2,
+                },
+            ),
+        ),
     ),
 )
 
@@ -201,7 +240,32 @@ RATIONAL_POLYNOMIAL_CAPABILITIES = (
         "polynomial",
         "rational",
         "evaluation",
-        invocation_examples=(example("rational_evaluate_x2_plus_one", "Evaluate x²+1 at 2.", {"polynomial": {"polynomial_schema_version": "1", "domain": "QQ", "variables": ["x"], "polynomial": {"terms": [{"coefficient": {"num": "1", "den": "1"}, "exponents": [2]}, {"coefficient": {"num": "1", "den": "1"}, "exponents": [0]}]}}, "point": {"num": "2", "den": "1"}}),),
+        invocation_examples=(
+            example(
+                "rational_evaluate_x2_plus_one",
+                "Evaluate x²+1 at 2.",
+                {
+                    "polynomial": {
+                        "polynomial_schema_version": "1",
+                        "domain": "QQ",
+                        "variables": ["x"],
+                        "polynomial": {
+                            "terms": [
+                                {
+                                    "coefficient": {"num": "1", "den": "1"},
+                                    "exponents": [2],
+                                },
+                                {
+                                    "coefficient": {"num": "1", "den": "1"},
+                                    "exponents": [0],
+                                },
+                            ]
+                        },
+                    },
+                    "point": {"num": "2", "den": "1"},
+                },
+            ),
+        ),
     ),
     polynomial_operation(
         "polynomial.rational.compute.derivative",
@@ -252,7 +316,27 @@ RATIONAL_POLYNOMIAL_CAPABILITIES = (
         "polynomial",
         "rational",
         "integration",
-        invocation_examples=(example("integral_two_x", "Integrate 2x with zero constant.", {"polynomial": {"polynomial_schema_version": "1", "domain": "QQ", "variables": ["x"], "polynomial": {"terms": [{"coefficient": {"num": "2", "den": "1"}, "exponents": [1]}]}}}),),
+        invocation_examples=(
+            example(
+                "integral_two_x",
+                "Integrate 2x with zero constant.",
+                {
+                    "polynomial": {
+                        "polynomial_schema_version": "1",
+                        "domain": "QQ",
+                        "variables": ["x"],
+                        "polynomial": {
+                            "terms": [
+                                {
+                                    "coefficient": {"num": "2", "den": "1"},
+                                    "exponents": [1],
+                                }
+                            ]
+                        },
+                    }
+                },
+            ),
+        ),
     ),
     polynomial_operation(
         "polynomial.rational.compute.partial_fraction_decomposition",
@@ -267,7 +351,44 @@ RATIONAL_POLYNOMIAL_CAPABILITIES = (
         "polynomial",
         "rational-function",
         "partial-fraction",
-        invocation_examples=(example("partial_fraction_one_over_x2_minus_one", "Decompose 1/(x²-1) into partial fractions.", {"numerator": {"polynomial_schema_version": "1", "domain": "QQ", "variables": ["x"], "polynomial": {"terms": [{"coefficient": {"num": "1", "den": "1"}, "exponents": [0]}]}}, "denominator": {"polynomial_schema_version": "1", "domain": "QQ", "variables": ["x"], "polynomial": {"terms": [{"coefficient": {"num": "1", "den": "1"}, "exponents": [2]}, {"coefficient": {"num": "-1", "den": "1"}, "exponents": [0]}]}}}),),
+        invocation_examples=(
+            example(
+                "partial_fraction_one_over_x2_minus_one",
+                "Decompose 1/(x²-1) into partial fractions.",
+                {
+                    "numerator": {
+                        "polynomial_schema_version": "1",
+                        "domain": "QQ",
+                        "variables": ["x"],
+                        "polynomial": {
+                            "terms": [
+                                {
+                                    "coefficient": {"num": "1", "den": "1"},
+                                    "exponents": [0],
+                                }
+                            ]
+                        },
+                    },
+                    "denominator": {
+                        "polynomial_schema_version": "1",
+                        "domain": "QQ",
+                        "variables": ["x"],
+                        "polynomial": {
+                            "terms": [
+                                {
+                                    "coefficient": {"num": "1", "den": "1"},
+                                    "exponents": [2],
+                                },
+                                {
+                                    "coefficient": {"num": "-1", "den": "1"},
+                                    "exponents": [0],
+                                },
+                            ]
+                        },
+                    },
+                },
+            ),
+        ),
     ),
 )
 

--- a/src/jacobian/domains/polynomial/invariants.py
+++ b/src/jacobian/domains/polynomial/invariants.py
@@ -30,7 +30,48 @@ POLYNOMIAL_INVARIANT_CAPABILITIES = (
         "polynomial",
         "gcd",
         "bezout",
-        invocation_examples=(example("gcd_x2_minus_one_x_minus_one", "Compute the GCD of x²-1 and x-1.", {"left": {"polynomial_schema_version": "1", "domain": "QQ", "variables": ["x"], "polynomial": {"terms": [{"coefficient": {"num": "1", "den": "1"}, "exponents": [2]}, {"coefficient": {"num": "-1", "den": "1"}, "exponents": [0]}]}}, "right": {"polynomial_schema_version": "1", "domain": "QQ", "variables": ["x"], "polynomial": {"terms": [{"coefficient": {"num": "1", "den": "1"}, "exponents": [1]}, {"coefficient": {"num": "-1", "den": "1"}, "exponents": [0]}]}}}),),
+        invocation_examples=(
+            example(
+                "gcd_x2_minus_one_x_minus_one",
+                "Compute the GCD of x²-1 and x-1.",
+                {
+                    "left": {
+                        "polynomial_schema_version": "1",
+                        "domain": "QQ",
+                        "variables": ["x"],
+                        "polynomial": {
+                            "terms": [
+                                {
+                                    "coefficient": {"num": "1", "den": "1"},
+                                    "exponents": [2],
+                                },
+                                {
+                                    "coefficient": {"num": "-1", "den": "1"},
+                                    "exponents": [0],
+                                },
+                            ]
+                        },
+                    },
+                    "right": {
+                        "polynomial_schema_version": "1",
+                        "domain": "QQ",
+                        "variables": ["x"],
+                        "polynomial": {
+                            "terms": [
+                                {
+                                    "coefficient": {"num": "1", "den": "1"},
+                                    "exponents": [1],
+                                },
+                                {
+                                    "coefficient": {"num": "-1", "den": "1"},
+                                    "exponents": [0],
+                                },
+                            ]
+                        },
+                    },
+                },
+            ),
+        ),
     ),
     polynomial_operation(
         "polynomial.compute.resultant",
@@ -42,7 +83,49 @@ POLYNOMIAL_INVARIANT_CAPABILITIES = (
         "polynomial",
         "resultant",
         "elimination",
-        invocation_examples=(example("resultant_x2_minus_one_x_minus_two", "Compute the resultant of x²-1 and x-2.", {"left": {"polynomial_schema_version": "1", "domain": "QQ", "variables": ["x"], "polynomial": {"terms": [{"coefficient": {"num": "1", "den": "1"}, "exponents": [2]}, {"coefficient": {"num": "-1", "den": "1"}, "exponents": [0]}]}}, "right": {"polynomial_schema_version": "1", "domain": "QQ", "variables": ["x"], "polynomial": {"terms": [{"coefficient": {"num": "1", "den": "1"}, "exponents": [1]}, {"coefficient": {"num": "-2", "den": "1"}, "exponents": [0]}]}}, "elimination_variable": "x"}),),
+        invocation_examples=(
+            example(
+                "resultant_x2_minus_one_x_minus_two",
+                "Compute the resultant of x²-1 and x-2.",
+                {
+                    "left": {
+                        "polynomial_schema_version": "1",
+                        "domain": "QQ",
+                        "variables": ["x"],
+                        "polynomial": {
+                            "terms": [
+                                {
+                                    "coefficient": {"num": "1", "den": "1"},
+                                    "exponents": [2],
+                                },
+                                {
+                                    "coefficient": {"num": "-1", "den": "1"},
+                                    "exponents": [0],
+                                },
+                            ]
+                        },
+                    },
+                    "right": {
+                        "polynomial_schema_version": "1",
+                        "domain": "QQ",
+                        "variables": ["x"],
+                        "polynomial": {
+                            "terms": [
+                                {
+                                    "coefficient": {"num": "1", "den": "1"},
+                                    "exponents": [1],
+                                },
+                                {
+                                    "coefficient": {"num": "-2", "den": "1"},
+                                    "exponents": [0],
+                                },
+                            ]
+                        },
+                    },
+                    "elimination_variable": "x",
+                },
+            ),
+        ),
     ),
     polynomial_operation(
         "polynomial.compute.discriminant",
@@ -53,7 +136,32 @@ POLYNOMIAL_INVARIANT_CAPABILITIES = (
         polynomial_discriminant,
         "polynomial",
         "discriminant",
-        invocation_examples=(example("discriminant_x2_minus_one", "Compute the discriminant of x²-1.", {"polynomial": {"polynomial_schema_version": "1", "domain": "QQ", "variables": ["x"], "polynomial": {"terms": [{"coefficient": {"num": "1", "den": "1"}, "exponents": [2]}, {"coefficient": {"num": "-1", "den": "1"}, "exponents": [0]}]}}, "variable": "x"}),),
+        invocation_examples=(
+            example(
+                "discriminant_x2_minus_one",
+                "Compute the discriminant of x²-1.",
+                {
+                    "polynomial": {
+                        "polynomial_schema_version": "1",
+                        "domain": "QQ",
+                        "variables": ["x"],
+                        "polynomial": {
+                            "terms": [
+                                {
+                                    "coefficient": {"num": "1", "den": "1"},
+                                    "exponents": [2],
+                                },
+                                {
+                                    "coefficient": {"num": "-1", "den": "1"},
+                                    "exponents": [0],
+                                },
+                            ]
+                        },
+                    },
+                    "variable": "x",
+                },
+            ),
+        ),
     ),
     polynomial_operation(
         "polynomial.compute.square_free_decomposition",
@@ -65,7 +173,31 @@ POLYNOMIAL_INVARIANT_CAPABILITIES = (
         "polynomial",
         "square-free",
         "multiplicity",
-        invocation_examples=(example("square_free_x2_minus_one", "Compute the square-free decomposition of x²-1.", {"polynomial": {"polynomial_schema_version": "1", "domain": "QQ", "variables": ["x"], "polynomial": {"terms": [{"coefficient": {"num": "1", "den": "1"}, "exponents": [2]}, {"coefficient": {"num": "-1", "den": "1"}, "exponents": [0]}]}}}),),
+        invocation_examples=(
+            example(
+                "square_free_x2_minus_one",
+                "Compute the square-free decomposition of x²-1.",
+                {
+                    "polynomial": {
+                        "polynomial_schema_version": "1",
+                        "domain": "QQ",
+                        "variables": ["x"],
+                        "polynomial": {
+                            "terms": [
+                                {
+                                    "coefficient": {"num": "1", "den": "1"},
+                                    "exponents": [2],
+                                },
+                                {
+                                    "coefficient": {"num": "-1", "den": "1"},
+                                    "exponents": [0],
+                                },
+                            ]
+                        },
+                    }
+                },
+            ),
+        ),
     ),
 )
 

--- a/src/jacobian/domains/polynomial/invariants.py
+++ b/src/jacobian/domains/polynomial/invariants.py
@@ -10,6 +10,7 @@ from jacobian.contracts.polynomial_operations import (
     PolynomialSquareFreeDecompositionResult,
     PolynomialSquareFreeRequest,
 )
+from jacobian.domains._examples import example
 from jacobian.domains.polynomial._support import polynomial_operation
 from jacobian.domains.polynomial.operations import (
     polynomial_discriminant,
@@ -29,6 +30,7 @@ POLYNOMIAL_INVARIANT_CAPABILITIES = (
         "polynomial",
         "gcd",
         "bezout",
+        invocation_examples=(example("gcd_x2_minus_one_x_minus_one", "Compute the GCD of x²-1 and x-1.", {"left": {"polynomial_schema_version": "1", "domain": "QQ", "variables": ["x"], "polynomial": {"terms": [{"coefficient": {"num": "1", "den": "1"}, "exponents": [2]}, {"coefficient": {"num": "-1", "den": "1"}, "exponents": [0]}]}}, "right": {"polynomial_schema_version": "1", "domain": "QQ", "variables": ["x"], "polynomial": {"terms": [{"coefficient": {"num": "1", "den": "1"}, "exponents": [1]}, {"coefficient": {"num": "-1", "den": "1"}, "exponents": [0]}]}}}),),
     ),
     polynomial_operation(
         "polynomial.compute.resultant",
@@ -40,6 +42,7 @@ POLYNOMIAL_INVARIANT_CAPABILITIES = (
         "polynomial",
         "resultant",
         "elimination",
+        invocation_examples=(example("resultant_x2_minus_one_x_minus_two", "Compute the resultant of x²-1 and x-2.", {"left": {"polynomial_schema_version": "1", "domain": "QQ", "variables": ["x"], "polynomial": {"terms": [{"coefficient": {"num": "1", "den": "1"}, "exponents": [2]}, {"coefficient": {"num": "-1", "den": "1"}, "exponents": [0]}]}}, "right": {"polynomial_schema_version": "1", "domain": "QQ", "variables": ["x"], "polynomial": {"terms": [{"coefficient": {"num": "1", "den": "1"}, "exponents": [1]}, {"coefficient": {"num": "-2", "den": "1"}, "exponents": [0]}]}}, "elimination_variable": "x"}),),
     ),
     polynomial_operation(
         "polynomial.compute.discriminant",
@@ -50,6 +53,7 @@ POLYNOMIAL_INVARIANT_CAPABILITIES = (
         polynomial_discriminant,
         "polynomial",
         "discriminant",
+        invocation_examples=(example("discriminant_x2_minus_one", "Compute the discriminant of x²-1.", {"polynomial": {"polynomial_schema_version": "1", "domain": "QQ", "variables": ["x"], "polynomial": {"terms": [{"coefficient": {"num": "1", "den": "1"}, "exponents": [2]}, {"coefficient": {"num": "-1", "den": "1"}, "exponents": [0]}]}}, "variable": "x"}),),
     ),
     polynomial_operation(
         "polynomial.compute.square_free_decomposition",
@@ -61,6 +65,7 @@ POLYNOMIAL_INVARIANT_CAPABILITIES = (
         "polynomial",
         "square-free",
         "multiplicity",
+        invocation_examples=(example("square_free_x2_minus_one", "Compute the square-free decomposition of x²-1.", {"polynomial": {"polynomial_schema_version": "1", "domain": "QQ", "variables": ["x"], "polynomial": {"terms": [{"coefficient": {"num": "1", "den": "1"}, "exponents": [2]}, {"coefficient": {"num": "-1", "den": "1"}, "exponents": [0]}]}}}),),
     ),
 )
 


### PR DESCRIPTION
## Summary

Add schema-valid invocation examples for elementary and invariant polynomial capabilities.

## Validation

- Catalog registration validates all examples against canonical schemas.
- Coverage rises from 136 to 147 of 217 capabilities.
- Ruff and git diff --check pass locally.
- Full pytest collection is blocked by the environment's missing timeout plugin and z3 dependency.

Reuses the existing CapabilityInvocationExample mechanism; no schemas or semantics changed.