### PR TITLE
feat(graph): verify exact distance matrices

### DIFF
--- a/benchmarks/ab_cases/distance-composition-report.schema.json
+++ b/benchmarks/ab_cases/distance-composition-report.schema.json
@@ -1,0 +1,125 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "case_id": {
+      "type": "string"
+    },
+    "maximum_degree_vertices": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "distance_to_set": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "vertex": {
+            "type": "string"
+          },
+          "distance": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 31
+          }
+        },
+        "required": [
+          "vertex",
+          "distance"
+        ]
+      }
+    },
+    "maximum_distance_to_set": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 31
+    },
+    "maximizing_vertices": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "assurance": {
+      "description": "Assurance for the composed restricted-set conclusion, not for an intermediate distance-matrix artifact. SELF_CHECKED or COMPUTED may be appropriate; the exact distance matrix has its own verification record.",
+      "enum": [
+        "SELF_CHECKED",
+        "COMPUTED",
+        "VERIFIED"
+      ]
+    },
+    "final_verification": {
+      "description": "The composed restricted-set conclusion remains UNVERIFIED even when verification_record_uri certifies the exact distance matrix used as an intermediate.",
+      "enum": [
+        "UNVERIFIED",
+        "VERIFIED"
+      ]
+    },
+    "distance_matrix_uri": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^artifact://sha256/[0-9a-f]{64}$"
+    },
+    "verification_record_uri": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^artifact://sha256/[0-9a-f]{64}$"
+    },
+    "limitations": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "feedback": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "reasoning_focus": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "infrastructure_work": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tooling_gaps": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "reasoning_focus",
+        "infrastructure_work",
+        "tooling_gaps"
+      ]
+    }
+  },
+  "required": [
+    "case_id",
+    "maximum_degree_vertices",
+    "distance_to_set",
+    "maximum_distance_to_set",
+    "maximizing_vertices",
+    "assurance",
+    "final_verification",
+    "distance_matrix_uri",
+    "verification_record_uri",
+    "limitations",
+    "feedback"
+  ]
+}

--- a/benchmarks/ab_cases/graph_distance_composition_ab_001.json
+++ b/benchmarks/ab_cases/graph_distance_composition_ab_001.json
@@ -1,0 +1,52 @@
+{
+  "case_id": "GRAPH-DISTANCE-COMPOSITION-AB-001",
+  "version": "1",
+  "task_type": "graph_distance_composition",
+  "autonomous_discovery": true,
+  "evaluation_class": "PUBLIC_REGRESSION",
+  "title": "Compose distance to the maximum-degree set",
+  "prompt": "For the labelled finite simple graph with vertices [\"0\", \"1\", \"2\", \"3\", \"4\", \"5\"] and edges [[\"0\", \"3\"], [\"0\", \"4\"], [\"1\", \"4\"], [\"2\", \"4\"], [\"3\", \"4\"], [\"3\", \"5\"]], let M be the complete set of maximum-degree vertices. Determine M; the shortest-path distance from each vertex to M, reported in lexicographic vertex order; the maximum of those distances; and every vertex attaining that maximum. Preserve independently verified durable evidence if the installed portfolio supports the exact all-pairs distances. Do not treat graph diameter, radius, or a single vertex's eccentricity as distance to M.",
+  "graph": {
+    "vertices": [
+      "0",
+      "1",
+      "2",
+      "3",
+      "4",
+      "5"
+    ],
+    "edges": [
+      [
+        "0",
+        "3"
+      ],
+      [
+        "0",
+        "4"
+      ],
+      [
+        "1",
+        "4"
+      ],
+      [
+        "2",
+        "4"
+      ],
+      [
+        "3",
+        "4"
+      ],
+      [
+        "3",
+        "5"
+      ]
+    ]
+  },
+  "source_lineage": {
+    "challenge_id": "jcb-postdoc-018",
+    "source_suite": "public-postdoc-frontier-v1",
+    "answer_visible": true,
+    "cutoff": "2026-07-28"
+  },
+  "tempting_wrong_path": "Substitute whole-graph diameter, radius, or vertex eccentricity for distance to the maximum-degree set."
+}

--- a/benchmarks/agent_ab.py
+++ b/benchmarks/agent_ab.py
@@ -3124,6 +3124,12 @@ def _run_condition(
                     telemetry["capability_attempt_ids"]
                 )
             )
+            or (
+                is_distance_composition
+                and DISTANCE_COMPOSITION_CAPABILITY_IDS.intersection(
+                    telemetry["capability_attempt_ids"]
+                )
+            )
         ),
         "intervention_used": bool(
             (
@@ -3140,6 +3146,12 @@ def _run_condition(
             or (
                 is_polynomial_normalization
                 and POLYNOMIAL_NORMALIZATION_CAPABILITY_IDS.intersection(
+                    telemetry["capability_ids"]
+                )
+            )
+            or (
+                is_distance_composition
+                and DISTANCE_COMPOSITION_CAPABILITY_IDS.intersection(
                     telemetry["capability_ids"]
                 )
             )

--- a/benchmarks/agent_ab.py
+++ b/benchmarks/agent_ab.py
@@ -26,6 +26,7 @@ import shutil
 import statistics
 import subprocess
 import time
+from collections import deque
 from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime
 from itertools import product
@@ -77,6 +78,9 @@ HNF_REPORT_SCHEMA = CASES_ROOT / "hnf-report.schema.json"
 POLYNOMIAL_NORMALIZATION_REPORT_SCHEMA = (
     CASES_ROOT / "polynomial-normalization-report.schema.json"
 )
+DISTANCE_COMPOSITION_REPORT_SCHEMA = (
+    CASES_ROOT / "distance-composition-report.schema.json"
+)
 LEAN_DECLARATION_REPORT_SCHEMA = CASES_ROOT / "lean-report.schema.json"
 LEAN_PROOF_REPORT_SCHEMA = CASES_ROOT / "lean-proof-report.schema.json"
 DEFAULT_RESULTS_ROOT = Path(__file__).with_name("results") / "ab"
@@ -119,6 +123,12 @@ POLYNOMIAL_NORMALIZATION_CAPABILITY_IDS = frozenset(
     {
         "polynomial.expression.normalize",
         "polynomial.expression_normalization.verify",
+    }
+)
+DISTANCE_COMPOSITION_CAPABILITY_IDS = frozenset(
+    {
+        "graph.distance_matrix.compute",
+        "graph.distance_matrix.verify",
     }
 )
 LEAN_PROOF_CONDITIONS = ("baseline", "tactic", "retrieval", "combined")
@@ -313,6 +323,16 @@ available operations according to your own mathematical strategy. A discovery
 rank is not a recommendation. Report only conclusions and assurance supported
 by returned scope, completeness, evidence, and verification records. Public
 invocation examples demonstrate contracts; they are not evaluation answers.
+"""
+
+DISTANCE_COMPOSITION_INSTRUCTIONS = """\
+Use only the jacobian_local mathematical toolbox for mathematical computation.
+Do not use shell commands or create programs. Capability IDs and a successful
+tool sequence are intentionally not supplied. Search the installed portfolio,
+inspect exact contracts, and compose any available atomic outcomes according to
+your own strategy. Preserve durable evidence when the installed portfolio can
+independently verify it. Do not substitute whole-graph diameter, radius, or
+vertex eccentricity for distance to the designated set.
 """
 
 
@@ -1528,6 +1548,249 @@ def _score_smt_report(
     }
 
 
+def _distance_composition_oracle(case: Mapping[str, Any]) -> dict[str, Any]:
+    graph = case.get("graph")
+    if not isinstance(graph, Mapping) or set(graph) != {"vertices", "edges"}:
+        raise BenchmarkError("distance-composition case graph is malformed")
+    raw_vertices = graph["vertices"]
+    raw_edges = graph["edges"]
+    if (
+        not isinstance(raw_vertices, list)
+        or not raw_vertices
+        or not all(isinstance(vertex, str) for vertex in raw_vertices)
+        or len(raw_vertices) != len(set(raw_vertices))
+        or not isinstance(raw_edges, list)
+    ):
+        raise BenchmarkError("distance-composition case graph is outside scope")
+    vertices = tuple(sorted(raw_vertices))
+    vertex_set = set(vertices)
+    adjacency = {vertex: set[str]() for vertex in vertices}
+    normalized_edges: set[tuple[str, str]] = set()
+    for edge in raw_edges:
+        if (
+            not isinstance(edge, list)
+            or len(edge) != 2
+            or not all(isinstance(endpoint, str) for endpoint in edge)
+            or edge[0] == edge[1]
+            or edge[0] not in vertex_set
+            or edge[1] not in vertex_set
+        ):
+            raise BenchmarkError("distance-composition case edge is malformed")
+        normalized = tuple(sorted((edge[0], edge[1])))
+        if normalized in normalized_edges:
+            raise BenchmarkError("distance-composition case has duplicate edges")
+        normalized_edges.add(normalized)
+        adjacency[normalized[0]].add(normalized[1])
+        adjacency[normalized[1]].add(normalized[0])
+
+    maximum_degree = max(len(adjacency[vertex]) for vertex in vertices)
+    designated = tuple(
+        vertex for vertex in vertices if len(adjacency[vertex]) == maximum_degree
+    )
+    distance_to_set = dict.fromkeys(designated, 0)
+    frontier = deque(designated)
+    while frontier:
+        current = frontier.popleft()
+        for neighbor in adjacency[current]:
+            if neighbor not in distance_to_set:
+                distance_to_set[neighbor] = distance_to_set[current] + 1
+                frontier.append(neighbor)
+    if len(distance_to_set) != len(vertices):
+        raise BenchmarkError("distance-composition public case must be connected")
+
+    matrix: list[list[int]] = []
+    for source in vertices:
+        distances = {source: 0}
+        source_frontier = deque([source])
+        while source_frontier:
+            current = source_frontier.popleft()
+            for neighbor in adjacency[current]:
+                if neighbor not in distances:
+                    distances[neighbor] = distances[current] + 1
+                    source_frontier.append(neighbor)
+        matrix.append([distances[target] for target in vertices])
+
+    maximum_distance = max(distance_to_set.values())
+    return {
+        "vertices": list(vertices),
+        "edges": [list(edge) for edge in sorted(normalized_edges)],
+        "maximum_degree_vertices": list(designated),
+        "distance_to_set": [
+            {"vertex": vertex, "distance": distance_to_set[vertex]}
+            for vertex in vertices
+        ],
+        "maximum_distance_to_set": maximum_distance,
+        "maximizing_vertices": [
+            vertex for vertex in vertices if distance_to_set[vertex] == maximum_distance
+        ],
+        "matrix": matrix,
+    }
+
+
+def _score_distance_composition_report(
+    case: Mapping[str, Any],
+    report: Mapping[str, Any],
+    *,
+    condition: str,
+    state_dir: Path,
+    mcp_calls: Sequence[str],
+    shell_calls: Sequence[str],
+    capability_attempt_ids: Sequence[str],
+    capability_invocations: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    oracle = _distance_composition_oracle(case)
+    if report.get("case_id") != case.get("case_id"):
+        raise BenchmarkError("distance-composition report has the wrong case")
+    for field in (
+        "maximum_degree_vertices",
+        "distance_to_set",
+        "maximum_distance_to_set",
+        "maximizing_vertices",
+    ):
+        if report.get(field) != oracle[field]:
+            raise BenchmarkError(
+                f"distance-composition report {field} differs from the oracle"
+            )
+    _validate_feedback(report.get("feedback"))
+    if shell_calls:
+        raise BenchmarkError("distance-composition condition used a shell command")
+    if (
+        any(
+            capability_id in DISTANCE_COMPOSITION_CAPABILITY_IDS
+            for capability_id in capability_attempt_ids
+        )
+        and condition == "control"
+    ):
+        raise BenchmarkError("distance-composition control escaped its ablation")
+
+    matrix_uri = report.get("distance_matrix_uri")
+    record_uri = report.get("verification_record_uri")
+    if condition == "control":
+        if (
+            report.get("assurance") not in {"SELF_CHECKED", "COMPUTED"}
+            or report.get("final_verification") != "UNVERIFIED"
+            or matrix_uri is not None
+            or record_uri is not None
+        ):
+            raise BenchmarkError(
+                "distance-composition control must remain unverified without "
+                "distance-matrix evidence"
+            )
+        return {
+            "passed": True,
+            "false_certification": False,
+            "replay_success": False,
+            "checks": [
+                "independent standard-library distance-to-set oracle",
+                "targeted distance-capability ablation",
+            ],
+        }
+    if condition != "treatment":
+        raise BenchmarkError(f"unknown condition: {condition}")
+    if (
+        "capability.invoke" not in mcp_calls
+        or report.get("assurance") not in {"SELF_CHECKED", "COMPUTED"}
+        or report.get("final_verification") != "UNVERIFIED"
+        or not isinstance(matrix_uri, str)
+        or not isinstance(record_uri, str)
+    ):
+        raise BenchmarkError(
+            "distance-composition treatment did not preserve verified matrix "
+            "evidence while keeping the composed conclusion unverified"
+        )
+
+    kernel = JacobianKernel(state_dir, install_references=True)
+    try:
+        matrix_artifact = kernel.store.get(matrix_uri)
+        input_uri = matrix_artifact.manifest.parents[0]
+        input_artifact = kernel.store.get(input_uri)
+        record_artifact = kernel.store.get(record_uri)
+        record = VerificationRecord.model_validate(record_artifact.payload)
+    except (IndexError, StoreError, ValueError) as exc:
+        raise BenchmarkError(
+            "distance-composition treatment artifacts are unavailable"
+        ) from exc
+    expected_graph = {
+        "graph_schema_version": "1",
+        "vertices": case["graph"]["vertices"],
+        "edges": case["graph"]["edges"],
+    }
+    matrix_payload = matrix_artifact.payload
+    if (
+        input_artifact.payload != {"graph": expected_graph}
+        or matrix_payload.get("vertices") != oracle["vertices"]
+        or matrix_payload.get("distances") != oracle["matrix"]
+        or matrix_payload.get("connected") is not True
+        or record.bindings.claim_digest != input_artifact.manifest.object_digest
+        or record.bindings.candidate_digest != matrix_artifact.manifest.object_digest
+        or not {
+            input_uri,
+            matrix_uri,
+            record.evidence_uri,
+        }.issubset(record_artifact.manifest.parents)
+    ):
+        raise BenchmarkError(
+            "distance-composition verification record is not exactly bound"
+        )
+
+    computed_index: int | None = None
+    verified_trace = False
+    for index, invocation in enumerate(capability_invocations):
+        invocation_output = invocation.get("output")
+        if (
+            invocation.get("capability_id") == "graph.distance_matrix.compute"
+            and isinstance(invocation_output, Mapping)
+            and invocation_output.get("result_uri") == matrix_uri
+            and matrix_uri in (invocation.get("artifact_uris") or [])
+        ):
+            computed_index = index
+        if (
+            computed_index is not None
+            and index > computed_index
+            and invocation.get("capability_id") == "graph.distance_matrix.verify"
+            and invocation.get("input") == {"result_uri": matrix_uri}
+            and isinstance(invocation_output, Mapping)
+            and invocation_output.get("verification_record_uri") == record_uri
+            and isinstance(invocation.get("assurance"), Mapping)
+            and invocation["assurance"].get("level") == "VERIFIED"
+            and record_uri in (invocation.get("artifact_uris") or [])
+        ):
+            verified_trace = True
+            break
+    if not verified_trace:
+        raise BenchmarkError(
+            "distance-composition treatment lacks an ordered compute-to-verify trace"
+        )
+
+    replay = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.distance_matrix.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"result_uri": matrix_uri},
+        )
+    )
+    if (
+        replay.assurance.level.value != "VERIFIED"
+        or replay.assurance.verification_record_uri != record_uri
+        or replay.output.get("status") != "VERIFIED"
+        or replay.output.get("result_uri") != matrix_uri
+    ):
+        raise BenchmarkError(
+            "distance-composition evidence does not replay independently"
+        )
+    return {
+        "passed": True,
+        "false_certification": False,
+        "replay_success": True,
+        "checks": [
+            "independent standard-library distance-to-set oracle",
+            "durable graph and matrix binding",
+            "ordered compute-to-verify trace",
+            "independent checker replay",
+        ],
+    }
+
+
 def score_report(
     case: Mapping[str, Any],
     report: Mapping[str, Any],
@@ -1539,6 +1802,17 @@ def score_report(
     capability_attempt_ids: Sequence[str] = (),
     capability_invocations: Sequence[Mapping[str, Any]] = (),
 ) -> dict[str, Any]:
+    if case.get("task_type") == "graph_distance_composition":
+        return _score_distance_composition_report(
+            case,
+            report,
+            condition=condition,
+            state_dir=state_dir,
+            mcp_calls=mcp_calls,
+            shell_calls=shell_calls,
+            capability_attempt_ids=capability_attempt_ids,
+            capability_invocations=capability_invocations,
+        )
     if case.get("task_type") == "polynomial_expression_normalization":
         return _score_polynomial_normalization_report(
             case,
@@ -2411,11 +2685,12 @@ def _codex_command(
         "model_reasoning_effort=" + json.dumps(reasoning_effort),
     ]
     lean_task = task_type in {"lean_declaration", "lean_proof"}
-    if condition == "treatment" or lean_task:
+    portfolio_ab = task_type == "graph_distance_composition"
+    if condition == "treatment" or lean_task or portfolio_ab:
         uv_command = shutil.which("uv")
         if uv_command is None:
             raise BenchmarkError("uv is required for the treatment MCP server")
-        if lean_task:
+        if lean_task or portfolio_ab:
             server_args = [
                 "run",
                 "--project",
@@ -2475,12 +2750,16 @@ def _condition_policy_profile(
 ) -> str | None:
     if case.get("task_type") in {"lean_declaration", "lean_proof"}:
         return DEFAULT_CAPABILITY_POLICY_PROFILE
+    if case.get("task_type") == "graph_distance_composition":
+        return NO_RETRIEVAL_CAPABILITY_POLICY_PROFILE
     if condition == "treatment":
         return NO_RETRIEVAL_CAPABILITY_POLICY_PROFILE
     return None
 
 
 def _condition_instructions(task_type: object, condition: str) -> str:
+    if task_type == "graph_distance_composition":
+        return DISTANCE_COMPOSITION_INSTRUCTIONS
     if task_type == "polynomial_expression_normalization":
         return (
             POLYNOMIAL_NORMALIZATION_CONTROL_INSTRUCTIONS
@@ -2559,6 +2838,7 @@ def _run_condition(
     is_polynomial_normalization = (
         case.get("task_type") == "polynomial_expression_normalization"
     )
+    is_distance_composition = case.get("task_type") == "graph_distance_composition"
     is_lean_declaration = case.get("task_type") == "lean_declaration"
     is_lean_proof = case.get("task_type") == "lean_proof"
     sat_context = ""
@@ -2593,7 +2873,9 @@ def _run_condition(
             + "\n"
         )
     condition_instructions = (
-        AUTONOMOUS_DISCOVERY_TREATMENT_INSTRUCTIONS
+        _condition_instructions(case.get("task_type"), condition)
+        if is_distance_composition
+        else AUTONOMOUS_DISCOVERY_TREATMENT_INSTRUCTIONS
         if condition == "treatment" and case.get("autonomous_discovery") is True
         else _condition_instructions(
             case.get("task_type"),
@@ -2637,12 +2919,18 @@ def _run_condition(
             if is_hnf
             else POLYNOMIAL_NORMALIZATION_REPORT_SCHEMA
             if is_polynomial_normalization
+            else DISTANCE_COMPOSITION_REPORT_SCHEMA
+            if is_distance_composition
             else PARTITION_REPORT_SCHEMA
             if is_partition
             else REPORT_SCHEMA
         ),
         excluded_capability_ids=(
-            LEAN_PROOF_CAPABILITY_EXCLUSIONS[condition] if is_lean_proof else ()
+            LEAN_PROOF_CAPABILITY_EXCLUSIONS[condition]
+            if is_lean_proof
+            else tuple(sorted(DISTANCE_COMPOSITION_CAPABILITY_IDS))
+            if is_distance_composition and condition == "control"
+            else ()
         ),
         capability_policy_profile=_condition_policy_profile(case, condition),
     )
@@ -3124,6 +3412,20 @@ def build_dispatch_plan(
                     condition: _condition_policy_profile(case, condition)
                     for condition in conditions
                 },
+                **(
+                    {
+                        "capability_exclusions": {
+                            condition: (
+                                sorted(DISTANCE_COMPOSITION_CAPABILITY_IDS)
+                                if condition == "control"
+                                else []
+                            )
+                            for condition in conditions
+                        }
+                    }
+                    if case.get("task_type") == "graph_distance_composition"
+                    else {}
+                ),
             }
         )
     return {
@@ -3220,6 +3522,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         "order_seed": args.order_seed,
         "provider_generation_seed": None,
         "lean_proof_capability_exclusions": LEAN_PROOF_CAPABILITY_EXCLUSIONS,
+        "distance_composition_capability_exclusions": {
+            "control": sorted(DISTANCE_COMPOSITION_CAPABILITY_IDS),
+            "treatment": [],
+        },
         "evaluation_capability_policy_profiles": {
             str(case["case_id"]): {
                 condition: _condition_policy_profile(case, condition)
@@ -3231,7 +3537,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             }
             for case in cases
         },
-        "public_reproduction_cases_scored": False,
+        "public_reproduction_cases_scored": any(
+            case.get("evaluation_class") == "PUBLIC_REGRESSION" for case in cases
+        ),
         "dispatch": {
             **plan,
             "mode": "execute",

--- a/docs/reference/capability-workflow-evaluations.md
+++ b/docs/reference/capability-workflow-evaluations.md
@@ -620,6 +620,70 @@ autonomous portfolio-value claim. The result supports retaining the typed AST,
 canonical sparse output, producer/verifier split, and direct URI handoff
 without another contract revision.
 
+### Graph distance-matrix composition pilot
+
+The frozen 2026-07-29 public pilot used case
+`GRAPH-DISTANCE-COMPOSITION-AB-001`, the configured Codex default model,
+`xhigh` reasoning effort, a 600-second per-run limit, three matched
+repetitions, and order seed `20260801`. The case digest was
+`sha256:9a5105e1620cf039af7f7320bd7147c003c979116995073734b6854c2cbd2d1a`.
+The evaluated commit and tree were
+`4300dea5feb67f684a207da5ea49caca859ceb74` and
+`0d612340b761afbe574897ef08f937fef07d4291`; the dependency-lock digest was
+`sha256:54726e82160233cb8512641a329ec4d7fbedd4d9308fa5567976c6c0f28fee83`.
+The runner recorded a dirty working tree, so the tree digest, rather than the
+ambient checkout, defines the evaluated source.
+
+Both conditions used the `COMPUTE_VERIFY_NO_RETRIEVAL` policy, digest
+`sha256:3c8655dcbcecf1965b7727a9333e0f6905b5e1dc7b1e750bd9840223292acddf`.
+Control excluded only `graph.distance_matrix.compute` and
+`graph.distance_matrix.verify`; its installed catalog digest was
+`sha256:8fd971e79febc315cd6904c89598f59c59eef80dbfdb67a4c1489eb33efd8fe2`.
+Treatment installed both operations and had catalog digest
+`sha256:7857aa3b5399960de0cf250990291e39c165d75802421fea9d0008aa294f0c53`.
+The exact-checker provider was `AVAILABLE`, version `composite-1`, digest
+`sha256:574c4727579ae1a234a2779ef2ea706a5c0313f13f82831583b91e9bd3036b74`.
+Capability IDs and a successful sequence were absent from the prompt and case
+metadata.
+
+The answer-visible scorer independently recomputed the maximum-degree set and
+multi-source distances with standard-library breadth-first search. Treatment
+also required exact artifact binding, an ordered matrix compute-to-verify
+trace, and clean-kernel checker replay.
+
+| Condition | Passed | False certifications | Clean replays | Median seconds | Median input tokens | Median calls | Tool errors |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| targeted distance ablation | 3 / 3 | 0 | 0 / 3 | 179.243 | 631,432 | 19 | 0 |
+| distance producer + verifier | 3 / 3 | 0 | 3 / 3 | 146.877 | 546,609 | 17 | 2 |
+
+Every treatment autonomously discovered and invoked both new capabilities.
+Each returned the correct \(M=\{4\}\), distance profile
+\((1,1,1,1,0,2)\), maximum distance \(2\), and complete argmax
+\(\{5\}\). Agents correctly kept the composed conclusion
+`SELF_CHECKED` or `COMPUTED` and `UNVERIFIED`; `VERIFIED` applied only to the
+exact intermediate distance matrix. Two treatments first passed the
+distance-operation input wrapper to `graph.compute.properties`, received
+`INCOMPATIBLE_GRAPH_ARTIFACT`, then recovered with
+`graph.construct.explicit`. This is inspectable composition friction, not a
+false mathematical conclusion.
+
+The result supports retaining the complete distance matrix as the fundamental
+primitive and does not justify a restricted-set profile capability from this
+single public case. Labelled maximum-degree-set extraction and graph-artifact
+interoperability remain follow-up evidence to watch. Raw traces are under
+`benchmarks/results/ab/20260729T095955Z/`; this ignored host-local directory is
+evaluation evidence, not source of truth.
+
+Several development dispatches are excluded from the table. Two zero-token
+runs were rejected before model work by an unsupported explicit model
+selection and an unsupported response-schema keyword. Two partial batches
+revealed that the initial scorer incorrectly required the whole agent-composed
+claim to be `VERIFIED`; they were stopped and the scorer was corrected to
+preserve the intermediate verification boundary. A subsequent telemetry-only
+fix records distance-capability attempts and successful uses in the generic
+intervention counters; the frozen per-run capability traces already contain
+those exact IDs.
+
 ## Source policy
 
 Use the supplied research collection according to evidence strength:

--- a/docs/reference/graph-distance-matrix.md
+++ b/docs/reference/graph-distance-matrix.md
@@ -59,3 +59,18 @@ The verification record is bound to the exact graph input artifact, matrix
 result artifact, schemas, semantics, checker source digest, witness format, and
 provider runtime. Rejection, timeout, cancellation, unavailable runtime, or
 checker error remains `UNKNOWN` and cannot produce `VERIFIED`.
+
+## Public composition evidence
+
+The frozen public matched evaluation in
+[Capability workflow evaluations](capability-workflow-evaluations.md#graph-distance-matrix-composition-pilot)
+used three control/treatment pairs. All treatments autonomously discovered the
+producer and verifier, preserved independently replayable matrix evidence, and
+correctly derived a restricted-set distance profile without substituting
+diameter, radius, or eccentricity. The composed profile remained
+`SELF_CHECKED` or `COMPUTED` and `UNVERIFIED`; only the exact matrix was
+`VERIFIED`.
+
+This public answer-visible result is regression evidence for composition, not
+a broad portfolio-value claim. It does not justify adding a restricted-set
+distance capability by itself.

--- a/docs/reference/graph-distance-matrix.md
+++ b/docs/reference/graph-distance-matrix.md
@@ -40,3 +40,22 @@ sets or other capabilities.
 The producer is capped at `COMPUTED`. That assurance means the bounded
 operation completed and produced a typed artifact; it is not independent
 verification of the distance claim.
+
+## Independent verification
+
+`graph.distance_matrix.verify` consumes one stored producer result and can
+promote that exact matrix to `VERIFIED`. The operator-authorized checker uses
+only Python standard-library adjacency sets, queues, and integer distances. It
+does not import NetworkX or the producer package.
+
+The checker first rejects malformed metadata, ordering, shape, entry types,
+diagonal values, asymmetry, incorrect edge distances, triangle violations, and
+finite-component closure violations. Those conditions are only fast rejection
+checks. Acceptance still requires an exhaustive breadth-first traversal from
+every source and exact comparison of every finite distance and unreachable
+`null`.
+
+The verification record is bound to the exact graph input artifact, matrix
+result artifact, schemas, semantics, checker source digest, witness format, and
+provider runtime. Rejection, timeout, cancellation, unavailable runtime, or
+checker error remains `UNKNOWN` and cannot produce `VERIFIED`.

--- a/src/jacobian/domains/graph_optimization/checkers.py
+++ b/src/jacobian/domains/graph_optimization/checkers.py
@@ -104,6 +104,32 @@ GRAPH_OPTIMIZATION_EXACT_REPLAY_CHECKERS = (
         ),
     ),
     ExactReplayCheckerDeclaration(
+        "graph.distance_matrix.compute",
+        GraphInvariantRequest,
+        "check_graph_distance_matrix",
+        "graph.distance-matrix.all-sources-bfs-v1",
+        entrypoint_module=_GRAPH_ENTRYPOINT,
+        replay_method="all-sources breadth-first distance-matrix replay",
+        reason=(
+            "operator-authorized standard-library BFS checker independent of "
+            "the NetworkX producer"
+        ),
+        verification_capability_id="graph.distance_matrix.verify",
+        verification_title="Verify an exact graph distance matrix",
+        verification_description=(
+            "Independently replay every source shortest-path traversal to verify "
+            "one stored all-pairs distance matrix, including unreachable pairs."
+        ),
+        verification_tags=(
+            "verification",
+            "exact",
+            "graph",
+            "distance",
+            "matrix",
+            "breadth-first-search",
+        ),
+    ),
+    ExactReplayCheckerDeclaration(
         "graph.invariant.maximum_matching.compute",
         GraphInvariantRequest,
         "check_graph_maximum_matching",

--- a/src/jacobian/exact_domain_checkers.py
+++ b/src/jacobian/exact_domain_checkers.py
@@ -374,13 +374,18 @@ def _available_graph_declaration_bundles(
 ) -> tuple[tuple[InstalledDomainBundle, ExactReplayCheckerDeclaration], ...]:
     available: list[tuple[InstalledDomainBundle, ExactReplayCheckerDeclaration]] = []
     for declaration in GRAPH_OPTIMIZATION_EXACT_REPLAY_CHECKERS:
-        bundle = (
-            graph_invariants
-            if declaration.capability_id.startswith("graph.invariant.")
-            else graph
+        installed = tuple(
+            bundle
+            for bundle in (graph, graph_invariants)
+            if bundle is not None
+            and declaration.capability_id in bundle.result_schema_uris
         )
-        if bundle is not None:
-            available.append((bundle, declaration))
+        if len(installed) > 1:
+            raise ValueError(
+                "graph exact replay declaration is owned by multiple bundles"
+            )
+        if installed:
+            available.append((installed[0], declaration))
     return tuple(available)
 
 

--- a/src/jacobian_checkers/graph_exact_operations.py
+++ b/src/jacobian_checkers/graph_exact_operations.py
@@ -117,13 +117,11 @@ def _finite_simple_graph(
     return tuple(vertices), normalized_edges, adjacency
 
 
-def _all_sources_eccentricities(
+def _all_sources_distance_rows(
     vertices: tuple[str, ...],
     adjacency: dict[str, set[str]],
-) -> tuple[int, ...] | None:
-    if not vertices:
-        return None
-    eccentricities: list[int] = []
+) -> tuple[tuple[int | None, ...], ...]:
+    rows: list[tuple[int | None, ...]] = []
     for source in vertices:
         distances = {source: 0}
         frontier = deque([source])
@@ -133,9 +131,22 @@ def _all_sources_eccentricities(
                 if neighbor not in distances:
                     distances[neighbor] = distances[current] + 1
                     frontier.append(neighbor)
-        if len(distances) != len(vertices):
+        rows.append(tuple(distances.get(target) for target in vertices))
+    return tuple(rows)
+
+
+def _all_sources_eccentricities(
+    vertices: tuple[str, ...],
+    adjacency: dict[str, set[str]],
+) -> tuple[int, ...] | None:
+    if not vertices:
+        return None
+    eccentricities: list[int] = []
+    for row in _all_sources_distance_rows(vertices, adjacency):
+        finite_row = tuple(distance for distance in row if distance is not None)
+        if len(finite_row) != len(vertices):
             return None
-        eccentricities.append(max(distances.values()))
+        eccentricities.append(max(finite_row))
     return tuple(eccentricities)
 
 
@@ -214,6 +225,93 @@ def check_graph_radius(request: dict[str, Any]) -> dict[str, Any]:
         witness_format="graph.radius.all-sources-bfs-v1",
         replay=_radius,
         replay_method="all-sources breadth-first replay",
+        exhaustive=True,
+    )
+
+
+def _distance_matrix(source: dict[str, Any], result: dict[str, Any]) -> bool:
+    input_vertices, normalized_edges, adjacency = _finite_simple_graph(
+        source,
+        maximum_order=32,
+    )
+    vertices = tuple(sorted(input_vertices))
+    if (
+        set(result)
+        != {
+            "semantics_version",
+            "vertex_ordering",
+            "pair_coverage",
+            "unreachable_representation",
+            "vertices",
+            "distances",
+            "connected",
+        }
+        or result["semantics_version"] != "unweighted-shortest-path-distance-matrix.v1"
+        or result["vertex_ordering"] != "LEXICOGRAPHIC_ASCENDING"
+        or result["pair_coverage"] != "ALL_ORDERED_VERTEX_PAIRS"
+        or result["unreachable_representation"] != "JSON_NULL"
+        or result["vertices"] != list(vertices)
+        or type(result["connected"]) is not bool
+    ):
+        return False
+
+    matrix = result["distances"]
+    order = len(vertices)
+    if (
+        not isinstance(matrix, list)
+        or len(matrix) != order
+        or any(not isinstance(row, list) or len(row) != order for row in matrix)
+    ):
+        return False
+    for source_index, row in enumerate(matrix):
+        for target_index, distance in enumerate(row):
+            if distance is not None and (
+                type(distance) is not int or distance < 0 or distance > 31
+            ):
+                return False
+            if source_index == target_index:
+                if distance != 0:
+                    return False
+            elif distance == 0:
+                return False
+            if distance != matrix[target_index][source_index]:
+                return False
+
+    vertex_indices = {vertex: index for index, vertex in enumerate(vertices)}
+    if any(
+        matrix[vertex_indices[left]][vertex_indices[right]] != 1
+        for left, right in normalized_edges
+    ):
+        return False
+    for source_index in range(order):
+        for intermediate_index in range(order):
+            left = matrix[source_index][intermediate_index]
+            if left is None:
+                continue
+            for target_index in range(order):
+                right = matrix[intermediate_index][target_index]
+                if right is None:
+                    continue
+                direct = matrix[source_index][target_index]
+                if direct is None or direct > left + right:
+                    return False
+
+    expected = _all_sources_distance_rows(vertices, adjacency)
+    expected_connected = bool(vertices) and all(
+        distance is not None for row in expected for distance in row
+    )
+    return matrix == [list(row) for row in expected] and (
+        result["connected"] is expected_connected
+    )
+
+
+def check_graph_distance_matrix(request: dict[str, Any]) -> dict[str, Any]:
+    return _run(
+        request,
+        operation_id="graph.distance_matrix.compute",
+        witness_format="graph.distance-matrix.all-sources-bfs-v1",
+        replay=_distance_matrix,
+        replay_method="all-sources breadth-first distance-matrix replay",
         exhaustive=True,
     )
 
@@ -500,6 +598,7 @@ def check_graph_maximum_matching(request: dict[str, Any]) -> dict[str, Any]:
 
 __all__ = [
     "check_graph_diameter",
+    "check_graph_distance_matrix",
     "check_graph_hamiltonian_path",
     "check_graph_induced_tree_maximum",
     "check_graph_maximum_matching",

--- a/tests/checkers/test_exact_domain_operation_checkers.py
+++ b/tests/checkers/test_exact_domain_operation_checkers.py
@@ -26,6 +26,7 @@ from jacobian_checkers.exact_domain_operations import (
 )
 from jacobian_checkers.graph_exact_operations import (
     check_graph_diameter,
+    check_graph_distance_matrix,
     check_graph_induced_tree_maximum,
     check_graph_maximum_matching,
     check_graph_radius,
@@ -357,6 +358,29 @@ _CASES: tuple[
                 "connected": True,
                 "exactness": "EXACT",
                 "detail": None,
+            },
+        ),
+    ),
+    (
+        check_graph_distance_matrix,
+        _request(
+            "graph.distance_matrix.compute",
+            "graph.distance-matrix.all-sources-bfs-v1",
+            {
+                "graph": {
+                    "graph_schema_version": "1",
+                    "vertices": ["c", "a", "b"],
+                    "edges": [["a", "b"], ["b", "c"]],
+                }
+            },
+            {
+                "semantics_version": ("unweighted-shortest-path-distance-matrix.v1"),
+                "vertex_ordering": "LEXICOGRAPHIC_ASCENDING",
+                "pair_coverage": "ALL_ORDERED_VERTEX_PAIRS",
+                "unreachable_representation": "JSON_NULL",
+                "vertices": ["a", "b", "c"],
+                "distances": [[0, 1, 2], [1, 0, 1], [2, 1, 0]],
+                "connected": True,
             },
         ),
     ),
@@ -899,6 +923,129 @@ def test_graph_metric_checker_accepts_singleton_zero(
     )
 
     assert checker(checker_request)["accepted"] is True
+
+
+def _distance_matrix_checker_request(
+    *,
+    vertices: list[str],
+    edges: list[list[str]],
+    result_vertices: list[str],
+    distances: list[list[int | None]],
+    connected: bool,
+) -> dict[str, Any]:
+    return _request(
+        "graph.distance_matrix.compute",
+        "graph.distance-matrix.all-sources-bfs-v1",
+        {
+            "graph": {
+                "graph_schema_version": "1",
+                "vertices": vertices,
+                "edges": edges,
+            }
+        },
+        {
+            "semantics_version": "unweighted-shortest-path-distance-matrix.v1",
+            "vertex_ordering": "LEXICOGRAPHIC_ASCENDING",
+            "pair_coverage": "ALL_ORDERED_VERTEX_PAIRS",
+            "unreachable_representation": "JSON_NULL",
+            "vertices": result_vertices,
+            "distances": distances,
+            "connected": connected,
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    "checker_request",
+    (
+        _distance_matrix_checker_request(
+            vertices=[],
+            edges=[],
+            result_vertices=[],
+            distances=[],
+            connected=False,
+        ),
+        _distance_matrix_checker_request(
+            vertices=["only"],
+            edges=[],
+            result_vertices=["only"],
+            distances=[[0]],
+            connected=True,
+        ),
+        _distance_matrix_checker_request(
+            vertices=["c", "a", "b"],
+            edges=[["a", "b"]],
+            result_vertices=["a", "b", "c"],
+            distances=[[0, 1, None], [1, 0, None], [None, None, 0]],
+            connected=False,
+        ),
+    ),
+    ids=("empty", "singleton", "disconnected"),
+)
+def test_distance_matrix_checker_accepts_exact_boundary_claims(
+    checker_request: dict[str, Any],
+) -> None:
+    decision = check_graph_distance_matrix(checker_request)
+
+    assert decision["accepted"] is True
+    assert decision["conclusion"] == "TRUE"
+    assert decision["method"] == "EXHAUSTIVE_FINITE"
+    assert decision["coverage"] == "EXHAUSTIVE"
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    (
+        lambda result: result.update(vertices=["b", "a", "c"]),
+        lambda result: result.update(
+            distances=[[0, 1], [1, 0]],
+        ),
+        lambda result: result["distances"][0].__setitem__(0, 1),
+        lambda result: result["distances"][0].__setitem__(1, 0),
+        lambda result: result["distances"][0].__setitem__(2, 1),
+        lambda result: result["distances"][2].__setitem__(0, 1),
+        lambda result: result.update(
+            distances=[[0, 1, 1], [1, 0, 1], [1, 1, 0]],
+        ),
+        lambda result: result.update(connected=False),
+        lambda result: result.update(
+            semantics_version="unweighted-shortest-path-distance-matrix.v2"
+        ),
+        lambda result: result.update(extra="forged"),
+        lambda result: result["distances"][0].__setitem__(1, True),
+    ),
+    ids=(
+        "wrong-order",
+        "wrong-shape",
+        "diagonal",
+        "off-diagonal-zero",
+        "asymmetric-left",
+        "asymmetric-right",
+        "wrong-shortest-paths",
+        "wrong-connectedness",
+        "wrong-semantics",
+        "extra-field",
+        "boolean-distance",
+    ),
+)
+def test_distance_matrix_checker_rejects_false_certification_paths(
+    mutate: Callable[[dict[str, Any]], object],
+) -> None:
+    checker_request = _distance_matrix_checker_request(
+        vertices=["c", "a", "b"],
+        edges=[["a", "b"], ["b", "c"]],
+        result_vertices=["a", "b", "c"],
+        distances=[[0, 1, 2], [1, 0, 1], [2, 1, 0]],
+        connected=True,
+    )
+    result = checker_request["candidate"]["payload"]
+    mutate(result)
+    checker_request["candidate"]["payload_digest"] = _digest(result)
+
+    decision = check_graph_distance_matrix(checker_request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/agent/test_agent_ab_cli.py
+++ b/tests/integration/agent/test_agent_ab_cli.py
@@ -220,3 +220,54 @@ def test_ab_non_retrieval_treatment_starts_profiled_mcp(
         "--capability-policy-profile",
         "COMPUTE_VERIFY_NO_RETRIEVAL",
     ]
+
+
+def test_ab_distance_composition_uses_same_mcp_with_targeted_ablation(
+    tmp_path: Path,
+    capsys: Any,
+) -> None:
+    assert (
+        benchmark.main(
+            [
+                "--case",
+                "GRAPH-DISTANCE-COMPOSITION-AB-001",
+                "--repetitions",
+                "3",
+            ]
+        )
+        == 0
+    )
+    plan = json.loads(capsys.readouterr().out)
+    case_plan = plan["cases"][0]
+    assert plan["model_run_count"] == 6
+    assert case_plan["capability_exclusions"] == {
+        "control": sorted(benchmark.DISTANCE_COMPOSITION_CAPABILITY_IDS),
+        "treatment": [],
+    }
+    assert case_plan["capability_policy_profiles"] == {
+        "control": "COMPUTE_VERIFY_NO_RETRIEVAL",
+        "treatment": "COMPUTE_VERIFY_NO_RETRIEVAL",
+    }
+
+    commands = {}
+    for condition in ("control", "treatment"):
+        commands[condition] = benchmark._codex_command(
+            codex_command="codex",
+            condition=condition,
+            workspace=tmp_path / condition / "workspace",
+            report_path=tmp_path / condition / "report.json",
+            state_dir=tmp_path / condition / "state",
+            model="gpt-5.6",
+            reasoning_effort="high",
+            task_type="graph_distance_composition",
+            excluded_capability_ids=(
+                tuple(benchmark.DISTANCE_COMPOSITION_CAPABILITY_IDS)
+                if condition == "control"
+                else ()
+            ),
+            capability_policy_profile="COMPUTE_VERIFY_NO_RETRIEVAL",
+        )
+    assert "agent_ab_mcp.py" in " ".join(commands["control"])
+    assert "agent_ab_mcp.py" in " ".join(commands["treatment"])
+    assert " ".join(commands["control"]).count("--exclude-capability") == 2
+    assert "--exclude-capability" not in " ".join(commands["treatment"])

--- a/tests/integration/agent/test_agent_ab_domain_scorers.py
+++ b/tests/integration/agent/test_agent_ab_domain_scorers.py
@@ -745,3 +745,118 @@ def test_ab_sat_scorer_rejects_unbound_verified_claim(
             mcp_calls=["capability.invoke"],
             capability_invocations=[],
         )
+
+
+def test_ab_distance_composition_scorer_requires_bound_matrix_replay(
+    tmp_path: Path,
+    kernel_store_template_with_references: Path,
+) -> None:
+    case = benchmark.load_cases(["GRAPH-DISTANCE-COMPOSITION-AB-001"])[0]
+    state_dir, kernel = _kernel_from_template(
+        tmp_path,
+        kernel_store_template_with_references,
+        name="distance-state",
+    )
+    computed = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.distance_matrix.compute",
+            input={"graph": case["graph"]},
+        )
+    )
+    verified = kernel.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.distance_matrix.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"result_uri": computed.output["result_uri"]},
+        )
+    )
+    report = {
+        "case_id": case["case_id"],
+        "maximum_degree_vertices": ["4"],
+        "distance_to_set": [
+            {"vertex": "0", "distance": 1},
+            {"vertex": "1", "distance": 1},
+            {"vertex": "2", "distance": 1},
+            {"vertex": "3", "distance": 1},
+            {"vertex": "4", "distance": 0},
+            {"vertex": "5", "distance": 2},
+        ],
+        "maximum_distance_to_set": 2,
+        "maximizing_vertices": ["5"],
+        "assurance": "SELF_CHECKED",
+        "final_verification": "UNVERIFIED",
+        "distance_matrix_uri": computed.output["result_uri"],
+        "verification_record_uri": verified.output["verification_record_uri"],
+        "limitations": ["public answer-visible harness validation"],
+        "feedback": {
+            "reasoning_focus": [],
+            "infrastructure_work": [],
+            "tooling_gaps": [],
+        },
+    }
+    invocations = [
+        {
+            "capability_id": "graph.distance_matrix.compute",
+            "input": {"graph": case["graph"]},
+            "output": computed.output,
+            "artifact_uris": list(computed.artifact_uris),
+            "assurance": computed.assurance.model_dump(mode="json"),
+        },
+        {
+            "capability_id": "graph.distance_matrix.verify",
+            "input": {"result_uri": computed.output["result_uri"]},
+            "output": verified.output,
+            "artifact_uris": list(verified.artifact_uris),
+            "assurance": verified.assurance.model_dump(mode="json"),
+        },
+    ]
+
+    score = benchmark.score_report(
+        case,
+        report,
+        condition="treatment",
+        state_dir=state_dir,
+        mcp_calls=["capability.describe", "capability.invoke", "capability.invoke"],
+        capability_attempt_ids=[
+            "graph.distance_matrix.compute",
+            "graph.distance_matrix.verify",
+        ],
+        capability_invocations=invocations,
+    )
+
+    assert score == {
+        "passed": True,
+        "false_certification": False,
+        "replay_success": True,
+        "checks": [
+            "independent standard-library distance-to-set oracle",
+            "durable graph and matrix binding",
+            "ordered compute-to-verify trace",
+            "independent checker replay",
+        ],
+    }
+
+    control = {
+        **report,
+        "distance_matrix_uri": None,
+        "verification_record_uri": None,
+    }
+    control_score = benchmark.score_report(
+        case,
+        control,
+        condition="control",
+        state_dir=tmp_path / "unused-control",
+        mcp_calls=["capability.describe"],
+    )
+    assert control_score["passed"] is True
+    assert control_score["replay_success"] is False
+
+    forged = {**report, "maximum_distance_to_set": 3}
+    with pytest.raises(benchmark.BenchmarkError, match="differs from the oracle"):
+        benchmark.score_report(
+            case,
+            forged,
+            condition="treatment",
+            state_dir=state_dir,
+            mcp_calls=["capability.invoke"],
+        )

--- a/tests/integration/domains/test_exact_domain_result_verification.py
+++ b/tests/integration/domains/test_exact_domain_result_verification.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 from tests.helpers.rationals import rational_payload as _q
 
@@ -400,6 +402,106 @@ def test_graph_metric_result_uses_independent_all_sources_bfs_replay(
     assert rejected.output["status"] == "REJECTED"
     assert rejected.output["conclusion"] == "UNKNOWN"
     assert rejected.output["verification_record_uri"] is None
+
+
+def test_distance_matrix_result_uses_independent_all_sources_bfs_replay(
+    kernel_with_references,
+) -> None:
+    graph: dict[str, Any] = {
+        "vertices": ["0", "1", "2", "3", "4", "5"],
+        "edges": [
+            ["0", "3"],
+            ["0", "4"],
+            ["1", "4"],
+            ["2", "4"],
+            ["3", "4"],
+            ["3", "5"],
+        ],
+    }
+    computed = kernel_with_references.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.distance_matrix.compute",
+            input={"graph": graph},
+        )
+    )
+    verified = kernel_with_references.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.distance_matrix.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"result_uri": computed.output["result_uri"]},
+        )
+    )
+
+    assert computed.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert verified.execution.status is ExecutionStatus.COMPLETED
+    assert verified.output["status"] == "VERIFIED"
+    assert verified.output["operation_id"] == "graph.distance_matrix.compute"
+    assert verified.output["result_uri"] == computed.output["result_uri"]
+    assert verified.output["verification_record_uri"] is not None
+    assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED
+    assert verified.output["verification_record_uri"] in verified.artifact_uris
+    assert len(verified.artifact_uris) == 4
+
+    matrix = computed.output["result"]["distances"]
+    degree = dict.fromkeys(graph["vertices"], 0)
+    for left, right in graph["edges"]:
+        degree[left] += 1
+        degree[right] += 1
+    maximum_degree = max(degree.values())
+    maximum_degree_vertices = sorted(
+        vertex for vertex, value in degree.items() if value == maximum_degree
+    )
+    matrix_vertices = computed.output["result"]["vertices"]
+    designated_indices = [
+        matrix_vertices.index(vertex) for vertex in maximum_degree_vertices
+    ]
+    distances_to_set = [
+        min(matrix[index][designated] for designated in designated_indices)
+        for index in range(len(matrix_vertices))
+    ]
+    maximum_distance = max(distances_to_set)
+    maximizing_vertices = [
+        vertex
+        for vertex, distance in zip(
+            matrix_vertices,
+            distances_to_set,
+            strict=True,
+        )
+        if distance == maximum_distance
+    ]
+    assert maximum_degree_vertices == ["4"]
+    assert distances_to_set == [1, 1, 1, 1, 0, 2]
+    assert maximum_distance == 2
+    assert maximizing_vertices == ["5"]
+
+    result_artifact = kernel_with_references.store.get(computed.output["result_uri"])
+    order = len(result_artifact.payload["vertices"])
+    false_result = kernel_with_references.artifacts.put(
+        schema_uri=result_artifact.manifest.schema_uri,
+        semantics_uri=result_artifact.manifest.semantics_uri,
+        parents=result_artifact.manifest.parents,
+        payload={
+            **result_artifact.payload,
+            "distances": [
+                [0 if source == target else 1 for target in range(order)]
+                for source in range(order)
+            ],
+        },
+        summary="adversarial metric-shaped but false graph distance matrix",
+    )
+    rejected = kernel_with_references.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.distance_matrix.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"result_uri": false_result.artifact_uri},
+        )
+    )
+
+    assert rejected.execution.status is ExecutionStatus.COMPLETED
+    assert rejected.output["status"] == "REJECTED"
+    assert rejected.output["conclusion"] == "UNKNOWN"
+    assert rejected.output["verification_record_uri"] is None
+    assert rejected.assurance.level is not CapabilityAssuranceLevel.VERIFIED
 
 
 @pytest.mark.parametrize("value", ("360", "-360", "1", "-1", "101"))


### PR DESCRIPTION
## Problem

`graph.distance_matrix.compute` produces a complete exact all-pairs distance artifact, but the portfolio had no independent path to promote that exact result beyond `COMPUTED`. The small-delta plan also calls for checking whether this fundamental primitive is sufficient for a restricted-set distance composition before adding a more specialized contract.

## Result

- adds domain-owned `graph.distance_matrix.verify` without changing shared envelopes or the public MCP surface;
- replays every source with a standard-library BFS checker independent of NetworkX/the producer;
- fail-closes on malformed semantics, ordering, shape, types, diagonal, symmetry, edge distances, triangle constraints, disconnected-component closure, binding mismatches, timeout, and checker failure;
- emits an operator-authorized verification record bound to the exact graph input, matrix candidate, semantics, checker identity, witness, and provider runtime;
- routes exact-domain verifier ownership by installed result schema rather than an ambiguous capability-ID prefix;
- adds boundary/adversarial checker tests, public compute→verify integration coverage, and contract/reference documentation;
- adds an answer-visible matched A/B harness case with independent multi-source BFS scoring, ordered trace checks, durable binding checks, and clean-kernel replay.

The producer remains capped at `COMPUTED`. Only this dedicated verifier can return `VERIFIED`, and that assurance covers the exact matrix—not agent-derived restricted-set conclusions.

## Compatibility

No changes to `CapabilityResult`, common request/result envelopes, artifact URI semantics, checker authorization policy, generic installers, or the two public MCP tools. The change is an explicit graph-domain bundle/checker addition.

## Evaluation handoff

- frozen evaluation commit: `4300dea5feb67f684a207da5ea49caca859ceb74`
- frozen tree: `0d612340b761afbe574897ef08f937fef07d4291`
- run: `20260729T095955Z`, three matched pairs, configured-default Codex model, `xhigh`, 600 seconds/run, seed `20260801`
- case digest: `sha256:9a5105e1620cf039af7f7320bd7147c003c979116995073734b6854c2cbd2d1a`
- treatment/control catalog digests: `sha256:7857aa3b5399960de0cf250990291e39c165d75802421fea9d0008aa294f0c53` / `sha256:8fd971e79febc315cd6904c89598f59c59eef80dbfdb67a4c1489eb33efd8fe2`
- checker-policy digest: `sha256:3c8655dcbcecf1965b7727a9333e0f6905b5e1dc7b1e750bd9840223292acddf`
- checker provider: `AVAILABLE`, `composite-1`, `sha256:574c4727579ae1a234a2779ef2ea706a5c0313f13f82831583b91e9bd3036b74`
- result: control 3/3 and treatment 3/3 passed; 0 false certifications; treatment 3/3 clean replay and 3/3 autonomous discovery/use
- raw local evidence: `benchmarks/results/ab/20260729T095955Z/`

The public case supports retaining the complete matrix primitive; it does not establish broad portfolio value or justify a restricted-set profile capability. Two treatment runs recovered from passing the distance input wrapper to a graph-artifact consumer, so labelled maximum-degree extraction and graph-artifact interoperability remain follow-up evidence to watch.

## Validation

- `make check` — Ruff, format, mypy, 151 unit tests
- `make test-fast` — 703 passed, 4 deselected
- `uv run pytest -q tests/integration/agent -m 'not lean_runtime'` — 44 passed, 3 deselected
- focused distance producer/verifier/scorer regression — 34 passed
- `make test-subprocess` — 46 passed
- `make check-static docs-linkcheck duplicate-code todo-check` — static analysis, package build, links, duplicate-code, and TODO policy passed
- matched model-in-the-loop evaluation — 6/6 valid runs passed

## Next action

Retain this atomic producer/verifier split and monitor additional frozen cases for repeated graph-artifact interoperability or restricted-set composition friction. Do not add the deferred specialized profile capability from this single public reproduction.
