### PR TITLE
feat(providers): spike CGAL exact Delaunay provider

### DIFF
--- a/benchmarks/cgal_delaunay_pin.json
+++ b/benchmarks/cgal_delaunay_pin.json
@@ -1,0 +1,33 @@
+{
+  "adapter_source_sha256": "sha256:7f063945328bf766d981c3a55df07de4adb659d2c86fde9653179c7644112886",
+  "archive_sha256": "sha256:f75d2b2486842fb47222c780c7241c262d392802d0811143c4e9b539972ee55b",
+  "contract": "jacobian.cgal-delaunay-spike/v1",
+  "download_url": "https://github.com/CGAL/cgal/releases/download/v6.2/CGAL-6.2-library.tar.xz",
+  "license": {
+    "commercial_alternative": true,
+    "open_source_id": "GPL-3.0-or-later",
+    "package": "2D Triangulations"
+  },
+  "manual_url": "https://doc.cgal.org/latest/Triangulation_2/index.html",
+  "provider": "cgal",
+  "reproductions": {
+    "cocircular": {
+      "command": [
+        "--cocircular"
+      ],
+      "expected_output": "contract jacobian.cgal-delaunay-spike/v1\ncgal_version 6.2\nkernel Exact_predicates_exact_constructions_kernel\nsemantics REQUIRE_UNIQUE\napplicable false\nreason COCIRCULAR\n",
+      "expected_output_sha256": "sha256:4260fdbc095751f5a880778590d0b0d5217f1042a61e14eb212320c390213372"
+    },
+    "unique": {
+      "command": [
+        "--unique"
+      ],
+      "expected_output": "contract jacobian.cgal-delaunay-spike/v1\ncgal_version 6.2\nkernel Exact_predicates_exact_constructions_kernel\nsemantics REQUIRE_UNIQUE\napplicable true\nvalid true\nsite_count 6\ntriangle 0 1 5\ntriangle 0 5 4\ntriangle 1 2 5\ntriangle 2 3 5\ntriangle 3 4 5\nedge 0 1\nedge 0 4\nedge 0 5\nedge 1 2\nedge 1 5\nedge 2 3\nedge 2 5\nedge 3 4\nedge 3 5\nedge 4 5\nhull_edge 0 1\nhull_edge 0 4\nhull_edge 1 2\nhull_edge 2 3\nhull_edge 3 4\n",
+      "expected_output_sha256": "sha256:a1cecc8c3781dfd8626e62da3d2ff4a4f974b31a3cb19c4baa23db0d11741ce9",
+      "scope": "six distinct rational sites in two dimensions with no four cocircular",
+      "site_count": 6
+    }
+  },
+  "supported_gnu_compiler_minimum": "13.3.0",
+  "version": "6.2"
+}

--- a/benchmarks/cgal_delaunay_spike.cpp
+++ b/benchmarks/cgal_delaunay_spike.cpp
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: MIT
+// Fixed reproduction transport for the CGAL optional-provider spike.
+
+#include <CGAL/Delaunay_triangulation_2.h>
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/Triangulation_data_structure_2.h>
+#include <CGAL/Triangulation_face_base_2.h>
+#include <CGAL/Triangulation_vertex_base_with_info_2.h>
+#include <CGAL/version.h>
+#include <boost/version.hpp>
+
+#include <algorithm>
+#include <array>
+#include <iostream>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+using Kernel = CGAL::Exact_predicates_exact_constructions_kernel;
+using Vertex_base = CGAL::Triangulation_vertex_base_with_info_2<unsigned, Kernel>;
+using Face_base = CGAL::Triangulation_face_base_2<Kernel>;
+using Data_structure = CGAL::Triangulation_data_structure_2<Vertex_base, Face_base>;
+using Delaunay = CGAL::Delaunay_triangulation_2<Kernel, Data_structure>;
+using Point = Kernel::Point_2;
+
+namespace {
+
+constexpr const char* contract = "jacobian.cgal-delaunay-spike/v1";
+
+std::array<unsigned, 3> canonical_face(Delaunay::Face_handle face) {
+  std::array<unsigned, 3> ids = {
+      face->vertex(0)->info(),
+      face->vertex(1)->info(),
+      face->vertex(2)->info(),
+  };
+  if (CGAL::orientation(face->vertex(0)->point(), face->vertex(1)->point(),
+                        face->vertex(2)->point()) == CGAL::RIGHT_TURN) {
+    std::swap(ids[1], ids[2]);
+  }
+  auto minimum = std::min_element(ids.begin(), ids.end());
+  std::rotate(ids.begin(), minimum, ids.end());
+  return ids;
+}
+
+int unique_reproduction() {
+  using FT = Kernel::FT;
+  const std::vector<std::pair<Point, unsigned>> sites = {
+      {Point(FT(0), FT(0)), 0},
+      {Point(FT(4), FT(0)), 1},
+      {Point(FT(5), FT(3)), 2},
+      {Point(FT(2), FT(5)), 3},
+      {Point(FT(-1), FT(3)), 4},
+      {Point(FT(3) / FT(2), FT(2)), 5},
+  };
+  Delaunay triangulation;
+  triangulation.insert(sites.begin(), sites.end());
+  if (!triangulation.is_valid() || triangulation.number_of_vertices() != sites.size()) {
+    return 2;
+  }
+
+  std::vector<std::array<unsigned, 3>> triangles;
+  std::set<std::pair<unsigned, unsigned>> edges;
+  std::set<std::pair<unsigned, unsigned>> hull_edges;
+  for (auto face = triangulation.finite_faces_begin();
+       face != triangulation.finite_faces_end(); ++face) {
+    auto ids = canonical_face(face);
+    triangles.push_back(ids);
+    for (int index = 0; index < 3; ++index) {
+      auto first = ids[index];
+      auto second = ids[(index + 1) % 3];
+      edges.emplace(std::min(first, second), std::max(first, second));
+    }
+  }
+  for (auto edge = triangulation.finite_edges_begin();
+       edge != triangulation.finite_edges_end(); ++edge) {
+    auto face = edge->first;
+    auto index = edge->second;
+    auto mirror = face->neighbor(index);
+    if (!triangulation.is_infinite(face) && !triangulation.is_infinite(mirror)) {
+      continue;
+    }
+    auto first = face->vertex((index + 1) % 3)->info();
+    auto second = face->vertex((index + 2) % 3)->info();
+    hull_edges.emplace(std::min(first, second), std::max(first, second));
+  }
+  std::sort(triangles.begin(), triangles.end());
+
+  std::cout << "contract " << contract << '\n';
+  std::cout << "cgal_version " << CGAL_VERSION_STR << '\n';
+  std::cout << "kernel Exact_predicates_exact_constructions_kernel\n";
+  std::cout << "semantics REQUIRE_UNIQUE\n";
+  std::cout << "applicable true\n";
+  std::cout << "valid true\n";
+  std::cout << "site_count " << sites.size() << '\n';
+  for (const auto& triangle : triangles) {
+    std::cout << "triangle " << triangle[0] << ' ' << triangle[1] << ' '
+              << triangle[2] << '\n';
+  }
+  for (const auto& edge : edges) {
+    std::cout << "edge " << edge.first << ' ' << edge.second << '\n';
+  }
+  for (const auto& edge : hull_edges) {
+    std::cout << "hull_edge " << edge.first << ' ' << edge.second << '\n';
+  }
+  return 0;
+}
+
+int cocircular_reproduction() {
+  using FT = Kernel::FT;
+  const std::array<Point, 4> sites = {
+      Point(FT(0), FT(0)),
+      Point(FT(2), FT(0)),
+      Point(FT(2), FT(2)),
+      Point(FT(0), FT(2)),
+  };
+  const auto side = CGAL::side_of_oriented_circle(
+      sites[0], sites[1], sites[2], sites[3]);
+  std::cout << "contract " << contract << '\n';
+  std::cout << "cgal_version " << CGAL_VERSION_STR << '\n';
+  std::cout << "kernel Exact_predicates_exact_constructions_kernel\n";
+  std::cout << "semantics REQUIRE_UNIQUE\n";
+  std::cout << "applicable false\n";
+  std::cout << "reason "
+            << (side == CGAL::ON_ORIENTED_BOUNDARY ? "COCIRCULAR" : "PROBE_ERROR")
+            << '\n';
+  return side == CGAL::ON_ORIENTED_BOUNDARY ? 0 : 3;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  if (argc != 2) {
+    return 64;
+  }
+  const std::string mode = argv[1];
+  if (mode == "--version") {
+    std::cout << contract << " CGAL " << CGAL_VERSION_STR << '\n';
+    std::cout << "compiler " << __VERSION__ << '\n';
+    std::cout << "boost " << BOOST_LIB_VERSION << '\n';
+    return 0;
+  }
+  if (mode == "--unique") {
+    return unique_reproduction();
+  }
+  if (mode == "--cocircular") {
+    return cocircular_reproduction();
+  }
+  return 64;
+}

--- a/benchmarks/cgal_delaunay_spike.py
+++ b/benchmarks/cgal_delaunay_spike.py
@@ -1,0 +1,337 @@
+"""Probe a pinned CGAL 6.2 exact-Delaunay spike executable."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import lzma
+import re
+import tarfile
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from jacobian.bounded_process import BoundedProcessResult, run_bounded_process
+
+PIN_PATH = Path(__file__).with_name("cgal_delaunay_pin.json")
+ADAPTER_SOURCE = Path(__file__).with_name("cgal_delaunay_spike.cpp")
+_SOURCE_MEMBERS = (
+    "CGAL-6.2/include/CGAL/version.h",
+    "CGAL-6.2/include/CGAL/Delaunay_triangulation_2.h",
+)
+_ENVIRONMENT = {"LANG": "C", "LC_ALL": "C", "TZ": "UTC"}
+ProcessRunner = Callable[..., BoundedProcessResult]
+
+
+class CgalSpikeError(RuntimeError):
+    def __init__(self, status: str, code: str, detail: str) -> None:
+        super().__init__(detail)
+        self.status = status
+        self.code = code
+        self.detail = detail
+
+
+def _sha256_bytes(payload: bytes) -> str:
+    return f"sha256:{hashlib.sha256(payload).hexdigest()}"
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def _load_pin(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise CgalSpikeError(
+            "ERROR", "INVALID_SPIKE_PIN", "The CGAL spike pin is unavailable."
+        ) from exc
+    if not isinstance(payload, dict) or payload.get("contract") != (
+        "jacobian.cgal-delaunay-spike/v1"
+    ):
+        raise CgalSpikeError(
+            "ERROR", "INVALID_SPIKE_PIN", "The CGAL spike pin is malformed."
+        )
+    return payload
+
+
+def _resolve_file(path: Path, role: str) -> Path:
+    try:
+        resolved = path.expanduser().resolve(strict=True)
+        if not resolved.is_file():
+            raise OSError
+    except OSError as exc:
+        raise CgalSpikeError(
+            "UNAVAILABLE",
+            "PROVIDER_FILE_UNAVAILABLE",
+            f"The explicitly selected {role} file is unavailable.",
+        ) from exc
+    return resolved
+
+
+def _inspect_source_archive(path: Path, pin: Mapping[str, Any]) -> dict[str, Any]:
+    resolved = _resolve_file(path, "CGAL source archive")
+    digest = _sha256_file(resolved)
+    if digest != pin["archive_sha256"]:
+        raise CgalSpikeError(
+            "REJECTED",
+            "SOURCE_VERSION_MISMATCH",
+            "The CGAL source archive does not match the frozen 6.2 digest.",
+        )
+    try:
+        with tarfile.open(resolved, mode="r:xz") as archive:
+            contents: dict[str, bytes] = {}
+            for name in _SOURCE_MEMBERS:
+                member = archive.getmember(name)
+                if not member.isfile() or member.size > 128 * 1024:
+                    raise ValueError("source identity member is invalid")
+                stream = archive.extractfile(member)
+                if stream is None:
+                    raise ValueError("source identity member is unreadable")
+                contents[name] = stream.read()
+    except (KeyError, OSError, lzma.LZMAError, tarfile.TarError, ValueError) as exc:
+        raise CgalSpikeError(
+            "REJECTED",
+            "SOURCE_ARCHIVE_MALFORMED",
+            "The pinned CGAL source archive could not be inspected safely.",
+        ) from exc
+    if (
+        b"#define CGAL_VERSION 6.2" not in contents[_SOURCE_MEMBERS[0]]
+        or b"SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial"
+        not in contents[_SOURCE_MEMBERS[1]]
+    ):
+        raise CgalSpikeError(
+            "REJECTED",
+            "SOURCE_METADATA_MISMATCH",
+            "CGAL version or package-license metadata differs from the pin.",
+        )
+    return {
+        "archive": str(resolved),
+        "archive_sha256": digest,
+        "download_url": pin["download_url"],
+        "manual_url": pin["manual_url"],
+    }
+
+
+def _run_checked(
+    runner: ProcessRunner,
+    command: Sequence[str],
+    *,
+    timeout_seconds: float,
+) -> bytes:
+    try:
+        completed = runner(
+            command,
+            input_bytes=b"",
+            timeout_seconds=timeout_seconds,
+            environment=_ENVIRONMENT,
+            stdout_limit=32_768,
+            stderr_limit=16_384,
+        )
+    except OSError as exc:
+        raise CgalSpikeError(
+            "ERROR", "PROVIDER_LAUNCH_ERROR", "The CGAL spike could not be launched."
+        ) from exc
+    if completed.cancelled:
+        raise CgalSpikeError(
+            "CANCELLED", "PROVIDER_CANCELLED", "The CGAL spike was cancelled."
+        )
+    if completed.timed_out:
+        raise CgalSpikeError("TIMEOUT", "PROVIDER_TIMEOUT", "The CGAL spike timed out.")
+    if completed.stdout_exceeded or completed.stderr_exceeded:
+        raise CgalSpikeError(
+            "ERROR", "PROVIDER_OUTPUT_LIMIT", "The CGAL spike exceeded output bounds."
+        )
+    if completed.returncode != 0:
+        raise CgalSpikeError(
+            "ERROR", "PROVIDER_CRASH", "The CGAL spike exited unsuccessfully."
+        )
+    return completed.stdout
+
+
+def _parse_version(output: bytes, pin: Mapping[str, Any]) -> dict[str, str]:
+    try:
+        lines = output.decode("ascii").splitlines()
+    except UnicodeDecodeError as exc:
+        raise CgalSpikeError(
+            "ERROR", "PROVIDER_OUTPUT_MALFORMED", "The version output is not ASCII."
+        ) from exc
+    expected = f"{pin['contract']} CGAL {pin['version']}"
+    if len(lines) != 3 or lines[0] != expected:
+        raise CgalSpikeError(
+            "REJECTED",
+            "PROVIDER_VERSION_MISMATCH",
+            "The executable does not expose the pinned CGAL spike protocol.",
+        )
+    fields = {}
+    for line, name in zip(lines[1:], ("compiler", "boost"), strict=True):
+        prefix = name + " "
+        if not line.startswith(prefix) or len(line) == len(prefix):
+            raise CgalSpikeError(
+                "ERROR",
+                "PROVIDER_OUTPUT_MALFORMED",
+                "The CGAL toolchain probe is malformed.",
+            )
+        fields[name] = line[len(prefix) :]
+    return fields
+
+
+def _compiler_support(compiler: str, minimum: str) -> str:
+    match = re.match(r"(\d+)\.(\d+)\.(\d+)", compiler)
+    if match is None:
+        return "UNKNOWN_COMPILER"
+    observed = tuple(int(part) for part in match.groups())
+    required = tuple(int(part) for part in minimum.split("."))
+    return "SUPPORTED" if observed >= required else "BELOW_DOCUMENTED_SUPPORT_FLOOR"
+
+
+def run_spike(
+    *,
+    executable: Path,
+    source_archive: Path,
+    timeout_seconds: float = 5,
+    runner: ProcessRunner = run_bounded_process,
+    pin_path: Path = PIN_PATH,
+    adapter_source: Path = ADAPTER_SOURCE,
+) -> dict[str, Any]:
+    try:
+        if timeout_seconds <= 0:
+            raise CgalSpikeError(
+                "ERROR", "INVALID_TIMEOUT", "The CGAL spike timeout must be positive."
+            )
+        pin = _load_pin(pin_path)
+        source = _inspect_source_archive(source_archive, pin)
+        resolved = _resolve_file(executable, "CGAL spike executable")
+        adapter = _resolve_file(adapter_source, "CGAL spike adapter source")
+        adapter_digest = _sha256_file(adapter)
+        if adapter_digest != pin["adapter_source_sha256"]:
+            raise CgalSpikeError(
+                "REJECTED",
+                "ADAPTER_SOURCE_MISMATCH",
+                "The CGAL adapter source does not match the frozen pin.",
+            )
+        toolchain = _parse_version(
+            _run_checked(
+                runner,
+                [str(resolved), "--version"],
+                timeout_seconds=timeout_seconds,
+            ),
+            pin,
+        )
+        observed: dict[str, str] = {}
+        for name in ("unique", "cocircular"):
+            case = pin["reproductions"][name]
+            output = _run_checked(
+                runner,
+                [str(resolved), *case["command"]],
+                timeout_seconds=timeout_seconds,
+            )
+            try:
+                decoded = output.decode("ascii")
+            except UnicodeDecodeError as exc:
+                raise CgalSpikeError(
+                    "ERROR",
+                    "PROVIDER_OUTPUT_MALFORMED",
+                    "CGAL returned non-ASCII reproduction output.",
+                ) from exc
+            if (
+                decoded != case["expected_output"]
+                or _sha256_bytes(output) != case["expected_output_sha256"]
+            ):
+                raise CgalSpikeError(
+                    "REJECTED",
+                    "REPRODUCTION_MISMATCH",
+                    f"The CGAL {name} reproduction differs from the frozen result.",
+                )
+            observed[name] = _sha256_bytes(output)
+        return {
+            "contract": pin["contract"],
+            "status": "COMPLETED",
+            "conclusion": "SPIKE_PASSED_PRODUCTION_DEFERRED",
+            "assurance": "OBSERVED_PROVIDER_BEHAVIOR",
+            "provider": {
+                "name": pin["provider"],
+                "version": pin["version"],
+                "install_tier": "T2",
+                "license": pin["license"],
+                "distribution_decision": "DO_NOT_DISTRIBUTE_WITH_MIT_CORE",
+                "deployment": (
+                    "operator-installed subprocess after license and toolchain review"
+                ),
+                "source": source,
+                "adapter_source_sha256": adapter_digest,
+                "executable": str(resolved),
+                "executable_sha256": _sha256_file(resolved),
+                "toolchain": {
+                    **toolchain,
+                    "documented_gnu_minimum": pin["supported_gnu_compiler_minimum"],
+                    "support": _compiler_support(
+                        toolchain["compiler"],
+                        pin["supported_gnu_compiler_minimum"],
+                    ),
+                },
+            },
+            "reproductions": {
+                "unique": {
+                    **pin["reproductions"]["unique"],
+                    "observed_output_sha256": observed["unique"],
+                },
+                "cocircular": {
+                    **pin["reproductions"]["cocircular"],
+                    "observed_output_sha256": observed["cocircular"],
+                },
+            },
+            "checker_feasibility": {
+                "decision": "REVISE",
+                "independent_exact_replay": "FEASIBLE_WITH_STDLIB_RATIONAL_ARITHMETIC",
+                "open_obligations": [
+                    "bind canonical rational sites, duplicate policy, and degeneracy mode",
+                    "verify triangle orientation, edge incidence, non-crossing, and hull coverage independently",
+                    "replay exact empty-circumcircle predicates for every triangle and site",
+                    "reject cocircular input under REQUIRE_UNIQUE or specify a canonical tie-break",
+                    "keep any Voronoi outcome in a separate capability and artifact",
+                ],
+            },
+            "capability_ids_registered": [],
+            "limitations": [
+                "the reproduction does not authorize CGAL as an independent checker",
+                "source, adapter, and executable digests are measured but lack build attestation",
+                "the local compiler is below the CGAL 6.2 documented GNU support floor",
+            ],
+        }
+    except CgalSpikeError as exc:
+        return {
+            "contract": "jacobian.cgal-delaunay-spike/v1",
+            "status": exc.status,
+            "conclusion": "NO_CONCLUSION",
+            "diagnostic": {"code": exc.code, "detail": exc.detail},
+            "capability_ids_registered": [],
+        }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--executable", type=Path, required=True)
+    parser.add_argument("--source-archive", type=Path, required=True)
+    parser.add_argument("--timeout-seconds", type=float, default=5)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args(argv)
+    report = run_spike(
+        executable=args.executable,
+        source_archive=args.source_archive,
+        timeout_seconds=args.timeout_seconds,
+    )
+    encoded = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output is not None:
+        args.output.write_text(encoded, encoding="utf-8")
+    print(encoded, end="")
+    return 0 if report["status"] == "COMPLETED" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/contributing/cgal-delaunay-provider-spike.md
+++ b/docs/contributing/cgal-delaunay-provider-spike.md
@@ -1,0 +1,102 @@
+# CGAL exact-Delaunay optional-provider spike
+
+This spike tests CGAL 6.2 as a producer for one future atomic outcome:
+the Delaunay triangulation of a bounded set of exact rational 2D sites. It does
+not register a capability, authorize CGAL as a checker, or include Voronoi
+construction in the same outcome.
+
+## Decision
+
+The exact-kernel reproduction passes; a production capability remains
+`REVISE`.
+
+- The producer uses
+  `Exact_predicates_exact_constructions_kernel` and
+  `Delaunay_triangulation_2`.
+- CGAL's 2D Triangulations package is
+  `GPL-3.0-or-later OR LicenseRef-Commercial`. Jacobian must not distribute the
+  GPL adapter executable with its MIT core. Any production deployment needs a
+  recorded legal/licensing decision and should remain an operator-installed
+  T2 subprocess.
+- The local reproduction compiled successfully with GCC 12.2 and Boost 1.74,
+  but CGAL 6.2 documents GNU g++ 13.3 or later as supported. Production images
+  must use a supported toolchain and record it.
+- Exact output remains `COMPUTED` at most. CGAL cannot independently verify its
+  own triangulation.
+
+The [official 6.2 release](https://www.cgal.org/2026/06/11/cgal62/),
+[2D Triangulations manual](https://doc.cgal.org/latest/Triangulation_2/index.html),
+[kernel manual](https://doc.cgal.org/latest/Kernel_23/index.html), and
+[package license inventory](https://doc.cgal.org/latest/Manual/packages.html)
+define the upstream boundary. The frozen source, adapter, commands, and outputs
+are in
+[`benchmarks/cgal_delaunay_pin.json`](../../benchmarks/cgal_delaunay_pin.json).
+
+## Reproduce
+
+Compile the checked-in fixed transport against the official library archive:
+
+```sh
+g++ -std=c++17 -O2 \
+  -I/path/to/CGAL-6.2/include \
+  benchmarks/cgal_delaunay_spike.cpp \
+  -lgmp -lmpfr -o /tmp/cgal-delaunay-spike
+
+uv run python benchmarks/cgal_delaunay_spike.py \
+  --source-archive /path/to/CGAL-6.2-library.tar.xz \
+  --executable /tmp/cgal-delaunay-spike \
+  --output /tmp/cgal-delaunay-provider-spike.json
+```
+
+The runner hashes the official archive, inspects the exact version and
+package-specific SPDX header without extraction, binds the checked-in adapter
+source, measures the executable, probes CGAL/compiler/Boost versions, and runs
+two bounded cases.
+
+The unique case contains six exact rational sites, including a non-integral
+site. It returns five consistently oriented triangles, ten edges, and five
+convex-hull boundary edges. The degenerate case uses four cocircular square
+vertices and returns `applicable false / COCIRCULAR` under `REQUIRE_UNIQUE`.
+
+Missing files, version/source/adapter mismatch, malformed output, timeout,
+cancellation, output overflow, and process crash are non-conclusions.
+
+## Production contract gate
+
+A future `geometry.points.delaunay_triangulation.compute` request must bind:
+
+- canonical exact rational sites and stable site IDs;
+- duplicate handling and at least three non-collinear unique points;
+- bounded site/output size;
+- `REQUIRE_UNIQUE` or a separately specified canonical tie-break;
+- exact-kernel provider identity and adapter/build provenance; and
+- explicit scope, execution, conclusion, completeness, and assurance.
+
+Its result should expose triangles, edges, adjacency, convex-hull boundary,
+orientation convention, empty-circumcircle evidence, and relationships to the
+exact point-set artifact.
+
+An independent checker using rational arithmetic can validate:
+
+1. all triangle IDs refer to input sites and every triangle is non-degenerate
+   and consistently oriented;
+2. edge incidence is one on the hull and two in the interior;
+3. triangle interiors do not cross;
+4. the boundary is the convex hull and triangles cover it;
+5. every other site is outside or on each triangle circumcircle; and
+6. `REQUIRE_UNIQUE` rejects any four cocircular sites.
+
+These checks are feasible without importing or invoking CGAL, but are not part
+of this provider spike. Until they exist and are operator-authorized, no result
+may be `VERIFIED`.
+
+Voronoi construction is a separate outcome. If later implemented, its artifact
+should relate to the Delaunay artifact rather than adding dual geometry to this
+contract.
+
+## Absence isolation
+
+The spike is under `benchmarks/` and is never imported during portfolio,
+kernel, CLI, or MCP startup. The absence test compares the complete catalog
+before and after a missing-provider probe. No capability ID is added or
+removed, and the existing exact planar geometry foundation remains available.

--- a/docs/index.md
+++ b/docs/index.md
@@ -124,6 +124,9 @@ measured test lanes, retained trust-boundary costs, and fast-feedback policy.
 The [nauty/Traces optional-provider spike](contributing/nauty-provider-spike.md)
 records the pinned external-provider reproduction, absence isolation, license
 decision, and unresolved checker gates without registering a capability.
+The [CGAL exact-Delaunay optional-provider spike](contributing/cgal-delaunay-provider-spike.md)
+records the exact-kernel reproduction, GPL/commercial deployment boundary,
+degeneracy semantics, and independent geometry-checker obligations.
 
 Recurring agent work is encoded in the repository-local skills under
 `.agents/skills/`. Start with `develop-math-capabilities` for a complete

--- a/tests/boundary/process/providers/test_cgal_delaunay_spike.py
+++ b/tests/boundary/process/providers/test_cgal_delaunay_spike.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import lzma
+import runpy
+import tarfile
+from collections.abc import Callable, Sequence
+from io import BytesIO
+from pathlib import Path
+from typing import Any, cast
+
+from jacobian.bounded_process import BoundedProcessResult
+
+PROJECT_ROOT = Path(__file__).resolve().parents[4]
+SPIKE = runpy.run_path(str(PROJECT_ROOT / "benchmarks" / "cgal_delaunay_spike.py"))
+BASE_PIN = json.loads(
+    (PROJECT_ROOT / "benchmarks" / "cgal_delaunay_pin.json").read_text(encoding="utf-8")
+)
+RunSpike = Callable[..., dict[str, Any]]
+RUN_SPIKE = cast(RunSpike, SPIKE["run_spike"])
+
+
+def _result(
+    *,
+    stdout: bytes = b"",
+    returncode: int | None = 0,
+    timed_out: bool = False,
+) -> BoundedProcessResult:
+    return BoundedProcessResult(
+        returncode=returncode,
+        stdout=stdout,
+        stderr=b"",
+        stdout_exceeded=False,
+        stderr_exceeded=False,
+        timed_out=timed_out,
+    )
+
+
+def _runner(
+    outcomes: Sequence[BoundedProcessResult],
+) -> Callable[..., BoundedProcessResult]:
+    remaining = iter(outcomes)
+
+    def run(*_args: object, **_kwargs: object) -> BoundedProcessResult:
+        return next(remaining)
+
+    return run
+
+
+def _fixture(tmp_path: Path) -> tuple[Path, Path, Path, Path]:
+    executable = tmp_path / "cgal-spike"
+    adapter = tmp_path / "cgal-spike.cpp"
+    executable.touch()
+    adapter.write_text("// fixture\n", encoding="utf-8")
+    archive = tmp_path / "CGAL-6.2-library.tar.xz"
+    with tarfile.open(archive, mode="w:xz") as bundle:
+        members = (
+            (
+                "CGAL-6.2/include/CGAL/version.h",
+                b"#define CGAL_VERSION 6.2\n",
+            ),
+            (
+                "CGAL-6.2/include/CGAL/Delaunay_triangulation_2.h",
+                (
+                    b"SPDX-License-Identifier: GPL-3.0-or-later "
+                    b"OR LicenseRef-Commercial\n"
+                ),
+            ),
+        )
+        for name, payload in members:
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            info.mtime = 0
+            bundle.addfile(info, BytesIO(payload))
+    pin = {
+        **BASE_PIN,
+        "archive_sha256": "sha256:" + hashlib.sha256(archive.read_bytes()).hexdigest(),
+        "adapter_source_sha256": (
+            "sha256:" + hashlib.sha256(adapter.read_bytes()).hexdigest()
+        ),
+    }
+    pin_path = tmp_path / "pin.json"
+    pin_path.write_text(json.dumps(pin), encoding="utf-8")
+    return executable, archive, adapter, pin_path
+
+
+def _successes() -> list[BoundedProcessResult]:
+    return [
+        _result(
+            stdout=(
+                b"jacobian.cgal-delaunay-spike/v1 CGAL 6.2\n"
+                b"compiler 13.3.0\n"
+                b"boost 1_79\n"
+            )
+        ),
+        _result(stdout=BASE_PIN["reproductions"]["unique"]["expected_output"].encode()),
+        _result(
+            stdout=BASE_PIN["reproductions"]["cocircular"]["expected_output"].encode()
+        ),
+    ]
+
+
+def test_exact_delaunay_spike_passes_but_defers_production(tmp_path: Path) -> None:
+    executable, archive, adapter, pin = _fixture(tmp_path)
+
+    report = RUN_SPIKE(
+        executable=executable,
+        source_archive=archive,
+        adapter_source=adapter,
+        pin_path=pin,
+        runner=_runner(_successes()),
+    )
+
+    assert report["status"] == "COMPLETED"
+    assert report["conclusion"] == "SPIKE_PASSED_PRODUCTION_DEFERRED"
+    assert report["provider"]["license"]["open_source_id"] == "GPL-3.0-or-later"
+    assert report["provider"]["distribution_decision"] == (
+        "DO_NOT_DISTRIBUTE_WITH_MIT_CORE"
+    )
+    assert report["provider"]["toolchain"]["support"] == "SUPPORTED"
+    assert report["checker_feasibility"]["decision"] == "REVISE"
+    assert report["capability_ids_registered"] == []
+
+
+def test_absent_provider_is_an_explicit_non_conclusion(tmp_path: Path) -> None:
+    _executable, archive, adapter, pin = _fixture(tmp_path)
+
+    report = RUN_SPIKE(
+        executable=tmp_path / "absent-cgal-spike",
+        source_archive=archive,
+        adapter_source=adapter,
+        pin_path=pin,
+    )
+
+    assert report["status"] == "UNAVAILABLE"
+    assert report["conclusion"] == "NO_CONCLUSION"
+    assert report["diagnostic"]["code"] == "PROVIDER_FILE_UNAVAILABLE"
+    assert report["capability_ids_registered"] == []
+
+
+def test_source_version_mismatch_fails_before_execution(tmp_path: Path) -> None:
+    executable, archive, adapter, _pin = _fixture(tmp_path)
+
+    report = RUN_SPIKE(
+        executable=executable,
+        source_archive=archive,
+        adapter_source=adapter,
+    )
+
+    assert report["status"] == "REJECTED"
+    assert report["diagnostic"]["code"] == "SOURCE_VERSION_MISMATCH"
+
+
+def test_protocol_version_and_malformed_result_fail_closed(tmp_path: Path) -> None:
+    executable, archive, adapter, pin = _fixture(tmp_path)
+    wrong_version = RUN_SPIKE(
+        executable=executable,
+        source_archive=archive,
+        adapter_source=adapter,
+        pin_path=pin,
+        runner=_runner([_result(stdout=b"CGAL 6.1\n")]),
+    )
+    malformed = RUN_SPIKE(
+        executable=executable,
+        source_archive=archive,
+        adapter_source=adapter,
+        pin_path=pin,
+        runner=_runner(
+            [
+                _successes()[0],
+                _result(stdout=b"partial triangulation\n"),
+            ]
+        ),
+    )
+
+    assert wrong_version["diagnostic"]["code"] == "PROVIDER_VERSION_MISMATCH"
+    assert malformed["diagnostic"]["code"] == "REPRODUCTION_MISMATCH"
+    assert wrong_version["conclusion"] == malformed["conclusion"] == "NO_CONCLUSION"
+
+
+def test_timeout_and_crash_are_distinct_non_conclusions(tmp_path: Path) -> None:
+    executable, archive, adapter, pin = _fixture(tmp_path)
+    timed_out = RUN_SPIKE(
+        executable=executable,
+        source_archive=archive,
+        adapter_source=adapter,
+        pin_path=pin,
+        runner=_runner([_result(timed_out=True)]),
+    )
+    crashed = RUN_SPIKE(
+        executable=executable,
+        source_archive=archive,
+        adapter_source=adapter,
+        pin_path=pin,
+        runner=_runner([_result(returncode=9)]),
+    )
+
+    assert (timed_out["status"], timed_out["diagnostic"]["code"]) == (
+        "TIMEOUT",
+        "PROVIDER_TIMEOUT",
+    )
+    assert (crashed["status"], crashed["diagnostic"]["code"]) == (
+        "ERROR",
+        "PROVIDER_CRASH",
+    )
+
+
+def test_malformed_xz_archive_does_not_escape_as_an_exception(
+    tmp_path: Path,
+) -> None:
+    executable = tmp_path / "cgal-spike"
+    adapter = tmp_path / "adapter.cpp"
+    archive = tmp_path / "CGAL-6.2-library.tar.xz"
+    executable.touch()
+    adapter.touch()
+    archive.write_bytes(lzma.compress(b"not a tar archive"))
+    pin = {
+        **BASE_PIN,
+        "archive_sha256": "sha256:" + hashlib.sha256(archive.read_bytes()).hexdigest(),
+    }
+    pin_path = tmp_path / "pin.json"
+    pin_path.write_text(json.dumps(pin), encoding="utf-8")
+
+    report = RUN_SPIKE(
+        executable=executable,
+        source_archive=archive,
+        adapter_source=adapter,
+        pin_path=pin_path,
+    )
+
+    assert report["status"] == "REJECTED"
+    assert report["diagnostic"]["code"] == "SOURCE_ARCHIVE_MALFORMED"

--- a/tests/composition/runtime/test_cgal_delaunay_spike_isolation.py
+++ b/tests/composition/runtime/test_cgal_delaunay_spike_isolation.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import runpy
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, cast
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+SPIKE = runpy.run_path(str(PROJECT_ROOT / "benchmarks" / "cgal_delaunay_spike.py"))
+RunSpike = Callable[..., dict[str, Any]]
+RUN_SPIKE = cast(RunSpike, SPIKE["run_spike"])
+
+
+def test_absent_cgal_spike_does_not_change_complete_runtime_catalog(
+    fresh_complete_runtime,
+    tmp_path: Path,
+) -> None:
+    before = fresh_complete_runtime.core.capabilities.catalog().model_dump(mode="json")
+
+    report = RUN_SPIKE(
+        executable=tmp_path / "absent-cgal-spike",
+        source_archive=tmp_path / "absent-CGAL-6.2.tar.xz",
+    )
+
+    after = fresh_complete_runtime.core.capabilities.catalog().model_dump(mode="json")
+    assert report["status"] == "UNAVAILABLE"
+    assert report["capability_ids_registered"] == []
+    assert after == before


### PR DESCRIPTION
## Outcome

Adds an auditable CGAL 6.2 exact-Delaunay provider spike without registering a capability or checker.

- Freezes the official 6.2 library archive, package-specific license, checked-in C++ transport, and exact bounded outputs.
- Uses `Exact_predicates_exact_constructions_kernel` with `Delaunay_triangulation_2`.
- Reproduces a unique six-site rational Delaunay triangulation and rejects a cocircular square under `REQUIRE_UNIQUE`.
- Exercises absent, source/version/adapter mismatch, malformed output, timeout, crash, and complete-catalog isolation.
- Keeps the future production contract at `REVISE` with independent rational checker obligations.

## License and deployment decision

The CGAL 2D Triangulations header is `GPL-3.0-or-later OR LicenseRef-Commercial`. Do not distribute the adapter binary with Jacobian MIT core. A future provider must remain an operator-installed T2 subprocess after an explicit GPL/commercial licensing review.

CGAL 6.2 documents GNU g++ 13.3 or later. The local fixed reproduction compiled and passed under GCC 12.2 / Boost 1.74, but the report records `BELOW_DOCUMENTED_SUPPORT_FLOOR`; production images must use a supported pinned toolchain.

## Real provider reproduction

- official library archive: `sha256:f75d2b2486842fb47222c780c7241c262d392802d0811143c4e9b539972ee55b`
- checked-in adapter source: `sha256:7f063945328bf766d981c3a55df07de4adb659d2c86fde9653179c7644112886`
- local executable: `sha256:27e62cbf10cbd5c938cabe90636e279804a5685bfc10aba91316625963d97355`
- unique output (5 triangles, 10 edges, 5 hull edges): `sha256:a1cecc8c3781dfd8626e62da3d2ff4a4f974b31a3cb19c4baa23db0d11741ce9`
- cocircular non-applicability output: `sha256:4260fdbc095751f5a880778590d0b0d5217f1042a61e14eb212320c390213372`
- result: `COMPLETED / SPIKE_PASSED_PRODUCTION_DEFERRED`

## Validation

Post-rebase clean receipts bind head `235378e5c6527fb37952c7c70d332eba0abf17fe` to tree digest `sha256:341bfa0b4fcf827ea36bcfb38ce126a812928fc45f3faa9ffe910c8899a50a31`, with `dirty=false`, unchanged tree, and exit 0.

- `make check` (29.87s; Ruff, format, mypy, 288 unit tests)
- `make test-process TESTS=tests/boundary/process/providers/test_cgal_delaunay_spike.py` (6 tests, 5.96s)
- `make test-composition TESTS=tests/composition/runtime/test_cgal_delaunay_spike_isolation.py` (1 test, 14.39s)
- `make check-static`
- `make docs-linkcheck`

## Capability-development handoff

- git tree: `235378e5c6527fb37952c7c70d332eba0abf17fe`
- installed catalog: 249 entries, `sha256:b58e07e4eef94af4507d98fa9a5647e2a249399ee0767bebef5f7a6397ffa645`
- policy: `DEFAULT`, `sha256:870a92b83d3e522e4015b6bb1cabda33086906f9de1c3c36e466251ea7ed1957`
- provider/runtime state: official CGAL 6.2 source and local fixed executable measured; no CGAL capability installed
- model/prompt settings: not applicable; deterministic executable reproduction only
- raw local trace: `/tmp/jcb-cgal-provider-spike.json`; portable pin, source, and decision are checked in
- unresolved obligations: licensing decision, supported compiler image, source-to-binary build attestation, rational-site/duplicate/degeneracy binding, independent orientation/incidence/non-crossing/hull/empty-circle replay, and separate Voronoi semantics
- next action: keep the provider spike; do not propose a production capability until deployment and checker gates are resolved
