### PR TITLE
docs(examples): cover Lean core statement comparison

### DIFF
--- a/src/jacobian/lean_statement_capabilities.py
+++ b/src/jacobian/lean_statement_capabilities.py
@@ -60,6 +60,7 @@ from jacobian.contracts.lean_statement import (
     LeanStatementProposalRequest,
 )
 from jacobian.contracts.results import Execution, ExecutionStatus
+from jacobian.domains._examples import example
 from jacobian.provider_runtime import jacobian_provider_runtime
 from jacobian.schema_registry import SchemaRegistry
 from jacobian.store import ArtifactStore
@@ -673,6 +674,7 @@ class LeanStatementCompareAdapter:
             input_schema=LeanStatementComparisonRequest.model_json_schema(),
             output_schema=LeanStatementComparisonOutput.model_json_schema(),
             tags=("lean", "statement", "comparison", "axiom-set"),
+            invocation_examples=(example("core_true_identity", "Compare identical Lean Core propositions.", {"environment": "CORE", "statement_a": "True", "statement_b": "True"}),),
         )
 
     @property

--- a/src/jacobian/lean_statement_capabilities.py
+++ b/src/jacobian/lean_statement_capabilities.py
@@ -674,7 +674,17 @@ class LeanStatementCompareAdapter:
             input_schema=LeanStatementComparisonRequest.model_json_schema(),
             output_schema=LeanStatementComparisonOutput.model_json_schema(),
             tags=("lean", "statement", "comparison", "axiom-set"),
-            invocation_examples=(example("core_true_identity", "Compare identical Lean Core propositions.", {"environment": "CORE", "statement_a": "True", "statement_b": "True"}),),
+            invocation_examples=(
+                example(
+                    "core_true_identity",
+                    "Compare identical Lean Core propositions.",
+                    {
+                        "environment": "CORE",
+                        "statement_a": "True",
+                        "statement_b": "True",
+                    },
+                ),
+            ),
         )
 
     @property


### PR DESCRIPTION
## Summary

Add one standalone CORE example for `lean.statement.compare`.

## Validation

- Catalog registration validates the example against the canonical schema.
- Coverage rises from 194 to 195 of 217 capabilities; schema failures remain zero.
- Ruff and git diff --check pass locally.
- Direct Lean smoke invocation was not run because the `lean` executable is unavailable in this environment.

No schemas, semantics, or prior examples were changed.