### PR TITLE
docs(examples): cover standalone inconsistency and HNF operations

### DIFF
--- a/src/jacobian/flint_hnf.py
+++ b/src/jacobian/flint_hnf.py
@@ -183,7 +183,13 @@ class PythonFlintHermiteNormalFormAdapter:
                 "exact",
                 "python-flint",
             ),
-            invocation_examples=(example("unit_matrix", "Compute the row HNF of the one-by-one unit matrix.", {"matrix": {"entries": [["1"]]}}),),
+            invocation_examples=(
+                example(
+                    "unit_matrix",
+                    "Compute the row HNF of the one-by-one unit matrix.",
+                    {"matrix": {"entries": [["1"]]}},
+                ),
+            ),
         )
 
     @property

--- a/src/jacobian/flint_hnf.py
+++ b/src/jacobian/flint_hnf.py
@@ -34,6 +34,7 @@ from jacobian.contracts.matrices import (
     MatrixHermiteNormalFormRequest,
 )
 from jacobian.contracts.results import Execution, ExecutionStatus
+from jacobian.domains._examples import example
 from jacobian.flint_hnf_worker import FLINT_HNF_WORKER_PROTOCOL
 from jacobian.matrix_normal_forms import MatrixNormalFormArtifactService
 from jacobian.provider_runtime import (
@@ -182,6 +183,7 @@ class PythonFlintHermiteNormalFormAdapter:
                 "exact",
                 "python-flint",
             ),
+            invocation_examples=(example("unit_matrix", "Compute the row HNF of the one-by-one unit matrix.", {"matrix": {"entries": [["1"]]}}),),
         )
 
     @property

--- a/src/jacobian/flint_linear.py
+++ b/src/jacobian/flint_linear.py
@@ -470,6 +470,7 @@ class PythonFlintRationalInconsistencyFindAdapter:
                 "certificate",
                 "python-flint",
             ),
+            invocation_examples=(example("inconsistent_one_variable", "Analyze x=1 and x=2 as an inconsistent system.", {"system": {"variables": ["x"], "coefficients": {"entries": [[{"num": "1", "den": "1"}], [{"num": "1", "den": "1"}]]}, "rhs": [{"num": "1", "den": "1"}, {"num": "2", "den": "1"}]}}),),
         )
 
     @property

--- a/src/jacobian/flint_linear.py
+++ b/src/jacobian/flint_linear.py
@@ -470,7 +470,24 @@ class PythonFlintRationalInconsistencyFindAdapter:
                 "certificate",
                 "python-flint",
             ),
-            invocation_examples=(example("inconsistent_one_variable", "Analyze x=1 and x=2 as an inconsistent system.", {"system": {"variables": ["x"], "coefficients": {"entries": [[{"num": "1", "den": "1"}], [{"num": "1", "den": "1"}]]}, "rhs": [{"num": "1", "den": "1"}, {"num": "2", "den": "1"}]}}),),
+            invocation_examples=(
+                example(
+                    "inconsistent_one_variable",
+                    "Analyze x=1 and x=2 as an inconsistent system.",
+                    {
+                        "system": {
+                            "variables": ["x"],
+                            "coefficients": {
+                                "entries": [
+                                    [{"num": "1", "den": "1"}],
+                                    [{"num": "1", "den": "1"}],
+                                ]
+                            },
+                            "rhs": [{"num": "1", "den": "1"}, {"num": "2", "den": "1"}],
+                        }
+                    },
+                ),
+            ),
         )
 
     @property


### PR DESCRIPTION
## Summary

Add minimal rational inconsistency and integer Hermite-normal-form examples.

## Validation

- Catalog registration validates all examples against canonical schemas.
- Coverage rises from 185 to 187 of 217 capabilities.
- Ruff and git diff --check pass locally.
- Full pytest remains unavailable because pytest-timeout and z3 are missing.
- Both examples use direct structured inputs and no artifact, plugin, checker, or experiment identifiers.