### PR TITLE
feat(benchmarks): spike exact cddlib H/V conversion provider

### DIFF
--- a/benchmarks/cddlib_hv_pin.json
+++ b/benchmarks/cddlib_hv_pin.json
@@ -1,0 +1,265 @@
+{
+  "adapter_source_sha256": "sha256:e6510a3b4b02d565241376149cde58dcd27e8d1c6860f0a3224beef89319433b",
+  "contract": "jacobian.cddlib-hv-spike/v1",
+  "provider": "cddlib/pycddlib",
+  "reproduction": {
+    "cases": [
+      {
+        "ambient_dimension": 2,
+        "case_id": "h_to_v_affine_ray",
+        "expected_output": {
+          "homogeneous_rows": [
+            [
+              "0",
+              "1",
+              "0"
+            ],
+            [
+              "1",
+              "1/2",
+              "1/3"
+            ]
+          ],
+          "linearity_rows": [],
+          "representation": "V"
+        },
+        "input": {
+          "homogeneous_rows": [
+            [
+              "-1/2",
+              "1",
+              "0"
+            ],
+            [
+              "-1/3",
+              "0",
+              "1"
+            ]
+          ],
+          "linearity_rows": [
+            1
+          ],
+          "representation": "H"
+        }
+      },
+      {
+        "ambient_dimension": 2,
+        "case_id": "h_to_v_strip_lineality",
+        "expected_output": {
+          "homogeneous_rows": [
+            [
+              "0",
+              "0",
+              "1"
+            ],
+            [
+              "1",
+              "0",
+              "0"
+            ],
+            [
+              "1",
+              "3/2",
+              "0"
+            ]
+          ],
+          "linearity_rows": [
+            0
+          ],
+          "representation": "V"
+        },
+        "input": {
+          "homogeneous_rows": [
+            [
+              "0",
+              "1",
+              "0"
+            ],
+            [
+              "3/2",
+              "-1",
+              "0"
+            ]
+          ],
+          "linearity_rows": [],
+          "representation": "H"
+        }
+      },
+      {
+        "ambient_dimension": 2,
+        "case_id": "v_to_h_affine_ray",
+        "expected_output": {
+          "homogeneous_rows": [
+            [
+              "-1/3",
+              "0",
+              "1"
+            ],
+            [
+              "-1",
+              "2",
+              "0"
+            ]
+          ],
+          "linearity_rows": [
+            0
+          ],
+          "representation": "H"
+        },
+        "input": {
+          "homogeneous_rows": [
+            [
+              "1",
+              "1/2",
+              "1/3"
+            ],
+            [
+              "0",
+              "1",
+              "0"
+            ]
+          ],
+          "linearity_rows": [],
+          "representation": "V"
+        }
+      },
+      {
+        "ambient_dimension": 2,
+        "case_id": "v_to_h_strip_lineality",
+        "expected_output": {
+          "homogeneous_rows": [
+            [
+              "3/2",
+              "-1",
+              "0"
+            ],
+            [
+              "0",
+              "1",
+              "0"
+            ]
+          ],
+          "linearity_rows": [],
+          "representation": "H"
+        },
+        "input": {
+          "homogeneous_rows": [
+            [
+              "1",
+              "0",
+              "0"
+            ],
+            [
+              "1",
+              "3/2",
+              "0"
+            ],
+            [
+              "0",
+              "0",
+              "1"
+            ]
+          ],
+          "linearity_rows": [
+            2
+          ],
+          "representation": "V"
+        }
+      }
+    ],
+    "exact_arithmetic_probe": "1208925819614629174706177/2288818359375",
+    "expected_mathematical_output_sha256": "sha256:46bc8c4f78c39fe5ddecd1731f6a1effc3351042e96f1a9d85f7fa97fae8acb4",
+    "scope": {
+      "ambient_dimension": 2,
+      "case_count": 4,
+      "covers": [
+        "H_TO_V",
+        "V_TO_H",
+        "AFFINE_DIMENSION",
+        "EQUALITY",
+        "INEQUALITY",
+        "VERTEX",
+        "RAY",
+        "LINEALITY",
+        "HOMOGENEOUS_NORMALIZATION"
+      ],
+      "exact_input": "fractions.Fraction through cdd.gmp",
+      "max_homogeneous_rows_per_case": 3
+    }
+  },
+  "sources": {
+    "cddlib": {
+      "archive_sha256": "sha256:b87ee07ba2c1d0ab92a3e4eccacdf568f981a095a392e3b9efd7e7e4a9e125b1",
+      "download_url": "https://github.com/cddlib/cddlib/releases/download/0.94n/cddlib-0.94n.tar.gz",
+      "identity_members": {
+        "cddlib-0.94n/COPYING": {
+          "max_bytes": 32768,
+          "required_ascii_markers": [
+            "GNU GENERAL PUBLIC LICENSE",
+            "Version 2, June 1991",
+            "any later version."
+          ],
+          "sha256": "sha256:91df39d1816bfb17a4dda2d3d2c83b1f6f2d38d53e53e41e8f97ad5ac46a0cad"
+        },
+        "cddlib-0.94n/lib-src/cddmp.h": {
+          "max_bytes": 65536,
+          "required_ascii_markers": [
+            "GMPRATIONAL",
+            "mpq_t"
+          ],
+          "sha256": "sha256:31bb10537de5f6442412f250f93a620857f02cb0a79297e94a89aaf7b03571e5"
+        }
+      },
+      "license_id": "GPL-2.0-or-later",
+      "tag": "0.94n",
+      "tag_commit": "86dfe60811ec879a46e73d488719acaa754536e4"
+    },
+    "pycddlib": {
+      "archive_sha256": "sha256:50f43f039818ab97c8cb44345eed9a365dae66789ce11cc8c95a74134a8907a7",
+      "download_url": "https://files.pythonhosted.org/packages/d2/25/85e2e17491a4d51f796f7212a13cef7d6d3b2967dfba104627a465224f06/pycddlib-3.0.2.tar.gz",
+      "identity_members": {
+        "pycddlib-3.0.2/LICENSE.md": {
+          "max_bytes": 32768,
+          "required_ascii_markers": [
+            "GNU GENERAL PUBLIC LICENSE",
+            "Version 2, June 1991",
+            "any later version."
+          ],
+          "sha256": "sha256:5d05a329bdd65bc1212fda57942ea90a2a810ff7ce192dc38d7042a55caa4a28"
+        },
+        "pycddlib-3.0.2/cython/_cddgmp.pyx": {
+          "max_bytes": 65536,
+          "required_ascii_markers": [
+            "NumberType = Fraction",
+            "include \"mytype_gmp.pxi\""
+          ],
+          "sha256": "sha256:9c9133f91062c00f123e36d8a8eb2063375e95b43a281e12c181c0810a0bbc54"
+        },
+        "pycddlib-3.0.2/cython/mytype_gmp.pxi": {
+          "max_bytes": 65536,
+          "required_ascii_markers": [
+            "from fractions import Fraction",
+            "cdef _get_mytype",
+            "cdef _set_mytype"
+          ],
+          "sha256": "sha256:1bd46a82f6cc0e3e71bbab8324d5e0a5cbd5cc379ec288ddc2af2bc4073e8b15"
+        },
+        "pycddlib-3.0.2/setup.py": {
+          "max_bytes": 16384,
+          "required_ascii_markers": [
+            "name=\"cdd.gmp\"",
+            "libraries=[\"cddgmp\", \"gmp\"]"
+          ],
+          "sha256": "sha256:90f98b2848d711d19decf5ee43922c73e02a67921d98b79a5d1a3291a97d09c6"
+        }
+      },
+      "license_id": "GPL-2.0-or-later",
+      "tag": "3.0.2",
+      "tag_commit": "2227de7b848014e634a81b8815327bc4de9a079a"
+    }
+  },
+  "versions": {
+    "cddlib": "0.94n",
+    "pycddlib": "3.0.2"
+  }
+}

--- a/benchmarks/cddlib_hv_spike.py
+++ b/benchmarks/cddlib_hv_spike.py
@@ -1,0 +1,926 @@
+"""Probe pinned cddlib/pycddlib exact H/V conversion without registration."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import sys
+import tarfile
+from collections.abc import Callable, Mapping, Sequence
+from fractions import Fraction
+from pathlib import Path
+from typing import Any
+
+PIN_PATH = Path(__file__).with_name("cddlib_hv_pin.json")
+ADAPTER_SOURCE = Path(__file__)
+_ENVIRONMENT = {"LANG": "C", "LC_ALL": "C", "TZ": "UTC"}
+_KIND_ORDER = {
+    "EQUALITY": 0,
+    "INEQUALITY": 1,
+    "VERTEX": 2,
+    "RAY": 3,
+    "LINEALITY": 4,
+}
+ProcessRunner = Callable[..., Any]
+
+
+def _default_runner(*args: object, **kwargs: object) -> Any:
+    from jacobian.bounded_process import run_bounded_process
+
+    return run_bounded_process(*args, **kwargs)
+
+
+class CddlibSpikeError(RuntimeError):
+    """A typed non-conclusion from the optional-provider spike."""
+
+    def __init__(self, status: str, code: str, detail: str) -> None:
+        super().__init__(detail)
+        self.status = status
+        self.code = code
+        self.detail = detail
+
+
+def _sha256_bytes(payload: bytes) -> str:
+    return f"sha256:{hashlib.sha256(payload).hexdigest()}"
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def _canonical_json(payload: object) -> bytes:
+    return (
+        json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+        + "\n"
+    ).encode("ascii")
+
+
+def _load_pin(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise CddlibSpikeError(
+            "ERROR", "INVALID_SPIKE_PIN", "The cddlib spike pin is unavailable."
+        ) from exc
+    if (
+        not isinstance(payload, dict)
+        or payload.get("contract") != "jacobian.cddlib-hv-spike/v1"
+    ):
+        raise CddlibSpikeError(
+            "ERROR", "INVALID_SPIKE_PIN", "The cddlib spike pin is malformed."
+        )
+    return payload
+
+
+def _resolve_file(path: Path, role: str) -> Path:
+    try:
+        resolved = path.expanduser().resolve(strict=True)
+        if not resolved.is_file():
+            raise OSError
+    except OSError as exc:
+        raise CddlibSpikeError(
+            "UNAVAILABLE",
+            "PROVIDER_FILE_UNAVAILABLE",
+            f"The explicitly selected {role} file is unavailable.",
+        ) from exc
+    return resolved
+
+
+def _resolve_interpreter(path: Path) -> Path:
+    selected = path.expanduser().absolute()
+    try:
+        target = selected.resolve(strict=True)
+        if not selected.is_file() or not target.is_file():
+            raise OSError
+    except OSError as exc:
+        raise CddlibSpikeError(
+            "UNAVAILABLE",
+            "PROVIDER_FILE_UNAVAILABLE",
+            "The explicitly selected pycddlib Python interpreter is unavailable.",
+        ) from exc
+    return selected
+
+
+def _inspect_archive(
+    path: Path,
+    *,
+    role: str,
+    source_pin: Mapping[str, Any],
+) -> dict[str, Any]:
+    resolved = _resolve_file(path, role)
+    digest = _sha256_file(resolved)
+    if digest != source_pin["archive_sha256"]:
+        raise CddlibSpikeError(
+            "REJECTED",
+            "SOURCE_VERSION_MISMATCH",
+            f"The {role} does not match its frozen digest.",
+        )
+    try:
+        with tarfile.open(resolved, mode="r:gz") as archive:
+            contents: dict[str, bytes] = {}
+            for member_name, expected in source_pin["identity_members"].items():
+                member = archive.getmember(member_name)
+                if not member.isfile() or member.size > expected["max_bytes"]:
+                    raise ValueError("source identity member is invalid")
+                stream = archive.extractfile(member)
+                if stream is None:
+                    raise ValueError("source identity member is unreadable")
+                contents[member_name] = stream.read()
+    except (KeyError, OSError, tarfile.TarError, ValueError) as exc:
+        raise CddlibSpikeError(
+            "REJECTED",
+            "SOURCE_ARCHIVE_MALFORMED",
+            f"The pinned {role} could not be inspected safely.",
+        ) from exc
+
+    for member_name, payload in contents.items():
+        expected = source_pin["identity_members"][member_name]
+        if _sha256_bytes(payload) != expected["sha256"]:
+            raise CddlibSpikeError(
+                "REJECTED",
+                "SOURCE_METADATA_MISMATCH",
+                f"The pinned identity member {member_name} differs.",
+            )
+        for marker in expected.get("required_ascii_markers", []):
+            if marker.encode("ascii") not in payload:
+                raise CddlibSpikeError(
+                    "REJECTED",
+                    "SOURCE_METADATA_MISMATCH",
+                    f"The pinned identity member {member_name} lost a required marker.",
+                )
+    return {
+        "archive": str(resolved),
+        "archive_sha256": digest,
+        "download_url": source_pin["download_url"],
+        "tag": source_pin["tag"],
+        "tag_commit": source_pin["tag_commit"],
+        "license_id": source_pin["license_id"],
+        "identity_members": source_pin["identity_members"],
+    }
+
+
+def _as_fraction(value: object) -> Fraction:
+    if isinstance(value, bool) or not isinstance(value, (int, str)):
+        raise ValueError("exact values must be integers or rational strings")
+    return Fraction(value)
+
+
+def _validate_cases(pin: Mapping[str, Any]) -> list[dict[str, Any]]:
+    reproduction = pin.get("reproduction")
+    cases = reproduction.get("cases") if isinstance(reproduction, dict) else None
+    if not isinstance(cases, list) or not 1 <= len(cases) <= 8:
+        raise CddlibSpikeError(
+            "ERROR", "INVALID_SPIKE_PIN", "The bounded H/V cases are invalid."
+        )
+    observed_ids: set[str] = set()
+    validated: list[dict[str, Any]] = []
+    for case in cases:
+        try:
+            case_id = case["case_id"]
+            representation = case["input"]["representation"]
+            rows = case["input"]["homogeneous_rows"]
+            linearity_rows = case["input"]["linearity_rows"]
+            ambient_dimension = case["ambient_dimension"]
+        except (KeyError, TypeError) as exc:
+            raise CddlibSpikeError(
+                "ERROR", "INVALID_SPIKE_PIN", "A bounded H/V case is malformed."
+            ) from exc
+        if (
+            not isinstance(case_id, str)
+            or not case_id
+            or case_id in observed_ids
+            or representation not in {"H", "V"}
+            or not isinstance(ambient_dimension, int)
+            or not 1 <= ambient_dimension <= 4
+            or not isinstance(rows, list)
+            or not 1 <= len(rows) <= 16
+            or not isinstance(linearity_rows, list)
+            or any(
+                not isinstance(index, int) or index < 0 or index >= len(rows)
+                for index in linearity_rows
+            )
+            or len(set(linearity_rows)) != len(linearity_rows)
+        ):
+            raise CddlibSpikeError(
+                "ERROR", "INVALID_SPIKE_PIN", "A bounded H/V case is invalid."
+            )
+        exact_rows: list[list[Fraction]] = []
+        try:
+            for row in rows:
+                if not isinstance(row, list) or len(row) != ambient_dimension + 1:
+                    raise ValueError
+                exact_rows.append([_as_fraction(value) for value in row])
+        except (ValueError, ZeroDivisionError) as exc:
+            raise CddlibSpikeError(
+                "ERROR",
+                "INVALID_SPIKE_PIN",
+                "A bounded H/V row is not an exact homogeneous row.",
+            ) from exc
+        observed_ids.add(case_id)
+        validated.append(
+            {
+                "case_id": case_id,
+                "ambient_dimension": ambient_dimension,
+                "representation": representation,
+                "rows": exact_rows,
+                "linearity_rows": set(linearity_rows),
+            }
+        )
+    if {case["representation"] for case in validated} != {"H", "V"}:
+        raise CddlibSpikeError(
+            "ERROR",
+            "INVALID_SPIKE_PIN",
+            "The spike must exercise both H-to-V and V-to-H conversion.",
+        )
+    return validated
+
+
+def _integer_normalize(row: Sequence[Fraction], *, sign_free: bool) -> list[Fraction]:
+    denominator_lcm = 1
+    for value in row:
+        denominator_lcm = math.lcm(denominator_lcm, value.denominator)
+    integers = [
+        value.numerator * (denominator_lcm // value.denominator) for value in row
+    ]
+    divisor = 0
+    for value in integers:
+        divisor = math.gcd(divisor, abs(value))
+    if divisor == 0:
+        return [Fraction(0) for _ in row]
+    integers = [value // divisor for value in integers]
+    if sign_free:
+        first = next((value for value in integers if value), 0)
+        if first < 0:
+            integers = [-value for value in integers]
+    return [Fraction(value) for value in integers]
+
+
+def _rank(rows: Sequence[Sequence[Fraction]]) -> int:
+    if not rows:
+        return 0
+    matrix = [list(row) for row in rows]
+    row_count = len(matrix)
+    column_count = len(matrix[0])
+    pivot_row = 0
+    for column in range(column_count):
+        pivot = next(
+            (index for index in range(pivot_row, row_count) if matrix[index][column]),
+            None,
+        )
+        if pivot is None:
+            continue
+        matrix[pivot_row], matrix[pivot] = matrix[pivot], matrix[pivot_row]
+        scale = matrix[pivot_row][column]
+        matrix[pivot_row] = [value / scale for value in matrix[pivot_row]]
+        for index in range(row_count):
+            if index == pivot_row or not matrix[index][column]:
+                continue
+            factor = matrix[index][column]
+            matrix[index] = [
+                value - factor * basis
+                for value, basis in zip(matrix[index], matrix[pivot_row], strict=True)
+            ]
+        pivot_row += 1
+        if pivot_row == row_count:
+            break
+    return pivot_row
+
+
+def _fraction_strings(values: Sequence[Fraction]) -> list[str]:
+    return [str(value) for value in values]
+
+
+def _summarize(
+    representation: str,
+    rows: Sequence[Sequence[Fraction]],
+    linearity_rows: set[int],
+    ambient_dimension: int,
+) -> dict[str, Any]:
+    if any(len(row) != ambient_dimension + 1 for row in rows):
+        raise ValueError("wrong homogeneous row width")
+    entries: list[tuple[str, list[Fraction]]] = []
+    if representation == "H":
+        for index, row in enumerate(rows):
+            kind = "EQUALITY" if index in linearity_rows else "INEQUALITY"
+            normalized = _integer_normalize(row, sign_free=kind == "EQUALITY")
+            if not any(normalized):
+                raise ValueError("zero H row")
+            entries.append((kind, normalized))
+        equality_normals = [row[1:] for kind, row in entries if kind == "EQUALITY"]
+        affine_dimension = ambient_dimension - _rank(equality_normals)
+    elif representation == "V":
+        vertices: list[list[Fraction]] = []
+        directions: list[list[Fraction]] = []
+        for index, row in enumerate(rows):
+            leading = row[0]
+            if index in linearity_rows:
+                if leading:
+                    raise ValueError("lineality row has nonzero homogenizing value")
+                kind = "LINEALITY"
+                normalized = _integer_normalize(row, sign_free=True)
+            elif leading == 1:
+                kind = "VERTEX"
+                normalized = list(row)
+            elif not leading:
+                kind = "RAY"
+                normalized = _integer_normalize(row, sign_free=False)
+            else:
+                raise ValueError("V row is not normalized to homogenizing value 0 or 1")
+            if not any(normalized):
+                raise ValueError("zero V row")
+            entries.append((kind, normalized))
+            if kind == "VERTEX":
+                vertices.append(normalized[1:])
+            else:
+                directions.append(normalized[1:])
+        base = vertices[0] if vertices else [Fraction(0)] * ambient_dimension
+        directions.extend(
+            [
+                [value - origin for value, origin in zip(vertex, base, strict=True)]
+                for vertex in vertices[1:]
+            ]
+        )
+        affine_dimension = _rank(directions)
+    else:
+        raise ValueError("unknown representation")
+
+    entries.sort(
+        key=lambda item: (
+            _KIND_ORDER[item[0]],
+            tuple(item[1]),
+        )
+    )
+    return {
+        "representation": representation,
+        "ambient_dimension": ambient_dimension,
+        "affine_dimension": affine_dimension,
+        "homogeneous_convention": (
+            "H:[b,a] means b+a*x>=0; H linearity means equality; "
+            "V:[1,x] vertex; V:[0,d] ray; V linearity means span(d)"
+        ),
+        "homogeneous_rows": [
+            {"kind": kind, "row": _fraction_strings(row)} for kind, row in entries
+        ],
+        "equalities": [
+            _fraction_strings(row) for kind, row in entries if kind == "EQUALITY"
+        ],
+        "inequalities": [
+            _fraction_strings(row) for kind, row in entries if kind == "INEQUALITY"
+        ],
+        "vertices": [
+            _fraction_strings(row[1:]) for kind, row in entries if kind == "VERTEX"
+        ],
+        "rays": [_fraction_strings(row[1:]) for kind, row in entries if kind == "RAY"],
+        "lineality": [
+            _fraction_strings(row[1:]) for kind, row in entries if kind == "LINEALITY"
+        ],
+    }
+
+
+def _parse_summary_rows(summary: Mapping[str, Any]) -> list[tuple[str, list[Fraction]]]:
+    try:
+        return [
+            (entry["kind"], [Fraction(value) for value in entry["row"]])
+            for entry in summary["homogeneous_rows"]
+        ]
+    except (KeyError, TypeError, ValueError, ZeroDivisionError) as exc:
+        raise CddlibSpikeError(
+            "REJECTED",
+            "PROVIDER_OUTPUT_MALFORMED",
+            "The provider returned a malformed exact H/V summary.",
+        ) from exc
+
+
+def _expected_mathematical(pin: Mapping[str, Any]) -> dict[str, Any]:
+    cases = _validate_cases(pin)
+    case_pins = {item["case_id"]: item for item in pin["reproduction"]["cases"]}
+    expected_cases = []
+    for case in cases:
+        expected_output = case_pins[case["case_id"]]["expected_output"]
+        output_rows = [
+            [_as_fraction(value) for value in row]
+            for row in expected_output["homogeneous_rows"]
+        ]
+        output_summary = _summarize(
+            expected_output["representation"],
+            output_rows,
+            set(expected_output["linearity_rows"]),
+            case["ambient_dimension"],
+        )
+        input_summary = _summarize(
+            case["representation"],
+            case["rows"],
+            case["linearity_rows"],
+            case["ambient_dimension"],
+        )
+        expected_cases.append(
+            {
+                "case_id": case["case_id"],
+                "conversion": (
+                    f"{case['representation']}_TO_{expected_output['representation']}"
+                ),
+                "input": input_summary,
+                "output": output_summary,
+                "same_provider_roundtrip": {
+                    "status": "MATCH",
+                    "result": input_summary,
+                    "independent": False,
+                },
+            }
+        )
+    probe = pin["reproduction"]["exact_arithmetic_probe"]
+    return {
+        "contract": pin["contract"],
+        "provider": pin["provider"],
+        "versions": pin["versions"],
+        "exact_arithmetic": {
+            "module": "cdd.gmp",
+            "number_type": "fractions.Fraction",
+            "large_fraction_input": probe,
+            "large_fraction_output": probe,
+            "roundtrip_exact": True,
+        },
+        "cases": expected_cases,
+    }
+
+
+def _independent_soundness(
+    case: Mapping[str, Any], output: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Check one containment direction using only stdlib Fraction arithmetic."""
+    input_representation = case["representation"]
+    input_summary = _summarize(
+        input_representation,
+        case["rows"],
+        case["linearity_rows"],
+        case["ambient_dimension"],
+    )
+    output_rows = _parse_summary_rows(output)
+    checks = 0
+
+    if input_representation == "H":
+        constraints = _parse_summary_rows(input_summary)
+        for output_kind, output_row in output_rows:
+            if output_kind not in {"VERTEX", "RAY", "LINEALITY"}:
+                raise CddlibSpikeError(
+                    "REJECTED",
+                    "INDEPENDENT_REPLAY_MISMATCH",
+                    "H-to-V output contains a non-generator row.",
+                )
+            point_or_direction = output_row[1:]
+            for constraint_kind, constraint in constraints:
+                value = sum(
+                    (
+                        coefficient * coordinate
+                        for coefficient, coordinate in zip(
+                            constraint[1:], point_or_direction, strict=True
+                        )
+                    ),
+                    constraint[0] if output_kind == "VERTEX" else Fraction(0),
+                )
+                if constraint_kind == "EQUALITY" or output_kind == "LINEALITY":
+                    accepted = value == 0
+                else:
+                    accepted = value >= 0
+                checks += 1
+                if not accepted:
+                    raise CddlibSpikeError(
+                        "REJECTED",
+                        "INDEPENDENT_REPLAY_MISMATCH",
+                        "A provider generator violates an input H row.",
+                    )
+        direction_summary = output
+    else:
+        generators = _parse_summary_rows(input_summary)
+        for output_kind, output_row in output_rows:
+            if output_kind not in {"EQUALITY", "INEQUALITY"}:
+                raise CddlibSpikeError(
+                    "REJECTED",
+                    "INDEPENDENT_REPLAY_MISMATCH",
+                    "V-to-H output contains a non-constraint row.",
+                )
+            for generator_kind, generator in generators:
+                value = sum(
+                    (
+                        coefficient * coordinate
+                        for coefficient, coordinate in zip(
+                            output_row[1:], generator[1:], strict=True
+                        )
+                    ),
+                    output_row[0] if generator_kind == "VERTEX" else Fraction(0),
+                )
+                if output_kind == "EQUALITY" or generator_kind == "LINEALITY":
+                    accepted = value == 0
+                else:
+                    accepted = value >= 0
+                checks += 1
+                if not accepted:
+                    raise CddlibSpikeError(
+                        "REJECTED",
+                        "INDEPENDENT_REPLAY_MISMATCH",
+                        "An output H row excludes an input generator.",
+                    )
+        direction_summary = input_summary
+
+    if output.get("affine_dimension") != direction_summary["affine_dimension"]:
+        raise CddlibSpikeError(
+            "REJECTED",
+            "INDEPENDENT_REPLAY_MISMATCH",
+            "The provider affine dimension disagrees with exact rank replay.",
+        )
+    return {
+        "case_id": case["case_id"],
+        "status": "SOUNDNESS_MATCH",
+        "exact_constraint_generator_checks": checks,
+        "affine_dimension": output["affine_dimension"],
+        "imports_provider": False,
+        "completeness": "NOT_ESTABLISHED",
+    }
+
+
+def _run_checked(
+    runner: ProcessRunner,
+    command: Sequence[str],
+    *,
+    timeout_seconds: float,
+) -> bytes:
+    try:
+        completed = runner(
+            command,
+            input_bytes=b"",
+            timeout_seconds=timeout_seconds,
+            environment=_ENVIRONMENT,
+            stdout_limit=128 * 1024,
+            stderr_limit=16 * 1024,
+        )
+    except OSError as exc:
+        raise CddlibSpikeError(
+            "ERROR",
+            "PROVIDER_LAUNCH_ERROR",
+            "The pycddlib spike could not be launched.",
+        ) from exc
+    if completed.cancelled:
+        raise CddlibSpikeError(
+            "CANCELLED", "PROVIDER_CANCELLED", "The pycddlib spike was cancelled."
+        )
+    if completed.timed_out:
+        raise CddlibSpikeError(
+            "TIMEOUT", "PROVIDER_TIMEOUT", "The pycddlib spike timed out."
+        )
+    if completed.stdout_exceeded or completed.stderr_exceeded:
+        raise CddlibSpikeError(
+            "ERROR",
+            "PROVIDER_OUTPUT_LIMIT",
+            "The pycddlib spike exceeded output bounds.",
+        )
+    if completed.returncode != 0:
+        raise CddlibSpikeError(
+            "ERROR", "PROVIDER_CRASH", "The pycddlib spike exited unsuccessfully."
+        )
+    return completed.stdout
+
+
+def _parse_provider_output(output: bytes, pin: Mapping[str, Any]) -> dict[str, Any]:
+    try:
+        payload = json.loads(output.decode("ascii"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise CddlibSpikeError(
+            "ERROR",
+            "PROVIDER_OUTPUT_MALFORMED",
+            "The pycddlib output is not canonical ASCII JSON.",
+        ) from exc
+    if not isinstance(payload, dict) or _canonical_json(payload) != output:
+        raise CddlibSpikeError(
+            "ERROR",
+            "PROVIDER_OUTPUT_MALFORMED",
+            "The pycddlib output is not one canonical JSON object.",
+        )
+    if (
+        payload.get("contract") != pin["contract"]
+        or payload.get("provider") != pin["provider"]
+        or payload.get("versions") != pin["versions"]
+    ):
+        raise CddlibSpikeError(
+            "REJECTED",
+            "PROVIDER_VERSION_MISMATCH",
+            "The interpreter does not expose the pinned cddlib spike protocol.",
+        )
+    runtime = payload.get("runtime")
+    if (
+        not isinstance(runtime, dict)
+        or runtime.get("pycddlib") != pin["versions"]["pycddlib"]
+        or runtime.get("number_type") != "fractions.Fraction"
+        or not isinstance(runtime.get("python"), str)
+        or not runtime["python"].startswith("3.12.")
+        or not isinstance(runtime.get("gmp_module_sha256"), str)
+        or not isinstance(runtime.get("distribution_record_sha256"), str)
+    ):
+        raise CddlibSpikeError(
+            "REJECTED",
+            "PROVIDER_RUNTIME_MISMATCH",
+            "The worker is not the pinned CPython 3.12 cdd.gmp runtime.",
+        )
+    mathematical = {key: value for key, value in payload.items() if key != "runtime"}
+    reproduction = pin["reproduction"]
+    if (
+        mathematical != _expected_mathematical(pin)
+        or _sha256_bytes(_canonical_json(mathematical))
+        != reproduction["expected_mathematical_output_sha256"]
+    ):
+        raise CddlibSpikeError(
+            "REJECTED",
+            "REPRODUCTION_MISMATCH",
+            "pycddlib did not reproduce the frozen exact H/V conversions.",
+        )
+    return payload
+
+
+def run_spike(
+    *,
+    python_executable: Path,
+    cddlib_source_archive: Path,
+    pycddlib_source_archive: Path,
+    timeout_seconds: float = 10,
+    runner: ProcessRunner = _default_runner,
+    pin_path: Path = PIN_PATH,
+    adapter_source: Path = ADAPTER_SOURCE,
+) -> dict[str, Any]:
+    """Run the bounded provider reproduction and independent soundness replay."""
+    try:
+        pin = _load_pin(pin_path)
+        resolved_python = _resolve_interpreter(python_executable)
+        cases = _validate_cases(pin)
+        cddlib_source = _inspect_archive(
+            cddlib_source_archive,
+            role="cddlib source archive",
+            source_pin=pin["sources"]["cddlib"],
+        )
+        pycddlib_source = _inspect_archive(
+            pycddlib_source_archive,
+            role="pycddlib source archive",
+            source_pin=pin["sources"]["pycddlib"],
+        )
+        resolved_adapter = _resolve_file(adapter_source, "cddlib spike adapter")
+        adapter_digest = _sha256_file(resolved_adapter)
+        if adapter_digest != pin["adapter_source_sha256"]:
+            raise CddlibSpikeError(
+                "REJECTED",
+                "ADAPTER_SOURCE_MISMATCH",
+                "The cddlib adapter source differs from the frozen digest.",
+            )
+        output = _run_checked(
+            runner,
+            [
+                str(resolved_python),
+                str(resolved_adapter),
+                "--worker",
+                "--pin",
+                str(pin_path.resolve()),
+            ],
+            timeout_seconds=timeout_seconds,
+        )
+        provider_output = _parse_provider_output(output, pin)
+        by_id = {case["case_id"]: case for case in cases}
+        independent = [
+            _independent_soundness(
+                by_id[observed["case_id"]],
+                observed["output"],
+            )
+            for observed in provider_output["cases"]
+        ]
+        return {
+            "contract": pin["contract"],
+            "status": "COMPLETED",
+            "conclusion": "SPIKE_PASSED_PRODUCTION_DEFERRED",
+            "assurance": "OBSERVED_EXACT_PROVIDER_BEHAVIOR_WITH_SOUNDNESS_REPLAY",
+            "provider": {
+                "name": pin["provider"],
+                "versions": pin["versions"],
+                "install_tier": "T1",
+                "deployment": (
+                    "operator-installed source build of GPL cddlib plus pycddlib"
+                ),
+                "distribution_decision": "GPL_OPTIONAL_PROVIDER_NOT_CORE_DEPENDENCY",
+                "sources": {
+                    "cddlib": cddlib_source,
+                    "pycddlib": pycddlib_source,
+                },
+                "adapter_source_sha256": adapter_digest,
+                "python_executable": str(resolved_python),
+                "runtime": provider_output["runtime"],
+            },
+            "reproduction": {
+                "scope": pin["reproduction"]["scope"],
+                "provider_output_sha256": _sha256_bytes(output),
+                "exact_arithmetic": provider_output["exact_arithmetic"],
+                "cases": provider_output["cases"],
+            },
+            "independent_replay": {
+                "algorithm": "STDLIB_FRACTION_CONSTRAINT_GENERATOR_REPLAY",
+                "status": "SOUNDNESS_MATCH",
+                "cases": independent,
+                "completeness": "NOT_ESTABLISHED",
+            },
+            "checker_feasibility": {
+                "decision": "REVISE",
+                "soundness_replay": "DEMONSTRATED_FOR_BOUNDED_CASES",
+                "same_provider_roundtrip": "EVIDENCE_ONLY_NOT_INDEPENDENT",
+                "open_obligations": [
+                    "freeze separate typed H and V artifacts with affine-hull semantics",
+                    "bind ambient and affine dimensions plus homogeneous normalization",
+                    "separate output soundness from reverse-containment completeness",
+                    "add independent Farkas, extremality, and lineality certificates",
+                    "authorize a checker package independent of cddlib and pycddlib",
+                    "measure the installed cddlib shared-library identity at runtime",
+                    "add adversarial omitted-facet, omitted-ray, sign, and rebinding cases",
+                ],
+            },
+            "capability_ids_registered": [],
+            "limitations": [
+                "all four cases are answer-visible bounded reproductions",
+                "same-provider round trips do not independently establish completeness",
+                "stdlib replay proves only that returned generators/constraints are sound",
+                "pycddlib exposes no cddlib runtime version API",
+                "GPL source builds remain operator-installed and outside core dependencies",
+            ],
+        }
+    except CddlibSpikeError as exc:
+        return {
+            "contract": "jacobian.cddlib-hv-spike/v1",
+            "status": exc.status,
+            "conclusion": "NO_CONCLUSION",
+            "diagnostic": {"code": exc.code, "detail": exc.detail},
+            "capability_ids_registered": [],
+        }
+
+
+def _worker(pin_path: Path) -> int:
+    """Run only inside the explicitly selected pycddlib interpreter."""
+    pin = _load_pin(pin_path)
+    cases = _validate_cases(pin)
+    try:
+        import importlib.metadata
+
+        import cdd.gmp as cdd
+    except ImportError as exc:
+        raise CddlibSpikeError(
+            "UNAVAILABLE",
+            "PROVIDER_IMPORT_ERROR",
+            "The pycddlib cdd.gmp module is unavailable.",
+        ) from exc
+    installed_version = importlib.metadata.version("pycddlib")
+    if installed_version != pin["versions"]["pycddlib"]:
+        sys.stdout.buffer.write(
+            _canonical_json(
+                {
+                    "contract": pin["contract"],
+                    "provider": pin["provider"],
+                    "versions": {
+                        **pin["versions"],
+                        "pycddlib": installed_version,
+                    },
+                }
+            )
+        )
+        return 0
+
+    observed_cases: list[dict[str, Any]] = []
+    for case in cases:
+        representation = (
+            cdd.RepType.INEQUALITY
+            if case["representation"] == "H"
+            else cdd.RepType.GENERATOR
+        )
+        matrix = cdd.matrix_from_array(
+            case["rows"],
+            lin_set=case["linearity_rows"],
+            rep_type=representation,
+        )
+        polyhedron = cdd.polyhedron_from_matrix(matrix)
+        output_matrix = cdd.copy_output(polyhedron)
+        cdd.matrix_canonicalize(output_matrix)
+        output_representation = "V" if case["representation"] == "H" else "H"
+        output_summary = _summarize(
+            output_representation,
+            output_matrix.array,
+            set(output_matrix.lin_set),
+            case["ambient_dimension"],
+        )
+        roundtrip_polyhedron = cdd.polyhedron_from_matrix(output_matrix)
+        roundtrip_matrix = cdd.copy_output(roundtrip_polyhedron)
+        cdd.matrix_canonicalize(roundtrip_matrix)
+        roundtrip_summary = _summarize(
+            case["representation"],
+            roundtrip_matrix.array,
+            set(roundtrip_matrix.lin_set),
+            case["ambient_dimension"],
+        )
+        input_summary = _summarize(
+            case["representation"],
+            case["rows"],
+            case["linearity_rows"],
+            case["ambient_dimension"],
+        )
+        observed_cases.append(
+            {
+                "case_id": case["case_id"],
+                "conversion": f"{case['representation']}_TO_{output_representation}",
+                "input": input_summary,
+                "output": output_summary,
+                "same_provider_roundtrip": {
+                    "status": (
+                        "MATCH" if roundtrip_summary == input_summary else "MISMATCH"
+                    ),
+                    "result": roundtrip_summary,
+                    "independent": False,
+                },
+            }
+        )
+
+    huge = Fraction(pin["reproduction"]["exact_arithmetic_probe"])
+    probe_matrix = cdd.matrix_from_array(
+        [[huge, Fraction(1)]],
+        rep_type=cdd.RepType.INEQUALITY,
+    )
+    exact_probe = probe_matrix.array[0][0]
+    gmp_module = Path(cdd.__file__).resolve()
+    distribution = importlib.metadata.distribution("pycddlib")
+    record_path = next(
+        (
+            Path(distribution.locate_file(item))
+            for item in distribution.files or ()
+            if item.name == "RECORD"
+        ),
+        None,
+    )
+    if record_path is None or not record_path.is_file():
+        raise CddlibSpikeError(
+            "REJECTED",
+            "PROVIDER_RUNTIME_MISMATCH",
+            "The installed pycddlib distribution RECORD is unavailable.",
+        )
+    payload = {
+        "contract": pin["contract"],
+        "provider": pin["provider"],
+        "versions": pin["versions"],
+        "exact_arithmetic": {
+            "module": "cdd.gmp",
+            "number_type": "fractions.Fraction",
+            "large_fraction_input": str(huge),
+            "large_fraction_output": str(exact_probe),
+            "roundtrip_exact": exact_probe == huge,
+        },
+        "cases": observed_cases,
+        "runtime": {
+            "python": sys.version.split()[0],
+            "pycddlib": installed_version,
+            "number_type": f"{cdd.NumberType.__module__}.{cdd.NumberType.__name__}",
+            "gmp_module_sha256": _sha256_file(gmp_module),
+            "distribution_record_sha256": _sha256_file(record_path),
+        },
+    }
+    sys.stdout.buffer.write(_canonical_json(payload))
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--python-executable", type=Path)
+    parser.add_argument("--cddlib-source-archive", type=Path)
+    parser.add_argument("--pycddlib-source-archive", type=Path)
+    parser.add_argument("--pin", type=Path, default=PIN_PATH)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--worker", action="store_true")
+    args = parser.parse_args(argv)
+    if args.worker:
+        return _worker(args.pin)
+    if (
+        args.python_executable is None
+        or args.cddlib_source_archive is None
+        or args.pycddlib_source_archive is None
+        or args.output is None
+    ):
+        parser.error(
+            "--python-executable, --cddlib-source-archive, "
+            "--pycddlib-source-archive, and --output are required"
+        )
+    report = run_spike(
+        python_executable=args.python_executable,
+        cddlib_source_archive=args.cddlib_source_archive,
+        pycddlib_source_archive=args.pycddlib_source_archive,
+        pin_path=args.pin,
+    )
+    args.output.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return 0 if report["status"] == "COMPLETED" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/contributing/cddlib-hv-provider-spike.md
+++ b/docs/contributing/cddlib-hv-provider-spike.md
@@ -1,0 +1,128 @@
+# cddlib exact H/V optional-provider spike
+
+[Documentation home](../index.md)
+
+- Status: provider evidence; production deferred
+- Frozen report contract: `jacobian.cddlib-hv-spike/v1`
+- Registered capability IDs: none
+
+## Decision
+
+The spike accepts cddlib `0.94n` with pycddlib `3.0.2` as a viable exact
+rational H/V conversion producer, but does not add it to Jacobian's locked
+environment or catalog. It must remain an operator-installed T1 provider.
+cddlib and pycddlib are GPL-2.0-or-later; their source build and distribution
+obligations are therefore an explicit deployment boundary, not a silent core
+dependency.
+
+The pins use the official
+[cddlib 0.94n release](https://github.com/cddlib/cddlib/releases/tag/0.94n)
+and the official
+[pycddlib 3.0.2 source distribution](https://pypi.org/project/pycddlib/3.0.2/).
+The source archives, tag commits, license files, GMP rational interface, and
+pycddlib `cdd.gmp` binding sources are digest-bound in
+`benchmarks/cddlib_hv_pin.json`.
+
+pycddlib 3.x intentionally separates the floating `cdd` module from the exact
+`cdd.gmp` module. This spike imports only `cdd.gmp`, supplies
+`fractions.Fraction`, and confirms a large rational value round-trips exactly.
+The official
+[pycddlib module reference](https://pycddlib.readthedocs.io/en/stable/cdd.html)
+defines the homogeneous H and V representations and their linearity sets.
+
+## Reproduce
+
+Linux has no official pycddlib wheel, so the recorded CPython 3.12 reproduction
+used an isolated source build. One equivalent setup is:
+
+```bash
+tar -xzf /tmp/cddlib-0.94n.tar.gz -C /tmp/cddlib-source
+cd /tmp/cddlib-source/cddlib-0.94n
+./configure --prefix=/tmp/cddlib-prefix
+make -j2
+make check
+make install
+
+uv venv --python 3.12 /tmp/pycddlib-venv
+env \
+  CFLAGS='-I/tmp/cddlib-prefix/include' \
+  LDFLAGS='-L/tmp/cddlib-prefix/lib -Wl,-rpath,/tmp/cddlib-prefix/lib' \
+  uv pip install \
+    --python /tmp/pycddlib-venv/bin/python \
+    /tmp/pycddlib-3.0.2.tar.gz
+```
+
+Run the bounded adapter from the locked Jacobian environment while selecting
+the isolated provider interpreter:
+
+```bash
+uv run python benchmarks/cddlib_hv_spike.py \
+  --python-executable /tmp/pycddlib-venv/bin/python \
+  --cddlib-source-archive /tmp/cddlib-0.94n.tar.gz \
+  --pycddlib-source-archive /tmp/pycddlib-3.0.2.tar.gz \
+  --output /tmp/jcb-cddlib-hv-spike.json
+```
+
+The frozen two-dimensional cases exercise both conversion directions:
+
+- an affine ray with one equality, one inequality, one vertex, and one ray;
+- a strip with two inequalities, two vertices, and one lineality direction;
+- the reverse V-to-H conversion of each representation; and
+- explicit affine dimension and homogeneous row normalization.
+
+The observed provider output digest is
+`sha256:ed554a7be4fedba9f5d6904a984030f96f9b9f8b513004d2252e0bb58df77e84`.
+All four same-provider round trips match the frozen normalized inputs. This is
+reproduction evidence, not independent completeness evidence.
+
+## Assurance boundary
+
+The controller independently replays every returned
+constraint/generator incidence with stdlib `Fraction` arithmetic and recomputes
+affine dimension from exact ranks. The four cases perform 4, 6, 4, and 6 exact
+checks. This establishes the demonstrated soundness direction:
+
+- for H-to-V, every returned vertex, ray, and lineality direction respects the
+  input constraints; and
+- for V-to-H, every returned equality and inequality contains the input
+  vertices, rays, and lineality directions.
+
+It does not establish the reverse containment. In particular, an omitted
+facet, vertex, or ray can pass one-direction soundness. Converting the result
+back with the same cddlib implementation is useful provider evidence but is not
+an independent checker. The spike therefore remains `COMPUTED`-eligible only
+and reports `REVISE` for checker feasibility.
+
+## Production contract gate
+
+Do not register `polytope.rational.h_to_v.compute` or
+`polytope.rational.v_to_h.compute` until a later change supplies:
+
+- separate typed H and V artifacts with ambient and affine dimensions;
+- explicit equalities, inequalities, vertices, rays, and lineality;
+- a versioned `[b,a]` / `[t,x]` homogeneous convention and normalization;
+- full request validation before provider execution or artifact writes;
+- bounded subprocess failure semantics for timeout, cancellation, crash,
+  malformed output, and version mismatch;
+- installed cddlib shared-library identity measurement, because pycddlib does
+  not expose a cddlib runtime version API;
+- independent bidirectional containment, Farkas/extremality/completeness
+  evidence, or an equivalently strong exact checker; and
+- adversarial omitted-row, omitted-generator, sign, scope, and artifact-binding
+  tests with zero false certification.
+
+Only an operator-authorized checker package independent of cddlib, pycddlib,
+proposal, search, and evaluation may return `VERIFIED`. Provider availability,
+GPL deployment approval, compatibility, and checker authority remain separate.
+
+## Handoff
+
+- Baseline: the git tree containing the spike; record the exact tree in the PR.
+- Provider state: cddlib and pycddlib absent from the locked Jacobian
+  environment; present only in the isolated reproduction prefix and venv.
+- Model/prompt settings: not applicable; this is a deterministic provider
+  reproduction.
+- Public/held-out role: all four cases are answer-visible regression evidence.
+- Raw report: `/tmp/jcb-cddlib-hv-spike.json` on the reproducing host.
+- Decision: retain the spike, register no capabilities, and require the
+  production contract and independent completeness gates above.

--- a/docs/index.md
+++ b/docs/index.md
@@ -130,6 +130,9 @@ degeneracy semantics, and independent geometry-checker obligations.
 The [GUDHI persistent-homology optional-provider spike](contributing/gudhi-persistence-provider-spike.md)
 records exact-rank transport, selected-module licensing, bounded pairing
 reproduction, and independent modular-reduction obligations.
+The [cddlib exact H/V optional-provider spike](contributing/cddlib-hv-provider-spike.md)
+records the GPL source-build boundary, exact GMP-rational reproduction,
+homogeneous representation semantics, and the unresolved completeness gate.
 
 Recurring agent work is encoded in the repository-local skills under
 `.agents/skills/`. Start with `develop-math-capabilities` for a complete

--- a/tests/boundary/process/providers/test_cddlib_hv_spike.py
+++ b/tests/boundary/process/providers/test_cddlib_hv_spike.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import runpy
+import tarfile
+from collections.abc import Callable, Sequence
+from io import BytesIO
+from pathlib import Path
+from typing import Any, cast
+
+from jacobian.bounded_process import BoundedProcessResult
+
+PROJECT_ROOT = Path(__file__).resolve().parents[4]
+SPIKE = runpy.run_path(str(PROJECT_ROOT / "benchmarks" / "cddlib_hv_spike.py"))
+BASE_PIN = json.loads(
+    (PROJECT_ROOT / "benchmarks" / "cddlib_hv_pin.json").read_text(encoding="utf-8")
+)
+RunSpike = Callable[..., dict[str, Any]]
+RUN_SPIKE = cast(RunSpike, SPIKE["run_spike"])
+EXPECTED_MATHEMATICAL = SPIKE["_expected_mathematical"](BASE_PIN)
+
+
+def _sha256(payload: bytes) -> str:
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def _canonical(payload: object) -> bytes:
+    return (
+        json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+        + "\n"
+    ).encode("ascii")
+
+
+def _result(
+    *,
+    stdout: bytes = b"",
+    returncode: int | None = 0,
+    timed_out: bool = False,
+) -> BoundedProcessResult:
+    return BoundedProcessResult(
+        returncode=returncode,
+        stdout=stdout,
+        stderr=b"",
+        stdout_exceeded=False,
+        stderr_exceeded=False,
+        timed_out=timed_out,
+    )
+
+
+def _runner(
+    outcomes: Sequence[BoundedProcessResult],
+) -> Callable[..., BoundedProcessResult]:
+    remaining = iter(outcomes)
+
+    def run(*_args: object, **_kwargs: object) -> BoundedProcessResult:
+        return next(remaining)
+
+    return run
+
+
+def _provider_output(
+    mathematical: dict[str, Any] | None = None,
+    *,
+    python_version: str = "3.12.13",
+    pycddlib_version: str = "3.0.2",
+) -> bytes:
+    payload = {
+        **(mathematical or EXPECTED_MATHEMATICAL),
+        "runtime": {
+            "distribution_record_sha256": "sha256:" + "1" * 64,
+            "gmp_module_sha256": "sha256:" + "2" * 64,
+            "number_type": "fractions.Fraction",
+            "pycddlib": pycddlib_version,
+            "python": python_version,
+        },
+    }
+    return _canonical(payload)
+
+
+def _archive(path: Path, members: dict[str, bytes]) -> None:
+    with tarfile.open(path, mode="w:gz") as archive:
+        for name, payload in members.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            info.mtime = 0
+            archive.addfile(info, BytesIO(payload))
+
+
+def _fixture(tmp_path: Path) -> tuple[Path, Path, Path, Path, Path]:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    python = tmp_path / "pycddlib-python"
+    adapter = tmp_path / "cddlib-spike.py"
+    python.touch()
+    adapter.write_text("# fixture\n", encoding="utf-8")
+
+    cdd_members = {
+        name: "\n".join(expected["required_ascii_markers"]).encode("ascii")
+        for name, expected in BASE_PIN["sources"]["cddlib"]["identity_members"].items()
+    }
+    pycdd_members = {
+        name: "\n".join(expected["required_ascii_markers"]).encode("ascii")
+        for name, expected in BASE_PIN["sources"]["pycddlib"][
+            "identity_members"
+        ].items()
+    }
+    cdd_source = tmp_path / "cddlib-0.94n.tar.gz"
+    pycdd_source = tmp_path / "pycddlib-3.0.2.tar.gz"
+    _archive(cdd_source, cdd_members)
+    _archive(pycdd_source, pycdd_members)
+
+    pin = {
+        **BASE_PIN,
+        "adapter_source_sha256": _sha256(adapter.read_bytes()),
+        "sources": {
+            "cddlib": {
+                **BASE_PIN["sources"]["cddlib"],
+                "archive_sha256": _sha256(cdd_source.read_bytes()),
+                "identity_members": {
+                    name: {
+                        **BASE_PIN["sources"]["cddlib"]["identity_members"][name],
+                        "sha256": _sha256(payload),
+                    }
+                    for name, payload in cdd_members.items()
+                },
+            },
+            "pycddlib": {
+                **BASE_PIN["sources"]["pycddlib"],
+                "archive_sha256": _sha256(pycdd_source.read_bytes()),
+                "identity_members": {
+                    name: {
+                        **BASE_PIN["sources"]["pycddlib"]["identity_members"][name],
+                        "sha256": _sha256(payload),
+                    }
+                    for name, payload in pycdd_members.items()
+                },
+            },
+        },
+    }
+    pin_path = tmp_path / "pin.json"
+    pin_path.write_text(json.dumps(pin), encoding="utf-8")
+    return python, cdd_source, pycdd_source, adapter, pin_path
+
+
+def test_exact_hv_spike_keeps_production_deferred(tmp_path: Path) -> None:
+    python, cdd_source, pycdd_source, adapter, pin = _fixture(tmp_path)
+
+    report = RUN_SPIKE(
+        python_executable=python,
+        cddlib_source_archive=cdd_source,
+        pycddlib_source_archive=pycdd_source,
+        runner=_runner([_result(stdout=_provider_output())]),
+        pin_path=pin,
+        adapter_source=adapter,
+    )
+
+    assert report["status"] == "COMPLETED"
+    assert report["conclusion"] == "SPIKE_PASSED_PRODUCTION_DEFERRED"
+    assert report["provider"]["distribution_decision"] == (
+        "GPL_OPTIONAL_PROVIDER_NOT_CORE_DEPENDENCY"
+    )
+    assert report["reproduction"]["exact_arithmetic"]["roundtrip_exact"] is True
+    assert [
+        item["exact_constraint_generator_checks"]
+        for item in report["independent_replay"]["cases"]
+    ] == [4, 6, 4, 6]
+    assert report["independent_replay"]["completeness"] == "NOT_ESTABLISHED"
+    assert report["checker_feasibility"]["decision"] == "REVISE"
+    assert report["capability_ids_registered"] == []
+
+
+def test_absent_provider_is_an_explicit_non_conclusion(tmp_path: Path) -> None:
+    report = RUN_SPIKE(
+        python_executable=tmp_path / "absent-python",
+        cddlib_source_archive=tmp_path / "absent-cddlib.tar.gz",
+        pycddlib_source_archive=tmp_path / "absent-pycddlib.tar.gz",
+    )
+
+    assert report == {
+        "contract": "jacobian.cddlib-hv-spike/v1",
+        "status": "UNAVAILABLE",
+        "conclusion": "NO_CONCLUSION",
+        "diagnostic": {
+            "code": "PROVIDER_FILE_UNAVAILABLE",
+            "detail": (
+                "The explicitly selected pycddlib Python interpreter is unavailable."
+            ),
+        },
+        "capability_ids_registered": [],
+    }
+
+
+def test_source_mismatch_fails_before_execution(tmp_path: Path) -> None:
+    python, cdd_source, pycdd_source, adapter, pin = _fixture(tmp_path)
+    cdd_source.write_bytes(b"wrong source")
+    calls = 0
+
+    def runner(*_args: object, **_kwargs: object) -> BoundedProcessResult:
+        nonlocal calls
+        calls += 1
+        return _result(stdout=_provider_output())
+
+    report = RUN_SPIKE(
+        python_executable=python,
+        cddlib_source_archive=cdd_source,
+        pycddlib_source_archive=pycdd_source,
+        runner=runner,
+        pin_path=pin,
+        adapter_source=adapter,
+    )
+
+    assert report["status"] == "REJECTED"
+    assert report["diagnostic"]["code"] == "SOURCE_VERSION_MISMATCH"
+    assert calls == 0
+
+
+def test_protocol_runtime_and_malformed_output_fail_closed(tmp_path: Path) -> None:
+    python, cdd_source, pycdd_source, adapter, pin = _fixture(tmp_path)
+    common = {
+        "python_executable": python,
+        "cddlib_source_archive": cdd_source,
+        "pycddlib_source_archive": pycdd_source,
+        "pin_path": pin,
+        "adapter_source": adapter,
+    }
+
+    malformed = RUN_SPIKE(runner=_runner([_result(stdout=b"not-json")]), **common)
+    wrong_version = {
+        **EXPECTED_MATHEMATICAL,
+        "versions": {"cddlib": "0.94n", "pycddlib": "9.9.9"},
+    }
+    version = RUN_SPIKE(
+        runner=_runner([_result(stdout=_provider_output(wrong_version))]), **common
+    )
+    runtime = RUN_SPIKE(
+        runner=_runner([_result(stdout=_provider_output(python_version="3.11.99"))]),
+        **common,
+    )
+
+    assert malformed["status"] == "ERROR"
+    assert malformed["diagnostic"]["code"] == "PROVIDER_OUTPUT_MALFORMED"
+    assert version["status"] == "REJECTED"
+    assert version["diagnostic"]["code"] == "PROVIDER_VERSION_MISMATCH"
+    assert runtime["status"] == "REJECTED"
+    assert runtime["diagnostic"]["code"] == "PROVIDER_RUNTIME_MISMATCH"
+
+
+def test_timeout_and_crash_are_distinct_non_conclusions(tmp_path: Path) -> None:
+    python, cdd_source, pycdd_source, adapter, pin = _fixture(tmp_path)
+    common = {
+        "python_executable": python,
+        "cddlib_source_archive": cdd_source,
+        "pycddlib_source_archive": pycdd_source,
+        "pin_path": pin,
+        "adapter_source": adapter,
+    }
+
+    timeout = RUN_SPIKE(
+        runner=_runner([_result(returncode=None, timed_out=True)]), **common
+    )
+    crash = RUN_SPIKE(runner=_runner([_result(returncode=7)]), **common)
+
+    assert timeout["status"] == "TIMEOUT"
+    assert timeout["diagnostic"]["code"] == "PROVIDER_TIMEOUT"
+    assert crash["status"] == "ERROR"
+    assert crash["diagnostic"]["code"] == "PROVIDER_CRASH"
+
+
+def test_independent_replay_rejects_self_consistent_unsound_output(
+    tmp_path: Path,
+) -> None:
+    python, cdd_source, pycdd_source, adapter, pin_path = _fixture(tmp_path)
+    pin = json.loads(pin_path.read_text(encoding="utf-8"))
+    pin["reproduction"]["cases"][0]["expected_output"] = {
+        "representation": "V",
+        "homogeneous_rows": [["1", "0", "0"], ["0", "1", "0"]],
+        "linearity_rows": [],
+    }
+    forged = SPIKE["_expected_mathematical"](pin)
+    pin["reproduction"]["expected_mathematical_output_sha256"] = _sha256(
+        _canonical(forged)
+    )
+    pin_path.write_text(json.dumps(pin), encoding="utf-8")
+
+    report = RUN_SPIKE(
+        python_executable=python,
+        cddlib_source_archive=cdd_source,
+        pycddlib_source_archive=pycdd_source,
+        runner=_runner([_result(stdout=_provider_output(forged))]),
+        pin_path=pin_path,
+        adapter_source=adapter,
+    )
+
+    assert report["status"] == "REJECTED"
+    assert report["diagnostic"]["code"] == "INDEPENDENT_REPLAY_MISMATCH"
+    assert report["capability_ids_registered"] == []
+
+
+def test_malformed_archives_do_not_escape_as_exceptions(tmp_path: Path) -> None:
+    python, cdd_source, pycdd_source, adapter, pin_path = _fixture(tmp_path)
+    pin = json.loads(pin_path.read_text(encoding="utf-8"))
+    pycdd_source.write_bytes(b"not-a-tar")
+    pin["sources"]["pycddlib"]["archive_sha256"] = _sha256(pycdd_source.read_bytes())
+    pin_path.write_text(json.dumps(pin), encoding="utf-8")
+
+    report = RUN_SPIKE(
+        python_executable=python,
+        cddlib_source_archive=cdd_source,
+        pycddlib_source_archive=pycdd_source,
+        pin_path=pin_path,
+        adapter_source=adapter,
+    )
+
+    assert report["status"] == "REJECTED"
+    assert report["diagnostic"]["code"] == "SOURCE_ARCHIVE_MALFORMED"

--- a/tests/composition/runtime/test_cddlib_hv_spike_isolation.py
+++ b/tests/composition/runtime/test_cddlib_hv_spike_isolation.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import runpy
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, cast
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+SPIKE = runpy.run_path(str(PROJECT_ROOT / "benchmarks" / "cddlib_hv_spike.py"))
+RunSpike = Callable[..., dict[str, Any]]
+RUN_SPIKE = cast(RunSpike, SPIKE["run_spike"])
+
+
+def test_absent_cddlib_does_not_change_complete_runtime_catalog(
+    fresh_complete_runtime,
+    tmp_path: Path,
+) -> None:
+    before = fresh_complete_runtime.core.capabilities.catalog().model_dump(mode="json")
+
+    report = RUN_SPIKE(
+        python_executable=tmp_path / "absent-pycddlib-python",
+        cddlib_source_archive=tmp_path / "absent-cddlib.tar.gz",
+        pycddlib_source_archive=tmp_path / "absent-pycddlib.tar.gz",
+    )
+
+    after = fresh_complete_runtime.core.capabilities.catalog().model_dump(mode="json")
+    assert report["status"] == "UNAVAILABLE"
+    assert report["capability_ids_registered"] == []
+    assert after == before


### PR DESCRIPTION
## Summary

- add a pinned cddlib 0.94n / pycddlib 3.0.2 exact H/V conversion provider spike
- exercise H-to-V and V-to-H on affine-ray and strip-with-lineality cases
- preserve affine dimension, equalities, inequalities, vertices, rays, lineality, and the homogeneous-row convention
- use only `cdd.gmp` with `fractions.Fraction`, including a beyond-float-precision rational round trip
- independently replay exact constraint/generator soundness and affine rank with stdlib `Fraction`
- keep completeness explicitly unestablished, production deferred, and capability registration empty
- prove an absent provider leaves the complete runtime catalog unchanged

## Provider evidence

- cddlib: `0.94n`
- cddlib tag commit: `86dfe60811ec879a46e73d488719acaa754536e4`
- cddlib official release archive: `sha256:b87ee07ba2c1d0ab92a3e4eccacdf568f981a095a392e3b9efd7e7e4a9e125b1`
- pycddlib: `3.0.2`
- pycddlib tag commit: `2227de7b848014e634a81b8815327bc4de9a079a`
- pycddlib PyPI sdist: `sha256:50f43f039818ab97c8cb44345eed9a365dae66789ce11cc8c95a74134a8907a7`
- license boundary: cddlib and pycddlib are `GPL-2.0-or-later`
- deployment: operator-installed T1 source build; no Linux wheel and no core dependency change
- local runtime: CPython `3.12.13`, `cdd.gmp`, `fractions.Fraction`
- installed pycddlib RECORD: `sha256:a577d25b1a78a46de10ef4966d64da0f29457c80e783119f9966647176598176`
- compiled `cdd.gmp` module: `sha256:0e420ba17b466cd55a6cee7840bc6baa49be464fd6d70ccde1c8345f8f361436`
- observed provider output: `sha256:ed554a7be4fedba9f5d6904a984030f96f9b9f8b513004d2252e0bb58df77e84`

The exact module returned
`1208925819614629174706177/2288818359375` unchanged. All four frozen
same-provider round trips matched.

## Assurance and decision

- execution: `COMPLETED`
- conclusion: `SPIKE_PASSED_PRODUCTION_DEFERRED`
- evidence: observed exact provider behavior plus provider-independent bounded soundness replay
- independent exact incidence checks: 20
- completeness: `NOT_ESTABLISHED`
- production/checker decision: `REVISE`
- registered capability IDs: none
- compatibility impact: none; no dependency, public contract, or catalog entry changes

The stdlib replay proves the demonstrated containment/soundness direction:
returned V generators satisfy the input H rows, and returned H rows contain the
input V generators. It does not prove reverse containment or that a facet,
vertex, or ray was not omitted. Same-provider conversion round trips are
evidence, not an independent checker.

Future `polytope.rational.h_to_v.compute` and
`polytope.rational.v_to_h.compute` capabilities remain gated on typed H/V
artifacts, installed cddlib shared-library identity, independent bidirectional
containment, Farkas/extremality/completeness evidence, operator checker
authorization, and adversarial omission/rebinding tests. Producers remain
capped at `COMPUTED`; this spike cannot return `VERIFIED`.

## Validation

Final rebased committed tree:

- HEAD: `1ac63f4ab19c8cc93341dfce2cc434241675d51d`
- git tree: `073d70771c1d00c1f7e3a58b02567f99cb617607`
- baseline: `af77c2cbb86afb2a0fe6f42847dceb4cbda3e8b1`
- worktree remained clean after validation

Passed after the final rebase:

- `make check` — lint, format, mypy, 288 unit tests
- `make check-static` — dependency/dead-code checks, architecture policy, mypy, package build
- `make docs-linkcheck`
- `make test-process TESTS=tests/boundary/process/providers/test_cddlib_hv_spike.py` — 7 passed
- `make test-composition TESTS=tests/composition/runtime/test_cddlib_hv_spike_isolation.py` — 1 passed
- real pinned cddlib/pycddlib source-build reproduction

## Handoff

- installed catalog: 282 capabilities, `sha256:7fb0a74a06d2684dab51905d87c92efd328f86108f447640cab621991f3339cd`
- DEFAULT policy: `sha256:870a92b83d3e522e4015b6bb1cabda33086906f9de1c3c36e466251ea7ed1957`
- provider state: absent from the locked Jacobian environment; installed only in `/tmp/jcb-cddlib-0.94n-prefix` and `/tmp/jcb-pycddlib-venv312`
- raw reproduction: `/tmp/jcb-cddlib-hv-spike.json`
- model/prompt settings: not applicable; deterministic provider reproduction
- public/held-out role: all four frozen cases are answer-visible regression evidence
- unresolved obligations: production artifact/contract split, installed cddlib runtime identity, independent completeness certificates/checker, authorization, adversarial binding suite, larger held-out comparison
- next action: retain the spike as evidence; do not register H/V conversion capabilities until all production and checker gates pass
