### PR TITLE
feat(graphs): add exact graph distance matrix capability

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -70,6 +70,7 @@ expectations.
 - [Fixed-registry graph invariant batches](reference/graph-invariant-batch.md)
 - [Maximum-matching certificate and verification](reference/graph-maximum-matching.md)
 - [Graph diameter and radius verification](reference/graph-metric-verification.md)
+- [Graph distance matrix](reference/graph-distance-matrix.md)
 - [Integer prime-factorization verification](reference/integer-prime-factorization-verification.md)
 - [Powerful-number decision](reference/integer-powerful-number-decision.md)
 - [Bounded finite exactly-once coverage](reference/finite-coverage-verification.md)

--- a/docs/reference/graph-distance-matrix.md
+++ b/docs/reference/graph-distance-matrix.md
@@ -1,0 +1,42 @@
+# Graph distance matrix
+
+[Documentation home](../index.md)
+
+`graph.distance_matrix.compute` returns one complete matrix of exact
+unweighted shortest-path distances for a bounded finite simple undirected
+graph. The producer uses the existing `GraphInvariantRequest` graph contract,
+so inputs retain the established limit of 32 vertices and 496 edges.
+
+## Result semantics
+
+The result is bound to
+`unweighted-shortest-path-distance-matrix.v1` and makes its representation
+choices explicit:
+
+- `vertices` is the complete input vertex set in lexicographic ascending order;
+- `distances[i][j]` covers every ordered pair of vertices in that order;
+- a finite entry is the number of edges in a shortest path;
+- an unreachable pair is represented by JSON `null`, never a numeric sentinel;
+- the diagonal is zero, finite off-diagonal entries are positive, and the
+  matrix is symmetric; and
+- `connected` is true exactly when the graph is nonempty and every matrix
+  entry is finite.
+
+The empty graph returns an empty matrix with `connected = false`. A singleton
+returns `[[0]]` with `connected = true`.
+
+The result model rejects inconsistent ordering, shape, diagonal, symmetry,
+component closure, triangle inequality, or connectedness before an artifact is
+written.
+
+## Scope and composition
+
+This capability exposes the distance matrix as one inspectable mathematical
+outcome. It does not compute a diameter, radius, vertex eccentricity, distance
+between derived vertex sets, or a conjecture-specific inequality. An agent can
+derive such quantities by composing this artifact with independently obtained
+sets or other capabilities.
+
+The producer is capped at `COMPUTED`. That assurance means the bounded
+operation completed and produced a typed artifact; it is not independent
+verification of the distance claim.

--- a/src/jacobian/contracts/graph_invariant_operations.py
+++ b/src/jacobian/contracts/graph_invariant_operations.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Literal, Self
+from typing import Annotated, Literal, Self
 
 from pydantic import Field, StrictBool, StrictInt, model_validator
 
@@ -17,6 +17,72 @@ from jacobian.contracts.results import ContractModel
 
 class GraphInvariantRequest(ContractModel):
     graph: ChromaticGraph
+
+
+GraphDistance = Annotated[StrictInt, Field(ge=0, le=31)] | None
+GraphDistanceRow = Annotated[
+    tuple[GraphDistance, ...],
+    Field(max_length=32),
+]
+
+
+class GraphDistanceMatrixResult(ContractModel):
+    """All exact unweighted shortest-path distances in canonical vertex order."""
+
+    semantics_version: Literal["unweighted-shortest-path-distance-matrix.v1"]
+    vertex_ordering: Literal["LEXICOGRAPHIC_ASCENDING"]
+    pair_coverage: Literal["ALL_ORDERED_VERTEX_PAIRS"]
+    unreachable_representation: Literal["JSON_NULL"]
+    vertices: tuple[GraphVertex, ...] = Field(max_length=32)
+    distances: tuple[GraphDistanceRow, ...] = Field(max_length=32)
+    connected: StrictBool
+
+    @model_validator(mode="after")
+    def bind_complete_metric(self) -> Self:
+        order = len(self.vertices)
+        if (
+            tuple(sorted(self.vertices)) != self.vertices
+            or len(set(self.vertices)) != order
+        ):
+            raise ValueError("distance-matrix vertices must be unique and sorted")
+        if len(self.distances) != order or any(
+            len(row) != order for row in self.distances
+        ):
+            raise ValueError("distance matrix must be square on the declared vertices")
+
+        for source in range(order):
+            for target in range(order):
+                distance = self.distances[source][target]
+                if source == target:
+                    if distance != 0:
+                        raise ValueError("distance-matrix diagonal must be zero")
+                elif distance == 0:
+                    raise ValueError("off-diagonal distances must be positive or null")
+                if distance != self.distances[target][source]:
+                    raise ValueError("undirected distance matrix must be symmetric")
+
+        for source in range(order):
+            for intermediate in range(order):
+                left = self.distances[source][intermediate]
+                if left is None:
+                    continue
+                for target in range(order):
+                    right = self.distances[intermediate][target]
+                    if right is None:
+                        continue
+                    direct = self.distances[source][target]
+                    if direct is None or direct > left + right:
+                        raise ValueError(
+                            "finite distances must satisfy component closure and "
+                            "the triangle inequality"
+                        )
+
+        expected_connected = order > 0 and all(
+            distance is not None for row in self.distances for distance in row
+        )
+        if self.connected != expected_connected:
+            raise ValueError("connected must match all-pairs finite reachability")
+        return self
 
 
 class GraphGirthResult(ContractModel):

--- a/src/jacobian/domains/graph_optimization/invariants.py
+++ b/src/jacobian/domains/graph_optimization/invariants.py
@@ -21,6 +21,7 @@ from jacobian.contracts.graph_invariant_operations import (
     GraphCoreRequest,
     GraphCoreResult,
     GraphDiameterResult,
+    GraphDistanceMatrixResult,
     GraphEdgeConnectivityResult,
     GraphEulerianResult,
     GraphGirthResult,
@@ -107,6 +108,30 @@ def _girth(graph: nx.Graph[str]) -> GraphGirthResult:
     value = nx.girth(graph)
     girth = 0 if math.isinf(value) else int(value)
     return GraphGirthResult(girth=girth, has_cycle=girth > 0)
+
+
+def _distance_matrix(graph: nx.Graph[str]) -> GraphDistanceMatrixResult:
+    vertices = tuple(sorted(graph.nodes))
+    shortest_paths = {
+        source: nx.single_source_shortest_path_length(graph, source)
+        for source in vertices
+    }
+    distances = tuple(
+        tuple(shortest_paths[source].get(target) for target in vertices)
+        for source in vertices
+    )
+    connected = bool(vertices) and all(
+        distance is not None for row in distances for distance in row
+    )
+    return GraphDistanceMatrixResult(
+        semantics_version="unweighted-shortest-path-distance-matrix.v1",
+        vertex_ordering="LEXICOGRAPHIC_ASCENDING",
+        pair_coverage="ALL_ORDERED_VERTEX_PAIRS",
+        unreachable_representation="JSON_NULL",
+        vertices=vertices,
+        distances=distances,
+        connected=connected,
+    )
 
 
 def _diameter(graph: nx.Graph[str]) -> GraphDiameterResult:
@@ -471,6 +496,31 @@ BOUNDED_GRAPH_INVARIANT_CAPABILITIES = (
 )
 
 EXACT_GRAPH_INVARIANT_CAPABILITIES = (
+    _computed(
+        "graph.distance_matrix.compute",
+        "All-pairs distance matrix",
+        (
+            "Compute every exact unweighted shortest-path distance in a bounded "
+            "finite simple graph, using JSON null for unreachable vertex pairs."
+        ),
+        GraphDistanceMatrixResult,
+        _distance_matrix,
+        "distance",
+        "matrix",
+        "exact",
+        invocation_examples=(
+            example(
+                "path_three_distance_matrix",
+                "Compute all ordered-pair distances in a three-vertex path.",
+                {
+                    "graph": {
+                        "vertices": ["c", "a", "b"],
+                        "edges": [["a", "b"], ["b", "c"]],
+                    }
+                },
+            ),
+        ),
+    ),
     _computed(
         "graph.invariant.triangle_count.compute",
         "Triangle count",

--- a/tests/integration/graph/test_graph_distance_matrix.py
+++ b/tests/integration/graph/test_graph_distance_matrix.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.contracts.capabilities import (
+    CapabilityAssuranceLevel,
+    CapabilityRequest,
+)
+from jacobian.contracts.graph_invariant_operations import GraphDistanceMatrixResult
+from jacobian.contracts.results import ExecutionStatus
+
+
+def _invoke(kernel, vertices: list[str], edges: list[list[str]]):
+    return kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.distance_matrix.compute",
+            input={"graph": {"vertices": vertices, "edges": edges}},
+        )
+    )
+
+
+def _result(**changes: object) -> GraphDistanceMatrixResult:
+    values: dict[str, object] = {
+        "semantics_version": "unweighted-shortest-path-distance-matrix.v1",
+        "vertex_ordering": "LEXICOGRAPHIC_ASCENDING",
+        "pair_coverage": "ALL_ORDERED_VERTEX_PAIRS",
+        "unreachable_representation": "JSON_NULL",
+        "vertices": ("a", "b", "c"),
+        "distances": ((0, 1, 2), (1, 0, 1), (2, 1, 0)),
+        "connected": True,
+    }
+    values.update(changes)
+    return GraphDistanceMatrixResult.model_validate(values)
+
+
+def test_distance_matrix_is_complete_canonical_and_lineage_bound(kernel) -> None:
+    result = _invoke(
+        kernel,
+        ["c", "a", "b"],
+        [["a", "b"], ["b", "c"]],
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert result.output["result"] == {
+        "semantics_version": "unweighted-shortest-path-distance-matrix.v1",
+        "vertex_ordering": "LEXICOGRAPHIC_ASCENDING",
+        "pair_coverage": "ALL_ORDERED_VERTEX_PAIRS",
+        "unreachable_representation": "JSON_NULL",
+        "vertices": ["a", "b", "c"],
+        "distances": [[0, 1, 2], [1, 0, 1], [2, 1, 0]],
+        "connected": True,
+    }
+    assert len(result.artifact_uris) == 2
+    input_uri, matrix_uri = result.artifact_uris
+    assert kernel.store.get(matrix_uri).manifest.parents == (input_uri,)
+    assert result.relationships[0].relation_id == "graph.distance_matrix.relation"
+    assert result.relationships[0].source_artifact_uris == (input_uri,)
+    assert result.relationships[0].target_artifact_uris == (matrix_uri,)
+
+
+def test_distance_matrix_represents_disconnected_pairs_with_null(kernel) -> None:
+    result = _invoke(kernel, ["c", "a", "b"], [["a", "b"]])
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output["result"]["vertices"] == ["a", "b", "c"]
+    assert result.output["result"]["distances"] == [
+        [0, 1, None],
+        [1, 0, None],
+        [None, None, 0],
+    ]
+    assert result.output["result"]["connected"] is False
+
+
+def test_distance_matrix_empty_and_singleton_conventions(kernel) -> None:
+    empty = _invoke(kernel, [], [])
+    singleton = _invoke(kernel, ["only"], [])
+
+    assert empty.output["result"]["vertices"] == []
+    assert empty.output["result"]["distances"] == []
+    assert empty.output["result"]["connected"] is False
+    assert singleton.output["result"]["vertices"] == ["only"]
+    assert singleton.output["result"]["distances"] == [[0]]
+    assert singleton.output["result"]["connected"] is True
+
+
+def test_distance_matrix_rejects_graph_above_existing_order_bound(kernel) -> None:
+    result = _invoke(kernel, [f"v{index:02d}" for index in range(33)], [])
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.artifact_uris == ()
+    assert result.diagnostics[0].code == "INVALID_REQUEST"
+
+
+@pytest.mark.parametrize(
+    ("changes", "message"),
+    (
+        ({"vertices": ("b", "a", "c")}, "unique and sorted"),
+        ({"distances": ((0, 1), (1, 0))}, "square"),
+        (
+            {"distances": ((1, 1, 2), (1, 0, 1), (2, 1, 0))},
+            "diagonal",
+        ),
+        (
+            {"distances": ((0, 0, 2), (0, 0, 1), (2, 1, 0))},
+            "off-diagonal",
+        ),
+        (
+            {"distances": ((0, 1, 2), (2, 0, 1), (2, 1, 0))},
+            "symmetric",
+        ),
+        (
+            {"distances": ((0, 1, 3), (1, 0, 1), (3, 1, 0))},
+            "triangle inequality",
+        ),
+        (
+            {"distances": ((0, 1, None), (1, 0, 1), (None, 1, 0))},
+            "component closure",
+        ),
+        ({"connected": False}, "connected"),
+    ),
+)
+def test_distance_matrix_result_rejects_inconsistent_claims(
+    changes: dict[str, object],
+    message: str,
+) -> None:
+    with pytest.raises(ValidationError, match=message):
+        _result(**changes)
+
+
+def test_distance_matrix_public_postdoc_graph(kernel) -> None:
+    result = _invoke(
+        kernel,
+        ["0", "1", "2", "3", "4", "5"],
+        [["0", "3"], ["0", "4"], ["1", "4"], ["2", "4"], ["3", "4"], ["3", "5"]],
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output["result"]["distances"] == [
+        [0, 2, 2, 1, 1, 2],
+        [2, 0, 2, 2, 1, 3],
+        [2, 2, 0, 2, 1, 3],
+        [1, 2, 2, 0, 1, 1],
+        [1, 1, 1, 1, 0, 2],
+        [2, 3, 3, 1, 2, 0],
+    ]
+    assert result.output["result"]["connected"] is True


### PR DESCRIPTION
## Summary

- add the atomic `graph.distance_matrix.compute` capability in the graph-optimization domain bundle
- return every ordered-pair unweighted shortest-path distance in canonical lexicographic vertex order
- represent unreachable pairs explicitly as JSON `null`, with typed matrix consistency and connectedness validation
- document empty/singleton/disconnected semantics and keep conjecture-specific derived quantities out of the capability

## Contract and evidence

- request: existing `GraphInvariantRequest` / `ChromaticGraph` bounds (32 vertices, 496 edges)
- result semantics: `unweighted-shortest-path-distance-matrix.v1`
- assurance: producer remains capped at `COMPUTED`
- artifacts: input and result, with `graph.distance_matrix.relation` lineage
- public reproduction: `jcb-postdoc-018` graph returns the frozen expected 6-by-6 matrix

## Validation

- `make check` — 151 unit tests plus lint, format, and full mypy
- `make test-contracts test-checkers test-subprocess` — 183 contract, 304 checker, 46 subprocess tests
- `make test-fast` — 684 passed, 4 deselected
- `make check-static docs-linkcheck duplicate-code todo-check` — passed, including wheel/sdist build
- focused graph integration — 17 passed
- clean CLI init — 8 reference domains, 268 capabilities
- clean MCP describe/invoke — capability discoverable first for its intent; public reproduction is `COMPLETED` / `COMPUTED` with 2 artifacts

## Reproducibility handoff

- commit: `6a40b4a3a8eb8b0a8519ad1458325bb191703714`
- git tree: `2e4efad71e2aa859d3ce5afe60ae4251a4191a21`
- catalog digest: `sha256:14e45cd4b4ccebfa4fa41cb481b8fc7d7d0de51192e4a8acbe0655e642862d74`
- policy: `DEFAULT`, `sha256:870a92b83d3e522e4015b6bb1cabda33086906f9de1c3c36e466251ea7ed1957`
- provider: `jacobian.graph-invariants`, composite runtime `composite-1`, digest `sha256:405b7e504e2dd3a96b66705a98121e2e6db1b7005f3a82e4ce3c044846aae274`, available
- model/prompt settings: none; frozen public reproduction only
- raw trace location: local test/MCP output (no model trace)
- unresolved obligation: independent replay is intentionally not claimed in this producer PR
- next action: add an operator-authorized standard-library BFS checker in a separate PR
