### PR TITLE
feat(providers): spike GUDHI persistent homology provider

### DIFF
--- a/benchmarks/gudhi_persistence_pin.json
+++ b/benchmarks/gudhi_persistence_pin.json
@@ -1,0 +1,258 @@
+{
+  "adapter_source_sha256": "sha256:1b3a6aedc33fc017abb7300ba500f6debcfe662de0e9b90b08b0fd5b2750b2fc",
+  "contract": "jacobian.gudhi-persistence-spike/v1",
+  "documentation_url": "https://gudhi.inria.fr/python/3.13.0/simplex_tree_ref.html",
+  "licensing_url": "https://gudhi.inria.fr/licensing/",
+  "provider": "gudhi",
+  "reproduction": {
+    "coefficient_prime": 2,
+    "expected_mathematical_output_sha256": "sha256:f57b4969027b4dd6ab6c6ff66b841d9dda3348f5eb00f04d200b38e6a02b17e9",
+    "expected_provider_output": {
+      "contract": "jacobian.gudhi-persistence-spike/v1",
+      "filtration": [
+        {
+          "rank": 0,
+          "simplex_id": "v0"
+        },
+        {
+          "rank": 1,
+          "simplex_id": "v1"
+        },
+        {
+          "rank": 2,
+          "simplex_id": "v2"
+        },
+        {
+          "rank": 3,
+          "simplex_id": "v3"
+        },
+        {
+          "rank": 4,
+          "simplex_id": "e01"
+        },
+        {
+          "rank": 5,
+          "simplex_id": "e12"
+        },
+        {
+          "rank": 6,
+          "simplex_id": "e23"
+        },
+        {
+          "rank": 7,
+          "simplex_id": "e03"
+        },
+        {
+          "rank": 8,
+          "simplex_id": "e02"
+        },
+        {
+          "rank": 9,
+          "simplex_id": "t012"
+        },
+        {
+          "rank": 10,
+          "simplex_id": "t023"
+        }
+      ],
+      "pairs": [
+        {
+          "birth_exact_value": "-2/3",
+          "birth_rank": 0,
+          "birth_simplex_id": "v0",
+          "death": {
+            "kind": "INFINITE"
+          },
+          "dimension": 0
+        },
+        {
+          "birth_exact_value": "1/7",
+          "birth_rank": 1,
+          "birth_simplex_id": "v1",
+          "death": {
+            "exact_value": "5/11",
+            "kind": "FINITE",
+            "rank": 4,
+            "simplex_id": "e01"
+          },
+          "dimension": 0
+        },
+        {
+          "birth_exact_value": "2/7",
+          "birth_rank": 2,
+          "birth_simplex_id": "v2",
+          "death": {
+            "exact_value": "7/13",
+            "kind": "FINITE",
+            "rank": 5,
+            "simplex_id": "e12"
+          },
+          "dimension": 0
+        },
+        {
+          "birth_exact_value": "1/3",
+          "birth_rank": 3,
+          "birth_simplex_id": "v3",
+          "death": {
+            "exact_value": "3/5",
+            "kind": "FINITE",
+            "rank": 6,
+            "simplex_id": "e23"
+          },
+          "dimension": 0
+        },
+        {
+          "birth_exact_value": "2/3",
+          "birth_rank": 7,
+          "birth_simplex_id": "e03",
+          "death": {
+            "exact_value": "8/9",
+            "kind": "FINITE",
+            "rank": 10,
+            "simplex_id": "t023"
+          },
+          "dimension": 1
+        },
+        {
+          "birth_exact_value": "5/7",
+          "birth_rank": 8,
+          "birth_simplex_id": "e02",
+          "death": {
+            "exact_value": "11/13",
+            "kind": "FINITE",
+            "rank": 9,
+            "simplex_id": "t012"
+          },
+          "dimension": 1
+        }
+      ],
+      "provider": "gudhi",
+      "version": "3.13.0"
+    },
+    "scope": "eleven simplices of a filtered triangulated square over F_2 with unique exact rational filtration values",
+    "simplices": [
+      {
+        "exact_value": "-2/3",
+        "rank": 0,
+        "simplex_id": "v0",
+        "vertices": [
+          0
+        ]
+      },
+      {
+        "exact_value": "1/7",
+        "rank": 1,
+        "simplex_id": "v1",
+        "vertices": [
+          1
+        ]
+      },
+      {
+        "exact_value": "2/7",
+        "rank": 2,
+        "simplex_id": "v2",
+        "vertices": [
+          2
+        ]
+      },
+      {
+        "exact_value": "1/3",
+        "rank": 3,
+        "simplex_id": "v3",
+        "vertices": [
+          3
+        ]
+      },
+      {
+        "exact_value": "5/11",
+        "rank": 4,
+        "simplex_id": "e01",
+        "vertices": [
+          0,
+          1
+        ]
+      },
+      {
+        "exact_value": "7/13",
+        "rank": 5,
+        "simplex_id": "e12",
+        "vertices": [
+          1,
+          2
+        ]
+      },
+      {
+        "exact_value": "3/5",
+        "rank": 6,
+        "simplex_id": "e23",
+        "vertices": [
+          2,
+          3
+        ]
+      },
+      {
+        "exact_value": "2/3",
+        "rank": 7,
+        "simplex_id": "e03",
+        "vertices": [
+          0,
+          3
+        ]
+      },
+      {
+        "exact_value": "5/7",
+        "rank": 8,
+        "simplex_id": "e02",
+        "vertices": [
+          0,
+          2
+        ]
+      },
+      {
+        "exact_value": "11/13",
+        "rank": 9,
+        "simplex_id": "t012",
+        "vertices": [
+          0,
+          1,
+          2
+        ]
+      },
+      {
+        "exact_value": "8/9",
+        "rank": 10,
+        "simplex_id": "t023",
+        "vertices": [
+          0,
+          2,
+          3
+        ]
+      }
+    ]
+  },
+  "source": {
+    "archive_sha256": "sha256:7640d716d6a118b7787602826e4144bfa1ad5903a31f4a760a7f3a1e68cfdc02",
+    "download_url": "https://github.com/GUDHI/gudhi-devel/archive/refs/tags/tags/gudhi-release-3.13.0.tar.gz",
+    "module_licenses": {
+      "persistent_cohomology": {
+        "header_sha256": "sha256:609291768ea884def951198f9a6f7d03acebbcbaae36eadf577b32881bf75680",
+        "license_id": "MIT"
+      },
+      "simplex_tree": {
+        "header_sha256": "sha256:81f7e4c1d21107afd62fa7f9e97f4cb6c2a3a238ad315fd9412b10b1bab356ce",
+        "license_id": "MIT"
+      }
+    },
+    "tag": "tags/gudhi-release-3.13.0",
+    "tag_commit": "5dbe510bed5d8d700ec7243fd915769fb67964a2"
+  },
+  "version": "3.13.0",
+  "wheel": {
+    "download_url": "https://files.pythonhosted.org/packages/02/fb/fad8db68c325617708b8033f196c09633fea0962c0878ccc73571ce889b2/gudhi-3.13.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+    "filename": "gudhi-3.13.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+    "license_member": "gudhi-3.13.0.dist-info/licenses/LICENSE",
+    "license_sha256": "sha256:ff415502301c693d016ef554143fdae8a2489e73f1ca06ad336dc2867d6ef544",
+    "metadata_member": "gudhi-3.13.0.dist-info/METADATA",
+    "sha256": "sha256:d7ce52905d147a7e599607758843c7f37525c98e7aeaca87cbbbcbd3adb71598"
+  }
+}

--- a/benchmarks/gudhi_persistence_spike.py
+++ b/benchmarks/gudhi_persistence_spike.py
@@ -1,0 +1,668 @@
+"""Probe a pinned GUDHI persistent-homology optional-provider candidate."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+import tarfile
+import zipfile
+from collections.abc import Callable, Mapping, Sequence
+from fractions import Fraction
+from pathlib import Path
+from typing import Any
+
+PIN_PATH = Path(__file__).with_name("gudhi_persistence_pin.json")
+ADAPTER_SOURCE = Path(__file__)
+_SOURCE_ROOT = "gudhi-devel-tags-gudhi-release-3.13.0"
+_SOURCE_MEMBERS = {
+    "simplex_tree": (f"{_SOURCE_ROOT}/src/Simplex_tree/include/gudhi/Simplex_tree.h"),
+    "persistent_cohomology": (
+        f"{_SOURCE_ROOT}/src/Persistent_cohomology/include/gudhi/"
+        "Persistent_cohomology.h"
+    ),
+}
+_ENVIRONMENT = {"LANG": "C", "LC_ALL": "C", "TZ": "UTC"}
+ProcessRunner = Callable[..., Any]
+
+
+def _default_runner(*args: object, **kwargs: object) -> Any:
+    from jacobian.bounded_process import run_bounded_process
+
+    return run_bounded_process(*args, **kwargs)
+
+
+class GudhiSpikeError(RuntimeError):
+    """A typed non-conclusion from the optional-provider spike."""
+
+    def __init__(self, status: str, code: str, detail: str) -> None:
+        super().__init__(detail)
+        self.status = status
+        self.code = code
+        self.detail = detail
+
+
+def _sha256_bytes(payload: bytes) -> str:
+    return f"sha256:{hashlib.sha256(payload).hexdigest()}"
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def _canonical_json(payload: object) -> bytes:
+    return (
+        json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+        + "\n"
+    ).encode("ascii")
+
+
+def _load_pin(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise GudhiSpikeError(
+            "ERROR", "INVALID_SPIKE_PIN", "The GUDHI spike pin is unavailable."
+        ) from exc
+    if (
+        not isinstance(payload, dict)
+        or payload.get("contract") != "jacobian.gudhi-persistence-spike/v1"
+    ):
+        raise GudhiSpikeError(
+            "ERROR", "INVALID_SPIKE_PIN", "The GUDHI spike pin is malformed."
+        )
+    return payload
+
+
+def _resolve_file(path: Path, role: str) -> Path:
+    try:
+        resolved = path.expanduser().resolve(strict=True)
+        if not resolved.is_file():
+            raise OSError
+    except OSError as exc:
+        raise GudhiSpikeError(
+            "UNAVAILABLE",
+            "PROVIDER_FILE_UNAVAILABLE",
+            f"The explicitly selected {role} file is unavailable.",
+        ) from exc
+    return resolved
+
+
+def _resolve_interpreter(path: Path) -> Path:
+    """Keep a venv launcher path while validating its resolved target."""
+    selected = path.expanduser().absolute()
+    try:
+        target = selected.resolve(strict=True)
+        if not selected.is_file() or not target.is_file():
+            raise OSError
+    except OSError as exc:
+        raise GudhiSpikeError(
+            "UNAVAILABLE",
+            "PROVIDER_FILE_UNAVAILABLE",
+            "The explicitly selected GUDHI Python interpreter is unavailable.",
+        ) from exc
+    return selected
+
+
+def _inspect_source_archive(path: Path, pin: Mapping[str, Any]) -> dict[str, Any]:
+    resolved = _resolve_file(path, "GUDHI source archive")
+    digest = _sha256_file(resolved)
+    source_pin = pin["source"]
+    if digest != source_pin["archive_sha256"]:
+        raise GudhiSpikeError(
+            "REJECTED",
+            "SOURCE_VERSION_MISMATCH",
+            "The GUDHI source archive does not match the frozen 3.13.0 digest.",
+        )
+    try:
+        with tarfile.open(resolved, mode="r:gz") as archive:
+            contents: dict[str, bytes] = {}
+            for role, member_name in _SOURCE_MEMBERS.items():
+                member = archive.getmember(member_name)
+                if not member.isfile() or member.size > 512 * 1024:
+                    raise ValueError("source identity member is invalid")
+                stream = archive.extractfile(member)
+                if stream is None:
+                    raise ValueError("source identity member is unreadable")
+                contents[role] = stream.read()
+    except (KeyError, OSError, tarfile.TarError, ValueError) as exc:
+        raise GudhiSpikeError(
+            "REJECTED",
+            "SOURCE_ARCHIVE_MALFORMED",
+            "The pinned GUDHI source archive could not be inspected safely.",
+        ) from exc
+
+    module_pins = source_pin["module_licenses"]
+    for role, payload in contents.items():
+        expected = module_pins[role]
+        if (
+            _sha256_bytes(payload) != expected["header_sha256"]
+            or b"released under MIT" not in payload[:1024]
+            or expected["license_id"] != "MIT"
+        ):
+            raise GudhiSpikeError(
+                "REJECTED",
+                "SOURCE_METADATA_MISMATCH",
+                f"The GUDHI {role} module license differs from the pin.",
+            )
+    return {
+        "archive": str(resolved),
+        "archive_sha256": digest,
+        "download_url": source_pin["download_url"],
+        "tag": source_pin["tag"],
+        "tag_commit": source_pin["tag_commit"],
+        "module_licenses": module_pins,
+    }
+
+
+def _inspect_wheel(path: Path, pin: Mapping[str, Any]) -> dict[str, Any]:
+    resolved = _resolve_file(path, "GUDHI CPython 3.12 wheel")
+    wheel_pin = pin["wheel"]
+    digest = _sha256_file(resolved)
+    if resolved.name != wheel_pin["filename"] or digest != wheel_pin["sha256"]:
+        raise GudhiSpikeError(
+            "REJECTED",
+            "WHEEL_VERSION_MISMATCH",
+            "The GUDHI wheel filename or digest differs from the CPython 3.12 pin.",
+        )
+    try:
+        with zipfile.ZipFile(resolved) as archive:
+            license_payload = archive.read(wheel_pin["license_member"])
+            metadata = archive.read(wheel_pin["metadata_member"])
+    except (KeyError, OSError, zipfile.BadZipFile, RuntimeError) as exc:
+        raise GudhiSpikeError(
+            "REJECTED",
+            "WHEEL_MALFORMED",
+            "The pinned GUDHI wheel could not be inspected safely.",
+        ) from exc
+    if (
+        _sha256_bytes(license_payload) != wheel_pin["license_sha256"]
+        or not license_payload.startswith(b"MIT License\n")
+        or b"Name: gudhi\n" not in metadata
+        or f"Version: {pin['version']}\n".encode() not in metadata
+        or b"Requires-Python: >=3.10\n" not in metadata
+    ):
+        raise GudhiSpikeError(
+            "REJECTED",
+            "WHEEL_METADATA_MISMATCH",
+            "The GUDHI wheel metadata or license differs from the pin.",
+        )
+    return {
+        "path": str(resolved),
+        "filename": resolved.name,
+        "sha256": digest,
+        "download_url": wheel_pin["download_url"],
+        "python_tag": "cp312",
+        "platform_tag": "manylinux_2_27_x86_64.manylinux_2_28_x86_64",
+        "license_id": "MIT",
+        "license_member": wheel_pin["license_member"],
+        "license_sha256": wheel_pin["license_sha256"],
+    }
+
+
+def _validate_reproduction(pin: Mapping[str, Any]) -> list[dict[str, Any]]:
+    reproduction = pin["reproduction"]
+    simplices = reproduction["simplices"]
+    if (
+        reproduction.get("coefficient_prime") not in {2, 3, 5, 7}
+        or not isinstance(simplices, list)
+        or not 1 <= len(simplices) <= 64
+    ):
+        raise GudhiSpikeError(
+            "ERROR", "INVALID_SPIKE_PIN", "The frozen persistence case is invalid."
+        )
+    ids: set[str] = set()
+    vertices_to_rank: dict[tuple[int, ...], int] = {}
+    previous_value: Fraction | None = None
+    for expected_rank, item in enumerate(simplices):
+        try:
+            simplex_id = item["simplex_id"]
+            vertices = tuple(item["vertices"])
+            rank = item["rank"]
+            value = Fraction(item["exact_value"])
+        except (KeyError, TypeError, ValueError, ZeroDivisionError) as exc:
+            raise GudhiSpikeError(
+                "ERROR", "INVALID_SPIKE_PIN", "A frozen simplex is malformed."
+            ) from exc
+        if (
+            not isinstance(simplex_id, str)
+            or not simplex_id
+            or simplex_id in ids
+            or rank != expected_rank
+            or not vertices
+            or tuple(sorted(set(vertices))) != vertices
+            or (previous_value is not None and value <= previous_value)
+        ):
+            raise GudhiSpikeError(
+                "ERROR", "INVALID_SPIKE_PIN", "The frozen filtration is not canonical."
+            )
+        for face_index in range(len(vertices)):
+            face = vertices[:face_index] + vertices[face_index + 1 :]
+            if face and face not in vertices_to_rank:
+                raise GudhiSpikeError(
+                    "ERROR",
+                    "INVALID_SPIKE_PIN",
+                    "A frozen simplex appears before one of its faces.",
+                )
+        ids.add(simplex_id)
+        vertices_to_rank[vertices] = rank
+        previous_value = value
+    return simplices
+
+
+def _run_checked(
+    runner: ProcessRunner,
+    command: Sequence[str],
+    *,
+    timeout_seconds: float,
+) -> bytes:
+    try:
+        completed = runner(
+            command,
+            input_bytes=b"",
+            timeout_seconds=timeout_seconds,
+            environment=_ENVIRONMENT,
+            stdout_limit=64 * 1024,
+            stderr_limit=16 * 1024,
+        )
+    except OSError as exc:
+        raise GudhiSpikeError(
+            "ERROR", "PROVIDER_LAUNCH_ERROR", "The GUDHI spike could not be launched."
+        ) from exc
+    if completed.cancelled:
+        raise GudhiSpikeError(
+            "CANCELLED", "PROVIDER_CANCELLED", "The GUDHI spike was cancelled."
+        )
+    if completed.timed_out:
+        raise GudhiSpikeError(
+            "TIMEOUT", "PROVIDER_TIMEOUT", "The GUDHI spike timed out."
+        )
+    if completed.stdout_exceeded or completed.stderr_exceeded:
+        raise GudhiSpikeError(
+            "ERROR", "PROVIDER_OUTPUT_LIMIT", "The GUDHI spike exceeded output bounds."
+        )
+    if completed.returncode != 0:
+        raise GudhiSpikeError(
+            "ERROR", "PROVIDER_CRASH", "The GUDHI spike exited unsuccessfully."
+        )
+    return completed.stdout
+
+
+def _parse_provider_output(output: bytes, pin: Mapping[str, Any]) -> dict[str, Any]:
+    try:
+        payload = json.loads(output.decode("ascii"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise GudhiSpikeError(
+            "ERROR",
+            "PROVIDER_OUTPUT_MALFORMED",
+            "The GUDHI provider output is not canonical ASCII JSON.",
+        ) from exc
+    if not isinstance(payload, dict):
+        raise GudhiSpikeError(
+            "ERROR", "PROVIDER_OUTPUT_MALFORMED", "The GUDHI output is not an object."
+        )
+    if (
+        payload.get("contract") != pin["contract"]
+        or payload.get("provider") != pin["provider"]
+        or payload.get("version") != pin["version"]
+    ):
+        raise GudhiSpikeError(
+            "REJECTED",
+            "PROVIDER_VERSION_MISMATCH",
+            "The interpreter does not expose the pinned GUDHI spike protocol.",
+        )
+    runtime = payload.get("runtime")
+    if (
+        not isinstance(runtime, dict)
+        or runtime.get("gudhi") != pin["version"]
+        or not isinstance(runtime.get("python"), str)
+        or not runtime["python"].startswith("3.12.")
+        or not isinstance(runtime.get("numpy"), str)
+        or not runtime["numpy"]
+    ):
+        raise GudhiSpikeError(
+            "REJECTED",
+            "PROVIDER_RUNTIME_MISMATCH",
+            "The GUDHI worker is not running in the pinned CPython 3.12 boundary.",
+        )
+    expected = pin["reproduction"]["expected_provider_output"]
+    mathematical_output = {
+        key: value for key, value in payload.items() if key != "runtime"
+    }
+    if (
+        mathematical_output != expected
+        or _sha256_bytes(_canonical_json(mathematical_output))
+        != pin["reproduction"]["expected_mathematical_output_sha256"]
+    ):
+        raise GudhiSpikeError(
+            "REJECTED",
+            "REPRODUCTION_MISMATCH",
+            "GUDHI did not reproduce the frozen exact-rank persistence pairing.",
+        )
+    return payload
+
+
+def _mod_inverse(value: int, prime: int) -> int:
+    return pow(value, -1, prime)
+
+
+def _independent_reduction(
+    simplices: Sequence[Mapping[str, Any]], prime: int
+) -> dict[str, Any]:
+    """Reduce the boundary matrix without importing or calling GUDHI."""
+    index_by_vertices = {
+        tuple(item["vertices"]): index for index, item in enumerate(simplices)
+    }
+    reduced_columns: list[dict[int, int]] = []
+    pivot_to_column: dict[int, int] = {}
+    ledger: list[dict[str, Any]] = []
+
+    for column_index, item in enumerate(simplices):
+        vertices = tuple(item["vertices"])
+        column: dict[int, int] = {}
+        for removed in range(len(vertices)):
+            face = vertices[:removed] + vertices[removed + 1 :]
+            if not face:
+                continue
+            row = index_by_vertices[face]
+            coefficient = 1 if removed % 2 == 0 else prime - 1
+            column[row] = coefficient
+        while column and max(column) in pivot_to_column:
+            pivot = max(column)
+            previous = reduced_columns[pivot_to_column[pivot]]
+            scale = column[pivot] * _mod_inverse(previous[pivot], prime) % prime
+            for row, coefficient in previous.items():
+                updated = (column.get(row, 0) - scale * coefficient) % prime
+                if updated:
+                    column[row] = updated
+                else:
+                    column.pop(row, None)
+        pivot = max(column) if column else None
+        if pivot is not None:
+            pivot_to_column[pivot] = column_index
+        reduced_columns.append(column)
+        ledger.append(
+            {
+                "column_simplex_id": item["simplex_id"],
+                "pivot_simplex_id": (
+                    simplices[pivot]["simplex_id"] if pivot is not None else None
+                ),
+                "reduced_entries": [
+                    {
+                        "simplex_id": simplices[row]["simplex_id"],
+                        "coefficient": coefficient,
+                    }
+                    for row, coefficient in sorted(column.items())
+                ],
+            }
+        )
+
+    pairs: list[dict[str, Any]] = []
+    for birth_index, item in enumerate(simplices):
+        if reduced_columns[birth_index]:
+            continue
+        death_index = pivot_to_column.get(birth_index)
+        pair = {
+            "dimension": len(item["vertices"]) - 1,
+            "birth_simplex_id": item["simplex_id"],
+            "birth_rank": item["rank"],
+            "birth_exact_value": item["exact_value"],
+            "death": {"kind": "INFINITE"},
+        }
+        if death_index is not None:
+            death = simplices[death_index]
+            pair["death"] = {
+                "kind": "FINITE",
+                "simplex_id": death["simplex_id"],
+                "rank": death["rank"],
+                "exact_value": death["exact_value"],
+            }
+        pairs.append(pair)
+    pairs.sort(
+        key=lambda pair: (
+            pair["dimension"],
+            pair["birth_rank"],
+            pair["death"].get("rank", len(simplices)),
+        )
+    )
+    return {
+        "algorithm": "STDLIB_MOD_P_BOUNDARY_COLUMN_REDUCTION",
+        "coefficient_prime": prime,
+        "pairs": pairs,
+        "reduced_columns": ledger,
+    }
+
+
+def run_spike(
+    *,
+    python_executable: Path,
+    wheel: Path,
+    source_archive: Path,
+    timeout_seconds: float = 10,
+    runner: ProcessRunner = _default_runner,
+    pin_path: Path = PIN_PATH,
+    adapter_source: Path = ADAPTER_SOURCE,
+) -> dict[str, Any]:
+    """Run the bounded provider reproduction and independent exact replay."""
+    try:
+        pin = _load_pin(pin_path)
+        resolved_python = _resolve_interpreter(python_executable)
+        source = _inspect_source_archive(source_archive, pin)
+        wheel_identity = _inspect_wheel(wheel, pin)
+        simplices = _validate_reproduction(pin)
+        resolved_adapter = _resolve_file(adapter_source, "GUDHI spike adapter")
+        adapter_digest = _sha256_file(resolved_adapter)
+        if adapter_digest != pin["adapter_source_sha256"]:
+            raise GudhiSpikeError(
+                "REJECTED",
+                "ADAPTER_SOURCE_MISMATCH",
+                "The GUDHI adapter source differs from the frozen digest.",
+            )
+        output = _run_checked(
+            runner,
+            [
+                str(resolved_python),
+                str(resolved_adapter),
+                "--worker",
+                "--pin",
+                str(pin_path.resolve()),
+            ],
+            timeout_seconds=timeout_seconds,
+        )
+        provider_output = _parse_provider_output(output, pin)
+        prime = pin["reproduction"]["coefficient_prime"]
+        independent = _independent_reduction(simplices, prime)
+        if independent["pairs"] != provider_output["pairs"]:
+            raise GudhiSpikeError(
+                "REJECTED",
+                "INDEPENDENT_REPLAY_MISMATCH",
+                "Independent modular reduction rejects the GUDHI pairing.",
+            )
+        return {
+            "contract": pin["contract"],
+            "status": "COMPLETED",
+            "conclusion": "SPIKE_PASSED_PRODUCTION_DEFERRED",
+            "assurance": "OBSERVED_PROVIDER_BEHAVIOR_WITH_INDEPENDENT_REPLAY",
+            "provider": {
+                "name": pin["provider"],
+                "version": pin["version"],
+                "install_tier": "T1",
+                "deployment": "operator-installed optional CPython wheel",
+                "distribution_decision": "MIT_COMPATIBLE_OPTIONAL_PROVIDER",
+                "source": source,
+                "wheel": wheel_identity,
+                "adapter_source_sha256": adapter_digest,
+                "python_executable": str(resolved_python),
+                "runtime": provider_output["runtime"],
+            },
+            "reproduction": {
+                "scope": pin["reproduction"]["scope"],
+                "coefficient_prime": prime,
+                "rank_transport": "UNIQUE_INTEGER_RANKS_NOT_EXACT_VALUES",
+                "exact_value_source": "FROZEN_CANONICAL_INPUT",
+                "provider_output_sha256": _sha256_bytes(output),
+                "pairs": provider_output["pairs"],
+                "filtration": provider_output["filtration"],
+            },
+            "independent_replay": {
+                **independent,
+                "status": "MATCH",
+                "imports_provider": False,
+            },
+            "checker_feasibility": {
+                "decision": "REVISE",
+                "independent_mod_p_replay": "DEMONSTRATED_FOR_BOUNDED_CASE",
+                "open_obligations": [
+                    "move the checker to an operator-authorized provider-independent package",
+                    "bind the canonical filtered-complex artifact, prime, dimensions, and tie order",
+                    "preserve provider pairings and independent reduced-column evidence as artifacts",
+                    "validate exact birth/death values only from bound input simplex identifiers",
+                    "represent essential intervals with a typed sentinel rather than float infinity",
+                    "add adversarial pairing, rank, value, and artifact-binding mutation tests",
+                ],
+            },
+            "capability_ids_registered": [],
+            "limitations": [
+                "GUDHI receives integer ranks because its Python filtration API uses float",
+                "the provider is a producer and is not authorized as its own checker",
+                "the spike records a wheel digest, not an installed RECORD runtime digest",
+                "only one bounded F_2 case was reproduced",
+            ],
+        }
+    except GudhiSpikeError as exc:
+        return {
+            "contract": "jacobian.gudhi-persistence-spike/v1",
+            "status": exc.status,
+            "conclusion": "NO_CONCLUSION",
+            "diagnostic": {"code": exc.code, "detail": exc.detail},
+            "capability_ids_registered": [],
+        }
+
+
+def _worker(pin_path: Path) -> int:
+    """Run only inside the explicitly selected provider interpreter."""
+    pin = _load_pin(pin_path)
+    simplices = _validate_reproduction(pin)
+    try:
+        import gudhi
+        import numpy
+    except ImportError as exc:
+        raise GudhiSpikeError(
+            "UNAVAILABLE", "PROVIDER_IMPORT_ERROR", "GUDHI or NumPy is unavailable."
+        ) from exc
+    if gudhi.__version__ != pin["version"]:
+        payload = {
+            "contract": pin["contract"],
+            "provider": pin["provider"],
+            "version": gudhi.__version__,
+        }
+        sys.stdout.buffer.write(_canonical_json(payload))
+        return 0
+
+    tree = gudhi.SimplexTree()
+    for item in simplices:
+        tree.insert(item["vertices"], filtration=float(item["rank"]))
+    observed_filtration = []
+    by_vertices = {tuple(item["vertices"]): item for item in simplices}
+    for vertices, rank_as_float in tree.get_filtration():
+        canonical = tuple(sorted(vertices))
+        item = by_vertices.get(canonical)
+        if (
+            item is None
+            or not rank_as_float.is_integer()
+            or int(rank_as_float) != item["rank"]
+        ):
+            raise GudhiSpikeError(
+                "REJECTED",
+                "FILTRATION_TRANSPORT_MISMATCH",
+                "GUDHI changed the unique integer-rank filtration.",
+            )
+        observed_filtration.append(
+            {"simplex_id": item["simplex_id"], "rank": item["rank"]}
+        )
+    tree.persistence(
+        homology_coeff_field=pin["reproduction"]["coefficient_prime"],
+        min_persistence=-1,
+        persistence_dim_max=True,
+    )
+    pairs = []
+    for birth_vertices, death_vertices in tree.persistence_pairs():
+        birth = by_vertices[tuple(sorted(birth_vertices))]
+        pair = {
+            "dimension": len(birth["vertices"]) - 1,
+            "birth_simplex_id": birth["simplex_id"],
+            "birth_rank": birth["rank"],
+            "birth_exact_value": birth["exact_value"],
+            "death": {"kind": "INFINITE"},
+        }
+        if death_vertices:
+            death = by_vertices[tuple(sorted(death_vertices))]
+            pair["death"] = {
+                "kind": "FINITE",
+                "simplex_id": death["simplex_id"],
+                "rank": death["rank"],
+                "exact_value": death["exact_value"],
+            }
+        pairs.append(pair)
+    pairs.sort(
+        key=lambda pair: (
+            pair["dimension"],
+            pair["birth_rank"],
+            pair["death"].get("rank", len(simplices)),
+        )
+    )
+    payload = {
+        "contract": pin["contract"],
+        "filtration": observed_filtration,
+        "pairs": pairs,
+        "provider": pin["provider"],
+        "runtime": {
+            "gudhi": gudhi.__version__,
+            "numpy": numpy.__version__,
+            "python": sys.version.split()[0],
+        },
+        "version": pin["version"],
+    }
+    sys.stdout.buffer.write(_canonical_json(payload))
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--python-executable", type=Path)
+    parser.add_argument("--wheel", type=Path)
+    parser.add_argument("--source-archive", type=Path)
+    parser.add_argument("--pin", type=Path, default=PIN_PATH)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--worker", action="store_true")
+    args = parser.parse_args(argv)
+    if args.worker:
+        return _worker(args.pin)
+    if (
+        args.python_executable is None
+        or args.wheel is None
+        or args.source_archive is None
+        or args.output is None
+    ):
+        parser.error(
+            "--python-executable, --wheel, --source-archive, and --output are required"
+        )
+    report = run_spike(
+        python_executable=args.python_executable,
+        wheel=args.wheel,
+        source_archive=args.source_archive,
+        pin_path=args.pin,
+    )
+    args.output.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return 0 if report["status"] == "COMPLETED" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/contributing/gudhi-persistence-provider-spike.md
+++ b/docs/contributing/gudhi-persistence-provider-spike.md
@@ -1,0 +1,119 @@
+# GUDHI persistent-homology optional-provider spike
+
+This spike tests GUDHI 3.13.0 as a producer for one future atomic outcome:
+persistent homology of a bounded filtered finite simplicial complex over a
+prime field. It does not register a capability or authorize GUDHI as a
+checker.
+
+## Decision
+
+The bounded provider reproduction and an independent modular reduction agree;
+a production capability remains `REVISE`.
+
+- The CPython API stores and returns filtration values as `float`. The adapter
+  therefore sends only unique integer ranks to GUDHI. Exact rational
+  birth/death values are rehydrated from bound input simplex IDs, never from a
+  provider float.
+- The selected `Simplex_tree` and `Persistent_cohomology` source modules both
+  declare MIT, and the CPython 3.12 wheel contains an MIT license. This selected
+  slice is license-compatible, but remains an operator-installed T1 optional
+  provider rather than a core dependency.
+- The worker returns birth and death simplex IDs, ranks, and a typed
+  `INFINITE` sentinel. The outer spike independently reduces the mod-2 boundary
+  matrix using only the standard library and records every reduced column.
+- A provider result remains `COMPUTED` at most. The demonstrated replay is
+  evidence that an independent checker is feasible, not operator authorization
+  of the spike as that checker.
+
+The [GUDHI 3.13.0 SimplexTree reference][simplex-tree], [GUDHI licensing
+inventory][licensing], [3.13.0 source tag][source-tag], and [PyPI 3.13.0
+files][pypi] define the upstream boundary. The frozen source and wheel digests,
+module-header digests, exact filtered complex, and expected mathematical output
+are in
+[`benchmarks/gudhi_persistence_pin.json`](../../benchmarks/gudhi_persistence_pin.json).
+
+[simplex-tree]: https://gudhi.inria.fr/python/3.13.0/simplex_tree_ref.html
+[licensing]: https://gudhi.inria.fr/licensing/
+[source-tag]: https://github.com/GUDHI/gudhi-devel/tree/tags/gudhi-release-3.13.0
+[pypi]: https://pypi.org/project/gudhi/3.13.0/
+
+## Reproduce
+
+Create an isolated Python 3.12 environment and install the pinned wheel plus a
+compatible NumPy:
+
+```sh
+uv venv /tmp/jcb-gudhi-venv --python 3.12
+uv pip install --python /tmp/jcb-gudhi-venv/bin/python \
+  /path/to/gudhi-3.13.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl \
+  numpy
+
+uv run python benchmarks/gudhi_persistence_spike.py \
+  --python-executable /tmp/jcb-gudhi-venv/bin/python \
+  --wheel /path/to/gudhi-3.13.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl \
+  --source-archive /path/to/gudhi-3.13.0-source.tar.gz \
+  --output /tmp/jcb-gudhi-provider-spike.json
+```
+
+The runner hashes and safely inspects the source archive and wheel before
+launch. It binds the checked-in adapter source, preserves the selected virtual
+environment launcher rather than resolving through its symlink, and executes a
+bounded worker with a sanitized environment.
+
+The frozen complex has eleven simplices. Four vertices and four boundary edges
+create a square cycle, a diagonal creates a second transient cycle, and two
+triangles fill them. Its eleven exact filtration values include non-binary
+rationals. GUDHI receives ranks 0 through 10, returns six persistence pairs,
+and never receives those rational values. The independent replay agrees on four
+dimension-0 pairs and two dimension-1 pairs, including one essential connected
+component represented by `{"kind": "INFINITE"}`.
+
+Missing files, source/wheel/adapter mismatch, malformed archives or output,
+wrong GUDHI or Python version, timeout, cancellation, output overflow, process
+crash, reproduction drift, and independent-replay disagreement are all
+non-conclusions.
+
+## Production contract gate
+
+A future `topology.filtered_complex.persistent_homology.compute` request must
+bind:
+
+- a canonical filtered-simplicial-complex artifact with stable simplex IDs;
+- exact rational filtration values and validated face monotonicity;
+- a prime coefficient field, requested homology dimensions, and size bounds;
+- a canonical total tie order in which every face precedes its cofaces;
+- the provider runtime identity and exact rank transport; and
+- execution status, mathematical conclusion, completeness, assurance, and
+  open obligations as separate fields.
+
+Its result should expose birth/death simplex IDs, exact values rehydrated from
+the input, finite versus essential interval type, provider pairing evidence,
+and a relationship to the source filtered complex. Pairing and reduced-column
+ledgers should be first-class artifacts rather than oversized summary fields.
+
+An operator-authorized independent checker must not import or call GUDHI. It
+should reconstruct the oriented boundary matrix over the requested prime,
+validate the filtration and tie order, replay column reduction, compare every
+pairing, and bind exact values to the corresponding input simplices. Forged
+simplex IDs, ranks, rational values, coefficients, pairings, infinity
+sentinels, artifact digests, and checker identities must all fail closed.
+
+Production remains deferred until that contract, artifact split, independent
+checker package, authorization declaration, and adversarial suite exist. GUDHI
+absence must continue to leave the built-in topology foundation and complete
+unrelated catalog available.
+
+## Handoff
+
+- Candidate: `persistent homology`; discovery decision `REVISE`.
+- Producer maximum: `COMPUTED`.
+- Provider: GUDHI 3.13.0, optional T1 CPython 3.12 wheel.
+- License audit: wheel, SimplexTree, and Persistent_cohomology selected slice
+  are MIT; unrelated GUDHI modules are outside this decision.
+- Public reproduction: one answer-visible deterministic filtered square over
+  `F_2`; this is not held-out portfolio evidence.
+- Checker evidence: independent stdlib modular reduction matches all six pairs
+  and preserves eleven reduced columns.
+- Open action: design the production filtered-complex contract and independent
+  checker, then run a held-out matched comparison before keeping the provider
+  capability.

--- a/docs/index.md
+++ b/docs/index.md
@@ -127,6 +127,9 @@ decision, and unresolved checker gates without registering a capability.
 The [CGAL exact-Delaunay optional-provider spike](contributing/cgal-delaunay-provider-spike.md)
 records the exact-kernel reproduction, GPL/commercial deployment boundary,
 degeneracy semantics, and independent geometry-checker obligations.
+The [GUDHI persistent-homology optional-provider spike](contributing/gudhi-persistence-provider-spike.md)
+records exact-rank transport, selected-module licensing, bounded pairing
+reproduction, and independent modular-reduction obligations.
 
 Recurring agent work is encoded in the repository-local skills under
 `.agents/skills/`. Start with `develop-math-capabilities` for a complete

--- a/src/jacobian/runtime/model.py
+++ b/src/jacobian/runtime/model.py
@@ -44,6 +44,7 @@ class JacobianRuntime:
 
         if self._closed:
             return
+        self.services.close()
         self.core.close()
         self._closed = True
 

--- a/src/jacobian/runtime/services.py
+++ b/src/jacobian/runtime/services.py
@@ -83,6 +83,11 @@ class ApplicationServices:
     shrinking: ShrinkService
     reference_installer: ReferenceInstaller
 
+    def close(self) -> None:
+        """Quiesce application-owned workers before foundational teardown."""
+
+        self.search.close()
+
 
 def build_application_services(core: CoreServices) -> ApplicationServices:
     """Build the capability-independent application service graph."""

--- a/src/jacobian/search.py
+++ b/src/jacobian/search.py
@@ -126,6 +126,8 @@ class SearchService:
         self._clock = clock
         self._threads: dict[str, threading.Thread] = {}
         self._thread_lock = threading.Lock()
+        self._closing = False
+        self._closed = False
         self.semantics_uri = store.register_descriptor(
             kind="semantics",
             name="jacobian.search-experiment",
@@ -157,6 +159,38 @@ class SearchService:
             schema=model_schema(EvaluationBatchResult),
         )
         self._initialize_database()
+
+    def close(self, *, timeout_seconds: float = 30) -> None:
+        """Quiesce runtime-owned workers before their shared store is closed."""
+
+        if timeout_seconds < 0:
+            raise ValueError("timeout_seconds must be non-negative")
+        deadline = time.monotonic() + timeout_seconds
+        with self._thread_lock:
+            if self._closed:
+                return
+            self._closing = True
+        while True:
+            with self._thread_lock:
+                active = tuple(
+                    thread for thread in self._threads.values() if thread.is_alive()
+                )
+                if not active:
+                    self._closed = True
+                    self._closing = False
+                    return
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise SearchError(
+                    "search workers did not quiesce before runtime shutdown"
+                )
+            for thread in active:
+                thread.join(timeout=min(remaining, 0.05))
+
+    def _require_open(self) -> None:
+        with self._thread_lock:
+            if self._closing or self._closed:
+                raise SearchError("search service is closing")
 
     def _connect(self) -> sqlite3.Connection:
         return open_experiment_database(self.store.db_path)
@@ -385,6 +419,7 @@ class SearchService:
     ) -> ExperimentHandle:
         """Commit one idempotent search request and launch it locally."""
 
+        self._require_open()
         selected = SearchRunRequest.model_validate(request)
         request_digest = _digest(selected.model_dump(mode="json"))
         with self._connect() as connection:
@@ -635,6 +670,7 @@ class SearchService:
     def resume(self, experiment_uri: str) -> ExperimentControlResult:
         """Resume the same invocation from its immutable checkpoint."""
 
+        self._require_open()
         with self._connect() as connection:
             connection.execute("BEGIN IMMEDIATE")
             snapshot = self._read_snapshot(connection, experiment_uri)
@@ -743,6 +779,8 @@ class SearchService:
 
     def _launch(self, experiment_uri: str) -> None:
         with self._thread_lock:
+            if self._closing or self._closed:
+                raise SearchError("search service is closing")
             current = self._threads.get(experiment_uri)
             if current is not None and current.is_alive():
                 return

--- a/tests/boundary/process/providers/test_gudhi_persistence_spike.py
+++ b/tests/boundary/process/providers/test_gudhi_persistence_spike.py
@@ -1,0 +1,359 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import runpy
+import tarfile
+import zipfile
+from collections.abc import Callable, Sequence
+from io import BytesIO
+from pathlib import Path
+from typing import Any, cast
+
+from jacobian.bounded_process import BoundedProcessResult
+
+PROJECT_ROOT = Path(__file__).resolve().parents[4]
+SPIKE = runpy.run_path(str(PROJECT_ROOT / "benchmarks" / "gudhi_persistence_spike.py"))
+BASE_PIN = json.loads(
+    (PROJECT_ROOT / "benchmarks" / "gudhi_persistence_pin.json").read_text(
+        encoding="utf-8"
+    )
+)
+RunSpike = Callable[..., dict[str, Any]]
+RUN_SPIKE = cast(RunSpike, SPIKE["run_spike"])
+
+
+def _sha256(payload: bytes) -> str:
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def _canonical(payload: object) -> bytes:
+    return (
+        json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+        + "\n"
+    ).encode("ascii")
+
+
+def _result(
+    *,
+    stdout: bytes = b"",
+    returncode: int | None = 0,
+    timed_out: bool = False,
+) -> BoundedProcessResult:
+    return BoundedProcessResult(
+        returncode=returncode,
+        stdout=stdout,
+        stderr=b"",
+        stdout_exceeded=False,
+        stderr_exceeded=False,
+        timed_out=timed_out,
+    )
+
+
+def _runner(
+    outcomes: Sequence[BoundedProcessResult],
+) -> Callable[..., BoundedProcessResult]:
+    remaining = iter(outcomes)
+
+    def run(*_args: object, **_kwargs: object) -> BoundedProcessResult:
+        return next(remaining)
+
+    return run
+
+
+def _provider_output(
+    mathematical: dict[str, Any] | None = None,
+    *,
+    gudhi_version: str = "3.13.0",
+    python_version: str = "3.12.13",
+) -> bytes:
+    payload = {
+        **(mathematical or BASE_PIN["reproduction"]["expected_provider_output"]),
+        "runtime": {
+            "gudhi": gudhi_version,
+            "numpy": "2.4.1",
+            "python": python_version,
+        },
+    }
+    return _canonical(payload)
+
+
+def _fixture(tmp_path: Path) -> tuple[Path, Path, Path, Path, Path]:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    python = tmp_path / "gudhi-python"
+    adapter = tmp_path / "gudhi-spike.py"
+    python.touch()
+    adapter.write_text("# fixture\n", encoding="utf-8")
+
+    source = tmp_path / "gudhi-3.13.0-source.tar.gz"
+    source_payloads = {
+        (
+            "gudhi-devel-tags-gudhi-release-3.13.0/src/Simplex_tree/"
+            "include/gudhi/Simplex_tree.h"
+        ): b"/* released under MIT */\n",
+        (
+            "gudhi-devel-tags-gudhi-release-3.13.0/src/Persistent_cohomology/"
+            "include/gudhi/Persistent_cohomology.h"
+        ): b"/* released under MIT */\n",
+    }
+    with tarfile.open(source, mode="w:gz") as archive:
+        for name, payload in source_payloads.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            info.mtime = 0
+            archive.addfile(info, BytesIO(payload))
+
+    license_payload = b"MIT License\nfixture\n"
+    metadata = b"Name: gudhi\nVersion: 3.13.0\nRequires-Python: >=3.10\n"
+    wheel = tmp_path / BASE_PIN["wheel"]["filename"]
+    with zipfile.ZipFile(wheel, mode="w") as archive:
+        archive.writestr(BASE_PIN["wheel"]["license_member"], license_payload)
+        archive.writestr(BASE_PIN["wheel"]["metadata_member"], metadata)
+
+    pin = {
+        **BASE_PIN,
+        "adapter_source_sha256": _sha256(adapter.read_bytes()),
+        "source": {
+            **BASE_PIN["source"],
+            "archive_sha256": _sha256(source.read_bytes()),
+            "module_licenses": {
+                "simplex_tree": {
+                    "header_sha256": _sha256(
+                        source_payloads[
+                            (
+                                "gudhi-devel-tags-gudhi-release-3.13.0/"
+                                "src/Simplex_tree/include/gudhi/Simplex_tree.h"
+                            )
+                        ]
+                    ),
+                    "license_id": "MIT",
+                },
+                "persistent_cohomology": {
+                    "header_sha256": _sha256(
+                        source_payloads[
+                            (
+                                "gudhi-devel-tags-gudhi-release-3.13.0/"
+                                "src/Persistent_cohomology/include/gudhi/"
+                                "Persistent_cohomology.h"
+                            )
+                        ]
+                    ),
+                    "license_id": "MIT",
+                },
+            },
+        },
+        "wheel": {
+            **BASE_PIN["wheel"],
+            "sha256": _sha256(wheel.read_bytes()),
+            "license_sha256": _sha256(license_payload),
+        },
+    }
+    pin_path = tmp_path / "pin.json"
+    pin_path.write_text(json.dumps(pin), encoding="utf-8")
+    return python, wheel, source, adapter, pin_path
+
+
+def test_persistence_spike_rehydrates_exact_values_and_defers_production(
+    tmp_path: Path,
+) -> None:
+    python, wheel, source, adapter, pin = _fixture(tmp_path)
+
+    report = RUN_SPIKE(
+        python_executable=python,
+        wheel=wheel,
+        source_archive=source,
+        adapter_source=adapter,
+        pin_path=pin,
+        runner=_runner([_result(stdout=_provider_output())]),
+    )
+
+    assert report["status"] == "COMPLETED"
+    assert report["conclusion"] == "SPIKE_PASSED_PRODUCTION_DEFERRED"
+    assert report["provider"]["install_tier"] == "T1"
+    assert report["provider"]["distribution_decision"] == (
+        "MIT_COMPATIBLE_OPTIONAL_PROVIDER"
+    )
+    assert report["reproduction"]["rank_transport"] == (
+        "UNIQUE_INTEGER_RANKS_NOT_EXACT_VALUES"
+    )
+    assert len(report["reproduction"]["pairs"]) == 6
+    assert report["reproduction"]["pairs"][0]["birth_exact_value"] == "-2/3"
+    assert report["reproduction"]["pairs"][0]["death"] == {"kind": "INFINITE"}
+    assert report["independent_replay"]["status"] == "MATCH"
+    assert len(report["independent_replay"]["reduced_columns"]) == 11
+    assert report["checker_feasibility"]["decision"] == "REVISE"
+    assert report["capability_ids_registered"] == []
+
+
+def test_absent_provider_is_an_explicit_non_conclusion(tmp_path: Path) -> None:
+    _python, wheel, source, adapter, pin = _fixture(tmp_path)
+
+    report = RUN_SPIKE(
+        python_executable=tmp_path / "absent-python",
+        wheel=wheel,
+        source_archive=source,
+        adapter_source=adapter,
+        pin_path=pin,
+    )
+
+    assert report["status"] == "UNAVAILABLE"
+    assert report["conclusion"] == "NO_CONCLUSION"
+    assert report["diagnostic"]["code"] == "PROVIDER_FILE_UNAVAILABLE"
+    assert report["capability_ids_registered"] == []
+
+
+def test_source_and_wheel_mismatch_fail_before_execution(tmp_path: Path) -> None:
+    python, wheel, source, adapter, pin = _fixture(tmp_path)
+    source.write_bytes(b"not the pinned archive")
+
+    source_report = RUN_SPIKE(
+        python_executable=python,
+        wheel=wheel,
+        source_archive=source,
+        adapter_source=adapter,
+        pin_path=pin,
+    )
+    assert source_report["status"] == "REJECTED"
+    assert source_report["diagnostic"]["code"] == "SOURCE_VERSION_MISMATCH"
+
+    _python, wheel, source, adapter, pin = _fixture(tmp_path / "wheel-case")
+    wheel.write_bytes(b"not the pinned wheel")
+    wheel_report = RUN_SPIKE(
+        python_executable=_python,
+        wheel=wheel,
+        source_archive=source,
+        adapter_source=adapter,
+        pin_path=pin,
+    )
+    assert wheel_report["status"] == "REJECTED"
+    assert wheel_report["diagnostic"]["code"] == "WHEEL_VERSION_MISMATCH"
+
+
+def test_protocol_runtime_and_malformed_output_fail_closed(tmp_path: Path) -> None:
+    python, wheel, source, adapter, pin = _fixture(tmp_path)
+    wrong_protocol = {
+        **BASE_PIN["reproduction"]["expected_provider_output"],
+        "version": "3.12.0",
+    }
+    version_report = RUN_SPIKE(
+        python_executable=python,
+        wheel=wheel,
+        source_archive=source,
+        adapter_source=adapter,
+        pin_path=pin,
+        runner=_runner([_result(stdout=_provider_output(wrong_protocol))]),
+    )
+    assert version_report["status"] == "REJECTED"
+    assert version_report["diagnostic"]["code"] == "PROVIDER_VERSION_MISMATCH"
+
+    runtime_report = RUN_SPIKE(
+        python_executable=python,
+        wheel=wheel,
+        source_archive=source,
+        adapter_source=adapter,
+        pin_path=pin,
+        runner=_runner([_result(stdout=_provider_output(python_version="3.11.9"))]),
+    )
+    assert runtime_report["status"] == "REJECTED"
+    assert runtime_report["diagnostic"]["code"] == "PROVIDER_RUNTIME_MISMATCH"
+
+    malformed_report = RUN_SPIKE(
+        python_executable=python,
+        wheel=wheel,
+        source_archive=source,
+        adapter_source=adapter,
+        pin_path=pin,
+        runner=_runner([_result(stdout=b"{not-json\n")]),
+    )
+    assert malformed_report["status"] == "ERROR"
+    assert malformed_report["diagnostic"]["code"] == "PROVIDER_OUTPUT_MALFORMED"
+
+
+def test_timeout_and_crash_are_distinct_non_conclusions(tmp_path: Path) -> None:
+    python, wheel, source, adapter, pin = _fixture(tmp_path)
+
+    timeout = RUN_SPIKE(
+        python_executable=python,
+        wheel=wheel,
+        source_archive=source,
+        adapter_source=adapter,
+        pin_path=pin,
+        runner=_runner([_result(returncode=None, timed_out=True)]),
+    )
+    assert timeout["status"] == "TIMEOUT"
+    assert timeout["diagnostic"]["code"] == "PROVIDER_TIMEOUT"
+
+    crash = RUN_SPIKE(
+        python_executable=python,
+        wheel=wheel,
+        source_archive=source,
+        adapter_source=adapter,
+        pin_path=pin,
+        runner=_runner([_result(returncode=7)]),
+    )
+    assert crash["status"] == "ERROR"
+    assert crash["diagnostic"]["code"] == "PROVIDER_CRASH"
+
+
+def test_independent_replay_rejects_a_self_consistent_forged_pin(
+    tmp_path: Path,
+) -> None:
+    python, wheel, source, adapter, pin_path = _fixture(tmp_path)
+    pin = json.loads(pin_path.read_text(encoding="utf-8"))
+    forged = json.loads(json.dumps(pin["reproduction"]["expected_provider_output"]))
+    forged["pairs"][1]["death"] = {
+        "kind": "FINITE",
+        "simplex_id": "e12",
+        "rank": 5,
+        "exact_value": "7/13",
+    }
+    pin["reproduction"]["expected_provider_output"] = forged
+    pin["reproduction"]["expected_mathematical_output_sha256"] = _sha256(
+        _canonical(forged)
+    )
+    pin_path.write_text(json.dumps(pin), encoding="utf-8")
+
+    report = RUN_SPIKE(
+        python_executable=python,
+        wheel=wheel,
+        source_archive=source,
+        adapter_source=adapter,
+        pin_path=pin_path,
+        runner=_runner([_result(stdout=_provider_output(forged))]),
+    )
+
+    assert report["status"] == "REJECTED"
+    assert report["diagnostic"]["code"] == "INDEPENDENT_REPLAY_MISMATCH"
+
+
+def test_malformed_archives_do_not_escape_as_exceptions(tmp_path: Path) -> None:
+    python, wheel, source, adapter, pin_path = _fixture(tmp_path)
+    pin = json.loads(pin_path.read_text(encoding="utf-8"))
+    source.write_bytes(b"bad gzip")
+    pin["source"]["archive_sha256"] = _sha256(source.read_bytes())
+    pin_path.write_text(json.dumps(pin), encoding="utf-8")
+
+    source_report = RUN_SPIKE(
+        python_executable=python,
+        wheel=wheel,
+        source_archive=source,
+        adapter_source=adapter,
+        pin_path=pin_path,
+    )
+    assert source_report["status"] == "REJECTED"
+    assert source_report["diagnostic"]["code"] == "SOURCE_ARCHIVE_MALFORMED"
+
+    python, wheel, source, adapter, pin_path = _fixture(tmp_path / "wheel")
+    pin = json.loads(pin_path.read_text(encoding="utf-8"))
+    wheel.write_bytes(b"bad zip")
+    pin["wheel"]["sha256"] = _sha256(wheel.read_bytes())
+    pin_path.write_text(json.dumps(pin), encoding="utf-8")
+    wheel_report = RUN_SPIKE(
+        python_executable=python,
+        wheel=wheel,
+        source_archive=source,
+        adapter_source=adapter,
+        pin_path=pin_path,
+    )
+    assert wheel_report["status"] == "REJECTED"
+    assert wheel_report["diagnostic"]["code"] == "WHEEL_MALFORMED"

--- a/tests/composition/runtime/test_gudhi_persistence_spike_isolation.py
+++ b/tests/composition/runtime/test_gudhi_persistence_spike_isolation.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import runpy
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, cast
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+SPIKE = runpy.run_path(str(PROJECT_ROOT / "benchmarks" / "gudhi_persistence_spike.py"))
+RunSpike = Callable[..., dict[str, Any]]
+RUN_SPIKE = cast(RunSpike, SPIKE["run_spike"])
+
+
+def test_absent_gudhi_does_not_change_complete_runtime_catalog(
+    fresh_complete_runtime,
+    tmp_path: Path,
+) -> None:
+    before = fresh_complete_runtime.core.capabilities.catalog().model_dump(mode="json")
+
+    report = RUN_SPIKE(
+        python_executable=tmp_path / "absent-gudhi-python",
+        wheel=tmp_path / "absent-gudhi.whl",
+        source_archive=tmp_path / "absent-gudhi-source.tar.gz",
+    )
+
+    after = fresh_complete_runtime.core.capabilities.catalog().model_dump(mode="json")
+    assert report["status"] == "UNAVAILABLE"
+    assert report["capability_ids_registered"] == []
+    assert after == before

--- a/tests/composition/runtime/test_runtime_lifecycle.py
+++ b/tests/composition/runtime/test_runtime_lifecycle.py
@@ -2,9 +2,9 @@
 
 These tests pin the runtime ownership contract: explicit ``close``,
 idempotence, context-manager semantics, partial-bootstrap failure cleanup,
-and use-after-close behavior. The runtime delegates storage ownership to
-:class:`ArtifactStore`; these tests verify that delegation closes the store
-and that construction failures release every owned resource.
+and use-after-close behavior. The runtime quiesces application-owned workers
+before delegating storage teardown to :class:`ArtifactStore`; these tests
+verify that ordering and that construction failures release every resource.
 
 The contract is verified through observable use-after-close behavior rather
 than private ``_closed`` flags wherever possible.
@@ -12,12 +12,15 @@ than private ``_closed`` flags wherever possible.
 
 from __future__ import annotations
 
+import threading
+import time
 from pathlib import Path
 
 import pytest
 
 from jacobian.runtime import create_runtime
 from jacobian.runtime.model import RuntimeClosedError
+from jacobian.search import SearchError, SearchService
 from jacobian.store import StoreClosedError
 
 pytestmark = pytest.mark.usefixtures("attached_complete_runtime")
@@ -70,6 +73,85 @@ def test_context_manager_exit_suppresses_no_exception(tmp_path: Path) -> None:
             version="1",
             definition={"type": "object"},
         )
+
+
+def test_close_quiesces_search_workers_before_closing_store(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = create_runtime(tmp_path)
+    worker_started = threading.Event()
+    release_worker = threading.Event()
+    worker_finished = threading.Event()
+    worker_errors: list[BaseException] = []
+
+    def blocked_run(service: SearchService, _experiment_uri: str) -> None:
+        worker_started.set()
+        release_worker.wait(timeout=2)
+        try:
+            service.store.register_descriptor(
+                kind="schema",
+                name="search-worker-during-close",
+                version="1",
+                definition={"type": "object"},
+            )
+        except BaseException as exc:
+            worker_errors.append(exc)
+        finally:
+            worker_finished.set()
+
+    monkeypatch.setattr(SearchService, "_run", blocked_run)
+    runtime.services.search._launch("experiment://runtime-close-regression")
+    assert worker_started.wait(timeout=1)
+
+    def release_after_close_begins() -> None:
+        time.sleep(0.05)
+        release_worker.set()
+
+    releaser = threading.Thread(target=release_after_close_begins)
+    releaser.start()
+    runtime.close()
+    releaser.join(timeout=1)
+
+    assert worker_finished.is_set()
+    assert worker_errors == []
+    with pytest.raises(StoreClosedError):
+        runtime.core.store.register_descriptor(
+            kind="schema",
+            name="after-worker-close",
+            version="1",
+            definition={"type": "object"},
+        )
+
+
+def test_search_close_timeout_keeps_store_open_for_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = create_runtime(tmp_path)
+    worker_started = threading.Event()
+    release_worker = threading.Event()
+
+    def blocked_run(_service: SearchService, _experiment_uri: str) -> None:
+        worker_started.set()
+        release_worker.wait(timeout=2)
+
+    monkeypatch.setattr(SearchService, "_run", blocked_run)
+    runtime.services.search._launch("experiment://runtime-close-timeout")
+    assert worker_started.wait(timeout=1)
+
+    with pytest.raises(SearchError, match="did not quiesce"):
+        runtime.services.search.close(timeout_seconds=0)
+
+    runtime.core.store.register_descriptor(
+        kind="schema",
+        name="store-remains-open-after-search-close-timeout",
+        version="1",
+        definition={"type": "object"},
+    )
+    release_worker.set()
+    runtime.services.search.close(timeout_seconds=1)
+    runtime.close()
 
 
 def test_partial_initialize_failure_releases_owned_store(


### PR DESCRIPTION
## Summary

- add a pinned GUDHI 3.13.0 persistent-homology optional-provider spike
- transport only unique integer filtration ranks through GUDHI's float API and rehydrate exact rational values from bound simplex IDs
- independently replay the bounded result with a stdlib mod-p boundary-column reduction, including a reduced-column ledger
- audit the selected SimplexTree/Persistent_cohomology modules and CPython 3.12 wheel as MIT
- keep production deferred and register no capability IDs
- prove missing-provider isolation against the complete runtime catalog
- quiesce runtime-owned search workers before closing the artifact store, including a fail-closed timeout/retry path

## Provider evidence

- GUDHI: `3.13.0`
- source tag commit: `5dbe510bed5d8d700ec7243fd915769fb67964a2`
- source archive: `sha256:7640d716d6a118b7787602826e4144bfa1ad5903a31f4a760a7f3a1e68cfdc02`
- CPython 3.12 manylinux wheel: `sha256:d7ce52905d147a7e599607758843c7f37525c98e7aeaca87cbbbcbd3adb71598`
- selected module licenses: SimplexTree MIT; Persistent_cohomology MIT
- wheel license: MIT
- local runtime: CPython `3.12.13`, NumPy `2.4.1`
- bounded output: 6 persistence pairs from 11 simplices
- observed output: `sha256:90ebbfc827be9becdfef622184a33dd2d9717d751846a373da854559abe5e77e`
- independent replay: `MATCH`, 11 reduced-column records

The selected slice is license-compatible but remains an operator-installed T1 optional provider. The spike records a wheel digest rather than claiming an installed `PYTHON_DISTRIBUTION_RECORD` identity.

## Assurance and decision

- execution: `COMPLETED`
- conclusion: `SPIKE_PASSED_PRODUCTION_DEFERRED`
- evidence: observed provider behavior plus independent bounded replay
- production/checker decision: `REVISE`
- registered capability IDs: none
- compatibility impact: none; no public contract or catalog entry changes

GUDHI is not authorized as its own checker. A future production checker must live in an operator-authorized provider-independent package, bind the filtered-complex artifact/prime/tie order, replay modular reduction, preserve pairing and reduced-column artifacts, validate exact values only through input simplex IDs, and reject forged bindings. Essential intervals use a typed sentinel, not float infinity.

## Validation

Final committed tree:

- HEAD: `1fc0cbb477babd82f18a8518f51333732d5da99e`
- git tree: `d49c9b83880490da051a26fe55c6d34c0b10fbbe`
- worktree remained clean after the final validation commands

Passed:

- `make check` — lint, format, mypy, 288 unit tests
- `make check-static` — dependency/dead-code checks, architecture policy, mypy, package build
- `make test-process TESTS=tests/boundary/process/providers/test_gudhi_persistence_spike.py` — 7 passed
- `make test-composition TESTS='tests/composition/runtime/test_gudhi_persistence_spike_isolation.py tests/composition/runtime/test_runtime_lifecycle.py'` — 9 passed
- `make test-storage` — 90 passed
- `make docs-linkcheck` — passed
- real pinned source/wheel/provider reproduction

The first two GitHub storage runs exposed a shutdown race: a runtime fixture
could close the SQLite-backed artifact store while a search worker was still
using it. `SearchService.close()` now blocks new launches and waits for owned
workers before `ApplicationServices` permits core/store shutdown. A timeout
fails closed without closing the store, and shutdown can be retried. Two
deterministic lifecycle regressions cover successful quiescence and timeout
retry; the complete storage lane passes after the fix.

## Handoff

- baseline git tree: `ac0e09724a7293fa02d2babd7c831f28adcfab48`
- installed catalog: 249 capabilities, `sha256:b58e07e4eef94af4507d98fa9a5647e2a249399ee0767bebef5f7a6397ffa645`
- DEFAULT policy: `sha256:870a92b83d3e522e4015b6bb1cabda33086906f9de1c3c36e466251ea7ed1957`
- provider/runtime state: GUDHI absent from the locked Jacobian environment; isolated pinned wheel installed only in `/tmp/jcb-gudhi-venv`
- raw local reproduction: `/tmp/jcb-gudhi-provider-spike.json`
- model/prompt settings: not applicable; this is a deterministic provider reproduction, not a model-in-the-loop evaluation
- public/held-out role: the frozen square is answer-visible regression evidence only
- unresolved obligations: production typed contract/artifact split, independent checker package and authorization, adversarial binding suite, installed-runtime RECORD identity, larger held-out comparison
- next action: keep this spike as evidence; do not register persistent-homology capability until the production contract/checker gates pass
