### PR TITLE
docs(examples): cover standalone geometry lattice and linear operations

### DIFF
--- a/src/jacobian/domains/matrix_lattice/lattice.py
+++ b/src/jacobian/domains/matrix_lattice/lattice.py
@@ -161,6 +161,12 @@ LATTICE_CAPABILITIES = (
         implementation=reduce_lattice_basis,
         relation_id="lattice.relation.reduced-basis-of",
         tags=("lattice", "lll", "exact-integer", "bounded", "python-flint"),
-        invocation_examples=(example("unit_basis", "Reduce the one-dimensional unit basis.", {"basis": {"entries": [["1"]]}}),),
+        invocation_examples=(
+            example(
+                "unit_basis",
+                "Reduce the one-dimensional unit basis.",
+                {"basis": {"entries": [["1"]]}},
+            ),
+        ),
     ),
 )

--- a/src/jacobian/domains/matrix_lattice/lattice.py
+++ b/src/jacobian/domains/matrix_lattice/lattice.py
@@ -18,6 +18,7 @@ from jacobian.contracts.matrix_operations import (
     LatticeReductionResult,
 )
 from jacobian.contracts.results import ExecutionStatus
+from jacobian.domains._examples import example
 from jacobian.operations import (
     ComputedOperation,
     ComputedOutcome,
@@ -160,5 +161,6 @@ LATTICE_CAPABILITIES = (
         implementation=reduce_lattice_basis,
         relation_id="lattice.relation.reduced-basis-of",
         tags=("lattice", "lll", "exact-integer", "bounded", "python-flint"),
+        invocation_examples=(example("unit_basis", "Reduce the one-dimensional unit basis.", {"basis": {"entries": [["1"]]}}),),
     ),
 )

--- a/src/jacobian/domains/projective_geometry/arrangements.py
+++ b/src/jacobian/domains/projective_geometry/arrangements.py
@@ -15,6 +15,7 @@ from jacobian.contracts.projective_geometry import (
     ProjectiveMultiplicityCount,
 )
 from jacobian.contracts.results import ContractModel
+from jacobian.domains._examples import example
 from jacobian.operations import (
     ComputedOperation,
     ComputedOperationFactory,
@@ -172,6 +173,7 @@ PROJECTIVE_LINE_ARRANGEMENT_CAPABILITY: ComputedOperation[
     "flats",
     "exact",
     relation_id="geometry.projective_line_arrangement.flats.relation",
+    invocation_examples=(example("two_coordinate_lines", "Materialize flats for two coordinate lines.", {"lines": [{"label": "x", "coefficients": [{"num": "1", "den": "1"}, {"num": "0", "den": "1"}, {"num": "0", "den": "1"}]}, {"label": "y", "coefficients": [{"num": "0", "den": "1"}, {"num": "1", "den": "1"}, {"num": "0", "den": "1"}]}]}),),
 )
 
 

--- a/src/jacobian/domains/projective_geometry/arrangements.py
+++ b/src/jacobian/domains/projective_geometry/arrangements.py
@@ -173,7 +173,32 @@ PROJECTIVE_LINE_ARRANGEMENT_CAPABILITY: ComputedOperation[
     "flats",
     "exact",
     relation_id="geometry.projective_line_arrangement.flats.relation",
-    invocation_examples=(example("two_coordinate_lines", "Materialize flats for two coordinate lines.", {"lines": [{"label": "x", "coefficients": [{"num": "1", "den": "1"}, {"num": "0", "den": "1"}, {"num": "0", "den": "1"}]}, {"label": "y", "coefficients": [{"num": "0", "den": "1"}, {"num": "1", "den": "1"}, {"num": "0", "den": "1"}]}]}),),
+    invocation_examples=(
+        example(
+            "two_coordinate_lines",
+            "Materialize flats for two coordinate lines.",
+            {
+                "lines": [
+                    {
+                        "label": "x",
+                        "coefficients": [
+                            {"num": "1", "den": "1"},
+                            {"num": "0", "den": "1"},
+                            {"num": "0", "den": "1"},
+                        ],
+                    },
+                    {
+                        "label": "y",
+                        "coefficients": [
+                            {"num": "0", "den": "1"},
+                            {"num": "1", "den": "1"},
+                            {"num": "0", "den": "1"},
+                        ],
+                    },
+                ]
+            },
+        ),
+    ),
 )
 
 

--- a/src/jacobian/flint_linear.py
+++ b/src/jacobian/flint_linear.py
@@ -35,6 +35,7 @@ from jacobian.contracts.linear import (
     LinearRationalSolutionFindRequest,
 )
 from jacobian.contracts.results import Execution, ExecutionStatus
+from jacobian.domains._examples import example
 from jacobian.flint_linear_worker import (
     FLINT_LINEAR_INCONSISTENCY_WORKER_PROTOCOL,
     FLINT_LINEAR_WORKER_PROTOCOL,
@@ -208,6 +209,7 @@ class PythonFlintRationalSolutionFindAdapter:
                 "witness",
                 "python-flint",
             ),
+            invocation_examples=(example("one_by_one_system", "Find the solution of x=1 over QQ.", {"system": {"variables": ["x"], "coefficients": {"entries": [[{"num": "1", "den": "1"}]]}, "rhs": [{"num": "1", "den": "1"}]}}),),
         )
 
     @property

--- a/src/jacobian/flint_linear.py
+++ b/src/jacobian/flint_linear.py
@@ -209,7 +209,19 @@ class PythonFlintRationalSolutionFindAdapter:
                 "witness",
                 "python-flint",
             ),
-            invocation_examples=(example("one_by_one_system", "Find the solution of x=1 over QQ.", {"system": {"variables": ["x"], "coefficients": {"entries": [[{"num": "1", "den": "1"}]]}, "rhs": [{"num": "1", "den": "1"}]}}),),
+            invocation_examples=(
+                example(
+                    "one_by_one_system",
+                    "Find the solution of x=1 over QQ.",
+                    {
+                        "system": {
+                            "variables": ["x"],
+                            "coefficients": {"entries": [[{"num": "1", "den": "1"}]]},
+                            "rhs": [{"num": "1", "den": "1"}],
+                        }
+                    },
+                ),
+            ),
         )
 
     @property


### PR DESCRIPTION
## Summary

Add minimal standalone examples for projective line arrangements, lattice reduction, and a one-variable rational linear system.

## Validation

- Catalog registration validates all examples against canonical schemas.
- Coverage rises from 176 to 179 of 217 capabilities.
- Ruff and git diff --check pass locally.
- Full pytest remains unavailable because pytest-timeout and z3 are missing.
- Optional runtime note: lattice and linear examples require the installed python-flint backend at invocation time.

No artifact URIs, plugin identifiers, or checker identifiers are used.