### PR TITLE
docs(examples): cover prime and sequence aggregates

### DIFF
--- a/src/jacobian/domains/number_theory/primes.py
+++ b/src/jacobian/domains/number_theory/primes.py
@@ -7,6 +7,7 @@ from jacobian.contracts.number_theory import (
     NonnegativeIntegerRequest,
     PositiveIntegerRequest,
 )
+from jacobian.domains._examples import example
 from jacobian.domains.number_theory._support import (
     number_theory_operation,
 )
@@ -31,6 +32,7 @@ PRIME_CAPABILITIES = (
         decide_prime,
         "number-theory",
         "predicate",
+        invocation_examples=(example("prime_17", "Check whether 17 is prime.", {"value": "17"}),),
     ),
     number_theory_operation(
         "integer.compute.next_prime",
@@ -41,6 +43,7 @@ PRIME_CAPABILITIES = (
         compute_next_prime,
         "number-theory",
         "prime",
+        invocation_examples=(example("next_prime_14", "Find the next prime after 14.", {"n": 14}),),
     ),
     number_theory_operation(
         "integer.compute.previous_prime",
@@ -51,6 +54,7 @@ PRIME_CAPABILITIES = (
         compute_previous_prime,
         "number-theory",
         "prime",
+        invocation_examples=(example("previous_prime_14", "Find the previous prime before 14.", {"n": 14}),),
     ),
     number_theory_operation(
         "integer.compute.prime_count",
@@ -61,6 +65,7 @@ PRIME_CAPABILITIES = (
         compute_prime_count,
         "number-theory",
         "prime",
+        invocation_examples=(example("prime_count_20", "Count primes through 20.", {"n": 20}),),
     ),
     number_theory_operation(
         "integer.compute.nth_prime",
@@ -71,6 +76,7 @@ PRIME_CAPABILITIES = (
         compute_nth_prime,
         "number-theory",
         "prime",
+        invocation_examples=(example("nth_prime_6", "Compute the sixth prime.", {"n": 6}),),
     ),
     number_theory_operation(
         "integer.compute.primorial",
@@ -81,6 +87,7 @@ PRIME_CAPABILITIES = (
         compute_primorial,
         "number-theory",
         "prime",
+        invocation_examples=(example("primorial_5", "Compute the product of the first five primes.", {"n": 5}),),
     ),
     number_theory_operation(
         "integer.compute.euler_totient",
@@ -91,6 +98,7 @@ PRIME_CAPABILITIES = (
         compute_euler_totient,
         "number-theory",
         "arithmetic-function",
+        invocation_examples=(example("totient_12", "Count residues coprime to 12.", {"n": 12}),),
     ),
     number_theory_operation(
         "integer.compute.mobius",
@@ -101,5 +109,6 @@ PRIME_CAPABILITIES = (
         compute_mobius,
         "number-theory",
         "arithmetic-function",
+        invocation_examples=(example("mobius_30", "Compute the Mobius value of 30.", {"n": 30}),),
     ),
 )

--- a/src/jacobian/domains/number_theory/primes.py
+++ b/src/jacobian/domains/number_theory/primes.py
@@ -32,7 +32,9 @@ PRIME_CAPABILITIES = (
         decide_prime,
         "number-theory",
         "predicate",
-        invocation_examples=(example("prime_17", "Check whether 17 is prime.", {"value": "17"}),),
+        invocation_examples=(
+            example("prime_17", "Check whether 17 is prime.", {"value": "17"}),
+        ),
     ),
     number_theory_operation(
         "integer.compute.next_prime",
@@ -43,7 +45,9 @@ PRIME_CAPABILITIES = (
         compute_next_prime,
         "number-theory",
         "prime",
-        invocation_examples=(example("next_prime_14", "Find the next prime after 14.", {"n": 14}),),
+        invocation_examples=(
+            example("next_prime_14", "Find the next prime after 14.", {"n": 14}),
+        ),
     ),
     number_theory_operation(
         "integer.compute.previous_prime",
@@ -54,7 +58,11 @@ PRIME_CAPABILITIES = (
         compute_previous_prime,
         "number-theory",
         "prime",
-        invocation_examples=(example("previous_prime_14", "Find the previous prime before 14.", {"n": 14}),),
+        invocation_examples=(
+            example(
+                "previous_prime_14", "Find the previous prime before 14.", {"n": 14}
+            ),
+        ),
     ),
     number_theory_operation(
         "integer.compute.prime_count",
@@ -65,7 +73,9 @@ PRIME_CAPABILITIES = (
         compute_prime_count,
         "number-theory",
         "prime",
-        invocation_examples=(example("prime_count_20", "Count primes through 20.", {"n": 20}),),
+        invocation_examples=(
+            example("prime_count_20", "Count primes through 20.", {"n": 20}),
+        ),
     ),
     number_theory_operation(
         "integer.compute.nth_prime",
@@ -76,7 +86,9 @@ PRIME_CAPABILITIES = (
         compute_nth_prime,
         "number-theory",
         "prime",
-        invocation_examples=(example("nth_prime_6", "Compute the sixth prime.", {"n": 6}),),
+        invocation_examples=(
+            example("nth_prime_6", "Compute the sixth prime.", {"n": 6}),
+        ),
     ),
     number_theory_operation(
         "integer.compute.primorial",
@@ -87,7 +99,11 @@ PRIME_CAPABILITIES = (
         compute_primorial,
         "number-theory",
         "prime",
-        invocation_examples=(example("primorial_5", "Compute the product of the first five primes.", {"n": 5}),),
+        invocation_examples=(
+            example(
+                "primorial_5", "Compute the product of the first five primes.", {"n": 5}
+            ),
+        ),
     ),
     number_theory_operation(
         "integer.compute.euler_totient",
@@ -98,7 +114,9 @@ PRIME_CAPABILITIES = (
         compute_euler_totient,
         "number-theory",
         "arithmetic-function",
-        invocation_examples=(example("totient_12", "Count residues coprime to 12.", {"n": 12}),),
+        invocation_examples=(
+            example("totient_12", "Count residues coprime to 12.", {"n": 12}),
+        ),
     ),
     number_theory_operation(
         "integer.compute.mobius",
@@ -109,6 +127,8 @@ PRIME_CAPABILITIES = (
         compute_mobius,
         "number-theory",
         "arithmetic-function",
-        invocation_examples=(example("mobius_30", "Compute the Mobius value of 30.", {"n": 30}),),
+        invocation_examples=(
+            example("mobius_30", "Compute the Mobius value of 30.", {"n": 30}),
+        ),
     ),
 )

--- a/src/jacobian/domains/sequences/aggregates.py
+++ b/src/jacobian/domains/sequences/aggregates.py
@@ -27,7 +27,13 @@ SEQUENCE_AGGREGATE_CAPABILITIES = (
         sequence_sum,
         "sequence",
         "exact",
-        invocation_examples=(example("sum_1_2_3", "Sum the sequence 1, 2, and 3.", {"values": ["1", "2", "3"]}),),
+        invocation_examples=(
+            example(
+                "sum_1_2_3",
+                "Sum the sequence 1, 2, and 3.",
+                {"values": ["1", "2", "3"]},
+            ),
+        ),
     ),
     sequence_operation(
         "sequence.compute.product",
@@ -38,7 +44,13 @@ SEQUENCE_AGGREGATE_CAPABILITIES = (
         sequence_product,
         "sequence",
         "exact",
-        invocation_examples=(example("product_2_3_4", "Multiply the sequence 2, 3, and 4.", {"values": ["2", "3", "4"]}),),
+        invocation_examples=(
+            example(
+                "product_2_3_4",
+                "Multiply the sequence 2, 3, and 4.",
+                {"values": ["2", "3", "4"]},
+            ),
+        ),
     ),
     sequence_operation(
         "sequence.compute.gcd",
@@ -49,7 +61,11 @@ SEQUENCE_AGGREGATE_CAPABILITIES = (
         sequence_gcd,
         "sequence",
         "divisibility",
-        invocation_examples=(example("gcd_12_18", "Compute the gcd of 12 and 18.", {"values": ["12", "18"]}),),
+        invocation_examples=(
+            example(
+                "gcd_12_18", "Compute the gcd of 12 and 18.", {"values": ["12", "18"]}
+            ),
+        ),
     ),
     sequence_operation(
         "sequence.compute.lcm",
@@ -60,7 +76,9 @@ SEQUENCE_AGGREGATE_CAPABILITIES = (
         sequence_lcm,
         "sequence",
         "divisibility",
-        invocation_examples=(example("lcm_4_6", "Compute the lcm of 4 and 6.", {"values": ["4", "6"]}),),
+        invocation_examples=(
+            example("lcm_4_6", "Compute the lcm of 4 and 6.", {"values": ["4", "6"]}),
+        ),
     ),
     sequence_operation(
         "sequence.compute.minimum",
@@ -71,7 +89,13 @@ SEQUENCE_AGGREGATE_CAPABILITIES = (
         sequence_minimum,
         "sequence",
         "order",
-        invocation_examples=(example("minimum_3_1_2", "Find the minimum of 3, 1, and 2.", {"values": ["3", "1", "2"]}),),
+        invocation_examples=(
+            example(
+                "minimum_3_1_2",
+                "Find the minimum of 3, 1, and 2.",
+                {"values": ["3", "1", "2"]},
+            ),
+        ),
     ),
     sequence_operation(
         "sequence.compute.maximum",
@@ -82,7 +106,13 @@ SEQUENCE_AGGREGATE_CAPABILITIES = (
         sequence_maximum,
         "sequence",
         "order",
-        invocation_examples=(example("maximum_1_3_2", "Find the maximum of 1, 3, and 2.", {"values": ["1", "3", "2"]}),),
+        invocation_examples=(
+            example(
+                "maximum_1_3_2",
+                "Find the maximum of 1, 3, and 2.",
+                {"values": ["1", "3", "2"]},
+            ),
+        ),
     ),
     sequence_operation(
         "sequence.compute.range",
@@ -93,7 +123,13 @@ SEQUENCE_AGGREGATE_CAPABILITIES = (
         sequence_range,
         "sequence",
         "statistic",
-        invocation_examples=(example("range_1_4_2", "Compute the range of 1, 4, and 2.", {"values": ["1", "4", "2"]}),),
+        invocation_examples=(
+            example(
+                "range_1_4_2",
+                "Compute the range of 1, 4, and 2.",
+                {"values": ["1", "4", "2"]},
+            ),
+        ),
     ),
     sequence_operation(
         "sequence.compute.distinct_count",
@@ -104,6 +140,12 @@ SEQUENCE_AGGREGATE_CAPABILITIES = (
         sequence_distinct_count,
         "sequence",
         "counting",
-        invocation_examples=(example("distinct_count_1_2_1", "Count distinct values in 1, 2, and 1.", {"values": ["1", "2", "1"]}),),
+        invocation_examples=(
+            example(
+                "distinct_count_1_2_1",
+                "Count distinct values in 1, 2, and 1.",
+                {"values": ["1", "2", "1"]},
+            ),
+        ),
     ),
 )

--- a/src/jacobian/domains/sequences/aggregates.py
+++ b/src/jacobian/domains/sequences/aggregates.py
@@ -4,6 +4,7 @@ from jacobian.contracts.sequences import (
     IntegerSequenceRequest,
     IntegerSequenceValueResult,
 )
+from jacobian.domains._examples import example
 from jacobian.domains.sequences._support import sequence_operation
 from jacobian.domains.sequences.operations import (
     sequence_distinct_count,
@@ -26,6 +27,7 @@ SEQUENCE_AGGREGATE_CAPABILITIES = (
         sequence_sum,
         "sequence",
         "exact",
+        invocation_examples=(example("sum_1_2_3", "Sum the sequence 1, 2, and 3.", {"values": ["1", "2", "3"]}),),
     ),
     sequence_operation(
         "sequence.compute.product",
@@ -36,6 +38,7 @@ SEQUENCE_AGGREGATE_CAPABILITIES = (
         sequence_product,
         "sequence",
         "exact",
+        invocation_examples=(example("product_2_3_4", "Multiply the sequence 2, 3, and 4.", {"values": ["2", "3", "4"]}),),
     ),
     sequence_operation(
         "sequence.compute.gcd",
@@ -46,6 +49,7 @@ SEQUENCE_AGGREGATE_CAPABILITIES = (
         sequence_gcd,
         "sequence",
         "divisibility",
+        invocation_examples=(example("gcd_12_18", "Compute the gcd of 12 and 18.", {"values": ["12", "18"]}),),
     ),
     sequence_operation(
         "sequence.compute.lcm",
@@ -56,6 +60,7 @@ SEQUENCE_AGGREGATE_CAPABILITIES = (
         sequence_lcm,
         "sequence",
         "divisibility",
+        invocation_examples=(example("lcm_4_6", "Compute the lcm of 4 and 6.", {"values": ["4", "6"]}),),
     ),
     sequence_operation(
         "sequence.compute.minimum",
@@ -66,6 +71,7 @@ SEQUENCE_AGGREGATE_CAPABILITIES = (
         sequence_minimum,
         "sequence",
         "order",
+        invocation_examples=(example("minimum_3_1_2", "Find the minimum of 3, 1, and 2.", {"values": ["3", "1", "2"]}),),
     ),
     sequence_operation(
         "sequence.compute.maximum",
@@ -76,6 +82,7 @@ SEQUENCE_AGGREGATE_CAPABILITIES = (
         sequence_maximum,
         "sequence",
         "order",
+        invocation_examples=(example("maximum_1_3_2", "Find the maximum of 1, 3, and 2.", {"values": ["1", "3", "2"]}),),
     ),
     sequence_operation(
         "sequence.compute.range",
@@ -86,6 +93,7 @@ SEQUENCE_AGGREGATE_CAPABILITIES = (
         sequence_range,
         "sequence",
         "statistic",
+        invocation_examples=(example("range_1_4_2", "Compute the range of 1, 4, and 2.", {"values": ["1", "4", "2"]}),),
     ),
     sequence_operation(
         "sequence.compute.distinct_count",
@@ -96,5 +104,6 @@ SEQUENCE_AGGREGATE_CAPABILITIES = (
         sequence_distinct_count,
         "sequence",
         "counting",
+        invocation_examples=(example("distinct_count_1_2_1", "Count distinct values in 1, 2, and 1.", {"values": ["1", "2", "1"]}),),
     ),
 )


### PR DESCRIPTION
## Summary

Add concise, deterministic invocation examples for remaining exact prime and sequence aggregate capabilities.

## Validation

- Catalog registration validates all examples against canonical schemas.
- Coverage rises from 147 to 163 of 217 capabilities.
- Ruff and git diff --check pass locally.
- Full pytest collection remains blocked by the environment's missing timeout plugin and z3 dependency.

Reuses the existing CapabilityInvocationExample mechanism; no schemas or semantics changed.