### PR TITLE
feat(polynomials): add verified bounded Gaussian polynomial moments

### DIFF
--- a/benchmarks/reproduction_cases/gaussian_polynomial_moment_public.json
+++ b/benchmarks/reproduction_cases/gaussian_polynomial_moment_public.json
@@ -1,0 +1,119 @@
+{
+  "suite_id": "GAUSSIAN-POLYNOMIAL-MOMENT-PUBLIC-001",
+  "version": "1",
+  "scored": false,
+  "purpose": "Answer-visible bounded exact reproductions only; never hidden evaluation and never evidence for an all-order identity",
+  "cases": [
+    {
+      "case_id": "STANDARD-REAL-SIXTH-MOMENT-001",
+      "source": "https://arxiv.org/abs/2607.18186, equation (5)",
+      "request": {
+        "polynomial": {
+          "variable_count": 1,
+          "terms": [
+            {
+              "coefficient": {
+                "real": {"num": "1", "den": "1"},
+                "imaginary": {"num": "0", "den": "1"}
+              },
+              "exponents": [1]
+            }
+          ]
+        },
+        "order": 6
+      },
+      "expected_moment": {
+        "real": {"num": "15", "den": "1"},
+        "imaginary": {"num": "0", "den": "1"}
+      }
+    },
+    {
+      "case_id": "COMPLEX-CANCELLATION-001",
+      "source": "Jacobian synthetic public contraction regression",
+      "request": {
+        "polynomial": {
+          "variable_count": 1,
+          "terms": [
+            {
+              "coefficient": {
+                "real": {"num": "1", "den": "1"},
+                "imaginary": {"num": "0", "den": "1"}
+              },
+              "exponents": [0]
+            },
+            {
+              "coefficient": {
+                "real": {"num": "0", "den": "1"},
+                "imaginary": {"num": "1", "den": "1"}
+              },
+              "exponents": [1]
+            }
+          ]
+        },
+        "order": 2
+      },
+      "expected_moment": {
+        "real": {"num": "0", "den": "1"},
+        "imaginary": {"num": "0", "den": "1"}
+      }
+    },
+    {
+      "case_id": "TWO-GAUSSIAN-SUM-FOURTH-MOMENT-001",
+      "source": "Jacobian synthetic public independence regression",
+      "request": {
+        "polynomial": {
+          "variable_count": 2,
+          "terms": [
+            {
+              "coefficient": {
+                "real": {"num": "1", "den": "1"},
+                "imaginary": {"num": "0", "den": "1"}
+              },
+              "exponents": [0, 1]
+            },
+            {
+              "coefficient": {
+                "real": {"num": "1", "den": "1"},
+                "imaginary": {"num": "0", "den": "1"}
+              },
+              "exponents": [1, 0]
+            }
+          ]
+        },
+        "order": 4
+      },
+      "expected_moment": {
+        "real": {"num": "12", "den": "1"},
+        "imaginary": {"num": "0", "den": "1"}
+      }
+    }
+  ],
+  "attack_coverage": [
+    {
+      "variant": "mutated expanded coefficient with a recomputed artifact digest",
+      "expected": "REJECTED with UNKNOWN conclusion and no verification record"
+    },
+    {
+      "variant": "omitted odd contraction or forged Gaussian moment factor",
+      "expected": "REJECTED with UNKNOWN conclusion and no verification record"
+    },
+    {
+      "variant": "a finite list of zero moments presented as an all-order identity",
+      "expected": "outside capability scope; no such conclusion is emitted"
+    }
+  ],
+  "held_out_evaluation": {
+    "status": "READY_NOT_RUN",
+    "case_source": "Freeze generated sparse polynomials after this public suite is excluded",
+    "independent_oracle": "separate standard-library Fraction coefficient contraction",
+    "control": "catalog without probability.gaussian_polynomial.moment.compute",
+    "treatment": "catalog with the producer and operator-authorized probability.result.verify",
+    "primary_metrics": [
+      "exact fixed-order answer correctness",
+      "checker-bound completion",
+      "false all-order generalization",
+      "false VERIFIED rate"
+    ],
+    "minimum_repetitions": 3
+  }
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,6 +60,7 @@ expectations.
 - [Tool surface](reference/tools.md)
 - [Domain operation library](reference/domain-operation-library.md)
 - [Finite probability operations](reference/finite-probability-operations.md)
+- [Bounded Gaussian polynomial moments](reference/gaussian-polynomial-moments.md)
 - [Exact planar geometry](reference/exact-planar-geometry.md)
 - [Finite simplicial topology](reference/finite-simplicial-topology.md)
 - [Finite posets](reference/finite-posets.md)

--- a/docs/reference/finite-probability-operations.md
+++ b/docs/reference/finite-probability-operations.md
@@ -49,6 +49,8 @@ that exact bound candidate returns `VERIFIED`. Malformed artifacts, substituted
 sources, altered ledgers, missing convolution pairs, and mathematically false
 but schema-valid candidates are rejected without a verification record.
 
-This foundation does not cover predicate-defined events, approximate or
-continuous distributions, Gaussian identities, Markov chains, graph
-reliability, or probabilistic inference strategy.
+This finite-distribution foundation does not cover predicate-defined events,
+approximate distributions, all-order Gaussian identities, Markov chains,
+graph reliability, or probabilistic inference strategy. The same probability
+bundle separately exposes one
+[bounded Gaussian polynomial moment](gaussian-polynomial-moments.md) outcome.

--- a/docs/reference/gaussian-polynomial-moments.md
+++ b/docs/reference/gaussian-polynomial-moments.md
@@ -1,0 +1,170 @@
+# Bounded Gaussian polynomial moments
+
+[Documentation home](../index.md)
+
+- Status: Current implementation reference; contract is experimental
+- Capability: `probability.gaussian_polynomial.moment.compute`
+- Verification: `probability.result.verify`
+- Producer: pinned Python-FLINT exact rational arithmetic
+- Checker: isolated Python standard-library `Fraction` coefficient contraction
+
+This capability computes one fixed-order moment
+
+\[
+  \mathbb E[P(X_1,\ldots,X_n)^m]
+\]
+
+where the \(X_j\) are independent standard real Gaussian variables and \(P\)
+is a canonical sparse polynomial with coefficients in
+\(\mathbb Q(i)\). It returns one exact complex-rational value and the complete
+bounded coefficient-contraction ledger for that request. It is a mathematical
+operation, not a Gaussian-identity search or proof workflow.
+
+## Contract and scope
+
+The request bounds are:
+
+| Field | Bound |
+| --- | --- |
+| Gaussian variables | 1–8 |
+| Nonzero sparse terms | 1–16 |
+| Total degree of each input term | at most 8 |
+| Fixed moment order \(m\) | 0–16 |
+| Raw ordered expansion paths | `term_count ** m <= 4096` |
+| Input rational numerator/denominator | at most 128 decimal digits |
+
+Terms use exponent vectors of length `variable_count`, in strictly increasing
+lexicographic order. A coefficient has separate canonical rational `real` and
+`imaginary` components. Duplicate monomials, zero coefficients, negative
+exponents, inconsistent dimensions, and requests beyond the complete-expansion
+bound fail validation before computation or artifact writes.
+
+The producer exactly expands \(P^m\), merges equal exponent vectors, and removes
+zero coefficients. For every remaining exponent vector
+\(\alpha=(\alpha_1,\ldots,\alpha_n)\), its ledger records:
+
+- the exact expanded coefficient;
+- each univariate factor
+  \(\mathbb E[X_j^{\alpha_j}]\), equal to zero for odd exponents and
+  \((\alpha_j-1)!!\) for even exponents;
+- the product of those factors; and
+- the exact complex-rational contribution.
+
+The result separately reports raw expansion-path count, canonical expanded
+monomial count, `COMPLETE_BOUNDED_EXPANSION`, the Gaussian model
+`INDEPENDENT_STANDARD_REAL`, and `UNVERIFIED`. Order zero returns the moment
+one and its constant contraction.
+
+## Claim boundary
+
+A successful result claims only the exact value for the polynomial and single
+integer order stored in its input artifact. It does not claim:
+
+- vanishing or nonvanishing for any other order;
+- an identity for all \(m\), eventual behavior, or an asymptotic;
+- a mixed moment such as \(\mathbb E[Q P^m]\) unless that complete polynomial
+  is itself supplied as the one bounded input;
+- a result for correlated, nonstandard, or complex Gaussian variables; or
+- support for algebraic coefficients outside \(\mathbb Q(i)\).
+
+In particular, checking finitely many moments cannot establish the all-order
+identities in
+[Small Counterexamples to the Gaussian Moments Conjecture](https://arxiv.org/abs/2607.18186).
+That public paper motivates the recurring contraction move, while an
+all-parameter identity needs a different symbolic certificate and checker.
+
+## Independent verification
+
+The producer remains `COMPUTED`. The operator-authorized checker runs in an
+isolated process, imports neither Python-FLINT nor the producer module, and
+reconstructs the sparse power using only `Fraction`. It independently checks:
+
+1. the exact source polynomial, dimension, order, and expansion bound;
+2. every merged coefficient of the canonical expansion;
+3. every odd/even univariate Gaussian factor;
+4. every contribution and the final complex-rational sum;
+5. the ledger length, ordering, completeness marker, and backend metadata; and
+6. the artifact, semantics, candidate, scope, witness-format, and checker
+   bindings supplied by the verification kernel.
+
+Only an accepted replay of that exact stored result may return `VERIFIED`.
+Missing entries, altered coefficients or factors, substituted sources,
+malformed metadata, checker unavailability, timeout, and process failure
+produce no verification record and no promoted conclusion.
+
+## Development handoff
+
+### Discovery
+
+- Status: accepted for the bounded fixed-order outcome only.
+- Evidence: arXiv:2607.18186 exposes repeated exact Gaussian coefficient
+  contractions; the pre-change catalog had 282 capabilities and only
+  finite-distribution probability moments.
+- Portfolio delta: this operation integrates a polynomial against the standard
+  Gaussian product measure. It does not duplicate
+  `probability.finite_distribution.raw_moment.compute`, which sums an explicit
+  finite atomic distribution, or generic polynomial normalization, which has
+  no probability semantics.
+- Public reproduction:
+  [`gaussian_polynomial_moment_public.json`](../../benchmarks/reproduction_cases/gaussian_polynomial_moment_public.json).
+- Evaluation hypothesis: a domain-owned fixed-order outcome plus independent
+  replay should reduce hand-written Wick arithmetic errors without increasing
+  false all-order claims or false `VERIFIED` results.
+
+### Implementation
+
+- Base revision: `7c205f59bbeb0ea6bb095fb1aaf22be28094d2ab`.
+- Runtime: CPython 3.12; pinned `python-flint==0.9.0`; no dependency change.
+- Live post-change catalog: 283 capabilities,
+  `sha256:eeb49bec370a6bef5f30646de13ccfce86b974865aac560f51c22ece79c1b722`.
+- Default policy:
+  `sha256:870a92b83d3e522e4015b6bb1cabda33086906f9de1c3c36e466251ea7ed1957`.
+- Producer distribution-record digest:
+  `sha256:8ade9b4c5c1972b029d9393bb2586e2097cc44149a84ef8ef9ef376d634c328f`.
+- Outcome: one exact fixed-order moment and its complete contraction ledger.
+- Failure semantics: all scope violations are input errors with no result
+  artifacts; execution failure is not a mathematical conclusion.
+- Compatibility: probability semantics advance from version 2 to version 3;
+  existing experimental finite-distribution request and result models are
+  unchanged.
+
+### Checker
+
+- Exact claim: the stored result equals the complete coefficient contraction
+  of the exact stored request under independent standard-real Gaussian
+  semantics.
+- Independence: source package `jacobian_checkers` uses only the standard
+  library and is invoked in a clean process; it does not import producer code
+  or Python-FLINT.
+- Authorization: checker installation and policy remain operator-owned.
+- Attack evidence: contract-valid changed contributions, changed metadata,
+  incomplete ledgers, and fresh payload digests are rejected with `UNKNOWN`
+  and no verification record.
+
+### Evaluation
+
+- Public cases: three answer-visible deterministic reproductions cover a
+  standard sixth moment, complex cancellation, and two-variable independence.
+  They are regressions, not held-out product evidence.
+- Held-out comparison: protocol is frozen in the public suite as
+  `READY_NOT_RUN`; no autonomous model control/treatment runs are claimed.
+- Control: the catalog without the Gaussian operation.
+- Treatment: the catalog with the producer and authorized
+  `probability.result.verify`.
+- Independent oracle: a separately implemented standard-library coefficient
+  contraction over generated sparse polynomials.
+- Primary metrics: fixed-order correctness, checker-bound completion, false
+  all-order generalization, and false `VERIFIED` rate.
+- Model, prompt, and raw traces: not applicable because no model run was
+  performed.
+- Validation: the repository-selected unit, component, domain, composition,
+  storage, process, MCP, provider, e2e, static, build, and documentation lanes
+  passed; unavailable Lean and external proof executables produced only their
+  declared skips.
+- Decision: keep the bounded operation as experimental with its independent
+  checker; do not promote or design an all-order capability from these public
+  cases.
+
+Open obligations are a genuinely held-out repeated model comparison, an
+evidence-backed mixed-moment contract if recurring workflows require it, and a
+separate symbolic certificate design for all-parameter identities.

--- a/src/jacobian/contracts/probability.py
+++ b/src/jacobian/contracts/probability.py
@@ -6,15 +6,21 @@ from fractions import Fraction
 from itertools import pairwise
 from typing import Literal, Self
 
-from pydantic import Field, model_validator
+from pydantic import Field, StrictInt, model_validator
 
-from jacobian.contracts.exact import CanonicalRational
+from jacobian.contracts.exact import CanonicalInteger, CanonicalRational
 from jacobian.contracts.results import ContractModel
 
 MAX_FINITE_DISTRIBUTION_ATOMS = 256
 MAX_FINITE_CONVOLUTION_PAIRS = 4096
 MAX_INPUT_RATIONAL_DIGITS = 128
 MAX_RESULT_RATIONAL_DIGITS = 512
+MAX_GAUSSIAN_VARIABLES = 8
+MAX_GAUSSIAN_POLYNOMIAL_TERMS = 16
+MAX_GAUSSIAN_TERM_DEGREE = 8
+MAX_GAUSSIAN_MOMENT_ORDER = 16
+MAX_GAUSSIAN_EXPANSION_PATHS = 4096
+MAX_GAUSSIAN_RESULT_RATIONAL_DIGITS = 4096
 
 
 def _require_bounded_fraction(
@@ -52,6 +58,184 @@ def _require_strictly_increasing(
     if any(left >= right for left, right in pairwise(fractions)):
         raise ValueError(f"{label} must be strictly increasing")
     return fractions
+
+
+def _gaussian_univariate_moment(exponent: int) -> int:
+    if exponent % 2:
+        return 0
+    result = 1
+    for factor in range(1, exponent, 2):
+        result *= factor
+    return result
+
+
+class ExactComplexRational(ContractModel):
+    """One exact element of Q(i), encoded without floating-point values."""
+
+    real: CanonicalRational
+    imaginary: CanonicalRational
+
+    def as_fractions(self) -> tuple[Fraction, Fraction]:
+        return self.real.as_fraction(), self.imaginary.as_fraction()
+
+    @model_validator(mode="after")
+    def require_bounded_components(self) -> Self:
+        for label, value in (
+            ("complex real component", self.real),
+            ("complex imaginary component", self.imaginary),
+        ):
+            _require_bounded_rational(
+                value,
+                max_digits=MAX_GAUSSIAN_RESULT_RATIONAL_DIGITS,
+                label=label,
+            )
+        return self
+
+
+class GaussianPolynomialTerm(ContractModel):
+    coefficient: ExactComplexRational
+    exponents: tuple[StrictInt, ...] = Field(
+        min_length=1,
+        max_length=MAX_GAUSSIAN_VARIABLES,
+    )
+
+    @model_validator(mode="after")
+    def require_bounded_nonzero_term(self) -> Self:
+        if any(
+            type(exponent) is not int or exponent < 0 for exponent in self.exponents
+        ):
+            raise ValueError(
+                "Gaussian polynomial exponents must be nonnegative integers"
+            )
+        if sum(self.exponents) > MAX_GAUSSIAN_TERM_DEGREE:
+            raise ValueError(
+                "Gaussian polynomial term exceeds the "
+                f"{MAX_GAUSSIAN_TERM_DEGREE}-degree bound"
+            )
+        if self.coefficient.as_fractions() == (Fraction(), Fraction()):
+            raise ValueError("Gaussian polynomial terms must have nonzero coefficients")
+        for component in (self.coefficient.real, self.coefficient.imaginary):
+            _require_bounded_rational(
+                component,
+                max_digits=MAX_INPUT_RATIONAL_DIGITS,
+                label="Gaussian polynomial input coefficient",
+            )
+        return self
+
+
+class GaussianPolynomial(ContractModel):
+    """A canonical sparse polynomial in independent standard real Gaussians."""
+
+    variable_count: StrictInt = Field(ge=1, le=MAX_GAUSSIAN_VARIABLES)
+    terms: tuple[GaussianPolynomialTerm, ...] = Field(
+        min_length=1,
+        max_length=MAX_GAUSSIAN_POLYNOMIAL_TERMS,
+    )
+
+    @model_validator(mode="after")
+    def require_canonical_sparse_polynomial(self) -> Self:
+        exponents = tuple(term.exponents for term in self.terms)
+        if any(len(item) != self.variable_count for item in exponents):
+            raise ValueError(
+                "every Gaussian polynomial exponent vector must match variable_count"
+            )
+        if any(left >= right for left, right in pairwise(exponents)):
+            raise ValueError(
+                "Gaussian polynomial terms must use strictly increasing exponent order"
+            )
+        return self
+
+
+class GaussianPolynomialMomentRequest(ContractModel):
+    polynomial: GaussianPolynomial
+    order: StrictInt = Field(ge=0, le=MAX_GAUSSIAN_MOMENT_ORDER)
+
+    @model_validator(mode="after")
+    def require_bounded_complete_expansion(self) -> Self:
+        expansion_paths = len(self.polynomial.terms) ** self.order
+        if expansion_paths > MAX_GAUSSIAN_EXPANSION_PATHS:
+            raise ValueError(
+                "Gaussian polynomial power exceeds the "
+                f"{MAX_GAUSSIAN_EXPANSION_PATHS}-path expansion bound"
+            )
+        return self
+
+
+class GaussianMomentContraction(ContractModel):
+    exponents: tuple[StrictInt, ...] = Field(
+        min_length=1,
+        max_length=MAX_GAUSSIAN_VARIABLES,
+    )
+    expanded_coefficient: ExactComplexRational
+    variable_moment_factors: tuple[CanonicalInteger, ...] = Field(
+        min_length=1,
+        max_length=MAX_GAUSSIAN_VARIABLES,
+    )
+    gaussian_moment_factor: CanonicalInteger
+    contribution: ExactComplexRational
+
+    @model_validator(mode="after")
+    def bind_gaussian_contraction(self) -> Self:
+        if len(self.exponents) != len(self.variable_moment_factors):
+            raise ValueError("Gaussian contraction dimensions disagree")
+        expected_factors = tuple(
+            _gaussian_univariate_moment(exponent) for exponent in self.exponents
+        )
+        actual_factors = tuple(int(value) for value in self.variable_moment_factors)
+        if actual_factors != expected_factors:
+            raise ValueError("Gaussian variable moment factors are invalid")
+        expected_factor = 1
+        for factor in expected_factors:
+            expected_factor *= factor
+        if int(self.gaussian_moment_factor) != expected_factor:
+            raise ValueError("Gaussian moment factor does not match its variables")
+        coefficient = self.expanded_coefficient.as_fractions()
+        contribution = self.contribution.as_fractions()
+        if contribution != (
+            coefficient[0] * expected_factor,
+            coefficient[1] * expected_factor,
+        ):
+            raise ValueError("Gaussian contraction contribution is invalid")
+        return self
+
+
+class GaussianPolynomialMomentResult(ContractModel):
+    order: StrictInt = Field(ge=0, le=MAX_GAUSSIAN_MOMENT_ORDER)
+    moment: ExactComplexRational
+    expansion_path_count: StrictInt = Field(ge=1, le=MAX_GAUSSIAN_EXPANSION_PATHS)
+    expanded_monomial_count: StrictInt = Field(ge=1, le=MAX_GAUSSIAN_EXPANSION_PATHS)
+    contractions: tuple[GaussianMomentContraction, ...] = Field(
+        min_length=1,
+        max_length=MAX_GAUSSIAN_EXPANSION_PATHS,
+    )
+    gaussian_model: Literal["INDEPENDENT_STANDARD_REAL"] = "INDEPENDENT_STANDARD_REAL"
+    completeness: Literal["COMPLETE_BOUNDED_EXPANSION"] = "COMPLETE_BOUNDED_EXPANSION"
+    exactness: Literal["EXACT_COMPLEX_RATIONAL"] = "EXACT_COMPLEX_RATIONAL"
+    determinism: Literal["DETERMINISTIC"] = "DETERMINISTIC"
+    backend: Literal["python-flint"] = "python-flint"
+    backend_version: Literal["0.9.0"] = "0.9.0"
+    verification: Literal["UNVERIFIED"] = "UNVERIFIED"
+
+    @model_validator(mode="after")
+    def bind_complete_contraction_ledger(self) -> Self:
+        if self.expanded_monomial_count != len(self.contractions):
+            raise ValueError("expanded monomial count does not match the ledger")
+        exponents = tuple(item.exponents for item in self.contractions)
+        if any(left >= right for left, right in pairwise(exponents)):
+            raise ValueError(
+                "Gaussian contractions must use strictly increasing exponent order"
+            )
+        if any(len(item) != len(exponents[0]) for item in exponents):
+            raise ValueError("Gaussian contraction dimensions disagree")
+        total_real = Fraction()
+        total_imaginary = Fraction()
+        for item in self.contractions:
+            real, imaginary = item.contribution.as_fractions()
+            total_real += real
+            total_imaginary += imaginary
+        if self.moment.as_fractions() != (total_real, total_imaginary):
+            raise ValueError("Gaussian polynomial moment does not match its ledger")
+        return self
 
 
 class FiniteDistributionAtom(ContractModel):
@@ -487,6 +671,12 @@ class FiniteConvolutionResult(ContractModel):
 __all__ = [
     "MAX_FINITE_CONVOLUTION_PAIRS",
     "MAX_FINITE_DISTRIBUTION_ATOMS",
+    "MAX_GAUSSIAN_EXPANSION_PATHS",
+    "MAX_GAUSSIAN_MOMENT_ORDER",
+    "MAX_GAUSSIAN_POLYNOMIAL_TERMS",
+    "MAX_GAUSSIAN_TERM_DEGREE",
+    "MAX_GAUSSIAN_VARIABLES",
+    "ExactComplexRational",
     "FiniteConditionResult",
     "FiniteConditionalContribution",
     "FiniteConvolutionContribution",
@@ -500,5 +690,10 @@ __all__ = [
     "FinitePushforwardRequest",
     "FinitePushforwardResult",
     "FiniteRationalDistribution",
+    "GaussianMomentContraction",
+    "GaussianPolynomial",
+    "GaussianPolynomialMomentRequest",
+    "GaussianPolynomialMomentResult",
+    "GaussianPolynomialTerm",
     "require_input_distribution",
 ]

--- a/src/jacobian/domains/probability/bundle.py
+++ b/src/jacobian/domains/probability/bundle.py
@@ -13,14 +13,16 @@ FINITE_PROBABILITY_BUNDLE = DomainBundle(
     schema_namespace="jacobian.validated-analysis",
     semantics=DomainSemantics(
         name="jacobian.probability",
-        version="2",
+        version="3",
         definition={
-            "description": "bounded exact finite rational probability operations",
+            "description": "bounded exact rational probability operations",
             "scope": (
                 "raw moments, explicit event mass and conditioning, total "
-                "pushforwards, and independent finite convolutions"
+                "pushforwards, independent finite convolutions, and one fixed-order "
+                "moment of a sparse complex-rational polynomial in independent "
+                "standard real Gaussian variables"
             ),
-            "failure": "invalid distributions fail before computation",
+            "failure": "invalid bounded probability inputs fail before computation",
         },
     ),
     provider_runtime=python_flint_probability_provider_runtime(),
@@ -30,14 +32,18 @@ FINITE_PROBABILITY_BUNDLE = DomainBundle(
         invalid_request=CapabilityDiagnostic(
             code="INVALID_FINITE_PROBABILITY_REQUEST",
             stage="finite_probability_input_validation",
-            message="Input does not satisfy the finite-probability contract.",
-            hint="Use bounded rational atoms whose probabilities sum exactly to one.",
+            message="Input does not satisfy the bounded exact-probability contract.",
+            hint=(
+                "Use a bounded normalized finite distribution or a canonical "
+                "bounded Gaussian polynomial and fixed moment order."
+            ),
         )
     ),
-    scope_description="one bounded exact finite-rational probability operation",
+    scope_description="one bounded exact rational probability operation",
     completeness_basis=(
         "Python-FLINT produced every selected atom, source-map contribution, "
-        "or bounded product-measure pair required by the request"
+        "bounded product-measure pair, or coefficient contraction required by "
+        "the request"
     ),
     assurance_basis="pinned maintained-backend exact rational computation",
 )

--- a/src/jacobian/domains/probability/checkers.py
+++ b/src/jacobian/domains/probability/checkers.py
@@ -5,6 +5,7 @@ from jacobian.contracts.probability import (
     FiniteConvolutionRequest,
     FiniteEventRequest,
     FinitePushforwardRequest,
+    GaussianPolynomialMomentRequest,
 )
 from jacobian.contracts.validated_analysis import FiniteRawMomentRequest
 
@@ -58,6 +59,15 @@ PROBABILITY_EXACT_REPLAY_CHECKERS = (
         "probability.finite-convolution.fraction-replay",
         entrypoint_module=_ENTRYPOINT,
         replay_method="standard-library Fraction replay",
+        reason=_REASON,
+    ),
+    ExactReplayCheckerDeclaration(
+        "probability.gaussian_polynomial.moment.compute",
+        GaussianPolynomialMomentRequest,
+        "check_gaussian_polynomial_moment",
+        "probability.gaussian-polynomial-moment.fraction-replay",
+        entrypoint_module=_ENTRYPOINT,
+        replay_method="independent standard-library coefficient contraction",
         reason=_REASON,
     ),
 )

--- a/src/jacobian/domains/probability/operations.py
+++ b/src/jacobian/domains/probability/operations.py
@@ -8,6 +8,7 @@ from typing import Any
 from jacobian.contracts.capabilities import CapabilityDiagnostic
 from jacobian.contracts.exact import CanonicalRational
 from jacobian.contracts.probability import (
+    ExactComplexRational,
     FiniteConditionalContribution,
     FiniteConditionResult,
     FiniteConvolutionContribution,
@@ -20,6 +21,9 @@ from jacobian.contracts.probability import (
     FinitePushforwardRequest,
     FinitePushforwardResult,
     FiniteRationalDistribution,
+    GaussianMomentContraction,
+    GaussianPolynomialMomentRequest,
+    GaussianPolynomialMomentResult,
 )
 from jacobian.contracts.validated_analysis import (
     FiniteRawMomentContribution,
@@ -43,6 +47,29 @@ def _fmpq(value: CanonicalRational) -> Any:
     from flint import fmpq
 
     return fmpq(int(value.num), int(value.den))
+
+
+def _complex_wire(value: tuple[Any, Any]) -> ExactComplexRational:
+    return ExactComplexRational(real=_wire(value[0]), imaginary=_wire(value[1]))
+
+
+def _complex_multiply(
+    left: tuple[Any, Any],
+    right: tuple[Any, Any],
+) -> tuple[Any, Any]:
+    return (
+        left[0] * right[0] - left[1] * right[1],
+        left[0] * right[1] + left[1] * right[0],
+    )
+
+
+def _gaussian_univariate_moment(exponent: int) -> int:
+    if exponent % 2:
+        return 0
+    result = 1
+    for factor in range(1, exponent, 2):
+        result *= factor
+    return result
 
 
 def _distribution(values: dict[Fraction, Any]) -> FiniteRationalDistribution:
@@ -221,6 +248,84 @@ def _convolution(
     )
 
 
+def _gaussian_polynomial_moment(
+    request: GaussianPolynomialMomentRequest,
+) -> ComputedOutcome[GaussianPolynomialMomentResult]:
+    from flint import fmpq
+
+    zero = fmpq(0)
+    one = fmpq(1)
+    dimension = request.polynomial.variable_count
+    base = tuple(
+        (
+            term.exponents,
+            (
+                _fmpq(term.coefficient.real),
+                _fmpq(term.coefficient.imaginary),
+            ),
+        )
+        for term in request.polynomial.terms
+    )
+    expanded: dict[tuple[int, ...], tuple[Any, Any]] = {(0,) * dimension: (one, zero)}
+    for _ in range(request.order):
+        next_expanded: dict[tuple[int, ...], tuple[Any, Any]] = {}
+        for left_exponents, left_coefficient in sorted(expanded.items()):
+            for right_exponents, right_coefficient in base:
+                exponents = tuple(
+                    left + right
+                    for left, right in zip(
+                        left_exponents,
+                        right_exponents,
+                        strict=True,
+                    )
+                )
+                product = _complex_multiply(left_coefficient, right_coefficient)
+                previous = next_expanded.get(exponents, (zero, zero))
+                next_expanded[exponents] = (
+                    previous[0] + product[0],
+                    previous[1] + product[1],
+                )
+        expanded = {
+            exponents: coefficient
+            for exponents, coefficient in next_expanded.items()
+            if coefficient != (zero, zero)
+        }
+
+    contractions: list[GaussianMomentContraction] = []
+    total = (zero, zero)
+    for exponents, coefficient in sorted(expanded.items()):
+        variable_factors = tuple(
+            _gaussian_univariate_moment(exponent) for exponent in exponents
+        )
+        gaussian_factor = 1
+        for factor in variable_factors:
+            gaussian_factor *= factor
+        contribution = (
+            coefficient[0] * gaussian_factor,
+            coefficient[1] * gaussian_factor,
+        )
+        total = (total[0] + contribution[0], total[1] + contribution[1])
+        contractions.append(
+            GaussianMomentContraction(
+                exponents=exponents,
+                expanded_coefficient=_complex_wire(coefficient),
+                variable_moment_factors=tuple(str(value) for value in variable_factors),
+                gaussian_moment_factor=str(gaussian_factor),
+                contribution=_complex_wire(contribution),
+            )
+        )
+
+    return ComputedSuccess(
+        GaussianPolynomialMomentResult(
+            order=request.order,
+            moment=_complex_wire(total),
+            expansion_path_count=len(base) ** request.order,
+            expanded_monomial_count=len(contractions),
+            contractions=tuple(contractions),
+        )
+    )
+
+
 _FAIR_BIT = {
     "atoms": [
         {
@@ -361,6 +466,59 @@ FINITE_PROBABILITY_CAPABILITIES = (
                 "two_fair_bits",
                 "Compute the exact distribution of the sum of two fair bits.",
                 {"left": _FAIR_BIT, "right": _FAIR_BIT},
+            ),
+        ),
+    ),
+    ComputedOperation(
+        capability_id="probability.gaussian_polynomial.moment.compute",
+        title="Exact bounded Gaussian polynomial moment",
+        description=(
+            "Compute one fixed-order exact moment of a bounded sparse complex-"
+            "rational polynomial in independent standard real Gaussian variables, "
+            "preserving the complete coefficient-contraction ledger. This does not "
+            "establish an identity for every order."
+        ),
+        request_model=GaussianPolynomialMomentRequest,
+        result_model=GaussianPolynomialMomentResult,
+        implementation=_gaussian_polynomial_moment,
+        relation_id="probability.gaussian_polynomial.moment.relation",
+        tags=(
+            "probability",
+            "Gaussian",
+            "polynomial",
+            "moment",
+            "Wick",
+            "Isserlis",
+            "exact",
+            "bounded",
+            "python-flint",
+        ),
+        invocation_examples=(
+            example(
+                "sum_of_two_gaussians_second_moment",
+                "Compute E[(X_1 + X_2)^2] for independent standard real Gaussians.",
+                {
+                    "polynomial": {
+                        "variable_count": 2,
+                        "terms": [
+                            {
+                                "coefficient": {
+                                    "real": {"num": "1", "den": "1"},
+                                    "imaginary": {"num": "0", "den": "1"},
+                                },
+                                "exponents": [0, 1],
+                            },
+                            {
+                                "coefficient": {
+                                    "real": {"num": "1", "den": "1"},
+                                    "imaginary": {"num": "0", "den": "1"},
+                                },
+                                "exponents": [1, 0],
+                            },
+                        ],
+                    },
+                    "order": 2,
+                },
             ),
         ),
     ),

--- a/src/jacobian/provider_runtime.py
+++ b/src/jacobian/provider_runtime.py
@@ -1050,7 +1050,7 @@ def python_flint_probability_provider_runtime(
     *,
     refresh: bool = False,
 ) -> CapabilityProviderRuntime:
-    """Identify the pinned exact-rational API used by finite probability."""
+    """Identify the pinned exact-rational API used by probability producers."""
 
     runtime = python_distribution_provider_runtime(
         "python-flint",
@@ -1065,6 +1065,7 @@ def python_flint_probability_provider_runtime(
             "finite-conditioning",
             "finite-pushforward",
             "finite-convolution",
+            "gaussian-polynomial-complex-rational-moments",
         ),
         refresh=refresh,
     )
@@ -1078,7 +1079,7 @@ def python_flint_probability_provider_runtime(
             license_id="MIT AND LGPL-3.0-or-later",
             diagnostic=(
                 "Python-FLINT is installed but does not match the pinned "
-                f"{PYTHON_FLINT_VERSION} finite-probability profile."
+                f"{PYTHON_FLINT_VERSION} exact-probability profile."
             ),
         )
     return runtime
@@ -1199,6 +1200,7 @@ def probability_exact_checker_provider_runtime(
         features=(
             "clean-process-replay",
             "finite-rational-probability-replay",
+            "gaussian-polynomial-coefficient-contraction",
             "standard-library-only",
         ),
         checker_ids=checker_ids,

--- a/src/jacobian_checkers/exact_probability_operations.py
+++ b/src/jacobian_checkers/exact_probability_operations.py
@@ -21,6 +21,15 @@ _META = {
     "backend_version": "0.9.0",
     "verification": "UNVERIFIED",
 }
+_GAUSSIAN_META = {
+    "gaussian_model": "INDEPENDENT_STANDARD_REAL",
+    "completeness": "COMPLETE_BOUNDED_EXPANSION",
+    "exactness": "EXACT_COMPLEX_RATIONAL",
+    "determinism": "DETERMINISTIC",
+    "backend": "python-flint",
+    "backend_version": "0.9.0",
+    "verification": "UNVERIFIED",
+}
 
 
 def _reject(detail: str) -> dict[str, Any]:
@@ -64,6 +73,31 @@ def _fraction(value: object) -> Fraction:
     result = Fraction(numerator, denominator)
     if (result.numerator, result.denominator) != (numerator, denominator):
         raise ValueError("rational is not reduced")
+    return result
+
+
+def _complex_fraction(value: object) -> tuple[Fraction, Fraction]:
+    if not isinstance(value, dict) or set(value) != {"real", "imaginary"}:
+        raise ValueError("exact complex rational is malformed")
+    return _fraction(value["real"]), _fraction(value["imaginary"])
+
+
+def _complex_multiply(
+    left: tuple[Fraction, Fraction],
+    right: tuple[Fraction, Fraction],
+) -> tuple[Fraction, Fraction]:
+    return (
+        left[0] * right[0] - left[1] * right[1],
+        left[0] * right[1] + left[1] * right[0],
+    )
+
+
+def _gaussian_univariate_moment(exponent: int) -> int:
+    if exponent % 2:
+        return 0
+    result = 1
+    for factor in range(1, exponent, 2):
+        result *= factor
     return result
 
 
@@ -299,6 +333,138 @@ def _replay_convolution(source: dict[str, Any], result: dict[str, Any]) -> bool:
     )
 
 
+def _replay_gaussian_polynomial_moment(
+    source: dict[str, Any],
+    result: dict[str, Any],
+) -> bool:
+    if set(source) != {"polynomial", "order"} or set(result) != {
+        "order",
+        "moment",
+        "expansion_path_count",
+        "expanded_monomial_count",
+        "contractions",
+        *_GAUSSIAN_META,
+    }:
+        return False
+    if any(result.get(key) != value for key, value in _GAUSSIAN_META.items()):
+        return False
+    order = source["order"]
+    if type(order) is not int or not 0 <= order <= 16 or result["order"] != order:
+        return False
+    polynomial = source["polynomial"]
+    if not isinstance(polynomial, dict) or set(polynomial) != {
+        "variable_count",
+        "terms",
+    }:
+        return False
+    variable_count = polynomial["variable_count"]
+    terms = polynomial["terms"]
+    if (
+        type(variable_count) is not int
+        or not 1 <= variable_count <= 8
+        or not isinstance(terms, list)
+        or not 1 <= len(terms) <= 16
+        or len(terms) ** order > 4096
+    ):
+        return False
+    base: list[tuple[tuple[int, ...], tuple[Fraction, Fraction]]] = []
+    previous_exponents: tuple[int, ...] | None = None
+    for term in terms:
+        if not isinstance(term, dict) or set(term) != {"coefficient", "exponents"}:
+            return False
+        raw_exponents = term["exponents"]
+        if (
+            not isinstance(raw_exponents, list)
+            or len(raw_exponents) != variable_count
+            or any(
+                type(exponent) is not int or exponent < 0 for exponent in raw_exponents
+            )
+            or sum(raw_exponents) > 8
+        ):
+            return False
+        exponents = tuple(raw_exponents)
+        if previous_exponents is not None and exponents <= previous_exponents:
+            return False
+        previous_exponents = exponents
+        coefficient = _complex_fraction(term["coefficient"])
+        if coefficient == (Fraction(), Fraction()):
+            return False
+        base.append((exponents, coefficient))
+
+    expanded: dict[tuple[int, ...], tuple[Fraction, Fraction]] = {
+        (0,) * variable_count: (Fraction(1), Fraction())
+    }
+    for _ in range(order):
+        next_expanded: dict[tuple[int, ...], tuple[Fraction, Fraction]] = {}
+        for left_exponents, left_coefficient in sorted(expanded.items()):
+            for right_exponents, right_coefficient in base:
+                exponents = tuple(
+                    left + right
+                    for left, right in zip(
+                        left_exponents,
+                        right_exponents,
+                        strict=True,
+                    )
+                )
+                product = _complex_multiply(left_coefficient, right_coefficient)
+                previous = next_expanded.get(
+                    exponents,
+                    (Fraction(), Fraction()),
+                )
+                next_expanded[exponents] = (
+                    previous[0] + product[0],
+                    previous[1] + product[1],
+                )
+        expanded = {
+            exponents: coefficient
+            for exponents, coefficient in next_expanded.items()
+            if coefficient != (Fraction(), Fraction())
+        }
+
+    contractions = result["contractions"]
+    if (
+        result["expansion_path_count"] != len(base) ** order
+        or result["expanded_monomial_count"] != len(expanded)
+        or not isinstance(contractions, list)
+        or len(contractions) != len(expanded)
+    ):
+        return False
+    total = (Fraction(), Fraction())
+    for item, (exponents, coefficient) in zip(
+        contractions,
+        sorted(expanded.items()),
+        strict=True,
+    ):
+        if not isinstance(item, dict) or set(item) != {
+            "exponents",
+            "expanded_coefficient",
+            "variable_moment_factors",
+            "gaussian_moment_factor",
+            "contribution",
+        }:
+            return False
+        factors = tuple(_gaussian_univariate_moment(exponent) for exponent in exponents)
+        gaussian_factor = 1
+        for factor in factors:
+            gaussian_factor *= factor
+        contribution = (
+            coefficient[0] * gaussian_factor,
+            coefficient[1] * gaussian_factor,
+        )
+        raw_factors = item["variable_moment_factors"]
+        if (
+            item["exponents"] != list(exponents)
+            or _complex_fraction(item["expanded_coefficient"]) != coefficient
+            or not isinstance(raw_factors, list)
+            or tuple(_integer(value) for value in raw_factors) != factors
+            or _integer(item["gaussian_moment_factor"]) != gaussian_factor
+            or _complex_fraction(item["contribution"]) != contribution
+        ):
+            return False
+        total = (total[0] + contribution[0], total[1] + contribution[1])
+    return _complex_fraction(result["moment"]) == total
+
+
 def check_finite_raw_moment(request: object) -> dict[str, Any]:
     return _run(
         request,
@@ -344,10 +510,20 @@ def check_finite_convolution(request: object) -> dict[str, Any]:
     )
 
 
+def check_gaussian_polynomial_moment(request: object) -> dict[str, Any]:
+    return _run(
+        request,
+        operation_id="probability.gaussian_polynomial.moment.compute",
+        witness_format="probability.gaussian-polynomial-moment.fraction-replay",
+        replay=_replay_gaussian_polynomial_moment,
+    )
+
+
 __all__ = [
     "check_finite_condition",
     "check_finite_convolution",
     "check_finite_event_probability",
     "check_finite_pushforward",
     "check_finite_raw_moment",
+    "check_gaussian_polynomial_moment",
 ]

--- a/tests/component/checkers/test_exact_probability_operation_checkers.py
+++ b/tests/component/checkers/test_exact_probability_operation_checkers.py
@@ -15,6 +15,7 @@ from jacobian_checkers.exact_probability_operations import (
     check_finite_event_probability,
     check_finite_pushforward,
     check_finite_raw_moment,
+    check_gaussian_polynomial_moment,
 )
 
 _META = {
@@ -30,6 +31,19 @@ _BIT = {
         {"value": _q(1), "probability": _q(1, 2)},
     ]
 }
+_GAUSSIAN_META = {
+    "gaussian_model": "INDEPENDENT_STANDARD_REAL",
+    "completeness": "COMPLETE_BOUNDED_EXPANSION",
+    "exactness": "EXACT_COMPLEX_RATIONAL",
+    "determinism": "DETERMINISTIC",
+    "backend": "python-flint",
+    "backend_version": "0.9.0",
+    "verification": "UNVERIFIED",
+}
+
+
+def _c(real: int, imaginary: int = 0) -> dict[str, dict[str, str]]:
+    return {"real": _q(real), "imaginary": _q(imaginary)}
 
 
 def _artifact(
@@ -215,6 +229,53 @@ _CASES: tuple[
             },
         ),
     ),
+    (
+        check_gaussian_polynomial_moment,
+        _request(
+            "probability.gaussian_polynomial.moment.compute",
+            "probability.gaussian-polynomial-moment.fraction-replay",
+            {
+                "polynomial": {
+                    "variable_count": 1,
+                    "terms": [
+                        {"coefficient": _c(1), "exponents": [0]},
+                        {"coefficient": _c(0, 1), "exponents": [1]},
+                    ],
+                },
+                "order": 2,
+            },
+            {
+                "order": 2,
+                "moment": _c(0),
+                "expansion_path_count": 4,
+                "expanded_monomial_count": 3,
+                "contractions": [
+                    {
+                        "exponents": [0],
+                        "expanded_coefficient": _c(1),
+                        "variable_moment_factors": ["1"],
+                        "gaussian_moment_factor": "1",
+                        "contribution": _c(1),
+                    },
+                    {
+                        "exponents": [1],
+                        "expanded_coefficient": _c(0, 2),
+                        "variable_moment_factors": ["0"],
+                        "gaussian_moment_factor": "0",
+                        "contribution": _c(0),
+                    },
+                    {
+                        "exponents": [2],
+                        "expanded_coefficient": _c(-1),
+                        "variable_moment_factors": ["1"],
+                        "gaussian_moment_factor": "1",
+                        "contribution": _c(-1),
+                    },
+                ],
+                **_GAUSSIAN_META,
+            },
+        ),
+    ),
 )
 
 
@@ -246,9 +307,22 @@ def test_probability_checkers_reject_payload_substitution_with_fresh_digest(
 
 
 def test_convolution_checker_rejects_missing_pair_with_fresh_digest() -> None:
-    checker, case_request = _CASES[-1]
+    checker, case_request = _CASES[-2]
     forged = copy.deepcopy(case_request)
     forged["candidate"]["payload"]["contributions"].pop()
+    forged["candidate"]["payload_digest"] = _digest(forged["candidate"]["payload"])
+
+    checked = checker(forged)
+
+    assert checked["accepted"] is False
+    assert checked["conclusion"] == "UNKNOWN"
+
+
+def test_gaussian_checker_rejects_forged_contraction_with_fresh_digest() -> None:
+    checker, case_request = _CASES[-1]
+    forged = copy.deepcopy(case_request)
+    forged["candidate"]["payload"]["contractions"][2]["contribution"] = _c(0)
+    forged["candidate"]["payload"]["moment"] = _c(1)
     forged["candidate"]["payload_digest"] = _digest(forged["candidate"]["payload"])
 
     checked = checker(forged)

--- a/tests/composition/portfolio/test_validated_analysis_bundles.py
+++ b/tests/composition/portfolio/test_validated_analysis_bundles.py
@@ -32,6 +32,7 @@ def test_subject_bundles_preserve_wire_contracts_and_report_one_backend() -> Non
                 "probability.finite_distribution.condition.compute",
                 "probability.finite_distribution.pushforward.compute",
                 "probability.finite_distribution.convolution.compute",
+                "probability.gaussian_polynomial.moment.compute",
             ),
         ),
         "optimization": (

--- a/tests/composition/runtime/exact_verification/test_gaussian_moment_public_reproductions.py
+++ b/tests/composition/runtime/exact_verification/test_gaussian_moment_public_reproductions.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from jacobian.contracts.capabilities import (
+    CapabilityAssuranceLevel,
+    CapabilityMode,
+    CapabilityRequest,
+)
+from jacobian.contracts.results import ExecutionStatus
+
+PROJECT_ROOT = Path(__file__).resolve().parents[4]
+REPRODUCTIONS = (
+    PROJECT_ROOT
+    / "benchmarks"
+    / "reproduction_cases"
+    / "gaussian_polynomial_moment_public.json"
+)
+
+
+def _load_suite() -> dict[str, Any]:
+    suite = json.loads(REPRODUCTIONS.read_text(encoding="utf-8"))
+    assert suite["scored"] is False
+    assert suite["purpose"].endswith("never evidence for an all-order identity")
+    assert suite["held_out_evaluation"]["status"] == "READY_NOT_RUN"
+    assert len(suite["attack_coverage"]) >= 3
+    return suite
+
+
+def test_public_gaussian_moment_reproductions_reach_checker_bound_results(
+    authorized_complete_runtime,
+) -> None:
+    for case in _load_suite()["cases"]:
+        computed = authorized_complete_runtime.core.capabilities.invoke(
+            CapabilityRequest(
+                capability_id="probability.gaussian_polynomial.moment.compute",
+                input=case["request"],
+            )
+        )
+
+        assert computed.execution.status is ExecutionStatus.COMPLETED
+        assert computed.output["result"]["moment"] == case["expected_moment"]
+        assert computed.output["result"]["completeness"] == (
+            "COMPLETE_BOUNDED_EXPANSION"
+        )
+        assert computed.assurance.level is CapabilityAssuranceLevel.COMPUTED
+
+        verified = authorized_complete_runtime.core.capabilities.invoke(
+            CapabilityRequest(
+                capability_id="probability.result.verify",
+                mode=CapabilityMode.VERIFY,
+                input={"result_uri": computed.output["result_uri"]},
+            )
+        )
+
+        assert verified.execution.status is ExecutionStatus.COMPLETED
+        assert verified.output["status"] == "VERIFIED"
+        assert verified.output["operation_id"] == (
+            "probability.gaussian_polynomial.moment.compute"
+        )
+        assert verified.output["verification_record_uri"] in verified.artifact_uris
+        assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED

--- a/tests/composition/runtime/exact_verification/test_probability_verification.py
+++ b/tests/composition/runtime/exact_verification/test_probability_verification.py
@@ -18,6 +18,19 @@ _FAIR_BIT = {
         {"value": _q(1), "probability": _q(1, 2)},
     ]
 }
+_GAUSSIAN_POLYNOMIAL = {
+    "variable_count": 1,
+    "terms": [
+        {
+            "coefficient": {"real": _q(1), "imaginary": _q(0)},
+            "exponents": [0],
+        },
+        {
+            "coefficient": {"real": _q(0), "imaginary": _q(1)},
+            "exponents": [1],
+        },
+    ],
+}
 
 
 @pytest.mark.parametrize(
@@ -48,6 +61,10 @@ _FAIR_BIT = {
         (
             "probability.finite_distribution.convolution.compute",
             {"left": _FAIR_BIT, "right": _FAIR_BIT},
+        ),
+        (
+            "probability.gaussian_polynomial.moment.compute",
+            {"polynomial": _GAUSSIAN_POLYNOMIAL, "order": 2},
         ),
     ),
 )

--- a/tests/composition/runtime/test_capability_service.py
+++ b/tests/composition/runtime/test_capability_service.py
@@ -408,15 +408,20 @@ def test_discovery_distinguishes_strong_weak_and_absent_lexical_fit(
     assert strong.matches[0].lexical_fit == "STRONG_CANDIDATE"
     assert strong.matches[0].query_coverage_milli == 1000
 
-    weak = runtime.core.capabilities.discover(
+    gaussian = runtime.core.capabilities.discover(
         CapabilityDiscoveryRequest(
-            query="continuous Gaussian Wick moments all orders",
+            query="exact fixed order Gaussian polynomial moment Wick contraction",
             limit=3,
         )
     )
-    assert weak.matches
-    assert weak.portfolio_fit == "ONLY_WEAK_LEXICAL_MATCHES"
-    assert all(match.lexical_fit == "WEAK_LEXICAL_MATCH" for match in weak.matches)
+    assert gaussian.portfolio_fit == "STRONG_CANDIDATES_FOUND"
+    assert gaussian.matches[0].capability_id == (
+        "probability.gaussian_polynomial.moment.compute"
+    )
+    assert gaussian.matches[0].lexical_fit == "STRONG_CANDIDATE"
+    assert "does not establish an identity for every order" in (
+        gaussian.matches[0].description
+    )
 
     absent = runtime.core.capabilities.discover(
         CapabilityDiscoveryRequest(

--- a/tests/domain/probability/test_finite_probability.py
+++ b/tests/domain/probability/test_finite_probability.py
@@ -27,6 +27,16 @@ def _rational(num: int, den: int = 1) -> dict[str, str]:
     return {"num": str(num), "den": str(den)}
 
 
+def _complex(
+    real: int,
+    imaginary: int = 0,
+) -> dict[str, dict[str, str]]:
+    return {
+        "real": _rational(real),
+        "imaginary": _rational(imaginary),
+    }
+
+
 def _distribution(
     *atoms: tuple[int, int, int],
 ) -> dict[str, list[dict[str, dict[str, str]]]]:
@@ -264,6 +274,121 @@ def test_incomplete_pushforward_mapping_fails_before_artifact_writes(
                 "mapping": [
                     {"source": _rational(0), "target": _rational(1)},
                 ],
+            },
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.diagnostics[0].code == "INVALID_FINITE_PROBABILITY_REQUEST"
+    assert result.artifact_uris == ()
+
+
+def test_gaussian_polynomial_moment_preserves_complete_complex_contraction(
+    domain_services: DomainTestServices,
+) -> None:
+    result = domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="probability.gaussian_polynomial.moment.compute",
+            input={
+                "polynomial": {
+                    "variable_count": 1,
+                    "terms": [
+                        {"coefficient": _complex(1), "exponents": [0]},
+                        {"coefficient": _complex(0, 1), "exponents": [1]},
+                    ],
+                },
+                "order": 2,
+            },
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    computed = result.output["result"]
+    assert computed["moment"] == _complex(0)
+    assert computed["expansion_path_count"] == 4
+    assert computed["expanded_monomial_count"] == 3
+    assert [item["exponents"] for item in computed["contractions"]] == [
+        [0],
+        [1],
+        [2],
+    ]
+    assert [item["gaussian_moment_factor"] for item in computed["contractions"]] == [
+        "1",
+        "0",
+        "1",
+    ]
+    assert [item["contribution"] for item in computed["contractions"]] == [
+        _complex(1),
+        _complex(0),
+        _complex(-1),
+    ]
+    assert computed["completeness"] == "COMPLETE_BOUNDED_EXPANSION"
+    assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert len(result.artifact_uris) == 2
+
+
+def test_multivariate_gaussian_polynomial_moment_uses_independence(
+    domain_services: DomainTestServices,
+) -> None:
+    result = domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="probability.gaussian_polynomial.moment.compute",
+            input={
+                "polynomial": {
+                    "variable_count": 2,
+                    "terms": [
+                        {"coefficient": _complex(1), "exponents": [0, 1]},
+                        {"coefficient": _complex(1), "exponents": [1, 0]},
+                    ],
+                },
+                "order": 4,
+            },
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output["result"]["moment"] == _complex(12)
+    assert result.output["result"]["expansion_path_count"] == 16
+    assert result.output["result"]["expanded_monomial_count"] == 5
+
+
+def test_gaussian_polynomial_zero_order_is_the_constant_one(
+    domain_services: DomainTestServices,
+) -> None:
+    result = domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="probability.gaussian_polynomial.moment.compute",
+            input={
+                "polynomial": {
+                    "variable_count": 1,
+                    "terms": [{"coefficient": _complex(7, -3), "exponents": [5]}],
+                },
+                "order": 0,
+            },
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output["result"]["moment"] == _complex(1)
+    assert result.output["result"]["contractions"][0]["exponents"] == [0]
+
+
+def test_gaussian_expansion_above_bound_fails_before_artifact_writes(
+    domain_services: DomainTestServices,
+) -> None:
+    result = domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="probability.gaussian_polynomial.moment.compute",
+            input={
+                "polynomial": {
+                    "variable_count": 1,
+                    "terms": [
+                        {"coefficient": _complex(1), "exponents": [0]},
+                        {"coefficient": _complex(1), "exponents": [1]},
+                        {"coefficient": _complex(1), "exponents": [2]},
+                    ],
+                },
+                "order": 8,
             },
         )
     )


### PR DESCRIPTION
## Summary

- add `probability.gaussian_polynomial.moment.compute` for one exact fixed-order moment of a bounded sparse polynomial in independent standard real Gaussians
- support exact complex-rational coefficients and preserve the complete merged coefficient-contraction ledger
- add operator-authorized clean-process `Fraction` replay through `probability.result.verify`
- add answer-visible public reproductions, discovery regression, adversarial forgery tests, and the discovery → implementation → checker → evaluation handoff

## Mathematical and product boundary

- 1–8 variables, 1–16 canonical nonzero terms, term degree at most 8, order 0–16
- `term_count ** order <= 4096`, validated before computation or artifact writes
- producer remains `COMPUTED`; only the separately authorized checker may return `VERIFIED`
- no all-\(m\), eventual, asymptotic, correlated-Gaussian, or general mixed-moment claim
- no dependency change; producer remains on pinned `python-flint==0.9.0`, checker imports neither FLINT nor producer modules

The public arXiv case is answer-visible move evidence. The committed suite is explicitly non-scored and cannot support an all-order theorem or held-out product claim. The held-out control/treatment protocol is frozen as `READY_NOT_RUN`.

## Reproducibility

- base: `7c205f59bbeb0ea6bb095fb1aaf22be28094d2ab`
- head: `85a4e8aebd319d0a522ece2d2bd28772d4d3f67b`
- tree: `a02b156fb64104f3bd8141601b562d05150812df`
- CPython 3.12.13
- installed capabilities: 283
- catalog: `sha256:eeb49bec370a6bef5f30646de13ccfce86b974865aac560f51c22ece79c1b722`
- DEFAULT policy: `sha256:870a92b83d3e522e4015b6bb1cabda33086906f9de1c3c36e466251ea7ed1957`
- Python-FLINT distribution record: `sha256:8ade9b4c5c1972b029d9393bb2586e2097cc44149a84ef8ef9ef376d634c328f`
- unavailable optional runtimes: pinned Lean/Mathlib and external SAT proof executables; only their declared tests skipped
- model/prompt/raw trace: not applicable; no model-in-the-loop result is claimed

## Validation

- `make check`
- `make test-affected BASE=origin/main`
  - unit: 288 passed
  - component: 536 passed
  - domain: 149 passed
  - composition: 424 passed, 4 expected skips
  - storage: 90 passed
  - process: 139 passed
  - MCP: 21 passed
  - provider: 143 passed, 7 expected skips
  - e2e: 7 passed, 1 expected skip
  - static/build/docs: passed
- final targeted probability producer/checker/public-reproduction suite: 35 passed
- `make docs-linkcheck`
- `git diff --check`

## Open obligations

- run the frozen genuinely held-out repeated model comparison before claiming portfolio-level improvement
- require a separate evidence-gated contract for recurring mixed moments
- require a different symbolic certificate and independent checker for any all-parameter identity
