### PR TITLE
feat(number-theory): decide powerful numbers

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -71,6 +71,7 @@ expectations.
 - [Maximum-matching certificate and verification](reference/graph-maximum-matching.md)
 - [Graph diameter and radius verification](reference/graph-metric-verification.md)
 - [Integer prime-factorization verification](reference/integer-prime-factorization-verification.md)
+- [Powerful-number decision](reference/integer-powerful-number-decision.md)
 - [Bounded finite exactly-once coverage](reference/finite-coverage-verification.md)
 - [Integer matrix Hermite normal form](reference/matrix-hermite-normal-form.md)
 - [Typed polynomial expression normalization](reference/polynomial-expression-normalization.md)

--- a/docs/reference/integer-powerful-number-decision.md
+++ b/docs/reference/integer-powerful-number-decision.md
@@ -1,0 +1,71 @@
+# Powerful-number decision
+
+[Documentation home](../index.md)
+
+`integer.decide.powerful` decides whether one positive integer is powerful and
+preserves the complete prime factorization used for the decision. The
+capability is an atomic predicate, not a range search or a proof of a statement
+about consecutive powerful numbers.
+
+## Contract and semantics
+
+The request contains:
+
+- `value`: one canonical positive decimal integer string of at most 256
+  characters; and
+- `resource_budget.wall_seconds`: an integer from 1 through 30, defaulting to
+  5 seconds.
+
+The result contains:
+
+- `semantics_version`:
+  `powerful-number.prime-exponents-at-least-two.v1`;
+- `is_powerful`: whether every prime in the complete factorization has
+  exponent at least two;
+- `factors`: the canonical ascending prime-power factorization; and
+- `violating_primes`: exactly the ascending factor bases whose exponent is
+  less than two.
+
+The value `1` is powerful: its factorization and violating-prime list are both
+empty. Zero and negative inputs fail full request validation before any
+operation artifacts are written.
+
+The result schema binds the boolean to the witness: factor bases must be
+strictly increasing and greater than one, `violating_primes` must exactly
+match the factors with exponent below two, and `is_powerful` must be true
+exactly when that list is empty.
+
+## Execution and assurance
+
+The capability extends the explicit number-theory factorization bundle and
+runs SymPy `factorint` inside the existing isolated, resource-bounded worker.
+A timeout, resource exhaustion, malformed worker response, cancellation, or
+worker error is a non-conclusion and never becomes `false`.
+
+Successful execution has `COMPLETE` completeness for the single input and
+`COMPUTED` assurance. The producer does not verify itself. An independent
+replay checker remains a separate implementation and authorization obligation.
+
+## Public reproduction and limits
+
+The public challenge `jcb-postdoc-016` asks about a bounded statement through
+`10^14` and an unbounded conjecture concerning three consecutive powerful
+numbers. Invoke this capability separately on `8`, `9`, and `10` to obtain
+inspectable single-value evidence:
+
+- `8 = 2^3` is powerful;
+- `9 = 3^2` is powerful; and
+- `10 = 2 × 5` is not powerful, with violating primes `2` and `5`.
+
+Those three completed decisions establish only those three cases. Repeating
+the capability over any finite caller-chosen sample does not certify exhaustive
+coverage of a range, replay the external `10^14` artifact, or prove the global
+conjecture. Those claims require separately scoped enumeration or formal
+certificate evidence.
+
+## Compatibility
+
+The capability adds one request subtype, one result model, and one operation to
+the existing number-theory bundle. Existing factorization request/result
+contracts, worker operations, capability IDs, provider runtime, and kernel
+installation paths are unchanged.

--- a/src/jacobian/contracts/number_theory.py
+++ b/src/jacobian/contracts/number_theory.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from typing import Annotated, Literal, Self
 
-from pydantic import Field, StrictInt, StringConstraints, model_validator
+from pydantic import Field, StrictBool, StrictInt, StringConstraints, model_validator
 
 from jacobian.contracts.results import ContractModel
 
@@ -65,6 +65,16 @@ class FactorizationRequest(ContractModel):
     resource_budget: FactorizationResourceBudget = Field(
         default_factory=FactorizationResourceBudget
     )
+
+
+class PowerfulNumberRequest(FactorizationRequest):
+    """One positive integer for an exact powerful-number decision."""
+
+    @model_validator(mode="after")
+    def require_positive_value(self) -> Self:
+        if int(self.value) < 1:
+            raise ValueError("powerful-number input must be positive")
+        return self
 
 
 class ArithmeticFunctionRequest(ContractModel):
@@ -297,6 +307,39 @@ class PrimeFactorizationResult(ContractModel):
         primes = [factor.prime for factor in self.factors]
         if len(set(primes)) != len(primes):
             raise ValueError("prime factors must be unique")
+        return self
+
+
+class PowerfulNumberResult(ContractModel):
+    """A powerful-number decision with its complete factor witness."""
+
+    semantics_version: Literal["powerful-number.prime-exponents-at-least-two.v1"]
+    is_powerful: StrictBool
+    factors: tuple[PrimePower, ...] = Field(
+        min_length=0,
+        max_length=_MAX_FACTOR_ENTRIES,
+    )
+    violating_primes: tuple[BoundedInteger, ...] = Field(
+        min_length=0,
+        max_length=_MAX_FACTOR_ENTRIES,
+    )
+
+    @model_validator(mode="after")
+    def bind_decision_to_canonical_factor_witness(self) -> Self:
+        primes = [int(factor.prime) for factor in self.factors]
+        if any(prime < 2 for prime in primes):
+            raise ValueError("factor bases must be greater than one")
+        if primes != sorted(set(primes)):
+            raise ValueError("factor bases must be strictly increasing")
+        expected_violations = tuple(
+            factor.prime for factor in self.factors if factor.power < 2
+        )
+        if self.violating_primes != expected_violations:
+            raise ValueError(
+                "violating primes must be exactly the factors with exponent below two"
+            )
+        if self.is_powerful != (not expected_violations):
+            raise ValueError("powerful decision does not match the factor exponents")
         return self
 
 

--- a/src/jacobian/domains/number_theory/factorization.py
+++ b/src/jacobian/domains/number_theory/factorization.py
@@ -19,6 +19,8 @@ from jacobian.contracts.number_theory import (
     DivisorListResult,
     FactorizationRequest,
     IntegerValueResult,
+    PowerfulNumberRequest,
+    PowerfulNumberResult,
     PrimeFactorizationResult,
 )
 from jacobian.contracts.results import ContractModel, ExecutionStatus
@@ -233,6 +235,26 @@ FACTORIZATION_CAPABILITIES = (
                 "prime_factorization_360",
                 "Factor 360 into prime powers.",
                 {"value": "360"},
+            ),
+        ),
+    ),
+    _operation(
+        capability_id="integer.decide.powerful",
+        title="Decide powerful-number status",
+        description=(
+            "Decide whether every prime exponent of one positive integer is at "
+            "least two, preserving the complete factor witness and every "
+            "violating prime from an isolated, resource-bounded SymPy worker."
+        ),
+        operation="powerful",
+        request_model=PowerfulNumberRequest,
+        result_model=PowerfulNumberResult,
+        tags=("number-theory", "factorization", "predicate"),
+        invocation_examples=(
+            example(
+                "powerful_72",
+                "Decide whether 72 is powerful and inspect its factor witness.",
+                {"value": "72"},
             ),
         ),
     ),

--- a/src/jacobian/domains/number_theory/factorization_worker.py
+++ b/src/jacobian/domains/number_theory/factorization_worker.py
@@ -11,10 +11,12 @@ from jacobian.canonical import canonicalize_json, loads_strict_json
 from jacobian.contracts.number_theory import (
     ArithmeticFunctionRequest,
     FactorizationRequest,
+    PowerfulNumberRequest,
 )
 from jacobian.contracts.results import ContractModel
 from jacobian.domains.number_theory.operations import (
     compute_radical,
+    decide_powerful,
     decide_squarefree,
     enumerate_divisors,
     enumerate_proper_divisors,
@@ -30,6 +32,7 @@ _OPERATIONS: dict[
     "divisors": (FactorizationRequest, enumerate_divisors),
     "proper_divisors": (FactorizationRequest, enumerate_proper_divisors),
     "prime_factorization": (FactorizationRequest, factorize_primes),
+    "powerful": (PowerfulNumberRequest, decide_powerful),
     "squarefree": (ArithmeticFunctionRequest, decide_squarefree),
     "radical": (ArithmeticFunctionRequest, compute_radical),
 }

--- a/src/jacobian/domains/number_theory/operations.py
+++ b/src/jacobian/domains/number_theory/operations.py
@@ -41,6 +41,8 @@ from jacobian.contracts.number_theory import (
     ModulusRequest,
     NonnegativeIntegerRequest,
     PositiveIntegerRequest,
+    PowerfulNumberRequest,
+    PowerfulNumberResult,
     PrimeFactorizationResult,
     PrimePower,
     QuadraticResiduesResult,
@@ -123,6 +125,26 @@ def factorize_primes(request: ContractModel) -> ContractModel:
         for prime, power in sorted(factorint(abs(value)).items())
     )
     return PrimeFactorizationResult(factors=factors)
+
+
+def decide_powerful(request: ContractModel) -> ContractModel:
+    """Decide whether every prime exponent is at least two."""
+    from sympy import factorint
+
+    value = int(cast(PowerfulNumberRequest, request).value)
+    factor_items = sorted(factorint(value).items())
+    factors = tuple(
+        PrimePower(prime=str(prime), power=int(power)) for prime, power in factor_items
+    )
+    violating_primes = tuple(
+        str(prime) for prime, power in factor_items if int(power) < 2
+    )
+    return PowerfulNumberResult(
+        semantics_version="powerful-number.prime-exponents-at-least-two.v1",
+        is_powerful=not violating_primes,
+        factors=factors,
+        violating_primes=violating_primes,
+    )
 
 
 def compute_valuation(request: ContractModel) -> ContractModel:

--- a/tests/integration/domains/test_domain_bundles.py
+++ b/tests/integration/domains/test_domain_bundles.py
@@ -45,6 +45,7 @@ from jacobian.contracts.number_theory import (
     ModularValueRequest,
     ModulusRequest,
     PositiveIntegerRequest,
+    PowerfulNumberRequest,
     ValuationRequest,
 )
 from jacobian.contracts.number_theory import (
@@ -133,6 +134,7 @@ EXPECTED_IDS: frozenset[str] = frozenset(
         "integer.decide.odd",
         "integer.decide.perfect",
         "integer.decide.prime",
+        "integer.decide.powerful",
         "integer.decide.square",
         "integer.decide.squarefree",
         "integer.transform.base_digits",
@@ -217,6 +219,10 @@ _REPR: list[tuple[type[ContractModel], dict[str, object]]] = [
     (
         FactorizationRequest,
         {"value": "12", "resource_budget": {"wall_seconds": 5}},
+    ),
+    (
+        PowerfulNumberRequest,
+        {"value": "72", "resource_budget": {"wall_seconds": 5}},
     ),
     (
         ArithmeticFunctionRequest,

--- a/tests/integration/domains/test_number_theory_combinatorics_migration.py
+++ b/tests/integration/domains/test_number_theory_combinatorics_migration.py
@@ -20,6 +20,7 @@ from jacobian.contracts.number_theory import (
     ModularValueRequest,
     NonnegativeIntegerRequest,
     PositiveIntegerRequest,
+    PowerfulNumberResult,
 )
 from jacobian.contracts.results import ExecutionStatus
 from jacobian.domains.combinatorics import COMBINATORICS_BUNDLE
@@ -267,6 +268,111 @@ def test_factorization_is_complete_in_an_isolated_bounded_worker(
 
 
 @pytest.mark.parametrize(
+    ("value", "is_powerful", "factors", "violating_primes"),
+    (
+        ("1", True, [], []),
+        ("72", True, [{"prime": "2", "power": 3}, {"prime": "3", "power": 2}], []),
+        (
+            "12",
+            False,
+            [{"prime": "2", "power": 2}, {"prime": "3", "power": 1}],
+            ["3"],
+        ),
+        (
+            "30",
+            False,
+            [
+                {"prime": "2", "power": 1},
+                {"prime": "3", "power": 1},
+                {"prime": "5", "power": 1},
+            ],
+            ["2", "3", "5"],
+        ),
+    ),
+)
+def test_powerful_number_decision_preserves_a_complete_factor_witness(
+    tmp_path: Path,
+    value: str,
+    is_powerful: bool,
+    factors: list[dict[str, object]],
+    violating_primes: list[str],
+) -> None:
+    service = _service(tmp_path)
+    result = service.invoke(
+        CapabilityRequest(
+            capability_id="integer.decide.powerful",
+            input={
+                "value": value,
+                "resource_budget": {"wall_seconds": 10},
+            },
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output["result"] == {
+        "semantics_version": "powerful-number.prime-exponents-at-least-two.v1",
+        "is_powerful": is_powerful,
+        "factors": factors,
+        "violating_primes": violating_primes,
+    }
+    assert result.completeness.status is CapabilityCompletenessStatus.COMPLETE
+    assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    input_uri, result_uri = result.artifact_uris
+    assert service.store.get(result_uri).manifest.parents == (input_uri,)
+    assert result.relationships[0].source_artifact_uris == (input_uri,)
+    assert result.relationships[0].target_artifact_uris == (result_uri,)
+
+
+@pytest.mark.parametrize("value", ["0", "-1", "-72"])
+def test_powerful_number_rejects_nonpositive_input_before_artifact_writes(
+    tmp_path: Path,
+    value: str,
+) -> None:
+    result = _service(tmp_path).invoke(
+        CapabilityRequest(
+            capability_id="integer.decide.powerful",
+            input={"value": value},
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.artifact_uris == ()
+
+
+@pytest.mark.parametrize(
+    "payload",
+    (
+        {
+            "semantics_version": "powerful-number.prime-exponents-at-least-two.v1",
+            "is_powerful": False,
+            "factors": [{"prime": "2", "power": 3}],
+            "violating_primes": [],
+        },
+        {
+            "semantics_version": "powerful-number.prime-exponents-at-least-two.v1",
+            "is_powerful": True,
+            "factors": [{"prime": "2", "power": 1}],
+            "violating_primes": ["2"],
+        },
+        {
+            "semantics_version": "powerful-number.prime-exponents-at-least-two.v1",
+            "is_powerful": False,
+            "factors": [
+                {"prime": "3", "power": 1},
+                {"prime": "2", "power": 2},
+            ],
+            "violating_primes": ["3"],
+        },
+    ),
+)
+def test_powerful_number_result_rejects_inconsistent_or_noncanonical_witnesses(
+    payload: dict[str, object],
+) -> None:
+    with pytest.raises(ValidationError):
+        PowerfulNumberResult.model_validate(payload)
+
+
+@pytest.mark.parametrize(
     ("capability_id", "expected"),
     (
         ("integer.decide.squarefree", {"holds": True}),
@@ -340,6 +446,10 @@ def test_factorization_timeout_is_an_artifact_free_non_conclusion(
         (
             "integer.compute.radical",
             {"n": 30, "resource_budget": {"wall_seconds": 1}},
+        ),
+        (
+            "integer.decide.powerful",
+            {"value": "72", "resource_budget": {"wall_seconds": 1}},
         ),
     ),
 )


### PR DESCRIPTION
## Summary

- add the atomic `integer.decide.powerful` outcome to the existing explicit number-theory factorization bundle
- validate one bounded canonical positive decimal before computation or artifact writes
- preserve a required semantics version, canonical complete prime-factor witness, exact violating primes, and a decision bound to that witness
- retain isolated resource-bounded SymPy execution and `COMPUTED` assurance
- document the `jcb-postdoc-016` single-value reproduction and its strict range/global-conjecture limits

The accepted plan used the provisional name `number_theory.powerful.decide`; this implementation normalizes it to `integer.decide.powerful` to match every nearby integer predicate (`integer.decide.squarefree`, `integer.decide.prime`, and others) without creating a one-off ID family.

## Semantics and failure behavior

A positive integer is powerful exactly when every prime exponent in its complete factorization is at least two. `1` is powerful with empty factors and violations. The producer reports all exponent-one factor bases as `violating_primes`. It answers one input only and makes no range-completeness claim.

Zero, negative values, noncanonical decimals, and invalid budgets fail full Pydantic validation before artifact writes. Timeout, resource exhaustion, worker/protocol error, and cancellation remain non-conclusions; they never become `false`.

## Validation

- `make check` — 151 passed, Ruff and Mypy passed
- focused domain bundle/migration tests — 39 passed
- focused powerful-number tests after the final required-semantics tightening — 11 passed
- `make test-contracts` — 183 passed
- `make test-checkers` — 288 passed
- `make test-subprocess` — 46 passed
- `make test-fast` — 668 passed, 4 deselected
- `make check-static` — Ruff, format, deptry, vulture, Mypy, source/wheel build passed
- `make docs-linkcheck` — passed
- `make duplicate-code todo-check` — no clones; passed
- clean-state initialization — 8 reference domains, 266 installed capabilities
- public reproduction — `8` and `9` completed powerful; `10` completed non-powerful with violations `2,5`; each retained two artifacts

## Capability-development handoff

```yaml
handoff:
  stage: implementation
  status: complete
  objective: add one inspectable powerful-number decision without a new installer or workflow policy
  base_main: 4b02dc2aca5eacd481661bc02ddf9b6b46e2332e
  git_commit: 988113312fd2a61933bbf3b8d0cd9036527e4ffd
  git_tree: 6f95ea2870a49857d0ad37e170f07d3cdd50b3e6
  availability_delta:
    before: 265
    after: 266
    added:
      - integer.decide.powerful
  catalog_digest: sha256:46cd67e95963e589f4c9a95ae51ded3d4ddef14af14adff7d2dd0df344c925c0
  policy_digest: sha256:870a92b83d3e522e4015b6bb1cabda33086906f9de1c3c36e466251ea7ed1957
  provider_runtime:
    backend: SymPy 1.14.0
    execution: isolated bounded Python worker
    protocol: jacobian.number-theory.factorization.sympy.v1
  public_reproduction: benchmarks/research_challenges/public_postdoc_frontier_v1.json#jcb-postdoc-016
  compatibility: experimental additive contract; existing factorization IDs and request/result schemas unchanged
  assurance_ceiling: COMPUTED
  unresolved_obligations:
    - independently replay the exact input, factorization, predicate, violations, and semantics
    - authorize that checker separately from the SymPy producer
    - do not infer bounded-range coverage or the global conjecture from repeated single-value decisions
  next_action: implement integer.powerful.verify through the established number-theory exact-domain checker path
```
