### PR TITLE
feat(integer): independently verify prime factorizations

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -70,6 +70,7 @@ expectations.
 - [Fixed-registry graph invariant batches](reference/graph-invariant-batch.md)
 - [Maximum-matching certificate and verification](reference/graph-maximum-matching.md)
 - [Graph diameter and radius verification](reference/graph-metric-verification.md)
+- [Integer prime-factorization verification](reference/integer-prime-factorization-verification.md)
 - [Bounded finite exactly-once coverage](reference/finite-coverage-verification.md)
 - [Integer matrix Hermite normal form](reference/matrix-hermite-normal-form.md)
 - [Typed polynomial expression normalization](reference/polynomial-expression-normalization.md)

--- a/docs/reference/integer-prime-factorization-verification.md
+++ b/docs/reference/integer-prime-factorization-verification.md
@@ -1,0 +1,61 @@
+# Integer prime-factorization verification
+
+[Documentation home](../index.md)
+
+`integer.compute.prime_factorization` retains its existing request and result
+contracts and returns `COMPUTED` assurance. The operator-authorized
+`integer.prime_factorization.verify` capability independently replays one
+stored result with Python-FLINT and may promote that exact result to
+`VERIFIED`.
+
+## Exact claim and scope
+
+The verifier checks:
+
+> The stored ascending prime-power list is the complete prime factorization of
+> the absolute value of the exact stored nonzero integer.
+
+The producer accepts one canonical decimal integer string of at most 256
+characters and an explicit wall-clock budget. Zero remains not applicable.
+Both `1` and `-1` have an empty factor list, and negative integers use the
+factorization of their absolute value.
+
+The verification request supplies a stored result URI, not a caller-selected
+integer or executable checker. The verification record binds the input
+artifact, result artifact, number-theory semantics, schemas, witness format,
+checker identity, checker source digest, and Python-FLINT runtime.
+
+## Independent replay
+
+The producer runs SymPy `factorint` in an isolated bounded process. The checker
+uses the separately maintained Python-FLINT runtime and does not import the
+producer, its worker, or SymPy.
+
+Before backend replay, the checker requires canonical integer encoding, a
+valid stored producer budget, exact result fields, positive exponents, prime
+bases greater than one, strict ascending order, no duplicates, and equality
+between the declared prime-power product and the input absolute value. It then
+compares the complete list with Python-FLINT's independent factorization.
+
+## Verification obligation ledger
+
+| Obligation | Independent replay | Failure meaning |
+| --- | --- | --- |
+| Artifact binding | Recompute and compare claim, semantics, candidate, lineage, witness-envelope, and payload digests. | Reject this evidence; no mathematical conclusion. |
+| Input domain | Require one canonical nonzero integer and the exact bounded producer budget shape. | Reject malformed, zero, or unsupported evidence. |
+| Result normalization | Require exact fields, canonical positive bases, positive exponents, strict ascending order, and no duplicates. | Reject noncanonical evidence. |
+| Reconstruction | Multiply every declared prime power with bounded exact integer arithmetic and require the product to equal the input absolute value. | Reject an incomplete or incorrect factor list. |
+| Primality and completeness | Independently factor the absolute value with Python-FLINT and compare every base and exponent. | Reject a composite base, missing factor, wrong power, or extra factor. |
+| Sign and unit convention | Replay `±1` as the empty factorization and ignore only the input sign for other nonzero integers. | Reject a mismatched unit or sign convention. |
+| Authorization and runtime | Dispatch only the operator-authorized checker matching the schemas, semantics, format, source digest, and pinned Python-FLINT runtime. | Unavailable, timeout, cancellation, or error remains non-conclusive. |
+
+A rejected candidate returns `UNKNOWN`; it does not assert a different
+factorization or a mathematical claim about another integer.
+
+## Compatibility
+
+The producer capability version, request schema, result schema, backend, and
+artifact relationships are unchanged. The catalog delta is one dedicated
+verification capability plus its operator-authorized checker registration.
+Installations without the number-theory bundle simply omit this verifier while
+retaining unrelated exact-domain checkers.

--- a/src/jacobian/domains/number_theory/checkers.py
+++ b/src/jacobian/domains/number_theory/checkers.py
@@ -1,0 +1,37 @@
+"""Independent checker declarations owned by the number-theory domain."""
+
+from jacobian.checker_operations import ExactReplayCheckerDeclaration
+from jacobian.contracts.number_theory import FactorizationRequest
+
+_EXACT_DOMAIN_ENTRYPOINT = "jacobian_checkers.exact_domain_operations"
+
+NUMBER_THEORY_EXACT_REPLAY_CHECKERS = (
+    ExactReplayCheckerDeclaration(
+        "integer.compute.prime_factorization",
+        FactorizationRequest,
+        "check_integer_prime_factorization",
+        "integer.prime-factorization.flint-replay",
+        entrypoint_module=_EXACT_DOMAIN_ENTRYPOINT,
+        replay_method="Python-FLINT prime-factorization replay",
+        reason=(
+            "operator-authorized Python-FLINT checker independent of the "
+            "isolated SymPy factorization producer"
+        ),
+        verification_capability_id="integer.prime_factorization.verify",
+        verification_title="Verify an integer prime factorization",
+        verification_description=(
+            "Independently verify the complete canonical prime-power "
+            "factorization of one stored nonzero integer result."
+        ),
+        verification_tags=(
+            "verification",
+            "exact",
+            "integer",
+            "number-theory",
+            "prime-factorization",
+        ),
+    ),
+)
+
+
+__all__ = ["NUMBER_THEORY_EXACT_REPLAY_CHECKERS"]

--- a/src/jacobian/exact_domain_checkers.py
+++ b/src/jacobian/exact_domain_checkers.py
@@ -41,6 +41,9 @@ from jacobian.domains.graph_optimization.checkers import (
     GRAPH_OPTIMIZATION_EXACT_REPLAY_CHECKERS,
 )
 from jacobian.domains.matrix_lattice.checkers import MATRIX_EXACT_REPLAY_CHECKERS
+from jacobian.domains.number_theory.checkers import (
+    NUMBER_THEORY_EXACT_REPLAY_CHECKERS,
+)
 from jacobian.domains.polynomial.checkers import POLYNOMIAL_EXACT_REPLAY_CHECKERS
 from jacobian.domains.projective_geometry.checkers import (
     PROJECTIVE_GEOMETRY_EXACT_REPLAY_CHECKERS,
@@ -97,6 +100,7 @@ def install_exact_domain_checkers(
     matrix: InstalledDomainBundle,
     graph: InstalledDomainBundle | None = None,
     graph_invariants: InstalledDomainBundle | None = None,
+    number_theory: InstalledDomainBundle | None = None,
     projective_geometry: InstalledDomainBundle | None = None,
     authorize: bool,
 ) -> ExactDomainCheckerInstallation:
@@ -117,6 +121,11 @@ def install_exact_domain_checkers(
         *_available_graph_declaration_bundles(
             graph=graph,
             graph_invariants=graph_invariants,
+        ),
+        *(
+            (number_theory, item)
+            for item in NUMBER_THEORY_EXACT_REPLAY_CHECKERS
+            if number_theory is not None
         ),
         *(
             (projective_geometry, item)
@@ -185,6 +194,7 @@ def install_exact_domain_verification(
     matrix: InstalledDomainBundle,
     graph: InstalledDomainBundle | None = None,
     graph_invariants: InstalledDomainBundle | None = None,
+    number_theory: InstalledDomainBundle | None = None,
     projective_geometry: InstalledDomainBundle | None = None,
     authorize: bool,
 ) -> tuple[tuple[CapabilityAdapter, ...], ExactDomainCheckerInstallation]:
@@ -196,6 +206,7 @@ def install_exact_domain_verification(
         matrix=matrix,
         graph=graph,
         graph_invariants=graph_invariants,
+        number_theory=number_theory,
         projective_geometry=projective_geometry,
         authorize=authorize,
     )
@@ -240,6 +251,19 @@ def install_exact_domain_verification(
         )
         if installation.checker_ids.get(declaration.capability_id) is not None
     )
+    number_theory_declarations = (
+        tuple(
+            _installed_declaration(
+                number_theory,
+                declaration,
+                installation,
+            )
+            for declaration in NUMBER_THEORY_EXACT_REPLAY_CHECKERS
+            if installation.checker_ids.get(declaration.capability_id) is not None
+        )
+        if number_theory is not None
+        else ()
+    )
     projective_declarations = (
         tuple(
             _installed_declaration(
@@ -260,6 +284,7 @@ def install_exact_domain_verification(
             if declaration.declaration.verification_capability_id is not None
         ),
         *graph_declarations,
+        *number_theory_declarations,
         *projective_declarations,
     )
     dedicated_adapters: tuple[CapabilityAdapter, ...] = tuple(

--- a/src/jacobian/kernel.py
+++ b/src/jacobian/kernel.py
@@ -946,6 +946,7 @@ class JacobianKernel:
         matrix = self.domain_bundles.get("matrix")
         graph = self.domain_bundles.get("graph_optimization")
         graph_invariants = self.domain_bundles.get("graph_invariants")
+        number_theory = self.domain_bundles.get("number_theory")
         projective_geometry = self.domain_bundles.get("projective_geometry")
         if polynomial is None or matrix is None:
             return
@@ -959,6 +960,7 @@ class JacobianKernel:
             matrix=matrix,
             graph=graph,
             graph_invariants=graph_invariants,
+            number_theory=number_theory,
             projective_geometry=projective_geometry,
             authorize=authorize,
         )

--- a/src/jacobian_checkers/exact_domain_operations.py
+++ b/src/jacobian_checkers/exact_domain_operations.py
@@ -202,6 +202,61 @@ def _run(
         return _reject("malformed, unsupported, or mismatched checker request")
 
 
+def _prime_factorization(source: dict[str, Any], result: dict[str, Any]) -> bool:
+    if set(source) != {"value", "resource_budget"} or set(result) != {"factors"}:
+        return False
+    budget = source["resource_budget"]
+    if (
+        not isinstance(budget, dict)
+        or set(budget) != {"wall_seconds"}
+        or type(budget["wall_seconds"]) is not int
+        or not 1 <= budget["wall_seconds"] <= 30
+    ):
+        return False
+    value = _integer(source["value"])
+    if value == 0:
+        return False
+    factors = result["factors"]
+    if not isinstance(factors, list) or len(factors) > 256:
+        return False
+
+    target = abs(value)
+    product = 1
+    parsed: list[tuple[int, int]] = []
+    previous_prime = 1
+    for factor in factors:
+        if not isinstance(factor, dict) or set(factor) != {"prime", "power"}:
+            return False
+        prime = _integer(factor["prime"])
+        power = factor["power"]
+        if prime <= previous_prime or type(power) is not int or not 1 <= power <= 1_000:
+            return False
+        for _ in range(power):
+            if product > target // prime:
+                return False
+            product *= prime
+        parsed.append((prime, power))
+        previous_prime = prime
+    if product != target:
+        return False
+
+    replayed = [
+        (int(prime), int(power)) for prime, power in flint.fmpz(target).factor()
+    ]
+    return parsed == replayed
+
+
+def check_integer_prime_factorization(
+    request: dict[str, Any],
+) -> dict[str, Any]:
+    return _run(
+        request,
+        operation_id="integer.compute.prime_factorization",
+        witness_format="integer.prime-factorization.flint-replay",
+        replay=_prime_factorization,
+    )
+
+
 def _gcd(source: dict[str, Any], result: dict[str, Any]) -> bool:
     if set(source) != {"left", "right"} or set(result) != {
         "gcd",
@@ -510,6 +565,7 @@ def check_matrix_smith_normal_form(request: dict[str, Any]) -> dict[str, Any]:
 
 
 __all__ = [
+    "check_integer_prime_factorization",
     "check_matrix_characteristic_polynomial",
     "check_matrix_nullspace",
     "check_matrix_rref",

--- a/tests/checkers/test_exact_domain_operation_checkers.py
+++ b/tests/checkers/test_exact_domain_operation_checkers.py
@@ -13,6 +13,7 @@ from tests.helpers.rationals import rational_payload as _q
 
 import jacobian_checkers.exact_domain_operations as checker_module
 from jacobian_checkers.exact_domain_operations import (
+    check_integer_prime_factorization,
     check_matrix_characteristic_polynomial,
     check_matrix_nullspace,
     check_matrix_rref,
@@ -277,6 +278,24 @@ _CASES: tuple[
         ),
     ),
     (
+        check_integer_prime_factorization,
+        _request(
+            "integer.compute.prime_factorization",
+            "integer.prime-factorization.flint-replay",
+            {
+                "value": "-360",
+                "resource_budget": {"wall_seconds": 5},
+            },
+            {
+                "factors": [
+                    {"prime": "2", "power": 3},
+                    {"prime": "3", "power": 2},
+                    {"prime": "5", "power": 1},
+                ]
+            },
+        ),
+    ),
+    (
         check_graph_diameter,
         _request(
             "graph.invariant.diameter.compute",
@@ -524,6 +543,98 @@ import jacobian_checkers.graph_exact_operations
     )
 
     assert completed.returncode == 0, completed.stderr
+
+
+@pytest.mark.parametrize(
+    ("value", "factors"),
+    (
+        ("1", []),
+        ("-1", []),
+        ("2", [{"prime": "2", "power": 1}]),
+        (
+            "-360",
+            [
+                {"prime": "2", "power": 3},
+                {"prime": "3", "power": 2},
+                {"prime": "5", "power": 1},
+            ],
+        ),
+    ),
+)
+def test_prime_factorization_checker_accepts_exact_boundaries(
+    value: str,
+    factors: list[dict[str, object]],
+) -> None:
+    checker_request = _request(
+        "integer.compute.prime_factorization",
+        "integer.prime-factorization.flint-replay",
+        {"value": value, "resource_budget": {"wall_seconds": 5}},
+        {"factors": factors},
+    )
+
+    decision = check_integer_prime_factorization(checker_request)
+
+    assert decision["accepted"] is True
+    assert decision["conclusion"] == "TRUE"
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    (
+        lambda factors: factors.__setitem__(
+            slice(None),
+            [{"prime": "6", "power": 1}, {"prime": "60", "power": 1}],
+        ),
+        lambda factors: factors.pop(),
+        lambda factors: factors.append({"prime": "5", "power": 1}),
+        lambda factors: factors[0].update(power=2),
+        lambda factors: factors.reverse(),
+        lambda factors: factors[0].update(prime="-2"),
+    ),
+    ids=(
+        "composite-bases",
+        "missing-factor",
+        "duplicate-base",
+        "wrong-power",
+        "noncanonical-order",
+        "negative-base",
+    ),
+)
+def test_prime_factorization_checker_rejects_false_or_noncanonical_factors(
+    mutate: Callable[[list[dict[str, object]]], object],
+) -> None:
+    checker_request = _request(
+        "integer.compute.prime_factorization",
+        "integer.prime-factorization.flint-replay",
+        {"value": "360", "resource_budget": {"wall_seconds": 5}},
+        {
+            "factors": [
+                {"prime": "2", "power": 3},
+                {"prime": "3", "power": 2},
+                {"prime": "5", "power": 1},
+            ]
+        },
+    )
+    mutate(checker_request["candidate"]["payload"]["factors"])
+    checker_request["candidate"]["payload_digest"] = _digest(
+        checker_request["candidate"]["payload"]
+    )
+
+    decision = check_integer_prime_factorization(checker_request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+def test_prime_factorization_checker_rejects_zero_source() -> None:
+    checker_request = _request(
+        "integer.compute.prime_factorization",
+        "integer.prime-factorization.flint-replay",
+        {"value": "0", "resource_budget": {"wall_seconds": 5}},
+        {"factors": []},
+    )
+
+    assert check_integer_prime_factorization(checker_request)["accepted"] is False
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/domains/test_exact_domain_result_verification.py
+++ b/tests/integration/domains/test_exact_domain_result_verification.py
@@ -402,6 +402,78 @@ def test_graph_metric_result_uses_independent_all_sources_bfs_replay(
     assert rejected.output["verification_record_uri"] is None
 
 
+@pytest.mark.parametrize("value", ("360", "-360", "1", "-1", "101"))
+def test_prime_factorization_result_uses_independent_python_flint_replay(
+    kernel_with_references,
+    value: str,
+) -> None:
+    producer_id = "integer.compute.prime_factorization"
+    verifier_id = "integer.prime_factorization.verify"
+    computed = kernel_with_references.capabilities.invoke(
+        CapabilityRequest(
+            capability_id=producer_id,
+            input={"value": value},
+        )
+    )
+
+    verified = kernel_with_references.capabilities.invoke(
+        CapabilityRequest(
+            capability_id=verifier_id,
+            mode=CapabilityMode.VERIFY,
+            input={"result_uri": computed.output["result_uri"]},
+        )
+    )
+
+    assert verified.execution.status is ExecutionStatus.COMPLETED
+    assert verified.output["status"] == "VERIFIED"
+    assert verified.output["operation_id"] == producer_id
+    assert verified.output["verification_record_uri"] is not None
+    assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED
+    assert verified.output["verification_record_uri"] in verified.artifact_uris
+    runtime = next(
+        descriptor.provider_runtime
+        for descriptor in kernel_with_references.capabilities.catalog().capabilities
+        if descriptor.capability_id == verifier_id
+    )
+    assert runtime is not None
+    assert runtime.provider == "jacobian.exact-domain-checkers"
+    assert {
+        component["provider"] for component in runtime.configuration["components"]
+    } == {"jacobian.exact-domain-checker-source", "python-flint"}
+
+
+def test_prime_factorization_verifier_rejects_incomplete_factor_list(
+    kernel_with_references,
+) -> None:
+    computed = kernel_with_references.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="integer.compute.prime_factorization",
+            input={"value": "360"},
+        )
+    )
+    result_artifact = kernel_with_references.store.get(computed.output["result_uri"])
+    false_result = kernel_with_references.artifacts.put(
+        schema_uri=result_artifact.manifest.schema_uri,
+        semantics_uri=result_artifact.manifest.semantics_uri,
+        parents=result_artifact.manifest.parents,
+        payload={"factors": result_artifact.payload["factors"][:-1]},
+        summary="adversarial incomplete prime factorization result",
+    )
+
+    rejected = kernel_with_references.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="integer.prime_factorization.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"result_uri": false_result.artifact_uri},
+        )
+    )
+
+    assert rejected.execution.status is ExecutionStatus.COMPLETED
+    assert rejected.output["status"] == "REJECTED"
+    assert rejected.output["conclusion"] == "UNKNOWN"
+    assert rejected.output["verification_record_uri"] is None
+
+
 def test_operator_can_leave_exact_result_verification_unavailable(
     kernel,
 ) -> None:

--- a/tests/unit/test_exact_domain_checker_installation.py
+++ b/tests/unit/test_exact_domain_checker_installation.py
@@ -15,6 +15,7 @@ from jacobian.contracts.matrix_operations import (
     RationalMatrixRequest,
     SquareRationalMatrixRequest,
 )
+from jacobian.contracts.number_theory import FactorizationRequest
 from jacobian.contracts.polynomial_operations import (
     PolynomialDiscriminantRequest,
     PolynomialGcdRequest,
@@ -69,6 +70,7 @@ def test_installer_authorizes_all_exact_domain_replays(tmp_path: Path) -> None:
         "graph.invariant.radius.compute",
         "graph.invariant.maximum_matching.compute",
     )
+    number_theory_ids = ("integer.compute.prime_factorization",)
     projective_ids = ("geometry.projective_line_arrangement.flats.materialize",)
     registry = CheckerRegistry(tmp_path / "checkers.sqlite3")
 
@@ -104,6 +106,11 @@ def test_installer_authorizes_all_exact_domain_replays(tmp_path: Path) -> None:
             graph_ids[2:],
             character="8",
         ),
+        number_theory=_installed(
+            (FactorizationRequest,),
+            number_theory_ids,
+            character="6",
+        ),
         projective_geometry=_installed(
             (ProjectiveLineArrangementRequest,),
             projective_ids,
@@ -113,7 +120,7 @@ def test_installer_authorizes_all_exact_domain_replays(tmp_path: Path) -> None:
     )
 
     assert set(installation.checker_ids) == set(
-        polynomial_ids + matrix_ids + graph_ids + projective_ids
+        polynomial_ids + matrix_ids + graph_ids + number_theory_ids + projective_ids
     )
     assert all(installation.checker_ids.values())
     for capability_id, checker_id in installation.checker_ids.items():


### PR DESCRIPTION
## Summary

- add `integer.prime_factorization.verify` for stored `integer.compute.prime_factorization` results
- independently replay canonical prime-power lists with Python-FLINT, separate from the isolated SymPy producer
- explicitly connect the optional number-theory bundle to the existing exact-domain checker installer
- verify input domain, `±1`, sign convention, canonical ordering, product reconstruction, primality, and completeness
- document the claim, obligation ledger, trust boundary, and compatibility

## Trust boundary

The producer remains `COMPUTED`. Only the operator-authorized Python-FLINT checker may return `VERIFIED`; the checker imports neither SymPy nor the producer worker. Composite bases, missing/extra factors, wrong powers, duplicate/reordered factors, zero input, substitutions, runtime failure, timeout, and malformed evidence remain `UNKNOWN`.

## Compatibility

No producer request/result schema, shared envelope, MCP surface, artifact store, or trust-policy changes. `number_theory` is an optional explicit installer input; installations that omit it retain all unrelated exact-domain checkers. The reference catalog grows from 264 to 265 capabilities and the policy digest is unchanged.

## Validation

- `make check` — 151 passed, 2 deselected; Ruff and mypy clean
- `make test-contracts` — 183 passed
- `make test-checkers` — 288 passed
- focused installer/public replay — 17 passed
- `make test-fast` — 668 passed, 4 deselected
- `make test-subprocess` — 46 passed
- `make check-static` — dependency/dead-code/type checks and wheel/sdist build passed
- `make docs-linkcheck` — passed
- clean-state init — 265 capabilities; `-360` compute → verify returned `VERIFIED`

## Capability-development handoff

```yaml
stage: checker
status: complete
subject:
  candidate_id: integer-prime-factorization-exact-replay
  capability_ids:
    - integer.prime_factorization.verify
evidence_refs:
  - ref: docs/reference/integer-prime-factorization-verification.md
  - ref: tests/checkers/test_exact_domain_operation_checkers.py
  - ref: tests/integration/domains/test_exact_domain_result_verification.py
contract_ref: existing FactorizationRequest and PrimeFactorizationResult producer contracts
runtime_snapshot:
  git_tree: 4d90c257bbc22638c97e6044446ea6780131ccdf
  base_tree: 2826ea2e3ec4665eb93eb3b96e060015013860f8
  control_catalog: sha256:dae6152e2982e289f4b6c57ba4902eaffdd021be696aca7368e72e7be3b6e709
  treatment_catalog: sha256:1a74b9eb133c020e463f385887ac457fb90a35f95f41c818a99db20ed23c42c9
  policy_digest: sha256:870a92b83d3e522e4015b6bb1cabda33086906f9de1c3c36e466251ea7ed1957
assurance: operator-authorized independent Python-FLINT factorization replay
open_obligations:
  - comparative model-in-the-loop evaluation remains a portfolio-value question
  - powerful-number verification will consume this infrastructure in a later focused PR
decision: add one dedicated VERIFY capability without changing the producer outcome
next_action: merge after CI, then implement number_theory.powerful.decide
```