### PR TITLE
feat(geometry): add exact planar geometry foundations

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -60,6 +60,7 @@ expectations.
 - [Tool surface](reference/tools.md)
 - [Domain operation library](reference/domain-operation-library.md)
 - [Finite probability operations](reference/finite-probability-operations.md)
+- [Exact planar geometry](reference/exact-planar-geometry.md)
 - [Provider runtime contract](reference/provider-runtime.md)
 - [Lean declaration discovery](reference/lean-declaration-discovery.md)
 - [Lean formal intermediates](reference/lean-formal-intermediates.md)

--- a/docs/reference/exact-planar-geometry.md
+++ b/docs/reference/exact-planar-geometry.md
@@ -1,0 +1,79 @@
+# Exact planar geometry
+
+[Documentation home](../index.md)
+
+- Status: Current implementation reference; contracts are experimental
+- Domain: `geometry`
+- Producer backend: pinned SymPy exact rational geometry
+- Checker backend: Python standard-library `Fraction`, isolated from SymPy
+
+The planar-geometry bundle exposes atomic outcomes over canonical rational
+coordinates. Inputs are bounded to at most 128 distinct polygon or point-set
+vertices and are fully validated before computation or artifact writes.
+
+## Closed segment intersection
+
+`geometry.segments.intersection.compute` accepts two closed segments. Equal
+endpoints are legal and explicitly denote a point segment. Its discriminated
+result preserves exactly one of:
+
+| Status | Data |
+| --- | --- |
+| `DISJOINT` | No intersection data |
+| `POINT` | Exact point plus `PROPER`, `ENDPOINT_TOUCH`, or `DEGENERATE_TOUCH` |
+| `OVERLAP` | The maximal common closed segment in canonical endpoint order |
+
+The result never collapses a collinear overlap or a degenerate touch into an
+untyped boolean.
+
+The older `geometry.segment.compute.midpoint` ID remains unchanged. The
+singular/plural difference is retained for compatibility: this addition does
+not rename or alias existing capability IDs.
+
+## Polygon decisions
+
+`geometry.polygon.simple.decide` accepts an open-ring representation: at least
+three unique vertices, without repeating the first vertex at the end. It checks
+every unordered edge pair in deterministic lexicographic index order. A
+positive result records the complete pair count. A negative result preserves
+the first violating pair and its exact point or overlap intersection.
+
+Adjacent edges are valid only when their intersection is exactly their shared
+endpoint. Non-adjacent edges must be disjoint. Consequently the decision
+detects proper self-crossings, self-touches, and adjacent collinear overlap.
+Duplicate vertices and zero-length ring edges are rejected structurally before
+the producer runs.
+
+`geometry.polygon.point.classify` returns `INSIDE`, `BOUNDARY`, or `OUTSIDE`.
+Its request is rejected before computation unless the supplied ring is simple.
+A boundary result identifies the exact edge containing the point. Reversing
+the ring orientation does not change the classification.
+
+## Convex hull normalization
+
+`geometry.points.compute.convex_hull` now emits a canonical candidate:
+
+- a point hull contains that point;
+- a collinear hull contains its two lexicographically ordered extremes; and
+- a polygon hull is strictly counterclockwise and starts at its least vertex.
+
+This normalization closes the previous checker gap without changing the
+capability ID.
+
+## Independent verification
+
+`geometry.result.verify` now supports the three operations above, convex hull,
+and the previously supported distance, midpoint, orientation, and centroid
+operations. The operator-authorized checker runs in a clean process and
+imports neither SymPy nor geometry producer modules.
+
+For segment and polygon results it independently replays rational
+determinants, interval containment, all required edge pairs, exact ray
+crossings, and boundary tests. Convex hull replay uses an independent monotone
+chain implementation. Verification binds the exact input artifact, result
+artifact, semantics, candidate digest, and witness envelope. Producers remain
+`COMPUTED`; only an accepted bound checker run returns `VERIFIED`.
+
+Delaunay/Voronoi construction, arbitrary algebraic coordinates, three-
+dimensional geometry, and H/V polyhedral conversion remain separate provider
+or capability gates.

--- a/src/jacobian/contracts/geometry.py
+++ b/src/jacobian/contracts/geometry.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from fractions import Fraction
 from typing import Literal, Self
 
-from pydantic import Field, model_validator
+from pydantic import Field, StrictInt, model_validator
 
 from jacobian.contracts.common import ArtifactUri
 from jacobian.contracts.exact import CanonicalRational
@@ -14,6 +15,102 @@ from jacobian.contracts.results import ContractModel
 class RationalPoint2D(ContractModel):
     x: CanonicalRational
     y: CanonicalRational
+
+
+def _point_key(point: RationalPoint2D) -> tuple[Fraction, Fraction]:
+    return point.x.as_fraction(), point.y.as_fraction()
+
+
+def _cross(
+    left: tuple[Fraction, Fraction],
+    right: tuple[Fraction, Fraction],
+) -> Fraction:
+    return left[0] * right[1] - left[1] * right[0]
+
+
+def _subtract(
+    left: tuple[Fraction, Fraction],
+    right: tuple[Fraction, Fraction],
+) -> tuple[Fraction, Fraction]:
+    return left[0] - right[0], left[1] - right[1]
+
+
+def _on_segment(
+    point: tuple[Fraction, Fraction],
+    start: tuple[Fraction, Fraction],
+    end: tuple[Fraction, Fraction],
+) -> bool:
+    return _cross(_subtract(point, start), _subtract(end, start)) == 0 and all(
+        min(left, right) <= value <= max(left, right)
+        for value, left, right in zip(point, start, end, strict=True)
+    )
+
+
+def _segment_intersection_status(
+    first: ClosedSegment2D,
+    second: ClosedSegment2D,
+) -> Literal["DISJOINT", "POINT", "OVERLAP"]:
+    first_start, first_end = _point_key(first.start), _point_key(first.end)
+    second_start, second_end = _point_key(second.start), _point_key(second.end)
+    if first_start == first_end:
+        return (
+            "POINT"
+            if _on_segment(first_start, second_start, second_end)
+            else "DISJOINT"
+        )
+    if second_start == second_end:
+        return (
+            "POINT" if _on_segment(second_start, first_start, first_end) else "DISJOINT"
+        )
+    first_direction = _subtract(first_end, first_start)
+    second_direction = _subtract(second_end, second_start)
+    denominator = _cross(first_direction, second_direction)
+    offset = _subtract(second_start, first_start)
+    if denominator != 0:
+        first_parameter = _cross(offset, second_direction) / denominator
+        second_parameter = _cross(offset, first_direction) / denominator
+        return (
+            "POINT"
+            if 0 <= first_parameter <= 1 and 0 <= second_parameter <= 1
+            else "DISJOINT"
+        )
+    if _cross(offset, first_direction) != 0:
+        return "DISJOINT"
+    common = {
+        point
+        for point in (first_start, first_end, second_start, second_end)
+        if _on_segment(point, first_start, first_end)
+        and _on_segment(point, second_start, second_end)
+    }
+    if not common:
+        return "DISJOINT"
+    return "POINT" if len(common) == 1 else "OVERLAP"
+
+
+def _edge(points: tuple[RationalPoint2D, ...], index: int) -> ClosedSegment2D:
+    return ClosedSegment2D(
+        start=points[index],
+        end=points[(index + 1) % len(points)],
+    )
+
+
+def _adjacent_edges(first: int, second: int, order: int) -> bool:
+    return (first - second) % order in {1, order - 1}
+
+
+def _is_simple_ring(points: tuple[RationalPoint2D, ...]) -> bool:
+    for first in range(len(points)):
+        for second in range(first + 1, len(points)):
+            status = _segment_intersection_status(
+                _edge(points, first),
+                _edge(points, second),
+            )
+            if _adjacent_edges(first, second, len(points)):
+                if status != "POINT":
+                    return False
+            elif status != "DISJOINT":
+                return False
+    return True
 
 
 class PointPairRequest(ContractModel):
@@ -70,6 +167,127 @@ class PolygonRequest(PointSetRequest):
     points: tuple[RationalPoint2D, ...] = Field(min_length=3, max_length=128)
 
 
+class ClosedSegment2D(ContractModel):
+    """One closed segment; equal endpoints explicitly denote a point segment."""
+
+    start: RationalPoint2D
+    end: RationalPoint2D
+
+
+class SegmentIntersectionRequest(ContractModel):
+    first: ClosedSegment2D
+    second: ClosedSegment2D
+
+
+class SegmentIntersectionResult(ContractModel):
+    status: Literal["DISJOINT", "POINT", "OVERLAP"]
+    point: RationalPoint2D | None = None
+    contact_kind: Literal["PROPER", "ENDPOINT_TOUCH", "DEGENERATE_TOUCH"] | None = None
+    overlap: ClosedSegment2D | None = None
+
+    @model_validator(mode="after")
+    def bind_discriminated_intersection(self) -> Self:
+        if self.status == "DISJOINT":
+            if (
+                self.point is not None
+                or self.contact_kind is not None
+                or self.overlap is not None
+            ):
+                raise ValueError("a disjoint segment result carries no intersection")
+            return self
+        if self.status == "POINT":
+            if (
+                self.point is None
+                or self.contact_kind is None
+                or self.overlap is not None
+            ):
+                raise ValueError(
+                    "a point segment intersection requires one contact classification"
+                )
+            return self
+        if (
+            self.point is not None
+            or self.contact_kind is not None
+            or self.overlap is None
+        ):
+            raise ValueError("an overlap result carries only one maximal segment")
+        if _point_key(self.overlap.start) >= _point_key(self.overlap.end):
+            raise ValueError("an overlap segment requires canonical distinct endpoints")
+        return self
+
+
+class PolygonIntersectionWitness(ContractModel):
+    first_edge_index: StrictInt = Field(ge=0, le=127)
+    second_edge_index: StrictInt = Field(ge=0, le=127)
+    intersection: SegmentIntersectionResult
+
+    @model_validator(mode="after")
+    def require_ordered_intersecting_pair(self) -> Self:
+        if self.first_edge_index >= self.second_edge_index:
+            raise ValueError("polygon witness edge indices must be strictly ordered")
+        if self.intersection.status == "DISJOINT":
+            raise ValueError("polygon witness edges must intersect")
+        return self
+
+
+class SimplePolygonDecisionResult(ContractModel):
+    vertex_count: StrictInt = Field(ge=3, le=128)
+    is_simple: bool
+    checked_edge_pairs: StrictInt = Field(ge=0, le=8128)
+    witness: PolygonIntersectionWitness | None = None
+
+    @model_validator(mode="after")
+    def bind_decision_to_witness(self) -> Self:
+        if self.is_simple is (self.witness is not None):
+            raise ValueError("exactly a non-simple polygon carries one witness")
+        total_pairs = self.vertex_count * (self.vertex_count - 1) // 2
+        if self.is_simple and self.checked_edge_pairs != total_pairs:
+            raise ValueError("a simple decision must exhaust every edge pair")
+        if self.witness is not None:
+            if self.witness.second_edge_index >= self.vertex_count:
+                raise ValueError("polygon witness edge index exceeds the ring")
+            expected_checked = (
+                self.witness.first_edge_index
+                * (2 * self.vertex_count - self.witness.first_edge_index - 1)
+                // 2
+                + self.witness.second_edge_index
+                - self.witness.first_edge_index
+            )
+            if self.checked_edge_pairs != expected_checked:
+                raise ValueError(
+                    "polygon witness does not match the checked pair prefix"
+                )
+        return self
+
+
+class SimplePolygonPointRequest(ContractModel):
+    polygon: PolygonRequest
+    point: RationalPoint2D
+
+    @model_validator(mode="after")
+    def require_simple_polygon(self) -> Self:
+        if not _is_simple_ring(self.polygon.points):
+            raise ValueError("point classification requires a simple polygon")
+        return self
+
+
+class PolygonPointClassificationResult(ContractModel):
+    polygon_vertex_count: StrictInt = Field(ge=3, le=128)
+    classification: Literal["INSIDE", "BOUNDARY", "OUTSIDE"]
+    boundary_edge_index: StrictInt | None = Field(default=None, ge=0, le=127)
+
+    @model_validator(mode="after")
+    def bind_boundary_witness(self) -> Self:
+        if (self.classification == "BOUNDARY") is (self.boundary_edge_index is None):
+            raise ValueError("only a boundary classification carries an edge index")
+        if (
+            self.boundary_edge_index is not None
+            and self.boundary_edge_index >= self.polygon_vertex_count
+        ):
+            raise ValueError("boundary edge index exceeds the polygon ring")
+        return self
+
+
 class GeometryBooleanResult(ContractModel):
     holds: bool
 
@@ -101,6 +319,32 @@ class GeometryPointSetResult(ContractModel):
     points: tuple[RationalPoint2D, ...]
 
 
+class GeometryConvexHullResult(ContractModel):
+    points: tuple[RationalPoint2D, ...] = Field(min_length=1, max_length=128)
+
+    @model_validator(mode="after")
+    def require_canonical_strict_convex_boundary(self) -> Self:
+        keys = tuple(_point_key(point) for point in self.points)
+        if len(keys) != len(set(keys)):
+            raise ValueError("convex-hull vertices must be unique")
+        if len(keys) <= 2:
+            if keys != tuple(sorted(keys)):
+                raise ValueError("a zero-dimensional hull must be canonical")
+            return self
+        if keys[0] != min(keys):
+            raise ValueError("a polygon hull must begin at its least vertex")
+        turns = tuple(
+            _cross(
+                _subtract(keys[(index + 1) % len(keys)], keys[index]),
+                _subtract(keys[(index + 2) % len(keys)], keys[index]),
+            )
+            for index in range(len(keys))
+        )
+        if any(turn <= 0 for turn in turns):
+            raise ValueError("a polygon hull must be strictly counterclockwise")
+        return self
+
+
 class GeometryCircleResult(ContractModel):
     center: RationalPoint2D
     radius_squared: CanonicalRational
@@ -121,8 +365,12 @@ class GeometryVerificationOutput(ContractModel):
     status: Literal["VERIFIED_RESULT", "REJECTED", "TIMEOUT", "CANCELLED", "ERROR"]
     conclusion: Literal["TRUE", "UNKNOWN"]
     operation_id: Literal[
+        "geometry.points.compute.convex_hull",
         "geometry.points.compute.squared_distance",
         "geometry.segment.compute.midpoint",
+        "geometry.segments.intersection.compute",
+        "geometry.polygon.simple.decide",
+        "geometry.polygon.point.classify",
         "geometry.triangle.compute.orientation",
         "geometry.triangle.compute.centroid",
     ]

--- a/src/jacobian/domains/geometry/bundle.py
+++ b/src/jacobian/domains/geometry/bundle.py
@@ -20,11 +20,14 @@ GEOMETRY_BUNDLE = DomainBundle(
     schema_namespace="jacobian.geometry",
     semantics=DomainSemantics(
         name="jacobian.exact-rational-plane-geometry",
-        version="1",
+        version="2",
         definition={
             "description": "Euclidean plane geometry over exact rational coordinates",
             "degeneracy": "operation-specific and fail-closed",
-            "assurance": "computed; no independent checker",
+            "assurance": (
+                "computed producers; selected results admit separately "
+                "authorized independent exact replay"
+            ),
         },
     ),
     provider_runtime=known_provider_runtime(

--- a/src/jacobian/domains/geometry/operations.py
+++ b/src/jacobian/domains/geometry/operations.py
@@ -8,12 +8,13 @@ from typing import Any, cast
 
 from jacobian.contracts.exact import CanonicalRational
 from jacobian.contracts.geometry import (
+    ClosedSegment2D,
     GeometryBooleanResult,
     GeometryCircleResult,
+    GeometryConvexHullResult,
     GeometryLineIntersectionResult,
     GeometryOrientationResult,
     GeometryPointResult,
-    GeometryPointSetResult,
     GeometryRationalResult,
     LinePairRequest,
     LineRequest,
@@ -22,8 +23,14 @@ from jacobian.contracts.geometry import (
     PointQuadrupleRequest,
     PointSetRequest,
     PointTripleRequest,
+    PolygonIntersectionWitness,
+    PolygonPointClassificationResult,
     PolygonRequest,
     RationalPoint2D,
+    SegmentIntersectionRequest,
+    SegmentIntersectionResult,
+    SimplePolygonDecisionResult,
+    SimplePolygonPointRequest,
 )
 from jacobian.contracts.results import ContractModel
 
@@ -62,6 +69,43 @@ def _wire_point(value: Any) -> RationalPoint2D:
     )
 
 
+def _canonical_points(values: tuple[Any, ...]) -> tuple[RationalPoint2D, ...]:
+    if len(values) <= 2:
+        values = tuple(sorted(values, key=lambda point: (point.x, point.y)))
+    else:
+        doubled_area = sum(
+            left.x * right.y - left.y * right.x
+            for left, right in zip(values, values[1:] + values[:1], strict=True)
+        )
+        if doubled_area < 0:
+            values = tuple(reversed(values))
+        start = min(
+            range(len(values)), key=lambda index: (values[index].x, values[index].y)
+        )
+        values = values[start:] + values[:start]
+    return tuple(_wire_point(point) for point in values)
+
+
+def _closed_segment(value: ClosedSegment2D) -> tuple[Any, Any]:
+    return _point(value.start), _point(value.end)
+
+
+def _cross(left: tuple[Any, Any], right: tuple[Any, Any]) -> Any:
+    return left[0] * right[1] - left[1] * right[0]
+
+
+def _subtract(left: Any, right: Any) -> tuple[Any, Any]:
+    return left.x - right.x, left.y - right.y
+
+
+def _on_segment(point: Any, start: Any, end: Any) -> bool:
+    return bool(
+        _cross(_subtract(point, start), _subtract(end, start)) == 0
+        and min(start.x, end.x) <= point.x <= max(start.x, end.x)
+        and min(start.y, end.y) <= point.y <= max(start.y, end.y)
+    )
+
+
 def _pair_points(request: ContractModel) -> tuple[Any, Any]:
     pair = cast(PointPairRequest, request)
     return _point(pair.first), _point(pair.second)
@@ -81,6 +125,85 @@ def squared_distance(request: ContractModel) -> ContractModel:
 def midpoint(request: ContractModel) -> ContractModel:
     first, second = _pair_points(request)
     return GeometryPointResult(point=_wire_point(first.midpoint(second)))
+
+
+def segment_intersection(request: ContractModel) -> ContractModel:
+    import sympy
+    from sympy.geometry import Point2D
+
+    pair = cast(SegmentIntersectionRequest, request)
+    first_start, first_end = _closed_segment(pair.first)
+    second_start, second_end = _closed_segment(pair.second)
+    first_degenerate = first_start == first_end
+    second_degenerate = second_start == second_end
+    if first_degenerate or second_degenerate:
+        if first_degenerate and _on_segment(first_start, second_start, second_end):
+            point = first_start
+        elif second_degenerate and _on_segment(second_start, first_start, first_end):
+            point = second_start
+        else:
+            return SegmentIntersectionResult(status="DISJOINT")
+        return SegmentIntersectionResult(
+            status="POINT",
+            point=_wire_point(point),
+            contact_kind="DEGENERATE_TOUCH",
+        )
+
+    first_direction = _subtract(first_end, first_start)
+    second_direction = _subtract(second_end, second_start)
+    denominator = _cross(first_direction, second_direction)
+    offset = _subtract(second_start, first_start)
+    if denominator != 0:
+        first_parameter = sympy.cancel(_cross(offset, second_direction) / denominator)
+        second_parameter = sympy.cancel(_cross(offset, first_direction) / denominator)
+        if not (0 <= first_parameter <= 1 and 0 <= second_parameter <= 1):
+            return SegmentIntersectionResult(status="DISJOINT")
+        point = Point2D(
+            first_start.x + first_parameter * first_direction[0],
+            first_start.y + first_parameter * first_direction[1],
+        )
+        return SegmentIntersectionResult(
+            status="POINT",
+            point=_wire_point(point),
+            contact_kind=(
+                "PROPER"
+                if 0 < first_parameter < 1 and 0 < second_parameter < 1
+                else "ENDPOINT_TOUCH"
+            ),
+        )
+    if _cross(offset, first_direction) != 0:
+        return SegmentIntersectionResult(status="DISJOINT")
+    common = tuple(
+        sorted(
+            {
+                point
+                for point in (
+                    first_start,
+                    first_end,
+                    second_start,
+                    second_end,
+                )
+                if _on_segment(point, first_start, first_end)
+                and _on_segment(point, second_start, second_end)
+            },
+            key=lambda point: (point.x, point.y),
+        )
+    )
+    if not common:
+        return SegmentIntersectionResult(status="DISJOINT")
+    if len(common) == 1:
+        return SegmentIntersectionResult(
+            status="POINT",
+            point=_wire_point(common[0]),
+            contact_kind="ENDPOINT_TOUCH",
+        )
+    return SegmentIntersectionResult(
+        status="OVERLAP",
+        overlap=ClosedSegment2D(
+            start=_wire_point(common[0]),
+            end=_wire_point(common[-1]),
+        ),
+    )
 
 
 def collinear(request: ContractModel) -> ContractModel:
@@ -202,6 +325,77 @@ def signed_area(request: ContractModel) -> ContractModel:
     return GeometryRationalResult(value=_wire_rational(value))
 
 
+def simple_polygon(request: ContractModel) -> ContractModel:
+    polygon = cast(PolygonRequest, request)
+    points = polygon.points
+    checked = 0
+    for first in range(len(points)):
+        for second in range(first + 1, len(points)):
+            checked += 1
+            intersection = cast(
+                SegmentIntersectionResult,
+                segment_intersection(
+                    SegmentIntersectionRequest(
+                        first=ClosedSegment2D(
+                            start=points[first],
+                            end=points[(first + 1) % len(points)],
+                        ),
+                        second=ClosedSegment2D(
+                            start=points[second],
+                            end=points[(second + 1) % len(points)],
+                        ),
+                    )
+                ),
+            )
+            adjacent = (first - second) % len(points) in {1, len(points) - 1}
+            shared = (
+                points[0] if (first, second) == (0, len(points) - 1) else points[second]
+            )
+            valid = (
+                intersection.status == "POINT"
+                and intersection.point == shared
+                and intersection.contact_kind == "ENDPOINT_TOUCH"
+                if adjacent
+                else intersection.status == "DISJOINT"
+            )
+            if not valid:
+                return SimplePolygonDecisionResult(
+                    vertex_count=len(points),
+                    is_simple=False,
+                    checked_edge_pairs=checked,
+                    witness=PolygonIntersectionWitness(
+                        first_edge_index=first,
+                        second_edge_index=second,
+                        intersection=intersection,
+                    ),
+                )
+    return SimplePolygonDecisionResult(
+        vertex_count=len(points),
+        is_simple=True,
+        checked_edge_pairs=checked,
+    )
+
+
+def classify_polygon_point(request: ContractModel) -> ContractModel:
+    from sympy.geometry import Polygon
+
+    value = cast(SimplePolygonPointRequest, request)
+    point = _point(value.point)
+    points = tuple(_point(item) for item in value.polygon.points)
+    for index, start in enumerate(points):
+        if _on_segment(point, start, points[(index + 1) % len(points)]):
+            return PolygonPointClassificationResult(
+                polygon_vertex_count=len(points),
+                classification="BOUNDARY",
+                boundary_edge_index=index,
+            )
+    polygon = Polygon(*points)
+    return PolygonPointClassificationResult(
+        polygon_vertex_count=len(points),
+        classification=("INSIDE" if polygon.encloses_point(point) else "OUTSIDE"),
+    )
+
+
 def convex_hull_points(request: ContractModel) -> ContractModel:
     from sympy.geometry import Line2D, Point2D, Polygon, Segment2D
     from sympy.geometry.util import convex_hull
@@ -219,4 +413,4 @@ def convex_hull_points(request: ContractModel) -> ContractModel:
         )
     else:
         points = tuple(cast(Polygon, hull).vertices)
-    return GeometryPointSetResult(points=tuple(_wire_point(point) for point in points))
+    return GeometryConvexHullResult(points=_canonical_points(points))

--- a/src/jacobian/domains/geometry/points.py
+++ b/src/jacobian/domains/geometry/points.py
@@ -2,7 +2,7 @@
 
 from jacobian.contracts.geometry import (
     GeometryBooleanResult,
-    GeometryPointSetResult,
+    GeometryConvexHullResult,
     GeometryRationalResult,
     PointPairRequest,
     PointQuadrupleRequest,
@@ -114,7 +114,7 @@ POINT_CAPABILITIES = (
         "Construct planar convex hull",
         "Construct the exact convex hull vertices of a finite rational point set.",
         PointSetRequest,
-        GeometryPointSetResult,
+        GeometryConvexHullResult,
         convex_hull_points,
         "geometry",
         "convexity",

--- a/src/jacobian/domains/geometry/polygons.py
+++ b/src/jacobian/domains/geometry/polygons.py
@@ -1,9 +1,26 @@
 """Polygon-owned exact geometry capabilities."""
 
-from jacobian.contracts.geometry import GeometryRationalResult, PolygonRequest
+from jacobian.contracts.geometry import (
+    GeometryRationalResult,
+    PolygonPointClassificationResult,
+    PolygonRequest,
+    SimplePolygonDecisionResult,
+    SimplePolygonPointRequest,
+)
 from jacobian.domains._examples import example
 from jacobian.domains.geometry._support import geometry_operation
-from jacobian.domains.geometry.operations import signed_area
+from jacobian.domains.geometry.operations import (
+    classify_polygon_point,
+    signed_area,
+    simple_polygon,
+)
+
+_UNIT_SQUARE = [
+    {"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}},
+    {"x": {"num": "1", "den": "1"}, "y": {"num": "0", "den": "1"}},
+    {"x": {"num": "1", "den": "1"}, "y": {"num": "1", "den": "1"}},
+    {"x": {"num": "0", "den": "1"}, "y": {"num": "1", "den": "1"}},
+]
 
 POLYGON_CAPABILITIES = (
     geometry_operation(
@@ -19,13 +36,56 @@ POLYGON_CAPABILITIES = (
             example(
                 "unit_square_signed_area",
                 "Compute the signed area of a unit square.",
+                {"points": _UNIT_SQUARE},
+            ),
+        ),
+    ),
+    geometry_operation(
+        "geometry.polygon.simple.decide",
+        "Decide exact simple-polygon validity",
+        (
+            "Decide whether a bounded rational polygon ring is simple and "
+            "preserve the first exact violating edge pair when it is not."
+        ),
+        PolygonRequest,
+        SimplePolygonDecisionResult,
+        simple_polygon,
+        "geometry",
+        "polygon",
+        "decision",
+        relation_id="geometry.polygon.simple.relation",
+        invocation_examples=(
+            example(
+                "unit_square_is_simple",
+                "Check every edge pair of a unit-square ring.",
+                {"points": _UNIT_SQUARE},
+            ),
+        ),
+    ),
+    geometry_operation(
+        "geometry.polygon.point.classify",
+        "Classify a point against a simple polygon",
+        (
+            "Classify one rational point as inside, on the boundary of, or "
+            "outside one structurally validated simple rational polygon."
+        ),
+        SimplePolygonPointRequest,
+        PolygonPointClassificationResult,
+        classify_polygon_point,
+        "geometry",
+        "polygon",
+        "classification",
+        relation_id="geometry.polygon.point.relation",
+        invocation_examples=(
+            example(
+                "unit_square_center",
+                "Classify the center of a unit square.",
                 {
-                    "points": [
-                        {"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}},
-                        {"x": {"num": "1", "den": "1"}, "y": {"num": "0", "den": "1"}},
-                        {"x": {"num": "1", "den": "1"}, "y": {"num": "1", "den": "1"}},
-                        {"x": {"num": "0", "den": "1"}, "y": {"num": "1", "den": "1"}},
-                    ]
+                    "polygon": {"points": _UNIT_SQUARE},
+                    "point": {
+                        "x": {"num": "1", "den": "2"},
+                        "y": {"num": "1", "den": "2"},
+                    },
                 },
             ),
         ),

--- a/src/jacobian/domains/geometry/segments.py
+++ b/src/jacobian/domains/geometry/segments.py
@@ -1,9 +1,14 @@
 """Segment-owned exact geometry capabilities."""
 
-from jacobian.contracts.geometry import GeometryPointResult, PointPairRequest
+from jacobian.contracts.geometry import (
+    GeometryPointResult,
+    PointPairRequest,
+    SegmentIntersectionRequest,
+    SegmentIntersectionResult,
+)
 from jacobian.domains._examples import example
 from jacobian.domains.geometry._support import geometry_operation
-from jacobian.domains.geometry.operations import midpoint
+from jacobian.domains.geometry.operations import midpoint, segment_intersection
 
 SEGMENT_CAPABILITIES = (
     geometry_operation(
@@ -27,6 +32,48 @@ SEGMENT_CAPABILITIES = (
                     "second": {
                         "x": {"num": "1", "den": "1"},
                         "y": {"num": "0", "den": "1"},
+                    },
+                },
+            ),
+        ),
+    ),
+    geometry_operation(
+        "geometry.segments.intersection.compute",
+        "Intersect two closed rational segments",
+        (
+            "Classify the exact intersection of two closed rational segments "
+            "as disjoint, one typed contact point, or one maximal overlap."
+        ),
+        SegmentIntersectionRequest,
+        SegmentIntersectionResult,
+        segment_intersection,
+        "geometry",
+        "intersection",
+        relation_id="geometry.segments.intersection.relation",
+        invocation_examples=(
+            example(
+                "crossing_segments",
+                "Intersect two closed rational segments at one proper crossing.",
+                {
+                    "first": {
+                        "start": {
+                            "x": {"num": "0", "den": "1"},
+                            "y": {"num": "0", "den": "1"},
+                        },
+                        "end": {
+                            "x": {"num": "2", "den": "1"},
+                            "y": {"num": "2", "den": "1"},
+                        },
+                    },
+                    "second": {
+                        "start": {
+                            "x": {"num": "0", "den": "1"},
+                            "y": {"num": "2", "den": "1"},
+                        },
+                        "end": {
+                            "x": {"num": "2", "den": "1"},
+                            "y": {"num": "0", "den": "1"},
+                        },
                     },
                 },
             ),

--- a/src/jacobian/geometry_verification.py
+++ b/src/jacobian/geometry_verification.py
@@ -28,7 +28,11 @@ from jacobian.contracts.geometry import (
     GeometryVerificationOutput,
     GeometryVerificationRequest,
     PointPairRequest,
+    PointSetRequest,
     PointTripleRequest,
+    PolygonRequest,
+    SegmentIntersectionRequest,
+    SimplePolygonPointRequest,
 )
 from jacobian.contracts.results import Conclusion, ExecutionStatus, Verification
 from jacobian.operation_installation import InstalledDomainBundle
@@ -39,8 +43,12 @@ from jacobian.store import ArtifactStore, StoredArtifact, StoreError
 from jacobian.verification import VerificationService
 
 _OPERATION_MODELS = {
+    "geometry.points.compute.convex_hull": PointSetRequest,
     "geometry.points.compute.squared_distance": PointPairRequest,
     "geometry.segment.compute.midpoint": PointPairRequest,
+    "geometry.segments.intersection.compute": SegmentIntersectionRequest,
+    "geometry.polygon.simple.decide": PolygonRequest,
+    "geometry.polygon.point.classify": SimplePolygonPointRequest,
     "geometry.triangle.compute.orientation": PointTripleRequest,
     "geometry.triangle.compute.centroid": PointTripleRequest,
 }
@@ -165,8 +173,8 @@ class GeometryResultVerificationAdapter:
             version="1",
             title="Verify an exact rational geometry result",
             description=(
-                "Independently replay selected point and triangle identities "
-                "over exact rational coordinates."
+                "Independently replay selected point, segment, polygon, hull, "
+                "and triangle outcomes over exact rational coordinates."
             ),
             provider="jacobian.exact-geometry-checker",
             provider_runtime=known_provider_runtime(

--- a/src/jacobian_checkers/exact_geometry.py
+++ b/src/jacobian_checkers/exact_geometry.py
@@ -33,7 +33,11 @@ _BINDING_KEYS = {
 }
 _OPERATIONS = {
     "geometry.points.compute.squared_distance",
+    "geometry.points.compute.convex_hull",
     "geometry.segment.compute.midpoint",
+    "geometry.segments.intersection.compute",
+    "geometry.polygon.simple.decide",
+    "geometry.polygon.point.classify",
     "geometry.triangle.compute.orientation",
     "geometry.triangle.compute.centroid",
 }
@@ -150,11 +154,274 @@ def _triple(payload: object) -> tuple[tuple[Fraction, Fraction], ...]:
     )
 
 
+def _points(payload: object) -> list[tuple[Fraction, Fraction]]:
+    if not isinstance(payload, dict) or set(payload) != {"points"}:
+        raise ValueError("point set has an invalid shape")
+    raw = payload["points"]
+    if not isinstance(raw, list) or not 1 <= len(raw) <= 128:
+        raise ValueError("point set has an invalid size")
+    points = [_point(item) for item in raw]
+    if len(points) != len(set(points)):
+        raise ValueError("point set repeats coordinates")
+    return points
+
+
+def _segment(
+    value: object,
+) -> tuple[
+    tuple[Fraction, Fraction],
+    tuple[Fraction, Fraction],
+]:
+    if not isinstance(value, dict) or set(value) != {"start", "end"}:
+        raise ValueError("closed segment has an invalid shape")
+    return _point(value["start"]), _point(value["end"])
+
+
+def _segment_pair(
+    payload: object,
+) -> tuple[
+    tuple[tuple[Fraction, Fraction], tuple[Fraction, Fraction]],
+    tuple[tuple[Fraction, Fraction], tuple[Fraction, Fraction]],
+]:
+    if not isinstance(payload, dict) or set(payload) != {"first", "second"}:
+        raise ValueError("segment pair has an invalid shape")
+    return _segment(payload["first"]), _segment(payload["second"])
+
+
+def _cross(
+    left: tuple[Fraction, Fraction],
+    right: tuple[Fraction, Fraction],
+) -> Fraction:
+    return left[0] * right[1] - left[1] * right[0]
+
+
+def _subtract(
+    left: tuple[Fraction, Fraction],
+    right: tuple[Fraction, Fraction],
+) -> tuple[Fraction, Fraction]:
+    return left[0] - right[0], left[1] - right[1]
+
+
+def _add_scaled(
+    point: tuple[Fraction, Fraction],
+    direction: tuple[Fraction, Fraction],
+    parameter: Fraction,
+) -> tuple[Fraction, Fraction]:
+    return (
+        point[0] + parameter * direction[0],
+        point[1] + parameter * direction[1],
+    )
+
+
+def _on_segment(
+    point: tuple[Fraction, Fraction],
+    start: tuple[Fraction, Fraction],
+    end: tuple[Fraction, Fraction],
+) -> bool:
+    return _cross(_subtract(point, start), _subtract(end, start)) == 0 and all(
+        min(left, right) <= value <= max(left, right)
+        for value, left, right in zip(point, start, end, strict=True)
+    )
+
+
+def _segment_intersection(
+    first: tuple[tuple[Fraction, Fraction], tuple[Fraction, Fraction]],
+    second: tuple[tuple[Fraction, Fraction], tuple[Fraction, Fraction]],
+) -> dict[str, object]:
+    first_start, first_end = first
+    second_start, second_end = second
+    first_degenerate = first_start == first_end
+    second_degenerate = second_start == second_end
+    if first_degenerate or second_degenerate:
+        if first_degenerate and _on_segment(first_start, second_start, second_end):
+            point = first_start
+        elif second_degenerate and _on_segment(second_start, first_start, first_end):
+            point = second_start
+        else:
+            return {
+                "status": "DISJOINT",
+                "point": None,
+                "contact_kind": None,
+                "overlap": None,
+            }
+        return {
+            "status": "POINT",
+            "point": point,
+            "contact_kind": "DEGENERATE_TOUCH",
+            "overlap": None,
+        }
+    first_direction = _subtract(first_end, first_start)
+    second_direction = _subtract(second_end, second_start)
+    denominator = _cross(first_direction, second_direction)
+    offset = _subtract(second_start, first_start)
+    if denominator != 0:
+        first_parameter = _cross(offset, second_direction) / denominator
+        second_parameter = _cross(offset, first_direction) / denominator
+        if not (0 <= first_parameter <= 1 and 0 <= second_parameter <= 1):
+            return {
+                "status": "DISJOINT",
+                "point": None,
+                "contact_kind": None,
+                "overlap": None,
+            }
+        return {
+            "status": "POINT",
+            "point": _add_scaled(
+                first_start,
+                first_direction,
+                first_parameter,
+            ),
+            "contact_kind": (
+                "PROPER"
+                if 0 < first_parameter < 1 and 0 < second_parameter < 1
+                else "ENDPOINT_TOUCH"
+            ),
+            "overlap": None,
+        }
+    if _cross(offset, first_direction) != 0:
+        return {
+            "status": "DISJOINT",
+            "point": None,
+            "contact_kind": None,
+            "overlap": None,
+        }
+    common = sorted(
+        {
+            point
+            for point in (first_start, first_end, second_start, second_end)
+            if _on_segment(point, first_start, first_end)
+            and _on_segment(point, second_start, second_end)
+        }
+    )
+    if not common:
+        return {
+            "status": "DISJOINT",
+            "point": None,
+            "contact_kind": None,
+            "overlap": None,
+        }
+    if len(common) == 1:
+        return {
+            "status": "POINT",
+            "point": common[0],
+            "contact_kind": "ENDPOINT_TOUCH",
+            "overlap": None,
+        }
+    return {
+        "status": "OVERLAP",
+        "point": None,
+        "contact_kind": None,
+        "overlap": (common[0], common[-1]),
+    }
+
+
+def _convex_hull(
+    points: list[tuple[Fraction, Fraction]],
+) -> list[tuple[Fraction, Fraction]]:
+    ordered = sorted(points)
+    if len(ordered) <= 1:
+        return ordered
+
+    def turn(
+        first: tuple[Fraction, Fraction],
+        second: tuple[Fraction, Fraction],
+        third: tuple[Fraction, Fraction],
+    ) -> Fraction:
+        return _cross(_subtract(second, first), _subtract(third, first))
+
+    lower: list[tuple[Fraction, Fraction]] = []
+    for point in ordered:
+        while len(lower) >= 2 and turn(lower[-2], lower[-1], point) <= 0:
+            lower.pop()
+        lower.append(point)
+    upper: list[tuple[Fraction, Fraction]] = []
+    for point in reversed(ordered):
+        while len(upper) >= 2 and turn(upper[-2], upper[-1], point) <= 0:
+            upper.pop()
+        upper.append(point)
+    return lower[:-1] + upper[:-1]
+
+
+def _polygon_decision(
+    points: list[tuple[Fraction, Fraction]],
+) -> dict[str, object]:
+    if len(points) < 3:
+        raise ValueError("polygon ring is too small")
+    checked = 0
+    for first in range(len(points)):
+        for second in range(first + 1, len(points)):
+            checked += 1
+            intersection = _segment_intersection(
+                (points[first], points[(first + 1) % len(points)]),
+                (points[second], points[(second + 1) % len(points)]),
+            )
+            adjacent = (first - second) % len(points) in {1, len(points) - 1}
+            shared = (
+                points[0] if (first, second) == (0, len(points) - 1) else points[second]
+            )
+            valid = (
+                intersection["status"] == "POINT"
+                and intersection["point"] == shared
+                and intersection["contact_kind"] == "ENDPOINT_TOUCH"
+                if adjacent
+                else intersection["status"] == "DISJOINT"
+            )
+            if not valid:
+                return {
+                    "vertex_count": len(points),
+                    "is_simple": False,
+                    "checked_edge_pairs": checked,
+                    "witness": {
+                        "first_edge_index": first,
+                        "second_edge_index": second,
+                        "intersection": intersection,
+                    },
+                }
+    return {
+        "vertex_count": len(points),
+        "is_simple": True,
+        "checked_edge_pairs": checked,
+        "witness": None,
+    }
+
+
+def _point_classification(
+    polygon: list[tuple[Fraction, Fraction]],
+    point: tuple[Fraction, Fraction],
+) -> dict[str, object]:
+    if not _polygon_decision(polygon)["is_simple"]:
+        raise ValueError("classification polygon is not simple")
+    for index, start in enumerate(polygon):
+        if _on_segment(point, start, polygon[(index + 1) % len(polygon)]):
+            return {
+                "polygon_vertex_count": len(polygon),
+                "classification": "BOUNDARY",
+                "boundary_edge_index": index,
+            }
+    inside = False
+    x, y = point
+    for index, start in enumerate(polygon):
+        end = polygon[(index + 1) % len(polygon)]
+        if (start[1] > y) != (end[1] > y):
+            crossing_x = start[0] + (y - start[1]) * (end[0] - start[0]) / (
+                end[1] - start[1]
+            )
+            if crossing_x > x:
+                inside = not inside
+    return {
+        "polygon_vertex_count": len(polygon),
+        "classification": "INSIDE" if inside else "OUTSIDE",
+        "boundary_edge_index": None,
+    }
+
+
 def _expected(operation: str, claim: object) -> dict[str, object]:
     if operation == "geometry.points.compute.squared_distance":
         first, second = _pair(claim)
         value = (first[0] - second[0]) ** 2 + (first[1] - second[1]) ** 2
         return {"value": value}
+    if operation == "geometry.points.compute.convex_hull":
+        return {"points": _convex_hull(_points(claim))}
     if operation == "geometry.segment.compute.midpoint":
         first, second = _pair(claim)
         return {
@@ -163,6 +430,17 @@ def _expected(operation: str, claim: object) -> dict[str, object]:
                 (first[1] + second[1]) / 2,
             )
         }
+    if operation == "geometry.segments.intersection.compute":
+        return _segment_intersection(*_segment_pair(claim))
+    if operation == "geometry.polygon.simple.decide":
+        return _polygon_decision(_points(claim))
+    if operation == "geometry.polygon.point.classify":
+        if not isinstance(claim, dict) or set(claim) != {"polygon", "point"}:
+            raise ValueError("polygon classification source has an invalid shape")
+        return _point_classification(
+            _points(claim["polygon"]),
+            _point(claim["point"]),
+        )
     first, second, third = _triple(claim)
     if operation == "geometry.triangle.compute.orientation":
         determinant = (second[0] - first[0]) * (third[1] - first[1]) - (
@@ -186,6 +464,8 @@ def _candidate(payload: object, operation: str) -> dict[str, object]:
         if set(payload) != {"value"}:
             raise ValueError("squared-distance candidate has an invalid shape")
         return {"value": _rational(payload["value"])}
+    if operation == "geometry.points.compute.convex_hull":
+        return {"points": _points(payload)}
     if operation in {
         "geometry.segment.compute.midpoint",
         "geometry.triangle.compute.centroid",
@@ -193,6 +473,83 @@ def _candidate(payload: object, operation: str) -> dict[str, object]:
         if set(payload) != {"point"}:
             raise ValueError("point candidate has an invalid shape")
         return {"point": _point(payload["point"])}
+    if operation == "geometry.segments.intersection.compute":
+        if set(payload) != {"status", "point", "contact_kind", "overlap"}:
+            raise ValueError("segment-intersection candidate has an invalid shape")
+        status = payload["status"]
+        if status not in {"DISJOINT", "POINT", "OVERLAP"}:
+            raise ValueError("segment-intersection status is invalid")
+        return {
+            "status": status,
+            "point": None if payload["point"] is None else _point(payload["point"]),
+            "contact_kind": payload["contact_kind"],
+            "overlap": (
+                None if payload["overlap"] is None else _segment(payload["overlap"])
+            ),
+        }
+    if operation == "geometry.polygon.simple.decide":
+        if set(payload) != {
+            "vertex_count",
+            "is_simple",
+            "checked_edge_pairs",
+            "witness",
+        }:
+            raise ValueError("simple-polygon candidate has an invalid shape")
+        if (
+            type(payload["vertex_count"]) is not int
+            or type(payload["is_simple"]) is not bool
+            or type(payload["checked_edge_pairs"]) is not int
+        ):
+            raise ValueError("simple-polygon decision fields are invalid")
+        witness = payload["witness"]
+        parsed_witness: dict[str, object] | None
+        if witness is None:
+            parsed_witness = None
+        else:
+            if not isinstance(witness, dict) or set(witness) != {
+                "first_edge_index",
+                "second_edge_index",
+                "intersection",
+            }:
+                raise ValueError("polygon witness has an invalid shape")
+            if (
+                type(witness["first_edge_index"]) is not int
+                or type(witness["second_edge_index"]) is not int
+            ):
+                raise ValueError("polygon witness indices are invalid")
+            parsed_witness = {
+                "first_edge_index": witness["first_edge_index"],
+                "second_edge_index": witness["second_edge_index"],
+                "intersection": _candidate(
+                    witness["intersection"],
+                    "geometry.segments.intersection.compute",
+                ),
+            }
+        return {
+            "vertex_count": payload["vertex_count"],
+            "is_simple": payload["is_simple"],
+            "checked_edge_pairs": payload["checked_edge_pairs"],
+            "witness": parsed_witness,
+        }
+    if operation == "geometry.polygon.point.classify":
+        if set(payload) != {
+            "polygon_vertex_count",
+            "classification",
+            "boundary_edge_index",
+        }:
+            raise ValueError("point-classification candidate has an invalid shape")
+        if type(payload["polygon_vertex_count"]) is not int:
+            raise ValueError("polygon vertex count is invalid")
+        if payload["classification"] not in {"INSIDE", "BOUNDARY", "OUTSIDE"}:
+            raise ValueError("point classification is invalid")
+        boundary = payload["boundary_edge_index"]
+        if boundary is not None and type(boundary) is not int:
+            raise ValueError("boundary edge index is invalid")
+        return {
+            "polygon_vertex_count": payload["polygon_vertex_count"],
+            "classification": payload["classification"],
+            "boundary_edge_index": boundary,
+        }
     if set(payload) != {"orientation"} or type(payload["orientation"]) is not int:
         raise ValueError("orientation candidate has an invalid shape")
     return {"orientation": payload["orientation"]}

--- a/tests/checkers/test_exact_geometry_checker.py
+++ b/tests/checkers/test_exact_geometry_checker.py
@@ -15,6 +15,13 @@ def _point(x: int, y: int) -> dict[str, dict[str, str]]:
     return {"x": _rational(x), "y": _rational(y)}
 
 
+def _segment(
+    start: dict[str, object],
+    end: dict[str, object],
+) -> dict[str, object]:
+    return {"start": start, "end": end}
+
+
 def _artifact(
     *,
     uri_character: str,
@@ -52,9 +59,79 @@ def _request(
     if operation_id == "geometry.points.compute.squared_distance":
         claim_payload = {"first": _point(1, 2), "second": _point(4, 6)}
         candidate_payload = {"value": _rational(25)}
+    elif operation_id == "geometry.points.compute.convex_hull":
+        claim_payload = {
+            "points": [
+                _point(1, 1),
+                _point(0, 0),
+                _point(2, 0),
+                _point(2, 2),
+                _point(0, 2),
+            ]
+        }
+        candidate_payload = {
+            "points": [
+                _point(0, 0),
+                _point(2, 0),
+                _point(2, 2),
+                _point(0, 2),
+            ]
+        }
     elif operation_id == "geometry.segment.compute.midpoint":
         claim_payload = {"first": _point(1, 2), "second": _point(5, 8)}
         candidate_payload = {"point": _point(3, 5)}
+    elif operation_id == "geometry.segments.intersection.compute":
+        claim_payload = {
+            "first": _segment(_point(0, 0), _point(2, 2)),
+            "second": _segment(_point(0, 2), _point(2, 0)),
+        }
+        candidate_payload = {
+            "status": "POINT",
+            "point": _point(1, 1),
+            "contact_kind": "PROPER",
+            "overlap": None,
+        }
+    elif operation_id == "geometry.polygon.simple.decide":
+        claim_payload = {
+            "points": [
+                _point(0, 0),
+                _point(2, 2),
+                _point(0, 2),
+                _point(2, 0),
+            ]
+        }
+        candidate_payload = {
+            "vertex_count": 4,
+            "is_simple": False,
+            "checked_edge_pairs": 2,
+            "witness": {
+                "first_edge_index": 0,
+                "second_edge_index": 2,
+                "intersection": {
+                    "status": "POINT",
+                    "point": _point(1, 1),
+                    "contact_kind": "PROPER",
+                    "overlap": None,
+                },
+            },
+        }
+    elif operation_id == "geometry.polygon.point.classify":
+        claim_payload = {
+            "polygon": {
+                "points": [
+                    _point(0, 0),
+                    _point(2, 0),
+                    _point(2, 2),
+                    _point(0, 2),
+                ]
+            },
+            "point": _point(1, 1),
+        }
+        candidate_payload = {
+            "polygon_vertex_count": 4,
+            "classification": "INSIDE",
+            "boundary_edge_index": None,
+        }
     elif operation_id == "geometry.triangle.compute.orientation":
         claim_payload = {
             "first": _point(0, 0),
@@ -131,7 +208,11 @@ def _refresh(artifact: dict[str, Any]) -> None:
     "operation_id",
     [
         "geometry.points.compute.squared_distance",
+        "geometry.points.compute.convex_hull",
         "geometry.segment.compute.midpoint",
+        "geometry.segments.intersection.compute",
+        "geometry.polygon.simple.decide",
+        "geometry.polygon.point.classify",
         "geometry.triangle.compute.orientation",
         "geometry.triangle.compute.centroid",
     ],
@@ -147,6 +228,46 @@ def test_checker_accepts_selected_exact_geometry_results(operation_id: str) -> N
 def test_checker_rejects_candidate_mutation_with_fresh_digest() -> None:
     request = _request()
     request["candidate"]["payload"]["value"] = _rational(24)
+    _refresh(request["candidate"])
+
+    decision = check_exact_geometry(request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+@pytest.mark.parametrize(
+    ("operation_id", "mutation"),
+    (
+        (
+            "geometry.points.compute.convex_hull",
+            lambda payload: payload["points"].pop(),
+        ),
+        (
+            "geometry.segments.intersection.compute",
+            lambda payload: payload.update(contact_kind="ENDPOINT_TOUCH"),
+        ),
+        (
+            "geometry.polygon.simple.decide",
+            lambda payload: payload.update(
+                vertex_count=4,
+                is_simple=True,
+                checked_edge_pairs=6,
+                witness=None,
+            ),
+        ),
+        (
+            "geometry.polygon.point.classify",
+            lambda payload: payload.update(classification="OUTSIDE"),
+        ),
+    ),
+)
+def test_checker_rejects_planar_mutation_with_fresh_digest(
+    operation_id: str,
+    mutation: Any,
+) -> None:
+    request = _request(operation_id)
+    mutation(request["candidate"]["payload"])
     _refresh(request["candidate"])
 
     decision = check_exact_geometry(request)

--- a/tests/integration/domains/test_geometry_capabilities.py
+++ b/tests/integration/domains/test_geometry_capabilities.py
@@ -1,3 +1,5 @@
+import pytest
+
 from jacobian.contracts.capabilities import (
     CapabilityAssuranceLevel,
     CapabilityRequest,
@@ -10,6 +12,8 @@ from jacobian.contracts.geometry import (
     PointSetRequest,
     PointTripleRequest,
     PolygonRequest,
+    SegmentIntersectionRequest,
+    SimplePolygonPointRequest,
 )
 from jacobian.contracts.results import ExecutionStatus
 from jacobian.domains.geometry import GEOMETRY_BUNDLE
@@ -21,6 +25,20 @@ P0 = {"x": ZERO, "y": ZERO}
 PX = {"x": TWO, "y": ZERO}
 PY = {"x": ZERO, "y": TWO}
 PXY = {"x": TWO, "y": TWO}
+
+
+def _point(x: int, y: int) -> dict[str, dict[str, str]]:
+    return {
+        "x": {"num": str(x), "den": "1"},
+        "y": {"num": str(y), "den": "1"},
+    }
+
+
+def _segment(
+    start: dict[str, object],
+    end: dict[str, object],
+) -> dict[str, object]:
+    return {"start": start, "end": end}
 
 
 def test_segment_midpoint_example_is_directly_invocable(runtime) -> None:
@@ -70,10 +88,18 @@ def test_geometry_capabilities_are_distinct_and_every_contract_completes(
         PointLineRequest: {"point": PXY, "line": line_x},
         PolygonRequest: {"points": [P0, PX, PY]},
         PointSetRequest: {"points": [P0, PX, PY, PXY]},
+        SegmentIntersectionRequest: {
+            "first": _segment(P0, PXY),
+            "second": _segment(PX, PY),
+        },
+        SimplePolygonPointRequest: {
+            "polygon": {"points": [P0, PX, PXY, PY]},
+            "point": {"x": ONE, "y": ONE},
+        },
     }
     ids = [operation.capability_id for operation in GEOMETRY_BUNDLE.capabilities]
 
-    assert len(ids) == 13
+    assert len(ids) == 16
     assert len(ids) == len(set(ids))
     for operation in GEOMETRY_BUNDLE.capabilities:
         result = runtime.core.capabilities.invoke(
@@ -175,3 +201,194 @@ def test_degenerate_geometry_fails_before_artifact_writes(runtime) -> None:
     assert collinear_circle.diagnostics[0].code == "GEOMETRY_OPERATION_NOT_APPLICABLE"
     assert invalid_line.artifact_uris == ()
     assert collinear_circle.artifact_uris == ()
+
+
+@pytest.mark.parametrize(
+    ("first", "second", "expected"),
+    (
+        (
+            _segment(_point(0, 0), _point(2, 2)),
+            _segment(_point(0, 2), _point(2, 0)),
+            {
+                "status": "POINT",
+                "point": _point(1, 1),
+                "contact_kind": "PROPER",
+                "overlap": None,
+            },
+        ),
+        (
+            _segment(_point(0, 0), _point(2, 0)),
+            _segment(_point(2, 0), _point(2, 2)),
+            {
+                "status": "POINT",
+                "point": _point(2, 0),
+                "contact_kind": "ENDPOINT_TOUCH",
+                "overlap": None,
+            },
+        ),
+        (
+            _segment(_point(0, 0), _point(3, 0)),
+            _segment(_point(1, 0), _point(2, 0)),
+            {
+                "status": "OVERLAP",
+                "point": None,
+                "contact_kind": None,
+                "overlap": _segment(_point(1, 0), _point(2, 0)),
+            },
+        ),
+        (
+            _segment(_point(0, 0), _point(0, 0)),
+            _segment(_point(-1, 0), _point(1, 0)),
+            {
+                "status": "POINT",
+                "point": _point(0, 0),
+                "contact_kind": "DEGENERATE_TOUCH",
+                "overlap": None,
+            },
+        ),
+        (
+            _segment(_point(0, 0), _point(1, 0)),
+            _segment(_point(2, 0), _point(3, 0)),
+            {
+                "status": "DISJOINT",
+                "point": None,
+                "contact_kind": None,
+                "overlap": None,
+            },
+        ),
+    ),
+)
+def test_closed_segment_intersection_preserves_degenerate_classification(
+    runtime,
+    first: dict[str, object],
+    second: dict[str, object],
+    expected: dict[str, object],
+) -> None:
+    result = runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="geometry.segments.intersection.compute",
+            input={"first": first, "second": second},
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output["result"] == expected
+    assert len(result.artifact_uris) == 2
+
+
+@pytest.mark.parametrize(
+    ("points", "is_simple", "witness_status"),
+    (
+        (
+            [_point(0, 0), _point(2, 0), _point(2, 2), _point(0, 2)],
+            True,
+            None,
+        ),
+        (
+            [_point(0, 0), _point(2, 2), _point(0, 2), _point(2, 0)],
+            False,
+            "POINT",
+        ),
+        (
+            [_point(0, 0), _point(3, 0), _point(1, 0), _point(1, 2)],
+            False,
+            "OVERLAP",
+        ),
+    ),
+)
+def test_simple_polygon_decision_exposes_first_exact_violation(
+    runtime,
+    points: list[dict[str, object]],
+    is_simple: bool,
+    witness_status: str | None,
+) -> None:
+    result = runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="geometry.polygon.simple.decide",
+            input={"points": points},
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output["result"]["is_simple"] is is_simple
+    witness = result.output["result"]["witness"]
+    assert (None if witness is None else witness["intersection"]["status"]) == (
+        witness_status
+    )
+
+
+@pytest.mark.parametrize(
+    ("point", "classification"),
+    (
+        (_point(1, 1), "INSIDE"),
+        (_point(2, 1), "BOUNDARY"),
+        (_point(3, 1), "OUTSIDE"),
+    ),
+)
+def test_simple_polygon_point_classification_is_exact_and_boundary_aware(
+    runtime,
+    point: dict[str, object],
+    classification: str,
+) -> None:
+    polygon = [_point(0, 0), _point(2, 0), _point(2, 2), _point(0, 2)]
+    forward = runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="geometry.polygon.point.classify",
+            input={"polygon": {"points": polygon}, "point": point},
+        )
+    )
+    reverse = runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="geometry.polygon.point.classify",
+            input={"polygon": {"points": list(reversed(polygon))}, "point": point},
+        )
+    )
+
+    assert forward.output["result"]["classification"] == classification
+    assert reverse.output["result"] == forward.output["result"]
+
+
+def test_point_classification_rejects_non_simple_polygon_before_writes(runtime) -> None:
+    result = runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="geometry.polygon.point.classify",
+            input={
+                "polygon": {
+                    "points": [
+                        _point(0, 0),
+                        _point(2, 2),
+                        _point(0, 2),
+                        _point(2, 0),
+                    ]
+                },
+                "point": _point(1, 1),
+            },
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.diagnostics[0].code == "INVALID_GEOMETRY_REQUEST"
+    assert result.artifact_uris == ()
+
+
+@pytest.mark.parametrize(
+    "points",
+    (
+        [_point(0, 0), _point(2, 0), _point(0, 2), _point(0, 0)],
+        [_point(0, 0), _point(2, 0), _point(2, 0), _point(0, 2)],
+    ),
+)
+def test_polygon_ring_rejects_repeated_closure_or_zero_edge_before_writes(
+    runtime,
+    points: list[dict[str, object]],
+) -> None:
+    result = runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="geometry.polygon.simple.decide",
+            input={"points": points},
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.diagnostics[0].code == "INVALID_GEOMETRY_REQUEST"
+    assert result.artifact_uris == ()

--- a/tests/integration/domains/test_geometry_verification.py
+++ b/tests/integration/domains/test_geometry_verification.py
@@ -94,6 +94,28 @@ def test_geometry_checker_availability_does_not_grant_authority(
             {"first": P0, "second": PXY},
         ),
         (
+            "geometry.points.compute.convex_hull",
+            {"points": [PXY, P0, PY, PX, {"x": ONE, "y": ONE}]},
+        ),
+        (
+            "geometry.segments.intersection.compute",
+            {
+                "first": {"start": P0, "end": PXY},
+                "second": {"start": PX, "end": PY},
+            },
+        ),
+        (
+            "geometry.polygon.simple.decide",
+            {"points": [P0, PXY, PY, PX]},
+        ),
+        (
+            "geometry.polygon.point.classify",
+            {
+                "polygon": {"points": [P0, PX, PXY, PY]},
+                "point": {"x": ONE, "y": ONE},
+            },
+        ),
+        (
             "geometry.triangle.compute.orientation",
             {"first": P0, "second": PX, "third": PY},
         ),
@@ -159,6 +181,45 @@ def test_mutated_geometry_candidate_is_rejected_without_false_conclusion(
     )
 
     assert rejected.execution.status is ExecutionStatus.COMPLETED
+    assert rejected.output["status"] == "REJECTED"
+    assert rejected.output["conclusion"] == "UNKNOWN"
+    assert rejected.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert rejected.assurance.verification_record_uri is None
+
+
+def test_schema_valid_false_simple_polygon_decision_is_rejected(
+    tmp_path: Path,
+) -> None:
+    runtime = _runtime_with_geometry_checker(tmp_path)
+    computed = runtime.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="geometry.polygon.simple.decide",
+            input={"points": [P0, PXY, PY, PX]},
+        )
+    )
+    mutated = runtime.artifacts.put(
+        schema_uri=runtime.geometry.result_schema_uris[
+            "geometry.polygon.simple.decide"
+        ],
+        semantics_uri=runtime.geometry.semantics_uri,
+        payload={
+            "vertex_count": 4,
+            "is_simple": True,
+            "checked_edge_pairs": 6,
+            "witness": None,
+        },
+        parents=(computed.output["input_uri"],),
+        summary="adversarial false simple-polygon decision",
+    )
+
+    rejected = runtime.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="geometry.result.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"result_uri": mutated.artifact_uri},
+        )
+    )
+
     assert rejected.output["status"] == "REJECTED"
     assert rejected.output["conclusion"] == "UNKNOWN"
     assert rejected.assurance.level is CapabilityAssuranceLevel.COMPUTED


### PR DESCRIPTION
## Summary
- add exact closed-segment intersection with DISJOINT, typed POINT contact, and maximal OVERLAP outcomes
- add bounded simple-polygon decision with deterministic complete pair enumeration or a first exact violation witness
- add exact INSIDE, BOUNDARY, and OUTSIDE point classification for structurally validated simple polygons
- canonicalize convex-hull candidates and close the existing independent-checker gap without changing its capability ID
- extend the existing geometry.result.verify seam instead of adding a parallel verifier

## Compatibility and assurance
- the existing singular geometry.segment.compute.midpoint ID is unchanged; the accepted plural segment-intersection ID is documented without a rename or alias
- zero-length input segments are legal point segments; repeated polygon closure vertices and zero-length ring edges fail before writes
- SymPy producers remain COMPUTED
- the clean-process checker imports neither SymPy nor geometry producer modules and independently replays Fraction determinants, interval containment, every polygon edge pair, exact ray crossings, and monotone-chain hull construction
- schema-valid false simplicity decisions and refreshed-digest geometry mutations are rejected without verification records

## Validation
Frozen commit: 0fc8f78ed9c5c6a2e774b7444f6a02fb19cedf7c
Tree digest: sha256:8bff0bd3a0ac1995d01c8e88e8068f4dcfe5c11f803dfa531cd68332348fe828
Receipt: /tmp/jcb_pr2_validation_receipt.json

- make check: Ruff, format, mypy, 243 fast unit passed
- make test-checkers: 342 passed
- make test-contracts: 189 passed
- focused geometry producer/checker/verification: 52 passed
- bundle-wide representative operations: 7 passed
- clean-tree make test-core: 824 passed
- clean-tree make test-integration-all: 816 passed, 5 expected environment skips
- clean-tree make check-static: passed
- clean-tree make build: passed
- clean-tree make docs-linkcheck: passed

The CI impact planner selected core, integration, static, build, and docs; no Lean lane is required for these paths.