### PR TITLE
feat(providers): spike nauty optional provider boundary

### DIFF
--- a/benchmarks/nauty_provider_pin.json
+++ b/benchmarks/nauty_provider_pin.json
@@ -1,0 +1,47 @@
+{
+  "archive_sha256": "sha256:9fc4edae04f88a0f5883985be3b39cf7f898fd6cc96e96b9ee25452743cc1b5b",
+  "canonicalization": {
+    "command": [
+      "labelg",
+      "-q"
+    ],
+    "expected_output_graph6": [
+      "CR",
+      "CR"
+    ],
+    "expected_output_sha256": "sha256:817bc1213291c8fbe5bd1c0301c12caca9388bbe1c8c65e1cdd519114e3c0a55",
+    "input_graph6": [
+      "Ch",
+      "CU"
+    ]
+  },
+  "contract": "jacobian.nauty-provider-spike/v1",
+  "download_url": "https://users.cecs.anu.edu.au/~bdm/nauty/nauty2_9_3.tar.gz",
+  "license_id": "Apache-2.0",
+  "manual_url": "https://users.cecs.anu.edu.au/~bdm/nauty/nug29.pdf",
+  "provider": "nauty-traces",
+  "reproduction": {
+    "command": [
+      "geng",
+      "-q",
+      "4"
+    ],
+    "expected_graph6": [
+      "C?",
+      "CC",
+      "CE",
+      "CF",
+      "CQ",
+      "CU",
+      "CT",
+      "CV",
+      "C]",
+      "C^",
+      "C~"
+    ],
+    "expected_output_sha256": "sha256:b809c405cd3b8fb3cc836a9e7471658a8cf02cbc258029bddbecc9f2caf2ea32",
+    "scope": "all simple undirected graphs on exactly four vertices, one representative per isomorphism class",
+    "vertex_count": 4
+  },
+  "version": "2.9.3"
+}

--- a/benchmarks/nauty_provider_spike.py
+++ b/benchmarks/nauty_provider_spike.py
@@ -1,0 +1,439 @@
+"""Probe pinned nauty gtools without registering production capabilities."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import tarfile
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from jacobian.bounded_process import BoundedProcessResult, run_bounded_process
+
+PIN_PATH = Path(__file__).with_name("nauty_provider_pin.json")
+_HELP_MARKERS = {
+    "geng": (
+        b"Usage: geng ",
+        b"Generate all graphs of a specified class.",
+        b"-q    : suppress auxiliary output",
+    ),
+    "labelg": (
+        b"Usage: labelg ",
+        b"Canonically label a file of graphs or digraphs.",
+        b"-q  suppress auxiliary information",
+    ),
+}
+_ENVIRONMENT = {
+    "LANG": "C",
+    "LC_ALL": "C",
+    "TZ": "UTC",
+}
+_SOURCE_MEMBERS = (
+    "nauty2_9_3/COPYRIGHT",
+    "nauty2_9_3/gtools.h",
+)
+
+ProcessRunner = Callable[..., BoundedProcessResult]
+
+
+class NautySpikeError(RuntimeError):
+    """A typed non-conclusion from the optional-provider spike."""
+
+    def __init__(self, status: str, code: str, detail: str) -> None:
+        super().__init__(detail)
+        self.status = status
+        self.code = code
+        self.detail = detail
+
+
+def _sha256_bytes(payload: bytes) -> str:
+    return f"sha256:{hashlib.sha256(payload).hexdigest()}"
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def _load_pin(path: Path = PIN_PATH) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise NautySpikeError(
+            "ERROR",
+            "INVALID_SPIKE_PIN",
+            "The checked-in nauty spike pin is unavailable or malformed.",
+        ) from exc
+    required = {
+        "archive_sha256",
+        "canonicalization",
+        "contract",
+        "download_url",
+        "license_id",
+        "manual_url",
+        "provider",
+        "reproduction",
+        "version",
+    }
+    if not isinstance(payload, dict) or set(payload) != required:
+        raise NautySpikeError(
+            "ERROR",
+            "INVALID_SPIKE_PIN",
+            "The checked-in nauty spike pin is malformed.",
+        )
+    return payload
+
+
+def _resolve_file(path: Path, *, role: str) -> Path:
+    try:
+        resolved = path.expanduser().resolve(strict=True)
+        if not resolved.is_file():
+            raise OSError
+    except OSError as exc:
+        raise NautySpikeError(
+            "UNAVAILABLE",
+            "PROVIDER_FILE_UNAVAILABLE",
+            f"The explicitly selected {role} file is unavailable.",
+        ) from exc
+    return resolved
+
+
+def _inspect_source_archive(path: Path, pin: Mapping[str, Any]) -> dict[str, Any]:
+    resolved = _resolve_file(path, role="source archive")
+    digest = _sha256_file(resolved)
+    if digest != pin["archive_sha256"]:
+        raise NautySpikeError(
+            "REJECTED",
+            "SOURCE_VERSION_MISMATCH",
+            "The nauty source archive does not match the frozen 2.9.3 digest.",
+        )
+    try:
+        with tarfile.open(resolved, mode="r:gz") as archive:
+            contents: dict[str, bytes] = {}
+            for member_name in _SOURCE_MEMBERS:
+                member = archive.getmember(member_name)
+                if not member.isfile() or member.size > 128 * 1024:
+                    raise ValueError("source identity member is invalid")
+                stream = archive.extractfile(member)
+                if stream is None:
+                    raise ValueError("source identity member is unreadable")
+                contents[member_name] = stream.read()
+    except (KeyError, OSError, tarfile.TarError, ValueError) as exc:
+        raise NautySpikeError(
+            "REJECTED",
+            "SOURCE_ARCHIVE_MALFORMED",
+            "The pinned nauty source archive could not be inspected safely.",
+        ) from exc
+    if (
+        b"Licensed under the Apache License, Version 2.0"
+        not in contents[_SOURCE_MEMBERS[0]]
+        or b"nauty version 2.9.3" not in contents[_SOURCE_MEMBERS[1]]
+    ):
+        raise NautySpikeError(
+            "REJECTED",
+            "SOURCE_METADATA_MISMATCH",
+            "The nauty source metadata does not match the frozen version and license.",
+        )
+    return {
+        "archive": str(resolved),
+        "archive_sha256": digest,
+        "download_url": pin["download_url"],
+        "license_id": pin["license_id"],
+        "manual_url": pin["manual_url"],
+    }
+
+
+def _run_checked(
+    runner: ProcessRunner,
+    command: Sequence[str],
+    *,
+    input_bytes: bytes,
+    timeout_seconds: float,
+    stdout_limit: int,
+) -> bytes:
+    try:
+        completed = runner(
+            command,
+            input_bytes=input_bytes,
+            timeout_seconds=timeout_seconds,
+            environment=_ENVIRONMENT,
+            stdout_limit=stdout_limit,
+            stderr_limit=16_384,
+        )
+    except OSError as exc:
+        raise NautySpikeError(
+            "ERROR",
+            "PROVIDER_LAUNCH_ERROR",
+            "The nauty probe process could not be launched.",
+        ) from exc
+    if completed.cancelled:
+        raise NautySpikeError(
+            "CANCELLED",
+            "PROVIDER_CANCELLED",
+            "The nauty probe was cancelled before a conclusion.",
+        )
+    if completed.timed_out:
+        raise NautySpikeError(
+            "TIMEOUT",
+            "PROVIDER_TIMEOUT",
+            "The nauty probe timed out before a conclusion.",
+        )
+    if completed.stdout_exceeded or completed.stderr_exceeded:
+        raise NautySpikeError(
+            "ERROR",
+            "PROVIDER_OUTPUT_LIMIT",
+            "The nauty probe exceeded its bounded output allowance.",
+        )
+    if completed.returncode != 0:
+        raise NautySpikeError(
+            "ERROR",
+            "PROVIDER_CRASH",
+            "The nauty probe process exited unsuccessfully.",
+        )
+    return completed.stdout
+
+
+def _strict_ascii_lines(payload: bytes, *, expected_width: int) -> tuple[str, ...]:
+    try:
+        decoded = payload.decode("ascii")
+    except UnicodeDecodeError as exc:
+        raise NautySpikeError(
+            "ERROR",
+            "PROVIDER_OUTPUT_MALFORMED",
+            "The nauty provider returned non-ASCII graph6 output.",
+        ) from exc
+    if not decoded.endswith("\n"):
+        raise NautySpikeError(
+            "ERROR",
+            "PROVIDER_OUTPUT_MALFORMED",
+            "The nauty provider returned an unterminated graph6 record.",
+        )
+    lines = tuple(decoded.splitlines())
+    if not lines or any(
+        len(line) != expected_width
+        or any(not 63 <= ord(character) <= 126 for character in line)
+        for line in lines
+    ):
+        raise NautySpikeError(
+            "ERROR",
+            "PROVIDER_OUTPUT_MALFORMED",
+            "The nauty provider returned malformed bounded graph6 output.",
+        )
+    return lines
+
+
+def _probe_help(
+    runner: ProcessRunner,
+    executable: Path,
+    *,
+    tool: str,
+    timeout_seconds: float,
+) -> None:
+    output = _run_checked(
+        runner,
+        [str(executable), "-help"],
+        input_bytes=b"",
+        timeout_seconds=timeout_seconds,
+        stdout_limit=16_384,
+    )
+    if any(marker not in output for marker in _HELP_MARKERS[tool]):
+        raise NautySpikeError(
+            "REJECTED",
+            "PROVIDER_FEATURE_MISMATCH",
+            f"The selected {tool} executable does not expose the pinned gtools interface.",
+        )
+
+
+def _success_report(
+    *,
+    pin: Mapping[str, Any],
+    source: Mapping[str, Any],
+    geng: Path,
+    labelg: Path,
+    generated: bytes,
+    canonicalized: bytes,
+) -> dict[str, Any]:
+    return {
+        "contract": pin["contract"],
+        "status": "COMPLETED",
+        "conclusion": "SPIKE_PASSED_PRODUCTION_DEFERRED",
+        "assurance": "OBSERVED_PROVIDER_BEHAVIOR",
+        "provider": {
+            "name": pin["provider"],
+            "version": pin["version"],
+            "install_tier": "T2",
+            "deployment": "operator-installed external executables; do not vendor",
+            "source": dict(source),
+            "executables": {
+                "geng": {
+                    "path": str(geng),
+                    "sha256": _sha256_file(geng),
+                },
+                "labelg": {
+                    "path": str(labelg),
+                    "sha256": _sha256_file(labelg),
+                },
+            },
+        },
+        "reproduction": {
+            **pin["reproduction"],
+            "observed_count": len(generated.splitlines()),
+            "observed_output_sha256": _sha256_bytes(generated),
+        },
+        "canonicalization": {
+            **pin["canonicalization"],
+            "observed_output_sha256": _sha256_bytes(canonicalized),
+            "isomorphic_inputs_converged": len(set(canonicalized.splitlines())) == 1,
+        },
+        "checker_feasibility": {
+            "canonical_label": {
+                "decision": "REVISE",
+                "open_obligations": [
+                    "bind input graph semantics, output canonical bytes, and any vertex permutation in one artifact",
+                    "define canonical minimality independently of the nauty search implementation",
+                    "use an operator-authorized checker that does not call nauty",
+                ],
+            },
+            "nonisomorphic_generation": {
+                "decision": "REVISE",
+                "open_obligations": [
+                    "make geng scope, res/mod partitioning, paging, and truncation explicit",
+                    "separate pairwise non-isomorphism from exhaustive completeness",
+                    "provide independent coverage evidence before claiming a complete enumeration",
+                ],
+            },
+        },
+        "capability_ids_registered": [],
+        "limitations": [
+            "the spike observes exact bounded outputs but does not establish mathematical verification",
+            "the executable digests are measured but not cryptographically derived from the source archive",
+            "no provider or checker is authorized by this benchmark",
+        ],
+    }
+
+
+def run_spike(
+    *,
+    geng: Path,
+    labelg: Path,
+    source_archive: Path,
+    timeout_seconds: float = 5,
+    runner: ProcessRunner = run_bounded_process,
+    pin_path: Path = PIN_PATH,
+) -> dict[str, Any]:
+    """Run the frozen probe and return a JSON-safe success or non-conclusion."""
+
+    try:
+        if timeout_seconds <= 0:
+            raise NautySpikeError(
+                "ERROR",
+                "INVALID_TIMEOUT",
+                "The nauty spike timeout must be positive.",
+            )
+        pin = _load_pin(pin_path)
+        source = _inspect_source_archive(source_archive, pin)
+        resolved_geng = _resolve_file(geng, role="geng executable")
+        resolved_labelg = _resolve_file(labelg, role="labelg executable")
+        _probe_help(
+            runner,
+            resolved_geng,
+            tool="geng",
+            timeout_seconds=timeout_seconds,
+        )
+        _probe_help(
+            runner,
+            resolved_labelg,
+            tool="labelg",
+            timeout_seconds=timeout_seconds,
+        )
+
+        generated = _run_checked(
+            runner,
+            [str(resolved_geng), "-q", "4"],
+            input_bytes=b"",
+            timeout_seconds=timeout_seconds,
+            stdout_limit=4096,
+        )
+        generated_lines = _strict_ascii_lines(generated, expected_width=2)
+        reproduction = pin["reproduction"]
+        if (
+            list(generated_lines) != reproduction["expected_graph6"]
+            or _sha256_bytes(generated) != reproduction["expected_output_sha256"]
+        ):
+            raise NautySpikeError(
+                "REJECTED",
+                "REPRODUCTION_MISMATCH",
+                "geng did not reproduce the frozen complete n=4 output.",
+            )
+
+        canonical_input = (
+            "\n".join(pin["canonicalization"]["input_graph6"]) + "\n"
+        ).encode("ascii")
+        canonicalized = _run_checked(
+            runner,
+            [str(resolved_labelg), "-q"],
+            input_bytes=canonical_input,
+            timeout_seconds=timeout_seconds,
+            stdout_limit=4096,
+        )
+        canonical_lines = _strict_ascii_lines(canonicalized, expected_width=2)
+        canonicalization = pin["canonicalization"]
+        if (
+            list(canonical_lines) != canonicalization["expected_output_graph6"]
+            or _sha256_bytes(canonicalized)
+            != canonicalization["expected_output_sha256"]
+        ):
+            raise NautySpikeError(
+                "REJECTED",
+                "CANONICALIZATION_MISMATCH",
+                "labelg did not reproduce the frozen isomorphic-pair output.",
+            )
+        return _success_report(
+            pin=pin,
+            source=source,
+            geng=resolved_geng,
+            labelg=resolved_labelg,
+            generated=generated,
+            canonicalized=canonicalized,
+        )
+    except NautySpikeError as exc:
+        return {
+            "contract": "jacobian.nauty-provider-spike/v1",
+            "status": exc.status,
+            "conclusion": "NO_CONCLUSION",
+            "diagnostic": {
+                "code": exc.code,
+                "detail": exc.detail,
+            },
+            "capability_ids_registered": [],
+        }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--geng", type=Path, required=True)
+    parser.add_argument("--labelg", type=Path, required=True)
+    parser.add_argument("--source-archive", type=Path, required=True)
+    parser.add_argument("--timeout-seconds", type=float, default=5)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args(argv)
+    report = run_spike(
+        geng=args.geng,
+        labelg=args.labelg,
+        source_archive=args.source_archive,
+        timeout_seconds=args.timeout_seconds,
+    )
+    encoded = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output is not None:
+        args.output.write_text(encoded, encoding="utf-8")
+    print(encoded, end="")
+    return 0 if report["status"] == "COMPLETED" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/contributing/nauty-provider-spike.md
+++ b/docs/contributing/nauty-provider-spike.md
@@ -1,0 +1,108 @@
+# nauty/Traces optional-provider spike
+
+This spike decides whether nauty/Traces is a viable optional provider for
+atomic graph canonicalization or non-isomorphic graph generation. It does not
+register a capability, authorize a checker, or promote provider output beyond
+an observed computation.
+
+## Decision
+
+nauty/Traces 2.9.3 passes the bounded provider and reproduction probes, but
+production capabilities remain deferred.
+
+- Deployment is an operator-installed T2 external provider. Jacobian should not
+  vendor the C sources or discover executables at import time.
+- Version 2.9.3 is licensed under Apache-2.0. The older custom restrictions
+  mentioned in pre-2.6 history do not govern this release.
+- A future adapter must require explicit executable paths and an
+  operator-managed provenance record binding the official source release to
+  the measured `geng` and `labelg` executable digests. Neither executable has a
+  machine-readable version command sufficient for the runtime contract.
+- The spike's success is `OBSERVED_PROVIDER_BEHAVIOR`, not mathematical
+  assurance. It adds no catalog entries.
+
+The version, source digest, license text, command profiles, and exact expected
+outputs are frozen in
+[`benchmarks/nauty_provider_pin.json`](../../benchmarks/nauty_provider_pin.json).
+The source and command semantics were checked against the
+[official nauty/Traces page](https://users.cecs.anu.edu.au/~bdm/nauty/) and the
+[2.9.3 user's guide](https://users.cecs.anu.edu.au/~bdm/nauty/nug29.pdf).
+
+## Bounded reproduction
+
+Build the official source archive outside the repository, then run:
+
+```sh
+uv run python benchmarks/nauty_provider_spike.py \
+  --source-archive /path/to/nauty2_9_3.tar.gz \
+  --geng /path/to/nauty2_9_3/geng \
+  --labelg /path/to/nauty2_9_3/labelg \
+  --output /tmp/nauty-provider-spike.json
+```
+
+The probe:
+
+1. hashes the exact official source archive and inspects its bounded
+   `COPYRIGHT` and `gtools.h` members without extracting them;
+2. resolves only the explicitly supplied executables and records their SHA-256
+   digests;
+3. checks the pinned `-help` feature surfaces under a sanitized environment and
+   bounded wall time/output;
+4. runs `geng -q 4` and requires the exact 11 graph6 representatives for all
+   simple undirected four-vertex graphs; and
+5. runs two differently labelled copies of the four-vertex path through
+   `labelg -q` and requires both to produce the frozen canonical graph6 bytes.
+
+The report records the exact command profiles, source and executable identities,
+bounded output digests, scope, observed count, limitations, and checker
+obligations. Missing files, source-version mismatch, malformed output, timeout,
+cancellation, output overflow, and process failure are explicit
+non-conclusions.
+
+## Production gates
+
+### Canonical graph labelling
+
+Status: `REVISE`.
+
+The candidate artifact must bind the input graph semantics, output canonical
+bytes, and any vertex permutation. `labelg` emits canonical graph bytes but
+does not expose the permutation needed for that stronger relationship, so a
+thin C adapter may be necessary.
+
+An independent isomorphism checker can establish that the input and output are
+isomorphic. It does not establish that the output is the selected canonical
+minimum. A production capability therefore needs a separately specified
+canonical-order obligation and an operator-authorized checker independent of
+the nauty search implementation. The provider cannot authorize itself.
+
+### Non-isomorphic graph generation
+
+Status: `REVISE`.
+
+Pairwise independent isomorphism replay can reject duplicate classes in a
+bounded page. It cannot prove that no class is missing. Any production
+enumeration must expose:
+
+- the exact graph class and order;
+- every `geng` filter and format option;
+- `res/mod` partition parameters;
+- page boundaries and an explicit truncation/stop reason;
+- whether the result claims only a sample/page or exhaustive coverage; and
+- coverage evidence independent of pairwise non-isomorphism.
+
+Timeout, cancellation, crash, output overflow, partial partitions, and failure
+to find a graph remain non-conclusions. A `COMPLETED` process alone cannot
+establish exhaustive completeness.
+
+## Absence isolation
+
+The spike module is not imported by runtime assembly, portfolio construction,
+the CLI, or MCP startup. Tests run it against an absent explicit provider and
+compare the complete catalog before and after. Since no nauty capability IDs
+exist, absence removes no existing entry and unrelated runtime startup remains
+unchanged.
+
+If a production adapter is proposed later, it must add installed, absent,
+version-mismatch, malformed-output, timeout, crash, catalog-isolation, CLI/MCP
+startup, and advertised-package-version tests before registration.

--- a/docs/index.md
+++ b/docs/index.md
@@ -121,6 +121,9 @@ records the formal-first backend research, ordering, installation tradeoffs,
 and evaluation gates used to decide which mathematical slices to build next.
 The [test-suite cost audit](contributing/test-suite-cost-audit.md) records the
 measured test lanes, retained trust-boundary costs, and fast-feedback policy.
+The [nauty/Traces optional-provider spike](contributing/nauty-provider-spike.md)
+records the pinned external-provider reproduction, absence isolation, license
+decision, and unresolved checker gates without registering a capability.
 
 Recurring agent work is encoded in the repository-local skills under
 `.agents/skills/`. Start with `develop-math-capabilities` for a complete

--- a/tests/boundary/process/providers/test_nauty_provider_spike.py
+++ b/tests/boundary/process/providers/test_nauty_provider_spike.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import runpy
+import tarfile
+from collections.abc import Callable, Sequence
+from io import BytesIO
+from pathlib import Path
+from typing import Any, cast
+
+from jacobian.bounded_process import BoundedProcessResult
+
+PROJECT_ROOT = Path(__file__).resolve().parents[4]
+SPIKE = runpy.run_path(str(PROJECT_ROOT / "benchmarks" / "nauty_provider_spike.py"))
+PIN = json.loads(
+    (PROJECT_ROOT / "benchmarks" / "nauty_provider_pin.json").read_text(
+        encoding="utf-8"
+    )
+)
+RunSpike = Callable[..., dict[str, Any]]
+RUN_SPIKE = cast(RunSpike, SPIKE["run_spike"])
+
+GENG_HELP = (
+    b"Usage: geng \n"
+    b"Generate all graphs of a specified class.\n"
+    b"-q    : suppress auxiliary output\n"
+)
+LABELG_HELP = (
+    b"Usage: labelg \n"
+    b"Canonically label a file of graphs or digraphs.\n"
+    b"-q  suppress auxiliary information\n"
+)
+GENG_OUTPUT = ("\n".join(PIN["reproduction"]["expected_graph6"]) + "\n").encode()
+LABELG_OUTPUT = (
+    "\n".join(PIN["canonicalization"]["expected_output_graph6"]) + "\n"
+).encode()
+
+
+def _result(
+    *,
+    stdout: bytes = b"",
+    returncode: int | None = 0,
+    timed_out: bool = False,
+    cancelled: bool = False,
+    stdout_exceeded: bool = False,
+) -> BoundedProcessResult:
+    return BoundedProcessResult(
+        returncode=returncode,
+        stdout=stdout,
+        stderr=b"",
+        stdout_exceeded=stdout_exceeded,
+        stderr_exceeded=False,
+        timed_out=timed_out,
+        cancelled=cancelled,
+    )
+
+
+def _runner(
+    outcomes: Sequence[BoundedProcessResult],
+) -> Callable[..., BoundedProcessResult]:
+    remaining = iter(outcomes)
+
+    def run(*_args: object, **_kwargs: object) -> BoundedProcessResult:
+        return next(remaining)
+
+    return run
+
+
+def _source_archive(tmp_path: Path, *, pin_digest: bool = True) -> Path:
+    archive_path = tmp_path / "nauty2_9_3.tar.gz"
+    copyright_notice = b"Licensed under the Apache License, Version 2.0 (the License)\n"
+    version_header = b"/* nauty version 2.9.3 */\n"
+    with tarfile.open(archive_path, mode="w:gz") as archive:
+        for name, payload in (
+            ("nauty2_9_3/COPYRIGHT", copyright_notice),
+            ("nauty2_9_3/gtools.h", version_header),
+        ):
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            info.mtime = 0
+            archive.addfile(info, BytesIO(payload))
+    if pin_digest:
+        digest = "sha256:" + hashlib.sha256(archive_path.read_bytes()).hexdigest()
+        PIN["archive_sha256"] = digest
+    return archive_path
+
+
+def _files(tmp_path: Path) -> tuple[Path, Path]:
+    geng = tmp_path / "geng"
+    labelg = tmp_path / "labelg"
+    geng.touch()
+    labelg.touch()
+    return geng, labelg
+
+
+def _pin_file(tmp_path: Path) -> Path:
+    path = tmp_path / "pin.json"
+    path.write_text(json.dumps(PIN), encoding="utf-8")
+    return path
+
+
+def _successful_outcomes() -> list[BoundedProcessResult]:
+    return [
+        _result(stdout=GENG_HELP),
+        _result(stdout=LABELG_HELP),
+        _result(stdout=GENG_OUTPUT),
+        _result(stdout=LABELG_OUTPUT),
+    ]
+
+
+def test_spike_records_exact_reproduction_and_defers_production(
+    tmp_path: Path,
+) -> None:
+    archive = _source_archive(tmp_path)
+    geng, labelg = _files(tmp_path)
+
+    report = RUN_SPIKE(
+        geng=geng,
+        labelg=labelg,
+        source_archive=archive,
+        runner=_runner(_successful_outcomes()),
+        pin_path=_pin_file(tmp_path),
+    )
+
+    assert report["status"] == "COMPLETED"
+    assert report["conclusion"] == "SPIKE_PASSED_PRODUCTION_DEFERRED"
+    assert report["provider"]["version"] == "2.9.3"
+    assert report["provider"]["source"]["license_id"] == "Apache-2.0"
+    assert report["reproduction"]["observed_count"] == 11
+    assert report["canonicalization"]["isomorphic_inputs_converged"] is True
+    assert report["checker_feasibility"]["canonical_label"]["decision"] == "REVISE"
+    assert (
+        report["checker_feasibility"]["nonisomorphic_generation"]["decision"]
+        == "REVISE"
+    )
+    assert report["capability_ids_registered"] == []
+
+
+def test_absent_explicit_executable_is_an_isolated_non_conclusion(
+    tmp_path: Path,
+) -> None:
+    archive = _source_archive(tmp_path)
+    _geng, labelg = _files(tmp_path)
+
+    report = RUN_SPIKE(
+        geng=tmp_path / "absent-geng",
+        labelg=labelg,
+        source_archive=archive,
+        pin_path=_pin_file(tmp_path),
+    )
+
+    assert report == {
+        "contract": "jacobian.nauty-provider-spike/v1",
+        "status": "UNAVAILABLE",
+        "conclusion": "NO_CONCLUSION",
+        "diagnostic": {
+            "code": "PROVIDER_FILE_UNAVAILABLE",
+            "detail": "The explicitly selected geng executable file is unavailable.",
+        },
+        "capability_ids_registered": [],
+    }
+
+
+def test_source_version_mismatch_fails_closed_before_execution(
+    tmp_path: Path,
+) -> None:
+    archive = _source_archive(tmp_path, pin_digest=False)
+    geng, labelg = _files(tmp_path)
+
+    report = RUN_SPIKE(
+        geng=geng,
+        labelg=labelg,
+        source_archive=archive,
+    )
+
+    assert report["status"] == "REJECTED"
+    assert report["conclusion"] == "NO_CONCLUSION"
+    assert report["diagnostic"]["code"] == "SOURCE_VERSION_MISMATCH"
+
+
+def test_invalid_timeout_fails_before_provider_inspection(tmp_path: Path) -> None:
+    report = RUN_SPIKE(
+        geng=tmp_path / "absent-geng",
+        labelg=tmp_path / "absent-labelg",
+        source_archive=tmp_path / "absent-nauty.tar.gz",
+        timeout_seconds=0,
+    )
+
+    assert report["status"] == "ERROR"
+    assert report["conclusion"] == "NO_CONCLUSION"
+    assert report["diagnostic"]["code"] == "INVALID_TIMEOUT"
+
+
+def test_malformed_generation_output_is_not_a_partial_result(tmp_path: Path) -> None:
+    archive = _source_archive(tmp_path)
+    geng, labelg = _files(tmp_path)
+    outcomes = [
+        _result(stdout=GENG_HELP),
+        _result(stdout=LABELG_HELP),
+        _result(stdout=b"not-graph6\n"),
+    ]
+
+    report = RUN_SPIKE(
+        geng=geng,
+        labelg=labelg,
+        source_archive=archive,
+        runner=_runner(outcomes),
+        pin_path=_pin_file(tmp_path),
+    )
+
+    assert report["status"] == "ERROR"
+    assert report["conclusion"] == "NO_CONCLUSION"
+    assert report["diagnostic"]["code"] == "PROVIDER_OUTPUT_MALFORMED"
+
+
+def test_timeout_and_crash_remain_distinct_non_conclusions(tmp_path: Path) -> None:
+    archive = _source_archive(tmp_path)
+    geng, labelg = _files(tmp_path)
+    pin_path = _pin_file(tmp_path)
+
+    timed_out = RUN_SPIKE(
+        geng=geng,
+        labelg=labelg,
+        source_archive=archive,
+        runner=_runner([_result(timed_out=True)]),
+        pin_path=pin_path,
+    )
+    crashed = RUN_SPIKE(
+        geng=geng,
+        labelg=labelg,
+        source_archive=archive,
+        runner=_runner([_result(returncode=9)]),
+        pin_path=pin_path,
+    )
+
+    assert (timed_out["status"], timed_out["diagnostic"]["code"]) == (
+        "TIMEOUT",
+        "PROVIDER_TIMEOUT",
+    )
+    assert (crashed["status"], crashed["diagnostic"]["code"]) == (
+        "ERROR",
+        "PROVIDER_CRASH",
+    )
+    assert timed_out["conclusion"] == crashed["conclusion"] == "NO_CONCLUSION"

--- a/tests/composition/runtime/test_nauty_provider_spike_isolation.py
+++ b/tests/composition/runtime/test_nauty_provider_spike_isolation.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import runpy
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, cast
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+SPIKE = runpy.run_path(str(PROJECT_ROOT / "benchmarks" / "nauty_provider_spike.py"))
+RunSpike = Callable[..., dict[str, Any]]
+RUN_SPIKE = cast(RunSpike, SPIKE["run_spike"])
+
+
+def test_absent_nauty_spike_does_not_change_complete_runtime_catalog(
+    fresh_complete_runtime,
+    tmp_path: Path,
+) -> None:
+    before = fresh_complete_runtime.core.capabilities.catalog().model_dump(mode="json")
+
+    report = RUN_SPIKE(
+        geng=tmp_path / "absent-geng",
+        labelg=tmp_path / "absent-labelg",
+        source_archive=tmp_path / "absent-nauty.tar.gz",
+    )
+
+    after = fresh_complete_runtime.core.capabilities.catalog().model_dump(mode="json")
+    assert report["status"] == "UNAVAILABLE"
+    assert report["capability_ids_registered"] == []
+    assert after == before


### PR DESCRIPTION
## Outcome

Adds an auditable nauty/Traces 2.9.3 optional-provider spike without registering or authorizing a production capability.

- Freezes the official source archive, Apache-2.0 license, command profiles, and bounded graph6 expectations.
- Probes only explicit `geng` and `labelg` paths through bounded subprocess execution.
- Reproduces all 11 non-isomorphic simple graphs on four vertices and a canonicalized isomorphic path pair.
- Keeps canonical-minimality and exhaustive-completeness claims at `REVISE`; provider success is observed behavior, never `VERIFIED`.
- Proves absent-provider execution leaves the complete runtime catalog unchanged.

The research corrected the earlier license assumption: the formal 2.9.3 package notice is Apache-2.0. Deployment is viable as an operator-installed T2 external provider, but production still needs an operator provenance sidecar that binds source release to executable digests. Jacobian should not vendor or discover nauty at import time.

## Provider reproduction

Built the official `nauty2_9_3.tar.gz` outside the repository with the documented Autoconf flow.

- source archive: `sha256:9fc4edae04f88a0f5883985be3b39cf7f898fd6cc96e96b9ee25452743cc1b5b`
- local `geng`: `sha256:1f5bff098bc28274b5ecbf01b795a3f26e38046ddca3c3fd90662a78235570db`
- local `labelg`: `sha256:992103307ce894e50d8203b42d7fdb23146085c9594de17154b29a194ebea879`
- `geng -q 4` output: 11 records, `sha256:b809c405cd3b8fb3cc836a9e7471658a8cf02cbc258029bddbecc9f2caf2ea32`
- canonical pair output: `CR\nCR\n`, `sha256:817bc1213291c8fbe5bd1c0301c12caca9388bbe1c8c65e1cdd519114e3c0a55`

## Validation

All clean receipts bind commit `175b7dd5f1fcccf3e330bcb0d64f407b7fb9e17e` to tree digest `sha256:83e8414e431afe1eaf00c53e2f286e42e6330b55819fb232b99b49cdb9dc6bf4`, with `dirty=false`, unchanged tree, and exit 0.

- `make check` (34.94s; Ruff, formatting, mypy, 288 unit tests)
- `make test-process TESTS=tests/boundary/process/providers/test_nauty_provider_spike.py` (6 tests, 6.62s)
- `make test-composition TESTS=tests/composition/runtime/test_nauty_provider_spike_isolation.py` (1 test, 16.23s)
- `make check-static`
- `make docs-linkcheck`
- real official-provider spike: `COMPLETED / SPIKE_PASSED_PRODUCTION_DEFERRED`

## Capability-development handoff

- git tree: `175b7dd5f1fcccf3e330bcb0d64f407b7fb9e17e`
- installed catalog: version 1, 249 entries, `sha256:b58e07e4eef94af4507d98fa9a5647e2a249399ee0767bebef5f7a6397ffa645`
- policy: `DEFAULT`, `sha256:870a92b83d3e522e4015b6bb1cabda33086906f9de1c3c36e466251ea7ed1957`
- provider/runtime state: official 2.9.3 source and locally built executables measured; no nauty runtime or capability installed in the portfolio
- model/prompt settings: not applicable; deterministic executable reproduction only
- raw local trace: `/tmp/jcb-nauty-provider-spike.json`; portable expectations and decisions are checked in under `benchmarks/` and `docs/contributing/`
- unresolved obligations: executable/source provenance, canonical permutation binding, independent canonical-order checker, explicit `geng` partition/paging/truncation semantics, and completeness evidence independent of pairwise isomorphism
- next action: retain this as a passed provider spike; propose a production contract only after the named checker and provenance gates are resolved
