### PR TITLE
feat(number-theory): verify powerful decisions

### DIFF
--- a/docs/reference/integer-powerful-number-decision.md
+++ b/docs/reference/integer-powerful-number-decision.md
@@ -43,8 +43,32 @@ A timeout, resource exhaustion, malformed worker response, cancellation, or
 worker error is a non-conclusion and never becomes `false`.
 
 Successful execution has `COMPLETE` completeness for the single input and
-`COMPUTED` assurance. The producer does not verify itself. An independent
-replay checker remains a separate implementation and authorization obligation.
+`COMPUTED` assurance. The producer does not verify itself.
+
+## Independent verification
+
+The operator-authorized `integer.powerful.verify` capability accepts the
+stored result URI and independently replays the exact claim with Python-FLINT.
+The checker imports neither SymPy nor the producer or worker modules. A
+successful replay creates a verification record and may promote that exact
+stored result to `VERIFIED`.
+
+The checker fails closed unless all of these obligations hold:
+
+| Obligation | Independent check |
+| --- | --- |
+| Artifact binding | Bind the exact input, result, semantics, schemas, lineage, witness envelope, and checker identity. |
+| Input domain | Require the canonical positive decimal and exact bounded producer-budget shape. |
+| Result fields | Require the exact semantics version, strict boolean, factor list, and violating-prime list. |
+| Complete factorization | Reconstruct the input product and compare every canonical prime power with Python-FLINT factorization. |
+| Predicate | Recompute whether every independently replayed exponent is at least two. |
+| Violations | Require exactly the ascending prime bases whose replayed exponent is below two. |
+| Runtime | Require the operator-authorized checker source and pinned Python-FLINT/FLINT runtime. |
+
+A malformed, substituted, incomplete, noncanonical, or mathematically false
+candidate is `REJECTED` with conclusion `UNKNOWN`; it is never converted into
+a contrary theorem. Checker unavailability, timeout, cancellation, or error is
+also non-conclusive.
 
 ## Public reproduction and limits
 

--- a/src/jacobian/domains/number_theory/checkers.py
+++ b/src/jacobian/domains/number_theory/checkers.py
@@ -1,7 +1,10 @@
 """Independent checker declarations owned by the number-theory domain."""
 
 from jacobian.checker_operations import ExactReplayCheckerDeclaration
-from jacobian.contracts.number_theory import FactorizationRequest
+from jacobian.contracts.number_theory import (
+    FactorizationRequest,
+    PowerfulNumberRequest,
+)
 
 _EXACT_DOMAIN_ENTRYPOINT = "jacobian_checkers.exact_domain_operations"
 
@@ -29,6 +32,31 @@ NUMBER_THEORY_EXACT_REPLAY_CHECKERS = (
             "integer",
             "number-theory",
             "prime-factorization",
+        ),
+    ),
+    ExactReplayCheckerDeclaration(
+        "integer.decide.powerful",
+        PowerfulNumberRequest,
+        "check_integer_powerful_number",
+        "integer.powerful.flint-replay",
+        entrypoint_module=_EXACT_DOMAIN_ENTRYPOINT,
+        replay_method="Python-FLINT powerful-number replay",
+        reason=(
+            "operator-authorized Python-FLINT checker independent of the "
+            "isolated SymPy powerful-number producer"
+        ),
+        verification_capability_id="integer.powerful.verify",
+        verification_title="Verify a powerful-number decision",
+        verification_description=(
+            "Independently verify one stored powerful-number decision, its "
+            "complete canonical factor witness, and every violating prime."
+        ),
+        verification_tags=(
+            "verification",
+            "exact",
+            "integer",
+            "number-theory",
+            "powerful-number",
         ),
     ),
 )

--- a/src/jacobian_checkers/exact_domain_operations.py
+++ b/src/jacobian_checkers/exact_domain_operations.py
@@ -202,9 +202,9 @@ def _run(
         return _reject("malformed, unsupported, or mismatched checker request")
 
 
-def _prime_factorization(source: dict[str, Any], result: dict[str, Any]) -> bool:
-    if set(source) != {"value", "resource_budget"} or set(result) != {"factors"}:
-        return False
+def _factorization_value(source: dict[str, Any], *, positive: bool) -> int:
+    if set(source) != {"value", "resource_budget"}:
+        raise ValueError("factorization source is malformed")
     budget = source["resource_budget"]
     if (
         not isinstance(budget, dict)
@@ -212,38 +212,53 @@ def _prime_factorization(source: dict[str, Any], result: dict[str, Any]) -> bool
         or type(budget["wall_seconds"]) is not int
         or not 1 <= budget["wall_seconds"] <= 30
     ):
-        return False
+        raise ValueError("factorization budget is malformed")
     value = _integer(source["value"])
-    if value == 0:
-        return False
-    factors = result["factors"]
-    if not isinstance(factors, list) or len(factors) > 256:
-        return False
+    if (positive and value < 1) or (not positive and value == 0):
+        raise ValueError("factorization source is outside the operation domain")
+    return value
 
-    target = abs(value)
+
+def _factorization_witness(
+    target: int,
+    factors: object,
+) -> list[tuple[int, int]]:
+    if not isinstance(factors, list) or len(factors) > 256:
+        raise ValueError("factorization witness is malformed")
+
     product = 1
     parsed: list[tuple[int, int]] = []
     previous_prime = 1
     for factor in factors:
         if not isinstance(factor, dict) or set(factor) != {"prime", "power"}:
-            return False
+            raise ValueError("prime-power entry is malformed")
         prime = _integer(factor["prime"])
         power = factor["power"]
         if prime <= previous_prime or type(power) is not int or not 1 <= power <= 1_000:
-            return False
+            raise ValueError("prime-power entry is noncanonical")
         for _ in range(power):
             if product > target // prime:
-                return False
+                raise ValueError("prime-power product exceeds the source")
             product *= prime
         parsed.append((prime, power))
         previous_prime = prime
     if product != target:
-        return False
+        raise ValueError("prime-power product does not equal the source")
 
     replayed = [
         (int(prime), int(power)) for prime, power in flint.fmpz(target).factor()
     ]
-    return parsed == replayed
+    if parsed != replayed:
+        raise ValueError("factorization differs from Python-FLINT replay")
+    return parsed
+
+
+def _prime_factorization(source: dict[str, Any], result: dict[str, Any]) -> bool:
+    if set(result) != {"factors"}:
+        return False
+    value = _factorization_value(source, positive=False)
+    _factorization_witness(abs(value), result["factors"])
+    return True
 
 
 def check_integer_prime_factorization(
@@ -254,6 +269,39 @@ def check_integer_prime_factorization(
         operation_id="integer.compute.prime_factorization",
         witness_format="integer.prime-factorization.flint-replay",
         replay=_prime_factorization,
+    )
+
+
+def _powerful_number(source: dict[str, Any], result: dict[str, Any]) -> bool:
+    if set(result) != {
+        "semantics_version",
+        "is_powerful",
+        "factors",
+        "violating_primes",
+    }:
+        return False
+    if (
+        result["semantics_version"] != "powerful-number.prime-exponents-at-least-two.v1"
+        or type(result["is_powerful"]) is not bool
+    ):
+        return False
+
+    value = _factorization_value(source, positive=True)
+    factors = _factorization_witness(value, result["factors"])
+    expected_violations = [str(prime) for prime, power in factors if power < 2]
+    expected_is_powerful = not expected_violations
+    return (
+        result["violating_primes"] == expected_violations
+        and result["is_powerful"] is expected_is_powerful
+    )
+
+
+def check_integer_powerful_number(request: dict[str, Any]) -> dict[str, Any]:
+    return _run(
+        request,
+        operation_id="integer.decide.powerful",
+        witness_format="integer.powerful.flint-replay",
+        replay=_powerful_number,
     )
 
 
@@ -565,6 +613,7 @@ def check_matrix_smith_normal_form(request: dict[str, Any]) -> dict[str, Any]:
 
 
 __all__ = [
+    "check_integer_powerful_number",
     "check_integer_prime_factorization",
     "check_matrix_characteristic_polynomial",
     "check_matrix_nullspace",

--- a/tests/checkers/test_exact_domain_operation_checkers.py
+++ b/tests/checkers/test_exact_domain_operation_checkers.py
@@ -13,6 +13,7 @@ from tests.helpers.rationals import rational_payload as _q
 
 import jacobian_checkers.exact_domain_operations as checker_module
 from jacobian_checkers.exact_domain_operations import (
+    check_integer_powerful_number,
     check_integer_prime_factorization,
     check_matrix_characteristic_polynomial,
     check_matrix_nullspace,
@@ -292,6 +293,28 @@ _CASES: tuple[
                     {"prime": "3", "power": 2},
                     {"prime": "5", "power": 1},
                 ]
+            },
+        ),
+    ),
+    (
+        check_integer_powerful_number,
+        _request(
+            "integer.decide.powerful",
+            "integer.powerful.flint-replay",
+            {
+                "value": "72",
+                "resource_budget": {"wall_seconds": 5},
+            },
+            {
+                "semantics_version": (
+                    "powerful-number.prime-exponents-at-least-two.v1"
+                ),
+                "is_powerful": True,
+                "factors": [
+                    {"prime": "2", "power": 3},
+                    {"prime": "3", "power": 2},
+                ],
+                "violating_primes": [],
             },
         ),
     ),
@@ -635,6 +658,137 @@ def test_prime_factorization_checker_rejects_zero_source() -> None:
     )
 
     assert check_integer_prime_factorization(checker_request)["accepted"] is False
+
+
+@pytest.mark.parametrize(
+    ("value", "result"),
+    (
+        (
+            "1",
+            {
+                "semantics_version": (
+                    "powerful-number.prime-exponents-at-least-two.v1"
+                ),
+                "is_powerful": True,
+                "factors": [],
+                "violating_primes": [],
+            },
+        ),
+        (
+            "72",
+            {
+                "semantics_version": (
+                    "powerful-number.prime-exponents-at-least-two.v1"
+                ),
+                "is_powerful": True,
+                "factors": [
+                    {"prime": "2", "power": 3},
+                    {"prime": "3", "power": 2},
+                ],
+                "violating_primes": [],
+            },
+        ),
+        (
+            "12",
+            {
+                "semantics_version": (
+                    "powerful-number.prime-exponents-at-least-two.v1"
+                ),
+                "is_powerful": False,
+                "factors": [
+                    {"prime": "2", "power": 2},
+                    {"prime": "3", "power": 1},
+                ],
+                "violating_primes": ["3"],
+            },
+        ),
+    ),
+)
+def test_powerful_number_checker_accepts_exact_decisions(
+    value: str,
+    result: dict[str, object],
+) -> None:
+    checker_request = _request(
+        "integer.decide.powerful",
+        "integer.powerful.flint-replay",
+        {"value": value, "resource_budget": {"wall_seconds": 5}},
+        result,
+    )
+
+    decision = check_integer_powerful_number(checker_request)
+
+    assert decision["accepted"] is True
+    assert decision["conclusion"] == "TRUE"
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    (
+        lambda result: result.update(is_powerful=False),
+        lambda result: result["violating_primes"].append("2"),
+        lambda result: result["factors"].pop(),
+        lambda result: result.update(
+            is_powerful=False,
+            factors=[
+                {"prime": "2", "power": 1},
+                {"prime": "6", "power": 2},
+            ],
+            violating_primes=["2"],
+        ),
+        lambda result: result.update(semantics_version="powerful-number.v2"),
+        lambda result: result["factors"].reverse(),
+    ),
+    ids=(
+        "wrong-decision",
+        "wrong-violations",
+        "incomplete-factorization",
+        "composite-factor-base",
+        "wrong-semantics",
+        "noncanonical-factor-order",
+    ),
+)
+def test_powerful_number_checker_rejects_false_or_rebound_results(
+    mutate: Callable[[dict[str, Any]], object],
+) -> None:
+    checker_request = _request(
+        "integer.decide.powerful",
+        "integer.powerful.flint-replay",
+        {"value": "72", "resource_budget": {"wall_seconds": 5}},
+        {
+            "semantics_version": "powerful-number.prime-exponents-at-least-two.v1",
+            "is_powerful": True,
+            "factors": [
+                {"prime": "2", "power": 3},
+                {"prime": "3", "power": 2},
+            ],
+            "violating_primes": [],
+        },
+    )
+    result = checker_request["candidate"]["payload"]
+    mutate(result)
+    checker_request["candidate"]["payload_digest"] = _digest(result)
+
+    decision = check_integer_powerful_number(checker_request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+@pytest.mark.parametrize("value", ("0", "-72"))
+def test_powerful_number_checker_rejects_nonpositive_source(value: str) -> None:
+    checker_request = _request(
+        "integer.decide.powerful",
+        "integer.powerful.flint-replay",
+        {"value": value, "resource_budget": {"wall_seconds": 5}},
+        {
+            "semantics_version": "powerful-number.prime-exponents-at-least-two.v1",
+            "is_powerful": True,
+            "factors": [],
+            "violating_primes": [],
+        },
+    )
+
+    assert check_integer_powerful_number(checker_request)["accepted"] is False
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/domains/test_exact_domain_result_verification.py
+++ b/tests/integration/domains/test_exact_domain_result_verification.py
@@ -474,6 +474,76 @@ def test_prime_factorization_verifier_rejects_incomplete_factor_list(
     assert rejected.output["verification_record_uri"] is None
 
 
+@pytest.mark.parametrize("value", ("1", "72", "12", "30"))
+def test_powerful_number_result_uses_independent_python_flint_replay(
+    kernel_with_references,
+    value: str,
+) -> None:
+    producer_id = "integer.decide.powerful"
+    verifier_id = "integer.powerful.verify"
+    computed = kernel_with_references.capabilities.invoke(
+        CapabilityRequest(
+            capability_id=producer_id,
+            input={"value": value},
+        )
+    )
+
+    verified = kernel_with_references.capabilities.invoke(
+        CapabilityRequest(
+            capability_id=verifier_id,
+            mode=CapabilityMode.VERIFY,
+            input={"result_uri": computed.output["result_uri"]},
+        )
+    )
+
+    assert verified.execution.status is ExecutionStatus.COMPLETED
+    assert verified.output["status"] == "VERIFIED"
+    assert verified.output["operation_id"] == producer_id
+    assert verified.output["verification_record_uri"] is not None
+    assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED
+    assert verified.output["verification_record_uri"] in verified.artifact_uris
+
+
+def test_powerful_number_verifier_rejects_schema_valid_wrong_factor_product(
+    kernel_with_references,
+) -> None:
+    computed = kernel_with_references.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="integer.decide.powerful",
+            input={"value": "72"},
+        )
+    )
+    result_artifact = kernel_with_references.store.get(computed.output["result_uri"])
+    false_result = kernel_with_references.artifacts.put(
+        schema_uri=result_artifact.manifest.schema_uri,
+        semantics_uri=result_artifact.manifest.semantics_uri,
+        parents=result_artifact.manifest.parents,
+        payload={
+            "semantics_version": "powerful-number.prime-exponents-at-least-two.v1",
+            "is_powerful": True,
+            "factors": [
+                {"prime": "2", "power": 2},
+                {"prime": "3", "power": 2},
+            ],
+            "violating_primes": [],
+        },
+        summary="adversarial wrong powerful-number factor product",
+    )
+
+    rejected = kernel_with_references.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="integer.powerful.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"result_uri": false_result.artifact_uri},
+        )
+    )
+
+    assert rejected.execution.status is ExecutionStatus.COMPLETED
+    assert rejected.output["status"] == "REJECTED"
+    assert rejected.output["conclusion"] == "UNKNOWN"
+    assert rejected.output["verification_record_uri"] is None
+
+
 def test_operator_can_leave_exact_result_verification_unavailable(
     kernel,
 ) -> None:

--- a/tests/unit/test_exact_domain_checker_installation.py
+++ b/tests/unit/test_exact_domain_checker_installation.py
@@ -15,7 +15,10 @@ from jacobian.contracts.matrix_operations import (
     RationalMatrixRequest,
     SquareRationalMatrixRequest,
 )
-from jacobian.contracts.number_theory import FactorizationRequest
+from jacobian.contracts.number_theory import (
+    FactorizationRequest,
+    PowerfulNumberRequest,
+)
 from jacobian.contracts.polynomial_operations import (
     PolynomialDiscriminantRequest,
     PolynomialGcdRequest,
@@ -70,7 +73,10 @@ def test_installer_authorizes_all_exact_domain_replays(tmp_path: Path) -> None:
         "graph.invariant.radius.compute",
         "graph.invariant.maximum_matching.compute",
     )
-    number_theory_ids = ("integer.compute.prime_factorization",)
+    number_theory_ids = (
+        "integer.compute.prime_factorization",
+        "integer.decide.powerful",
+    )
     projective_ids = ("geometry.projective_line_arrangement.flats.materialize",)
     registry = CheckerRegistry(tmp_path / "checkers.sqlite3")
 
@@ -107,7 +113,7 @@ def test_installer_authorizes_all_exact_domain_replays(tmp_path: Path) -> None:
             character="8",
         ),
         number_theory=_installed(
-            (FactorizationRequest,),
+            (FactorizationRequest, PowerfulNumberRequest),
             number_theory_ids,
             character="6",
         ),


### PR DESCRIPTION
## Summary

- add the operator-authorized `integer.powerful.verify` capability beside the existing powerful-number producer
- independently replay the exact positive input and complete canonical factorization with Python-FLINT
- recompute the powerful predicate and every exponent-one violating prime instead of trusting the SymPy producer
- bind the exact semantics version, candidate, lineage, witness envelope, checker source, and pinned runtime
- share only checker-side factorization parsing with the existing independent prime-factorization replay

## Fail-closed behavior

The checker requires exact source and result fields, canonical decimal encoding, the producer budget shape, strict factor ordering, bounded positive exponents, exact product reconstruction, and equality with Python-FLINT's complete factorization. It then independently derives `is_powerful` and `violating_primes`.

Malformed or substituted artifacts, wrong semantics, an inconsistent predicate, wrong violations, missing factors, composite bases, noncanonical order, negative/zero sources, runtime mismatch, timeout, cancellation, and checker error cannot certify. A mathematically false but result-schema-valid factor product returns `REJECTED` / `UNKNOWN` and no verification record.

## Validation

- `make check` — 151 passed, Ruff and Mypy passed
- focused checker/installer/public-verification suite — 143 passed
- final powerful/prime replay focus — 32 passed
- `make test-contracts` — 183 passed
- `make test-checkers` — 304 passed
- `make test-subprocess` — 46 passed
- `make test-fast` — 684 passed, 4 deselected
- `make check-static` — Ruff, format, deptry, vulture, Mypy, source/wheel build passed
- `make docs-linkcheck` — passed
- `make duplicate-code todo-check` — no clones; passed
- clean public MCP smoke — `8`, `9`, and `10` each computed and independently reached `VERIFIED`; every verification record was included in `artifact_uris`
- clean MCP catalog — 267 capabilities; `integer.decide.powerful` and `integer.powerful.verify` are both advertised

## Capability-development handoff

```yaml
handoff:
  stage: verification
  status: complete
  objective: independently replay one stored powerful-number result without importing producer semantics or implementation
  base_main: 2fb1c0ff65223edf9d2e50d6add621cab9c9d6ea
  git_commit: ee946ad733277a66cda5d21c63290f84995c9fbd
  git_tree: 2c483eb8667420fc1c5b20e5a4ae553d4aafc609
  availability_delta:
    before: 266
    after: 267
    added:
      - integer.powerful.verify
  catalog_digest: sha256:bc6b2140e36f178f3e6eeff4560569e5f3ed02ef607a2e40b7d860441d086291
  policy_digest: sha256:870a92b83d3e522e4015b6bb1cabda33086906f9de1c3c36e466251ea7ed1957
  producer:
    provider: SymPy 1.14.0
    execution: isolated bounded worker
  checker:
    provider: Python-FLINT 0.9.0 / FLINT 3.6.0
    entrypoint: jacobian_checkers.exact_domain_operations:check_integer_powerful_number
    witness_format: integer.powerful.flint-replay
    authorization: operator-owned exact-domain checker declaration
  independence:
    - checker module imports neither SymPy nor Jacobian producer code
    - Python-FLINT independently determines the complete prime-power list
    - predicate and violations are derived only after independent factor replay
  public_reproduction: benchmarks/research_challenges/public_postdoc_frontier_v1.json#jcb-postdoc-016
  compatibility: additive experimental verifier; producer contract and existing checker IDs unchanged
  verified_claim_scope: one exact stored positive integer result only
  unresolved_obligations:
    - no range enumeration or range-completeness certificate
    - no replay of the external 10^14 formal artifact
    - no implication for the unbounded conjecture
  next_action: evaluate the single-value producer/checker as a composable primitive without promoting finite samples to coverage
```
