### PR TITLE
docs(examples): cover sequence statistics and search

### DIFF
--- a/src/jacobian/domains/sequences/search.py
+++ b/src/jacobian/domains/sequences/search.py
@@ -5,6 +5,7 @@ from jacobian.contracts.sequences import (
     IntegerSequenceIndexListResult,
     IntegerSequenceRequest,
 )
+from jacobian.domains._examples import example
 from jacobian.domains.sequences._support import sequence_operation
 from jacobian.domains.sequences.operations import (
     frequencies,
@@ -21,6 +22,7 @@ SEQUENCE_SEARCH_CAPABILITIES = (
         frequencies,
         "sequence",
         "counting",
+        invocation_examples=(example("frequencies_1_2_1", "Count frequencies in 1, 2, and 1.", {"values": ["1", "2", "1"]}),),
     ),
     sequence_operation(
         "sequence.compute.zero_indices",
@@ -31,5 +33,6 @@ SEQUENCE_SEARCH_CAPABILITIES = (
         zero_indices,
         "sequence",
         "search",
+        invocation_examples=(example("zero_indices_2_0_3", "Locate zero terms in 2, 0, and 3.", {"values": ["2", "0", "3"]}),),
     ),
 )

--- a/src/jacobian/domains/sequences/search.py
+++ b/src/jacobian/domains/sequences/search.py
@@ -22,7 +22,13 @@ SEQUENCE_SEARCH_CAPABILITIES = (
         frequencies,
         "sequence",
         "counting",
-        invocation_examples=(example("frequencies_1_2_1", "Count frequencies in 1, 2, and 1.", {"values": ["1", "2", "1"]}),),
+        invocation_examples=(
+            example(
+                "frequencies_1_2_1",
+                "Count frequencies in 1, 2, and 1.",
+                {"values": ["1", "2", "1"]},
+            ),
+        ),
     ),
     sequence_operation(
         "sequence.compute.zero_indices",
@@ -33,6 +39,12 @@ SEQUENCE_SEARCH_CAPABILITIES = (
         zero_indices,
         "sequence",
         "search",
-        invocation_examples=(example("zero_indices_2_0_3", "Locate zero terms in 2, 0, and 3.", {"values": ["2", "0", "3"]}),),
+        invocation_examples=(
+            example(
+                "zero_indices_2_0_3",
+                "Locate zero terms in 2, 0, and 3.",
+                {"values": ["2", "0", "3"]},
+            ),
+        ),
     ),
 )

--- a/src/jacobian/domains/sequences/statistics.py
+++ b/src/jacobian/domains/sequences/statistics.py
@@ -21,7 +21,13 @@ SEQUENCE_STATISTIC_CAPABILITIES = (
         sequence_mean,
         "sequence",
         "statistic",
-        invocation_examples=(example("mean_1_2_3", "Compute the mean of 1, 2, and 3.", {"values": ["1", "2", "3"]}),),
+        invocation_examples=(
+            example(
+                "mean_1_2_3",
+                "Compute the mean of 1, 2, and 3.",
+                {"values": ["1", "2", "3"]},
+            ),
+        ),
     ),
     sequence_operation(
         "sequence.compute.median",
@@ -32,6 +38,12 @@ SEQUENCE_STATISTIC_CAPABILITIES = (
         sequence_median,
         "sequence",
         "statistic",
-        invocation_examples=(example("median_1_3_2", "Compute the median of 1, 3, and 2.", {"values": ["1", "3", "2"]}),),
+        invocation_examples=(
+            example(
+                "median_1_3_2",
+                "Compute the median of 1, 3, and 2.",
+                {"values": ["1", "3", "2"]},
+            ),
+        ),
     ),
 )

--- a/src/jacobian/domains/sequences/statistics.py
+++ b/src/jacobian/domains/sequences/statistics.py
@@ -4,6 +4,7 @@ from jacobian.contracts.sequences import (
     IntegerSequenceRationalResult,
     IntegerSequenceRequest,
 )
+from jacobian.domains._examples import example
 from jacobian.domains.sequences._support import sequence_operation
 from jacobian.domains.sequences.operations import (
     sequence_mean,
@@ -20,6 +21,7 @@ SEQUENCE_STATISTIC_CAPABILITIES = (
         sequence_mean,
         "sequence",
         "statistic",
+        invocation_examples=(example("mean_1_2_3", "Compute the mean of 1, 2, and 3.", {"values": ["1", "2", "3"]}),),
     ),
     sequence_operation(
         "sequence.compute.median",
@@ -30,5 +32,6 @@ SEQUENCE_STATISTIC_CAPABILITIES = (
         sequence_median,
         "sequence",
         "statistic",
+        invocation_examples=(example("median_1_3_2", "Compute the median of 1, 3, and 2.", {"values": ["1", "3", "2"]}),),
     ),
 )


### PR DESCRIPTION
## Summary

Add schema-valid invocation examples for sequence mean, median, frequencies, and zero-index search.

## Validation

- Catalog registration validates all examples against canonical schemas.
- Coverage rises from 163 to 167 of 217 capabilities.
- Ruff and git diff --check pass locally.
- Full pytest collection remains blocked by missing timeout and z3 dependencies.

Reuses the existing CapabilityInvocationExample mechanism; no schemas or semantics changed.