### PR TITLE
docs(examples): cover standalone bounded analysis and partition operations

### DIFF
--- a/src/jacobian/domains/analysis/operations.py
+++ b/src/jacobian/domains/analysis/operations.py
@@ -18,6 +18,7 @@ from jacobian.contracts.validated_analysis import (
     ArbPointEnclosureRequest,
     ArbPointEnclosureResult,
 )
+from jacobian.domains._examples import example
 from jacobian.operations import (
     BoundedSearchIncomplete,
     BoundedSearchInterrupted,
@@ -182,6 +183,7 @@ POINT_ENCLOSURE_CAPABILITIES = (
             "the declared bounded execution"
         ),
         tags=("analysis", "validated", "arb", "enclosure", "bounded"),
+        invocation_examples=(example("sqrt_zero", "Enclose sqrt(0) at 32-bit precision.", {"function": "SQRT", "argument": {"num": "0", "den": "1"}, "precision_bits": 32, "wall_seconds": 1}),),
     ),
 )
 

--- a/src/jacobian/domains/analysis/operations.py
+++ b/src/jacobian/domains/analysis/operations.py
@@ -183,7 +183,18 @@ POINT_ENCLOSURE_CAPABILITIES = (
             "the declared bounded execution"
         ),
         tags=("analysis", "validated", "arb", "enclosure", "bounded"),
-        invocation_examples=(example("sqrt_zero", "Enclose sqrt(0) at 32-bit precision.", {"function": "SQRT", "argument": {"num": "0", "den": "1"}, "precision_bits": 32, "wall_seconds": 1}),),
+        invocation_examples=(
+            example(
+                "sqrt_zero",
+                "Enclose sqrt(0) at 32-bit precision.",
+                {
+                    "function": "SQRT",
+                    "argument": {"num": "0", "den": "1"},
+                    "precision_bits": 32,
+                    "wall_seconds": 1,
+                },
+            ),
+        ),
     ),
 )
 

--- a/src/jacobian/domains/number_theory/discrete_logarithm.py
+++ b/src/jacobian/domains/number_theory/discrete_logarithm.py
@@ -15,6 +15,7 @@ from jacobian.contracts.number_theory import (
     DiscreteLogarithmResult,
 )
 from jacobian.contracts.results import ExecutionStatus
+from jacobian.domains._examples import example
 from jacobian.operations import (
     BoundedSearchOperation,
     BoundedSearchOutcome,
@@ -160,4 +161,5 @@ DISCRETE_LOGARITHM_CAPABILITY = BoundedSearchOperation(
     obligation=_obligation,
     incomplete_basis="the bounded worker did not establish a conclusion",
     tags=("number-theory", "modular", "discrete-logarithm", "bounded", "sympy"),
+    invocation_examples=(example("two_to_one_mod_three", "Solve 2^x = 1 modulo 3.", {"base": 2, "target": 1, "modulus": 3, "resource_budget": {"wall_seconds": 1}}),),
 )

--- a/src/jacobian/domains/number_theory/discrete_logarithm.py
+++ b/src/jacobian/domains/number_theory/discrete_logarithm.py
@@ -161,5 +161,16 @@ DISCRETE_LOGARITHM_CAPABILITY = BoundedSearchOperation(
     obligation=_obligation,
     incomplete_basis="the bounded worker did not establish a conclusion",
     tags=("number-theory", "modular", "discrete-logarithm", "bounded", "sympy"),
-    invocation_examples=(example("two_to_one_mod_three", "Solve 2^x = 1 modulo 3.", {"base": 2, "target": 1, "modulus": 3, "resource_budget": {"wall_seconds": 1}}),),
+    invocation_examples=(
+        example(
+            "two_to_one_mod_three",
+            "Solve 2^x = 1 modulo 3.",
+            {
+                "base": 2,
+                "target": 1,
+                "modulus": 3,
+                "resource_budget": {"wall_seconds": 1},
+            },
+        ),
+    ),
 )

--- a/src/jacobian/finite_partition.py
+++ b/src/jacobian/finite_partition.py
@@ -34,6 +34,7 @@ from jacobian.contracts.results import (
     ResultEnvelope,
     Verification,
 )
+from jacobian.domains._examples import example
 from jacobian.provider_runtime import known_provider_runtime
 from jacobian.registry import CheckerRegistry
 from jacobian.schema_registry import SchemaRegistry, model_schema
@@ -272,6 +273,7 @@ class FinitePartitionAdapter:
                 "additionalProperties": False,
             },
             tags=("cases", "finite", "coverage", "verification"),
+            invocation_examples=(example("singleton_partition", "Partition a singleton universe into one case.", {"universe": ["a"], "cases": [{"case_id": "all", "members": ["a"]}]}),),
         )
 
     @property

--- a/src/jacobian/finite_partition.py
+++ b/src/jacobian/finite_partition.py
@@ -273,7 +273,16 @@ class FinitePartitionAdapter:
                 "additionalProperties": False,
             },
             tags=("cases", "finite", "coverage", "verification"),
-            invocation_examples=(example("singleton_partition", "Partition a singleton universe into one case.", {"universe": ["a"], "cases": [{"case_id": "all", "members": ["a"]}]}),),
+            invocation_examples=(
+                example(
+                    "singleton_partition",
+                    "Partition a singleton universe into one case.",
+                    {
+                        "universe": ["a"],
+                        "cases": [{"case_id": "all", "members": ["a"]}],
+                    },
+                ),
+            ),
         )
 
     @property


### PR DESCRIPTION
## Summary

Add tiny deterministic examples for Arb point enclosure, finite partitioning, and bounded discrete logarithm.

## Validation

- Catalog registration validates all examples against canonical schemas.
- Coverage rises from 182 to 185 of 217 capabilities.
- Ruff and git diff --check pass locally.
- Full pytest remains unavailable because pytest-timeout and z3 are missing.
- Arb and isolated SymPy worker availability is runtime-dependent; payloads remain retained as valid examples.

No artifact, plugin, checker, or experiment identifiers are used.