### PR TITLE
feat(graphs): add verified small-graph reliability

### DIFF
--- a/benchmarks/reproduction_cases/graph_reliability_public.json
+++ b/benchmarks/reproduction_cases/graph_reliability_public.json
@@ -1,0 +1,88 @@
+{
+  "suite_id": "SMALL-GRAPH-RELIABILITY-PUBLIC-001",
+  "version": "1",
+  "scored": false,
+  "purpose": "Answer-visible small exact reliability regressions only; never hidden evaluation and never evidence for the 7222-vertex bunkbed counterexample",
+  "cases": [
+    {
+      "case_id": "SINGLE-EDGE-001",
+      "source": "Jacobian synthetic public boundary",
+      "request": {
+        "graph": {"vertices": ["a", "b"], "edges": [["a", "b"]]},
+        "edge_probabilities": [
+          {
+            "edge": ["a", "b"],
+            "open_probability": {"num": "1", "den": "3"}
+          }
+        ],
+        "terminals": ["a", "b"]
+      },
+      "expected_probability": {"num": "1", "den": "3"},
+      "expected_states": 2
+    },
+    {
+      "case_id": "TRIANGLE-FAIR-001",
+      "source": "Jacobian synthetic public parallel-path regression",
+      "request": {
+        "graph": {
+          "vertices": ["a", "b", "c"],
+          "edges": [["a", "b"], ["a", "c"], ["b", "c"]]
+        },
+        "edge_probabilities": [
+          {
+            "edge": ["a", "b"],
+            "open_probability": {"num": "1", "den": "2"}
+          },
+          {
+            "edge": ["a", "c"],
+            "open_probability": {"num": "1", "den": "2"}
+          },
+          {
+            "edge": ["b", "c"],
+            "open_probability": {"num": "1", "den": "2"}
+          }
+        ],
+        "terminals": ["a", "c"]
+      },
+      "expected_probability": {"num": "5", "den": "8"},
+      "expected_states": 8
+    },
+    {
+      "case_id": "SERIES-PATH-001",
+      "source": "Jacobian synthetic public heterogeneous-edge regression",
+      "request": {
+        "graph": {
+          "vertices": ["a", "b", "c"],
+          "edges": [["a", "b"], ["b", "c"]]
+        },
+        "edge_probabilities": [
+          {
+            "edge": ["a", "b"],
+            "open_probability": {"num": "1", "den": "2"}
+          },
+          {
+            "edge": ["b", "c"],
+            "open_probability": {"num": "2", "den": "3"}
+          }
+        ],
+        "terminals": ["a", "c"]
+      },
+      "expected_probability": {"num": "1", "den": "3"},
+      "expected_states": 4
+    }
+  ],
+  "held_out_evaluation": {
+    "status": "READY_NOT_RUN",
+    "control": "catalog without the graph reliability capability",
+    "treatment": "catalog with producer and operator-authorized probability.result.verify",
+    "case_source": "freeze generated labelled graphs with 0-10 edges after excluding this public suite",
+    "independent_oracle": "separate Fraction powerset enumeration and BFS",
+    "primary_metrics": [
+      "exact probability correctness",
+      "checker-bound completion",
+      "false completeness claims",
+      "false VERIFIED rate"
+    ],
+    "minimum_repetitions": 3
+  }
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,6 +61,7 @@ expectations.
 - [Domain operation library](reference/domain-operation-library.md)
 - [Finite probability operations](reference/finite-probability-operations.md)
 - [Bounded Gaussian polynomial moments](reference/gaussian-polynomial-moments.md)
+- [Small exact graph reliability](reference/graph-reliability.md)
 - [Exact planar geometry](reference/exact-planar-geometry.md)
 - [Finite simplicial topology](reference/finite-simplicial-topology.md)
 - [Finite posets](reference/finite-posets.md)

--- a/docs/reference/finite-probability-operations.md
+++ b/docs/reference/finite-probability-operations.md
@@ -53,4 +53,5 @@ This finite-distribution foundation does not cover predicate-defined events,
 approximate distributions, all-order Gaussian identities, Markov chains,
 graph reliability, or probabilistic inference strategy. The same probability
 bundle separately exposes one
-[bounded Gaussian polynomial moment](gaussian-polynomial-moments.md) outcome.
+[bounded Gaussian polynomial moment](gaussian-polynomial-moments.md) and one
+[small exact graph reliability](graph-reliability.md) outcome.

--- a/docs/reference/graph-reliability.md
+++ b/docs/reference/graph-reliability.md
@@ -1,0 +1,89 @@
+# Small exact graph reliability
+
+[Documentation home](../index.md)
+
+- Capability: `probability.graph_reliability.connection_probability.compute`
+- Verification: `probability.result.verify`
+- Producer: pinned Python-FLINT exact rational arithmetic
+- Checker: isolated standard-library `Fraction` enumeration and graph traversal
+
+The capability computes one atomic outcome: the exact probability that two
+explicit terminals are connected when every edge of one finite simple
+undirected graph is independently open with its declared rational probability.
+
+## Bounded contract
+
+The request uses the existing canonical `SimpleUndirectedGraph`, at most 16
+vertices and 12 edges, one rational probability in \([0,1]\) for every edge in
+the graph's exact order, and two distinct declared terminals. Full request
+validation precedes computation and artifact writes.
+
+The producer exhausts all \(2^{|E|}\) edge subsets. Every state records its
+canonical index, open edges, exact product-measure mass, and terminal
+connectivity. The result reports `visited_states`, `COMPLETE_EDGE_SUBSETS`,
+`COMPLETE`, `truncated=false`, and `EXHAUSTED` separately from execution and
+assurance. It therefore has no prefix, timeout, or failed-witness semantics.
+
+The producer remains `COMPUTED`. The operator-authorized checker independently
+parses the graph and probabilities, enumerates the entire powerset with
+standard-library `Fraction`, recomputes connectivity by graph traversal, and
+binds every state and the final sum to the stored request and result.
+
+## Excluded claims
+
+This capability does not construct bunkbed graphs, compare two events, exploit
+symmetry, emit a reliability polynomial, prescribe a search, or support more
+than 12 edges. In particular, the explicit 7,222-vertex counterexample in
+[The bunkbed conjecture is false](https://arxiv.org/abs/2410.02545) is
+answer-visible motivation, not an acceptance target. Scaling that case requires
+separate compressed graph and symmetry artifacts; raising a JSON limit would
+not establish a complete calculation.
+
+## Development handoff
+
+### Discovery and implementation
+
+- Decision: accept only bounded terminal connection probability.
+- Portfolio delta: existing graph capabilities compute structural invariants;
+  finite-distribution probability operations do not bind independent edge
+  states to graph connectivity.
+- Contract: 16 vertices, 12 edges, 4,096 states maximum; exact heterogeneous
+  rational probabilities; complete state ledger.
+- Base revision: `765cf5cb48dcf0f2b40e8dc3bffc3988ae8aa7e1`.
+- Runtime: CPython 3.12 and pinned `python-flint==0.9.0`; no dependency change.
+- Public reproduction:
+  [`graph_reliability_public.json`](../../benchmarks/reproduction_cases/graph_reliability_public.json).
+
+### Checker and evaluation
+
+- Exact claim: the reported sum is exactly the mass of every edge subset in
+  which the stored terminals are connected.
+- Independence: clean-process checker, no FLINT and no producer import.
+- Attacks: changed connectivity, state mass, state omission, metadata, source,
+  and fresh payload digest must produce `REJECTED/UNKNOWN` and no record.
+- Public cases are answer-visible and unscored.
+- Held-out control/treatment protocol is frozen as `READY_NOT_RUN`; no model,
+  prompt, or raw trace exists and no portfolio improvement is claimed.
+- Primary evaluation metrics are exact-answer correctness, checker-bound
+  completion, false completeness, and false `VERIFIED` rate.
+- Decision: keep the bounded experimental operation; hand compressed/symmetric
+  scaling to a separate discovery batch.
+
+### Reproducibility snapshot
+
+- Installed catalog: 284 capabilities, catalog version 1,
+  `sha256:532e6ccb09bc8552c5a10d7d464b211546f514b83c9f86db7543d4e46432ed8c`.
+- Policy: `DEFAULT`,
+  `sha256:870a92b83d3e522e4015b6bb1cabda33086906f9de1c3c36e466251ea7ed1957`.
+- Producer runtime: `python-flint==0.9.0`, available on `linux-x86_64`;
+  Python distribution RECORD digest
+  `sha256:8ade9b4c5c1972b029d9393bb2586e2097cc44149a84ef8ef9ef376d634c328f`.
+- Validation: focused producer, checker, verification, discovery, and public
+  reproduction tests passed; `make check` passed with 288 unit tests; and
+  `make test-affected BASE=origin/main` passed every selected lane (`unit`,
+  `component`, `domain`, `composition`, `storage`, `process`, `mcp`,
+  `provider`, `e2e`, `static`, `build`, and `docs`). Skips were limited to the
+  documented unavailable Lean and external proof runtimes.
+- Open obligations: the held-out model-in-the-loop comparison is not run, and
+  no claim is made for compressed graphs, symmetry reduction, reliability
+  polynomials, bunkbed event comparison, or the 7,222-vertex counterexample.

--- a/src/jacobian/contracts/probability.py
+++ b/src/jacobian/contracts/probability.py
@@ -9,6 +9,7 @@ from typing import Literal, Self
 from pydantic import Field, StrictInt, model_validator
 
 from jacobian.contracts.exact import CanonicalInteger, CanonicalRational
+from jacobian.contracts.graph_isomorphism import SimpleUndirectedGraph
 from jacobian.contracts.results import ContractModel
 
 MAX_FINITE_DISTRIBUTION_ATOMS = 256
@@ -21,6 +22,9 @@ MAX_GAUSSIAN_TERM_DEGREE = 8
 MAX_GAUSSIAN_MOMENT_ORDER = 16
 MAX_GAUSSIAN_EXPANSION_PATHS = 4096
 MAX_GAUSSIAN_RESULT_RATIONAL_DIGITS = 4096
+MAX_GRAPH_RELIABILITY_VERTICES = 16
+MAX_GRAPH_RELIABILITY_EDGES = 12
+MAX_GRAPH_RELIABILITY_STATES = 1 << MAX_GRAPH_RELIABILITY_EDGES
 
 
 def _require_bounded_fraction(
@@ -235,6 +239,116 @@ class GaussianPolynomialMomentResult(ContractModel):
             total_imaginary += imaginary
         if self.moment.as_fractions() != (total_real, total_imaginary):
             raise ValueError("Gaussian polynomial moment does not match its ledger")
+        return self
+
+
+class GraphReliabilityEdgeProbability(ContractModel):
+    edge: tuple[str, str]
+    open_probability: CanonicalRational
+
+    @model_validator(mode="after")
+    def require_canonical_bounded_probability(self) -> Self:
+        if len(self.edge) != 2 or self.edge[0] >= self.edge[1]:
+            raise ValueError("reliability edge must contain two ordered vertices")
+        _require_bounded_rational(
+            self.open_probability,
+            max_digits=MAX_INPUT_RATIONAL_DIGITS,
+            label="graph reliability edge probability",
+        )
+        if not 0 <= self.open_probability.as_fraction() <= 1:
+            raise ValueError("graph reliability probabilities must lie in [0, 1]")
+        return self
+
+
+class GraphConnectionProbabilityRequest(ContractModel):
+    graph: SimpleUndirectedGraph
+    edge_probabilities: tuple[GraphReliabilityEdgeProbability, ...] = Field(
+        max_length=MAX_GRAPH_RELIABILITY_EDGES
+    )
+    terminals: tuple[str, str]
+    event: Literal["TERMINALS_CONNECTED"] = "TERMINALS_CONNECTED"
+
+    @model_validator(mode="after")
+    def require_bounded_fully_weighted_graph(self) -> Self:
+        if len(self.graph.vertices) > MAX_GRAPH_RELIABILITY_VERTICES:
+            raise ValueError(
+                "graph reliability exceeds the "
+                f"{MAX_GRAPH_RELIABILITY_VERTICES}-vertex bound"
+            )
+        if len(self.graph.edges) > MAX_GRAPH_RELIABILITY_EDGES:
+            raise ValueError(
+                "graph reliability exceeds the "
+                f"{MAX_GRAPH_RELIABILITY_EDGES}-edge bound"
+            )
+        if tuple(item.edge for item in self.edge_probabilities) != self.graph.edges:
+            raise ValueError(
+                "edge probabilities must cover graph edges in canonical graph order"
+            )
+        if (
+            len(self.terminals) != 2
+            or self.terminals[0] == self.terminals[1]
+            or any(terminal not in self.graph.vertices for terminal in self.terminals)
+        ):
+            raise ValueError("terminals must be two distinct declared graph vertices")
+        return self
+
+
+class GraphReliabilityState(ContractModel):
+    state_index: StrictInt = Field(ge=0, lt=MAX_GRAPH_RELIABILITY_STATES)
+    open_edges: tuple[tuple[str, str], ...] = Field(
+        max_length=MAX_GRAPH_RELIABILITY_EDGES
+    )
+    terminals_connected: bool
+    state_probability: CanonicalRational
+
+
+class GraphConnectionProbabilityResult(ContractModel):
+    terminals: tuple[str, str]
+    connection_probability: CanonicalRational
+    edge_count: StrictInt = Field(ge=0, le=MAX_GRAPH_RELIABILITY_EDGES)
+    visited_states: StrictInt = Field(ge=1, le=MAX_GRAPH_RELIABILITY_STATES)
+    states: tuple[GraphReliabilityState, ...] = Field(
+        min_length=1,
+        max_length=MAX_GRAPH_RELIABILITY_STATES,
+    )
+    event: Literal["TERMINALS_CONNECTED"] = "TERMINALS_CONNECTED"
+    edge_independence: Literal["INDEPENDENT_BERNOULLI"] = "INDEPENDENT_BERNOULLI"
+    enumeration: Literal["COMPLETE_EDGE_SUBSETS"] = "COMPLETE_EDGE_SUBSETS"
+    completeness: Literal["COMPLETE"] = "COMPLETE"
+    truncated: Literal[False] = False
+    termination_reason: Literal["EXHAUSTED"] = "EXHAUSTED"
+    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
+    determinism: Literal["DETERMINISTIC"] = "DETERMINISTIC"
+    backend: Literal["python-flint"] = "python-flint"
+    backend_version: Literal["0.9.0"] = "0.9.0"
+    verification: Literal["UNVERIFIED"] = "UNVERIFIED"
+
+    @model_validator(mode="after")
+    def bind_complete_state_mass(self) -> Self:
+        if self.visited_states != 1 << self.edge_count:
+            raise ValueError("visited state count is not the full edge powerset")
+        if len(self.states) != self.visited_states:
+            raise ValueError("state ledger length does not match visited states")
+        if tuple(item.state_index for item in self.states) != tuple(
+            range(self.visited_states)
+        ):
+            raise ValueError("state ledger indices must be complete and canonical")
+        total = sum(
+            (item.state_probability.as_fraction() for item in self.states),
+            start=Fraction(),
+        )
+        connected = sum(
+            (
+                item.state_probability.as_fraction()
+                for item in self.states
+                if item.terminals_connected
+            ),
+            start=Fraction(),
+        )
+        if total != 1:
+            raise ValueError("graph reliability state probabilities must sum to one")
+        if self.connection_probability.as_fraction() != connected:
+            raise ValueError("connection probability does not match connected states")
         return self
 
 
@@ -676,6 +790,9 @@ __all__ = [
     "MAX_GAUSSIAN_POLYNOMIAL_TERMS",
     "MAX_GAUSSIAN_TERM_DEGREE",
     "MAX_GAUSSIAN_VARIABLES",
+    "MAX_GRAPH_RELIABILITY_EDGES",
+    "MAX_GRAPH_RELIABILITY_STATES",
+    "MAX_GRAPH_RELIABILITY_VERTICES",
     "ExactComplexRational",
     "FiniteConditionResult",
     "FiniteConditionalContribution",
@@ -695,5 +812,9 @@ __all__ = [
     "GaussianPolynomialMomentRequest",
     "GaussianPolynomialMomentResult",
     "GaussianPolynomialTerm",
+    "GraphConnectionProbabilityRequest",
+    "GraphConnectionProbabilityResult",
+    "GraphReliabilityEdgeProbability",
+    "GraphReliabilityState",
     "require_input_distribution",
 ]

--- a/src/jacobian/domains/probability/bundle.py
+++ b/src/jacobian/domains/probability/bundle.py
@@ -13,14 +13,15 @@ FINITE_PROBABILITY_BUNDLE = DomainBundle(
     schema_namespace="jacobian.validated-analysis",
     semantics=DomainSemantics(
         name="jacobian.probability",
-        version="3",
+        version="4",
         definition={
             "description": "bounded exact rational probability operations",
             "scope": (
                 "raw moments, explicit event mass and conditioning, total "
                 "pushforwards, independent finite convolutions, and one fixed-order "
                 "moment of a sparse complex-rational polynomial in independent "
-                "standard real Gaussian variables"
+                "standard real Gaussian variables, and exact small-graph terminal "
+                "connection reliability"
             ),
             "failure": "invalid bounded probability inputs fail before computation",
         },
@@ -35,7 +36,7 @@ FINITE_PROBABILITY_BUNDLE = DomainBundle(
             message="Input does not satisfy the bounded exact-probability contract.",
             hint=(
                 "Use a bounded normalized finite distribution or a canonical "
-                "bounded Gaussian polynomial and fixed moment order."
+                "bounded Gaussian polynomial, or a fully weighted small graph."
             ),
         )
     ),
@@ -43,7 +44,7 @@ FINITE_PROBABILITY_BUNDLE = DomainBundle(
     completeness_basis=(
         "Python-FLINT produced every selected atom, source-map contribution, "
         "bounded product-measure pair, or coefficient contraction required by "
-        "the request"
+        "the request, or exhausted every bounded graph edge subset"
     ),
     assurance_basis="pinned maintained-backend exact rational computation",
 )

--- a/src/jacobian/domains/probability/checkers.py
+++ b/src/jacobian/domains/probability/checkers.py
@@ -6,6 +6,7 @@ from jacobian.contracts.probability import (
     FiniteEventRequest,
     FinitePushforwardRequest,
     GaussianPolynomialMomentRequest,
+    GraphConnectionProbabilityRequest,
 )
 from jacobian.contracts.validated_analysis import FiniteRawMomentRequest
 
@@ -68,6 +69,15 @@ PROBABILITY_EXACT_REPLAY_CHECKERS = (
         "probability.gaussian-polynomial-moment.fraction-replay",
         entrypoint_module=_ENTRYPOINT,
         replay_method="independent standard-library coefficient contraction",
+        reason=_REASON,
+    ),
+    ExactReplayCheckerDeclaration(
+        "probability.graph_reliability.connection_probability.compute",
+        GraphConnectionProbabilityRequest,
+        "check_graph_connection_probability",
+        "probability.graph-reliability-connection.fraction-replay",
+        entrypoint_module=_ENTRYPOINT,
+        replay_method="independent exhaustive edge-subset replay",
         reason=_REASON,
     ),
 )

--- a/src/jacobian/domains/probability/operations.py
+++ b/src/jacobian/domains/probability/operations.py
@@ -24,6 +24,9 @@ from jacobian.contracts.probability import (
     GaussianMomentContraction,
     GaussianPolynomialMomentRequest,
     GaussianPolynomialMomentResult,
+    GraphConnectionProbabilityRequest,
+    GraphConnectionProbabilityResult,
+    GraphReliabilityState,
 )
 from jacobian.contracts.validated_analysis import (
     FiniteRawMomentContribution,
@@ -326,6 +329,74 @@ def _gaussian_polynomial_moment(
     )
 
 
+def _terminals_connected(
+    vertices: tuple[str, ...],
+    open_edges: tuple[tuple[str, str], ...],
+    terminals: tuple[str, str],
+) -> bool:
+    adjacency: dict[str, set[str]] = {vertex: set() for vertex in vertices}
+    for left, right in open_edges:
+        adjacency[left].add(right)
+        adjacency[right].add(left)
+    seen = {terminals[0]}
+    pending = [terminals[0]]
+    while pending:
+        vertex = pending.pop()
+        for neighbor in adjacency[vertex] - seen:
+            if neighbor == terminals[1]:
+                return True
+            seen.add(neighbor)
+            pending.append(neighbor)
+    return terminals[1] in seen
+
+
+def _graph_connection_probability(
+    request: GraphConnectionProbabilityRequest,
+) -> ComputedOutcome[GraphConnectionProbabilityResult]:
+    from flint import fmpq
+
+    probabilities = tuple(
+        _fmpq(item.open_probability) for item in request.edge_probabilities
+    )
+    states: list[GraphReliabilityState] = []
+    connection_probability = fmpq(0)
+    for state_index in range(1 << len(request.graph.edges)):
+        open_edges = tuple(
+            edge
+            for index, edge in enumerate(request.graph.edges)
+            if state_index & (1 << index)
+        )
+        state_probability = fmpq(1)
+        for index, probability in enumerate(probabilities):
+            state_probability *= (
+                probability if state_index & (1 << index) else 1 - probability
+            )
+        connected = _terminals_connected(
+            request.graph.vertices,
+            open_edges,
+            request.terminals,
+        )
+        if connected:
+            connection_probability += state_probability
+        states.append(
+            GraphReliabilityState(
+                state_index=state_index,
+                open_edges=open_edges,
+                terminals_connected=connected,
+                state_probability=_wire(state_probability),
+            )
+        )
+    return ComputedSuccess(
+        GraphConnectionProbabilityResult(
+            terminals=request.terminals,
+            connection_probability=_wire(connection_probability),
+            edge_count=len(request.graph.edges),
+            visited_states=len(states),
+            states=tuple(states),
+        )
+    )
+
+
 _FAIR_BIT = {
     "atoms": [
         {
@@ -518,6 +589,57 @@ FINITE_PROBABILITY_CAPABILITIES = (
                         ],
                     },
                     "order": 2,
+                },
+            ),
+        ),
+    ),
+    ComputedOperation(
+        capability_id="probability.graph_reliability.connection_probability.compute",
+        title="Exact small-graph terminal connection probability",
+        description=(
+            "Compute the exact probability that two explicit terminals are "
+            "connected in one bounded undirected graph with independent rational "
+            "edge-open probabilities, preserving the complete edge-subset ledger."
+        ),
+        request_model=GraphConnectionProbabilityRequest,
+        result_model=GraphConnectionProbabilityResult,
+        implementation=_graph_connection_probability,
+        relation_id="probability.graph_reliability.connection_probability.relation",
+        tags=(
+            "probability",
+            "graph",
+            "reliability",
+            "percolation",
+            "connection",
+            "terminals",
+            "exact",
+            "bounded",
+            "python-flint",
+        ),
+        invocation_examples=(
+            example(
+                "triangle_terminal_reliability",
+                "Compute the exact terminal connection probability in a fair-edge triangle.",
+                {
+                    "graph": {
+                        "vertices": ["a", "b", "c"],
+                        "edges": [["a", "b"], ["a", "c"], ["b", "c"]],
+                    },
+                    "edge_probabilities": [
+                        {
+                            "edge": ["a", "b"],
+                            "open_probability": {"num": "1", "den": "2"},
+                        },
+                        {
+                            "edge": ["a", "c"],
+                            "open_probability": {"num": "1", "den": "2"},
+                        },
+                        {
+                            "edge": ["b", "c"],
+                            "open_probability": {"num": "1", "den": "2"},
+                        },
+                    ],
+                    "terminals": ["a", "c"],
                 },
             ),
         ),

--- a/src/jacobian/provider_runtime.py
+++ b/src/jacobian/provider_runtime.py
@@ -1066,6 +1066,7 @@ def python_flint_probability_provider_runtime(
             "finite-pushforward",
             "finite-convolution",
             "gaussian-polynomial-complex-rational-moments",
+            "small-graph-exact-reliability",
         ),
         refresh=refresh,
     )
@@ -1201,6 +1202,7 @@ def probability_exact_checker_provider_runtime(
             "clean-process-replay",
             "finite-rational-probability-replay",
             "gaussian-polynomial-coefficient-contraction",
+            "small-graph-reliability-exhaustive-replay",
             "standard-library-only",
         ),
         checker_ids=checker_ids,

--- a/src/jacobian_checkers/exact_probability_operations.py
+++ b/src/jacobian_checkers/exact_probability_operations.py
@@ -30,6 +30,19 @@ _GAUSSIAN_META = {
     "backend_version": "0.9.0",
     "verification": "UNVERIFIED",
 }
+_GRAPH_RELIABILITY_META = {
+    "event": "TERMINALS_CONNECTED",
+    "edge_independence": "INDEPENDENT_BERNOULLI",
+    "enumeration": "COMPLETE_EDGE_SUBSETS",
+    "completeness": "COMPLETE",
+    "truncated": False,
+    "termination_reason": "EXHAUSTED",
+    "exactness": "EXACT_RATIONAL",
+    "determinism": "DETERMINISTIC",
+    "backend": "python-flint",
+    "backend_version": "0.9.0",
+    "verification": "UNVERIFIED",
+}
 
 
 def _reject(detail: str) -> dict[str, Any]:
@@ -465,6 +478,148 @@ def _replay_gaussian_polynomial_moment(
     return _complex_fraction(result["moment"]) == total
 
 
+def _canonical_graph(value: object) -> tuple[list[str], list[tuple[str, str]]]:
+    if not isinstance(value, dict) or set(value) != {
+        "graph_schema_version",
+        "vertices",
+        "edges",
+    }:
+        raise ValueError("graph is malformed")
+    if value["graph_schema_version"] != "1":
+        raise ValueError("graph schema version is unsupported")
+    vertices = value["vertices"]
+    edges = value["edges"]
+    if (
+        not isinstance(vertices, list)
+        or not isinstance(edges, list)
+        or len(vertices) > 16
+        or len(edges) > 12
+        or any(not isinstance(vertex, str) or not vertex for vertex in vertices)
+        or len(set(vertices)) != len(vertices)
+    ):
+        raise ValueError("graph bounds or vertices are invalid")
+    parsed_edges: list[tuple[str, str]] = []
+    for edge in edges:
+        if (
+            not isinstance(edge, list)
+            or len(edge) != 2
+            or not all(isinstance(vertex, str) for vertex in edge)
+        ):
+            raise ValueError("graph edge is malformed")
+        parsed = (edge[0], edge[1])
+        if (
+            parsed[0] >= parsed[1]
+            or parsed[0] not in vertices
+            or parsed[1] not in vertices
+        ):
+            raise ValueError("graph edge is not canonical")
+        parsed_edges.append(parsed)
+    if len(set(parsed_edges)) != len(parsed_edges):
+        raise ValueError("graph edges are repeated")
+    return vertices, parsed_edges
+
+
+def _connected(
+    vertices: list[str],
+    open_edges: list[tuple[str, str]],
+    terminals: tuple[str, str],
+) -> bool:
+    adjacency: dict[str, set[str]] = {vertex: set() for vertex in vertices}
+    for left, right in open_edges:
+        adjacency[left].add(right)
+        adjacency[right].add(left)
+    seen = {terminals[0]}
+    pending = [terminals[0]]
+    while pending:
+        vertex = pending.pop()
+        for neighbor in adjacency[vertex] - seen:
+            seen.add(neighbor)
+            pending.append(neighbor)
+    return terminals[1] in seen
+
+
+def _replay_graph_connection_probability(
+    source: dict[str, Any],
+    result: dict[str, Any],
+) -> bool:
+    if set(source) != {"graph", "edge_probabilities", "terminals", "event"}:
+        return False
+    if set(result) != {
+        "terminals",
+        "connection_probability",
+        "edge_count",
+        "visited_states",
+        "states",
+        *_GRAPH_RELIABILITY_META,
+    } or any(
+        result.get(key) != value for key, value in _GRAPH_RELIABILITY_META.items()
+    ):
+        return False
+    if source["event"] != "TERMINALS_CONNECTED":
+        return False
+    vertices, edges = _canonical_graph(source["graph"])
+    raw_terminals = source["terminals"]
+    if (
+        not isinstance(raw_terminals, list)
+        or len(raw_terminals) != 2
+        or raw_terminals[0] == raw_terminals[1]
+        or any(terminal not in vertices for terminal in raw_terminals)
+    ):
+        return False
+    terminals = (raw_terminals[0], raw_terminals[1])
+    raw_probabilities = source["edge_probabilities"]
+    if not isinstance(raw_probabilities, list) or len(raw_probabilities) != len(edges):
+        return False
+    probabilities: list[Fraction] = []
+    for expected_edge, item in zip(edges, raw_probabilities, strict=True):
+        if not isinstance(item, dict) or set(item) != {"edge", "open_probability"}:
+            return False
+        if item["edge"] != list(expected_edge):
+            return False
+        probability = _fraction(item["open_probability"])
+        if not 0 <= probability <= 1:
+            return False
+        probabilities.append(probability)
+    raw_states = result["states"]
+    expected_count = 1 << len(edges)
+    if (
+        result["terminals"] != list(terminals)
+        or result["edge_count"] != len(edges)
+        or result["visited_states"] != expected_count
+        or not isinstance(raw_states, list)
+        or len(raw_states) != expected_count
+    ):
+        return False
+    connected_mass = Fraction()
+    for state_index, item in enumerate(raw_states):
+        if not isinstance(item, dict) or set(item) != {
+            "state_index",
+            "open_edges",
+            "terminals_connected",
+            "state_probability",
+        }:
+            return False
+        open_edges = [
+            edge for index, edge in enumerate(edges) if state_index & (1 << index)
+        ]
+        probability = Fraction(1)
+        for index, edge_probability in enumerate(probabilities):
+            probability *= (
+                edge_probability if state_index & (1 << index) else 1 - edge_probability
+            )
+        connected = _connected(vertices, open_edges, terminals)
+        if (
+            item["state_index"] != state_index
+            or item["open_edges"] != [list(edge) for edge in open_edges]
+            or item["terminals_connected"] is not connected
+            or _fraction(item["state_probability"]) != probability
+        ):
+            return False
+        if connected:
+            connected_mass += probability
+    return _fraction(result["connection_probability"]) == connected_mass
+
+
 def check_finite_raw_moment(request: object) -> dict[str, Any]:
     return _run(
         request,
@@ -519,6 +674,15 @@ def check_gaussian_polynomial_moment(request: object) -> dict[str, Any]:
     )
 
 
+def check_graph_connection_probability(request: object) -> dict[str, Any]:
+    return _run(
+        request,
+        operation_id="probability.graph_reliability.connection_probability.compute",
+        witness_format="probability.graph-reliability-connection.fraction-replay",
+        replay=_replay_graph_connection_probability,
+    )
+
+
 __all__ = [
     "check_finite_condition",
     "check_finite_convolution",
@@ -526,4 +690,5 @@ __all__ = [
     "check_finite_pushforward",
     "check_finite_raw_moment",
     "check_gaussian_polynomial_moment",
+    "check_graph_connection_probability",
 ]

--- a/tests/component/checkers/test_exact_probability_operation_checkers.py
+++ b/tests/component/checkers/test_exact_probability_operation_checkers.py
@@ -16,6 +16,7 @@ from jacobian_checkers.exact_probability_operations import (
     check_finite_pushforward,
     check_finite_raw_moment,
     check_gaussian_polynomial_moment,
+    check_graph_connection_probability,
 )
 
 _META = {
@@ -35,6 +36,19 @@ _GAUSSIAN_META = {
     "gaussian_model": "INDEPENDENT_STANDARD_REAL",
     "completeness": "COMPLETE_BOUNDED_EXPANSION",
     "exactness": "EXACT_COMPLEX_RATIONAL",
+    "determinism": "DETERMINISTIC",
+    "backend": "python-flint",
+    "backend_version": "0.9.0",
+    "verification": "UNVERIFIED",
+}
+_GRAPH_RELIABILITY_META = {
+    "event": "TERMINALS_CONNECTED",
+    "edge_independence": "INDEPENDENT_BERNOULLI",
+    "enumeration": "COMPLETE_EDGE_SUBSETS",
+    "completeness": "COMPLETE",
+    "truncated": False,
+    "termination_reason": "EXHAUSTED",
+    "exactness": "EXACT_RATIONAL",
     "determinism": "DETERMINISTIC",
     "backend": "python-flint",
     "backend_version": "0.9.0",
@@ -276,6 +290,46 @@ _CASES: tuple[
             },
         ),
     ),
+    (
+        check_graph_connection_probability,
+        _request(
+            "probability.graph_reliability.connection_probability.compute",
+            "probability.graph-reliability-connection.fraction-replay",
+            {
+                "graph": {
+                    "graph_schema_version": "1",
+                    "vertices": ["a", "b"],
+                    "edges": [["a", "b"]],
+                },
+                "edge_probabilities": [
+                    {"edge": ["a", "b"], "open_probability": _q(1, 3)}
+                ],
+                "terminals": ["a", "b"],
+                "event": "TERMINALS_CONNECTED",
+            },
+            {
+                "terminals": ["a", "b"],
+                "connection_probability": _q(1, 3),
+                "edge_count": 1,
+                "visited_states": 2,
+                "states": [
+                    {
+                        "state_index": 0,
+                        "open_edges": [],
+                        "terminals_connected": False,
+                        "state_probability": _q(2, 3),
+                    },
+                    {
+                        "state_index": 1,
+                        "open_edges": [["a", "b"]],
+                        "terminals_connected": True,
+                        "state_probability": _q(1, 3),
+                    },
+                ],
+                **_GRAPH_RELIABILITY_META,
+            },
+        ),
+    ),
 )
 
 
@@ -307,7 +361,9 @@ def test_probability_checkers_reject_payload_substitution_with_fresh_digest(
 
 
 def test_convolution_checker_rejects_missing_pair_with_fresh_digest() -> None:
-    checker, case_request = _CASES[-2]
+    checker, case_request = next(
+        case for case in _CASES if case[0] is check_finite_convolution
+    )
     forged = copy.deepcopy(case_request)
     forged["candidate"]["payload"]["contributions"].pop()
     forged["candidate"]["payload_digest"] = _digest(forged["candidate"]["payload"])
@@ -319,10 +375,23 @@ def test_convolution_checker_rejects_missing_pair_with_fresh_digest() -> None:
 
 
 def test_gaussian_checker_rejects_forged_contraction_with_fresh_digest() -> None:
-    checker, case_request = _CASES[-1]
+    checker, case_request = _CASES[-2]
     forged = copy.deepcopy(case_request)
     forged["candidate"]["payload"]["contractions"][2]["contribution"] = _c(0)
     forged["candidate"]["payload"]["moment"] = _c(1)
+    forged["candidate"]["payload_digest"] = _digest(forged["candidate"]["payload"])
+
+    checked = checker(forged)
+
+    assert checked["accepted"] is False
+    assert checked["conclusion"] == "UNKNOWN"
+
+
+def test_graph_reliability_checker_rejects_forged_connectivity() -> None:
+    checker, case_request = _CASES[-1]
+    forged = copy.deepcopy(case_request)
+    forged["candidate"]["payload"]["states"][0]["terminals_connected"] = True
+    forged["candidate"]["payload"]["connection_probability"] = _q(1)
     forged["candidate"]["payload_digest"] = _digest(forged["candidate"]["payload"])
 
     checked = checker(forged)

--- a/tests/composition/portfolio/test_validated_analysis_bundles.py
+++ b/tests/composition/portfolio/test_validated_analysis_bundles.py
@@ -33,6 +33,7 @@ def test_subject_bundles_preserve_wire_contracts_and_report_one_backend() -> Non
                 "probability.finite_distribution.pushforward.compute",
                 "probability.finite_distribution.convolution.compute",
                 "probability.gaussian_polynomial.moment.compute",
+                "probability.graph_reliability.connection_probability.compute",
             ),
         ),
         "optimization": (

--- a/tests/composition/runtime/exact_verification/test_graph_reliability_public_reproductions.py
+++ b/tests/composition/runtime/exact_verification/test_graph_reliability_public_reproductions.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from jacobian.contracts.capabilities import (
+    CapabilityAssuranceLevel,
+    CapabilityMode,
+    CapabilityRequest,
+)
+from jacobian.contracts.results import ExecutionStatus
+
+PROJECT_ROOT = Path(__file__).resolve().parents[4]
+REPRODUCTIONS = (
+    PROJECT_ROOT / "benchmarks" / "reproduction_cases" / "graph_reliability_public.json"
+)
+
+
+def _suite() -> dict[str, Any]:
+    suite = json.loads(REPRODUCTIONS.read_text(encoding="utf-8"))
+    assert suite["scored"] is False
+    assert suite["held_out_evaluation"]["status"] == "READY_NOT_RUN"
+    return suite
+
+
+def test_public_small_graph_reliability_reaches_checker_bound_results(
+    authorized_complete_runtime,
+) -> None:
+    for case in _suite()["cases"]:
+        computed = authorized_complete_runtime.core.capabilities.invoke(
+            CapabilityRequest(
+                capability_id=(
+                    "probability.graph_reliability.connection_probability.compute"
+                ),
+                input=case["request"],
+            )
+        )
+        assert computed.execution.status is ExecutionStatus.COMPLETED
+        assert (
+            computed.output["result"]["connection_probability"]
+            == (case["expected_probability"])
+        )
+        assert computed.output["result"]["visited_states"] == case["expected_states"]
+        assert computed.output["result"]["completeness"] == "COMPLETE"
+        assert computed.assurance.level is CapabilityAssuranceLevel.COMPUTED
+
+        verified = authorized_complete_runtime.core.capabilities.invoke(
+            CapabilityRequest(
+                capability_id="probability.result.verify",
+                mode=CapabilityMode.VERIFY,
+                input={"result_uri": computed.output["result_uri"]},
+            )
+        )
+        assert verified.output["status"] == "VERIFIED"
+        assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED

--- a/tests/composition/runtime/exact_verification/test_probability_verification.py
+++ b/tests/composition/runtime/exact_verification/test_probability_verification.py
@@ -66,6 +66,22 @@ _GAUSSIAN_POLYNOMIAL = {
             "probability.gaussian_polynomial.moment.compute",
             {"polynomial": _GAUSSIAN_POLYNOMIAL, "order": 2},
         ),
+        (
+            "probability.graph_reliability.connection_probability.compute",
+            {
+                "graph": {
+                    "vertices": ["a", "b"],
+                    "edges": [["a", "b"]],
+                },
+                "edge_probabilities": [
+                    {
+                        "edge": ["a", "b"],
+                        "open_probability": _q(1, 3),
+                    }
+                ],
+                "terminals": ["a", "b"],
+            },
+        ),
     ),
 )
 def test_probability_results_are_independently_replayed(
@@ -128,3 +144,49 @@ def test_probability_checker_rejects_forged_event_mass(
     assert rejected.output["conclusion"] == "UNKNOWN"
     assert rejected.output["verification_record_uri"] is None
     assert rejected.assurance.level is CapabilityAssuranceLevel.COMPUTED
+
+
+def test_probability_checker_rejects_forged_graph_reliability(
+    authorized_complete_runtime,
+) -> None:
+    computed = authorized_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id=(
+                "probability.graph_reliability.connection_probability.compute"
+            ),
+            input={
+                "graph": {"vertices": ["a", "b"], "edges": [["a", "b"]]},
+                "edge_probabilities": [
+                    {"edge": ["a", "b"], "open_probability": _q(1, 3)}
+                ],
+                "terminals": ["a", "b"],
+            },
+        )
+    )
+    result_artifact = authorized_complete_runtime.core.store.get(
+        computed.output["result_uri"]
+    )
+    false_payload = dict(result_artifact.payload)
+    false_states = [dict(state) for state in false_payload["states"]]
+    false_states[0]["terminals_connected"] = True
+    false_payload["states"] = false_states
+    false_payload["connection_probability"] = _q(1)
+    false_result = authorized_complete_runtime.core.artifacts.put(
+        schema_uri=result_artifact.manifest.schema_uri,
+        semantics_uri=result_artifact.manifest.semantics_uri,
+        parents=result_artifact.manifest.parents,
+        payload=false_payload,
+        summary="adversarial false graph reliability",
+    )
+
+    rejected = authorized_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="probability.result.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"result_uri": false_result.artifact_uri},
+        )
+    )
+
+    assert rejected.output["status"] == "REJECTED"
+    assert rejected.output["conclusion"] == "UNKNOWN"
+    assert rejected.output["verification_record_uri"] is None

--- a/tests/composition/runtime/test_capability_service.py
+++ b/tests/composition/runtime/test_capability_service.py
@@ -423,6 +423,17 @@ def test_discovery_distinguishes_strong_weak_and_absent_lexical_fit(
         gaussian.matches[0].description
     )
 
+    reliability = runtime.core.capabilities.discover(
+        CapabilityDiscoveryRequest(
+            query="exact small graph reliability terminal connection probability",
+            limit=3,
+        )
+    )
+    assert reliability.portfolio_fit == "STRONG_CANDIDATES_FOUND"
+    assert reliability.matches[0].capability_id == (
+        "probability.graph_reliability.connection_probability.compute"
+    )
+
     absent = runtime.core.capabilities.discover(
         CapabilityDiscoveryRequest(
             query="quuxonium frobnicator",

--- a/tests/domain/probability/test_finite_probability.py
+++ b/tests/domain/probability/test_finite_probability.py
@@ -396,3 +396,86 @@ def test_gaussian_expansion_above_bound_fails_before_artifact_writes(
     assert result.execution.status is ExecutionStatus.ERROR
     assert result.diagnostics[0].code == "INVALID_FINITE_PROBABILITY_REQUEST"
     assert result.artifact_uris == ()
+
+
+def test_graph_reliability_exhausts_all_edge_states_exactly(
+    domain_services: DomainTestServices,
+) -> None:
+    result = domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id=(
+                "probability.graph_reliability.connection_probability.compute"
+            ),
+            input={
+                "graph": {
+                    "vertices": ["a", "b", "c"],
+                    "edges": [["a", "b"], ["a", "c"], ["b", "c"]],
+                },
+                "edge_probabilities": [
+                    {"edge": edge, "open_probability": _rational(1, 2)}
+                    for edge in (["a", "b"], ["a", "c"], ["b", "c"])
+                ],
+                "terminals": ["a", "c"],
+            },
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    computed = result.output["result"]
+    assert computed["connection_probability"] == _rational(5, 8)
+    assert computed["visited_states"] == 8
+    assert len(computed["states"]) == 8
+    assert computed["completeness"] == "COMPLETE"
+    assert computed["truncated"] is False
+    assert computed["termination_reason"] == "EXHAUSTED"
+    assert sum(1 for state in computed["states"] if state["terminals_connected"]) == 5
+    assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
+
+
+def test_graph_reliability_disconnected_terminals_have_zero_probability(
+    domain_services: DomainTestServices,
+) -> None:
+    result = domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id=(
+                "probability.graph_reliability.connection_probability.compute"
+            ),
+            input={
+                "graph": {"vertices": ["a", "b"], "edges": []},
+                "edge_probabilities": [],
+                "terminals": ["a", "b"],
+            },
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output["result"]["connection_probability"] == _rational(0)
+    assert result.output["result"]["visited_states"] == 1
+
+
+def test_graph_reliability_rejects_incomplete_edge_probability_binding(
+    domain_services: DomainTestServices,
+) -> None:
+    result = domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id=(
+                "probability.graph_reliability.connection_probability.compute"
+            ),
+            input={
+                "graph": {
+                    "vertices": ["a", "b", "c"],
+                    "edges": [["a", "b"], ["b", "c"]],
+                },
+                "edge_probabilities": [
+                    {
+                        "edge": ["a", "b"],
+                        "open_probability": _rational(1, 2),
+                    }
+                ],
+                "terminals": ["a", "c"],
+            },
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.artifact_uris == ()


### PR DESCRIPTION
## Outcome

Adds one bounded, atomic probability capability for exact terminal connection reliability in a finite simple undirected graph with independent rational edge-open probabilities, plus an operator-authorized independent checker.

## Contract and boundary

- Capability: `probability.graph_reliability.connection_probability.compute`
- Reuses canonical `SimpleUndirectedGraph`.
- Maximum 16 vertices, 12 edges, and 4,096 fully enumerated edge states.
- Validates the complete edge/probability binding and distinct declared terminals before computation or artifact writes.
- Preserves every state, exact state mass, connectivity outcome, and explicit complete/exhausted metadata.
- Producer remains `COMPUTED`; `probability.result.verify` reaches `VERIFIED` only through isolated standard-library `Fraction` enumeration and graph traversal.
- Does not claim symmetry reduction, reliability polynomials, bunkbed event comparison, or support for the published 7,222-vertex counterexample. Those scaling artifacts remain a separate batch.

## Reproducibility

- Base: `765cf5cb48dcf0f2b40e8dc3bffc3988ae8aa7e1`
- Head: `889836171b5a2b8d0d37c9d7bd5b355fcf817b99`
- Tree: `7f06ef634dc496f3b522bc8790e281539af40c07`
- Installed catalog: 284 capabilities, catalog version 1
- Catalog digest: `sha256:532e6ccb09bc8552c5a10d7d464b211546f514b83c9f86db7543d4e46432ed8c`
- Policy: `DEFAULT`
- Policy digest: `sha256:870a92b83d3e522e4015b6bb1cabda33086906f9de1c3c36e466251ea7ed1957`
- Producer: `python-flint==0.9.0`, AVAILABLE, `linux-x86_64`
- Provider digest: `sha256:8ade9b4c5c1972b029d9393bb2586e2097cc44149a84ef8ef9ef376d634c328f`

## Validation

- `make test-plan BASE=origin/main`
- `make test-affected BASE=origin/main` — all selected lanes passed: unit, component, domain, composition, storage, process, mcp, provider, e2e, static, build, docs
- `make check` — ruff, formatting, mypy, 288 unit tests passed
- `make docs-linkcheck`
- Focused producer/checker/verification/public reproduction suite — 43 passed
- `git diff --check`

Expected skips were limited to unavailable Lean and external proof runtimes documented by the repository.

## Evaluation status and obligations

The answer-visible public suite is an unscored regression suite. A held-out control/treatment protocol with a separate `Fraction` powerset/BFS oracle is frozen as `READY_NOT_RUN`; no model trace or portfolio-improvement claim is reported. Compressed graph and symmetry artifacts are deferred to the next batch.

