### PR TITLE
feat(graph): independently verify diameter and radius

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -69,6 +69,7 @@ expectations.
 - [Graph counterexample shrinking](reference/graph-counterexample-shrinking.md)
 - [Fixed-registry graph invariant batches](reference/graph-invariant-batch.md)
 - [Maximum-matching certificate and verification](reference/graph-maximum-matching.md)
+- [Graph diameter and radius verification](reference/graph-metric-verification.md)
 - [Bounded finite exactly-once coverage](reference/finite-coverage-verification.md)
 - [Integer matrix Hermite normal form](reference/matrix-hermite-normal-form.md)
 - [Typed polynomial expression normalization](reference/polynomial-expression-normalization.md)

--- a/docs/reference/graph-metric-verification.md
+++ b/docs/reference/graph-metric-verification.md
@@ -1,0 +1,62 @@
+# Graph diameter and radius verification
+
+[Documentation home](../index.md)
+
+`graph.invariant.diameter.compute` and
+`graph.invariant.radius.compute` version `2` retain their existing producer
+contracts and `COMPUTED` assurance. Operator-authorized
+`graph.invariant.diameter.verify` and `graph.invariant.radius.verify`
+capabilities can promote one exact stored result to `VERIFIED` after
+independent all-sources breadth-first replay.
+
+## Exact claims and conventions
+
+Each verifier checks one stored producer result against the exact stored finite
+simple undirected graph:
+
+- for a nonempty connected graph, diameter is the maximum vertex eccentricity
+  and radius is the minimum vertex eccentricity;
+- a singleton graph has diameter and radius zero; and
+- an empty or disconnected graph has no numeric value under these contracts
+  and returns `status = NOT_APPLICABLE`, `connected = false`, and
+  `exactness = NOT_APPLICABLE`.
+
+The claim is bound to the input artifact, result artifact, graph semantics,
+result schema, checker identity, checker source digest, and provider runtime.
+The verifier does not certify a directly supplied graph, an unbounded graph
+family, or a theorem that later uses the metric.
+
+## Independent replay
+
+The producers use NetworkX. The checker is separately implemented with Python
+standard-library adjacency sets, queues, and integer distances. It imports
+neither NetworkX nor the producer package.
+
+For every source vertex, the checker runs breadth-first traversal, rejects a
+connected claim if any vertex is unreachable, and records the maximum finite
+distance as that source's eccentricity. It then independently takes the
+maximum for diameter or minimum for radius. The producer and checker share only
+passive artifact-envelope parsing.
+
+## Verification obligation ledger
+
+| Obligation | Independent replay | Failure meaning |
+| --- | --- | --- |
+| Artifact binding | Recompute and compare claim, semantics, candidate, lineage, witness-envelope, and payload digests. | Reject this evidence; no mathematical conclusion. |
+| Graph validity | Parse the complete graph and reject malformed vertices, loops, duplicate undirected edges, undeclared endpoints, and order above 32. | Reject malformed or unsupported evidence. |
+| Connectivity convention | Exhaust traversal from every source, with empty and disconnected graphs mapped only to the contract's inapplicable result. | Reject a mismatched status or numeric value. |
+| Exact metric | Recompute every eccentricity and its exact maximum or minimum. | Reject a forged diameter or radius. |
+| Result normalization | Require the exact result fields and consistent status, value, connectivity, exactness, and detail. | Reject noncanonical or internally inconsistent evidence. |
+| Authorization and runtime | Dispatch only the operator-authorized checker matching the schemas, semantics, format, source digest, and provider runtime. | Unavailable, timeout, cancellation, or error remains non-conclusive. |
+
+Acceptance reports exhaustive finite replay. A rejection means only that the
+submitted result was not verified; it never establishes another diameter,
+radius, or connectivity claim.
+
+## Compatibility
+
+The producer request and result schemas are unchanged. Existing version `2`
+artifacts remain valid candidates when their exact schemas and semantics are
+available locally. The catalog delta consists only of the two dedicated
+verification capability IDs and their operator-authorized checker
+registrations.

--- a/src/jacobian/domains/graph_optimization/checkers.py
+++ b/src/jacobian/domains/graph_optimization/checkers.py
@@ -54,6 +54,56 @@ GRAPH_OPTIMIZATION_EXACT_REPLAY_CHECKERS = (
         verification_tags=("verification", "exact", "graph", "induced-tree"),
     ),
     ExactReplayCheckerDeclaration(
+        "graph.invariant.diameter.compute",
+        GraphInvariantRequest,
+        "check_graph_diameter",
+        "graph.diameter.all-sources-bfs-v1",
+        entrypoint_module=_GRAPH_ENTRYPOINT,
+        replay_method="all-sources breadth-first replay",
+        reason=(
+            "operator-authorized standard-library BFS checker independent of "
+            "the NetworkX producer"
+        ),
+        verification_capability_id="graph.invariant.diameter.verify",
+        verification_title="Verify an exact graph diameter",
+        verification_description=(
+            "Independently replay all-source shortest paths to verify one stored "
+            "diameter result, including its disconnected-graph convention."
+        ),
+        verification_tags=(
+            "verification",
+            "exact",
+            "graph",
+            "diameter",
+            "breadth-first-search",
+        ),
+    ),
+    ExactReplayCheckerDeclaration(
+        "graph.invariant.radius.compute",
+        GraphInvariantRequest,
+        "check_graph_radius",
+        "graph.radius.all-sources-bfs-v1",
+        entrypoint_module=_GRAPH_ENTRYPOINT,
+        replay_method="all-sources breadth-first replay",
+        reason=(
+            "operator-authorized standard-library BFS checker independent of "
+            "the NetworkX producer"
+        ),
+        verification_capability_id="graph.invariant.radius.verify",
+        verification_title="Verify an exact graph radius",
+        verification_description=(
+            "Independently replay all-source shortest paths to verify one stored "
+            "radius result, including its disconnected-graph convention."
+        ),
+        verification_tags=(
+            "verification",
+            "exact",
+            "graph",
+            "radius",
+            "breadth-first-search",
+        ),
+    ),
+    ExactReplayCheckerDeclaration(
         "graph.invariant.maximum_matching.compute",
         GraphInvariantRequest,
         "check_graph_maximum_matching",

--- a/src/jacobian/domains/graph_optimization/invariants.py
+++ b/src/jacobian/domains/graph_optimization/invariants.py
@@ -562,7 +562,10 @@ EXACT_GRAPH_INVARIANT_CAPABILITIES = (
     _computed(
         "graph.invariant.diameter.compute",
         "Diameter",
-        "Compute the exact diameter, using -1 for a disconnected graph.",
+        (
+            "Compute the exact diameter of a nonempty connected graph; return "
+            "NOT_APPLICABLE without a numeric value otherwise."
+        ),
         GraphDiameterResult,
         _diameter,
         "diameter",

--- a/src/jacobian_checkers/graph_exact_operations.py
+++ b/src/jacobian_checkers/graph_exact_operations.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import deque
 from collections.abc import Callable
 from functools import cache
 from itertools import combinations, pairwise
@@ -50,6 +51,7 @@ def _run(
     witness_format: str,
     replay_method: str,
     replay: Callable[[dict[str, Any], dict[str, Any]], bool],
+    exhaustive: bool = False,
 ) -> dict[str, Any]:
     try:
         source, result = bound_request(
@@ -61,7 +63,8 @@ def _run(
             return _reject(
                 f"declared result does not match independent {replay_method}"
             )
-        return _accept(f"independent {replay_method} accepted {operation_id}")
+        detail = f"independent {replay_method} accepted {operation_id}"
+        return _accept_exhaustive(detail) if exhaustive else _accept(detail)
     except (KeyError, TypeError, ValueError, OverflowError):
         return _reject("malformed, unsupported, or mismatched checker request")
 
@@ -112,6 +115,107 @@ def _finite_simple_graph(
         adjacency[left].add(right)
         adjacency[right].add(left)
     return tuple(vertices), normalized_edges, adjacency
+
+
+def _all_sources_eccentricities(
+    vertices: tuple[str, ...],
+    adjacency: dict[str, set[str]],
+) -> tuple[int, ...] | None:
+    if not vertices:
+        return None
+    eccentricities: list[int] = []
+    for source in vertices:
+        distances = {source: 0}
+        frontier = deque([source])
+        while frontier:
+            current = frontier.popleft()
+            for neighbor in adjacency[current]:
+                if neighbor not in distances:
+                    distances[neighbor] = distances[current] + 1
+                    frontier.append(neighbor)
+        if len(distances) != len(vertices):
+            return None
+        eccentricities.append(max(distances.values()))
+    return tuple(eccentricities)
+
+
+def _graph_metric(
+    source: dict[str, Any],
+    result: dict[str, Any],
+    *,
+    field: str,
+    inapplicable_detail: str,
+    aggregate: Callable[[tuple[int, ...]], int],
+) -> bool:
+    vertices, _, adjacency = _finite_simple_graph(source, maximum_order=32)
+    if set(result) != {
+        "status",
+        field,
+        "connected",
+        "exactness",
+        "detail",
+    }:
+        return False
+    eccentricities = _all_sources_eccentricities(vertices, adjacency)
+    if eccentricities is None:
+        return (
+            result["status"] == "NOT_APPLICABLE"
+            and result[field] is None
+            and result["connected"] is False
+            and result["exactness"] == "NOT_APPLICABLE"
+            and result["detail"] == inapplicable_detail
+        )
+    claimed = result[field]
+    return (
+        result["status"] == "COMPUTED"
+        and type(claimed) is int
+        and claimed == aggregate(eccentricities)
+        and result["connected"] is True
+        and result["exactness"] == "EXACT"
+        and result["detail"] is None
+    )
+
+
+def _diameter(source: dict[str, Any], result: dict[str, Any]) -> bool:
+    return _graph_metric(
+        source,
+        result,
+        field="diameter",
+        inapplicable_detail="diameter requires a nonempty connected graph",
+        aggregate=max,
+    )
+
+
+def check_graph_diameter(request: dict[str, Any]) -> dict[str, Any]:
+    return _run(
+        request,
+        operation_id="graph.invariant.diameter.compute",
+        witness_format="graph.diameter.all-sources-bfs-v1",
+        replay=_diameter,
+        replay_method="all-sources breadth-first replay",
+        exhaustive=True,
+    )
+
+
+def _radius(source: dict[str, Any], result: dict[str, Any]) -> bool:
+    return _graph_metric(
+        source,
+        result,
+        field="radius",
+        inapplicable_detail="radius requires a nonempty connected graph",
+        aggregate=min,
+    )
+
+
+def check_graph_radius(request: dict[str, Any]) -> dict[str, Any]:
+    return _run(
+        request,
+        operation_id="graph.invariant.radius.compute",
+        witness_format="graph.radius.all-sources-bfs-v1",
+        replay=_radius,
+        replay_method="all-sources breadth-first replay",
+        exhaustive=True,
+    )
 
 
 def _induced_tree_maximum(
@@ -395,7 +499,9 @@ def check_graph_maximum_matching(request: dict[str, Any]) -> dict[str, Any]:
 
 
 __all__ = [
+    "check_graph_diameter",
     "check_graph_hamiltonian_path",
     "check_graph_induced_tree_maximum",
     "check_graph_maximum_matching",
+    "check_graph_radius",
 ]

--- a/tests/checkers/test_exact_domain_operation_checkers.py
+++ b/tests/checkers/test_exact_domain_operation_checkers.py
@@ -23,8 +23,10 @@ from jacobian_checkers.exact_domain_operations import (
     check_polynomial_square_free,
 )
 from jacobian_checkers.graph_exact_operations import (
+    check_graph_diameter,
     check_graph_induced_tree_maximum,
     check_graph_maximum_matching,
+    check_graph_radius,
 )
 
 
@@ -275,6 +277,48 @@ _CASES: tuple[
         ),
     ),
     (
+        check_graph_diameter,
+        _request(
+            "graph.invariant.diameter.compute",
+            "graph.diameter.all-sources-bfs-v1",
+            {
+                "graph": {
+                    "graph_schema_version": "1",
+                    "vertices": ["a", "b", "c", "d"],
+                    "edges": [["a", "b"], ["b", "c"], ["c", "d"]],
+                }
+            },
+            {
+                "status": "COMPUTED",
+                "diameter": 3,
+                "connected": True,
+                "exactness": "EXACT",
+                "detail": None,
+            },
+        ),
+    ),
+    (
+        check_graph_radius,
+        _request(
+            "graph.invariant.radius.compute",
+            "graph.radius.all-sources-bfs-v1",
+            {
+                "graph": {
+                    "graph_schema_version": "1",
+                    "vertices": ["a", "b", "c", "d"],
+                    "edges": [["a", "b"], ["b", "c"], ["c", "d"]],
+                }
+            },
+            {
+                "status": "COMPUTED",
+                "radius": 2,
+                "connected": True,
+                "exactness": "EXACT",
+                "detail": None,
+            },
+        ),
+    ),
+    (
         check_graph_induced_tree_maximum,
         _request(
             "graph.induced_tree.maximum.compute",
@@ -480,6 +524,186 @@ import jacobian_checkers.graph_exact_operations
     )
 
     assert completed.returncode == 0, completed.stderr
+
+
+@pytest.mark.parametrize(
+    ("checker", "operation_id", "witness_format", "result"),
+    (
+        (
+            check_graph_diameter,
+            "graph.invariant.diameter.compute",
+            "graph.diameter.all-sources-bfs-v1",
+            {
+                "status": "NOT_APPLICABLE",
+                "diameter": None,
+                "connected": False,
+                "exactness": "NOT_APPLICABLE",
+                "detail": "diameter requires a nonempty connected graph",
+            },
+        ),
+        (
+            check_graph_radius,
+            "graph.invariant.radius.compute",
+            "graph.radius.all-sources-bfs-v1",
+            {
+                "status": "NOT_APPLICABLE",
+                "radius": None,
+                "connected": False,
+                "exactness": "NOT_APPLICABLE",
+                "detail": "radius requires a nonempty connected graph",
+            },
+        ),
+    ),
+)
+@pytest.mark.parametrize(
+    "graph",
+    (
+        {
+            "graph_schema_version": "1",
+            "vertices": [],
+            "edges": [],
+        },
+        {
+            "graph_schema_version": "1",
+            "vertices": ["a", "b", "c"],
+            "edges": [["a", "b"]],
+        },
+    ),
+    ids=("empty", "disconnected"),
+)
+def test_graph_metric_checker_accepts_exact_inapplicable_boundary(
+    checker: Callable[[dict[str, Any]], dict[str, Any]],
+    operation_id: str,
+    witness_format: str,
+    result: dict[str, Any],
+    graph: dict[str, Any],
+) -> None:
+    checker_request = _request(
+        operation_id,
+        witness_format,
+        {"graph": graph},
+        result,
+    )
+
+    decision = checker(checker_request)
+
+    assert decision["accepted"] is True
+    assert decision["conclusion"] == "TRUE"
+
+
+@pytest.mark.parametrize(
+    ("checker", "operation_id", "witness_format", "field"),
+    (
+        (
+            check_graph_diameter,
+            "graph.invariant.diameter.compute",
+            "graph.diameter.all-sources-bfs-v1",
+            "diameter",
+        ),
+        (
+            check_graph_radius,
+            "graph.invariant.radius.compute",
+            "graph.radius.all-sources-bfs-v1",
+            "radius",
+        ),
+    ),
+)
+def test_graph_metric_checker_accepts_singleton_zero(
+    checker: Callable[[dict[str, Any]], dict[str, Any]],
+    operation_id: str,
+    witness_format: str,
+    field: str,
+) -> None:
+    checker_request = _request(
+        operation_id,
+        witness_format,
+        {
+            "graph": {
+                "graph_schema_version": "1",
+                "vertices": ["only"],
+                "edges": [],
+            }
+        },
+        {
+            "status": "COMPUTED",
+            field: 0,
+            "connected": True,
+            "exactness": "EXACT",
+            "detail": None,
+        },
+    )
+
+    assert checker(checker_request)["accepted"] is True
+
+
+@pytest.mark.parametrize(
+    ("checker", "operation_id", "witness_format", "field"),
+    (
+        (
+            check_graph_diameter,
+            "graph.invariant.diameter.compute",
+            "graph.diameter.all-sources-bfs-v1",
+            "diameter",
+        ),
+        (
+            check_graph_radius,
+            "graph.invariant.radius.compute",
+            "graph.radius.all-sources-bfs-v1",
+            "radius",
+        ),
+    ),
+)
+@pytest.mark.parametrize(
+    "mutation",
+    (
+        lambda result, field: result.update({field: 0}),
+        lambda result, field: result.update(status="NOT_APPLICABLE"),
+        lambda result, field: result.update(connected=False),
+        lambda result, field: result.update(exactness="NOT_APPLICABLE"),
+        lambda result, field: result.update(detail="forged"),
+    ),
+    ids=(
+        "wrong-value",
+        "wrong-status",
+        "wrong-connectivity",
+        "wrong-exactness",
+        "detail",
+    ),
+)
+def test_graph_metric_checker_rejects_forged_connected_result(
+    checker: Callable[[dict[str, Any]], dict[str, Any]],
+    operation_id: str,
+    witness_format: str,
+    field: str,
+    mutation: Callable[[dict[str, Any], str], object],
+) -> None:
+    checker_request = _request(
+        operation_id,
+        witness_format,
+        {
+            "graph": {
+                "graph_schema_version": "1",
+                "vertices": ["a", "b", "c", "d"],
+                "edges": [["a", "b"], ["b", "c"], ["c", "d"]],
+            }
+        },
+        {
+            "status": "COMPUTED",
+            field: 3 if field == "diameter" else 2,
+            "connected": True,
+            "exactness": "EXACT",
+            "detail": None,
+        },
+    )
+    mutation(checker_request["candidate"]["payload"], field)
+    checker_request["candidate"]["payload_digest"] = _digest(
+        checker_request["candidate"]["payload"]
+    )
+
+    decision = checker(checker_request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/domains/test_exact_domain_result_verification.py
+++ b/tests/integration/domains/test_exact_domain_result_verification.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pytest
 from tests.helpers.rationals import rational_payload as _q
 
 from jacobian.contracts.capabilities import (
@@ -309,6 +310,87 @@ def test_maximum_matching_result_uses_independent_tutte_berge_replay(
     rejected = kernel_with_references.capabilities.invoke(
         CapabilityRequest(
             capability_id="graph.invariant.maximum_matching.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"result_uri": false_result.artifact_uri},
+        )
+    )
+
+    assert rejected.execution.status is ExecutionStatus.COMPLETED
+    assert rejected.output["status"] == "REJECTED"
+    assert rejected.output["conclusion"] == "UNKNOWN"
+    assert rejected.output["verification_record_uri"] is None
+
+
+@pytest.mark.parametrize(
+    ("producer_id", "verifier_id", "result_field", "expected"),
+    (
+        (
+            "graph.invariant.diameter.compute",
+            "graph.invariant.diameter.verify",
+            "diameter",
+            3,
+        ),
+        (
+            "graph.invariant.radius.compute",
+            "graph.invariant.radius.verify",
+            "radius",
+            2,
+        ),
+    ),
+)
+def test_graph_metric_result_uses_independent_all_sources_bfs_replay(
+    kernel_with_references,
+    producer_id: str,
+    verifier_id: str,
+    result_field: str,
+    expected: int,
+) -> None:
+    computed = kernel_with_references.capabilities.invoke(
+        CapabilityRequest(
+            capability_id=producer_id,
+            input={
+                "graph": {
+                    "vertices": ["a", "b", "c", "d"],
+                    "edges": [["a", "b"], ["b", "c"], ["c", "d"]],
+                }
+            },
+        )
+    )
+
+    verified = kernel_with_references.capabilities.invoke(
+        CapabilityRequest(
+            capability_id=verifier_id,
+            mode=CapabilityMode.VERIFY,
+            input={"result_uri": computed.output["result_uri"]},
+        )
+    )
+
+    assert computed.output["result"][result_field] == expected
+    assert verified.execution.status is ExecutionStatus.COMPLETED
+    assert verified.output["status"] == "VERIFIED"
+    assert verified.output["operation_id"] == producer_id
+    assert verified.output["verification_record_uri"] is not None
+    assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED
+    assert verified.output["verification_record_uri"] in verified.artifact_uris
+    runtime = next(
+        descriptor.provider_runtime
+        for descriptor in kernel_with_references.capabilities.catalog().capabilities
+        if descriptor.capability_id == verifier_id
+    )
+    assert runtime is not None
+    assert runtime.provider == "jacobian.graph-exact-checkers"
+
+    result_artifact = kernel_with_references.store.get(computed.output["result_uri"])
+    false_result = kernel_with_references.artifacts.put(
+        schema_uri=result_artifact.manifest.schema_uri,
+        semantics_uri=result_artifact.manifest.semantics_uri,
+        parents=result_artifact.manifest.parents,
+        payload={**result_artifact.payload, result_field: 0},
+        summary=f"adversarial false {result_field} result",
+    )
+    rejected = kernel_with_references.capabilities.invoke(
+        CapabilityRequest(
+            capability_id=verifier_id,
             mode=CapabilityMode.VERIFY,
             input={"result_uri": false_result.artifact_uri},
         )

--- a/tests/unit/test_exact_domain_checker_installation.py
+++ b/tests/unit/test_exact_domain_checker_installation.py
@@ -65,6 +65,8 @@ def test_installer_authorizes_all_exact_domain_replays(tmp_path: Path) -> None:
     graph_ids = (
         "graph.hamiltonian_path.decide",
         "graph.induced_tree.maximum.compute",
+        "graph.invariant.diameter.compute",
+        "graph.invariant.radius.compute",
         "graph.invariant.maximum_matching.compute",
     )
     projective_ids = ("geometry.projective_line_arrangement.flats.materialize",)
@@ -99,7 +101,7 @@ def test_installer_authorizes_all_exact_domain_replays(tmp_path: Path) -> None:
         ),
         graph_invariants=_installed(
             (GraphInvariantRequest,),
-            (graph_ids[2],),
+            graph_ids[2:],
             character="8",
         ),
         projective_geometry=_installed(
@@ -232,7 +234,11 @@ def test_installer_skips_checkers_for_an_unavailable_graph_bundle(
     )
     graph_invariants = _installed(
         (GraphInvariantRequest,),
-        ("graph.invariant.maximum_matching.compute",),
+        (
+            "graph.invariant.diameter.compute",
+            "graph.invariant.radius.compute",
+            "graph.invariant.maximum_matching.compute",
+        ),
         character="8",
     )
 
@@ -248,7 +254,11 @@ def test_installer_skips_checkers_for_an_unavailable_graph_bundle(
         (
             "invariants-only",
             {"graph_invariants": graph_invariants},
-            {"graph.invariant.maximum_matching.compute"},
+            {
+                "graph.invariant.diameter.compute",
+                "graph.invariant.radius.compute",
+                "graph.invariant.maximum_matching.compute",
+            },
         ),
     ):
         registry_path = tmp_path / name / "checkers.sqlite3"


### PR DESCRIPTION
## Summary

- add dedicated `graph.invariant.diameter.verify` and `graph.invariant.radius.verify` capabilities
- independently replay all-source shortest paths with standard-library BFS, separate from the NetworkX producers
- bind graph, result, semantics, checker identity, and runtime through the existing exact-domain verification path
- preserve the existing producer request/result schemas and correct the stale disconnected-diameter descriptor text
- document exact claims, disconnected conventions, obligation ledger, and compatibility

## Trust boundary

The producer remains `COMPUTED`. Only the operator-authorized clean-process checker may return `VERIFIED`. Empty and disconnected graphs replay to the existing `NOT_APPLICABLE` result; malformed, substituted, forged, unavailable, timeout, or error outcomes remain non-conclusive.

The checker imports neither NetworkX nor Jacobian producer code. Its only shared component is passive bound-artifact envelope parsing.

## Compatibility

No shared envelope, MCP tool, artifact-store, provider-discovery, or producer schema changes. The installed reference catalog grows from 262 to 264 capabilities; the policy digest remains unchanged.

## Validation

- `make check` — 151 passed, 2 deselected; Ruff and mypy clean
- `make test-contracts` — 183 passed
- `make test-checkers` — 272 passed
- focused checker/installer/public-dispatch replay — 100 passed
- `make test-fast` — 652 passed, 4 deselected
- `make test-subprocess` — 46 passed
- `make check-static` — dependency/dead-code/type checks and wheel/sdist build passed
- `make docs-linkcheck` — passed
- clean-state `jacobian init` — 264 capabilities; public diameter compute → verify smoke returned `VERIFIED`

## Capability-development handoff

```yaml
stage: checker
status: complete
subject:
  candidate_id: graph-metric-exact-replay
  capability_ids:
    - graph.invariant.diameter.verify
    - graph.invariant.radius.verify
evidence_refs:
  - ref: docs/reference/graph-metric-verification.md
  - ref: tests/checkers/test_exact_domain_operation_checkers.py
  - ref: tests/integration/domains/test_exact_domain_result_verification.py
contract_ref: existing GraphInvariantRequest, GraphDiameterResult, and GraphRadiusResult version-2 producer contracts
runtime_snapshot:
  git_tree: 46a4bd0
  base_tree: 4bd31f4969697b7d6f04e496f96b355a7c89f1d6
  control_catalog: sha256:47d76fd595fe1204977a12bd38d8f8da50c6b5a60c005f48db3b6d637739d270
  treatment_catalog: sha256:dae6152e2982e289f4b6c57ba4902eaffdd021be696aca7368e72e7be3b6e709
  policy_digest: sha256:870a92b83d3e522e4015b6bb1cabda33086906f9de1c3c36e466251ea7ed1957
assurance: operator-authorized independent exhaustive finite BFS replay
open_obligations:
  - comparative model-in-the-loop evaluation remains a portfolio-value question, not a local verification obligation
decision: add two dedicated VERIFY capabilities without changing producer outcomes
next_action: merge after CI and review gates, then proceed to prime-factorization exact replay
```