### PR TITLE
fix(devex): align CLI onboarding and validation workflows

### DIFF
--- a/.factory/droids/jacobian-dev.md
+++ b/.factory/droids/jacobian-dev.md
@@ -40,7 +40,7 @@ the research strategy.
 ```sh
 make setup
 make test-fast
-make validate
+make validate-full
 ```
 
 ## Package Structure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
     name: Documentation
     needs: plan
     if: ${{ !cancelled() }}
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Require a valid documentation plan

--- a/.github/workflows/scheduled-validation.yml
+++ b/.github/workflows/scheduled-validation.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   stress:
-    name: Stress property tests
+    name: Repeated contract and checker tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,8 +116,9 @@ Non-obvious caveats:
   not break the kernel, catalog, or the core test suites. Only install Lean/elan
   or those executables when specifically exercising `lean_runtime` tests or SAT
   proof-artifact capabilities.
-- `make test-fast` is the quick core loop; `make check` (lint + typecheck +
-  test-fast) is the pre-push gate. Never run bare `uv run pytest` across the whole
+- `make test-fast` is the quick full-core loop; `make test-unit-fast` is the
+  unit-only pre-push test lane, and `make check` combines it with lint and
+  typecheck. Never run bare `uv run pytest` across the whole
   suite — it mixes `lean_runtime` tests into the xdist pool and pytest rejects it;
   use the `make test-*` targets instead. Parallel xdist is enabled by Make
   targets (`test`, `test-core`, `test-integration`), not by global pytest addopts.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,10 +24,13 @@ make test-fast
 ```
 
 `make test-fast` is the short sequential non-integration feedback loop; it
-excludes tests explicitly marked `slow`. `make test-core` runs the same core
-directories with default xdist parallelism and includes `slow` cases; CI's core
-lane uses that target. Run `make check` before pushing; it performs fast Ruff,
-strict typing, and `test-fast`. Push after that check and let CI own
+excludes tests explicitly marked `slow`. `make test-unit-fast` is the smaller
+unit-only lane used by the pre-push `make check`; contract, checker, and
+reference tests remain available through their focused targets and CI. `make
+test-core` runs the same core directories with default xdist parallelism and
+includes `slow` cases; CI's core lane uses that target. Run `make check` before
+pushing; it performs fast Ruff, strict typing, and `test-unit-fast`. Push after
+that check and let CI own
 path-planned validation: static analysis, package builds, planned Python lanes,
 and Lean/npm/security/duplicate-code when the impact manifest selects them.
 Coverage and Python 3.13 compatibility run only on exhaustive plans (merge
@@ -52,10 +55,12 @@ make test-lean TESTS=tests/integration/lean/test_lean.py PYTEST_ARGS="-k inducti
 ```
 
 Run `make hooks` once to install commit-time formatting, syntax, secret,
-large-file, dead-code, and actionlint hooks plus the `make check` pre-push
-gate. Commit hooks are a narrower hygiene pass than `make check` (which adds
-mypy and `test-fast`); pre-push is the routine correctness gate. Hooks remain
-bypassable for exceptional cases with Git's standard `--no-verify` option.
+large-file, dead-code, and actionlint hooks plus the fast `make check`
+pre-push gate. `make check` runs Ruff, mypy, and the unit-only fast lane;
+contract, checker, and reference suites remain in CI. Use
+`make pre-push-full` when a local push also needs the sequential core tests.
+Hooks remain bypassable for exceptional cases with Git's standard
+`--no-verify` option.
 `make fix` applies Ruff's safe lint fixes followed by formatting. `make
 precommit` applies those fixes and then runs the routine handoff checks.
 

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,14 @@ UV_RUN := uv run --locked
 PYTEST_ARGS ?=
 TESTS ?=
 EVAL_ARGS ?=
+ORDERING_DEFAULT_SEED := --randomly-seed=17
 CORE_TEST_PATHS := tests/unit tests/contract tests/checkers tests/reference
 INTEGRATION_TEST_PATHS := tests/integration tests/end_to_end
 RUFF_PATHS := src tests benchmarks
 # Four workers cap memory and repeated per-worker kernel-template setup.
 PYTEST_XDIST_ARGS := -n auto --maxprocesses=4 --dist=worksteal
 
-.PHONY: help setup hooks fix lint lint-full security-audit typecheck test test-fast test-core test-integration test-contracts test-checkers test-mcp test-storage test-lean test-failed test-stress test-ordering duplicate-code npm-test todo-check coverage build check precommit check-static validate-full agent-eval bench-core clean docs-linkcheck
+.PHONY: help setup hooks fix lint lint-full security-audit typecheck test test-fast test-unit-fast test-core test-integration test-contracts test-checkers test-mcp test-storage test-lean test-failed test-stress test-ordering duplicate-code npm-test todo-check coverage build check pre-push-full precommit check-static validate-full agent-eval bench-core clean docs-linkcheck
 
 help: ## Show available developer commands.
 	@awk 'BEGIN {FS = ":.*## "; printf "Jacobian developer commands:\n\n"} /^[a-zA-Z_-]+:.*## / {printf "  %-18s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -47,6 +48,9 @@ test-fast: ## Sequential core edit loop (unit/contract/checkers/reference, no xd
 	$(UV_RUN) pytest -n 0 -m "not lean_runtime and not slow" \
 		$(if $(TESTS),$(TESTS),$(CORE_TEST_PATHS)) $(PYTEST_ARGS)
 
+test-unit-fast: ## Sequential unit-only edit loop (excludes slow tests).
+	$(UV_RUN) pytest -n 0 -m "not lean_runtime and not slow" tests/unit $(PYTEST_ARGS)
+
 test-core: ## Parallel core suites (same paths as test-fast, uses xdist by default).
 	$(UV_RUN) pytest $(PYTEST_XDIST_ARGS) -m "not lean_runtime" \
 		$(if $(TESTS),$(TESTS),$(CORE_TEST_PATHS)) $(PYTEST_ARGS)
@@ -81,11 +85,13 @@ test-lean: ## Run pinned Lean tests serially; narrow with TESTS=... and PYTEST_A
 test-failed: ## Re-run failures from the previous pytest invocation.
 	$(UV_RUN) pytest $(PYTEST_XDIST_ARGS) --lf -m "not lean_runtime" $(PYTEST_ARGS)
 
-test-stress: ## Reproduce scheduled property stress (pytest-repeat --count=3).
-	$(UV_RUN) pytest -n 0 -m "property and not lean_runtime" --count=3 $(PYTEST_ARGS)
+test-stress: ## Repeat contract, checker, and property tests (pytest-repeat --count=3).
+	$(UV_RUN) pytest -n 0 -m "not lean_runtime" --count=3 \
+		$(if $(TESTS),$(TESTS),tests/contract tests/checkers) $(PYTEST_ARGS)
 
-test-ordering: ## Reproduce scheduled ordering with PYTEST_ARGS=--randomly-seed=N.
-	$(UV_RUN) pytest -n 0 -m "not lean_runtime" $(PYTEST_ARGS)
+test-ordering: ## Reproduce scheduled ordering (default seed 17; override with PYTEST_ARGS).
+	$(UV_RUN) pytest -n 0 -m "not lean_runtime" \
+		$(if $(findstring --randomly-seed,$(PYTEST_ARGS)),,$(ORDERING_DEFAULT_SEED)) $(PYTEST_ARGS)
 
 duplicate-code: ## Run the CI duplicate-code detector locally.
 	npx --yes jscpd@5.0.12 --config .jscpd.json .
@@ -110,7 +116,9 @@ coverage: ## Combine coverage data files and enforce the repository threshold.
 build: ## Build Python source and wheel distributions.
 	uv build
 
-check: lint typecheck test-fast ## Run the fast routine local handoff checks.
+check: lint typecheck test-unit-fast ## Run the fast routine local handoff checks.
+
+pre-push-full: lint typecheck test-fast ## Run the routine checks plus all fast core tests.
 
 precommit: ## Fix and run every routine local handoff check.
 	$(MAKE) fix

--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ uv sync --dev
 uv run jacobian --state-dir .jacobian init
 ```
 
+The default `init` output is a short onboarding summary. Add `init --json`
+when a script needs the complete reference catalog.
+
 Use `uv run jacobian --help` to inspect the CLI or `uv run jacobian-mcp` to
 start the MCP adapter.
 

--- a/docs/contributing/test-suite-cost-audit.md
+++ b/docs/contributing/test-suite-cost-audit.md
@@ -84,9 +84,13 @@ make validate-full
 
 `make test-fast` is the normal edit loop. Use focused integration tests while
 changing stores, adapters, plugins, subprocesses, or checker execution.
-`make check` combines fast Ruff checks, strict typing, and that loop.
+`make check` combines fast Ruff checks, strict typing, and the unit-only loop;
+use `make test-fast` for the full sequential core edit loop.
 Dependency and dead-code analysis and package builds remain available through
 `make check-static` but are CI-owned rather than routine local handoff work.
+The installed pre-push hook uses `make check` for the fast Ruff, mypy, and
+unit-only gate; `make pre-push-full` adds the sequential core tests when
+needed.
 `make test` runs the complete non-Lean suite, and `make test-lean` keeps the
 memory-heavy backend serial. Neither is a routine pre-push requirement; CI
 owns exhaustive validation.

--- a/docs/reference/testing-strategy.md
+++ b/docs/reference/testing-strategy.md
@@ -81,15 +81,19 @@ suite selection.
 Named contract, checker, MCP, and storage targets
 make common affected areas discoverable without adding another test runner.
 `make test-stress` and `make test-ordering` reproduce the scheduled validation
-property-repeat and ordering-seed lanes using locked `pytest-repeat` and
-`pytest-randomly`.
+lanes using locked `pytest-repeat` and `pytest-randomly`. The stress lane
+repeats contract and checker tests, including the marked property tests; the
+ordering lane exercises the non-Lean suite under a fixed seed.
 CI integration shards use one fixed `pytest-randomly` seed from
 `.github/ci-config.json`. Every shard must collect tests in the same order
 before `pytest-split` partitions them; otherwise independently randomized
 collections can overlap or omit tests. The merged timing artifact rejects
 duplicate node IDs instead of concealing such an overlap.
-`make check` combines fast Ruff, strict typing, and non-integration test
-feedback as the routine local pre-push gate. Developers should push after it and
+`make check` combines fast Ruff, strict typing, and unit test
+feedback as the routine local pre-push gate. The installed hook's `make check`
+also runs the unit-only fast lane; use `make pre-push-full` when all fast core
+tests should run before pushing. Developers should push after the chosen local
+gate and
 let CI own dependency and dead-code analysis, package builds, and exhaustive
 validation. `make check-static` reproduces those CI-owned static and package
 checks when relevant.

--- a/src/jacobian/cli.py
+++ b/src/jacobian/cli.py
@@ -259,21 +259,42 @@ def configure(
 
 
 @app.command("init")
-def initialize(context: typer.Context) -> None:
-    """Initialize storage and print installed reference identifiers."""
+def initialize(
+    context: typer.Context,
+    json_output: Annotated[
+        bool,
+        typer.Option(
+            "--json",
+            help="Print the complete machine-readable reference catalog.",
+        ),
+    ] = False,
+) -> None:
+    """Initialize storage and summarize the installed reference domains."""
 
     state = _state(context)
-    _emit(
-        reference_catalog(
-            state.kernel.references,
-            graph=state.kernel.graph,
-            polytope=state.kernel.polytope,
-            polytope_checkers=state.kernel.polytope_checkers,
-            polynomial=state.kernel.polynomial,
-            universal_algebra=state.kernel.universal_algebra,
-            lean=state.kernel.lean_checkers,
-        )
+    catalog = reference_catalog(
+        state.kernel.references,
+        graph=state.kernel.graph,
+        polytope=state.kernel.polytope,
+        polytope_checkers=state.kernel.polytope_checkers,
+        polynomial=state.kernel.polynomial,
+        universal_algebra=state.kernel.universal_algebra,
+        lean=state.kernel.lean_checkers,
     )
+    if json_output:
+        _emit(catalog)
+        return
+
+    capability_count = len(state.kernel.capabilities.catalog().capabilities)
+    typer.echo(f"Initialized Jacobian state in {state.kernel.store.root}")
+    typer.echo(
+        f"Installed {len(catalog)} reference domains and "
+        f"{capability_count} capabilities."
+    )
+    if catalog:
+        typer.echo("Reference domains:")
+        for domain_id in sorted(catalog):
+            typer.echo(f"  - {domain_id}")
 
 
 @app.command("provider-measure")

--- a/tests/contract/test_pilot_invocation_examples.py
+++ b/tests/contract/test_pilot_invocation_examples.py
@@ -60,10 +60,9 @@ def test_pilot_manifest_is_small_source_backed_and_review_gated() -> None:
 
 
 def test_installed_public_pilot_examples_use_descriptor_mechanism(
-    tmp_path: Path,
+    kernel: JacobianKernel,
 ) -> None:
     pilot = _pilot()
-    kernel = JacobianKernel(tmp_path, install_references=False)
     installed = {
         descriptor.capability_id: descriptor
         for descriptor in kernel.capabilities.catalog().capabilities
@@ -89,8 +88,9 @@ def test_installed_public_pilot_examples_use_descriptor_mechanism(
     }
 
 
-def test_search_pilot_boundaries_use_typed_public_results(tmp_path: Path) -> None:
-    kernel = JacobianKernel(tmp_path, install_references=False)
+def test_search_pilot_boundaries_use_typed_public_results(
+    kernel: JacobianKernel,
+) -> None:
     artifact_uri = "artifact://sha256/" + "a" * 64
     payload = {
         "claim_uri": artifact_uri,

--- a/tests/integration/infrastructure/test_cli.py
+++ b/tests/integration/infrastructure/test_cli.py
@@ -16,7 +16,7 @@ def test_cli_init_reports_reference_domains_and_polytope_formats(
 ) -> None:
     result = CliRunner().invoke(
         app,
-        ["--state-dir", str(tmp_path), "init"],
+        ["--state-dir", str(tmp_path), "init", "--json"],
     )
 
     assert result.exit_code == 0
@@ -42,6 +42,17 @@ def test_cli_init_reports_reference_domains_and_polytope_formats(
         "fabf563a7c95a166b8d7b6efca11c8b4dc9d911f"
     )
     assert catalog["lean4"]["profiles"]["MATHLIB"]["checker_timeout_seconds"] == 225
+
+
+def test_cli_init_has_a_human_readable_default_summary(tmp_path: Path) -> None:
+    result = CliRunner().invoke(app, ["--state-dir", str(tmp_path), "init"])
+
+    assert result.exit_code == 0
+    assert len(result.stdout) < 1_000
+    assert f"Initialized Jacobian state in {tmp_path.resolve()}" in result.stdout
+    assert "reference domains" in result.stdout
+    assert "capabilities" in result.stdout
+    assert "graph_paths" in result.stdout
 
 
 def test_cli_help_exposes_v02_operations() -> None:

--- a/tests/unit/test_bounded_process.py
+++ b/tests/unit/test_bounded_process.py
@@ -133,6 +133,7 @@ def test_clean_worker_exit_drains_pipes_inherited_by_descendants() -> None:
     os.name != "posix",
     reason="detached process groups are exercised on POSIX",
 )
+@pytest.mark.slow
 def test_detached_descendant_with_inherited_pipe_fails_closed() -> None:
     completed = run_bounded_process(
         [


### PR DESCRIPTION
## Problem
Several documented developer workflows were misleading or broken: `jacobian init` emitted a 9.5 KB one-line catalog, documentation-only CI used an unavailable runner label, scheduled stress repeated one property test, the development droid referenced a nonexistent target, and the pre-push path paid for the full core suite. Two pilot tests also bypassed the shared kernel fixture.

## Solution
- Make `init` human-readable by default and preserve the complete catalog behind `init --json`.
- Repair the documentation runner and broaden scheduled stress coverage to repeated contract/checker tests.
- Add a default ordering seed and a unit-only `make check` lane; keep the full sequential core lane available as `make pre-push-full`.
- Mark the intentionally waiting descendant-process regression as slow so it remains in CI core coverage, and reuse the seeded kernel fixture in pilot tests.
- Align repository onboarding and test-lane documentation with the commands that exist.

## Testing
- `make check` — 137 passed, 2 deselected in 17.79s.
- `uv run --locked pytest -n 0 tests/integration/infrastructure/test_cli.py -k init` — 2 passed.
- `uv run --locked pytest -n 0 tests/contract/test_pilot_invocation_examples.py` — 3 passed.
- `uv run --locked pytest -n 0 tests/unit/test_bounded_process.py tests/unit/test_atomic_capabilities.py` — 7 passed.
- `make test-stress PYTEST_ARGS="-q"` — 1,287 passed in 104.79s.
- `uv run --locked pre-commit run check-yaml --all-files` and `actionlint --all-files` — passed.
- `make docs-linkcheck` — passed.

## Trust & Compatibility Impact
This changes CLI presentation and local/scheduled test selection only. The full JSON catalog remains available through `init --json`; no artifact format, checker authorization, or verification semantics changed.

## Checklist
- [x] Routine local validation passes (`make check`)
- [x] Relevant focused tests are listed above