### PR TITLE
feat(probability): add exact finite probability foundations

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -59,6 +59,7 @@ expectations.
 
 - [Tool surface](reference/tools.md)
 - [Domain operation library](reference/domain-operation-library.md)
+- [Finite probability operations](reference/finite-probability-operations.md)
 - [Provider runtime contract](reference/provider-runtime.md)
 - [Lean declaration discovery](reference/lean-declaration-discovery.md)
 - [Lean formal intermediates](reference/lean-formal-intermediates.md)

--- a/docs/reference/finite-probability-operations.md
+++ b/docs/reference/finite-probability-operations.md
@@ -1,0 +1,54 @@
+# Finite probability operations
+
+[Documentation home](../index.md)
+
+- Status: Current implementation reference; contracts are experimental
+- Domain: `probability`
+- Producer backend: pinned Python-FLINT exact rational arithmetic
+- Checker backend: Python standard-library `Fraction`, isolated from the producer
+
+Jacobian's finite-probability bundle exposes exact, bounded operations on
+explicit rational distributions. Each distribution has at most 256
+strictly increasing, distinct rational support values, nonnegative rational
+masses, and total mass exactly one. Inputs are completely validated before
+backend execution or artifact writes.
+
+## Operations
+
+| Capability | Atomic outcome | Inspectable ledger |
+| --- | --- | --- |
+| `probability.finite_distribution.raw_moment.compute` | One exact raw moment of order 0 through 128 | Per-atom power and weighted contribution |
+| `probability.finite_distribution.event_probability.compute` | Exact mass of an explicit support subset | Every selected source atom |
+| `probability.finite_distribution.condition.compute` | Normalized distribution on one positive-mass explicit event | Source and conditioned mass per selected atom |
+| `probability.finite_distribution.pushforward.compute` | Exact distribution under one total finite lookup map | Source, target, and transported mass per atom |
+| `probability.finite_distribution.convolution.compute` | Sum distribution for two explicitly independent finite variables | Every bounded product-measure pair |
+
+Event inputs contain canonical support values rather than executable
+predicates. Pushforward inputs must cover every source atom exactly once in
+canonical source order. Convolution is capped at 4,096 pairs, and validates
+the size and rational-growth bounds before computation.
+
+Conditioning on an exact zero-mass event returns
+`FINITE_CONDITIONING_ZERO_MASS` as a non-applicability outcome, with no result
+artifacts and no mathematical conclusion. Validation errors, unavailable
+providers, timeouts, and execution errors likewise do not establish a
+probability claim.
+
+## Independent verification
+
+`probability.result.verify` accepts the stored result URI of any operation
+above. The operator-authorized checker runs in a clean process and uses only
+standard-library rational arithmetic for the mathematical replay. It binds the
+source and result artifacts, semantics, candidate digest, witness format, and
+complete contribution ledger.
+
+The checker replays normalization, event membership, conditional division,
+pushforward aggregation, or every convolution pair as appropriate. A producer
+result remains `COMPUTED`; only an accepted, locally recorded checker run for
+that exact bound candidate returns `VERIFIED`. Malformed artifacts, substituted
+sources, altered ledgers, missing convolution pairs, and mathematically false
+but schema-valid candidates are rejected without a verification record.
+
+This foundation does not cover predicate-defined events, approximate or
+continuous distributions, Gaussian identities, Markov chains, graph
+reliability, or probabilistic inference strategy.

--- a/src/jacobian/contracts/probability.py
+++ b/src/jacobian/contracts/probability.py
@@ -1,0 +1,499 @@
+"""Bounded exact finite-probability contracts."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from itertools import pairwise
+from typing import Literal, Self
+
+from pydantic import Field, model_validator
+
+from jacobian.contracts.exact import CanonicalRational
+from jacobian.contracts.results import ContractModel
+
+MAX_FINITE_DISTRIBUTION_ATOMS = 256
+MAX_FINITE_CONVOLUTION_PAIRS = 4096
+MAX_INPUT_RATIONAL_DIGITS = 128
+MAX_RESULT_RATIONAL_DIGITS = 512
+
+
+def _require_bounded_fraction(
+    value: Fraction,
+    *,
+    max_digits: int,
+    label: str,
+) -> None:
+    if (
+        len(str(abs(value.numerator))) > max_digits
+        or len(str(value.denominator)) > max_digits
+    ):
+        raise ValueError(f"{label} exceeds the {max_digits}-digit bound")
+
+
+def _require_bounded_rational(
+    value: CanonicalRational,
+    *,
+    max_digits: int,
+    label: str,
+) -> None:
+    _require_bounded_fraction(
+        value.as_fraction(),
+        max_digits=max_digits,
+        label=label,
+    )
+
+
+def _require_strictly_increasing(
+    values: tuple[CanonicalRational, ...],
+    *,
+    label: str,
+) -> tuple[Fraction, ...]:
+    fractions = tuple(value.as_fraction() for value in values)
+    if any(left >= right for left, right in pairwise(fractions)):
+        raise ValueError(f"{label} must be strictly increasing")
+    return fractions
+
+
+class FiniteDistributionAtom(ContractModel):
+    value: CanonicalRational
+    probability: CanonicalRational
+
+    @model_validator(mode="after")
+    def require_bounded_nonnegative_probability(self) -> Self:
+        _require_bounded_rational(
+            self.value,
+            max_digits=MAX_RESULT_RATIONAL_DIGITS,
+            label="finite-distribution atom",
+        )
+        _require_bounded_rational(
+            self.probability,
+            max_digits=MAX_RESULT_RATIONAL_DIGITS,
+            label="finite-distribution probability",
+        )
+        if self.probability.as_fraction() < 0:
+            raise ValueError("finite-distribution probabilities must be nonnegative")
+        return self
+
+
+class FiniteRationalDistribution(ContractModel):
+    atoms: tuple[FiniteDistributionAtom, ...] = Field(
+        min_length=1,
+        max_length=MAX_FINITE_DISTRIBUTION_ATOMS,
+    )
+
+    @model_validator(mode="after")
+    def require_canonical_probability_distribution(self) -> Self:
+        _require_strictly_increasing(
+            tuple(atom.value for atom in self.atoms),
+            label="finite-distribution support values",
+        )
+        if (
+            sum(
+                (atom.probability.as_fraction() for atom in self.atoms),
+                start=Fraction(),
+            )
+            != 1
+        ):
+            raise ValueError("finite-distribution probabilities must sum exactly to 1")
+        return self
+
+
+def require_input_distribution(
+    atoms: tuple[FiniteDistributionAtom, ...],
+    *,
+    require_canonical: bool,
+) -> tuple[Fraction, ...]:
+    values = tuple(atom.value.as_fraction() for atom in atoms)
+    if len(values) != len(set(values)):
+        raise ValueError("finite-distribution support values must be unique")
+    if require_canonical and any(left >= right for left, right in pairwise(values)):
+        raise ValueError(
+            "finite-distribution support values must be strictly increasing"
+        )
+    for atom in atoms:
+        _require_bounded_rational(
+            atom.value,
+            max_digits=MAX_INPUT_RATIONAL_DIGITS,
+            label="finite-distribution input atom",
+        )
+        _require_bounded_rational(
+            atom.probability,
+            max_digits=MAX_INPUT_RATIONAL_DIGITS,
+            label="finite-distribution input probability",
+        )
+    if (
+        sum(
+            (atom.probability.as_fraction() for atom in atoms),
+            start=Fraction(),
+        )
+        != 1
+    ):
+        raise ValueError("finite-distribution probabilities must sum exactly to 1")
+    return values
+
+
+class FiniteEventRequest(ContractModel):
+    distribution: FiniteRationalDistribution
+    event_values: tuple[CanonicalRational, ...] = Field(
+        max_length=MAX_FINITE_DISTRIBUTION_ATOMS
+    )
+
+    @model_validator(mode="after")
+    def require_explicit_support_subset(self) -> Self:
+        support = set(
+            require_input_distribution(
+                self.distribution.atoms,
+                require_canonical=True,
+            )
+        )
+        event = _require_strictly_increasing(
+            self.event_values,
+            label="finite event values",
+        )
+        for value in self.event_values:
+            _require_bounded_rational(
+                value,
+                max_digits=MAX_INPUT_RATIONAL_DIGITS,
+                label="finite event value",
+            )
+        if not set(event).issubset(support):
+            raise ValueError("finite event values must belong to the distribution")
+        event_mass = sum(
+            (
+                atom.probability.as_fraction()
+                for atom in self.distribution.atoms
+                if atom.value.as_fraction() in set(event)
+            ),
+            start=Fraction(),
+        )
+        _require_bounded_fraction(
+            event_mass,
+            max_digits=MAX_RESULT_RATIONAL_DIGITS,
+            label="finite event probability",
+        )
+        return self
+
+
+class FiniteEventProbabilityResult(ContractModel):
+    event_probability: CanonicalRational
+    selected_atoms: tuple[FiniteDistributionAtom, ...] = Field(
+        max_length=MAX_FINITE_DISTRIBUTION_ATOMS
+    )
+    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
+    determinism: Literal["DETERMINISTIC"] = "DETERMINISTIC"
+    backend: Literal["python-flint"] = "python-flint"
+    backend_version: Literal["0.9.0"] = "0.9.0"
+    verification: Literal["UNVERIFIED"] = "UNVERIFIED"
+
+    @model_validator(mode="after")
+    def bind_selected_atom_contributions(self) -> Self:
+        _require_strictly_increasing(
+            tuple(atom.value for atom in self.selected_atoms),
+            label="selected finite-event atoms",
+        )
+        total = sum(
+            (atom.probability.as_fraction() for atom in self.selected_atoms),
+            start=Fraction(),
+        )
+        if self.event_probability.as_fraction() != total:
+            raise ValueError("event probability does not equal selected atom mass")
+        return self
+
+
+class FiniteConditionalContribution(ContractModel):
+    value: CanonicalRational
+    source_probability: CanonicalRational
+    conditioned_probability: CanonicalRational
+
+    @model_validator(mode="after")
+    def require_bounded_nonnegative_masses(self) -> Self:
+        for label, value in (
+            ("conditional value", self.value),
+            ("conditional source probability", self.source_probability),
+            ("conditioned probability", self.conditioned_probability),
+        ):
+            _require_bounded_rational(
+                value,
+                max_digits=MAX_RESULT_RATIONAL_DIGITS,
+                label=label,
+            )
+        if (
+            self.source_probability.as_fraction() < 0
+            or self.conditioned_probability.as_fraction() < 0
+        ):
+            raise ValueError("conditional contribution masses must be nonnegative")
+        return self
+
+
+class FiniteConditionResult(ContractModel):
+    event_probability: CanonicalRational
+    distribution: FiniteRationalDistribution
+    contributions: tuple[FiniteConditionalContribution, ...] = Field(
+        min_length=1,
+        max_length=MAX_FINITE_DISTRIBUTION_ATOMS,
+    )
+    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
+    determinism: Literal["DETERMINISTIC"] = "DETERMINISTIC"
+    backend: Literal["python-flint"] = "python-flint"
+    backend_version: Literal["0.9.0"] = "0.9.0"
+    verification: Literal["UNVERIFIED"] = "UNVERIFIED"
+
+    @model_validator(mode="after")
+    def bind_normalized_contributions(self) -> Self:
+        event_probability = self.event_probability.as_fraction()
+        if event_probability <= 0:
+            raise ValueError("conditional distribution requires positive event mass")
+        values = tuple(item.value for item in self.contributions)
+        _require_strictly_increasing(
+            values,
+            label="conditional contribution values",
+        )
+        expected_atoms: list[tuple[Fraction, Fraction]] = []
+        source_total = Fraction()
+        for item in self.contributions:
+            source = item.source_probability.as_fraction()
+            conditioned = item.conditioned_probability.as_fraction()
+            if source < 0 or conditioned != source / event_probability:
+                raise ValueError("conditioned probability does not match source mass")
+            source_total += source
+            expected_atoms.append((item.value.as_fraction(), conditioned))
+        if source_total != event_probability:
+            raise ValueError("conditional contributions do not equal event mass")
+        actual_atoms = [
+            (atom.value.as_fraction(), atom.probability.as_fraction())
+            for atom in self.distribution.atoms
+        ]
+        if actual_atoms != expected_atoms:
+            raise ValueError("conditional distribution does not match contributions")
+        return self
+
+
+class FinitePushforwardMapEntry(ContractModel):
+    source: CanonicalRational
+    target: CanonicalRational
+
+
+class FinitePushforwardRequest(ContractModel):
+    distribution: FiniteRationalDistribution
+    mapping: tuple[FinitePushforwardMapEntry, ...] = Field(
+        min_length=1,
+        max_length=MAX_FINITE_DISTRIBUTION_ATOMS,
+    )
+
+    @model_validator(mode="after")
+    def require_total_canonical_lookup(self) -> Self:
+        source_values = require_input_distribution(
+            self.distribution.atoms,
+            require_canonical=True,
+        )
+        mapping_sources = tuple(item.source.as_fraction() for item in self.mapping)
+        if mapping_sources != source_values:
+            raise ValueError(
+                "pushforward mapping must cover each source atom in canonical order"
+            )
+        aggregated: dict[Fraction, Fraction] = {}
+        for atom, item in zip(self.distribution.atoms, self.mapping, strict=True):
+            _require_bounded_rational(
+                item.source,
+                max_digits=MAX_INPUT_RATIONAL_DIGITS,
+                label="pushforward source",
+            )
+            _require_bounded_rational(
+                item.target,
+                max_digits=MAX_INPUT_RATIONAL_DIGITS,
+                label="pushforward target",
+            )
+            target = item.target.as_fraction()
+            aggregated[target] = (
+                aggregated.get(target, Fraction()) + atom.probability.as_fraction()
+            )
+        for target, probability in aggregated.items():
+            _require_bounded_fraction(
+                target,
+                max_digits=MAX_RESULT_RATIONAL_DIGITS,
+                label="pushforward target",
+            )
+            _require_bounded_fraction(
+                probability,
+                max_digits=MAX_RESULT_RATIONAL_DIGITS,
+                label="pushforward probability",
+            )
+        return self
+
+
+class FinitePushforwardContribution(ContractModel):
+    source: CanonicalRational
+    target: CanonicalRational
+    probability: CanonicalRational
+
+    @model_validator(mode="after")
+    def require_bounded_nonnegative_mass(self) -> Self:
+        for label, value in (
+            ("pushforward source", self.source),
+            ("pushforward target", self.target),
+            ("pushforward probability", self.probability),
+        ):
+            _require_bounded_rational(
+                value,
+                max_digits=MAX_RESULT_RATIONAL_DIGITS,
+                label=label,
+            )
+        if self.probability.as_fraction() < 0:
+            raise ValueError("pushforward contribution mass must be nonnegative")
+        return self
+
+
+class FinitePushforwardResult(ContractModel):
+    distribution: FiniteRationalDistribution
+    contributions: tuple[FinitePushforwardContribution, ...] = Field(
+        min_length=1,
+        max_length=MAX_FINITE_DISTRIBUTION_ATOMS,
+    )
+    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
+    determinism: Literal["DETERMINISTIC"] = "DETERMINISTIC"
+    backend: Literal["python-flint"] = "python-flint"
+    backend_version: Literal["0.9.0"] = "0.9.0"
+    verification: Literal["UNVERIFIED"] = "UNVERIFIED"
+
+    @model_validator(mode="after")
+    def bind_aggregated_pushforward(self) -> Self:
+        _require_strictly_increasing(
+            tuple(item.source for item in self.contributions),
+            label="pushforward contribution sources",
+        )
+        aggregated: dict[Fraction, Fraction] = {}
+        for item in self.contributions:
+            target = item.target.as_fraction()
+            probability = item.probability.as_fraction()
+            aggregated[target] = aggregated.get(target, Fraction()) + probability
+        expected = sorted(aggregated.items())
+        actual = [
+            (atom.value.as_fraction(), atom.probability.as_fraction())
+            for atom in self.distribution.atoms
+        ]
+        if actual != expected:
+            raise ValueError("pushforward distribution does not match contributions")
+        return self
+
+
+class FiniteConvolutionRequest(ContractModel):
+    left: FiniteRationalDistribution
+    right: FiniteRationalDistribution
+
+    @model_validator(mode="after")
+    def require_bounded_pair_product(self) -> Self:
+        require_input_distribution(self.left.atoms, require_canonical=True)
+        require_input_distribution(self.right.atoms, require_canonical=True)
+        pair_count = len(self.left.atoms) * len(self.right.atoms)
+        if pair_count > MAX_FINITE_CONVOLUTION_PAIRS:
+            raise ValueError(
+                "finite convolution exceeds the "
+                f"{MAX_FINITE_CONVOLUTION_PAIRS}-pair bound"
+            )
+        aggregated: dict[Fraction, Fraction] = {}
+        for left in self.left.atoms:
+            for right in self.right.atoms:
+                value = left.value.as_fraction() + right.value.as_fraction()
+                probability = (
+                    left.probability.as_fraction() * right.probability.as_fraction()
+                )
+                aggregated[value] = aggregated.get(value, Fraction()) + probability
+        for value, probability in aggregated.items():
+            _require_bounded_fraction(
+                value,
+                max_digits=MAX_RESULT_RATIONAL_DIGITS,
+                label="convolution atom",
+            )
+            _require_bounded_fraction(
+                probability,
+                max_digits=MAX_RESULT_RATIONAL_DIGITS,
+                label="convolution probability",
+            )
+        return self
+
+
+class FiniteConvolutionContribution(ContractModel):
+    left_value: CanonicalRational
+    right_value: CanonicalRational
+    sum_value: CanonicalRational
+    probability: CanonicalRational
+
+    @model_validator(mode="after")
+    def require_bounded_nonnegative_mass(self) -> Self:
+        for label, value in (
+            ("convolution left value", self.left_value),
+            ("convolution right value", self.right_value),
+            ("convolution sum value", self.sum_value),
+            ("convolution probability", self.probability),
+        ):
+            _require_bounded_rational(
+                value,
+                max_digits=MAX_RESULT_RATIONAL_DIGITS,
+                label=label,
+            )
+        if self.probability.as_fraction() < 0:
+            raise ValueError("convolution contribution mass must be nonnegative")
+        return self
+
+
+class FiniteConvolutionResult(ContractModel):
+    distribution: FiniteRationalDistribution
+    contributions: tuple[FiniteConvolutionContribution, ...] = Field(
+        min_length=1,
+        max_length=MAX_FINITE_CONVOLUTION_PAIRS,
+    )
+    independence: Literal["PRODUCT_MEASURE"] = "PRODUCT_MEASURE"
+    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
+    determinism: Literal["DETERMINISTIC"] = "DETERMINISTIC"
+    backend: Literal["python-flint"] = "python-flint"
+    backend_version: Literal["0.9.0"] = "0.9.0"
+    verification: Literal["UNVERIFIED"] = "UNVERIFIED"
+
+    @model_validator(mode="after")
+    def bind_aggregated_pairs(self) -> Self:
+        aggregated: dict[Fraction, Fraction] = {}
+        previous: tuple[Fraction, Fraction] | None = None
+        for item in self.contributions:
+            left = item.left_value.as_fraction()
+            right = item.right_value.as_fraction()
+            pair = (left, right)
+            if previous is not None and pair <= previous:
+                raise ValueError(
+                    "convolution contributions must use canonical pair order"
+                )
+            previous = pair
+            value = item.sum_value.as_fraction()
+            if value != left + right:
+                raise ValueError("convolution sum value does not match its pair")
+            probability = item.probability.as_fraction()
+            aggregated[value] = aggregated.get(value, Fraction()) + probability
+        expected = sorted(aggregated.items())
+        actual = [
+            (atom.value.as_fraction(), atom.probability.as_fraction())
+            for atom in self.distribution.atoms
+        ]
+        if actual != expected:
+            raise ValueError(
+                "convolution distribution does not match pair contributions"
+            )
+        return self
+
+
+__all__ = [
+    "MAX_FINITE_CONVOLUTION_PAIRS",
+    "MAX_FINITE_DISTRIBUTION_ATOMS",
+    "FiniteConditionResult",
+    "FiniteConditionalContribution",
+    "FiniteConvolutionContribution",
+    "FiniteConvolutionRequest",
+    "FiniteConvolutionResult",
+    "FiniteDistributionAtom",
+    "FiniteEventProbabilityResult",
+    "FiniteEventRequest",
+    "FinitePushforwardContribution",
+    "FinitePushforwardMapEntry",
+    "FinitePushforwardRequest",
+    "FinitePushforwardResult",
+    "FiniteRationalDistribution",
+    "require_input_distribution",
+]

--- a/src/jacobian/contracts/validated_analysis.py
+++ b/src/jacobian/contracts/validated_analysis.py
@@ -9,6 +9,10 @@ from typing import Literal, Self
 from pydantic import Field, StrictInt, model_validator
 
 from jacobian.contracts.exact import CanonicalRational
+from jacobian.contracts.probability import (
+    FiniteDistributionAtom,
+    require_input_distribution,
+)
 from jacobian.contracts.results import ContractModel
 
 MAX_RATIONAL_DIGITS = 128
@@ -123,19 +127,6 @@ class ArbPointEnclosureObligation(ContractModel):
     )
 
 
-class FiniteDistributionAtom(ContractModel):
-    value: CanonicalRational
-    probability: CanonicalRational
-
-    @model_validator(mode="after")
-    def require_bounded_nonnegative_probability(self) -> Self:
-        _require_bounded_rational(self.value)
-        _require_bounded_rational(self.probability)
-        if self.probability.as_fraction() < 0:
-            raise ValueError("finite-distribution probabilities must be nonnegative")
-        return self
-
-
 class FiniteRawMomentRequest(ContractModel):
     atoms: tuple[FiniteDistributionAtom, ...] = Field(
         min_length=1,
@@ -145,17 +136,7 @@ class FiniteRawMomentRequest(ContractModel):
 
     @model_validator(mode="after")
     def require_probability_distribution(self) -> Self:
-        values = tuple(atom.value.as_fraction() for atom in self.atoms)
-        if len(values) != len(set(values)):
-            raise ValueError("finite-distribution support values must be unique")
-        if (
-            sum(
-                (atom.probability.as_fraction() for atom in self.atoms),
-                start=0,
-            )
-            != 1
-        ):
-            raise ValueError("finite-distribution probabilities must sum exactly to 1")
+        require_input_distribution(self.atoms, require_canonical=False)
         return self
 
 

--- a/src/jacobian/domains/probability/bundle.py
+++ b/src/jacobian/domains/probability/bundle.py
@@ -1,7 +1,7 @@
 """Finite-probability domain bundle."""
 
 from jacobian.contracts.capabilities import CapabilityDiagnostic
-from jacobian.domains.probability.operations import FINITE_MOMENT_CAPABILITIES
+from jacobian.domains.probability.operations import FINITE_PROBABILITY_CAPABILITIES
 from jacobian.operations import DomainBundle, DomainDiagnostics, DomainSemantics
 from jacobian.provider_runtime import (
     PYTHON_FLINT_VERSION,
@@ -13,16 +13,19 @@ FINITE_PROBABILITY_BUNDLE = DomainBundle(
     schema_namespace="jacobian.validated-analysis",
     semantics=DomainSemantics(
         name="jacobian.probability",
-        version="1",
+        version="2",
         definition={
-            "description": "exact finite probability calculations",
-            "scope": "one raw moment of a normalized finite rational distribution",
+            "description": "bounded exact finite rational probability operations",
+            "scope": (
+                "raw moments, explicit event mass and conditioning, total "
+                "pushforwards, and independent finite convolutions"
+            ),
             "failure": "invalid distributions fail before computation",
         },
     ),
     provider_runtime=python_flint_probability_provider_runtime(),
     backend_version=f"python-flint-{PYTHON_FLINT_VERSION}",
-    capabilities=FINITE_MOMENT_CAPABILITIES,
+    capabilities=FINITE_PROBABILITY_CAPABILITIES,
     diagnostics=DomainDiagnostics(
         invalid_request=CapabilityDiagnostic(
             code="INVALID_FINITE_PROBABILITY_REQUEST",
@@ -31,8 +34,11 @@ FINITE_PROBABILITY_BUNDLE = DomainBundle(
             hint="Use bounded rational atoms whose probabilities sum exactly to one.",
         )
     ),
-    scope_description="one exact finite-probability request",
-    completeness_basis="Python-FLINT produced every exact atom contribution",
+    scope_description="one bounded exact finite-rational probability operation",
+    completeness_basis=(
+        "Python-FLINT produced every selected atom, source-map contribution, "
+        "or bounded product-measure pair required by the request"
+    ),
     assurance_basis="pinned maintained-backend exact rational computation",
 )
 

--- a/src/jacobian/domains/probability/checkers.py
+++ b/src/jacobian/domains/probability/checkers.py
@@ -1,0 +1,65 @@
+"""Independent checker declarations owned by the probability domain."""
+
+from jacobian.checker_operations import ExactReplayCheckerDeclaration
+from jacobian.contracts.probability import (
+    FiniteConvolutionRequest,
+    FiniteEventRequest,
+    FinitePushforwardRequest,
+)
+from jacobian.contracts.validated_analysis import FiniteRawMomentRequest
+
+_ENTRYPOINT = "jacobian_checkers.exact_probability_operations"
+_REASON = (
+    "operator-authorized standard-library Fraction replay independent of the "
+    "Python-FLINT producer"
+)
+
+PROBABILITY_EXACT_REPLAY_CHECKERS = (
+    ExactReplayCheckerDeclaration(
+        "probability.finite_distribution.raw_moment.compute",
+        FiniteRawMomentRequest,
+        "check_finite_raw_moment",
+        "probability.finite-raw-moment.fraction-replay",
+        entrypoint_module=_ENTRYPOINT,
+        replay_method="standard-library Fraction replay",
+        reason=_REASON,
+    ),
+    ExactReplayCheckerDeclaration(
+        "probability.finite_distribution.event_probability.compute",
+        FiniteEventRequest,
+        "check_finite_event_probability",
+        "probability.finite-event.fraction-replay",
+        entrypoint_module=_ENTRYPOINT,
+        replay_method="standard-library Fraction replay",
+        reason=_REASON,
+    ),
+    ExactReplayCheckerDeclaration(
+        "probability.finite_distribution.condition.compute",
+        FiniteEventRequest,
+        "check_finite_condition",
+        "probability.finite-condition.fraction-replay",
+        entrypoint_module=_ENTRYPOINT,
+        replay_method="standard-library Fraction replay",
+        reason=_REASON,
+    ),
+    ExactReplayCheckerDeclaration(
+        "probability.finite_distribution.pushforward.compute",
+        FinitePushforwardRequest,
+        "check_finite_pushforward",
+        "probability.finite-pushforward.fraction-replay",
+        entrypoint_module=_ENTRYPOINT,
+        replay_method="standard-library Fraction replay",
+        reason=_REASON,
+    ),
+    ExactReplayCheckerDeclaration(
+        "probability.finite_distribution.convolution.compute",
+        FiniteConvolutionRequest,
+        "check_finite_convolution",
+        "probability.finite-convolution.fraction-replay",
+        entrypoint_module=_ENTRYPOINT,
+        replay_method="standard-library Fraction replay",
+        reason=_REASON,
+    ),
+)
+
+__all__ = ["PROBABILITY_EXACT_REPLAY_CHECKERS"]

--- a/src/jacobian/domains/probability/operations.py
+++ b/src/jacobian/domains/probability/operations.py
@@ -1,8 +1,26 @@
 """Exact finite probability operations backed by Python-FLINT."""
 
+from __future__ import annotations
+
+from fractions import Fraction
 from typing import Any
 
+from jacobian.contracts.capabilities import CapabilityDiagnostic
 from jacobian.contracts.exact import CanonicalRational
+from jacobian.contracts.probability import (
+    FiniteConditionalContribution,
+    FiniteConditionResult,
+    FiniteConvolutionContribution,
+    FiniteConvolutionRequest,
+    FiniteConvolutionResult,
+    FiniteDistributionAtom,
+    FiniteEventProbabilityResult,
+    FiniteEventRequest,
+    FinitePushforwardContribution,
+    FinitePushforwardRequest,
+    FinitePushforwardResult,
+    FiniteRationalDistribution,
+)
 from jacobian.contracts.validated_analysis import (
     FiniteRawMomentContribution,
     FiniteRawMomentRequest,
@@ -10,6 +28,7 @@ from jacobian.contracts.validated_analysis import (
 )
 from jacobian.domains._examples import example
 from jacobian.operations import (
+    ComputedNotApplicable,
     ComputedOperation,
     ComputedOutcome,
     ComputedSuccess,
@@ -20,6 +39,27 @@ def _wire(value: Any) -> CanonicalRational:
     return CanonicalRational(num=str(value.p), den=str(value.q))
 
 
+def _fmpq(value: CanonicalRational) -> Any:
+    from flint import fmpq
+
+    return fmpq(int(value.num), int(value.den))
+
+
+def _distribution(values: dict[Fraction, Any]) -> FiniteRationalDistribution:
+    return FiniteRationalDistribution(
+        atoms=tuple(
+            FiniteDistributionAtom(
+                value=CanonicalRational(
+                    num=str(value.numerator),
+                    den=str(value.denominator),
+                ),
+                probability=_wire(probability),
+            )
+            for value, probability in sorted(values.items())
+        )
+    )
+
+
 def _raw_moment(
     request: FiniteRawMomentRequest,
 ) -> ComputedOutcome[FiniteRawMomentResult]:
@@ -28,11 +68,8 @@ def _raw_moment(
     contributions: list[FiniteRawMomentContribution] = []
     total = fmpq(0)
     for atom in request.atoms:
-        value = fmpq(int(atom.value.num), int(atom.value.den))
-        probability = fmpq(
-            int(atom.probability.num),
-            int(atom.probability.den),
-        )
+        value = _fmpq(atom.value)
+        probability = _fmpq(atom.probability)
         powered = value**request.order
         contribution = probability * powered
         total += contribution
@@ -53,7 +90,152 @@ def _raw_moment(
     )
 
 
-FINITE_MOMENT_CAPABILITIES = (
+def _event_probability(
+    request: FiniteEventRequest,
+) -> ComputedOutcome[FiniteEventProbabilityResult]:
+    from flint import fmpq
+
+    selected_values = {value.as_fraction() for value in request.event_values}
+    selected = tuple(
+        atom
+        for atom in request.distribution.atoms
+        if atom.value.as_fraction() in selected_values
+    )
+    total = fmpq(0)
+    for atom in selected:
+        total += _fmpq(atom.probability)
+    return ComputedSuccess(
+        FiniteEventProbabilityResult(
+            event_probability=_wire(total),
+            selected_atoms=selected,
+        )
+    )
+
+
+def _condition(
+    request: FiniteEventRequest,
+) -> ComputedOutcome[FiniteConditionResult]:
+    from flint import fmpq
+
+    selected_values = {value.as_fraction() for value in request.event_values}
+    selected = tuple(
+        atom
+        for atom in request.distribution.atoms
+        if atom.value.as_fraction() in selected_values
+    )
+    event_probability = fmpq(0)
+    for atom in selected:
+        event_probability += _fmpq(atom.probability)
+    if event_probability == 0:
+        return ComputedNotApplicable(
+            CapabilityDiagnostic(
+                code="FINITE_CONDITIONING_ZERO_MASS",
+                stage="finite_probability_conditioning",
+                message="The selected finite event has exact probability zero.",
+                hint="Condition only on an explicitly selected positive-mass event.",
+            )
+        )
+    contributions = tuple(
+        FiniteConditionalContribution(
+            value=atom.value,
+            source_probability=atom.probability,
+            conditioned_probability=_wire(_fmpq(atom.probability) / event_probability),
+        )
+        for atom in selected
+    )
+    return ComputedSuccess(
+        FiniteConditionResult(
+            event_probability=_wire(event_probability),
+            distribution=FiniteRationalDistribution(
+                atoms=tuple(
+                    FiniteDistributionAtom(
+                        value=item.value,
+                        probability=item.conditioned_probability,
+                    )
+                    for item in contributions
+                )
+            ),
+            contributions=contributions,
+        )
+    )
+
+
+def _pushforward(
+    request: FinitePushforwardRequest,
+) -> ComputedOutcome[FinitePushforwardResult]:
+    from flint import fmpq
+
+    aggregated: dict[Fraction, Any] = {}
+    contributions: list[FinitePushforwardContribution] = []
+    for atom, mapping in zip(
+        request.distribution.atoms,
+        request.mapping,
+        strict=True,
+    ):
+        target = mapping.target.as_fraction()
+        probability = _fmpq(atom.probability)
+        aggregated[target] = aggregated.get(target, fmpq(0)) + probability
+        contributions.append(
+            FinitePushforwardContribution(
+                source=atom.value,
+                target=mapping.target,
+                probability=atom.probability,
+            )
+        )
+    return ComputedSuccess(
+        FinitePushforwardResult(
+            distribution=_distribution(aggregated),
+            contributions=tuple(contributions),
+        )
+    )
+
+
+def _convolution(
+    request: FiniteConvolutionRequest,
+) -> ComputedOutcome[FiniteConvolutionResult]:
+    from flint import fmpq
+
+    aggregated: dict[Fraction, Any] = {}
+    contributions: list[FiniteConvolutionContribution] = []
+    for left in request.left.atoms:
+        for right in request.right.atoms:
+            sum_value = left.value.as_fraction() + right.value.as_fraction()
+            probability = _fmpq(left.probability) * _fmpq(right.probability)
+            aggregated[sum_value] = aggregated.get(sum_value, fmpq(0)) + probability
+            contributions.append(
+                FiniteConvolutionContribution(
+                    left_value=left.value,
+                    right_value=right.value,
+                    sum_value=CanonicalRational(
+                        num=str(sum_value.numerator),
+                        den=str(sum_value.denominator),
+                    ),
+                    probability=_wire(probability),
+                )
+            )
+    return ComputedSuccess(
+        FiniteConvolutionResult(
+            distribution=_distribution(aggregated),
+            contributions=tuple(contributions),
+        )
+    )
+
+
+_FAIR_BIT = {
+    "atoms": [
+        {
+            "value": {"num": "0", "den": "1"},
+            "probability": {"num": "1", "den": "2"},
+        },
+        {
+            "value": {"num": "1", "den": "1"},
+            "probability": {"num": "1", "den": "2"},
+        },
+    ]
+}
+
+
+FINITE_PROBABILITY_CAPABILITIES = (
     ComputedOperation(
         capability_id="probability.finite_distribution.raw_moment.compute",
         title="Exact finite-distribution raw moment",
@@ -71,21 +253,124 @@ FINITE_MOMENT_CAPABILITIES = (
                 "fair_bit_second_moment",
                 "Compute the second raw moment of a fair distribution on 0 and 1.",
                 {
-                    "atoms": [
-                        {
-                            "value": {"num": "0", "den": "1"},
-                            "probability": {"num": "1", "den": "2"},
-                        },
-                        {
-                            "value": {"num": "1", "den": "1"},
-                            "probability": {"num": "1", "den": "2"},
-                        },
-                    ],
+                    "atoms": _FAIR_BIT["atoms"],
                     "order": 2,
                 },
             ),
         ),
     ),
+    ComputedOperation(
+        capability_id="probability.finite_distribution.event_probability.compute",
+        title="Exact finite-event probability",
+        description=(
+            "Sum the exact mass of one explicit subset of a canonical finite "
+            "rational distribution and preserve every selected atom."
+        ),
+        request_model=FiniteEventRequest,
+        result_model=FiniteEventProbabilityResult,
+        implementation=_event_probability,
+        relation_id="probability.finite_distribution.event_probability.relation",
+        tags=("probability", "event", "finite", "exact", "python-flint"),
+        invocation_examples=(
+            example(
+                "fair_bit_is_one",
+                "Compute the exact probability that a fair bit equals one.",
+                {
+                    "distribution": _FAIR_BIT,
+                    "event_values": [{"num": "1", "den": "1"}],
+                },
+            ),
+        ),
+    ),
+    ComputedOperation(
+        capability_id="probability.finite_distribution.condition.compute",
+        title="Condition an exact finite distribution",
+        description=(
+            "Normalize one explicit positive-mass event of a canonical finite "
+            "rational distribution, preserving each source contribution."
+        ),
+        request_model=FiniteEventRequest,
+        result_model=FiniteConditionResult,
+        implementation=_condition,
+        relation_id="probability.finite_distribution.condition.relation",
+        tags=("probability", "conditioning", "finite", "exact", "python-flint"),
+        invocation_examples=(
+            example(
+                "fair_bit_given_one",
+                "Condition a fair bit on the positive-mass event that it equals one.",
+                {
+                    "distribution": _FAIR_BIT,
+                    "event_values": [{"num": "1", "den": "1"}],
+                },
+            ),
+        ),
+    ),
+    ComputedOperation(
+        capability_id="probability.finite_distribution.pushforward.compute",
+        title="Push forward an exact finite distribution",
+        description=(
+            "Apply one explicit total rational lookup map and exactly aggregate "
+            "all source masses with the same target."
+        ),
+        request_model=FinitePushforwardRequest,
+        result_model=FinitePushforwardResult,
+        implementation=_pushforward,
+        relation_id="probability.finite_distribution.pushforward.relation",
+        tags=("probability", "pushforward", "finite", "exact", "python-flint"),
+        invocation_examples=(
+            example(
+                "collapse_fair_bit",
+                "Map both atoms of a fair bit to one exact target.",
+                {
+                    "distribution": _FAIR_BIT,
+                    "mapping": [
+                        {
+                            "source": {"num": "0", "den": "1"},
+                            "target": {"num": "0", "den": "1"},
+                        },
+                        {
+                            "source": {"num": "1", "den": "1"},
+                            "target": {"num": "0", "den": "1"},
+                        },
+                    ],
+                },
+            ),
+        ),
+    ),
+    ComputedOperation(
+        capability_id="probability.finite_distribution.convolution.compute",
+        title="Convolve two exact finite distributions",
+        description=(
+            "Compute the bounded product-measure distribution of the sum of "
+            "two independent finite rational random variables."
+        ),
+        request_model=FiniteConvolutionRequest,
+        result_model=FiniteConvolutionResult,
+        implementation=_convolution,
+        relation_id="probability.finite_distribution.convolution.relation",
+        tags=(
+            "probability",
+            "convolution",
+            "independence",
+            "finite",
+            "exact",
+            "python-flint",
+        ),
+        invocation_examples=(
+            example(
+                "two_fair_bits",
+                "Compute the exact distribution of the sum of two fair bits.",
+                {"left": _FAIR_BIT, "right": _FAIR_BIT},
+            ),
+        ),
+    ),
 )
 
-__all__ = ["FINITE_MOMENT_CAPABILITIES"]
+# Kept as a source-level alias for callers that imported the experimental tuple.
+FINITE_MOMENT_CAPABILITIES = FINITE_PROBABILITY_CAPABILITIES[:1]
+
+
+__all__ = [
+    "FINITE_MOMENT_CAPABILITIES",
+    "FINITE_PROBABILITY_CAPABILITIES",
+]

--- a/src/jacobian/exact_domain_checkers.py
+++ b/src/jacobian/exact_domain_checkers.py
@@ -45,6 +45,7 @@ from jacobian.domains.number_theory.checkers import (
     NUMBER_THEORY_EXACT_REPLAY_CHECKERS,
 )
 from jacobian.domains.polynomial.checkers import POLYNOMIAL_EXACT_REPLAY_CHECKERS
+from jacobian.domains.probability.checkers import PROBABILITY_EXACT_REPLAY_CHECKERS
 from jacobian.domains.projective_geometry.checkers import (
     PROJECTIVE_GEOMETRY_EXACT_REPLAY_CHECKERS,
 )
@@ -53,6 +54,7 @@ from jacobian.provider_runtime import (
     exact_domain_checker_provider_runtime,
     graded_syzygy_checker_provider_runtime,
     graph_exact_checker_provider_runtime,
+    probability_exact_checker_provider_runtime,
     projective_arrangement_checker_provider_runtime,
 )
 from jacobian.registry import CheckerRegistry
@@ -84,6 +86,11 @@ def _provider_runtime_key(declaration: ExactReplayCheckerDeclaration) -> str:
         return "python-flint"
     if declaration.entrypoint_module == "jacobian_checkers.graph_exact_operations":
         return "finite-graph"
+    if (
+        declaration.entrypoint_module
+        == "jacobian_checkers.exact_probability_operations"
+    ):
+        return "finite-probability"
     if declaration.entrypoint_module == "jacobian_checkers.jacobian_syzygy":
         return "graded-syzygy"
     if declaration.entrypoint_module == "jacobian_checkers.projective_arrangements":
@@ -101,6 +108,7 @@ def install_exact_domain_checkers(
     graph: InstalledDomainBundle | None = None,
     graph_invariants: InstalledDomainBundle | None = None,
     number_theory: InstalledDomainBundle | None = None,
+    probability: InstalledDomainBundle | None = None,
     projective_geometry: InstalledDomainBundle | None = None,
     authorize: bool,
 ) -> ExactDomainCheckerInstallation:
@@ -110,6 +118,7 @@ def install_exact_domain_checkers(
     provider_runtimes = {
         "python-flint": exact_domain_checker_provider_runtime(),
         "finite-graph": graph_exact_checker_provider_runtime(),
+        "finite-probability": probability_exact_checker_provider_runtime(),
         "graded-syzygy": graded_syzygy_checker_provider_runtime(),
         "projective-arrangement": (projective_arrangement_checker_provider_runtime()),
     }
@@ -126,6 +135,11 @@ def install_exact_domain_checkers(
             (number_theory, item)
             for item in NUMBER_THEORY_EXACT_REPLAY_CHECKERS
             if number_theory is not None
+        ),
+        *(
+            (probability, item)
+            for item in PROBABILITY_EXACT_REPLAY_CHECKERS
+            if probability is not None
         ),
         *(
             (projective_geometry, item)
@@ -171,6 +185,9 @@ def install_exact_domain_checkers(
             "finite-graph": graph_exact_checker_provider_runtime(
                 checker_ids=authorized_ids["finite-graph"]
             ),
+            "finite-probability": probability_exact_checker_provider_runtime(
+                checker_ids=authorized_ids["finite-probability"]
+            ),
             "graded-syzygy": graded_syzygy_checker_provider_runtime(
                 checker_ids=authorized_ids["graded-syzygy"]
             ),
@@ -195,6 +212,7 @@ def install_exact_domain_verification(
     graph: InstalledDomainBundle | None = None,
     graph_invariants: InstalledDomainBundle | None = None,
     number_theory: InstalledDomainBundle | None = None,
+    probability: InstalledDomainBundle | None = None,
     projective_geometry: InstalledDomainBundle | None = None,
     authorize: bool,
 ) -> tuple[tuple[CapabilityAdapter, ...], ExactDomainCheckerInstallation]:
@@ -207,6 +225,7 @@ def install_exact_domain_verification(
         graph=graph,
         graph_invariants=graph_invariants,
         number_theory=number_theory,
+        probability=probability,
         projective_geometry=projective_geometry,
         authorize=authorize,
     )
@@ -277,6 +296,19 @@ def install_exact_domain_verification(
         if projective_geometry is not None
         else ()
     )
+    probability_declarations = (
+        tuple(
+            _installed_declaration(
+                probability,
+                declaration,
+                installation,
+            )
+            for declaration in PROBABILITY_EXACT_REPLAY_CHECKERS
+            if installation.checker_ids.get(declaration.capability_id) is not None
+        )
+        if probability is not None
+        else ()
+    )
     dedicated_declarations = (
         *(
             declaration
@@ -342,6 +374,25 @@ def install_exact_domain_verification(
                 declarations=matrix_declarations,
                 witness_schema_uri=witness_schema_uri,
                 provider_runtime=installation.provider_runtimes["python-flint"],
+            )
+        )
+    if probability_declarations:
+        adapters.append(
+            ExactDomainResultVerificationAdapter(
+                capability_id="probability.result.verify",
+                title="Verify an exact finite-probability result",
+                description=(
+                    "Independently replay one supported stored finite-probability "
+                    "result against its exact input lineage."
+                ),
+                tags=("verification", "exact", "probability", "finite"),
+                store=store,
+                schemas=schemas,
+                artifacts=artifacts,
+                verification=verification,
+                declarations=probability_declarations,
+                witness_schema_uri=witness_schema_uri,
+                provider_runtime=installation.provider_runtimes["finite-probability"],
             )
         )
     adapters.extend(dedicated_adapters)

--- a/src/jacobian/portfolio/core_installation.py
+++ b/src/jacobian/portfolio/core_installation.py
@@ -233,6 +233,7 @@ class CoreApplicationInstaller:
             graph=result.domain_bundles.get("graph_optimization"),
             graph_invariants=result.domain_bundles.get("graph_invariants"),
             number_theory=result.domain_bundles.get("number_theory"),
+            probability=result.domain_bundles.get("probability"),
             projective_geometry=result.domain_bundles.get("projective_geometry"),
             authorize=ctx.authorizes_bundled_checkers,
         )

--- a/src/jacobian/provider_runtime.py
+++ b/src/jacobian/provider_runtime.py
@@ -1059,7 +1059,13 @@ def python_flint_probability_provider_runtime(
         required_attributes=("fmpq",),
         install_tier=CapabilityInstallTier.T1,
         license_id="MIT AND LGPL-3.0-or-later",
-        features=("exact-rational-moments",),
+        features=(
+            "exact-rational-moments",
+            "finite-event-probability",
+            "finite-conditioning",
+            "finite-pushforward",
+            "finite-convolution",
+        ),
         refresh=refresh,
     )
     if (
@@ -1152,6 +1158,47 @@ def graph_exact_checker_provider_runtime(
             "finite-subset-exhaustive-replay",
             "hamiltonian-path-exhaustive-replay",
             "tutte-berge-barrier-replay",
+            "standard-library-only",
+        ),
+        checker_ids=checker_ids,
+    )
+
+
+def probability_exact_checker_provider_runtime(
+    *,
+    checker_ids: tuple[str, ...] = (),
+) -> CapabilityProviderRuntime:
+    """Bind the independent finite-probability checker source without FLINT."""
+
+    try:
+        version, _, license_files = _jacobian_identity()
+    except ProviderRuntimeError:
+        source = _unavailable_runtime(
+            provider="jacobian.probability-exact-checker-source",
+            install_tier=CapabilityInstallTier.T1,
+            license_id="MIT",
+            diagnostic=(
+                "The finite-probability checker source could not be identified."
+            ),
+        )
+    else:
+        source = source_provider_runtime(
+            "jacobian.probability-exact-checker-source",
+            version=version,
+            entrypoint=(
+                "jacobian_checkers.exact_probability_operations:check_finite_raw_moment"
+            ),
+            install_tier=CapabilityInstallTier.T1,
+            license_id="MIT",
+            license_files=license_files,
+            features=("clean-process-replay", "standard-library-only"),
+        )
+    return composite_provider_runtime(
+        "jacobian.probability-exact-checkers",
+        components=(source,),
+        features=(
+            "clean-process-replay",
+            "finite-rational-probability-replay",
             "standard-library-only",
         ),
         checker_ids=checker_ids,

--- a/src/jacobian_checkers/exact_probability_operations.py
+++ b/src/jacobian_checkers/exact_probability_operations.py
@@ -1,0 +1,353 @@
+"""Standard-library replay for exact finite-probability results.
+
+This independent checker imports neither Python-FLINT nor producer modules.
+Only passive, artifact-bound JSON values cross the checker boundary.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from fractions import Fraction
+from typing import Any
+
+from jacobian_checkers.bound_artifacts import bound_request as _bound_request
+
+_INTEGER = re.compile(r"^-?(?:0|[1-9][0-9]*)$")
+_META = {
+    "exactness": "EXACT_RATIONAL",
+    "determinism": "DETERMINISTIC",
+    "backend": "python-flint",
+    "backend_version": "0.9.0",
+    "verification": "UNVERIFIED",
+}
+
+
+def _reject(detail: str) -> dict[str, Any]:
+    return {
+        "accepted": False,
+        "conclusion": "UNKNOWN",
+        "arithmetic": "EXACT_RATIONAL",
+        "method": "DIRECT_WITNESS",
+        "coverage": "NOT_APPLICABLE",
+        "detail": detail,
+    }
+
+
+def _accept(operation_id: str) -> dict[str, Any]:
+    return {
+        "accepted": True,
+        "conclusion": "TRUE",
+        "arithmetic": "EXACT_RATIONAL",
+        "method": "DIRECT_WITNESS",
+        "coverage": "NOT_APPLICABLE",
+        "detail": f"independent standard-library Fraction replay accepted {operation_id}",
+    }
+
+
+def _integer(value: object) -> int:
+    if not isinstance(value, str) or _INTEGER.fullmatch(value) is None:
+        raise ValueError("integer is not canonical")
+    parsed = int(value)
+    if str(parsed) != value:
+        raise ValueError("integer is not canonical")
+    return parsed
+
+
+def _fraction(value: object) -> Fraction:
+    if not isinstance(value, dict) or set(value) != {"num", "den"}:
+        raise ValueError("rational is malformed")
+    numerator = _integer(value["num"])
+    denominator = _integer(value["den"])
+    if denominator <= 0:
+        raise ValueError("rational denominator must be positive")
+    result = Fraction(numerator, denominator)
+    if (result.numerator, result.denominator) != (numerator, denominator):
+        raise ValueError("rational is not reduced")
+    return result
+
+
+def _atom(value: object) -> tuple[Fraction, Fraction]:
+    if not isinstance(value, dict) or set(value) != {"value", "probability"}:
+        raise ValueError("finite-distribution atom is malformed")
+    probability = _fraction(value["probability"])
+    if probability < 0:
+        raise ValueError("finite-distribution probability is negative")
+    return _fraction(value["value"]), probability
+
+
+def _atoms(value: object, *, canonical: bool) -> list[tuple[Fraction, Fraction]]:
+    if not isinstance(value, list) or not 1 <= len(value) <= 256:
+        raise ValueError("finite distribution is malformed")
+    atoms = [_atom(item) for item in value]
+    support = [atom[0] for atom in atoms]
+    if len(support) != len(set(support)):
+        raise ValueError("finite distribution repeats a support value")
+    if canonical and support != sorted(support):
+        raise ValueError("finite distribution is not canonical")
+    if sum((atom[1] for atom in atoms), start=Fraction()) != 1:
+        raise ValueError("finite distribution is not normalized")
+    return atoms
+
+
+def _distribution(value: object) -> list[tuple[Fraction, Fraction]]:
+    if not isinstance(value, dict) or set(value) != {"atoms"}:
+        raise ValueError("finite distribution wrapper is malformed")
+    return _atoms(value["atoms"], canonical=True)
+
+
+def _metadata(result: dict[str, Any], fields: set[str]) -> bool:
+    return set(result) == fields | set(_META) and all(
+        result.get(key) == value for key, value in _META.items()
+    )
+
+
+def _event(
+    source: dict[str, Any],
+) -> tuple[list[tuple[Fraction, Fraction]], list[Fraction]]:
+    if set(source) != {"distribution", "event_values"}:
+        raise ValueError("finite event source is malformed")
+    atoms = _distribution(source["distribution"])
+    raw_event = source["event_values"]
+    if not isinstance(raw_event, list) or len(raw_event) > 256:
+        raise ValueError("finite event is malformed")
+    event = [_fraction(value) for value in raw_event]
+    if event != sorted(set(event)) or not set(event).issubset(
+        {value for value, _ in atoms}
+    ):
+        raise ValueError("finite event is not a canonical support subset")
+    return atoms, event
+
+
+def _run(
+    request: object,
+    *,
+    operation_id: str,
+    witness_format: str,
+    replay: Callable[[dict[str, Any], dict[str, Any]], bool],
+) -> dict[str, Any]:
+    try:
+        source, result = _bound_request(
+            request,
+            operation_id=operation_id,
+            witness_format=witness_format,
+        )
+        if not replay(source, result):
+            return _reject("declared result does not match independent Fraction replay")
+        return _accept(operation_id)
+    except (KeyError, TypeError, ValueError, ZeroDivisionError, OverflowError):
+        return _reject("malformed, unsupported, or mismatched checker request")
+
+
+def _replay_raw_moment(source: dict[str, Any], result: dict[str, Any]) -> bool:
+    if set(source) != {"atoms", "order"} or not _metadata(
+        result, {"order", "moment", "contributions"}
+    ):
+        return False
+    atoms = _atoms(source["atoms"], canonical=False)
+    order = source["order"]
+    if type(order) is not int or not 0 <= order <= 128 or result["order"] != order:
+        return False
+    contributions = result["contributions"]
+    if not isinstance(contributions, list) or len(contributions) != len(atoms):
+        return False
+    total = Fraction()
+    for atom, contribution in zip(atoms, contributions, strict=True):
+        if not isinstance(contribution, dict) or set(contribution) != {
+            "value",
+            "probability",
+            "powered_value",
+            "contribution",
+        }:
+            return False
+        value, probability = atom
+        powered = value**order
+        term = probability * powered
+        if (
+            _fraction(contribution["value"]) != value
+            or _fraction(contribution["probability"]) != probability
+            or _fraction(contribution["powered_value"]) != powered
+            or _fraction(contribution["contribution"]) != term
+        ):
+            return False
+        total += term
+    return _fraction(result["moment"]) == total
+
+
+def _replay_event_probability(source: dict[str, Any], result: dict[str, Any]) -> bool:
+    if not _metadata(result, {"event_probability", "selected_atoms"}):
+        return False
+    atoms, event = _event(source)
+    selected = [atom for atom in atoms if atom[0] in set(event)]
+    return (
+        isinstance(result["selected_atoms"], list)
+        and [_atom(item) for item in result["selected_atoms"]] == selected
+        and _fraction(result["event_probability"])
+        == sum((probability for _, probability in selected), start=Fraction())
+    )
+
+
+def _replay_condition(source: dict[str, Any], result: dict[str, Any]) -> bool:
+    if not _metadata(result, {"event_probability", "distribution", "contributions"}):
+        return False
+    atoms, event = _event(source)
+    selected = [atom for atom in atoms if atom[0] in set(event)]
+    mass = sum((probability for _, probability in selected), start=Fraction())
+    if mass <= 0 or _fraction(result["event_probability"]) != mass:
+        return False
+    expected = [(value, probability / mass) for value, probability in selected]
+    if _distribution(result["distribution"]) != expected:
+        return False
+    contributions = result["contributions"]
+    if not isinstance(contributions, list) or len(contributions) != len(selected):
+        return False
+    for item, ((value, probability), (_, conditioned)) in zip(
+        contributions, zip(selected, expected, strict=True), strict=True
+    ):
+        if not isinstance(item, dict) or set(item) != {
+            "value",
+            "source_probability",
+            "conditioned_probability",
+        }:
+            return False
+        if (
+            _fraction(item["value"]) != value
+            or _fraction(item["source_probability"]) != probability
+            or _fraction(item["conditioned_probability"]) != conditioned
+        ):
+            return False
+    return True
+
+
+def _replay_pushforward(source: dict[str, Any], result: dict[str, Any]) -> bool:
+    if set(source) != {"distribution", "mapping"} or not _metadata(
+        result, {"distribution", "contributions"}
+    ):
+        return False
+    atoms = _distribution(source["distribution"])
+    mapping = source["mapping"]
+    contributions = result["contributions"]
+    if (
+        not isinstance(mapping, list)
+        or not isinstance(contributions, list)
+        or len(mapping) != len(atoms)
+        or len(contributions) != len(atoms)
+    ):
+        return False
+    aggregated: dict[Fraction, Fraction] = {}
+    for atom, item, contribution in zip(atoms, mapping, contributions, strict=True):
+        if not isinstance(item, dict) or set(item) != {"source", "target"}:
+            return False
+        if not isinstance(contribution, dict) or set(contribution) != {
+            "source",
+            "target",
+            "probability",
+        }:
+            return False
+        value, probability = atom
+        source_value, target = _fraction(item["source"]), _fraction(item["target"])
+        if source_value != value or (
+            _fraction(contribution["source"]),
+            _fraction(contribution["target"]),
+            _fraction(contribution["probability"]),
+        ) != (value, target, probability):
+            return False
+        aggregated[target] = aggregated.get(target, Fraction()) + probability
+    return _distribution(result["distribution"]) == sorted(aggregated.items())
+
+
+def _replay_convolution(source: dict[str, Any], result: dict[str, Any]) -> bool:
+    if set(source) != {"left", "right"} or not _metadata(
+        result, {"distribution", "contributions", "independence"}
+    ):
+        return False
+    if result["independence"] != "PRODUCT_MEASURE":
+        return False
+    left, right = _distribution(source["left"]), _distribution(source["right"])
+    contributions = result["contributions"]
+    if not isinstance(contributions, list) or len(contributions) != len(left) * len(
+        right
+    ):
+        return False
+    expected: list[tuple[Fraction, Fraction, Fraction, Fraction]] = []
+    aggregated: dict[Fraction, Fraction] = {}
+    for left_value, left_probability in left:
+        for right_value, right_probability in right:
+            value = left_value + right_value
+            probability = left_probability * right_probability
+            expected.append((left_value, right_value, value, probability))
+            aggregated[value] = aggregated.get(value, Fraction()) + probability
+    actual = []
+    for item in contributions:
+        if not isinstance(item, dict) or set(item) != {
+            "left_value",
+            "right_value",
+            "sum_value",
+            "probability",
+        }:
+            return False
+        actual.append(
+            (
+                _fraction(item["left_value"]),
+                _fraction(item["right_value"]),
+                _fraction(item["sum_value"]),
+                _fraction(item["probability"]),
+            )
+        )
+    return actual == expected and _distribution(result["distribution"]) == sorted(
+        aggregated.items()
+    )
+
+
+def check_finite_raw_moment(request: object) -> dict[str, Any]:
+    return _run(
+        request,
+        operation_id="probability.finite_distribution.raw_moment.compute",
+        witness_format="probability.finite-raw-moment.fraction-replay",
+        replay=_replay_raw_moment,
+    )
+
+
+def check_finite_event_probability(request: object) -> dict[str, Any]:
+    return _run(
+        request,
+        operation_id="probability.finite_distribution.event_probability.compute",
+        witness_format="probability.finite-event.fraction-replay",
+        replay=_replay_event_probability,
+    )
+
+
+def check_finite_condition(request: object) -> dict[str, Any]:
+    return _run(
+        request,
+        operation_id="probability.finite_distribution.condition.compute",
+        witness_format="probability.finite-condition.fraction-replay",
+        replay=_replay_condition,
+    )
+
+
+def check_finite_pushforward(request: object) -> dict[str, Any]:
+    return _run(
+        request,
+        operation_id="probability.finite_distribution.pushforward.compute",
+        witness_format="probability.finite-pushforward.fraction-replay",
+        replay=_replay_pushforward,
+    )
+
+
+def check_finite_convolution(request: object) -> dict[str, Any]:
+    return _run(
+        request,
+        operation_id="probability.finite_distribution.convolution.compute",
+        witness_format="probability.finite-convolution.fraction-replay",
+        replay=_replay_convolution,
+    )
+
+
+__all__ = [
+    "check_finite_condition",
+    "check_finite_convolution",
+    "check_finite_event_probability",
+    "check_finite_pushforward",
+    "check_finite_raw_moment",
+]

--- a/tests/checkers/test_exact_probability_operation_checkers.py
+++ b/tests/checkers/test_exact_probability_operation_checkers.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+import copy
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+from tests.helpers.artifacts import artifact_uri as _uri
+from tests.helpers.artifacts import canonical_digest as _digest
+from tests.helpers.rationals import rational_payload as _q
+
+from jacobian_checkers.exact_probability_operations import (
+    check_finite_condition,
+    check_finite_convolution,
+    check_finite_event_probability,
+    check_finite_pushforward,
+    check_finite_raw_moment,
+)
+
+_META = {
+    "exactness": "EXACT_RATIONAL",
+    "determinism": "DETERMINISTIC",
+    "backend": "python-flint",
+    "backend_version": "0.9.0",
+    "verification": "UNVERIFIED",
+}
+_BIT = {
+    "atoms": [
+        {"value": _q(0), "probability": _q(1, 2)},
+        {"value": _q(1), "probability": _q(1, 2)},
+    ]
+}
+
+
+def _artifact(
+    character: str,
+    payload: dict[str, Any],
+    *,
+    semantics: str,
+    parents: list[str],
+) -> dict[str, Any]:
+    return {
+        "artifact_uri": _uri(character),
+        "object_digest": "sha256:" + character * 64,
+        "payload_digest": _digest(payload),
+        "schema_uri": _uri(chr(ord(character) + 1)),
+        "semantics_uri": semantics,
+        "parents": parents,
+        "payload": payload,
+    }
+
+
+def _request(
+    operation_id: str,
+    witness_format: str,
+    source: dict[str, Any],
+    result: dict[str, Any],
+) -> dict[str, Any]:
+    semantics = _uri("e")
+    semantics_artifact = _artifact(
+        "e", {"kind": "semantics"}, semantics=_uri("0"), parents=[]
+    )
+    semantics_artifact["object_digest"] = "sha256:" + "8" * 64
+    claim = _artifact("1", source, semantics=semantics, parents=[])
+    candidate = _artifact(
+        "3", result, semantics=semantics, parents=[claim["artifact_uri"]]
+    )
+    bindings = {
+        "claim_digest": claim["object_digest"],
+        "semantics_digest": semantics_artifact["object_digest"],
+        "candidate_digest": candidate["object_digest"],
+        "scope_digest": None,
+        "encoding_digest": None,
+    }
+    witness_payload = {
+        "evidence_schema_version": "1",
+        "witness_format": witness_format,
+        "format_version": "1",
+        "role": "SUPPORTS_CLAIM",
+        "bindings": bindings,
+        "payload": {
+            "operation_id": operation_id,
+            "input_uri": claim["artifact_uri"],
+            "result_uri": candidate["artifact_uri"],
+        },
+    }
+    witness = _artifact(
+        "5",
+        witness_payload,
+        semantics=semantics,
+        parents=[claim["artifact_uri"], candidate["artifact_uri"]],
+    )
+    return {
+        "request_version": "1",
+        "claim": claim,
+        "candidate": candidate,
+        "semantics": semantics_artifact,
+        "scope": None,
+        "witness": witness,
+        "expected_bindings": bindings,
+    }
+
+
+_CASES: tuple[
+    tuple[Callable[[dict[str, Any]], dict[str, Any]], dict[str, Any]], ...
+] = (
+    (
+        check_finite_raw_moment,
+        _request(
+            "probability.finite_distribution.raw_moment.compute",
+            "probability.finite-raw-moment.fraction-replay",
+            {"atoms": _BIT["atoms"], "order": 2},
+            {
+                "order": 2,
+                "moment": _q(1, 2),
+                "contributions": [
+                    {
+                        "value": _q(0),
+                        "probability": _q(1, 2),
+                        "powered_value": _q(0),
+                        "contribution": _q(0),
+                    },
+                    {
+                        "value": _q(1),
+                        "probability": _q(1, 2),
+                        "powered_value": _q(1),
+                        "contribution": _q(1, 2),
+                    },
+                ],
+                **_META,
+            },
+        ),
+    ),
+    (
+        check_finite_event_probability,
+        _request(
+            "probability.finite_distribution.event_probability.compute",
+            "probability.finite-event.fraction-replay",
+            {"distribution": _BIT, "event_values": [_q(1)]},
+            {
+                "event_probability": _q(1, 2),
+                "selected_atoms": [_BIT["atoms"][1]],
+                **_META,
+            },
+        ),
+    ),
+    (
+        check_finite_condition,
+        _request(
+            "probability.finite_distribution.condition.compute",
+            "probability.finite-condition.fraction-replay",
+            {"distribution": _BIT, "event_values": [_q(1)]},
+            {
+                "event_probability": _q(1, 2),
+                "distribution": {"atoms": [{"value": _q(1), "probability": _q(1)}]},
+                "contributions": [
+                    {
+                        "value": _q(1),
+                        "source_probability": _q(1, 2),
+                        "conditioned_probability": _q(1),
+                    }
+                ],
+                **_META,
+            },
+        ),
+    ),
+    (
+        check_finite_pushforward,
+        _request(
+            "probability.finite_distribution.pushforward.compute",
+            "probability.finite-pushforward.fraction-replay",
+            {
+                "distribution": _BIT,
+                "mapping": [
+                    {"source": _q(0), "target": _q(0)},
+                    {"source": _q(1), "target": _q(0)},
+                ],
+            },
+            {
+                "distribution": {"atoms": [{"value": _q(0), "probability": _q(1)}]},
+                "contributions": [
+                    {"source": _q(0), "target": _q(0), "probability": _q(1, 2)},
+                    {"source": _q(1), "target": _q(0), "probability": _q(1, 2)},
+                ],
+                **_META,
+            },
+        ),
+    ),
+    (
+        check_finite_convolution,
+        _request(
+            "probability.finite_distribution.convolution.compute",
+            "probability.finite-convolution.fraction-replay",
+            {"left": _BIT, "right": _BIT},
+            {
+                "distribution": {
+                    "atoms": [
+                        {"value": _q(0), "probability": _q(1, 4)},
+                        {"value": _q(1), "probability": _q(1, 2)},
+                        {"value": _q(2), "probability": _q(1, 4)},
+                    ]
+                },
+                "contributions": [
+                    {
+                        "left_value": _q(left),
+                        "right_value": _q(right),
+                        "sum_value": _q(left + right),
+                        "probability": _q(1, 4),
+                    }
+                    for left in (0, 1)
+                    for right in (0, 1)
+                ],
+                "independence": "PRODUCT_MEASURE",
+                **_META,
+            },
+        ),
+    ),
+)
+
+
+@pytest.mark.parametrize(("checker", "case_request"), _CASES)
+def test_probability_checkers_accept_complete_exact_replay(
+    checker: Callable[[dict[str, Any]], dict[str, Any]],
+    case_request: dict[str, Any],
+) -> None:
+    checked = checker(case_request)
+
+    assert checked["accepted"] is True
+    assert checked["conclusion"] == "TRUE"
+    assert "Fraction replay accepted" in checked["detail"]
+
+
+@pytest.mark.parametrize(("checker", "case_request"), _CASES)
+def test_probability_checkers_reject_payload_substitution_with_fresh_digest(
+    checker: Callable[[dict[str, Any]], dict[str, Any]],
+    case_request: dict[str, Any],
+) -> None:
+    forged = copy.deepcopy(case_request)
+    forged["candidate"]["payload"]["backend_version"] = "0.9.1"
+    forged["candidate"]["payload_digest"] = _digest(forged["candidate"]["payload"])
+
+    checked = checker(forged)
+
+    assert checked["accepted"] is False
+    assert checked["conclusion"] == "UNKNOWN"
+
+
+def test_convolution_checker_rejects_missing_pair_with_fresh_digest() -> None:
+    checker, case_request = _CASES[-1]
+    forged = copy.deepcopy(case_request)
+    forged["candidate"]["payload"]["contributions"].pop()
+    forged["candidate"]["payload_digest"] = _digest(forged["candidate"]["payload"])
+
+    checked = checker(forged)
+
+    assert checked["accepted"] is False
+    assert checked["conclusion"] == "UNKNOWN"

--- a/tests/integration/domains/test_exact_domain_result_verification.py
+++ b/tests/integration/domains/test_exact_domain_result_verification.py
@@ -56,6 +56,7 @@ def _install_verification(
         runtime.core.checkers,
         polynomial=runtime.portfolio.domain_bundles["polynomial"],
         matrix=runtime.portfolio.domain_bundles["matrix"],
+        probability=runtime.portfolio.domain_bundles.get("probability"),
         authorize=authorize,
     )
     for adapter in adapters:
@@ -73,6 +74,105 @@ def _computed_gcd(runtime: JacobianRuntime):
             },
         )
     )
+
+
+_FAIR_BIT = {
+    "atoms": [
+        {"value": _q(0), "probability": _q(1, 2)},
+        {"value": _q(1), "probability": _q(1, 2)},
+    ]
+}
+
+
+@pytest.mark.parametrize(
+    ("capability_id", "payload"),
+    (
+        (
+            "probability.finite_distribution.raw_moment.compute",
+            {"atoms": _FAIR_BIT["atoms"], "order": 2},
+        ),
+        (
+            "probability.finite_distribution.event_probability.compute",
+            {"distribution": _FAIR_BIT, "event_values": [_q(1)]},
+        ),
+        (
+            "probability.finite_distribution.condition.compute",
+            {"distribution": _FAIR_BIT, "event_values": [_q(1)]},
+        ),
+        (
+            "probability.finite_distribution.pushforward.compute",
+            {
+                "distribution": _FAIR_BIT,
+                "mapping": [
+                    {"source": _q(0), "target": _q(0)},
+                    {"source": _q(1), "target": _q(0)},
+                ],
+            },
+        ),
+        (
+            "probability.finite_distribution.convolution.compute",
+            {"left": _FAIR_BIT, "right": _FAIR_BIT},
+        ),
+    ),
+)
+def test_probability_results_are_independently_replayed(
+    runtime,
+    capability_id: str,
+    payload: dict[str, Any],
+) -> None:
+    _install_verification(runtime, authorize=True)
+    computed = runtime.core.capabilities.invoke(
+        CapabilityRequest(capability_id=capability_id, input=payload)
+    )
+
+    verified = runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="probability.result.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"result_uri": computed.output["result_uri"]},
+        )
+    )
+
+    assert computed.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert verified.execution.status is ExecutionStatus.COMPLETED
+    assert verified.output["status"] == "VERIFIED"
+    assert verified.output["operation_id"] == capability_id
+    assert verified.output["verification_record_uri"] in verified.artifact_uris
+    assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED
+
+
+def test_probability_checker_rejects_forged_event_mass(runtime) -> None:
+    _install_verification(runtime, authorize=True)
+    computed = runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id=("probability.finite_distribution.event_probability.compute"),
+            input={"distribution": _FAIR_BIT, "event_values": [_q(1)]},
+        )
+    )
+    result_artifact = runtime.core.store.get(computed.output["result_uri"])
+    false_payload = dict(result_artifact.payload)
+    false_payload["event_probability"] = _q(1)
+    false_payload["selected_atoms"] = _FAIR_BIT["atoms"]
+    false_result = runtime.core.artifacts.put(
+        schema_uri=result_artifact.manifest.schema_uri,
+        semantics_uri=result_artifact.manifest.semantics_uri,
+        parents=result_artifact.manifest.parents,
+        payload=false_payload,
+        summary="adversarial false finite-event probability",
+    )
+
+    rejected = runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="probability.result.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"result_uri": false_result.artifact_uri},
+        )
+    )
+
+    assert rejected.output["status"] == "REJECTED"
+    assert rejected.output["conclusion"] == "UNKNOWN"
+    assert rejected.output["verification_record_uri"] is None
+    assert rejected.assurance.level is CapabilityAssuranceLevel.COMPUTED
 
 
 def test_public_seam_verifies_exact_producer_result(runtime) -> None:

--- a/tests/integration/domains/test_validated_analysis_domain.py
+++ b/tests/integration/domains/test_validated_analysis_domain.py
@@ -32,6 +32,20 @@ def _rational(num: int, den: int = 1) -> dict[str, str]:
     return {"num": str(num), "den": str(den)}
 
 
+def _distribution(
+    *atoms: tuple[int, int, int],
+) -> dict[str, list[dict[str, dict[str, str]]]]:
+    return {
+        "atoms": [
+            {
+                "value": _rational(value),
+                "probability": _rational(numerator, denominator),
+            }
+            for value, numerator, denominator in atoms
+        ]
+    }
+
+
 @pytest.fixture(scope="module")
 def analysis_runtime(tmp_path_factory: pytest.TempPathFactory) -> _Runtime:
     store = ArtifactStore(tmp_path_factory.mktemp("validated-analysis"))
@@ -77,7 +91,13 @@ def test_subject_bundles_preserve_wire_contracts_and_report_one_backend() -> Non
         "probability": (
             "python-flint",
             "jacobian.validated-analysis",
-            ("probability.finite_distribution.raw_moment.compute",),
+            (
+                "probability.finite_distribution.raw_moment.compute",
+                "probability.finite_distribution.event_probability.compute",
+                "probability.finite_distribution.condition.compute",
+                "probability.finite_distribution.pushforward.compute",
+                "probability.finite_distribution.convolution.compute",
+            ),
         ),
         "optimization": (
             "jacobian.sympy",
@@ -218,6 +238,161 @@ def test_invalid_finite_distribution_fails_before_artifact_writes(
                     {"value": _rational(1), "probability": _rational(1, 3)},
                 ],
                 "order": 1,
+            },
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.diagnostics[0].code == "INVALID_FINITE_PROBABILITY_REQUEST"
+    assert result.artifact_uris == ()
+
+
+def test_finite_event_probability_preserves_selected_atom_contributions(
+    analysis_runtime: _Runtime,
+) -> None:
+    result = analysis_runtime.capabilities.invoke(
+        CapabilityRequest(
+            capability_id=("probability.finite_distribution.event_probability.compute"),
+            input={
+                "distribution": _distribution(
+                    (-1, 1, 4),
+                    (0, 1, 2),
+                    (2, 1, 4),
+                ),
+                "event_values": [_rational(-1), _rational(2)],
+            },
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output["result"]["event_probability"] == _rational(1, 2)
+    assert result.output["result"]["selected_atoms"] == [
+        {
+            "value": _rational(-1),
+            "probability": _rational(1, 4),
+        },
+        {
+            "value": _rational(2),
+            "probability": _rational(1, 4),
+        },
+    ]
+    assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert len(result.artifact_uris) == 2
+
+
+def test_finite_conditioning_returns_one_normalized_distribution(
+    analysis_runtime: _Runtime,
+) -> None:
+    result = analysis_runtime.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="probability.finite_distribution.condition.compute",
+            input={
+                "distribution": _distribution(
+                    (-1, 1, 6),
+                    (0, 1, 3),
+                    (2, 1, 2),
+                ),
+                "event_values": [_rational(-1), _rational(2)],
+            },
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output["result"]["event_probability"] == _rational(2, 3)
+    assert result.output["result"]["distribution"] == _distribution(
+        (-1, 1, 4),
+        (2, 3, 4),
+    )
+    assert [
+        contribution["conditioned_probability"]
+        for contribution in result.output["result"]["contributions"]
+    ] == [_rational(1, 4), _rational(3, 4)]
+
+
+def test_zero_mass_conditioning_is_a_non_conclusion_without_artifacts(
+    analysis_runtime: _Runtime,
+) -> None:
+    result = analysis_runtime.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="probability.finite_distribution.condition.compute",
+            input={
+                "distribution": _distribution(
+                    (0, 0, 1),
+                    (1, 1, 1),
+                ),
+                "event_values": [_rational(0)],
+            },
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.diagnostics[0].code == "FINITE_CONDITIONING_ZERO_MASS"
+    assert result.assurance.level is CapabilityAssuranceLevel.HEURISTIC
+    assert result.completeness.status is CapabilityCompletenessStatus.NOT_APPLICABLE
+    assert result.artifact_uris == ()
+    assert result.episode_uri is None
+
+
+def test_finite_pushforward_collapses_equal_target_atoms(
+    analysis_runtime: _Runtime,
+) -> None:
+    result = analysis_runtime.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="probability.finite_distribution.pushforward.compute",
+            input={
+                "distribution": _distribution(
+                    (-1, 1, 4),
+                    (0, 1, 2),
+                    (1, 1, 4),
+                ),
+                "mapping": [
+                    {"source": _rational(-1), "target": _rational(1)},
+                    {"source": _rational(0), "target": _rational(0)},
+                    {"source": _rational(1), "target": _rational(1)},
+                ],
+            },
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output["result"]["distribution"] == _distribution(
+        (0, 1, 2),
+        (1, 1, 2),
+    )
+    assert len(result.output["result"]["contributions"]) == 3
+
+
+def test_finite_convolution_aggregates_all_independent_pairs(
+    analysis_runtime: _Runtime,
+) -> None:
+    fair_bit = _distribution((0, 1, 2), (1, 1, 2))
+    result = analysis_runtime.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="probability.finite_distribution.convolution.compute",
+            input={"left": fair_bit, "right": fair_bit},
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output["result"]["distribution"] == _distribution(
+        (0, 1, 4),
+        (1, 1, 2),
+        (2, 1, 4),
+    )
+    assert len(result.output["result"]["contributions"]) == 4
+
+
+def test_incomplete_pushforward_mapping_fails_before_artifact_writes(
+    analysis_runtime: _Runtime,
+) -> None:
+    result = analysis_runtime.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="probability.finite_distribution.pushforward.compute",
+            input={
+                "distribution": _distribution((0, 1, 2), (1, 1, 2)),
+                "mapping": [
+                    {"source": _rational(0), "target": _rational(1)},
+                ],
             },
         )
     )


### PR DESCRIPTION
## Summary
- add bounded exact finite rational event probability, conditioning, pushforward, and convolution producers alongside raw moments
- preserve complete atom, map, normalization, and product-pair contribution ledgers with fail-closed zero-mass conditioning
- add operator-authorized standard-library Fraction replay for all five probability results through probability.result.verify
- document the experimental contracts, bounds, assurance boundary, and excluded scope

## Independence and assurance
- producers use pinned Python-FLINT exact rational arithmetic and remain COMPUTED
- checkers import neither Python-FLINT nor probability producer modules
- VERIFIED is returned only after clean-process artifact-bound replay of the exact source, semantics, candidate, witness format, and full contribution ledger
- schema-valid false event results, refreshed-digest payload substitutions, and missing convolution pairs are rejected without verification records

## Validation
Frozen commit: 03f1d549b067b8ce7e016beae40165e9ebfb77c2
Tree digest: sha256:9babc3207acafa599866ebe4ef507a2c9cb2eeccd33504ce2d73beac980dc452

- make check: Ruff, format, mypy, 243 fast unit passed
- make test-checkers: 334 passed
- make test-contracts: 189 passed
- focused probability producer/checker/verification tests: 17 passed
- clean-tree make test-core: 816 passed
- clean-tree make test-integration-all: 797 passed, 5 expected environment skips
- clean-tree make check-static: passed
- clean-tree make build: passed
- clean-tree make docs-linkcheck: passed

Lean and external Carcara runtimes are absent locally; CI owns those planned lanes.