### PR TITLE
perf(providers): speed up populated runtime attachment and make validation diff-aware

### DIFF
--- a/.github/scripts/plan-local-tests
+++ b/.github/scripts/plan-local-tests
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Print the CI lanes and local commands implied by repository changes."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+CLASSIFIER = ROOT / ".github" / "scripts" / "classify-ci-paths"
+
+COMMANDS = {
+    "core": "make test-core",
+    "integration": "make test-integration",
+    "lean": "make test-lean",
+    "npm": "make npm-test",
+    "static": "make check-static",
+    "build": "make build",
+    "security": "make security-audit",
+    "duplicate": "make duplicate-code",
+    "docs": "make docs-linkcheck",
+}
+
+
+def git_paths(*args: str) -> list[str]:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [path for path in result.stdout.splitlines() if path]
+
+
+def changed_paths(base: str) -> list[str]:
+    subprocess.run(
+        ["git", "rev-parse", "--verify", f"{base}^{{commit}}"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+    )
+    paths = {
+        *git_paths("diff", "--name-only", f"{base}..HEAD"),
+        *git_paths("diff", "--name-only"),
+        *git_paths("diff", "--cached", "--name-only"),
+        *git_paths("ls-files", "--others", "--exclude-standard"),
+    }
+    return sorted(paths)
+
+
+def classify(paths: list[str]) -> dict[str, str]:
+    if not paths:
+        return {"classification": "clean"}
+    result = subprocess.run(
+        [sys.executable, str(CLASSIFIER), "--", *paths],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return dict(line.split("=", 1) for line in result.stdout.splitlines())
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base", required=True, help="Base commit or ref.")
+    args = parser.parse_args()
+
+    try:
+        paths = changed_paths(args.base)
+    except subprocess.CalledProcessError:
+        parser.error(f"base is not a commit: {args.base}")
+    plan = classify(paths)
+    lanes = [suite for suite in COMMANDS if plan.get(f"run-{suite}") == "true"]
+
+    print(f"base: {args.base}")
+    print(f"classification: {plan['classification']}")
+    print("paths:")
+    for path in paths:
+        print(f"  {path}")
+    print("lanes:")
+    for lane in lanes:
+        print(f"  {lane}")
+    print("commands:")
+    for lane in lanes:
+        print(f"  {COMMANDS[lane]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/summarize-ci-timings
+++ b/.github/scripts/summarize-ci-timings
@@ -57,7 +57,7 @@ def render(payload: Any) -> str:
         "",
         "| Metric | Value |",
         "| --- | ---: |",
-        f"| Critical path (workflow elapsed) | {critical_minutes:.1f} min |",
+        f"| Critical span | {critical_minutes:.1f} min |",
         f"| Total runner time | {total_minutes:.1f} min |",
         f"| Longest job | {longest_name} ({longest_seconds / 60:.1f} min) |",
         f"| Completed jobs | {len(rows)} |",

--- a/.github/scripts/validation-receipt
+++ b/.github/scripts/validation-receipt
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Run a command and write a receipt bound to the full Git working tree."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def git(*args: str, check: bool = True) -> bytes:
+    return subprocess.run(
+        ["git", *args],
+        cwd=ROOT,
+        check=check,
+        capture_output=True,
+    ).stdout
+
+
+def _add_file(digest: Any, label: bytes, path: str) -> None:
+    encoded = os.fsencode(path)
+    digest.update(label)
+    digest.update(len(encoded).to_bytes(8, "big"))
+    digest.update(encoded)
+    target = ROOT / path
+    if target.is_symlink():
+        content = os.fsencode(target.readlink())
+        kind = b"symlink"
+    elif target.is_file():
+        content = target.read_bytes()
+        kind = b"file"
+    else:
+        content = b""
+        kind = b"missing"
+    digest.update(kind)
+    digest.update(len(content).to_bytes(8, "big"))
+    digest.update(content)
+
+
+def tree_state() -> dict[str, object]:
+    digest = hashlib.sha256()
+    head = git("rev-parse", "HEAD").decode().strip()
+    status = git("status", "--porcelain=v1", "-z")
+    unstaged = [
+        os.fsdecode(path)
+        for path in git("diff", "--name-only", "-z").split(b"\0")
+        if path
+    ]
+    untracked = [
+        os.fsdecode(path)
+        for path in git("ls-files", "--others", "--exclude-standard", "-z").split(b"\0")
+        if path
+    ]
+
+    digest.update(b"HEAD\0" + head.encode() + b"\0")
+    # Index entries bind staged modes and content-addressed blob identities.
+    index = git("ls-files", "--stage", "-z")
+    digest.update(b"index\0")
+    digest.update(len(index).to_bytes(8, "big"))
+    digest.update(index)
+    for path in unstaged:
+        _add_file(digest, b"worktree\0", path)
+    for path in untracked:
+        _add_file(digest, b"untracked\0", path)
+
+    return {
+        "head": head,
+        "dirty": bool(status),
+        "digest": f"sha256:{digest.hexdigest()}",
+    }
+
+
+def make_receipt(
+    command: list[str],
+    exit_code: int,
+    before: dict[str, object],
+    after: dict[str, object],
+    *,
+    started_at: str,
+    finished_at: str,
+    duration_seconds: float,
+) -> dict[str, object]:
+    exact_tree = before["digest"] == after["digest"]
+    return {
+        "version": 1,
+        "command": command,
+        "exit_code": exit_code,
+        "started_at": started_at,
+        "finished_at": finished_at,
+        "duration_seconds": duration_seconds,
+        "head": after["head"],
+        "dirty": after["dirty"],
+        "tree_digest": after["digest"],
+        "tree_unchanged_during_validation": exact_tree,
+        "head_matches_validated_tree": exact_tree and not bool(after["dirty"]),
+    }
+
+
+def output_path(raw_path: Path, parser: argparse.ArgumentParser) -> Path:
+    path = raw_path.resolve()
+    try:
+        relative = path.relative_to(ROOT)
+    except ValueError:
+        return path
+    ignored = subprocess.run(
+        ["git", "check-ignore", "--quiet", "--", str(relative)],
+        cwd=ROOT,
+        check=False,
+    )
+    if ignored.returncode != 0:
+        parser.error("receipt output inside the repository must be ignored")
+    return path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+    command = args.command[1:] if args.command[:1] == ["--"] else args.command
+    if not command:
+        parser.error("a command is required after --")
+    destination = output_path(args.output, parser)
+
+    before = tree_state()
+    started_at = datetime.now(UTC).isoformat()
+    started = time.monotonic()
+    completed = subprocess.run(command, cwd=ROOT, check=False)
+    duration_seconds = time.monotonic() - started
+    finished_at = datetime.now(UTC).isoformat()
+    after = tree_state()
+    receipt = make_receipt(
+        command,
+        completed.returncode,
+        before,
+        after,
+        started_at=started_at,
+        finished_at=finished_at,
+        duration_seconds=duration_seconds,
+    )
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(
+        json.dumps(receipt, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    raise SystemExit(completed.returncode)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,27 +91,15 @@ jobs:
             echo "$plan_output"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
-
-  prepare-test-timings:
-    name: Prepare integration timing hint
-    needs: plan
-    if: needs.plan.outputs.run-integration == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    permissions:
-      actions: read
-      contents: read
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
       - name: Prepare integration timing hint
+        if: steps.classify.outputs.run-integration == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: >-
           .github/scripts/manage-test-timings prepare
           --output .ci/test-durations.json
       - name: Share integration timing hint
+        if: steps.classify.outputs.run-integration == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: integration-test-durations-input
@@ -313,7 +301,7 @@ jobs:
     name: >-
       Tests (integration ${{ matrix.shard }} of ${{ needs.plan.outputs.integration-shard-count }},
       Python 3.12)
-    needs: [plan, prepare-test-timings]
+    needs: plan
     if: needs.plan.outputs.run-integration == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -865,7 +853,7 @@ jobs:
           gh api
           "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/jobs?per_page=100"
           --paginate --slurp > ci-jobs.json
-      - name: Report critical path and runner time
+      - name: Report critical span and runner time
         run: |
           .github/scripts/summarize-ci-timings ci-jobs.json | tee ci-timings.md
           cat ci-timings.md >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,12 @@ checker authorization out of plugins and search code.
 
 ## Repository Gotchas
 
+- Before final validation, use `make test-plan BASE=<revision>`, freeze the exact
+  tree, and run the selected gate through `make validation-receipt
+  COMMAND='<command>'` so the receipt is tied to its tree digest and HEAD SHA. In
+  a shared checkout, agents must own disjoint paths and must not switch
+  branches, stage, commit, clean, or rewrite shared files until their work is
+  integrated.
 - Jacobian is pre-stable. Release specifications capture supported snapshots;
   they do not order capability research.
 - Validate the complete Pydantic request model before computation or artifact

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,6 +103,31 @@ coverage as exhaustive gates. Successful `main` runs publish fresh integration
 shard timings. Timing history is not committed, and missing or invalid history
 falls back to equal-weight sharding.
 
+Use `make test-plan BASE=<revision>` to preview the same changed-path routing
+before validation:
+
+| Change | Local handoff | CI adds |
+| --- | --- | --- |
+| Docs only | `make docs-linkcheck` | Documentation |
+| Focused Python | affected target, then `make check` | Planned Python/static/package lanes |
+| Lean runtime | focused `make test-lean`, then `make check` | Lean plus affected lanes |
+| CI, dependencies, or unknown paths | `make check-static` plus affected tests | Fail-closed functional lanes |
+
+Freeze the behavioral tree before the final broad validation. Record its tree
+digest and HEAD SHA in the receipt produced by
+`make validation-receipt COMMAND='make check'`, together with the
+`make test-plan BASE=<revision>` selection and
+checks that actually ran. If the tree changes, discard only evidence invalidated
+by that change and rerun it; do not describe results from an earlier tree as
+final-tree validation.
+
+Parallel agents sharing one checkout must divide path ownership before editing.
+They must not switch branches, stage, commit, clean, or rewrite shared files
+while another agent is working. Integrate their edits first, freeze one tree,
+then run the planned checks through `make validation-receipt` and produce one
+receipt for that exact
+tree. Use isolated worktrees only when the workflow explicitly assigns them.
+
 Keep the local edit loop on directory-owned Make targets rather than inventing
 marker filters:
 

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@
 UV_RUN := uv run --locked
 PYTEST_ARGS ?=
 TESTS ?=
+COMMAND ?= make check
+RECEIPT ?= /tmp/jacobian-validation-receipt.json
 EVAL_ARGS ?=
 ORDERING_DEFAULT_SEED := --randomly-seed=17
 PYTEST_DIAGNOSTIC_ARGS ?= --durations=10
@@ -18,7 +20,7 @@ PYTEST_CORE_XDIST_ARGS := -n auto --maxprocesses=4 --dist=loadgroup
 # memory contention while retaining useful parallel feedback.
 PYTEST_SUBPROCESS_XDIST_ARGS := -n auto --maxprocesses=2 --dist=worksteal
 
-.PHONY: help setup hooks fix lint lint-full security-audit typecheck test test-fast test-unit-fast test-subprocess test-core test-integration test-contracts test-checkers test-mcp test-storage test-lean test-failed test-stress test-ordering duplicate-code npm-test todo-check coverage build check pre-push-full precommit check-static validate-full agent-eval bench-core clean docs-linkcheck deploy-check
+.PHONY: help setup hooks fix lint lint-full security-audit typecheck test test-plan validation-receipt test-fast test-unit-fast test-subprocess test-core test-integration test-contracts test-checkers test-mcp test-storage test-lean test-failed test-stress test-ordering duplicate-code npm-test todo-check coverage build check pre-push-full precommit check-static validate-full agent-eval bench-core clean docs-linkcheck deploy-check
 
 help: ## Show available developer commands.
 	@awk 'BEGIN {FS = ":.*## "; printf "Jacobian developer commands:\n\n"} /^[a-zA-Z_-]+:.*## / {printf "  %-18s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -54,6 +56,13 @@ typecheck: ## Run strict static type checking.
 
 test: ## Run tests; narrow with TESTS=... and PYTEST_ARGS=....
 	$(UV_RUN) pytest $(PYTEST_XDIST_ARGS) -m "not lean_runtime" $(TESTS) $(PYTEST_DIAGNOSTIC_ARGS) $(PYTEST_ARGS)
+
+test-plan: ## Print local validation selected for BASE..HEAD and working changes.
+	@test -n "$(BASE)" || { echo "BASE is required (for example: make test-plan BASE=origin/main)" >&2; exit 2; }
+	@$(UV_RUN) python .github/scripts/plan-local-tests --base "$(BASE)"
+
+validation-receipt: ## Run COMMAND and bind its result to the exact working tree.
+	@$(UV_RUN) python .github/scripts/validation-receipt --output "$(RECEIPT)" -- $(COMMAND)
 
 test-fast: ## Sequential core edit loop (unit/contract/checkers/reference, no xdist).
 	$(UV_RUN) pytest -n 0 -m "not lean_runtime and not slow" \

--- a/benchmarks/benchmark_runtime_startup.py
+++ b/benchmarks/benchmark_runtime_startup.py
@@ -31,7 +31,11 @@ def main() -> None:
     runner.metadata["suite"] = "jacobian-runtime-startup"
     with tempfile.TemporaryDirectory(prefix="jacobian-runtime-startup-") as directory:
         root = Path(directory)
-        create_runtime(root, checker_authority=CheckerAuthorityMode.INSTALL_BUNDLED)
+        initial = create_runtime(
+            root,
+            checker_authority=CheckerAuthorityMode.INSTALL_BUNDLED,
+        )
+        initial.close()
         runner.bench_func(
             "runtime-populated-same-process",
             partial(

--- a/docs/contributing/test-suite-cost-audit.md
+++ b/docs/contributing/test-suite-cost-audit.md
@@ -160,12 +160,14 @@ remote reproduction without rerunning unrelated matrices. On the measured
 host, the resulting `make check` completed 256 selected tests in 8.36 seconds.
 
 Source-to-suite impact is declared in `.github/ci-impact.json` and tested
-against tracked source files. Unknown paths still fail closed. Each CI run
-reports workflow elapsed time (the observable critical path), summed runner
-minutes, and its longest job, making both reviewer latency and compute growth
-visible. Scheduled lanes exercise repeated property tests, alternate orders,
-optional providers, and the core performance benchmark outside the
-pull-request critical path.
+against tracked source files. Unknown paths still fail closed. Each measured CI
+run reports its critical span, summed runner minutes, and longest job, making
+both reviewer latency and compute growth visible. The critical span is the
+interval from the earliest reported job start to the latest reported job end;
+it is not a dependency-graph reconstruction or the full workflow elapsed time.
+Scheduled lanes exercise repeated property tests, alternate orders, optional
+providers, and the core performance benchmark outside the pull-request
+critical span.
 
 Do not run the complete non-Lean and Lean suites repeatedly during
 implementation and then immediately repeat them in pull-request CI. Use
@@ -174,7 +176,7 @@ pass on the final tree. Run `make validate-full` locally only when CI is
 unavailable or an environment-specific failure needs reproduction.
 
 Some short CI jobs still overlap in setup or packaging work, but they run in
-parallel and were not on the measured critical path. Consolidating them would
+parallel and were not on the measured critical span. Consolidating them would
 increase workflow coupling without materially shortening feedback, so this
 audit leaves them unchanged.
 

--- a/src/jacobian/providers/__init__.py
+++ b/src/jacobian/providers/__init__.py
@@ -12,7 +12,7 @@ This package provides two independent, composable primitives:
 
 The package deliberately avoids registries, package discovery, import-time
 registration, and compatibility shims. Each loader is an independent, owned
-object; metadata helpers are pure functions.
+object; successful metadata identities are deduplicated process-locally.
 """
 
 from __future__ import annotations

--- a/src/jacobian/providers/metadata.py
+++ b/src/jacobian/providers/metadata.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from importlib.metadata import PackageNotFoundError, distribution, version
+from threading import RLock
 
 
 @dataclass(frozen=True, slots=True)
@@ -19,13 +20,29 @@ class DistributionSummary:
     version: str
 
 
-def distribution_version(distribution_name: str) -> str | None:
-    """Return installed distribution metadata without importing its package."""
+_cache_lock = RLock()
+_version_cache: dict[str, str] = {}
+_summary_cache: dict[str, DistributionSummary] = {}
 
-    try:
-        return version(distribution_name)
-    except PackageNotFoundError:
-        return None
+
+def distribution_version(distribution_name: str) -> str | None:
+    """Return installed distribution metadata without importing its package.
+
+    Successful identity lookups are cached for the process. Missing
+    distributions are deliberately not cached: a long-lived process may gain
+    an optional provider after its environment or import path changes.
+    """
+
+    with _cache_lock:
+        cached = _version_cache.get(distribution_name)
+        if cached is not None:
+            return cached
+        try:
+            installed_version = version(distribution_name)
+        except PackageNotFoundError:
+            return None
+        _version_cache[distribution_name] = installed_version
+        return installed_version
 
 
 def distribution_summary(distribution_name: str) -> DistributionSummary | None:
@@ -36,12 +53,18 @@ def distribution_summary(distribution_name: str) -> DistributionSummary | None:
     the recorded ``Name`` header is missing or empty.
     """
 
-    try:
-        dist = distribution(distribution_name)
-    except PackageNotFoundError:
-        return None
-    recorded_name = dist.metadata["Name"]
-    return DistributionSummary(
-        name=recorded_name or distribution_name,
-        version=dist.version,
-    )
+    with _cache_lock:
+        cached = _summary_cache.get(distribution_name)
+        if cached is not None:
+            return cached
+        try:
+            dist = distribution(distribution_name)
+        except PackageNotFoundError:
+            return None
+        recorded_name = dist.metadata["Name"]
+        summary = DistributionSummary(
+            name=recorded_name or distribution_name,
+            version=dist.version,
+        )
+        _summary_cache[distribution_name] = summary
+        return summary

--- a/src/jacobian/schema_registry.py
+++ b/src/jacobian/schema_registry.py
@@ -150,6 +150,14 @@ class SchemaRegistry:
             version=version,
             schema=model_schema(model),
         )
+        self._bind_model_contract(schema_uri, model)
+        return schema_uri
+
+    def _bind_model_contract(
+        self,
+        schema_uri: str,
+        model: type[BaseModel],
+    ) -> None:
         transaction_identity = self.store.transaction_identity
         model_contracts = self._model_contracts
         if transaction_identity is not None:
@@ -160,7 +168,6 @@ class SchemaRegistry:
                 "one schema URI cannot use multiple model-backed contracts"
             )
         model_contracts[schema_uri] = model
-        return schema_uri
 
     def resolve(self, schema_uri: str) -> dict[str, Any]:
         """Load a previously registered schema definition."""

--- a/src/jacobian/store.py
+++ b/src/jacobian/store.py
@@ -794,6 +794,20 @@ class ArtifactStore:
         )
         manifest_digest = _sha256(manifest_bytes)
         artifact_uri = _uri_from_digest(manifest_digest)
+
+        # Re-registering identical content is common while assembling built-in
+        # portfolios. Validate the committed artifact before returning so the
+        # idempotent path avoids both blob publication and metadata writes
+        # without allowing missing or corrupted content to be silently healed.
+        if self._artifact_exists(artifact_uri):
+            self.get(artifact_uri)
+            return ArtifactPutResult(
+                artifact_uri=artifact_uri,
+                object_digest=object_digest,
+                manifest_digest=manifest_digest,
+                canonicalizer_digest=CANONICALIZER_DIGEST,
+            )
+
         self._write_blob(canonical_bytes)
         self._write_blob(manifest_bytes)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,13 @@ import pytest
 from filelock import FileLock
 
 from jacobian.runtime import CheckerAuthorityMode, create_runtime
+from jacobian.runtime.bootstrap import bootstrap_services
+from jacobian.runtime.config import RuntimeOptions
 from jacobian.runtime.model import JacobianRuntime
+from tests.helpers.runtime import (
+    CapabilityTestServices,
+    open_capability_test_services,
+)
 
 
 def _freeze_runtime_store(root: Path) -> None:
@@ -58,6 +64,29 @@ def _shared_worker_template(
         raise RuntimeError("xdist worker did not provide a test-run identity")
     root = tmp_path_factory.getbasetemp().parent / f"{name}-{run_id}"
     return root, FileLock(root.with_suffix(".lock"))
+
+
+@pytest.fixture(scope="session")
+def core_services_store_template(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Path:
+    """Build only the capability-independent service descriptors once."""
+
+    template = tmp_path_factory.mktemp("core-services-store-template")
+    core = bootstrap_services(template, RuntimeOptions())
+    core.close()
+    _freeze_runtime_store(template)
+    return template
+
+
+@pytest.fixture
+def initialized_core_services_store(
+    tmp_path: Path,
+    core_services_store_template: Path,
+) -> None:
+    """Seed a test root without assembling the mathematical portfolio."""
+
+    shutil.copytree(core_services_store_template, tmp_path, dirs_exist_ok=True)
 
 
 @pytest.fixture(scope="session")
@@ -187,6 +216,27 @@ def runtime_with_references(
     )
     yield runtime
     runtime.close()
+
+
+@pytest.fixture
+def complete_runtime_with_references(
+    runtime_with_references: JacobianRuntime,
+) -> JacobianRuntime:
+    """Name the expensive, fully assembled runtime explicitly at call sites."""
+
+    return runtime_with_references
+
+
+@pytest.fixture
+def capability_core_services(
+    tmp_path: Path,
+    initialized_core_services_store: None,
+) -> Iterator[CapabilityTestServices]:
+    """Open only the services required by capability-service integration tests."""
+
+    _ = initialized_core_services_store
+    with open_capability_test_services(tmp_path) as services:
+        yield services
 
 
 @pytest.hookimpl(trylast=True)

--- a/tests/contract/test_schema_registry.py
+++ b/tests/contract/test_schema_registry.py
@@ -216,3 +216,34 @@ def test_model_backed_schema_applies_cross_field_contracts(
     }
     with pytest.raises(SchemaValidationError, match="pair must be ordered"):
         registry.validate(schema_uri, {"first": 2, "second": 1})
+
+
+def test_existing_model_schema_reattaches_without_durable_writes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = ArtifactStore(tmp_path)
+    installer = SchemaRegistry(store)
+    schema_uri = installer.register_model(
+        name="ordered-pair",
+        version="1",
+        model=_OrderedPair,
+    )
+    runtime_registry = SchemaRegistry(store)
+
+    def unexpected_blob_write(_data: bytes) -> str:
+        pytest.fail("reattaching a model rewrote durable schema content")
+
+    monkeypatch.setattr(store, "_write_blob", unexpected_blob_write)
+
+    assert (
+        runtime_registry.register_model(
+            name="ordered-pair",
+            version="1",
+            model=_OrderedPair,
+        )
+        == schema_uri
+    )
+
+    with pytest.raises(SchemaValidationError, match="pair must be ordered"):
+        runtime_registry.validate(schema_uri, {"first": 2, "second": 1})

--- a/tests/helpers/provider_runtime.py
+++ b/tests/helpers/provider_runtime.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from functools import lru_cache
+
+from jacobian_checkers import lean4
+
+PINNED_MATHLIB_RUNTIME_UNAVAILABLE_REASON = (
+    "the pinned Lean and Mathlib runtime is unavailable"
+)
+
+
+@lru_cache(maxsize=1)
+def pinned_mathlib_runtime_available() -> bool:
+    """Return whether the exact pinned Lean and Mathlib runtime is usable."""
+
+    try:
+        lean4.inspect_runtime(require_mathlib=True)
+    except (OSError, RuntimeError):
+        return False
+    return True

--- a/tests/helpers/runtime.py
+++ b/tests/helpers/runtime.py
@@ -1,0 +1,49 @@
+"""Narrow, explicitly owned runtime graphs for integration tests."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+
+from jacobian.installation.context import InstallationContext
+from jacobian.runtime.bootstrap import bootstrap_services
+from jacobian.runtime.config import CheckerAuthorityMode, RuntimeOptions
+from jacobian.runtime.services import CoreServices
+from jacobian.verification import VerificationService
+
+
+@dataclass(frozen=True, slots=True)
+class CapabilityTestServices:
+    """Services and installation boundary needed by capability tests."""
+
+    core: CoreServices
+    installation: InstallationContext
+
+
+@contextmanager
+def open_capability_test_services(
+    root: Path,
+) -> Iterator[CapabilityTestServices]:
+    """Open a capability service graph without assembling the built-in portfolio."""
+
+    options = RuntimeOptions(
+        checker_authority=CheckerAuthorityMode.NONE,
+    )
+    core = bootstrap_services(root, options)
+    try:
+        installation = InstallationContext(
+            store=core.store,
+            schemas=core.schemas,
+            artifacts=core.artifacts,
+            capabilities=core.capabilities,
+            checkers=core.checkers,
+            verification=VerificationService(core.store, core.checkers),
+            operations=core.operations,
+            checker_authority=options.checker_authority,
+            register_capability=core.capabilities.register,
+        )
+        yield CapabilityTestServices(core=core, installation=installation)
+    finally:
+        core.close()

--- a/tests/integration/agent/test_agent_ab_cli.py
+++ b/tests/integration/agent/test_agent_ab_cli.py
@@ -6,6 +6,10 @@ from typing import Any
 
 import pytest
 from benchmarks import agent_ab as benchmark
+from tests.helpers.provider_runtime import (
+    PINNED_MATHLIB_RUNTIME_UNAVAILABLE_REASON,
+    pinned_mathlib_runtime_available,
+)
 from tests.integration.agent._agent_ab_support import _write_private_case
 
 from jacobian.contracts.capabilities import (
@@ -113,6 +117,10 @@ def test_agent_eval_plan_counts_each_lean_capability_condition(
 
 
 @pytest.mark.lean_runtime
+@pytest.mark.skipif(
+    not pinned_mathlib_runtime_available(),
+    reason=PINNED_MATHLIB_RUNTIME_UNAVAILABLE_REASON,
+)
 @pytest.mark.usefixtures("initialized_runtime_store_with_references")
 def test_ab_lean_control_ablation_removes_only_declaration_discovery(
     tmp_path: Path,

--- a/tests/integration/agent/test_agent_ab_lean.py
+++ b/tests/integration/agent/test_agent_ab_lean.py
@@ -5,18 +5,23 @@ from typing import Any, cast
 
 import pytest
 from benchmarks import agent_ab as benchmark
+from tests.helpers.provider_runtime import (
+    PINNED_MATHLIB_RUNTIME_UNAVAILABLE_REASON,
+    pinned_mathlib_runtime_available,
+)
 from tests.integration.agent._agent_ab_support import (
     _lean_proof_case,
     _runtime_from_template,
 )
 
-from jacobian.contracts.capabilities import (
-    CapabilityMode,
-    CapabilityRequest,
-)
+from jacobian.contracts.capabilities import CapabilityMode, CapabilityRequest
 
 
 @pytest.mark.lean_runtime
+@pytest.mark.skipif(
+    not pinned_mathlib_runtime_available(),
+    reason=PINNED_MATHLIB_RUNTIME_UNAVAILABLE_REASON,
+)
 def test_lean_ab_scorer_accepts_any_exact_replayable_proof(
     tmp_path: Path,
     runtime_store_template_with_references: Path,
@@ -176,8 +181,13 @@ def test_lean_ab_summary_compares_each_ablation_to_baseline() -> None:
 
 
 @pytest.mark.lean_runtime
+@pytest.mark.skipif(
+    not pinned_mathlib_runtime_available(),
+    reason=PINNED_MATHLIB_RUNTIME_UNAVAILABLE_REASON,
+)
 def test_ab_lean_scorer_requires_exact_checker_bound_trace(
-    tmp_path: Path, runtime_store_template_with_references: Path
+    tmp_path: Path,
+    runtime_store_template_with_references: Path,
 ) -> None:
     load_cases = benchmark.load_cases
     score_report = benchmark.score_report

--- a/tests/integration/infrastructure/test_artifact_store.py
+++ b/tests/integration/infrastructure/test_artifact_store.py
@@ -191,6 +191,104 @@ def test_artifact_identity_uses_canonical_payload_schema_and_semantics(
     assert store.get(first.artifact_uri).payload == {"weight": {"den": "2", "num": "1"}}
 
 
+def test_repeated_put_validates_without_blob_or_metadata_writes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = ArtifactStore(tmp_path)
+    schema = store.register_descriptor(
+        kind="schema",
+        name="example.candidate",
+        version="1",
+        definition={"type": "object"},
+    )
+    semantics = store.register_descriptor(
+        kind="semantics",
+        name="example.meaning",
+        version="1",
+        definition={"description": "meaning"},
+    )
+    expected = store.put(
+        schema_uri=schema,
+        semantics_uri=semantics,
+        payload={"value": "unchanged"},
+        summary="candidate",
+    )
+
+    original_connect = store._connect
+
+    def connect_read_only() -> sqlite3.Connection:
+        connection = original_connect()
+
+        def deny_metadata_writes(
+            action: int,
+            _argument_one: str | None,
+            _argument_two: str | None,
+            _database: str | None,
+            _trigger: str | None,
+        ) -> int:
+            if action in {
+                sqlite3.SQLITE_DELETE,
+                sqlite3.SQLITE_INSERT,
+                sqlite3.SQLITE_UPDATE,
+            }:
+                return sqlite3.SQLITE_DENY
+            return sqlite3.SQLITE_OK
+
+        connection.set_authorizer(deny_metadata_writes)
+        return connection
+
+    monkeypatch.setattr(store, "_connect", connect_read_only)
+
+    def reject_blob_write(_data: bytes) -> str:
+        pytest.fail("an idempotent put must not publish blobs")
+
+    monkeypatch.setattr(store, "_write_blob", reject_blob_write)
+
+    repeated = store.put(
+        schema_uri=schema,
+        semantics_uri=semantics,
+        payload={"value": "unchanged"},
+        summary="candidate",
+    )
+
+    assert repeated == expected
+
+
+def test_repeated_put_rejects_corrupted_committed_blob(tmp_path: Path) -> None:
+    store = ArtifactStore(tmp_path)
+    schema = store.register_descriptor(
+        kind="schema",
+        name="example.candidate",
+        version="1",
+        definition={"type": "object"},
+    )
+    semantics = store.register_descriptor(
+        kind="semantics",
+        name="example.meaning",
+        version="1",
+        definition={"description": "meaning"},
+    )
+    store.put(
+        schema_uri=schema,
+        semantics_uri=semantics,
+        payload={"value": "original"},
+    )
+    payload_path = next(
+        path
+        for path in (tmp_path / "blobs" / "sha256").glob("*/*")
+        if path.read_bytes() == b'{"value":"original"}'
+    )
+    payload_path.write_bytes(b'{"value":"tampered"}')
+
+    with pytest.raises(ArtifactIntegrityError, match="blob digest mismatch"):
+        store.put(
+            schema_uri=schema,
+            semantics_uri=semantics,
+            payload={"value": "original"},
+        )
+
+
 @pytest.mark.conformance
 def test_modified_blob_is_rejected_on_read(tmp_path: Path) -> None:
     store = ArtifactStore(tmp_path)

--- a/tests/integration/infrastructure/test_builtin_portfolio_installation.py
+++ b/tests/integration/infrastructure/test_builtin_portfolio_installation.py
@@ -1,0 +1,26 @@
+"""Whole-portfolio installation coverage belongs to the integration lane."""
+
+from jacobian.portfolio import BUILTIN_PORTFOLIO
+from jacobian.portfolio.result import BundleInstallationStatus
+from jacobian.runtime.model import JacobianRuntime
+
+
+def test_builtin_portfolio_installs_cleanly(runtime: JacobianRuntime) -> None:
+    installation = runtime.portfolio
+
+    assert installation.portfolio_diagnostics == ()
+    assert set(installation.domain_bundles) == set(BUILTIN_PORTFOLIO.domain_ids)
+    assert all(
+        outcome.status is BundleInstallationStatus.INSTALLED
+        for outcome in installation.portfolio_outcomes
+    )
+    expected_capability_ids = {
+        operation.capability_id
+        for bundle in BUILTIN_PORTFOLIO.domain_bundles
+        for operation in bundle.capabilities
+    }
+    installed_capability_ids = {
+        descriptor.capability_id
+        for descriptor in runtime.core.capabilities.catalog().capabilities
+    }
+    assert expected_capability_ids <= installed_capability_ids

--- a/tests/integration/infrastructure/test_capability_service.py
+++ b/tests/integration/infrastructure/test_capability_service.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
-import shutil
 from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
+from tests.helpers.provider_runtime import (
+    PINNED_MATHLIB_RUNTIME_UNAVAILABLE_REASON,
+    pinned_mathlib_runtime_available,
+)
+from tests.helpers.runtime import CapabilityTestServices
 
 from jacobian.capabilities import CapabilityError
 from jacobian.contracts.capabilities import (
@@ -28,9 +32,8 @@ from jacobian.contracts.results import (
     Execution,
     ExecutionStatus,
 )
-from jacobian.runtime import CheckerAuthorityMode, create_runtime
-
-pytestmark = pytest.mark.usefixtures("initialized_runtime_store_with_references")
+from jacobian.runtime import create_runtime
+from jacobian.runtime.model import JacobianRuntime
 
 TEST_RUNTIME = CapabilityProviderRuntime(
     provider="tests",
@@ -291,12 +294,12 @@ class MisboundVerifiedAdapter:
 
 
 def test_external_adapter_invocation_is_recorded_and_retrievable(
-    tmp_path: Path,
+    capability_core_services: CapabilityTestServices,
 ) -> None:
-    runtime = create_runtime(tmp_path)
-    runtime.core.capabilities.register(ComputedAdapter())
+    core = capability_core_services.core
+    capability_core_services.installation.register_capability(ComputedAdapter())
 
-    result = runtime.core.capabilities.invoke(
+    result = core.capabilities.invoke(
         CapabilityRequest(
             capability_id="example.double",
             input={"value": 21},
@@ -306,24 +309,24 @@ def test_external_adapter_invocation_is_recorded_and_retrievable(
     assert result.output == {"value": 42}
     assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
     assert result.episode_uri is not None
-    episode = runtime.core.store.get(result.episode_uri)
+    episode = core.store.get(result.episode_uri)
     assert episode.payload["result"]["response_version"] == "2"
     assert episode.payload["result"]["completeness"]["status"] == "NOT_APPLICABLE"
-    hits = runtime.core.memory.search(query="double computed").hits
+    hits = core.memory.search(query="double computed").hits
     assert [hit.episode_uri for hit in hits] == [result.episode_uri]
 
 
 def test_installed_capability_discovery_is_compact_deterministic_and_transparent(
-    tmp_path: Path,
+    capability_core_services: CapabilityTestServices,
 ) -> None:
-    runtime = create_runtime(tmp_path)
+    core = capability_core_services.core
     schema = {
         "type": "object",
         "properties": {"value": {"type": "integer"}},
         "required": ["value"],
         "additionalProperties": False,
     }
-    runtime.core.capabilities.register(
+    capability_core_services.installation.register_capability(
         DiscoveryAdapter(
             CapabilityDescriptor(
                 capability_id="fixture_algebra.search.countermodel",
@@ -347,7 +350,7 @@ def test_installed_capability_discovery_is_compact_deterministic_and_transparent
             )
         )
     )
-    runtime.core.capabilities.register(
+    capability_core_services.installation.register_capability(
         DiscoveryAdapter(
             CapabilityDescriptor(
                 capability_id="fixture_graph.verify.coloring",
@@ -370,8 +373,8 @@ def test_installed_capability_discovery_is_compact_deterministic_and_transparent
         mode=CapabilityMode.EXPLORE,
         limit=10,
     )
-    first = runtime.core.capabilities.discover(request)
-    second = runtime.core.capabilities.discover(request)
+    first = core.capabilities.discover(request)
+    second = core.capabilities.discover(request)
 
     assert first == second
     assert [match.capability_id for match in first.matches] == [
@@ -388,9 +391,9 @@ def test_installed_capability_discovery_is_compact_deterministic_and_transparent
 
 
 def test_discovery_distinguishes_strong_weak_and_absent_lexical_fit(
-    tmp_path: Path,
+    complete_runtime_with_references: JacobianRuntime,
 ) -> None:
-    runtime = create_runtime(tmp_path)
+    runtime = complete_runtime_with_references
 
     strong = runtime.core.capabilities.discover(
         CapabilityDiscoveryRequest(
@@ -426,9 +429,8 @@ def test_discovery_distinguishes_strong_weak_and_absent_lexical_fit(
 
 
 def test_capability_registration_rejects_an_invalid_invocation_example(
-    tmp_path: Path,
+    capability_core_services: CapabilityTestServices,
 ) -> None:
-    runtime = create_runtime(tmp_path)
     adapter = DiscoveryAdapter(
         CapabilityDescriptor(
             capability_id="example.invalid-example",
@@ -457,13 +459,13 @@ def test_capability_registration_rejects_an_invalid_invocation_example(
     )
 
     with pytest.raises(CapabilityError, match="invocation example"):
-        runtime.core.capabilities.register(adapter)
+        capability_core_services.installation.register_capability(adapter)
 
 
 def test_knowledge_search_filters_episode_domain_tags_and_failures(
-    tmp_path: Path,
+    complete_runtime_with_references: JacobianRuntime,
 ) -> None:
-    runtime = create_runtime(tmp_path)
+    runtime = complete_runtime_with_references
     graph_episode = ResearchEpisode(
         capability_id="graph.compute.properties",
         capability_version="1",
@@ -529,9 +531,9 @@ def test_knowledge_search_filters_episode_domain_tags_and_failures(
 
 
 def test_knowledge_search_reports_snapshot_bounded_partial_results(
-    tmp_path: Path,
+    complete_runtime_with_references: JacobianRuntime,
 ) -> None:
-    runtime = create_runtime(tmp_path)
+    runtime = complete_runtime_with_references
     for value in (1, 2):
         runtime.core.memory.record(
             ResearchEpisode(
@@ -563,10 +565,13 @@ def test_knowledge_search_reports_snapshot_bounded_partial_results(
     assert result.output["completeness"] == "PARTIAL"
 
 
-def test_unknown_capability_returns_an_actionable_result(tmp_path: Path) -> None:
-    runtime = create_runtime(tmp_path)
+def test_unknown_capability_returns_an_actionable_result(
+    capability_core_services: CapabilityTestServices,
+) -> None:
+    core = capability_core_services.core
+    capability_core_services.installation.register_capability(ComputedAdapter())
 
-    result = runtime.core.capabilities.invoke(
+    result = core.capabilities.invoke(
         CapabilityRequest(
             capability_id="missing.capability",
             input={},
@@ -584,11 +589,13 @@ def test_unknown_capability_returns_an_actionable_result(tmp_path: Path) -> None
     assert result.output["available_capability_ids"]
 
 
-def test_unsupported_capability_mode_lists_available_modes(tmp_path: Path) -> None:
-    runtime = create_runtime(tmp_path)
-    runtime.core.capabilities.register(ComputedAdapter())
+def test_unsupported_capability_mode_lists_available_modes(
+    capability_core_services: CapabilityTestServices,
+) -> None:
+    core = capability_core_services.core
+    capability_core_services.installation.register_capability(ComputedAdapter())
 
-    result = runtime.core.capabilities.invoke(
+    result = core.capabilities.invoke(
         CapabilityRequest(
             capability_id="example.double",
             mode=CapabilityMode.VERIFY,
@@ -602,11 +609,13 @@ def test_unsupported_capability_mode_lists_available_modes(tmp_path: Path) -> No
     assert result.output["available_modes"] == ["EXPLORE"]
 
 
-def test_invalid_capability_input_does_not_echo_payload(tmp_path: Path) -> None:
-    runtime = create_runtime(tmp_path)
-    runtime.core.capabilities.register(ComputedAdapter())
+def test_invalid_capability_input_does_not_echo_payload(
+    capability_core_services: CapabilityTestServices,
+) -> None:
+    core = capability_core_services.core
+    capability_core_services.installation.register_capability(ComputedAdapter())
 
-    result = runtime.core.capabilities.invoke(
+    result = core.capabilities.invoke(
         CapabilityRequest(
             capability_id="example.double",
             input={"value": "fixture-secret-value"},
@@ -630,12 +639,12 @@ def test_invalid_capability_input_does_not_echo_payload(tmp_path: Path) -> None:
 
 
 def test_adapter_failure_does_not_expose_internal_exception_text(
-    tmp_path: Path,
+    capability_core_services: CapabilityTestServices,
 ) -> None:
-    runtime = create_runtime(tmp_path)
-    runtime.core.capabilities.register(CrashingAdapter())
+    core = capability_core_services.core
+    capability_core_services.installation.register_capability(CrashingAdapter())
 
-    result = runtime.core.capabilities.invoke(
+    result = core.capabilities.invoke(
         CapabilityRequest(
             capability_id="example.crash",
             input={},
@@ -655,15 +664,17 @@ def test_adapter_failure_does_not_expose_internal_exception_text(
     assert "RuntimeError" not in result.execution.detail
 
 
-def test_adapter_cannot_forge_provider_provenance(tmp_path: Path) -> None:
-    runtime = create_runtime(tmp_path)
-    runtime.core.capabilities.register(ForgedProviderAdapter())
+def test_adapter_cannot_forge_provider_provenance(
+    capability_core_services: CapabilityTestServices,
+) -> None:
+    core = capability_core_services.core
+    capability_core_services.installation.register_capability(ForgedProviderAdapter())
 
     with pytest.raises(
         CapabilityError,
         match="provider runtime differs from its descriptor",
     ):
-        runtime.core.capabilities.invoke(
+        core.capabilities.invoke(
             CapabilityRequest(
                 capability_id="example.forged-provider",
                 input={},
@@ -671,7 +682,11 @@ def test_adapter_cannot_forge_provider_provenance(tmp_path: Path) -> None:
         )
 
 
-def test_external_adapter_loads_from_an_operator_entrypoint(tmp_path: Path) -> None:
+def test_external_adapter_loads_from_an_operator_entrypoint(
+    tmp_path: Path,
+    initialized_runtime_store: None,
+) -> None:
+    _ = initialized_runtime_store
     runtime = create_runtime(
         tmp_path,
         capability_adapter_entrypoints=(
@@ -679,24 +694,26 @@ def test_external_adapter_loads_from_an_operator_entrypoint(tmp_path: Path) -> N
         ),
     )
 
-    result = runtime.core.capabilities.invoke(
-        CapabilityRequest(
-            capability_id="fixture.increment",
-            input={"value": 4},
+    try:
+        result = runtime.core.capabilities.invoke(
+            CapabilityRequest(
+                capability_id="fixture.increment",
+                input={"value": 4},
+            )
         )
-    )
-
-    assert result.output == {"value": 5}
+        assert result.output == {"value": 5}
+    finally:
+        runtime.close()
 
 
 def test_adapter_cannot_promote_without_a_local_verification_record(
-    tmp_path: Path,
+    capability_core_services: CapabilityTestServices,
 ) -> None:
-    runtime = create_runtime(tmp_path)
-    runtime.core.capabilities.register(ForgedVerifiedAdapter())
+    core = capability_core_services.core
+    capability_core_services.installation.register_capability(ForgedVerifiedAdapter())
 
     with pytest.raises(CapabilityError, match="verification record"):
-        runtime.core.capabilities.invoke(
+        core.capabilities.invoke(
             CapabilityRequest(
                 capability_id="example.forged",
                 mode=CapabilityMode.VERIFY,
@@ -706,13 +723,15 @@ def test_adapter_cannot_promote_without_a_local_verification_record(
 
 
 def test_first_class_relationship_endpoints_must_be_exposed(
-    tmp_path: Path,
+    capability_core_services: CapabilityTestServices,
 ) -> None:
-    runtime = create_runtime(tmp_path)
-    runtime.core.capabilities.register(OmittedRelationshipArtifactAdapter())
+    core = capability_core_services.core
+    capability_core_services.installation.register_capability(
+        OmittedRelationshipArtifactAdapter()
+    )
 
     with pytest.raises(CapabilityError, match="missing from artifact_uris"):
-        runtime.core.capabilities.invoke(
+        core.capabilities.invoke(
             CapabilityRequest(
                 capability_id="example.relationship",
                 input={},
@@ -721,11 +740,9 @@ def test_first_class_relationship_endpoints_must_be_exposed(
 
 
 def test_verified_relationship_must_match_checker_selected_endpoints(
-    tmp_path: Path,
+    complete_runtime_with_references: JacobianRuntime,
 ) -> None:
-    runtime = create_runtime(
-        tmp_path, checker_authority=CheckerAuthorityMode.INSTALL_BUNDLED
-    )
+    runtime = complete_runtime_with_references
     verified = runtime.core.capabilities.invoke(
         CapabilityRequest(
             capability_id="case.partition.finite",
@@ -763,11 +780,9 @@ def test_verified_relationship_must_match_checker_selected_endpoints(
 
 
 def test_verified_relationship_must_match_checker_selected_obligation(
-    tmp_path: Path,
+    complete_runtime_with_references: JacobianRuntime,
 ) -> None:
-    runtime = create_runtime(
-        tmp_path, checker_authority=CheckerAuthorityMode.INSTALL_BUNDLED
-    )
+    runtime = complete_runtime_with_references
     verified = runtime.core.capabilities.invoke(
         CapabilityRequest(
             capability_id="case.partition.finite",
@@ -804,13 +819,13 @@ def test_verified_relationship_must_match_checker_selected_obligation(
 
 @pytest.mark.lean_runtime
 @pytest.mark.skipif(
-    shutil.which("lean") is None,
-    reason="Lean is not installed",
+    not pinned_mathlib_runtime_available(),
+    reason=PINNED_MATHLIB_RUNTIME_UNAVAILABLE_REASON,
 )
-def test_lean_capability_returns_bound_verified_result(tmp_path: Path) -> None:
-    runtime = create_runtime(
-        tmp_path, checker_authority=CheckerAuthorityMode.INSTALL_BUNDLED
-    )
+def test_lean_capability_returns_bound_verified_result(
+    complete_runtime_with_references: JacobianRuntime,
+) -> None:
+    runtime = complete_runtime_with_references
 
     result = runtime.core.capabilities.invoke(
         CapabilityRequest(
@@ -831,15 +846,13 @@ def test_lean_capability_returns_bound_verified_result(tmp_path: Path) -> None:
 
 @pytest.mark.lean_runtime
 @pytest.mark.skipif(
-    shutil.which("lean") is None,
-    reason="Lean is not installed",
+    not pinned_mathlib_runtime_available(),
+    reason=PINNED_MATHLIB_RUNTIME_UNAVAILABLE_REASON,
 )
 def test_lean_capability_projects_repairable_checker_diagnostics(
-    tmp_path: Path,
+    complete_runtime_with_references: JacobianRuntime,
 ) -> None:
-    runtime = create_runtime(
-        tmp_path, checker_authority=CheckerAuthorityMode.INSTALL_BUNDLED
-    )
+    runtime = complete_runtime_with_references
 
     result = runtime.core.capabilities.invoke(
         CapabilityRequest(

--- a/tests/integration/infrastructure/test_runtime_lifecycle.py
+++ b/tests/integration/infrastructure/test_runtime_lifecycle.py
@@ -1,4 +1,4 @@
-"""Behavioral audit of :class:`JacobianRuntime` lifecycle ownership.
+"""Integration coverage of :class:`JacobianRuntime` lifecycle ownership.
 
 These tests pin the runtime ownership contract: explicit ``close``,
 idempotence, context-manager semantics, partial-bootstrap failure cleanup,
@@ -19,6 +19,8 @@ import pytest
 from jacobian.runtime import create_runtime
 from jacobian.runtime.model import RuntimeClosedError
 from jacobian.store import StoreClosedError
+
+pytestmark = pytest.mark.usefixtures("initialized_runtime_store")
 
 
 def test_close_is_idempotent(tmp_path: Path) -> None:

--- a/tests/integration/sat_smt/test_cadical_external_backend.py
+++ b/tests/integration/sat_smt/test_cadical_external_backend.py
@@ -10,7 +10,7 @@ from jacobian.provider_runtime import CADICAL_VERSION, cadical_provider_runtime
 
 pytestmark = [
     pytest.mark.external_backend,
-    pytest.mark.usefixtures("initialized_kernel_store"),
+    pytest.mark.usefixtures("initialized_runtime_store"),
     pytest.mark.skipif(
         shutil.which("cadical") is None,
         reason="CaDiCaL is not installed",

--- a/tests/integration/sat_smt/test_cvc5.py
+++ b/tests/integration/sat_smt/test_cvc5.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import shutil
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
@@ -17,6 +18,7 @@ from jacobian.contracts.capabilities import (
 )
 from jacobian.contracts.results import ExecutionStatus
 from jacobian.provider_measurements import measure_provider
+from jacobian.provider_runtime import cvc5_provider_runtime
 from jacobian.runtime import create_runtime
 from jacobian.runtime.model import JacobianRuntime
 from jacobian.smt import SmtArtifactError
@@ -66,10 +68,17 @@ def _invoke(runtime: JacobianRuntime, text: str, *, logic: str = "QF_UF"):
 def runtime(
     tmp_path_factory: pytest.TempPathFactory,
     runtime_store_template: Path,
-) -> JacobianRuntime:
+) -> Iterator[JacobianRuntime]:
+    provider = cvc5_provider_runtime()
+    if provider.availability is not CapabilityProviderAvailability.AVAILABLE:
+        pytest.skip("the pinned cvc5 runtime is unavailable")
     root = tmp_path_factory.mktemp("cvc5-runtime")
     shutil.copytree(runtime_store_template, root, dirs_exist_ok=True)
-    return create_runtime(root)
+    runtime = create_runtime(root)
+    try:
+        yield runtime
+    finally:
+        runtime.close()
 
 
 def test_pinned_cvc5_capability_is_discoverable(runtime: JacobianRuntime) -> None:

--- a/tests/unit/test_ci_timings.py
+++ b/tests/unit/test_ci_timings.py
@@ -46,7 +46,7 @@ def test_ci_timing_summary_reports_elapsed_and_runner_minutes(tmp_path: Path) ->
 
     completed = run_ci_script("summarize-ci-timings", jobs_json, check=True)
 
-    assert "Critical path (workflow elapsed) | 5.0 min" in completed.stdout
+    assert "Critical span | 5.0 min" in completed.stdout
     assert "Total runner time | 12.5 min" in completed.stdout
     assert "Tests (integration 1 of 4, Python 3.12) (4.0 min)" in completed.stdout
     assert "Integration shard skew (max/min) | 2.00x" in completed.stdout

--- a/tests/unit/test_local_validation_tools.py
+++ b/tests/unit/test_local_validation_tools.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import Mock
+
+ROOT = Path(__file__).parents[2]
+SCRIPTS = ROOT / ".github" / "scripts"
+
+
+def _load(name: str, filename: str) -> ModuleType:
+    loader = SourceFileLoader(name, str(SCRIPTS / filename))
+    spec = importlib.util.spec_from_loader(name, loader)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_plan_combines_commit_worktree_staged_and_untracked_paths(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    planner = _load("plan_local_tests", "plan-local-tests")
+    responses = {
+        ("diff", "--name-only", "base..HEAD"): ["committed.py", "same.py"],
+        ("diff", "--name-only"): ["unstaged.py", "same.py"],
+        ("diff", "--cached", "--name-only"): ["staged.py"],
+        ("ls-files", "--others", "--exclude-standard"): ["untracked.py"],
+    }
+    monkeypatch.setattr(planner, "ROOT", tmp_path)
+    monkeypatch.setattr(planner, "git_paths", lambda *args: responses[args])
+    monkeypatch.setattr(subprocess, "run", lambda *args, **kwargs: None)
+
+    assert planner.changed_paths("base") == [
+        "committed.py",
+        "same.py",
+        "staged.py",
+        "unstaged.py",
+        "untracked.py",
+    ]
+
+
+def test_clean_test_plan_selects_no_lanes() -> None:
+    planner = _load("plan_local_tests_clean", "plan-local-tests")
+
+    assert planner.classify([]) == {"classification": "clean"}
+
+
+def test_validation_receipt_distinguishes_dirty_tree_from_exact_head() -> None:
+    receipts = _load("validation_receipt_dirty", "validation-receipt")
+    state = {"head": "abc123", "dirty": True, "digest": "sha256:tree"}
+    receipt = receipts.make_receipt(
+        ["make", "check"],
+        0,
+        state,
+        state,
+        started_at="2026-07-29T00:00:00+00:00",
+        finished_at="2026-07-29T00:00:01+00:00",
+        duration_seconds=1.0,
+    )
+
+    assert receipt["command"] == ["make", "check"]
+    assert receipt["exit_code"] == 0
+    assert receipt["duration_seconds"] == 1.0
+    assert receipt["tree_digest"] == "sha256:tree"
+    assert receipt["tree_unchanged_during_validation"] is True
+    assert receipt["dirty"] is True
+    assert receipt["head_matches_validated_tree"] is False
+
+
+def test_tree_digest_binds_staged_unstaged_and_untracked_content(
+    tmp_path: Path,
+) -> None:
+    receipts = _load("validation_receipt", "validation-receipt")
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=tmp_path,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=tmp_path,
+        check=True,
+    )
+    tracked = tmp_path / "tracked"
+    tracked.write_text("tracked", encoding="utf-8")
+    subprocess.run(["git", "add", "tracked"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-qm", "initial"], cwd=tmp_path, check=True)
+    receipts.ROOT = tmp_path
+
+    path = tmp_path / "untracked"
+    path.write_text("first", encoding="utf-8")
+    first = receipts.tree_state()["digest"]
+    path.write_text("second", encoding="utf-8")
+    second = receipts.tree_state()["digest"]
+
+    assert first != second
+
+    subprocess.run(["git", "add", "untracked"], cwd=tmp_path, check=True)
+    staged_first = receipts.tree_state()["digest"]
+    path.write_text("third", encoding="utf-8")
+    subprocess.run(["git", "add", "untracked"], cwd=tmp_path, check=True)
+    staged_second = receipts.tree_state()["digest"]
+
+    assert staged_first != staged_second
+
+    tracked.write_text("unstaged-first", encoding="utf-8")
+    unstaged_first = receipts.tree_state()["digest"]
+    tracked.write_text("unstaged-second", encoding="utf-8")
+    unstaged_second = receipts.tree_state()["digest"]
+
+    assert unstaged_first != unstaged_second
+
+
+def test_receipt_rejects_non_ignored_repository_output(tmp_path: Path) -> None:
+    receipts = _load("validation_receipt_output", "validation-receipt")
+    receipts.ROOT = tmp_path
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    parser = Mock()
+    parser.error.side_effect = ValueError
+
+    try:
+        receipts.output_path(tmp_path / "receipt.json", parser)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("non-ignored receipt path was accepted")

--- a/tests/unit/test_portfolio_assembler.py
+++ b/tests/unit/test_portfolio_assembler.py
@@ -305,32 +305,6 @@ def test_empty_plan_yields_complete_empty_result(
     assert result.skipped_domain_ids == ()
 
 
-def test_builtin_portfolio_installs_cleanly_under_a_fresh_context(
-    assembly: _RecordingContext,
-) -> None:
-    from jacobian.portfolio import BUILTIN_PORTFOLIO
-
-    assembler = PortfolioAssembler(assembly.context)
-
-    result = assembler.install_domains(BUILTIN_PORTFOLIO)
-
-    assert result.is_complete
-    assert result.diagnostics == ()
-    assert set(result.installed) == set(BUILTIN_PORTFOLIO.domain_ids)
-    # Every built-in bundle is available in the test environment.
-    assert result.skipped_domain_ids == ()
-    for outcome in result.outcomes:
-        assert outcome.status is BundleInstallationStatus.INSTALLED
-        assert outcome.installed is not None
-    # The installed bundle's adapters were all registered.
-    expected_capability_ids = {
-        operation.capability_id
-        for bundle in BUILTIN_PORTFOLIO.domain_bundles
-        for operation in bundle.capabilities
-    }
-    assert set(assembly.registered) == expected_capability_ids
-
-
 def test_outcome_for_and_diagnostic_for_return_none_for_unknown_domains(
     assembly: _RecordingContext,
 ) -> None:

--- a/tests/unit/test_provider_metadata.py
+++ b/tests/unit/test_provider_metadata.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib.metadata import PackageNotFoundError
+
+import pytest
+
+import jacobian.providers.metadata as provider_metadata
+
+
+@dataclass
+class _Distribution:
+    requested_name: str
+
+    @property
+    def metadata(self) -> dict[str, str]:
+        return {"Name": f"recorded-{self.requested_name}"}
+
+    @property
+    def version(self) -> str:
+        return f"1.0-{self.requested_name}"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_metadata_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(provider_metadata, "_version_cache", {})
+    monkeypatch.setattr(provider_metadata, "_summary_cache", {})
+
+
+def test_distribution_summary_computes_identical_identity_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requested: list[str] = []
+
+    def lookup(name: str) -> _Distribution:
+        requested.append(name)
+        return _Distribution(name)
+
+    monkeypatch.setattr(provider_metadata, "distribution", lookup)
+
+    first = provider_metadata.distribution_summary("provider-alpha")
+    second = provider_metadata.distribution_summary("provider-alpha")
+
+    assert second is first
+    assert requested == ["provider-alpha"]
+
+
+def test_distribution_summary_keeps_distinct_inputs_distinct(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requested: list[str] = []
+
+    def lookup(name: str) -> _Distribution:
+        requested.append(name)
+        return _Distribution(name)
+
+    monkeypatch.setattr(provider_metadata, "distribution", lookup)
+
+    alpha = provider_metadata.distribution_summary("provider-alpha")
+    beta = provider_metadata.distribution_summary("provider-beta")
+
+    assert alpha != beta
+    assert requested == ["provider-alpha", "provider-beta"]
+
+
+def test_missing_distribution_is_not_cached(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+
+    def lookup(name: str) -> _Distribution:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise PackageNotFoundError(name)
+        return _Distribution(name)
+
+    monkeypatch.setattr(provider_metadata, "distribution", lookup)
+
+    assert provider_metadata.distribution_summary("provider-later") is None
+    assert provider_metadata.distribution_summary("provider-later") is not None
+    assert calls == 2


### PR DESCRIPTION
## Problem

The runtime decomposition removed eager heavy-provider imports, but repeated construction still rewrote and fsynced content-addressed descriptors that were already committed. A populated-store attachment measured about 10.2 seconds on this host. Test ownership amplified that cost: complete runtime lifecycle and portfolio installation cases lived in the unit lane, and capability-service tests assembled more of the application than they exercised.

The repository also had CI path classification but no local command that answered which lanes a diff selected, and local validation results were not bound to the exact staged, unstaged, and untracked tree.

## Solution

- Make identical artifact registration validate and reuse the committed artifact before any blob or SQLite write. Successful provider metadata lookups are cached without caching missing providers.
- Add a capability-only test service graph, move complete runtime/portfolio coverage to integration, and guard Lean/CVC5 tests by exact provider availability rather than executable presence.
- Add `make test-plan BASE=<revision>` and receipt-bound validation via `make validation-receipt COMMAND=<command>`.
- Fold integration timing-hint preparation into the CI plan job and report the measured interval as a critical span.

On the same host, a single current-tree measurement created a fresh runtime in 37.0 seconds and reattached over its populated store in 1.49 seconds. The routine unit lane fell from 93.09 seconds on the immediately preceding tree to 33.49 seconds after moving the full-portfolio smoke to integration. Timings are machine-local observations, not performance gates.

## Testing

- `make validation-receipt COMMAND="make check"` — Ruff, formatting, mypy, and 223 unit tests passed on clean commit `70b3d9f`; the receipt reports an unchanged tree matching HEAD.
- Focused storage/schema/tooling suite — 45 passed.
- Narrow CapabilityService slice — 10 passed in 8.73 seconds.
- CapabilityService plus runtime lifecycle slice — 22 passed, 2 Lean cases deselected.
- Built-in portfolio installation and CaDiCaL collection — 1 passed, 1 skipped because CaDiCaL is unavailable.
- `make docs-linkcheck` and actionlint — passed while preparing the CI/docs change.

The changed-path planner selects the full boundary set for this PR. Exhaustive integration, Lean, package, security, duplicate-code, and npm validation are intentionally left to CI on the pushed commit.

## Trust & Compatibility Impact

The artifact URI/manifest format and public runtime API are unchanged. The duplicate-registration fast path calls the existing full integrity read before returning, so missing or corrupted blobs still fail closed. Provider misses are not cached. Verification authority and checker policy are unchanged.

## Suggested review order

1. `src/jacobian/store.py` and its corruption/write-free regressions.
2. Narrow fixtures and test ownership moves under `tests/`.
3. Local planner/receipt scripts, then the CI timing-job consolidation.

## Checklist

- [x] Routine local validation passes (`make check`)
- [x] Relevant focused tests are listed above