### PR TITLE
perf(cli): speed up kernel startup and developer validation

### DIFF
--- a/.factory/droids/jacobian-dev.md
+++ b/.factory/droids/jacobian-dev.md
@@ -39,9 +39,12 @@ the research strategy.
 
 ```sh
 make setup
-make test-fast
-make validate-full
+make check
 ```
+
+Use focused `make test-*` targets while developing. `make validate-full` is the
+slow broad local subset for exceptional CI-unavailable work; it does not
+reproduce every CI lane.
 
 ## Package Structure
 

--- a/.github/actions/setup-lean/action.yml
+++ b/.github/actions/setup-lean/action.yml
@@ -18,6 +18,7 @@ runs:
       with:
         lake-package-directory: lean
         use-mathlib-cache: true
+        build: false
         test: false
         lint: false
     - name: Record Lean setup timing

--- a/.github/ci-impact.json
+++ b/.github/ci-impact.json
@@ -60,6 +60,19 @@
       "suites": ["core", "integration", "lean", "static", "build"]
     },
     {
+      "name": "lean-shared-contracts",
+      "patterns": [
+        "src/jacobian/contracts/capabilities.py",
+        "src/jacobian/contracts/checkers.py",
+        "src/jacobian/contracts/common.py",
+        "src/jacobian/contracts/evidence.py",
+        "src/jacobian/contracts/plugins.py",
+        "src/jacobian/contracts/results.py",
+        "src/jacobian/contracts/verification.py"
+      ],
+      "suites": ["lean"]
+    },
+    {
       "name": "npm-facing-adapter",
       "patterns": ["src/jacobian/adapters/mcp/**"],
       "suites": ["core", "integration", "npm", "static", "build"]

--- a/.github/ci-impact.json
+++ b/.github/ci-impact.json
@@ -46,7 +46,6 @@
       "name": "verification-boundary",
       "patterns": [
         "src/jacobian/kernel.py",
-        "src/jacobian/contracts/**",
         "src/jacobian/artifacts.py",
         "src/jacobian/checker_artifacts.py",
         "src/jacobian/registry.py",

--- a/.github/scripts/manage-test-timings
+++ b/.github/scripts/manage-test-timings
@@ -9,6 +9,7 @@ import json
 import math
 import os
 import sys
+import urllib.parse
 import urllib.request
 import zipfile
 from datetime import UTC, datetime
@@ -24,6 +25,38 @@ MAX_ENTRIES = 10_000
 MAX_CANDIDATES = 5
 HTTP_TIMEOUT_SECONDS = 10
 TEST_ROOTS = ("tests/integration/", "tests/end_to_end/")
+
+
+class CrossOriginRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Keep API credentials on GitHub's HTTPS origin during archive redirects."""
+
+    def redirect_request(
+        self,
+        request: urllib.request.Request,
+        file_pointer: Any,
+        code: int,
+        message: str,
+        headers: Any,
+        new_url: str,
+    ) -> urllib.request.Request | None:
+        redirected = super().redirect_request(
+            request,
+            file_pointer,
+            code,
+            message,
+            headers,
+            new_url,
+        )
+        if redirected is None:
+            return None
+        original = urllib.parse.urlsplit(request.full_url)
+        redirected_url = urllib.parse.urlsplit(new_url)
+        if (original.scheme, original.netloc) != (
+            redirected_url.scheme,
+            redirected_url.netloc,
+        ):
+            redirected.remove_header("Authorization")
+        return redirected
 
 
 def integration_shard_count() -> int:
@@ -129,7 +162,8 @@ def download(url: str, token: str) -> bytes:
             "X-GitHub-Api-Version": "2022-11-28",
         },
     )
-    with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+    opener = urllib.request.build_opener(CrossOriginRedirectHandler())
+    with opener.open(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
         return response.read(MAX_BYTES + 1)
 
 
@@ -205,7 +239,12 @@ def prepare(output: Path) -> None:
                 TypeError,
                 ValueError,
                 zipfile.BadZipFile,
-            ):
+            ) as exc:
+                artifact_id = artifact.get("id", "unknown")
+                warning(
+                    "rejected integration timing artifact "
+                    f"{artifact_id}: {type(exc).__name__}"
+                )
                 continue
             if durations is not None:
                 break

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ INTEGRATION_TEST_PATHS := tests/integration tests/end_to_end
 RUFF_PATHS := src tests benchmarks
 # Four workers cap memory and repeated per-worker kernel-template setup.
 PYTEST_XDIST_ARGS := -n auto --maxprocesses=4 --dist=worksteal
+# Keep modules that share an expensive fixture template on one core worker.
+# Ungrouped tests still distribute individually under loadgroup.
+PYTEST_CORE_XDIST_ARGS := -n auto --maxprocesses=4 --dist=loadgroup
 # Clean-process tests also construct kernel stores; two workers avoid I/O and
 # memory contention while retaining useful parallel feedback.
 PYTEST_SUBPROCESS_XDIST_ARGS := -n auto --maxprocesses=2 --dist=worksteal
@@ -63,7 +66,7 @@ test-subprocess: ## Run clean-process replay tests selected by the subprocess ma
 	$(UV_RUN) pytest $(PYTEST_SUBPROCESS_XDIST_ARGS) -m "subprocess and not lean_runtime" $(PYTEST_DIAGNOSTIC_ARGS) $(PYTEST_ARGS)
 
 test-core: ## Parallel core suites (same paths as test-fast, uses xdist by default).
-	$(UV_RUN) pytest $(PYTEST_XDIST_ARGS) -m "not lean_runtime" \
+	$(UV_RUN) pytest $(PYTEST_CORE_XDIST_ARGS) -m "not lean_runtime" \
 		$(if $(TESTS),$(TESTS),$(CORE_TEST_PATHS)) $(PYTEST_DIAGNOSTIC_ARGS) $(PYTEST_ARGS)
 
 test-integration: ## Run the directory-owned integration suites.

--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ precommit: ## Fix and run every routine local handoff check.
 
 check-static: lint-full typecheck todo-check build ## Run CI-owned static checks plus a local package build.
 
-validate-full: lint-full typecheck test test-lean build ## Run broad local validation (slow; omits security/duplicate/npm CI lanes).
+validate-full: lint-full typecheck test test-lean build ## Run the broad local subset; CI also owns Python 3.13, coverage, security, duplicate, and npm.
 
 agent-eval: ## Plan a local agent eval; execution requires explicit EVAL_ARGS.
 	$(UV_RUN) python benchmarks/agent_ab.py $(EVAL_ARGS)

--- a/docs/contributing/test-suite-cost-audit.md
+++ b/docs/contributing/test-suite-cost-audit.md
@@ -26,6 +26,20 @@ from 237.91 seconds wall time to 56.55 seconds while selecting 591 tests; three
 exhaustive cases were explicitly marked `slow` and excluded from that lane.
 These are single-host observations, not timing gates.
 
+## 2026-07-29 core scheduler follow-up
+
+The core lane was benchmarked in three alternating, same-seed pairs with four
+workers. Targeted `loadgroup` scheduling, with only the reference claim schema
+module grouped around its expensive shared fixture, had a 45.5-second median
+wall time. The existing `worksteal` scheduler had a 46.9-second median. Host
+noise was material, so this is a small scheduling improvement rather than a
+performance guarantee.
+
+`make test-core` therefore uses `loadgroup`, while integration and general
+parallel targets retain `worksteal`. A global `loadscope` policy was rejected:
+it groups every module whether or not it shares expensive setup and produced
+worse balancing in a controlled run.
+
 ## Measured lanes
 
 | Lane | Selected tests | Observed wall time | Purpose |

--- a/src/jacobian/cli.py
+++ b/src/jacobian/cli.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Annotated, Any
+from typing import TYPE_CHECKING, Annotated, Any
 
 import typer
 from pydantic import ValidationError
@@ -26,7 +26,6 @@ from jacobian.contracts.polytope import PolytopeSeparateRequest
 from jacobian.contracts.search import SearchBudget, SearchRunRequest
 from jacobian.experiments import ExperimentError, ExperimentNotFoundError
 from jacobian.implementation import ImplementationError
-from jacobian.kernel import JacobianKernel
 from jacobian.plugins.registry import PluginRegistryError
 from jacobian.provider_measurements import measure_provider
 from jacobian.references import reference_catalog
@@ -46,6 +45,9 @@ from jacobian.store import (
     StoreLimitError,
 )
 from jacobian.verification import CheckerExecutionError
+
+if TYPE_CHECKING:
+    from jacobian.kernel import JacobianKernel
 
 
 class JacobianGroup(TyperGroup):
@@ -228,8 +230,21 @@ def _public_error(exc: Exception) -> tuple[dict[str, str], int]:
 
 
 class CliState:
-    def __init__(self, kernel: JacobianKernel) -> None:
-        self.kernel = kernel
+    def __init__(self, state_dir: Path, *, install_references: bool) -> None:
+        self.state_dir = state_dir
+        self.install_references = install_references
+        self._kernel: JacobianKernel | None = None
+
+    @property
+    def kernel(self) -> JacobianKernel:
+        if self._kernel is None:
+            from jacobian.kernel import JacobianKernel
+
+            self._kernel = JacobianKernel(
+                self.state_dir,
+                install_references=self.install_references,
+            )
+        return self._kernel
 
 
 @app.callback()
@@ -251,10 +266,8 @@ def configure(
     ] = True,
 ) -> None:
     context.obj = CliState(
-        JacobianKernel(
-            state_dir,
-            install_references=install_references,
-        )
+        state_dir,
+        install_references=install_references,
     )
 
 

--- a/src/jacobian/kernel.py
+++ b/src/jacobian/kernel.py
@@ -264,35 +264,36 @@ class JacobianKernel:
             self.artifacts,
         )
         self.domain_bundles: dict[str, InstalledDomainBundle] = {}
-        self.sat: SatArtifactService = install_sat_artifacts(
-            self.store,
-            self.schemas,
-            self.artifacts,
-        )
-        self.smt: SmtArtifactService = install_smt_artifacts(
-            self.store,
-            self.schemas,
-            self.artifacts,
-        )
-        self.linear: LinearArtifactService = install_linear_artifacts(
-            self.store,
-            self.schemas,
-            self.artifacts,
-        )
-        self.matrix_normal_forms: MatrixNormalFormArtifactService = (
-            install_matrix_normal_form_artifacts(
+        with self.store.transaction():
+            self.sat: SatArtifactService = install_sat_artifacts(
                 self.store,
                 self.schemas,
                 self.artifacts,
             )
-        )
-        self.polynomial_expressions: PolynomialExpressionArtifactService = (
-            install_polynomial_expression_artifacts(
+            self.smt: SmtArtifactService = install_smt_artifacts(
                 self.store,
                 self.schemas,
                 self.artifacts,
             )
-        )
+            self.linear: LinearArtifactService = install_linear_artifacts(
+                self.store,
+                self.schemas,
+                self.artifacts,
+            )
+            self.matrix_normal_forms: MatrixNormalFormArtifactService = (
+                install_matrix_normal_form_artifacts(
+                    self.store,
+                    self.schemas,
+                    self.artifacts,
+                )
+            )
+            self.polynomial_expressions: PolynomialExpressionArtifactService = (
+                install_polynomial_expression_artifacts(
+                    self.store,
+                    self.schemas,
+                    self.artifacts,
+                )
+            )
         self.memory = ResearchMemory(self.store, self.schemas)
         self.workspaces = WorkspaceService(self.store, self.schemas)
         self.plugins = PluginRegistry(self.store)

--- a/src/jacobian/schema_registry.py
+++ b/src/jacobian/schema_registry.py
@@ -88,19 +88,27 @@ class SchemaRegistry:
     def __init__(self, store: ArtifactStore) -> None:
         self.store = store
         self._model_contracts: dict[str, type[BaseModel]] = {}
+        self._schema_bytes: dict[str, bytes] = {}
+        self._registrations: dict[tuple[str, str, bytes], str] = {}
 
     def register(self, *, name: str, version: str, schema: dict[str, Any]) -> str:
         """Register a schema after rejecting unsupported external references."""
 
         canonical_schema = canonicalize_json(schema)
-        normalized = loads_strict_json(canonical_schema)
         _validated_schema(canonical_schema)
-        return self.store.register_descriptor(
+        registration = (name, version, canonical_schema)
+        cached_uri = self._registrations.get(registration)
+        if cached_uri is not None:
+            return cached_uri
+        schema_uri = self.store.register_descriptor(
             kind="schema",
             name=name,
             version=version,
-            definition=normalized,
+            definition=loads_strict_json(canonical_schema),
         )
+        self._registrations[registration] = schema_uri
+        self._schema_bytes[schema_uri] = canonical_schema
+        return schema_uri
 
     def register_model(
         self,
@@ -133,6 +141,9 @@ class SchemaRegistry:
     def resolve(self, schema_uri: str) -> dict[str, Any]:
         """Load a previously registered schema definition."""
 
+        cached_schema = self._schema_bytes.get(schema_uri)
+        if cached_schema is not None:
+            return cast(dict[str, Any], loads_strict_json(cached_schema))
         try:
             descriptor = self.store.get_descriptor(
                 schema_uri,
@@ -144,7 +155,10 @@ class SchemaRegistry:
         if not isinstance(definition, dict):
             raise SchemaRegistryError("schema descriptor has no object definition")
         _reject_external_references(definition)
-        return definition
+        canonical_schema = canonicalize_json(definition)
+        _validated_schema(canonical_schema)
+        self._schema_bytes[schema_uri] = canonical_schema
+        return cast(dict[str, Any], loads_strict_json(canonical_schema))
 
     def validate(self, schema_uri: str, payload: Any) -> Any:
         """Validate and canonically normalize a payload."""

--- a/src/jacobian/schema_registry.py
+++ b/src/jacobian/schema_registry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from functools import lru_cache
 from typing import Any, cast
 
@@ -33,6 +34,13 @@ class SchemaValidationError(SchemaRegistryError):
         super().__init__(message)
         self.path = path
         self.required_field = required_field
+
+
+@dataclass(slots=True)
+class _PendingRegistrations:
+    schemas: dict[str, bytes] = field(default_factory=dict)
+    registrations: dict[tuple[str, str, bytes], str] = field(default_factory=dict)
+    model_contracts: dict[str, type[BaseModel]] = field(default_factory=dict)
 
 
 @lru_cache(maxsize=1024)
@@ -90,14 +98,23 @@ class SchemaRegistry:
         self._model_contracts: dict[str, type[BaseModel]] = {}
         self._schema_bytes: dict[str, bytes] = {}
         self._registrations: dict[tuple[str, str, bytes], str] = {}
+        self._pending: dict[int, _PendingRegistrations] = {}
 
     def register(self, *, name: str, version: str, schema: dict[str, Any]) -> str:
         """Register a schema after rejecting unsupported external references."""
 
+        self._reconcile_pending()
         canonical_schema = canonicalize_json(schema)
         _validated_schema(canonical_schema)
         registration = (name, version, canonical_schema)
-        cached_uri = self._registrations.get(registration)
+        transaction_identity = self.store.transaction_identity
+        registrations = self._registrations
+        if transaction_identity is not None:
+            registrations = self._pending.setdefault(
+                transaction_identity,
+                _PendingRegistrations(),
+            ).registrations
+        cached_uri = registrations.get(registration)
         if cached_uri is not None:
             return cached_uri
         schema_uri = self.store.register_descriptor(
@@ -106,8 +123,11 @@ class SchemaRegistry:
             version=version,
             definition=loads_strict_json(canonical_schema),
         )
-        self._registrations[registration] = schema_uri
-        self._schema_bytes[schema_uri] = canonical_schema
+        registrations[registration] = schema_uri
+        if transaction_identity is None:
+            self._schema_bytes[schema_uri] = canonical_schema
+        else:
+            self._pending[transaction_identity].schemas[schema_uri] = canonical_schema
         return schema_uri
 
     def register_model(
@@ -130,20 +150,34 @@ class SchemaRegistry:
             version=version,
             schema=model_schema(model),
         )
-        registered = self._model_contracts.get(schema_uri)
+        transaction_identity = self.store.transaction_identity
+        model_contracts = self._model_contracts
+        if transaction_identity is not None:
+            model_contracts = self._pending[transaction_identity].model_contracts
+        registered = model_contracts.get(schema_uri)
         if registered is not None and registered is not model:
             raise SchemaRegistryError(
                 "one schema URI cannot use multiple model-backed contracts"
             )
-        self._model_contracts[schema_uri] = model
+        model_contracts[schema_uri] = model
         return schema_uri
 
     def resolve(self, schema_uri: str) -> dict[str, Any]:
         """Load a previously registered schema definition."""
 
-        cached_schema = self._schema_bytes.get(schema_uri)
-        if cached_schema is not None:
-            return cast(dict[str, Any], loads_strict_json(cached_schema))
+        self._reconcile_pending()
+        transaction_identity = self.store.transaction_identity
+        if transaction_identity is None:
+            cached_schema = self._schema_bytes.get(schema_uri)
+            if cached_schema is not None:
+                return cast(dict[str, Any], loads_strict_json(cached_schema))
+        else:
+            pending_schema = self._pending.get(
+                transaction_identity,
+                _PendingRegistrations(),
+            ).schemas.get(schema_uri)
+            if pending_schema is not None:
+                return cast(dict[str, Any], loads_strict_json(pending_schema))
         try:
             descriptor = self.store.get_descriptor(
                 schema_uri,
@@ -157,8 +191,25 @@ class SchemaRegistry:
         _reject_external_references(definition)
         canonical_schema = canonicalize_json(definition)
         _validated_schema(canonical_schema)
-        self._schema_bytes[schema_uri] = canonical_schema
+        if transaction_identity is None:
+            self._schema_bytes[schema_uri] = canonical_schema
         return cast(dict[str, Any], loads_strict_json(canonical_schema))
+
+    def _reconcile_pending(self) -> None:
+        active_identity = self.store.transaction_identity
+        for transaction_identity, pending in tuple(self._pending.items()):
+            if transaction_identity == active_identity:
+                continue
+            witness_uri = next(iter(pending.schemas))
+            try:
+                self.store.get_descriptor(witness_uri, expected_kind="schema")
+            except StoreError:
+                del self._pending[transaction_identity]
+                continue
+            self._schema_bytes.update(pending.schemas)
+            self._registrations.update(pending.registrations)
+            self._model_contracts.update(pending.model_contracts)
+            del self._pending[transaction_identity]
 
     def validate(self, schema_uri: str, payload: Any) -> Any:
         """Validate and canonically normalize a payload."""

--- a/src/jacobian/store.py
+++ b/src/jacobian/store.py
@@ -225,6 +225,13 @@ class ArtifactStore:
 
         return self._connection_state.transaction is not None
 
+    @property
+    def transaction_identity(self) -> int | None:
+        """Process-local identity of this thread's active transaction."""
+
+        transaction = self._connection_state.transaction
+        return None if transaction is None else id(transaction)
+
     @contextmanager
     def transaction(self) -> Iterator[None]:
         """Commit related store operations through one SQLite transaction.

--- a/tests/contract/test_schema_registry.py
+++ b/tests/contract/test_schema_registry.py
@@ -80,6 +80,29 @@ def test_schema_validator_cache_is_bound_to_canonical_schema(
         registry.validate(string_schema, {"value": 1})
 
 
+def test_registered_schema_resolves_from_immutable_local_cache(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = ArtifactStore(tmp_path)
+    registry = SchemaRegistry(store)
+    schema_uri = registry.register(
+        name="local-cache",
+        version="1",
+        schema={"type": "object"},
+    )
+
+    first = registry.resolve(schema_uri)
+    first["type"] = "array"
+
+    def unexpected_store_read(*_args: object, **_kwargs: object) -> dict[str, object]:
+        pytest.fail("registered schema was read from the store again")
+
+    monkeypatch.setattr(store, "get_descriptor", unexpected_store_read)
+
+    assert registry.resolve(schema_uri) == {"type": "object"}
+
+
 def test_model_backed_schema_applies_cross_field_contracts(
     tmp_path: Path,
 ) -> None:

--- a/tests/contract/test_schema_registry.py
+++ b/tests/contract/test_schema_registry.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Self
+from typing import Any, Self
 
 import pytest
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, ConfigDict, model_validator
 
 from jacobian.schema_registry import (
     SchemaRegistry,
@@ -16,6 +16,12 @@ from jacobian.store import ArtifactStore
 
 
 class _CachedSchemaModel(BaseModel):
+    value: int
+
+
+class _EquivalentCachedSchemaModel(BaseModel):
+    model_config = ConfigDict(title="_CachedSchemaModel")
+
     value: int
 
 
@@ -101,6 +107,97 @@ def test_registered_schema_resolves_from_immutable_local_cache(
     monkeypatch.setattr(store, "get_descriptor", unexpected_store_read)
 
     assert registry.resolve(schema_uri) == {"type": "object"}
+
+
+@pytest.mark.parametrize("inside_transaction", [False, True])
+def test_identical_registration_writes_one_descriptor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    inside_transaction: bool,
+) -> None:
+    store = ArtifactStore(tmp_path)
+    registry = SchemaRegistry(store)
+    calls = 0
+    register_descriptor = store.register_descriptor
+
+    def counting_register_descriptor(
+        *,
+        kind: str,
+        name: str,
+        version: str,
+        definition: Any,
+    ) -> str:
+        nonlocal calls
+        calls += 1
+        return register_descriptor(
+            kind=kind,
+            name=name,
+            version=version,
+            definition=definition,
+        )
+
+    monkeypatch.setattr(store, "register_descriptor", counting_register_descriptor)
+
+    def register_twice() -> None:
+        for _ in range(2):
+            registry.register(
+                name="deduplicated",
+                version="1",
+                schema={"type": "object"},
+            )
+
+    if inside_transaction:
+        with store.transaction():
+            register_twice()
+    else:
+        register_twice()
+
+    assert calls == 1
+
+
+@pytest.mark.parametrize("model", [None, _CachedSchemaModel])
+def test_rolled_back_schema_is_not_retained_in_local_cache(
+    tmp_path: Path,
+    model: type[BaseModel] | None,
+) -> None:
+    store = ArtifactStore(tmp_path)
+    registry = SchemaRegistry(store)
+    schema_uri = ""
+
+    with pytest.raises(RuntimeError, match="rollback"), store.transaction():
+        schema_uri = (
+            registry.register(
+                name="rolled-back",
+                version="1",
+                schema={"type": "object"},
+            )
+            if model is None
+            else registry.register_model(
+                name="rolled-back",
+                version="1",
+                model=model,
+            )
+        )
+        registry.resolve(schema_uri)
+        raise RuntimeError("rollback")
+
+    with pytest.raises(SchemaRegistryError, match="unregistered schema"):
+        registry.resolve(schema_uri)
+
+    schema_uri = (
+        registry.register(
+            name="rolled-back",
+            version="1",
+            schema={"type": "object"},
+        )
+        if model is None
+        else registry.register_model(
+            name="rolled-back",
+            version="1",
+            model=_EquivalentCachedSchemaModel,
+        )
+    )
+    assert registry.resolve(schema_uri)["type"] == "object"
 
 
 def test_model_backed_schema_applies_cross_field_contracts(

--- a/tests/fixtures/plugin_functions.py
+++ b/tests/fixtures/plugin_functions.py
@@ -45,13 +45,15 @@ def emit_large_diagnostic(_request: dict[str, Any]) -> dict[str, Any]:
 def spawn_delayed_child(request: dict[str, Any]) -> dict[str, Any]:
     marker = request["marker"]
     started_marker = request["started_marker"]
+    pid_marker = request["pid_marker"]
     delay_seconds = request.get("delay_seconds", 1)
     script = (
         "import pathlib,time;"
         f"time.sleep({delay_seconds!r});"
         f"pathlib.Path({marker!r}).write_text('survived', encoding='utf-8')"
     )
-    subprocess.Popen([sys.executable, "-c", script])
+    child = subprocess.Popen([sys.executable, "-c", script])
+    pathlib.Path(pid_marker).write_text(str(child.pid), encoding="utf-8")
     pathlib.Path(started_marker).write_text("started", encoding="utf-8")
     time.sleep(60)
     return {"unreachable": True}
@@ -61,29 +63,33 @@ def spawn_child_then_return(request: dict[str, Any]) -> dict[str, Any]:
     """Exit the worker while a descendant still owns its output pipes."""
 
     marker = request["marker"]
+    pid_marker = request["pid_marker"]
     delay_seconds = request.get("delay_seconds", 1)
     script = (
         "import pathlib,time;"
         f"time.sleep({delay_seconds!r});"
         f"pathlib.Path({marker!r}).write_text('survived', encoding='utf-8')"
     )
-    subprocess.Popen([sys.executable, "-c", script])
+    child = subprocess.Popen([sys.executable, "-c", script])
+    pathlib.Path(pid_marker).write_text(str(child.pid), encoding="utf-8")
     return {"worker": "returned"}
 
 
 def spawn_detached_child_then_return(request: dict[str, Any]) -> dict[str, Any]:
     marker = request["marker"]
+    pid_marker = request["pid_marker"]
     script = (
         "import pathlib,time;"
         "time.sleep(1);"
         f"pathlib.Path({marker!r}).write_text('survived', encoding='utf-8')"
     )
-    subprocess.Popen(
+    child = subprocess.Popen(
         [sys.executable, "-c", script],
         stdin=subprocess.DEVNULL,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
+    pathlib.Path(pid_marker).write_text(str(child.pid), encoding="utf-8")
     return {"worker": "returned"}
 
 

--- a/tests/fixtures/plugin_functions.py
+++ b/tests/fixtures/plugin_functions.py
@@ -11,6 +11,18 @@ import time
 from typing import Any
 
 
+def _linux_process_start_time(pid: int) -> str:
+    stat = pathlib.Path(f"/proc/{pid}/stat").read_text(encoding="utf-8")
+    return stat.rsplit(")", 1)[1].split()[19]
+
+
+def _record_child_identity(child: subprocess.Popen[bytes], pid_marker: str) -> None:
+    pathlib.Path(pid_marker).write_text(
+        f"{child.pid}:{_linux_process_start_time(child.pid)}",
+        encoding="utf-8",
+    )
+
+
 def echo(request: dict[str, Any]) -> dict[str, Any]:
     print("untrusted plugin diagnostic")
     return {"seen": request}
@@ -46,14 +58,18 @@ def spawn_delayed_child(request: dict[str, Any]) -> dict[str, Any]:
     marker = request["marker"]
     started_marker = request["started_marker"]
     pid_marker = request["pid_marker"]
+    ready_marker = f"{pid_marker}.ready"
     delay_seconds = request.get("delay_seconds", 1)
     script = (
         "import pathlib,time;"
+        f"pathlib.Path({ready_marker!r}).write_text('ready', encoding='utf-8');"
         f"time.sleep({delay_seconds!r});"
         f"pathlib.Path({marker!r}).write_text('survived', encoding='utf-8')"
     )
     child = subprocess.Popen([sys.executable, "-c", script])
-    pathlib.Path(pid_marker).write_text(str(child.pid), encoding="utf-8")
+    _record_child_identity(child, pid_marker)
+    while not pathlib.Path(ready_marker).exists():
+        time.sleep(0.005)
     pathlib.Path(started_marker).write_text("started", encoding="utf-8")
     time.sleep(60)
     return {"unreachable": True}
@@ -64,22 +80,28 @@ def spawn_child_then_return(request: dict[str, Any]) -> dict[str, Any]:
 
     marker = request["marker"]
     pid_marker = request["pid_marker"]
+    ready_marker = f"{pid_marker}.ready"
     delay_seconds = request.get("delay_seconds", 1)
     script = (
         "import pathlib,time;"
+        f"pathlib.Path({ready_marker!r}).write_text('ready', encoding='utf-8');"
         f"time.sleep({delay_seconds!r});"
         f"pathlib.Path({marker!r}).write_text('survived', encoding='utf-8')"
     )
     child = subprocess.Popen([sys.executable, "-c", script])
-    pathlib.Path(pid_marker).write_text(str(child.pid), encoding="utf-8")
+    _record_child_identity(child, pid_marker)
+    while not pathlib.Path(ready_marker).exists():
+        time.sleep(0.005)
     return {"worker": "returned"}
 
 
 def spawn_detached_child_then_return(request: dict[str, Any]) -> dict[str, Any]:
     marker = request["marker"]
     pid_marker = request["pid_marker"]
+    ready_marker = f"{pid_marker}.ready"
     script = (
         "import pathlib,time;"
+        f"pathlib.Path({ready_marker!r}).write_text('ready', encoding='utf-8');"
         "time.sleep(1);"
         f"pathlib.Path({marker!r}).write_text('survived', encoding='utf-8')"
     )
@@ -89,7 +111,9 @@ def spawn_detached_child_then_return(request: dict[str, Any]) -> dict[str, Any]:
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
-    pathlib.Path(pid_marker).write_text(str(child.pid), encoding="utf-8")
+    _record_child_identity(child, pid_marker)
+    while not pathlib.Path(ready_marker).exists():
+        time.sleep(0.005)
     return {"worker": "returned"}
 
 

--- a/tests/integration/infrastructure/test_cli.py
+++ b/tests/integration/infrastructure/test_cli.py
@@ -106,12 +106,13 @@ def test_cli_missing_input_file_returns_an_actionable_json_error(
     tmp_path: Path,
 ) -> None:
     missing = tmp_path / "missing.json"
+    state_dir = tmp_path / "state"
 
     result = CliRunner().invoke(
         app,
         [
             "--state-dir",
-            str(tmp_path / "state"),
+            str(state_dir),
             "artifact-put",
             "schema://missing",
             "semantics://missing",
@@ -130,6 +131,7 @@ def test_cli_missing_input_file_returns_an_actionable_json_error(
     }
     assert "Traceback" not in result.stderr
     assert str(missing) not in result.stderr
+    assert not state_dir.exists()
 
 
 def test_cli_invalid_json_returns_an_actionable_json_error(tmp_path: Path) -> None:

--- a/tests/integration/infrastructure/test_plugin_execution.py
+++ b/tests/integration/infrastructure/test_plugin_execution.py
@@ -9,16 +9,28 @@ import pytest
 
 from jacobian.plugin_execution import PluginExecutor
 
+_HAS_LINUX_PROCESS_IDENTITIES = Path("/proc/self/stat").exists()
 
-def _wait_until_process_exits(pid: int, *, timeout_seconds: float = 2) -> None:
+
+def _wait_until_process_exits(
+    identity: str,
+    *,
+    timeout_seconds: float = 2,
+) -> None:
+    pid_text, expected_start_time = identity.split(":", 1)
+    stat_path = Path(f"/proc/{pid_text}/stat")
     deadline = time.monotonic() + timeout_seconds
     while True:
         try:
-            os.kill(pid, 0)
-        except ProcessLookupError:
+            current_start_time = (
+                stat_path.read_text(encoding="utf-8").rsplit(")", 1)[1].split()[19]
+            )
+        except FileNotFoundError:
+            return
+        if current_start_time != expected_start_time:
             return
         if time.monotonic() >= deadline:
-            pytest.fail(f"descendant process {pid} remained alive")
+            pytest.fail(f"descendant process {pid_text} remained alive")
         time.sleep(0.01)
 
 
@@ -126,6 +138,10 @@ def test_plugin_diagnostic_limit_fails_closed() -> None:
     )
 
 
+@pytest.mark.skipif(
+    not _HAS_LINUX_PROCESS_IDENTITIES,
+    reason="requires non-signaling Linux process identities",
+)
 def test_plugin_timeout_kills_descendant_processes(tmp_path: Path) -> None:
     marker = tmp_path / "descendant-survived"
     started_marker = tmp_path / "descendant-started"
@@ -144,10 +160,14 @@ def test_plugin_timeout_kills_descendant_processes(tmp_path: Path) -> None:
 
     assert started_marker.read_text(encoding="utf-8") == "started"
     assert result.status.value == "TIMEOUT"
-    _wait_until_process_exits(int(pid_marker.read_text(encoding="utf-8")))
+    _wait_until_process_exits(pid_marker.read_text(encoding="utf-8"))
     assert not marker.exists()
 
 
+@pytest.mark.skipif(
+    not _HAS_LINUX_PROCESS_IDENTITIES,
+    reason="requires non-signaling Linux process identities",
+)
 def test_plugin_success_kills_descendant_holding_output_pipes(tmp_path: Path) -> None:
     marker = tmp_path / "pipe-holder-survived"
     pid_marker = tmp_path / "pipe-holder-pid"
@@ -164,10 +184,14 @@ def test_plugin_success_kills_descendant_holding_output_pipes(tmp_path: Path) ->
     assert elapsed < 30
     assert result.status.value == "COMPLETED"
     assert result.output == {"worker": "returned"}
-    _wait_until_process_exits(int(pid_marker.read_text(encoding="utf-8")))
+    _wait_until_process_exits(pid_marker.read_text(encoding="utf-8"))
     assert not marker.exists()
 
 
+@pytest.mark.skipif(
+    not _HAS_LINUX_PROCESS_IDENTITIES,
+    reason="requires non-signaling Linux process identities",
+)
 def test_plugin_success_still_kills_detached_descendants(tmp_path: Path) -> None:
     marker = tmp_path / "detached-descendant-survived"
     pid_marker = tmp_path / "detached-descendant-pid"
@@ -179,7 +203,7 @@ def test_plugin_success_still_kills_detached_descendants(tmp_path: Path) -> None
     )
 
     assert result.status.value == "COMPLETED"
-    _wait_until_process_exits(int(pid_marker.read_text(encoding="utf-8")))
+    _wait_until_process_exits(pid_marker.read_text(encoding="utf-8"))
     assert not marker.exists()
 
 

--- a/tests/integration/infrastructure/test_plugin_execution.py
+++ b/tests/integration/infrastructure/test_plugin_execution.py
@@ -10,6 +10,18 @@ import pytest
 from jacobian.plugin_execution import PluginExecutor
 
 
+def _wait_until_process_exits(pid: int, *, timeout_seconds: float = 2) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return
+        if time.monotonic() >= deadline:
+            pytest.fail(f"descendant process {pid} remained alive")
+        time.sleep(0.01)
+
+
 def test_plugin_executor_returns_only_canonical_result() -> None:
     result = PluginExecutor().run(
         entrypoint="tests.fixtures.plugin_functions:echo",
@@ -117,53 +129,57 @@ def test_plugin_diagnostic_limit_fails_closed() -> None:
 def test_plugin_timeout_kills_descendant_processes(tmp_path: Path) -> None:
     marker = tmp_path / "descendant-survived"
     started_marker = tmp_path / "descendant-started"
+    pid_marker = tmp_path / "descendant-pid"
 
     result = PluginExecutor().run(
         entrypoint="tests.fixtures.plugin_functions:spawn_delayed_child",
         request={
             "marker": str(marker),
             "started_marker": str(started_marker),
+            "pid_marker": str(pid_marker),
             "delay_seconds": 3,
         },
         timeout_seconds=2,
     )
-    time.sleep(1.2)
 
     assert started_marker.read_text(encoding="utf-8") == "started"
     assert result.status.value == "TIMEOUT"
+    _wait_until_process_exits(int(pid_marker.read_text(encoding="utf-8")))
     assert not marker.exists()
 
 
 def test_plugin_success_kills_descendant_holding_output_pipes(tmp_path: Path) -> None:
     marker = tmp_path / "pipe-holder-survived"
+    pid_marker = tmp_path / "pipe-holder-pid"
     start = time.monotonic()
 
     result = PluginExecutor().run(
         entrypoint="tests.fixtures.plugin_functions:spawn_child_then_return",
-        request={"marker": str(marker)},
+        request={"marker": str(marker), "pid_marker": str(pid_marker)},
         timeout_seconds=2,
     )
     elapsed = time.monotonic() - start
-    time.sleep(1.2)
 
     # Bound kill latency under load; not a performance SLO.
     assert elapsed < 30
     assert result.status.value == "COMPLETED"
     assert result.output == {"worker": "returned"}
+    _wait_until_process_exits(int(pid_marker.read_text(encoding="utf-8")))
     assert not marker.exists()
 
 
 def test_plugin_success_still_kills_detached_descendants(tmp_path: Path) -> None:
     marker = tmp_path / "detached-descendant-survived"
+    pid_marker = tmp_path / "detached-descendant-pid"
 
     result = PluginExecutor().run(
         entrypoint=("tests.fixtures.plugin_functions:spawn_detached_child_then_return"),
-        request={"marker": str(marker)},
+        request={"marker": str(marker), "pid_marker": str(pid_marker)},
         timeout_seconds=5,
     )
-    time.sleep(1.2)
 
     assert result.status.value == "COMPLETED"
+    _wait_until_process_exits(int(pid_marker.read_text(encoding="utf-8")))
     assert not marker.exists()
 
 

--- a/tests/reference/test_reference_claim_schemas.py
+++ b/tests/reference/test_reference_claim_schemas.py
@@ -5,6 +5,8 @@ import pytest
 from jacobian.artifacts import ArtifactValidationError
 from jacobian.kernel import JacobianKernel
 
+pytestmark = pytest.mark.xdist_group("reference-claim-schemas")
+
 
 @pytest.fixture
 def kernel(kernel_with_references: JacobianKernel) -> JacobianKernel:

--- a/tests/unit/test_ci_plan.py
+++ b/tests/unit/test_ci_plan.py
@@ -163,12 +163,25 @@ def _expected_plan(classification: str, *enabled: str) -> dict[str, str]:
                 "run-python",
                 "run-core",
                 "run-integration",
+                "run-lean",
                 "run-static",
                 "run-build",
             ),
         ),
         (
             ("src/jacobian/contracts/lean.py",),
+            _expected_plan(
+                "selective",
+                "run-python",
+                "run-core",
+                "run-integration",
+                "run-lean",
+                "run-static",
+                "run-build",
+            ),
+        ),
+        (
+            ("src/jacobian/contracts/plugins.py",),
             _expected_plan(
                 "selective",
                 "run-python",

--- a/tests/unit/test_ci_plan.py
+++ b/tests/unit/test_ci_plan.py
@@ -157,6 +157,29 @@ def _expected_plan(classification: str, *enabled: str) -> dict[str, str]:
             ),
         ),
         (
+            ("src/jacobian/contracts/results.py",),
+            _expected_plan(
+                "selective",
+                "run-python",
+                "run-core",
+                "run-integration",
+                "run-static",
+                "run-build",
+            ),
+        ),
+        (
+            ("src/jacobian/contracts/lean.py",),
+            _expected_plan(
+                "selective",
+                "run-python",
+                "run-core",
+                "run-integration",
+                "run-lean",
+                "run-static",
+                "run-build",
+            ),
+        ),
+        (
             ("src/jacobian_checkers/graph_invariants.py",),
             _expected_plan(
                 "selective",

--- a/tests/unit/test_ci_test_timings.py
+++ b/tests/unit/test_ci_test_timings.py
@@ -2,9 +2,68 @@ from __future__ import annotations
 
 import json
 import os
+import runpy
+import threading
+from collections.abc import Callable
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+from typing import cast
 
 from tests.helpers.ci import run_ci_script
+
+
+def test_archive_download_does_not_forward_token_across_origins() -> None:
+    received_authorization: list[str | None] = []
+
+    class StorageHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            received_authorization.append(self.headers.get("Authorization"))
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"timing archive")
+
+        def log_message(self, _format: str, *args: object) -> None:
+            pass
+
+    storage = ThreadingHTTPServer(("127.0.0.1", 0), StorageHandler)
+    storage_thread = threading.Thread(target=storage.serve_forever)
+    storage_thread.start()
+    storage_url = f"http://127.0.0.1:{storage.server_port}/archive"
+
+    class ApiHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            assert self.headers["Authorization"] == "Bearer test-token"
+            self.send_response(302)
+            self.send_header("Location", storage_url)
+            self.end_headers()
+
+        def log_message(self, _format: str, *args: object) -> None:
+            pass
+
+    api = ThreadingHTTPServer(("127.0.0.1", 0), ApiHandler)
+    api_thread = threading.Thread(target=api.serve_forever)
+    api_thread.start()
+    try:
+        namespace = runpy.run_path(
+            Path(__file__).parents[2] / ".github" / "scripts" / "manage-test-timings"
+        )
+        download = cast(Callable[[str, str], bytes], namespace["download"])
+
+        assert (
+            download(
+                f"http://127.0.0.1:{api.server_port}/artifact",
+                "test-token",
+            )
+            == b"timing archive"
+        )
+        assert received_authorization == [None]
+    finally:
+        api.shutdown()
+        storage.shutdown()
+        api.server_close()
+        storage.server_close()
+        api_thread.join()
+        storage_thread.join()
 
 
 def plan_outputs() -> dict[str, str]:


### PR DESCRIPTION
## Problem

Routine developer and PR feedback still paid for avoidable kernel initialization, repeated descriptor work, ineffective integration timing history, and over-broad Lean validation. Several process tests also used fixed sleeps, while `validate-full` was easy to mistake for an exact CI reproduction.

## Solution

- Batch foundational descriptor installation and cache immutable schema definitions without sharing store-bound kernel state. Transaction-local registrations remain pending until a durable witness confirms commit, so rollback cannot leave phantom schemas or model contracts.
- Construct the CLI kernel only when a command actually needs it. Help and input-validation failures no longer create a state directory.
- Restore integration timing artifact downloads by stripping GitHub credentials on cross-origin redirects. The live downloader now loads 756 historical durations instead of silently falling back to equal weighting.
- Use fixture-aware `loadgroup` scheduling only for the core reference module. Three alternating same-seed pairs measured a 45.5s median versus 46.9s for work stealing; integration retains `worksteal`.
- Skip the duplicate default Lean build and classify only Lean adapters plus their shared contract dependency closure for the Lean lane.
- Replace three fixed 1.2s waits with child-authored readiness and non-signaling Linux process identities.
- Clarify that `validate-full` is a broad local subset and make `make check` the routine workflow.

The Lean GitHub cache remains enabled. One observed run suggested its transfer may be expensive, but changing cache policy needs cold and warm CI measurements rather than a single sample.

## Testing

```sh
make check
# 154 passed, 2 deselected; Ruff and mypy passed

make test-core PYTEST_ARGS="--randomly-seed=2501237858"
# 681 passed in 38.23s

uv run --locked pytest -n 0 tests/integration/infrastructure/test_plugin_execution.py tests/integration/infrastructure/test_cli.py -q
# 22 passed in 62.30s

uv run --locked pytest -n 0 tests/integration/infrastructure/test_hydrate_authorized.py tests/integration/infrastructure/test_suite_fixtures.py -q
# focused kernel hydration and fixture coverage passed
```

Manual verification:

- `uv run --locked jacobian --help` completed in 1.00s.
- The GitHub timing downloader produced 756 historical duration entries.
- JSON and composite-action YAML validation passed.

## Trust & Compatibility Impact

No artifact format, public capability contract, checker authority, or verification assurance changes. Schema caches remain exact-byte keyed and store-local; transaction rollback is covered for plain and model-backed schemas. Process lifecycle assertions are explicitly Linux-only where `/proc` identities are available.

Suggested review order: schema transaction handling, timing redirect security, CI classification, then CLI and test scheduling.

## Checklist

- [x] Routine local validation passes (`make check`)
- [x] Relevant focused tests are listed above