### PR TITLE
docs(examples): complete standalone polynomial and algebra coverage

### DIFF
--- a/src/jacobian/polynomial_capabilities.py
+++ b/src/jacobian/polynomial_capabilities.py
@@ -959,6 +959,7 @@ class PolynomialCollisionSearchAdapter:
             input_schema=model_schema(PolynomialCollisionSearchRequest),
             output_schema=model_schema(PolynomialCollisionSearchOutput),
             tags=("polynomial", "map", "collision", "bounded-search"),
+            invocation_examples=(example("constant_map_collision", "Find a collision for the constant zero map on a tiny grid.", {"map": {"variables": ["x"], "coordinates": [{"terms": []}]}, "max_abs_numerator": 1, "max_denominator": 1}),),
         )
 
     @property

--- a/src/jacobian/polynomial_capabilities.py
+++ b/src/jacobian/polynomial_capabilities.py
@@ -959,7 +959,17 @@ class PolynomialCollisionSearchAdapter:
             input_schema=model_schema(PolynomialCollisionSearchRequest),
             output_schema=model_schema(PolynomialCollisionSearchOutput),
             tags=("polynomial", "map", "collision", "bounded-search"),
-            invocation_examples=(example("constant_map_collision", "Find a collision for the constant zero map on a tiny grid.", {"map": {"variables": ["x"], "coordinates": [{"terms": []}]}, "max_abs_numerator": 1, "max_denominator": 1}),),
+            invocation_examples=(
+                example(
+                    "constant_map_collision",
+                    "Find a collision for the constant zero map on a tiny grid.",
+                    {
+                        "map": {"variables": ["x"], "coordinates": [{"terms": []}]},
+                        "max_abs_numerator": 1,
+                        "max_denominator": 1,
+                    },
+                ),
+            ),
         )
 
     @property

--- a/src/jacobian/polynomial_interval_capabilities.py
+++ b/src/jacobian/polynomial_interval_capabilities.py
@@ -77,6 +77,7 @@ from jacobian.contracts.results import (
     ExecutionStatus,
     Verification,
 )
+from jacobian.domains._examples import example
 from jacobian.provider_runtime import known_provider_runtime
 from jacobian.registry import CheckerRegistry
 from jacobian.schema_registry import SchemaRegistry, model_schema
@@ -267,6 +268,7 @@ class PolynomialIntervalEncloseAdapter:
                 "bernstein",
                 "exact-computation",
             ),
+            invocation_examples=(example("constant_zero_interval", "Enclose the zero polynomial on [0,1].", {"polynomial": {"variable": "x", "polynomial": {"terms": []}}, "interval": {"lo": {"num": "0", "den": "1"}, "hi": {"num": "1", "den": "1"}}}),),
         )
 
     @property

--- a/src/jacobian/polynomial_interval_capabilities.py
+++ b/src/jacobian/polynomial_interval_capabilities.py
@@ -268,7 +268,19 @@ class PolynomialIntervalEncloseAdapter:
                 "bernstein",
                 "exact-computation",
             ),
-            invocation_examples=(example("constant_zero_interval", "Enclose the zero polynomial on [0,1].", {"polynomial": {"variable": "x", "polynomial": {"terms": []}}, "interval": {"lo": {"num": "0", "den": "1"}, "hi": {"num": "1", "den": "1"}}}),),
+            invocation_examples=(
+                example(
+                    "constant_zero_interval",
+                    "Enclose the zero polynomial on [0,1].",
+                    {
+                        "polynomial": {"variable": "x", "polynomial": {"terms": []}},
+                        "interval": {
+                            "lo": {"num": "0", "den": "1"},
+                            "hi": {"num": "1", "den": "1"},
+                        },
+                    },
+                ),
+            ),
         )
 
     @property

--- a/src/jacobian/polynomial_positivity_capabilities.py
+++ b/src/jacobian/polynomial_positivity_capabilities.py
@@ -262,7 +262,29 @@ class PolynomialIntervalPositivityDecideAdapter:
                 "sturm",
                 "exact-decision",
             ),
-            invocation_examples=(example("constant_one_positive", "Decide positivity of 1 on [0,1].", {"polynomial": {"variable": "x", "polynomial": {"terms": [{"coefficient": {"num": "1", "den": "1"}, "exponents": [0]}]}}, "interval": {"lo": {"num": "0", "den": "1"}, "hi": {"num": "1", "den": "1"}}}),),
+            invocation_examples=(
+                example(
+                    "constant_one_positive",
+                    "Decide positivity of 1 on [0,1].",
+                    {
+                        "polynomial": {
+                            "variable": "x",
+                            "polynomial": {
+                                "terms": [
+                                    {
+                                        "coefficient": {"num": "1", "den": "1"},
+                                        "exponents": [0],
+                                    }
+                                ]
+                            },
+                        },
+                        "interval": {
+                            "lo": {"num": "0", "den": "1"},
+                            "hi": {"num": "1", "den": "1"},
+                        },
+                    },
+                ),
+            ),
         )
 
     @property

--- a/src/jacobian/polynomial_positivity_capabilities.py
+++ b/src/jacobian/polynomial_positivity_capabilities.py
@@ -78,6 +78,7 @@ from jacobian.contracts.results import (
     ExecutionStatus,
     Verification,
 )
+from jacobian.domains._examples import example
 from jacobian.provider_runtime import known_provider_runtime
 from jacobian.registry import CheckerRegistry
 from jacobian.schema_registry import SchemaRegistry, model_schema
@@ -261,6 +262,7 @@ class PolynomialIntervalPositivityDecideAdapter:
                 "sturm",
                 "exact-decision",
             ),
+            invocation_examples=(example("constant_one_positive", "Decide positivity of 1 on [0,1].", {"polynomial": {"variable": "x", "polynomial": {"terms": [{"coefficient": {"num": "1", "den": "1"}, "exponents": [0]}]}}, "interval": {"lo": {"num": "0", "den": "1"}, "hi": {"num": "1", "den": "1"}}}),),
         )
 
     @property

--- a/src/jacobian/polynomial_system_search.py
+++ b/src/jacobian/polynomial_system_search.py
@@ -56,7 +56,29 @@ class PolynomialSystemRationalSearchAdapter:
             input_schema=PolynomialSystemRationalSearchRequest.model_json_schema(),
             output_schema=PolynomialSystemRationalSearchOutput.model_json_schema(),
             tags=("polynomial", "system", "solution", "bounded-search"),
-            invocation_examples=(example("zero_system", "Find zero for x=0 on the smallest grid.", {"system": {"variables": ["x"], "equations": [{"terms": [{"coefficient": {"num": "1", "den": "1"}, "exponents": [1]}]}]}, "max_abs_numerator": 0, "max_denominator": 1}),),
+            invocation_examples=(
+                example(
+                    "zero_system",
+                    "Find zero for x=0 on the smallest grid.",
+                    {
+                        "system": {
+                            "variables": ["x"],
+                            "equations": [
+                                {
+                                    "terms": [
+                                        {
+                                            "coefficient": {"num": "1", "den": "1"},
+                                            "exponents": [1],
+                                        }
+                                    ]
+                                }
+                            ],
+                        },
+                        "max_abs_numerator": 0,
+                        "max_denominator": 1,
+                    },
+                ),
+            ),
         )
 
     @property

--- a/src/jacobian/polynomial_system_search.py
+++ b/src/jacobian/polynomial_system_search.py
@@ -29,6 +29,7 @@ from jacobian.contracts.polynomial_systems import (
     RationalPolynomialAssignment,
 )
 from jacobian.contracts.results import Execution, ExecutionStatus
+from jacobian.domains._examples import example
 from jacobian.polynomial_system_capabilities import (
     PolynomialSystemInstallation,
     _evaluate_request,
@@ -55,6 +56,7 @@ class PolynomialSystemRationalSearchAdapter:
             input_schema=PolynomialSystemRationalSearchRequest.model_json_schema(),
             output_schema=PolynomialSystemRationalSearchOutput.model_json_schema(),
             tags=("polynomial", "system", "solution", "bounded-search"),
+            invocation_examples=(example("zero_system", "Find zero for x=0 on the smallest grid.", {"system": {"variables": ["x"], "equations": [{"terms": [{"coefficient": {"num": "1", "den": "1"}, "exponents": [1]}]}]}, "max_abs_numerator": 0, "max_denominator": 1}),),
         )
 
     @property

--- a/src/jacobian/universal_algebra_capabilities.py
+++ b/src/jacobian/universal_algebra_capabilities.py
@@ -234,7 +234,29 @@ class UniversalAlgebraEvaluateLawsAdapter:
                 "law-evaluation",
                 "counterexample",
             ),
-            invocation_examples=(example("one_element_idempotence", "Evaluate x*x=x on the one-element magma.", {"problem": {"structure": {"order": 1, "table": [[0]]}, "laws": [{"law_id": "idempotence", "variables": ["x"], "left": {"kind": "PRODUCT", "left": {"kind": "VARIABLE", "variable": "x"}, "right": {"kind": "VARIABLE", "variable": "x"}}, "right": {"kind": "VARIABLE", "variable": "x"}}]}}),),
+            invocation_examples=(
+                example(
+                    "one_element_idempotence",
+                    "Evaluate x*x=x on the one-element magma.",
+                    {
+                        "problem": {
+                            "structure": {"order": 1, "table": [[0]]},
+                            "laws": [
+                                {
+                                    "law_id": "idempotence",
+                                    "variables": ["x"],
+                                    "left": {
+                                        "kind": "PRODUCT",
+                                        "left": {"kind": "VARIABLE", "variable": "x"},
+                                        "right": {"kind": "VARIABLE", "variable": "x"},
+                                    },
+                                    "right": {"kind": "VARIABLE", "variable": "x"},
+                                }
+                            ],
+                        }
+                    },
+                ),
+            ),
         )
 
     @property

--- a/src/jacobian/universal_algebra_capabilities.py
+++ b/src/jacobian/universal_algebra_capabilities.py
@@ -234,7 +234,7 @@ class UniversalAlgebraEvaluateLawsAdapter:
                 "law-evaluation",
                 "counterexample",
             ),
-            invocation_examples=(example("one_element_idempotence", "Evaluate x=x on the one-element magma.", {"problem": {"structure": {"order": 1, "table": [[0]]}, "laws": [{"law_id": "idempotence", "variables": ["x"], "left": {"kind": "VARIABLE", "variable": "x"}, "right": {"kind": "VARIABLE", "variable": "x"}}]}}),),
+            invocation_examples=(example("one_element_idempotence", "Evaluate x*x=x on the one-element magma.", {"problem": {"structure": {"order": 1, "table": [[0]]}, "laws": [{"law_id": "idempotence", "variables": ["x"], "left": {"kind": "PRODUCT", "left": {"kind": "VARIABLE", "variable": "x"}, "right": {"kind": "VARIABLE", "variable": "x"}}, "right": {"kind": "VARIABLE", "variable": "x"}}]}}),),
         )
 
     @property

--- a/src/jacobian/universal_algebra_capabilities.py
+++ b/src/jacobian/universal_algebra_capabilities.py
@@ -234,6 +234,7 @@ class UniversalAlgebraEvaluateLawsAdapter:
                 "law-evaluation",
                 "counterexample",
             ),
+            invocation_examples=(example("one_element_idempotence", "Evaluate x=x on the one-element magma.", {"problem": {"structure": {"order": 1, "table": [[0]]}, "laws": [{"law_id": "idempotence", "variables": ["x"], "left": {"kind": "VARIABLE", "variable": "x"}, "right": {"kind": "VARIABLE", "variable": "x"}}]}}),),
         )
 
     @property

--- a/tests/integration/domains/test_universal_algebra_capabilities.py
+++ b/tests/integration/domains/test_universal_algebra_capabilities.py
@@ -73,6 +73,44 @@ def test_countermodel_descriptor_publishes_a_model_valid_invocation_example(
     assert validated.target_law.law_id == "associative"
 
 
+def test_evaluate_laws_descriptor_example_encodes_idempotence(
+    kernel_with_references,
+) -> None:
+    descriptor = next(
+        descriptor
+        for descriptor in kernel_with_references.capabilities.catalog().capabilities
+        if descriptor.capability_id == "universal_algebra.evaluate_laws"
+    )
+    example = descriptor.invocation_examples[0]
+    law = example.input["problem"]["laws"][0]
+
+    assert law["law_id"] == "idempotence"
+    assert law["left"] == {
+        "kind": "PRODUCT",
+        "left": {"kind": "VARIABLE", "variable": "x"},
+        "right": {"kind": "VARIABLE", "variable": "x"},
+    }
+    assert law["right"] == {"kind": "VARIABLE", "variable": "x"}
+
+    result = kernel_with_references.capabilities.invoke(
+        CapabilityRequest(
+            capability_id=descriptor.capability_id,
+            mode=example.mode,
+            input=example.input,
+        )
+    )
+
+    assert result.output["records"] == [
+        {
+            "law_id": "idempotence",
+            "holds": True,
+            "coverage": "EXHAUSTIVE",
+            "checked_valuations": 1,
+            "counterexample": None,
+        }
+    ]
+
+
 def test_evaluate_laws_returns_exact_truth_and_counterexample(
     kernel_with_references,
 ) -> None:


### PR DESCRIPTION
## Summary

Complete the standalone invocation-example pass for the remaining five capabilities:

- polynomial.interval.enclose
- polynomial.interval.positivity.decide
- polynomial.map.collision.search
- polynomial.system.rational_solution.search
- universal_algebra.evaluate_laws

## Validation

- Catalog registration validates all examples against canonical schemas.
- Coverage rises from 189 to 194 of 217 capabilities.
- Ruff and git diff --check pass locally.
- Full pytest remains unavailable because pytest-timeout and z3 are missing.
- SymPy and finite-algebra runtime availability is environment-dependent; payloads remain retained as schema-valid examples.

No artifact, plugin, checker, experiment, witness, or certificate identifiers were added.