### PR TITLE
docs(examples): cover standalone finite and graph operations

### DIFF
--- a/src/jacobian/graph_capabilities.py
+++ b/src/jacobian/graph_capabilities.py
@@ -550,7 +550,13 @@ class GraphAtlasSearchAdapter:
                 "additionalProperties": False,
             },
             tags=("graph", "construction", "bounded-search"),
-            invocation_examples=(example("empty_graph_search", "Find the order-zero graph in the atlas.", {"order": 0, "constraints": {}, "limit": 1}),),
+            invocation_examples=(
+                example(
+                    "empty_graph_search",
+                    "Find the order-zero graph in the atlas.",
+                    {"order": 0, "constraints": {}, "limit": 1},
+                ),
+            ),
         )
 
     @property
@@ -839,7 +845,13 @@ class GraphDegreeSequenceAdapter:
                 "construction",
                 "counterexample",
             ),
-            invocation_examples=(example("triangle_degree_sequence", "Realize the degree sequence of a triangle.", {"degree_sequence": [2, 2, 2]}),),
+            invocation_examples=(
+                example(
+                    "triangle_degree_sequence",
+                    "Realize the degree sequence of a triangle.",
+                    {"degree_sequence": [2, 2, 2]},
+                ),
+            ),
         )
 
     @property

--- a/src/jacobian/graph_capabilities.py
+++ b/src/jacobian/graph_capabilities.py
@@ -62,6 +62,7 @@ from jacobian.contracts.graph_invariants import (
 )
 from jacobian.contracts.graph_isomorphism import SimpleUndirectedGraph
 from jacobian.contracts.results import Execution, ExecutionStatus
+from jacobian.domains._examples import example
 from jacobian.graph_atlas import graph_atlas_order
 from jacobian.provider_runtime import known_provider_runtime
 from jacobian.registry import CheckerRegistry
@@ -549,6 +550,7 @@ class GraphAtlasSearchAdapter:
                 "additionalProperties": False,
             },
             tags=("graph", "construction", "bounded-search"),
+            invocation_examples=(example("empty_graph_search", "Find the order-zero graph in the atlas.", {"order": 0, "constraints": {}, "limit": 1}),),
         )
 
     @property
@@ -837,6 +839,7 @@ class GraphDegreeSequenceAdapter:
                 "construction",
                 "counterexample",
             ),
+            invocation_examples=(example("triangle_degree_sequence", "Realize the degree sequence of a triangle.", {"degree_sequence": [2, 2, 2]}),),
         )
 
     @property

--- a/src/jacobian/graph_coloring_capabilities.py
+++ b/src/jacobian/graph_coloring_capabilities.py
@@ -37,6 +37,7 @@ from jacobian.contracts.graph_coloring import (
     GraphColoringEncodingScope,
 )
 from jacobian.contracts.results import Execution, ExecutionStatus
+from jacobian.domains._examples import example
 from jacobian.graph_coloring_semantics import canonical_graph, coloring_cnf
 from jacobian.provider_runtime import known_provider_runtime
 from jacobian.registry import CheckerRegistry
@@ -178,6 +179,7 @@ class GraphColoringEncodingAdapter:
             input_schema=model_schema(GraphColoringEncodingRequest),
             output_schema=model_schema(GraphColoringEncodingOutput),
             tags=("graph", "coloring", "sat", "cnf", "encoding"),
+            invocation_examples=(example("single_vertex_two_colors", "Encode a one-vertex graph with two colors.", {"graph": {"vertices": ["v"], "edges": []}, "colors": 2}),),
         )
 
     @property

--- a/src/jacobian/graph_coloring_capabilities.py
+++ b/src/jacobian/graph_coloring_capabilities.py
@@ -179,7 +179,13 @@ class GraphColoringEncodingAdapter:
             input_schema=model_schema(GraphColoringEncodingRequest),
             output_schema=model_schema(GraphColoringEncodingOutput),
             tags=("graph", "coloring", "sat", "cnf", "encoding"),
-            invocation_examples=(example("single_vertex_two_colors", "Encode a one-vertex graph with two colors.", {"graph": {"vertices": ["v"], "edges": []}, "colors": 2}),),
+            invocation_examples=(
+                example(
+                    "single_vertex_two_colors",
+                    "Encode a one-vertex graph with two colors.",
+                    {"graph": {"vertices": ["v"], "edges": []}, "colors": 2},
+                ),
+            ),
         )
 
     @property

--- a/src/jacobian/graph_composition_capabilities.py
+++ b/src/jacobian/graph_composition_capabilities.py
@@ -51,6 +51,7 @@ from jacobian.contracts.graph_composition import (
     GraphEnumerationScopeArtifact,
 )
 from jacobian.contracts.results import Execution, ExecutionStatus
+from jacobian.domains._examples import example
 from jacobian.graph_atlas import graph_atlas_order
 from jacobian.provider_runtime import known_provider_runtime
 from jacobian.schema_registry import SchemaRegistry, model_schema
@@ -428,6 +429,7 @@ class GraphEnumerateNonisomorphicAdapter:
                 "nonisomorphic",
                 "bounded-search",
             ),
+            invocation_examples=(example("order_zero", "Enumerate graphs of order zero.", {"order": 0, "limit": 1, "offset": 0}),),
         )
 
     @property

--- a/src/jacobian/graph_composition_capabilities.py
+++ b/src/jacobian/graph_composition_capabilities.py
@@ -429,7 +429,13 @@ class GraphEnumerateNonisomorphicAdapter:
                 "nonisomorphic",
                 "bounded-search",
             ),
-            invocation_examples=(example("order_zero", "Enumerate graphs of order zero.", {"order": 0, "limit": 1, "offset": 0}),),
+            invocation_examples=(
+                example(
+                    "order_zero",
+                    "Enumerate graphs of order zero.",
+                    {"order": 0, "limit": 1, "offset": 0},
+                ),
+            ),
         )
 
     @property

--- a/src/jacobian/universal_algebra_capabilities.py
+++ b/src/jacobian/universal_algebra_capabilities.py
@@ -59,6 +59,7 @@ from jacobian.contracts.universal_algebra import (
     UniversalAlgebraEvaluationRequest,
     UniversalAlgebraVerificationHandoff,
 )
+from jacobian.domains._examples import example
 from jacobian.provider_runtime import known_provider_runtime
 from jacobian.registry import CheckerRegistry
 from jacobian.schema_registry import SchemaRegistry, model_schema
@@ -617,6 +618,7 @@ class FiniteMagmaTableEnumerateAdapter:
             input_schema=model_schema(FiniteMagmaTableEnumerationRequest),
             output_schema=model_schema(FiniteMagmaTableEnumerationOutput),
             tags=("universal-algebra", "finite-model", "enumeration"),
+            invocation_examples=(example("order_one", "Enumerate the unique binary table of order one.", {"order": 1}),),
         )
 
     @property

--- a/src/jacobian/universal_algebra_capabilities.py
+++ b/src/jacobian/universal_algebra_capabilities.py
@@ -618,7 +618,13 @@ class FiniteMagmaTableEnumerateAdapter:
             input_schema=model_schema(FiniteMagmaTableEnumerationRequest),
             output_schema=model_schema(FiniteMagmaTableEnumerationOutput),
             tags=("universal-algebra", "finite-model", "enumeration"),
-            invocation_examples=(example("order_one", "Enumerate the unique binary table of order one.", {"order": 1}),),
+            invocation_examples=(
+                example(
+                    "order_one",
+                    "Enumerate the unique binary table of order one.",
+                    {"order": 1},
+                ),
+            ),
         )
 
     @property


### PR DESCRIPTION
## Summary

Add tiny deterministic examples for finite-magma enumeration and standalone graph coloring, atlas enumeration/search, and degree-sequence realization.

## Validation

- Catalog registration validates all examples against canonical schemas.
- Coverage rises from 171 to 176 of 217 capabilities.
- Ruff and git diff --check pass locally.
- Full pytest remains unavailable because pytest-timeout and z3 are missing.

Inputs are standalone; examples use the smallest bounded cases and preserve existing computed assurance.