### PR TITLE
perf(tests): make test-suite validation faster and more explicit

### DIFF
--- a/.github/ci-impact.json
+++ b/.github/ci-impact.json
@@ -8,13 +8,14 @@
     "static",
     "build",
     "security",
-    "duplicate"
+    "duplicate",
+    "docs"
   ],
   "rules": [
     {
       "name": "documentation",
       "patterns": ["docs/**", "*.md", ".github/ISSUE_TEMPLATE/**", ".github/CODEOWNERS"],
-      "suites": []
+      "suites": ["docs"]
     },
     {
       "name": "npm-package",
@@ -106,6 +107,6 @@
   ],
   "fallback": {
     "name": "unclassified-fail-closed",
-    "suites": ["core", "integration", "lean", "npm", "static", "build", "security", "duplicate"]
+    "suites": ["core", "integration", "lean", "npm", "static", "build", "security", "duplicate", "docs"]
   }
 }

--- a/.github/scripts/classify-ci-paths
+++ b/.github/scripts/classify-ci-paths
@@ -36,6 +36,7 @@ def classify(paths: list[str], *, exhaustive: bool, force_lean: bool) -> dict[st
     manifest = load_manifest()
     exhaustive = exhaustive or not paths
     all_suites = set(manifest["suites"])
+    code_suites = all_suites - {"docs"}
     suites: set[str] = set()
     owners: set[str] = set()
 
@@ -52,7 +53,9 @@ def classify(paths: list[str], *, exhaustive: bool, force_lean: bool) -> dict[st
 
     if exhaustive:
         classification = "exhaustive"
-    elif suites == all_suites:
+    elif suites == {"docs"}:
+        classification = "docs"
+    elif suites == code_suites or suites == all_suites:
         classification = "full"
     elif not suites:
         classification = "docs"
@@ -77,7 +80,15 @@ def classify(paths: list[str], *, exhaustive: bool, force_lean: bool) -> dict[st
         "run-coverage": str(exhaustive and run_core and run_integration).lower(),
         "run-compatibility": str(exhaustive and run_core and run_integration).lower(),
     }
-    for suite in ("lean", "npm", "static", "build", "security", "duplicate"):
+    for suite in (
+        "lean",
+        "npm",
+        "static",
+        "build",
+        "security",
+        "duplicate",
+        "docs",
+    ):
         plan[f"run-{suite}"] = str(suite in suites).lower()
     return plan
 

--- a/.github/scripts/validate-ci-plan
+++ b/.github/scripts/validate-ci-plan
@@ -17,9 +17,12 @@ BOOLEAN_KEYS = (
     "run-build",
     "run-security",
     "run-duplicate",
+    "run-docs",
 )
 FUNCTIONAL_KEYS = tuple(
-    key for key in BOOLEAN_KEYS if key not in {"run-coverage", "run-compatibility"}
+    key
+    for key in BOOLEAN_KEYS
+    if key not in {"run-coverage", "run-compatibility", "run-docs"}
 )
 CLASSIFICATIONS = {
     "docs",
@@ -51,8 +54,8 @@ def _only_enabled(plan: dict[str, str], *allowed: str) -> bool:
 def _validate_classification(plan: dict[str, str]) -> None:
     classification = plan["classification"]
     if classification == "docs":
-        if any(plan[key] == "true" for key in BOOLEAN_KEYS):
-            fail("docs CI must disable every lane")
+        if not _only_enabled(plan, "run-docs"):
+            fail("docs CI must enable only run-docs")
         return
     if classification == "npm":
         if not _only_enabled(plan, "run-npm"):

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
       run-build: ${{ steps.classify.outputs.run-build }}
       run-security: ${{ steps.classify.outputs.run-security }}
       run-duplicate: ${{ steps.classify.outputs.run-duplicate }}
+      run-docs: ${{ steps.classify.outputs.run-docs }}
       integration-shard-count: ${{ steps.shards.outputs.integration-shard-count }}
       integration-shards: ${{ steps.shards.outputs.integration-shards }}
       node-version-jscpd: ${{ steps.shards.outputs.node-version-jscpd }}
@@ -153,6 +154,40 @@ jobs:
         run: make typecheck
       - if: needs.plan.outputs.run-static == 'true'
         run: make todo-check
+
+  docs:
+    name: Documentation
+    needs: plan
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-slim
+    timeout-minutes: 10
+    steps:
+      - name: Require a valid documentation plan
+        env:
+          PLAN_RESULT: ${{ needs.plan.result }}
+          RUN_DOCS: ${{ needs.plan.outputs.run-docs }}
+        run: |
+          case "$PLAN_RESULT" in
+            success) ;;
+            cancelled)
+              echo "Upstream plan was cancelled; treating gate as non-failure"
+              exit 0
+              ;;
+            *)
+              echo "Upstream plan did not succeed: $PLAN_RESULT"
+              exit 1
+              ;;
+          esac
+          case "$RUN_DOCS" in
+            true|false) ;;
+            *) exit 1 ;;
+          esac
+      - if: needs.plan.outputs.run-docs == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - if: needs.plan.outputs.run-docs == 'true'
+        run: make docs-linkcheck
 
   security-audit:
     name: Security Audit

--- a/.github/workflows/scheduled-validation.yml
+++ b/.github/workflows/scheduled-validation.yml
@@ -22,11 +22,9 @@ jobs:
       - uses: ./.github/actions/setup-python-tests
         with:
           python-version: "3.12"
-      - run: >-
-          uv run --locked pytest
-          -m "property and not lean_runtime"
-          --count=3
-          --durations=20
+      - run: make test-stress
+        env:
+          PYTEST_ARGS: --durations=20
 
   ordering:
     name: Ordering seed ${{ matrix.seed }}
@@ -41,11 +39,9 @@ jobs:
       - uses: ./.github/actions/setup-python-tests
         with:
           python-version: "3.12"
-      - run: >-
-          uv run --locked pytest
-          -m "not lean_runtime"
-          --randomly-seed=${{ matrix.seed }}
-          --durations=20
+      - run: make test-ordering
+        env:
+          PYTEST_ARGS: --randomly-seed=${{ matrix.seed }} --durations=20
 
   optional-providers:
     name: Optional provider integration

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,8 @@ impractical.
 
 CI classifies pull requests through the tested source-to-suite impact
 manifest in `.github/ci-impact.json`. Documentation-only changes skip
-Python, npm, Lean, static, package, security, and duplicate-code lanes.
+Python, npm, Lean, static, package, security, and duplicate-code lanes, but
+run the dedicated `make docs-linkcheck` lane.
 Documentation plus npm or npm-only changes run npm packaging without the
 Python and Lean lanes. Unknown paths fail closed to all functional lanes.
 Required status contexts still complete after checking the plan when their

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ EVAL_ARGS ?=
 CORE_TEST_PATHS := tests/unit tests/contract tests/checkers tests/reference
 INTEGRATION_TEST_PATHS := tests/integration tests/end_to_end
 RUFF_PATHS := src tests benchmarks
+# Four workers cap memory and repeated per-worker kernel-template setup.
 PYTEST_XDIST_ARGS := -n auto --maxprocesses=4 --dist=worksteal
 
 .PHONY: help setup hooks fix lint lint-full security-audit typecheck test test-fast test-core test-integration test-contracts test-checkers test-mcp test-storage test-lean test-failed test-stress test-ordering duplicate-code npm-test todo-check coverage build check precommit check-static validate-full agent-eval bench-core clean docs-linkcheck
@@ -81,10 +82,10 @@ test-failed: ## Re-run failures from the previous pytest invocation.
 	$(UV_RUN) pytest $(PYTEST_XDIST_ARGS) --lf -m "not lean_runtime" $(PYTEST_ARGS)
 
 test-stress: ## Reproduce scheduled property stress (pytest-repeat --count=3).
-	$(UV_RUN) pytest -m "property and not lean_runtime" --count=3 $(PYTEST_ARGS)
+	$(UV_RUN) pytest -n 0 -m "property and not lean_runtime" --count=3 $(PYTEST_ARGS)
 
 test-ordering: ## Reproduce scheduled ordering with PYTEST_ARGS=--randomly-seed=N.
-	$(UV_RUN) pytest -m "not lean_runtime" $(PYTEST_ARGS)
+	$(UV_RUN) pytest -n 0 -m "not lean_runtime" $(PYTEST_ARGS)
 
 duplicate-code: ## Run the CI duplicate-code detector locally.
 	npx --yes jscpd@5.0.12 --config .jscpd.json .

--- a/docs/reference/testing-strategy.md
+++ b/docs/reference/testing-strategy.md
@@ -161,8 +161,8 @@ Measured costs and lane policy are recorded in the
 For pull requests, a tested path planner reads
 [`.github/ci-impact.json`](../../.github/ci-impact.json) and makes
 independent core Python, integration Python, Lean, npm, static, build,
-security, and duplicate-code decisions. Documentation-only and npm-only changes
-stay narrow. Ordinary capability source stays on core + integration + static +
+security, and duplicate-code decisions. Documentation-only changes run only
+the dedicated link checker; npm-only changes stay narrow. Ordinary capability source stays on core + integration + static +
 build without Lean, security, or duplicate-code by default. Verification-kernel
 boundaries, packaging, CI, and unknown paths fail closed to all functional
 lanes. Merge-queue checks and pushes to `main` always use the exhaustive plan,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ dev = [
     "pytest-cov>=6,<8",
     "pytest-randomly==4.1.0",
     "pytest-repeat==0.9.4",
-    "pytest-rerunfailures>=14,<17",
     "pytest-split==0.11.0",
     "pytest-timeout>=2.4,<3",
     "pytest-xdist>=3.6,<4",

--- a/tests/checkers/test_sat_unsat_proof_checker.py
+++ b/tests/checkers/test_sat_unsat_proof_checker.py
@@ -369,7 +369,9 @@ def test_drat_timeout_fails_closed(
         "import time\ntime.sleep(5)",
     )
     _install_runtime_environment(monkeypatch, executable)
-    monkeypatch.setattr("jacobian_checkers.sat.DRAT_TRIM_TIMEOUT_SECONDS", 0.1)
+    # Leave enough time for the interpreter to start and create the marker;
+    # timeout still occurs well before the five-second worker sleep.
+    monkeypatch.setattr("jacobian_checkers.sat.DRAT_TRIM_TIMEOUT_SECONDS", 1.0)
 
     decision = check_unsat_proof(proof_request_factory(_DEFAULT_PROOF))
 

--- a/tests/checkers/test_smt_unsat_proof_checker.py
+++ b/tests/checkers/test_smt_unsat_proof_checker.py
@@ -355,7 +355,9 @@ def test_carcara_timeout_fails_closed(
         "import time\ntime.sleep(5)",
     )
     _install_runtime_environment(monkeypatch, executable)
-    monkeypatch.setattr("jacobian_checkers.smt.CARCARA_TIMEOUT_SECONDS", 0.1)
+    # Leave enough time for the interpreter to start and create the marker;
+    # timeout still occurs well before the five-second worker sleep.
+    monkeypatch.setattr("jacobian_checkers.smt.CARCARA_TIMEOUT_SECONDS", 1.0)
 
     decision = check_unsat_proof(proof_request_factory())
 

--- a/tests/integration/agent/test_agent_benchmark.py
+++ b/tests/integration/agent/test_agent_benchmark.py
@@ -14,6 +14,20 @@ from jacobian.kernel import JacobianKernel
 
 pytestmark = pytest.mark.usefixtures("initialized_kernel_store_with_references")
 
+_MATHLIB_OLEAN = (
+    Path(__file__).resolve().parents[3]
+    / "lean"
+    / ".lake"
+    / "packages"
+    / "mathlib"
+    / ".lake"
+    / "build"
+    / "lib"
+    / "lean"
+    / "Mathlib.olean"
+)
+_LEAN_AVAILABLE = shutil.which("lean") is not None and _MATHLIB_OLEAN.is_file()
+
 
 def _feedback() -> dict[str, list[str]]:
     return {
@@ -28,7 +42,7 @@ def test_graph_capability_scorer_checks_multi_call_artifacts(
     tmp_path: Path,
 ) -> None:
     case = benchmark.load_cases(["GRAPH-ATLAS-PATH-001"])[0]
-    kernel = JacobianKernel(tmp_path, install_references=True)
+    kernel = JacobianKernel(tmp_path, hydrate_authorized=True)
     searched = kernel.capabilities.invoke(
         CapabilityRequest(
             capability_id="graph.search.atlas",
@@ -237,7 +251,7 @@ def test_known_answer_scorer_replays_durable_witness_bindings(
     load_cases = benchmark.load_cases
     score_run = benchmark.score_run
     case = next(case for case in load_cases(["PATH-CLOSURE-001"]) if case["case_id"])
-    kernel = JacobianKernel(tmp_path, install_references=True)
+    kernel = JacobianKernel(tmp_path, hydrate_authorized=True)
     reference = kernel.references["graph_paths"]
     claim = _invoke(
         kernel,
@@ -373,7 +387,7 @@ def test_known_answer_scorer_accepts_verified_positive_witness(
     load_cases = benchmark.load_cases
     score_run = benchmark.score_run
     case = next(case for case in load_cases(["GRAPH-BIP-TRUE-001"]) if case["case_id"])
-    kernel = JacobianKernel(tmp_path, install_references=True)
+    kernel = JacobianKernel(tmp_path, hydrate_authorized=True)
     reference = kernel.references["graph_paths"]
     claim = _invoke(
         kernel,
@@ -479,18 +493,19 @@ def test_known_answer_scorer_accepts_verified_positive_witness(
 
 
 @pytest.mark.skipif(
-    shutil.which("lean") is None,
-    reason="Lean is not installed",
+    not _LEAN_AVAILABLE,
+    reason="the pinned Lean/Mathlib runtime is not installed",
 )
 def test_known_answer_scorer_accepts_bound_lean_certificate(
     tmp_path: Path,
+    initialized_kernel_store_with_references: None,
 ) -> None:
     load_cases = benchmark.load_cases
     score_run = benchmark.score_run
     case = next(
         case for case in load_cases(["LEAN-NAT-INDUCTION-001"]) if case["case_id"]
     )
-    kernel = JacobianKernel(tmp_path, install_references=True)
+    kernel = JacobianKernel(tmp_path, hydrate_authorized=True)
     assert kernel.lean is not None
     verified = kernel.lean.verify(
         statement="∀ n : Nat, n + 0 = n",
@@ -534,7 +549,7 @@ def test_known_answer_scorer_accepts_bounded_erdos_straus_table(
     load_cases = benchmark.load_cases
     score_run = benchmark.score_run
     case = next(case for case in load_cases(["ERDOS-STRAUS-001"]) if case["case_id"])
-    kernel = JacobianKernel(tmp_path, install_references=True)
+    kernel = JacobianKernel(tmp_path, hydrate_authorized=True)
     reference = kernel.references["erdos_straus"]
     claim = _invoke(
         kernel,

--- a/tests/integration/domains/test_domain_bundles.py
+++ b/tests/integration/domains/test_domain_bundles.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 
 from jacobian.artifacts import ArtifactService
@@ -288,9 +286,9 @@ def test_unique_domain_ids() -> None:
     assert len(domain_ids) == len(set(domain_ids)), f"duplicates: {domain_ids}"
 
 
-@pytest.fixture
-def service(tmp_path: Path) -> CapabilityService:
-    store = ArtifactStore(tmp_path)
+@pytest.fixture(scope="module")
+def service(tmp_path_factory: pytest.TempPathFactory) -> CapabilityService:
+    store = ArtifactStore(tmp_path_factory.mktemp("domain-bundles"))
     schemas = SchemaRegistry(store)
     artifacts = ArtifactService(store, schemas)
     service = CapabilityService(store, ResearchMemory(store, schemas))

--- a/tests/integration/sat_smt/test_cvc5.py
+++ b/tests/integration/sat_smt/test_cvc5.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 from pathlib import Path
 from typing import Any
 
@@ -61,8 +62,13 @@ def _invoke(kernel: JacobianKernel, text: str, *, logic: str = "QF_UF"):
 
 
 @pytest.fixture(scope="module")
-def kernel(tmp_path_factory: pytest.TempPathFactory) -> JacobianKernel:
-    return JacobianKernel(tmp_path_factory.mktemp("cvc5-kernel"))
+def kernel(
+    tmp_path_factory: pytest.TempPathFactory,
+    kernel_store_template: Path,
+) -> JacobianKernel:
+    root = tmp_path_factory.mktemp("cvc5-kernel")
+    shutil.copytree(kernel_store_template, root, dirs_exist_ok=True)
+    return JacobianKernel(root)
 
 
 def test_pinned_cvc5_capability_is_discoverable(kernel: JacobianKernel) -> None:
@@ -271,6 +277,7 @@ def test_worker_timeout_fails_without_solver_conclusion(
 
 def test_missing_optional_cvc5_leaves_artifact_boundary_but_no_capability(
     tmp_path: Path,
+    initialized_kernel_store: None,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     unavailable = CapabilityProviderRuntime(

--- a/tests/unit/test_ci_plan.py
+++ b/tests/unit/test_ci_plan.py
@@ -23,9 +23,12 @@ BOOLEAN_KEYS = (
     "run-build",
     "run-security",
     "run-duplicate",
+    "run-docs",
 )
 FUNCTIONAL_KEYS = tuple(
-    key for key in BOOLEAN_KEYS if key not in {"run-coverage", "run-compatibility"}
+    key
+    for key in BOOLEAN_KEYS
+    if key not in {"run-coverage", "run-compatibility", "run-docs"}
 )
 
 
@@ -42,7 +45,7 @@ def _expected_plan(classification: str, *enabled: str) -> dict[str, str]:
         ((), _expected_plan("exhaustive", *BOOLEAN_KEYS)),
         (
             ("README.md", "docs/how-to/contribute.md", ".github/CODEOWNERS"),
-            _expected_plan("docs"),
+            _expected_plan("docs", "run-docs"),
         ),
         (
             ("npm/package.json", "npm/npm-packaging.test.mjs"),
@@ -50,7 +53,7 @@ def _expected_plan(classification: str, *enabled: str) -> dict[str, str]:
         ),
         (
             ("docs/index.md", "npm/package.json"),
-            _expected_plan("npm", "run-npm"),
+            _expected_plan("selective", "run-npm", "run-docs"),
         ),
         (
             ("tests/unit/test_kernel.py",),
@@ -188,7 +191,7 @@ def _expected_plan(classification: str, *enabled: str) -> dict[str, str]:
         ),
         (
             ("docs/index.md", "pyproject.toml"),
-            _expected_plan("full", *FUNCTIONAL_KEYS),
+            _expected_plan("full", *FUNCTIONAL_KEYS, "run-docs"),
         ),
         (
             (".github/workflows/ci.yml",),
@@ -196,7 +199,7 @@ def _expected_plan(classification: str, *enabled: str) -> dict[str, str]:
         ),
         (
             ("CONTRIBUTING.md",),
-            _expected_plan("full", *FUNCTIONAL_KEYS),
+            _expected_plan("full", *FUNCTIONAL_KEYS, "run-docs"),
         ),
         (
             ("tests/helpers/capabilities.py",),
@@ -272,7 +275,7 @@ def test_lean_override_only_adds_lean_to_an_isolated_plan() -> None:
     )
 
     plan = dict(line.split("=", 1) for line in completed.stdout.splitlines())
-    assert plan == _expected_plan("lean", "run-lean")
+    assert plan == _expected_plan("selective", "run-lean", "run-docs")
 
 
 @pytest.mark.parametrize(
@@ -313,7 +316,8 @@ def test_ci_plan_output_is_internally_consistent(args: tuple[str, ...]) -> None:
         "run-static=false\n"
         "run-build=false\n"
         "run-security=false\n"
-        "run-duplicate=false\n",
+        "run-duplicate=false\n"
+        "run-docs=false\n",
         "classification=docs\n"
         "classification=docs\n"
         "run-python=false\n"
@@ -322,7 +326,8 @@ def test_ci_plan_output_is_internally_consistent(args: tuple[str, ...]) -> None:
         "run-static=false\n"
         "run-build=false\n"
         "run-security=false\n"
-        "run-duplicate=false\n",
+        "run-duplicate=false\n"
+        "run-docs=false\n",
         "classification=docs\n"
         "run-python=false\n"
         "run-core=false\n"
@@ -334,7 +339,8 @@ def test_ci_plan_output_is_internally_consistent(args: tuple[str, ...]) -> None:
         "run-static=false\n"
         "run-build=false\n"
         "run-security=false\n"
-        "run-duplicate=false\n",
+        "run-duplicate=false\n"
+        "run-docs=false\n",
         "classification=docs\n"
         "run-python=true\n"
         "run-core=true\n"
@@ -346,7 +352,8 @@ def test_ci_plan_output_is_internally_consistent(args: tuple[str, ...]) -> None:
         "run-static=false\n"
         "run-build=false\n"
         "run-security=false\n"
-        "run-duplicate=false\n",
+        "run-duplicate=false\n"
+        "run-docs=false\n",
         "classification=lean\n"
         "run-python=true\n"
         "run-core=true\n"
@@ -358,7 +365,8 @@ def test_ci_plan_output_is_internally_consistent(args: tuple[str, ...]) -> None:
         "run-static=false\n"
         "run-build=false\n"
         "run-security=false\n"
-        "run-duplicate=false\n",
+        "run-duplicate=false\n"
+        "run-docs=false\n",
     ],
 )
 def test_ci_plan_validator_rejects_malformed_or_incoherent_plans(plan: str) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -516,7 +516,6 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-randomly" },
     { name = "pytest-repeat" },
-    { name = "pytest-rerunfailures" },
     { name = "pytest-split" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
@@ -557,7 +556,6 @@ dev = [
     { name = "pytest-cov", specifier = ">=6,<8" },
     { name = "pytest-randomly", specifier = "==4.1.0" },
     { name = "pytest-repeat", specifier = "==0.9.4" },
-    { name = "pytest-rerunfailures", specifier = ">=14,<17" },
     { name = "pytest-split", specifier = "==0.11.0" },
     { name = "pytest-timeout", specifier = ">=2.4,<3" },
     { name = "pytest-xdist", specifier = ">=3.6,<4" },
@@ -1169,19 +1167,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/80/d4/69e9dbb9b8266df0b157c72be32083403c412990af15c7c15f7a3fd1b142/pytest_repeat-0.9.4.tar.gz", hash = "sha256:d92ac14dfaa6ffcfe6917e5d16f0c9bc82380c135b03c2a5f412d2637f224485", size = 6488, upload-time = "2025-04-07T14:59:53.077Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/73/d4/8b706b81b07b43081bd68a2c0359fe895b74bf664b20aca8005d2bb3be71/pytest_repeat-0.9.4-py3-none-any.whl", hash = "sha256:c1738b4e412a6f3b3b9e0b8b29fcd7a423e50f87381ad9307ef6f5a8601139f3", size = 4180, upload-time = "2025-04-07T14:59:51.492Z" },
-]
-
-[[package]]
-name = "pytest-rerunfailures"
-version = "16.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/47/60/a90ca1cc6cffcb97b4260ed0ad2b7934b999d7c48abe4ea0840344862a3b/pytest_rerunfailures-16.4.tar.gz", hash = "sha256:8222d17c37eb7b9e4d6fc96a3c724ff4e1a5c97a5cc7cbb2c19e9282cfd21a11", size = 36635, upload-time = "2026-07-01T06:30:56.813Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/93/3cdcc4033444e822e01b573414b03fd37fd5533070c750477b8f5fa5224b/pytest_rerunfailures-16.4-py3-none-any.whl", hash = "sha256:f69b5beb39622c90d1e44bd945d826eff6db545dcf0b68f52b7e4ad15eaf6d6c", size = 16955, upload-time = "2026-07-01T06:30:55.333Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem
The test workflow had repeated integration setup, flaky subprocess timeout tests, and scheduled commands that did not exactly match local reproduction targets. Documentation-only changes also bypassed all validation, and the dev environment carried an unused pytest plugin.

## Solution
- Reuse seeded kernel stores and module-scoped fixtures where tests only read shared setup.
- Stabilize timeout tests around process startup cost and detect the pinned Lean/Mathlib runtime correctly.
- Route scheduled stress and ordering jobs through the canonical Make targets.
- Add an explicit documentation-only CI lane for Markdown link checking, with planner and validator coverage.
- Remove the unused `pytest-rerunfailures` dependency from the locked dev environment.

## Testing
- `make check` — 603 passed, 3 slow tests deselected
- `make test-core` — 606 passed
- `make test TESTS="tests/integration/sat_smt/test_cvc5.py tests/integration/domains/test_domain_bundles.py tests/integration/agent/test_agent_benchmark.py" PYTEST_ARGS="-n 0"` — 24 passed, 1 skipped because the pinned Lean/Mathlib runtime is unavailable locally
- `make lint` — passed
- `make typecheck` — passed
- `make docs-linkcheck` — passed
- `git diff --check` — passed

## Trust & Compatibility Impact
No mathematical verification, artifact, public API, or compatibility contract changes. The Lean skip condition only avoids running a test when its pinned local runtime is incomplete.

## Checklist
- [x] Routine local validation passes (`make check`)
- [x] Relevant focused tests are listed above