### PR TITLE
test(ci): reduce kernel setup and CI feedback overhead

### DIFF
--- a/.github/ci-impact.json
+++ b/.github/ci-impact.json
@@ -71,28 +71,39 @@
       "suites": ["core", "integration", "static", "build"]
     },
     {
-      "name": "ci-and-packaging",
-      "patterns": [
-        ".github/actions/**",
-        ".github/scripts/**",
-        ".github/workflows/**",
-        ".github/ci-impact.json",
-        ".github/ci-config.json",
-        "pyproject.toml",
-        "uv.lock",
-        "Makefile"
-      ],
+      "name": "ci-automation",
+      "patterns": [".github/actions/**", ".github/workflows/**"],
+      "suites": ["core", "integration", "static", "build"]
+    },
+    {
+      "name": "ci-scripts",
+      "patterns": [".github/scripts/**"],
+      "suites": ["core", "integration", "static", "build"]
+    },
+    {
+      "name": "ci-plan-config",
+      "patterns": [".github/ci-impact.json", ".github/ci-config.json"],
+      "suites": ["core", "integration", "static", "build"]
+    },
+    {
+      "name": "makefile",
+      "patterns": ["Makefile"],
+      "suites": ["core", "integration", "lean", "npm", "static", "build"]
+    },
+    {
+      "name": "python-packaging",
+      "patterns": ["pyproject.toml", "uv.lock"],
       "suites": ["core", "integration", "lean", "npm", "static", "build", "security", "duplicate"]
     },
     {
-      "name": "repository-policy",
-      "patterns": [
-        "AGENTS.md",
-        "CONTRIBUTING.md",
-        ".pre-commit-config.yaml",
-        ".jscpd.json"
-      ],
-      "suites": ["core", "integration", "lean", "npm", "static", "build", "security", "duplicate"]
+      "name": "pre-commit",
+      "patterns": [".pre-commit-config.yaml"],
+      "suites": ["static"]
+    },
+    {
+      "name": "duplicate-code-policy",
+      "patterns": [".jscpd.json"],
+      "suites": ["duplicate"]
     },
     {
       "name": "test-support",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,19 +52,6 @@ jobs:
       - id: shards
         name: Load integration shard configuration
         run: .github/scripts/manage-test-timings emit-plan-outputs >> "$GITHUB_OUTPUT"
-      - name: Prepare integration timing hint
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: >-
-          .github/scripts/manage-test-timings prepare
-          --output .ci/test-durations.json
-      - name: Share integration timing hint
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: integration-test-durations-input
-          path: .ci/test-durations.json
-          include-hidden-files: true
-          retention-days: 1
       - id: classify
         name: Classify changed paths
         env:
@@ -104,6 +91,33 @@ jobs:
             echo "$plan_output"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+
+  prepare-test-timings:
+    name: Prepare integration timing hint
+    needs: plan
+    if: needs.plan.outputs.run-integration == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Prepare integration timing hint
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          .github/scripts/manage-test-timings prepare
+          --output .ci/test-durations.json
+      - name: Share integration timing hint
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: integration-test-durations-input
+          path: .ci/test-durations.json
+          include-hidden-files: true
+          retention-days: 1
 
   lint:
     name: Lint & Format
@@ -277,7 +291,6 @@ jobs:
           PYTEST_ARGS: >-
             --junitxml=pytest.xml
             ${{ needs.plan.outputs.run-coverage == 'true' && '--cov --cov-report= --cov-fail-under=0' || '' }}
-            --durations=10
       - if: ${{ !cancelled() }}
         run: uv cache prune --ci
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -300,7 +313,7 @@ jobs:
     name: >-
       Tests (integration ${{ matrix.shard }} of ${{ needs.plan.outputs.integration-shard-count }},
       Python 3.12)
-    needs: plan
+    needs: [plan, prepare-test-timings]
     if: needs.plan.outputs.run-integration == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -332,7 +345,6 @@ jobs:
             --clean-durations
             --junitxml=pytest.xml
             ${{ needs.plan.outputs.run-coverage == 'true' && '--cov --cov-report= --cov-fail-under=0' || '' }}
-            --durations=10
       - name: Upload integration shard timings
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -411,7 +423,7 @@ jobs:
           python-version: "3.13"
       - run: make test
         env:
-          PYTEST_ARGS: --junitxml=pytest.xml --durations=10
+          PYTEST_ARGS: --junitxml=pytest.xml
       - if: ${{ !cancelled() }}
         run: uv cache prune --ci
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -492,8 +504,6 @@ jobs:
           set -e
           echo "| Selected Lean tests | $((SECONDS - started)) |" >> "$GITHUB_STEP_SUMMARY"
           exit "$status"
-        env:
-          PYTEST_ARGS: --durations=10
 
   lean-test:
     name: Lean Tests
@@ -823,7 +833,7 @@ jobs:
 
   ci-metrics:
     name: CI Metrics
-    if: ${{ !cancelled() }}
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs:
       - plan
       - lint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,11 @@ make test-storage PYTEST_ARGS="-k workspace"
 make test-lean TESTS=tests/integration/lean/test_lean.py PYTEST_ARGS="-k induction"
 ```
 
+All Makefile pytest targets print their ten slowest tests by default. Set
+`PYTEST_DIAGNOSTIC_ARGS=--durations=0` to suppress that report, or use a larger
+value such as `PYTEST_DIAGNOSTIC_ARGS=--durations=25` while investigating a
+regression.
+
 Run `make hooks` once to install commit-time formatting, syntax, secret,
 large-file, dead-code, and actionlint hooks plus the fast `make check`
 pre-push gate. `make check` runs Ruff, mypy, and the unit-only fast lane;

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ PYTEST_ARGS ?=
 TESTS ?=
 EVAL_ARGS ?=
 ORDERING_DEFAULT_SEED := --randomly-seed=17
+PYTEST_DIAGNOSTIC_ARGS ?= --durations=10
 CORE_TEST_PATHS := tests/unit tests/contract tests/checkers tests/reference
 INTEGRATION_TEST_PATHS := tests/integration tests/end_to_end
 RUFF_PATHS := src tests benchmarks
@@ -42,32 +43,32 @@ typecheck: ## Run strict static type checking.
 	$(UV_RUN) mypy
 
 test: ## Run tests; narrow with TESTS=... and PYTEST_ARGS=....
-	$(UV_RUN) pytest $(PYTEST_XDIST_ARGS) -m "not lean_runtime" $(TESTS) $(PYTEST_ARGS)
+	$(UV_RUN) pytest $(PYTEST_XDIST_ARGS) -m "not lean_runtime" $(TESTS) $(PYTEST_DIAGNOSTIC_ARGS) $(PYTEST_ARGS)
 
 test-fast: ## Sequential core edit loop (unit/contract/checkers/reference, no xdist).
 	$(UV_RUN) pytest -n 0 -m "not lean_runtime and not slow" \
-		$(if $(TESTS),$(TESTS),$(CORE_TEST_PATHS)) $(PYTEST_ARGS)
+		$(if $(TESTS),$(TESTS),$(CORE_TEST_PATHS)) $(PYTEST_DIAGNOSTIC_ARGS) $(PYTEST_ARGS)
 
 test-unit-fast: ## Sequential unit-only edit loop (excludes slow tests).
-	$(UV_RUN) pytest -n 0 -m "not lean_runtime and not slow" tests/unit $(PYTEST_ARGS)
+	$(UV_RUN) pytest -n 0 -m "not lean_runtime and not slow" tests/unit $(PYTEST_DIAGNOSTIC_ARGS) $(PYTEST_ARGS)
 
 test-core: ## Parallel core suites (same paths as test-fast, uses xdist by default).
 	$(UV_RUN) pytest $(PYTEST_XDIST_ARGS) -m "not lean_runtime" \
-		$(if $(TESTS),$(TESTS),$(CORE_TEST_PATHS)) $(PYTEST_ARGS)
+		$(if $(TESTS),$(TESTS),$(CORE_TEST_PATHS)) $(PYTEST_DIAGNOSTIC_ARGS) $(PYTEST_ARGS)
 
 test-integration: ## Run the directory-owned integration suites.
 	$(UV_RUN) pytest $(PYTEST_XDIST_ARGS) -m "not lean_runtime" \
-		$(if $(TESTS),$(TESTS),$(INTEGRATION_TEST_PATHS)) $(PYTEST_ARGS)
+		$(if $(TESTS),$(TESTS),$(INTEGRATION_TEST_PATHS)) $(PYTEST_DIAGNOSTIC_ARGS) $(PYTEST_ARGS)
 
 test-contracts: ## Run contract tests.
-	$(UV_RUN) pytest -n 0 tests/contract $(PYTEST_ARGS)
+	$(UV_RUN) pytest -n 0 tests/contract $(PYTEST_DIAGNOSTIC_ARGS) $(PYTEST_ARGS)
 
 test-checkers: ## Run independent checker tests.
-	$(UV_RUN) pytest -n 0 tests/checkers $(PYTEST_ARGS)
+	$(UV_RUN) pytest -n 0 tests/checkers $(PYTEST_DIAGNOSTIC_ARGS) $(PYTEST_ARGS)
 
 test-mcp: ## Run focused local and remote MCP integration tests.
 	$(UV_RUN) pytest -n 0 tests/integration/infrastructure/test_mcp_adapter.py \
-		tests/integration/infrastructure/test_remote_mcp.py $(PYTEST_ARGS)
+		tests/integration/infrastructure/test_remote_mcp.py $(PYTEST_DIAGNOSTIC_ARGS) $(PYTEST_ARGS)
 
 test-storage: ## Run artifact, registry, and workspace integration tests.
 	$(UV_RUN) pytest -n 0 tests/integration/infrastructure/test_artifact_store.py \
@@ -77,21 +78,21 @@ test-storage: ## Run artifact, registry, and workspace integration tests.
 		tests/integration/infrastructure/test_workspace_lifecycle.py \
 		tests/integration/infrastructure/test_workspace_scaling.py \
 		tests/integration/infrastructure/test_workspace_invalidation.py \
-		$(PYTEST_ARGS)
+		$(PYTEST_DIAGNOSTIC_ARGS) $(PYTEST_ARGS)
 
 test-lean: ## Run pinned Lean tests serially; narrow with TESTS=... and PYTEST_ARGS=....
-	$(UV_RUN) pytest -n 0 -m lean_runtime $(TESTS) $(PYTEST_ARGS)
+	$(UV_RUN) pytest -n 0 -m lean_runtime $(TESTS) $(PYTEST_DIAGNOSTIC_ARGS) $(PYTEST_ARGS)
 
 test-failed: ## Re-run failures from the previous pytest invocation.
-	$(UV_RUN) pytest $(PYTEST_XDIST_ARGS) --lf -m "not lean_runtime" $(PYTEST_ARGS)
+	$(UV_RUN) pytest $(PYTEST_XDIST_ARGS) --lf -m "not lean_runtime" $(PYTEST_DIAGNOSTIC_ARGS) $(PYTEST_ARGS)
 
 test-stress: ## Repeat contract, checker, and property tests (pytest-repeat --count=3).
 	$(UV_RUN) pytest -n 0 -m "not lean_runtime" --count=3 \
-		$(if $(TESTS),$(TESTS),tests/contract tests/checkers) $(PYTEST_ARGS)
+		$(if $(TESTS),$(TESTS),tests/contract tests/checkers) $(PYTEST_DIAGNOSTIC_ARGS) $(PYTEST_ARGS)
 
 test-ordering: ## Reproduce scheduled ordering (default seed 17; override with PYTEST_ARGS).
 	$(UV_RUN) pytest -n 0 -m "not lean_runtime" \
-		$(if $(findstring --randomly-seed,$(PYTEST_ARGS)),,$(ORDERING_DEFAULT_SEED)) $(PYTEST_ARGS)
+		$(if $(findstring --randomly-seed,$(PYTEST_ARGS)),,$(ORDERING_DEFAULT_SEED)) $(PYTEST_DIAGNOSTIC_ARGS) $(PYTEST_ARGS)
 
 duplicate-code: ## Run the CI duplicate-code detector locally.
 	npx --yes jscpd@5.0.12 --config .jscpd.json .

--- a/docs/reference/testing-strategy.md
+++ b/docs/reference/testing-strategy.md
@@ -73,6 +73,11 @@ make docs-linkcheck
 make clean
 ```
 
+The Makefile pytest targets emit the ten slowest tests by default so local
+commands provide actionable duration telemetry. Override this with
+`PYTEST_DIAGNOSTIC_ARGS=--durations=0`, or increase the count when profiling a
+slow lane.
+
 `make test-fast` collects only unit, contract, checker, and reference
 directories and excludes `slow` cases under a single process. Prefer the
 function-scoped `kernel` / `kernel_with_references` fixtures when attaching to

--- a/tests/end_to_end/test_reference_kernel.py
+++ b/tests/end_to_end/test_reference_kernel.py
@@ -4,7 +4,6 @@ import hashlib
 import json
 import subprocess
 import sys
-from pathlib import Path
 
 import pytest
 
@@ -21,8 +20,9 @@ def kernel(kernel_with_references: JacobianKernel) -> JacobianKernel:
     return kernel_with_references
 
 
-def test_graph_search_witness_and_independent_replay(tmp_path: Path) -> None:
-    kernel = JacobianKernel(tmp_path, install_references=True)
+def test_graph_search_witness_and_independent_replay(
+    kernel: JacobianKernel,
+) -> None:
     reference = kernel.references["graph_paths"]
     claim = kernel.artifacts.put(
         schema_uri=reference.claim_schema_uri,
@@ -106,7 +106,7 @@ def test_graph_search_witness_and_independent_replay(tmp_path: Path) -> None:
                 "witness_uri=sys.argv[4],checker_id=sys.argv[5]);"
                 "print(json.dumps(result.model_dump(mode='json'),sort_keys=True))"
             ),
-            str(tmp_path),
+            str(kernel.store.root),
             claim.artifact_uri,
             candidate.artifact_uri,
             found.witness_uri,

--- a/tests/integration/domains/test_frontier_capabilities.py
+++ b/tests/integration/domains/test_frontier_capabilities.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shutil
 from copy import deepcopy
 
 import pytest
@@ -12,11 +13,13 @@ from jacobian.kernel import JacobianKernel
 
 
 @pytest.fixture(scope="module")
-def kernel(tmp_path_factory: pytest.TempPathFactory) -> JacobianKernel:
-    return JacobianKernel(
-        tmp_path_factory.mktemp("frontier-capabilities"),
-        install_references=True,
-    )
+def kernel(
+    tmp_path_factory: pytest.TempPathFactory,
+    kernel_store_template_with_references,
+) -> JacobianKernel:
+    root = tmp_path_factory.mktemp("frontier-capabilities")
+    shutil.copytree(kernel_store_template_with_references, root, dirs_exist_ok=True)
+    return JacobianKernel(root, hydrate_authorized=True)
 
 
 def _q(value: int) -> dict[str, str]:

--- a/tests/integration/sat_smt/test_sat_lrat_verification.py
+++ b/tests/integration/sat_smt/test_sat_lrat_verification.py
@@ -113,7 +113,8 @@ def test_timeout_and_cancellation_are_fail_closed(kernel_with_references) -> Non
     assert cancelled.execution.status is ExecutionStatus.CANCELLED
 
 
-def test_capability_is_absent_without_operator_authorized_references(tmp_path) -> None:
-    kernel = JacobianKernel(tmp_path, install_references=False)
+def test_capability_is_absent_without_operator_authorized_references(
+    kernel: JacobianKernel,
+) -> None:
     ids = {item.capability_id for item in kernel.capabilities.catalog().capabilities}
     assert "sat.lrat.verify" not in ids

--- a/tests/unit/test_ci_plan.py
+++ b/tests/unit/test_ci_plan.py
@@ -47,6 +47,9 @@ def _expected_plan(classification: str, *enabled: str) -> dict[str, str]:
             ("README.md", "docs/how-to/contribute.md", ".github/CODEOWNERS"),
             _expected_plan("docs", "run-docs"),
         ),
+        (("AGENTS.md",), _expected_plan("docs", "run-docs")),
+        ((".pre-commit-config.yaml",), _expected_plan("selective", "run-static")),
+        ((".jscpd.json",), _expected_plan("selective", "run-duplicate")),
         (
             ("npm/package.json", "npm/npm-packaging.test.mjs"),
             _expected_plan("npm", "run-npm"),
@@ -195,11 +198,42 @@ def _expected_plan(classification: str, *enabled: str) -> dict[str, str]:
         ),
         (
             (".github/workflows/ci.yml",),
-            _expected_plan("full", *FUNCTIONAL_KEYS),
+            _expected_plan(
+                "selective",
+                "run-python",
+                "run-core",
+                "run-integration",
+                "run-static",
+                "run-build",
+            ),
+        ),
+        (
+            (".github/scripts/classify-ci-paths",),
+            _expected_plan(
+                "selective",
+                "run-python",
+                "run-core",
+                "run-integration",
+                "run-static",
+                "run-build",
+            ),
+        ),
+        (
+            ("Makefile",),
+            _expected_plan(
+                "selective",
+                "run-python",
+                "run-core",
+                "run-integration",
+                "run-lean",
+                "run-npm",
+                "run-static",
+                "run-build",
+            ),
         ),
         (
             ("CONTRIBUTING.md",),
-            _expected_plan("full", *FUNCTIONAL_KEYS, "run-docs"),
+            _expected_plan("docs", "run-docs"),
         ),
         (
             ("tests/helpers/capabilities.py",),


### PR DESCRIPTION
## Summary

This follow-up reduces developer feedback cost without sharing mutable kernel state or weakening verification-boundary coverage.

- Reuses immutable seeded kernel stores in the remaining high-cost integration fixtures while retaining per-test/module filesystem isolation.
- Adds local pytest duration telemetry to every Makefile test target.
- Moves integration timing-history retrieval out of the CI planning job, so the GitHub API lookup no longer delays unrelated CI lanes.
- Restricts CI impact ownership for automation and repository-policy files to the suites they can affect, with planner regression coverage.

The CI automation split remains deliberately fail-closed: workflow and helper-script changes still run core, integration, static, and build validation; Makefile changes retain the Lean/npm lanes because those targets are exposed there. Documentation, pre-commit, and duplicate-code policy changes no longer trigger unrelated product/runtime suites.

## Review order

1. `ac84162` — seeded kernel fixture reuse
2. `0adfc1c` — local duration telemetry and CI timing preparation
3. `586a295` — CI impact ownership and planner tests

## Performance evidence

Measured on the shared Linux 2-vCPU runner:

| Check | Before | After |
| --- | ---: | ---: |
| `make test-fast` | 111.50s, 612 passed | 90.55s, 617 passed |

The counts differ because the CI-plan regression cases are part of the final tree. The remaining slowest setup is intentionally the one-time kernel template construction; the changed integration cases now attach to seeded stores rather than rebuilding empty stores.

## Validation

- `make check` — passed; Ruff, formatting, mypy, and 142 unit tests
- `make test-fast PYTEST_ARGS='-q'` — 617 passed, 4 deselected in 90.55s
- Focused fixture integration tests — 23 passed
- `uv run --locked pytest -n 0 tests/unit/test_ci_plan.py -q` — 50 passed
- actionlint — passed
- `git diff --check` — passed

The full integration matrix remains delegated to CI; the affected end-to-end, SAT/LRAT, and frontier fixture tests were run locally.