### PR TITLE
docs(examples): cover standalone polynomial factor and Groebner operations

### DIFF
--- a/src/jacobian/domains/polynomial/groebner.py
+++ b/src/jacobian/domains/polynomial/groebner.py
@@ -172,7 +172,29 @@ POLYNOMIAL_GROEBNER_CAPABILITY = BoundedSearchOperation(
         "supports an ideal conclusion"
     ),
     tags=("polynomial", "groebner", "ideal", "bounded", "exact"),
-    invocation_examples=(example("unit_ideal", "Compute a Groebner basis for the unit ideal in one variable.", {"generators": [{"variables": ["x"], "polynomial": {"terms": [{"coefficient": {"num": "1", "den": "1"}, "exponents": [0]}]}}], "monomial_order": "lex", "resource_budget": {"wall_seconds": 1}}),),
+    invocation_examples=(
+        example(
+            "unit_ideal",
+            "Compute a Groebner basis for the unit ideal in one variable.",
+            {
+                "generators": [
+                    {
+                        "variables": ["x"],
+                        "polynomial": {
+                            "terms": [
+                                {
+                                    "coefficient": {"num": "1", "den": "1"},
+                                    "exponents": [0],
+                                }
+                            ]
+                        },
+                    }
+                ],
+                "monomial_order": "lex",
+                "resource_budget": {"wall_seconds": 1},
+            },
+        ),
+    ),
 )
 
 __all__ = ["POLYNOMIAL_GROEBNER_CAPABILITY"]

--- a/src/jacobian/domains/polynomial/groebner.py
+++ b/src/jacobian/domains/polynomial/groebner.py
@@ -15,6 +15,7 @@ from jacobian.contracts.polynomial_operations import (
     PolynomialGroebnerBasisResult,
 )
 from jacobian.contracts.results import ExecutionStatus
+from jacobian.domains._examples import example
 from jacobian.operations import (
     BoundedSearchOperation,
     BoundedSearchOutcome,
@@ -171,6 +172,7 @@ POLYNOMIAL_GROEBNER_CAPABILITY = BoundedSearchOperation(
         "supports an ideal conclusion"
     ),
     tags=("polynomial", "groebner", "ideal", "bounded", "exact"),
+    invocation_examples=(example("unit_ideal", "Compute a Groebner basis for the unit ideal in one variable.", {"generators": [{"variables": ["x"], "polynomial": {"terms": [{"coefficient": {"num": "1", "den": "1"}, "exponents": [0]}]}}], "monomial_order": "lex", "resource_budget": {"wall_seconds": 1}}),),
 )
 
 __all__ = ["POLYNOMIAL_GROEBNER_CAPABILITY"]

--- a/src/jacobian/polynomial_capabilities.py
+++ b/src/jacobian/polynomial_capabilities.py
@@ -1353,7 +1353,27 @@ class PolynomialFactorAdapter:
             input_schema=model_schema(PolynomialFactorRequest),
             output_schema=model_schema(PolynomialFactorOutput),
             tags=("polynomial", "factorization", "exact-computation"),
-            invocation_examples=(example("factor_x_squared_minus_one", "Factor x^2-1 over QQ.", {"variable": "x", "polynomial": {"terms": [{"coefficient": {"num": "1", "den": "1"}, "exponents": [2]}, {"coefficient": {"num": "-1", "den": "1"}, "exponents": [0]}]}}),),
+            invocation_examples=(
+                example(
+                    "factor_x_squared_minus_one",
+                    "Factor x^2-1 over QQ.",
+                    {
+                        "variable": "x",
+                        "polynomial": {
+                            "terms": [
+                                {
+                                    "coefficient": {"num": "1", "den": "1"},
+                                    "exponents": [2],
+                                },
+                                {
+                                    "coefficient": {"num": "-1", "den": "1"},
+                                    "exponents": [0],
+                                },
+                            ]
+                        },
+                    },
+                ),
+            ),
         )
 
     @property

--- a/src/jacobian/polynomial_capabilities.py
+++ b/src/jacobian/polynomial_capabilities.py
@@ -1353,6 +1353,7 @@ class PolynomialFactorAdapter:
             input_schema=model_schema(PolynomialFactorRequest),
             output_schema=model_schema(PolynomialFactorOutput),
             tags=("polynomial", "factorization", "exact-computation"),
+            invocation_examples=(example("factor_x_squared_minus_one", "Factor x^2-1 over QQ.", {"variable": "x", "polynomial": {"terms": [{"coefficient": {"num": "1", "den": "1"}, "exponents": [2]}, {"coefficient": {"num": "-1", "den": "1"}, "exponents": [0]}]}}),),
         )
 
     @property


### PR DESCRIPTION
## Summary

Add tiny deterministic examples for univariate factorization and one-variable Groebner basis computation.

## Validation

- Catalog registration validates all examples against canonical schemas.
- Coverage rises from 187 to 189 of 217 capabilities.
- Ruff and git diff --check pass locally.
- Full pytest remains unavailable because pytest-timeout and z3 are missing.
- SymPy worker execution is bounded to one second in the examples.