### PR TITLE
docs(examples): cover standalone polynomial maps and optimization

### DIFF
--- a/src/jacobian/domains/optimization/operations.py
+++ b/src/jacobian/domains/optimization/operations.py
@@ -18,6 +18,7 @@ from jacobian.contracts.validated_analysis import (
     RationalLinearProgramRequest,
     RationalLinearProgramResult,
 )
+from jacobian.domains._examples import example
 from jacobian.operations import (
     BoundedSearchIncomplete,
     BoundedSearchInterrupted,
@@ -159,6 +160,7 @@ RATIONAL_LINEAR_CAPABILITIES = (
             "certificate",
             "bounded",
         ),
+        invocation_examples=(example("one_variable_unit_lp", "Optimize x subject to x=1 and x>=0.", {"program": {"variables": ["x"], "objective": [{"num": "1", "den": "1"}], "coefficients": [[{"num": "1", "den": "1"}]], "rhs": [{"num": "1", "den": "1"}]}, "wall_seconds": 5}),),
     ),
 )
 

--- a/src/jacobian/domains/optimization/operations.py
+++ b/src/jacobian/domains/optimization/operations.py
@@ -160,7 +160,21 @@ RATIONAL_LINEAR_CAPABILITIES = (
             "certificate",
             "bounded",
         ),
-        invocation_examples=(example("one_variable_unit_lp", "Optimize x subject to x=1 and x>=0.", {"program": {"variables": ["x"], "objective": [{"num": "1", "den": "1"}], "coefficients": [[{"num": "1", "den": "1"}]], "rhs": [{"num": "1", "den": "1"}]}, "wall_seconds": 5}),),
+        invocation_examples=(
+            example(
+                "one_variable_unit_lp",
+                "Optimize x subject to x=1 and x>=0.",
+                {
+                    "program": {
+                        "variables": ["x"],
+                        "objective": [{"num": "1", "den": "1"}],
+                        "coefficients": [[{"num": "1", "den": "1"}]],
+                        "rhs": [{"num": "1", "den": "1"}],
+                    },
+                    "wall_seconds": 5,
+                },
+            ),
+        ),
     ),
 )
 

--- a/src/jacobian/operation_installation.py
+++ b/src/jacobian/operation_installation.py
@@ -320,6 +320,7 @@ class BoundedSearchOperationAdapter:
             input_schema=model_schema(operation.request_model),
             output_schema=model_schema(operation.result_model),
             tags=operation.tags,
+            invocation_examples=operation.invocation_examples,
         )
 
     @property

--- a/src/jacobian/operations.py
+++ b/src/jacobian/operations.py
@@ -206,6 +206,7 @@ class BoundedSearchOperation[
     obligation: Callable[[RequestT, ResultT], ContractModel]
     incomplete_basis: str
     tags: tuple[str, ...] = ()
+    invocation_examples: tuple[CapabilityInvocationExample, ...] = ()
     invalid_request: CapabilityDiagnostic | None = None
     version: str = "1"
 

--- a/src/jacobian/polynomial_capabilities.py
+++ b/src/jacobian/polynomial_capabilities.py
@@ -97,6 +97,7 @@ from jacobian.contracts.results import (
     ExecutionStatus,
     Verification,
 )
+from jacobian.domains._examples import example
 from jacobian.provider_runtime import known_provider_runtime
 from jacobian.registry import CheckerRegistry
 from jacobian.schema_registry import SchemaRegistry, model_schema
@@ -471,6 +472,7 @@ class PolynomialMapEvaluationAdapter:
             input_schema=model_schema(PolynomialEvaluationRequest),
             output_schema=model_schema(PolynomialEvaluationOutput),
             tags=("polynomial", "map", "evaluation", "exact-computation"),
+            invocation_examples=(example("identity_at_zero", "Evaluate x at zero.", {"map": {"variables": ["x"], "coordinates": [{"terms": [{"coefficient": {"num": "1", "den": "1"}, "exponents": [1]}]}]}, "point": [{"num": "0", "den": "1"}]}),),
         )
 
     @property
@@ -554,6 +556,7 @@ class PolynomialJacobianAdapter:
             input_schema=model_schema(PolynomialJacobianRequest),
             output_schema=model_schema(PolynomialJacobianOutput),
             tags=("polynomial", "jacobian", "determinant", "exact-computation"),
+            invocation_examples=(example("identity_jacobian", "Compute the Jacobian of x.", {"map": {"variables": ["x"], "coordinates": [{"terms": [{"coefficient": {"num": "1", "den": "1"}, "exponents": [1]}]}]}}),),
         )
 
     @property

--- a/src/jacobian/polynomial_capabilities.py
+++ b/src/jacobian/polynomial_capabilities.py
@@ -472,7 +472,28 @@ class PolynomialMapEvaluationAdapter:
             input_schema=model_schema(PolynomialEvaluationRequest),
             output_schema=model_schema(PolynomialEvaluationOutput),
             tags=("polynomial", "map", "evaluation", "exact-computation"),
-            invocation_examples=(example("identity_at_zero", "Evaluate x at zero.", {"map": {"variables": ["x"], "coordinates": [{"terms": [{"coefficient": {"num": "1", "den": "1"}, "exponents": [1]}]}]}, "point": [{"num": "0", "den": "1"}]}),),
+            invocation_examples=(
+                example(
+                    "identity_at_zero",
+                    "Evaluate x at zero.",
+                    {
+                        "map": {
+                            "variables": ["x"],
+                            "coordinates": [
+                                {
+                                    "terms": [
+                                        {
+                                            "coefficient": {"num": "1", "den": "1"},
+                                            "exponents": [1],
+                                        }
+                                    ]
+                                }
+                            ],
+                        },
+                        "point": [{"num": "0", "den": "1"}],
+                    },
+                ),
+            ),
         )
 
     @property
@@ -556,7 +577,27 @@ class PolynomialJacobianAdapter:
             input_schema=model_schema(PolynomialJacobianRequest),
             output_schema=model_schema(PolynomialJacobianOutput),
             tags=("polynomial", "jacobian", "determinant", "exact-computation"),
-            invocation_examples=(example("identity_jacobian", "Compute the Jacobian of x.", {"map": {"variables": ["x"], "coordinates": [{"terms": [{"coefficient": {"num": "1", "den": "1"}, "exponents": [1]}]}]}}),),
+            invocation_examples=(
+                example(
+                    "identity_jacobian",
+                    "Compute the Jacobian of x.",
+                    {
+                        "map": {
+                            "variables": ["x"],
+                            "coordinates": [
+                                {
+                                    "terms": [
+                                        {
+                                            "coefficient": {"num": "1", "den": "1"},
+                                            "exponents": [1],
+                                        }
+                                    ]
+                                }
+                            ],
+                        }
+                    },
+                ),
+            ),
         )
 
     @property


### PR DESCRIPTION
## Summary

Add tiny standalone examples for polynomial-map evaluation/Jacobian computation and a one-variable rational linear program. Extend the existing bounded-operation example passthrough only.

## Validation

- Catalog registration validates all examples against canonical schemas.
- Coverage rises from 179 to 182 of 217 capabilities.
- Ruff and git diff --check pass locally.
- Full pytest remains unavailable because pytest-timeout and z3 are missing.
- Polynomial and optimization execution uses the existing SymPy runtime; no artifact/plugin/checker identifiers are supplied.