### PR TITLE
feat(matrices): add certified Smith transformations and integral homology

### DIFF
--- a/benchmarks/reproduction_cases/certified_snf_integral_homology_public.json
+++ b/benchmarks/reproduction_cases/certified_snf_integral_homology_public.json
@@ -1,0 +1,92 @@
+{
+  "suite_id": "CERTIFIED-SNF-INTEGRAL-HOMOLOGY-PUBLIC-001",
+  "version": "1",
+  "scored": false,
+  "purpose": "Answer-visible certificate and integral-homology regressions only; never hidden evaluation or evidence of model improvement",
+  "smith_cases": [
+    {
+      "case_id": "SMITH-RECTANGULAR-001",
+      "source": "Jacobian synthetic public transformation-certificate regression",
+      "matrix": {
+        "row_count": 2,
+        "column_count": 3,
+        "entries": [["2", "4", "4"], ["6", "6", "12"]]
+      },
+      "expected_rank": 2,
+      "expected_invariant_factors": ["2", "6"]
+    },
+    {
+      "case_id": "SMITH-RANK-DEFICIENT-001",
+      "source": "Jacobian synthetic public rank-deficient boundary",
+      "matrix": {
+        "row_count": 3,
+        "column_count": 2,
+        "entries": [["2", "4"], ["4", "8"], ["6", "12"]]
+      },
+      "expected_rank": 1,
+      "expected_invariant_factors": ["2"]
+    }
+  ],
+  "homology_cases": [
+    {
+      "case_id": "INTEGRAL-CIRCLE-001",
+      "source": "Triangle-boundary simplicial model of S^1",
+      "presentation": {
+        "vertices": ["a", "b", "c"],
+        "facets": [["a", "b"], ["a", "c"], ["b", "c"]]
+      },
+      "convention": "UNREDUCED",
+      "expected_free_ranks": [1, 1],
+      "expected_torsion": [[], []]
+    },
+    {
+      "case_id": "INTEGRAL-PROJECTIVE-PLANE-001",
+      "source": "Six-vertex triangulation of the real projective plane",
+      "presentation": {
+        "vertices": ["0", "1", "2", "3", "4", "5"],
+        "facets": [
+          ["0", "1", "2"],
+          ["0", "1", "3"],
+          ["0", "2", "4"],
+          ["0", "3", "5"],
+          ["0", "4", "5"],
+          ["1", "2", "5"],
+          ["1", "3", "4"],
+          ["1", "4", "5"],
+          ["2", "3", "4"],
+          ["2", "3", "5"]
+        ]
+      },
+      "convention": "UNREDUCED",
+      "expected_free_ranks": [1, 0, 0],
+      "expected_torsion": [[], ["2"], []]
+    },
+    {
+      "case_id": "REDUCED-POINT-001",
+      "source": "Jacobian synthetic reduced-homology boundary",
+      "presentation": {
+        "vertices": ["p"],
+        "facets": [["p"]]
+      },
+      "convention": "REDUCED",
+      "expected_free_ranks": [0],
+      "expected_torsion": [[]]
+    }
+  ],
+  "held_out_evaluation": {
+    "status": "READY_NOT_RUN",
+    "control": "catalog with diagonal-only Smith normal form and prime-field simplicial homology",
+    "treatment": "catalog with transformation-certified Smith normal form and dedicated integral-homology verifier",
+    "case_source": "freeze unseen bounded integer matrices and relabelled finite simplicial complexes after excluding this public suite",
+    "independent_oracle": "separate exact matrix relation, determinant, chain-boundary, and finite-abelian-group replay",
+    "primary_metrics": [
+      "correct canonical invariant factors",
+      "valid full transformation certificates",
+      "correct free and torsion decomposition",
+      "generator and bounding-chain correctness",
+      "false VERIFIED rate",
+      "diagonal-only capability selection regression"
+    ],
+    "minimum_repetitions": 3
+  }
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -65,6 +65,7 @@ expectations.
 - [Declared graph-symmetry orbits](reference/graph-symmetry-orbits.md)
 - [Exact planar geometry](reference/exact-planar-geometry.md)
 - [Finite simplicial topology](reference/finite-simplicial-topology.md)
+- [Certified Smith normal form and integral homology](reference/certified-smith-integral-homology.md)
 - [Finite posets](reference/finite-posets.md)
 - [Recurrences and rational generating series](reference/recurrences-and-generating-series.md)
 - [Provider runtime contract](reference/provider-runtime.md)

--- a/docs/reference/certified-smith-integral-homology.md
+++ b/docs/reference/certified-smith-integral-homology.md
@@ -1,0 +1,200 @@
+# Certified Smith normal form and integral homology
+
+[Documentation home](../index.md)
+
+- Status: Current implementation reference; contracts are experimental
+- Matrix producer backend: bounded standard-library elementary operations
+- Topology producer backend: exact integer chain arithmetic over canonical
+  simplex bases
+- Checker backend: isolated standard-library replay with no producer or public
+  contract imports
+
+This family adds two atomic mathematical outcomes:
+
+- `matrix.normal_form.smith.certified.compute` returns a canonical Smith
+  diagonal and both complete basis changes for one integer matrix; and
+- `topology.simplicial_homology.integral.compute` returns the free and torsion
+  decomposition, concrete generators, bounding chains, and the transformation
+  certificates needed to inspect every integral homology group of one finite
+  simplicial complex.
+
+The corresponding operator-authorized verification capabilities are
+`matrix.normal_form.smith.certified.verify` and
+`topology.simplicial_homology.integral.verify`. Producers remain capped at
+`COMPUTED`; only an accepted independent replay can return `VERIFIED`.
+
+## Portfolio boundary
+
+`matrix.normal_form.smith.compute` remains the lightweight, diagonal-only
+matrix outcome. It explicitly reports that transformations are unavailable.
+The certified operation is separate because full basis changes are a larger
+artifact, have tighter input limits, and create different proof obligations.
+It does not infer a cokernel, homology group, or preferred downstream use.
+
+The integral topology operation is also separate from
+`topology.simplicial_homology.compute`. The latter exposes bases over one
+bounded prime field. The integral operation exposes finitely generated abelian
+groups, including torsion, and therefore requires integer basis changes and
+different witnesses. Neither operation ranks or prescribes the other.
+
+## Transformation-certified Smith normal form
+
+For a nonempty integer matrix \(A\), the result contains matrices \(D,U,V\)
+with the exact relation
+
+\[
+D=UAV.
+\]
+
+Here \(U\) and \(V\) are square unimodular matrices, so their determinants are
+\(\pm1\). The nonzero diagonal entries of \(D\) are positive and form the
+canonical divisibility chain
+
+\[
+d_1\mid d_2\mid\cdots\mid d_r.
+\]
+
+The certificate records the source matrix, all three result matrices, the
+rank, invariant factors, determinant claims, relation, transformation scope,
+and normalization convention. This keeps the complete row and column basis
+changes visible instead of retaining only the diagonal.
+
+The request is bounded to 1–16 rows, 1–16 columns, canonical decimal integer
+strings, and 32 input digits per entry. Certificate matrices support explicit
+zero dimensions for reuse in chain-complex witnesses. Every output integer is
+bounded to 4,096 digits. Complete request validation occurs before computation
+or artifact writes.
+
+The implementation uses exact elementary row and column operations and has no
+optional-provider availability gate. Python-FLINT 0.9.0's Python API exposes a
+diagonal-only `snf()` operation even though current FLINT C documentation also
+describes `fmpz_mat_snf_transform`; SymPy's public normal-form API likewise
+returns the Smith form without full transformations. Those systems are
+independent test oracles for invariant factors, not hidden runtime
+dependencies of this producer.
+
+## Integral simplicial homology
+
+The input is the canonical materialized finite complex described by
+[Finite simplicial topology](finite-simplicial-topology.md), plus an explicit
+`REDUCED` or `UNREDUCED` convention. Every simplex uses lexicographic vertex
+orientation. For each dimension \(k\), the result exposes:
+
+- the dimensions and ranks of \(C_k\), \(\partial_k\), and
+  \(\operatorname{im}\partial_{k+1}\);
+- the free rank and torsion invariant factors of \(H_k\);
+- free and torsion cycle generators in the canonical \(k\)-simplex basis;
+- cycle coordinates in an explicit kernel basis;
+- a bounding \((k+1)\)-chain for every torsion generator; and
+- Smith certificates for the outgoing boundary and the incoming boundary
+  expressed in kernel coordinates.
+
+If
+
+\[
+U_k\partial_kV_k=D_k
+\]
+
+has rank \(r_k\), the last columns of \(V_k\) form the declared integral
+kernel basis \(K_k\). The producer records the exact factorization
+
+\[
+\partial_{k+1}=K_kQ_k
+\]
+
+and a second certificate
+
+\[
+\widehat U_kQ_k\widehat V_k=\widehat D_k.
+\]
+
+The nonunit entries of \(\widehat D_k\) are the torsion orders. Each reported
+free or torsion coordinate \(y\) is bound by
+\(\widehat U_ky=e_i\), and its simplex-basis cycle is \(K_ky\). For torsion
+order \(d_i\), the recorded bounding chain \(b_i\) additionally satisfies
+
+\[
+\partial_{k+1}b_i=d_iK_ky.
+\]
+
+Thus the result is not merely a tuple of Betti numbers and abstract invariant
+factors: the cycles, coordinate changes, quotient decomposition, and torsion
+bounds are first-class inspectable artifacts.
+
+Reduced degree-zero homology uses the augmentation kernel. It does not invent
+or store a negative-dimensional simplex.
+
+### Integral-specific bounds
+
+The general topology materialization limits still apply. Integral homology has
+tighter certificate limits:
+
+| Quantity | Limit |
+| --- | ---: |
+| Simplices in one chain group | 16 |
+| Sum of all chain-group ranks | 32 |
+| Cells in one dense boundary shape | 256 |
+| Decimal digits in an integral homology result integer | 256 |
+
+These limits are independently enforced by the public request/result
+contracts and the checker. Artifact-budget regressions cover a maximum-shape
+certified Smith request and the 31-simplex triangulation of
+\(\mathbb{RP}^2\).
+
+## Independent verification
+
+The certified-Smith checker strictly parses canonical integer encodings,
+recomputes both matrix products, computes both determinants with a
+fraction-free Bareiss algorithm, and checks the positive divisibility
+diagonal. It never calls the producer's reduction implementation.
+
+The integral-homology checker first reconstructs every oriented integer
+boundary from the passive canonical complex. It then checks, in every
+dimension:
+
+1. the outgoing source and complete Smith relation;
+2. the kernel basis from the certified right transformation;
+3. the exact factorization of the incoming boundary through that kernel;
+4. the second Smith relation and all free and torsion ranks;
+5. every generator's kernel and simplex-basis coordinates; and
+6. every torsion order and bounding-chain equation.
+
+Replay binds the exact input and result artifacts, semantics, candidate digest,
+witness format, and checker identity. Malformed data, unsupported scope,
+timeout, cancellation, arithmetic failure, or a false relation returns
+`UNKNOWN` and creates no verification record. A failed replay is not evidence
+for an opposite mathematical claim.
+
+## Public reproductions and evaluation status
+
+The answer-visible, unscored reproduction file
+[`certified_snf_integral_homology_public.json`](../../benchmarks/reproduction_cases/certified_snf_integral_homology_public.json)
+contains rectangular and rank-deficient matrix cases, a circle,
+\(\mathbb{RP}^2\), and reduced-point homology. It also records a frozen
+held-out comparison design. That held-out evaluation remains
+`READY_NOT_RUN`; public regression success is not evidence of autonomous-agent
+improvement. No evaluation model, prompt, scorer run, or raw model trace exists
+for that future comparison.
+
+Discovery found the repeated missing move—recovering and independently
+checking basis transformations rather than only invariant factors.
+Implementation split the matrix and topology outcomes, checker development
+used independent relation replay, and evaluation froze public reproductions
+plus a future held-out design. The handoff retains unresolved obligations:
+run the held-out baseline/treatment study before making portfolio-value claims,
+and reconsider the bounds only with new artifact-size and runtime evidence.
+
+## Nonclaims
+
+This family does not provide persistent homology, a homology ring, cup
+products, canonical generators independent of the declared simplex
+orientation, manifold recognition, a preferred proof strategy, or conclusions
+beyond the supplied bounded complex. It does not make optional FLINT or SymPy
+providers authoritative checkers.
+
+## Primary references
+
+- [FLINT integer-matrix normal-form documentation](https://flintlib.org/doc/fmpz_mat.html#normal-forms)
+- [Python-FLINT integer-matrix API](https://python-flint.readthedocs.io/en/latest/fmpz_mat.html)
+- [SymPy normal-form API](https://docs.sympy.org/latest/modules/matrices/normalforms.html)
+- [Hatcher, *Algebraic Topology*, Chapter 2](https://pi.math.cornell.edu/~hatcher/AT/ATch2.pdf)

--- a/docs/reference/domain-operation-library.md
+++ b/docs/reference/domain-operation-library.md
@@ -38,10 +38,13 @@ finite sets, sequences, Euclidean and projective geometry, graph optimization
 and invariants, matrices, lattices, polynomials, validated real analysis,
 finite probability, and rational optimization. Catalog membership remains the
 authority for actual availability. The current portfolio also includes finite
-simplicial-complex materialization, oriented chain complexes, and prime-field
-homology under the `topology` domain, plus canonical finite partial orders,
-Dilworth width certificates, complete ideal recurrences, and Möbius values
-under the `poset` domain.
+simplicial-complex materialization, oriented chain complexes, prime-field
+homology, and transformation-certified integral homology under the `topology`
+domain. A dedicated `certified_snf` bundle supplies bounded full left/right
+Smith basis changes without replacing the existing diagonal-only matrix
+outcome. The portfolio also includes canonical finite partial orders, Dilworth
+width certificates, complete ideal recurrences, and Möbius values under the
+`poset` domain.
 
 ## Computed operations
 

--- a/docs/reference/finite-simplicial-topology.md
+++ b/docs/reference/finite-simplicial-topology.md
@@ -7,15 +7,18 @@
 - Producer backend: Jacobian standard-library exact finite and modular arithmetic
 - Checker backend: isolated standard-library replay with no producer imports
 
-The topology bundle exposes three atomic outcomes over bounded finite abstract
+The topology bundle exposes four atomic outcomes over bounded finite abstract
 simplicial complexes:
 
 - `topology.simplicial_complex.materialize`
 - `topology.simplicial_complex.chain_complex.compute`
 - `topology.simplicial_homology.compute`
+- `topology.simplicial_homology.integral.compute`
 
-Each producer remains `COMPUTED`. An operator-authorized
-`topology.result.verify` replay is the only path in this family to `VERIFIED`.
+Each producer remains `COMPUTED`. Operator-authorized independent replay is
+the only path in this family to `VERIFIED`. The first three outcomes use
+`topology.result.verify`; integral homology has the dedicated
+`topology.simplicial_homology.integral.verify` capability.
 
 ## Canonical finite complexes
 
@@ -83,6 +86,16 @@ bounded prime field. For every dimension it preserves:
 The operation supports explicit `REDUCED` and `UNREDUCED` conventions. Its
 dimension range always covers every chain group of the supplied complex.
 
+## Integral homology
+
+`topology.simplicial_homology.integral.compute` exposes every free rank,
+torsion invariant factor, simplex-basis cycle generator, torsion bounding
+chain, and the two full Smith transformation certificates used in each
+dimension. It supports the same explicit reduced and unreduced conventions but
+has tighter certificate-size limits than prime-field homology. See
+[Certified Smith normal form and integral homology](certified-smith-integral-homology.md)
+for the exact relations, bounds, and independent checker obligations.
+
 ## Bounds
 
 Version 1 uses these fail-closed limits:
@@ -96,6 +109,10 @@ Version 1 uses these fail-closed limits:
 | One chain group used for linear algebra | 512 |
 | One dense boundary shape | 131,072 cells |
 | Coefficient prime | 251 |
+
+Integral homology further limits one chain group to 16 simplices, the sum of
+all chain ranks to 32, one dense boundary to 256 cells, and result integers to
+256 decimal digits.
 
 A complex can be materialized when it fits the closure bound but still be
 rejected by chain or homology computation when a linear-algebra bound is
@@ -121,7 +138,8 @@ The regression suite includes:
 | Six-vertex real projective plane | `(6, 15, 10)` | `(1, 1, 1)` over \(F_2\); `(1, 0, 0)` over \(F_3\) |
 
 The same suite covers disjoint unions, reduced \(H_0\), vertex relabeling,
-caller simplex order, boundary signs, and forged cycle evidence.
+caller simplex order, boundary signs, forged cycle evidence, integral
+\(H_1(\mathbb{RP}^2)\cong\mathbb Z/2\), and torsion bounding chains.
 
 ## Independent verification
 
@@ -141,7 +159,10 @@ candidate digest, witness format, and checker identity. A malformed,
 interrupted, unsupported, or false replay returns no opposite mathematical
 conclusion and creates no verification record.
 
-Integral homology, torsion generators, persistent homology, and
-low-dimensional manifold recognition remain outside this contract. Integral
-generators require certified Smith transformations; persistence requires a
-separate exact-filtration and GUDHI provider gate.
+The integral checker additionally replays both Smith relations per dimension,
+the incoming-boundary factorization through the certified kernel basis, every
+free and torsion generator, and every torsion bounding-chain equation.
+
+Persistent homology, homology rings, and low-dimensional manifold recognition
+remain outside this contract. Persistence requires a separate exact-filtration
+and GUDHI provider gate.

--- a/docs/reference/matrix-hermite-normal-form.md
+++ b/docs/reference/matrix-hermite-normal-form.md
@@ -5,6 +5,12 @@ finite integer matrix. `matrix.normal_form.hermite.verify` independently
 checks the stored result. Computation and verification are separate trust
 boundaries.
 
+This row-Hermite outcome is distinct from the full two-sided relation
+documented in
+[Certified Smith normal form and integral homology](certified-smith-integral-homology.md).
+Neither normal form is presented as a replacement or preferred strategy for
+the other.
+
 ## Input contract
 
 The producer accepts one nonempty rectangular matrix over `ZZ`:

--- a/src/jacobian/contracts/certified_snf.py
+++ b/src/jacobian/contracts/certified_snf.py
@@ -1,0 +1,163 @@
+"""Bounded contracts for transformation-certified Smith normal forms."""
+
+from __future__ import annotations
+
+from itertools import pairwise
+from typing import Literal, Self
+
+from pydantic import Field, StrictInt, model_validator
+
+from jacobian.contracts.exact import CanonicalInteger
+from jacobian.contracts.results import ContractModel
+
+MAX_CERTIFIED_SNF_DIMENSION = 32
+MAX_CERTIFIED_SNF_INPUT_DIMENSION = 16
+MAX_CERTIFIED_SNF_INPUT_DIGITS = 32
+MAX_CERTIFIED_SNF_OUTPUT_DIGITS = 4_096
+
+
+def _integer_digits(value: str) -> int:
+    return len(value.lstrip("-"))
+
+
+class CertifiedIntegerMatrix(ContractModel):
+    """One bounded integer matrix, including matrices with a zero dimension."""
+
+    matrix_schema_version: Literal["1"] = "1"
+    domain: Literal["ZZ"] = "ZZ"
+    row_count: StrictInt = Field(ge=0, le=MAX_CERTIFIED_SNF_DIMENSION)
+    column_count: StrictInt = Field(ge=0, le=MAX_CERTIFIED_SNF_DIMENSION)
+    entries: tuple[tuple[CanonicalInteger, ...], ...] = Field(
+        default=(),
+        max_length=MAX_CERTIFIED_SNF_DIMENSION,
+    )
+
+    @model_validator(mode="after")
+    def require_declared_shape_and_output_budget(self) -> Self:
+        if len(self.entries) != self.row_count or any(
+            len(row) != self.column_count for row in self.entries
+        ):
+            raise ValueError("certified integer matrix entries must match its shape")
+        if any(
+            _integer_digits(value) > MAX_CERTIFIED_SNF_OUTPUT_DIGITS
+            for row in self.entries
+            for value in row
+        ):
+            raise ValueError("certified integer matrix exceeds the output digit bound")
+        return self
+
+
+class CertifiedSmithNormalFormRequest(ContractModel):
+    matrix: CertifiedIntegerMatrix
+
+    @model_validator(mode="after")
+    def require_nonempty_bounded_input(self) -> Self:
+        if (
+            not 1 <= self.matrix.row_count <= MAX_CERTIFIED_SNF_INPUT_DIMENSION
+            or not 1 <= self.matrix.column_count <= MAX_CERTIFIED_SNF_INPUT_DIMENSION
+        ):
+            raise ValueError(
+                "certified Smith input must be a nonempty matrix of at most "
+                f"{MAX_CERTIFIED_SNF_INPUT_DIMENSION} by "
+                f"{MAX_CERTIFIED_SNF_INPUT_DIMENSION}"
+            )
+        if any(
+            _integer_digits(value) > MAX_CERTIFIED_SNF_INPUT_DIGITS
+            for row in self.matrix.entries
+            for value in row
+        ):
+            raise ValueError(
+                "certified Smith input entries may contain at most "
+                f"{MAX_CERTIFIED_SNF_INPUT_DIGITS} decimal digits"
+            )
+        return self
+
+
+class SmithNormalFormCertificate(ContractModel):
+    """A proposed exact relation ``D = U A V`` with unimodular ``U`` and ``V``."""
+
+    certificate_schema_version: Literal["1"] = "1"
+    source: CertifiedIntegerMatrix
+    diagonal: CertifiedIntegerMatrix
+    left_transformation: CertifiedIntegerMatrix
+    right_transformation: CertifiedIntegerMatrix
+    rank: StrictInt = Field(ge=0, le=MAX_CERTIFIED_SNF_DIMENSION)
+    invariant_factors: tuple[CanonicalInteger, ...] = Field(
+        max_length=MAX_CERTIFIED_SNF_DIMENSION
+    )
+    left_determinant: Literal["-1", "1"]
+    right_determinant: Literal["-1", "1"]
+    relation: Literal["DIAGONAL_EQUALS_LEFT_TIMES_SOURCE_TIMES_RIGHT"] = (
+        "DIAGONAL_EQUALS_LEFT_TIMES_SOURCE_TIMES_RIGHT"
+    )
+    transformation_scope: Literal["FULL_BASIS_BOTH_SIDES"] = "FULL_BASIS_BOTH_SIDES"
+    convention: Literal["POSITIVE_DIVISIBILITY_DIAGONAL"] = (
+        "POSITIVE_DIVISIBILITY_DIAGONAL"
+    )
+
+    @model_validator(mode="after")
+    def require_coherent_shapes_and_canonical_diagonal(self) -> Self:
+        rows = self.source.row_count
+        columns = self.source.column_count
+        if (
+            (self.diagonal.row_count, self.diagonal.column_count) != (rows, columns)
+            or (
+                self.left_transformation.row_count,
+                self.left_transformation.column_count,
+            )
+            != (rows, rows)
+            or (
+                self.right_transformation.row_count,
+                self.right_transformation.column_count,
+            )
+            != (columns, columns)
+        ):
+            raise ValueError("Smith certificate matrix shapes are incompatible")
+        diagonal_count = min(rows, columns)
+        diagonal = tuple(
+            int(self.diagonal.entries[index][index]) for index in range(diagonal_count)
+        )
+        if any(
+            int(self.diagonal.entries[row][column]) != 0
+            for row in range(rows)
+            for column in range(columns)
+            if row != column
+        ):
+            raise ValueError("Smith normal form must be diagonal")
+        factors = tuple(int(value) for value in self.invariant_factors)
+        if (
+            self.rank != len(factors)
+            or self.rank > diagonal_count
+            or any(value <= 0 for value in factors)
+            or diagonal[: self.rank] != factors
+            or any(value != 0 for value in diagonal[self.rank :])
+            or any(right % left for left, right in pairwise(factors))
+        ):
+            raise ValueError(
+                "Smith invariant factors must be the positive divisibility diagonal"
+            )
+        return self
+
+
+class CertifiedSmithNormalFormResult(ContractModel):
+    certificate: SmithNormalFormCertificate
+    exactness: Literal["EXACT_INTEGER"] = "EXACT_INTEGER"
+    determinism: Literal["DETERMINISTIC"] = "DETERMINISTIC"
+    backend: Literal["jacobian-stdlib-elementary-operations"] = (
+        "jacobian-stdlib-elementary-operations"
+    )
+    backend_version: Literal["1"] = "1"
+    completeness: Literal["FULL_MATRIX_TRANSFORMATIONS"] = "FULL_MATRIX_TRANSFORMATIONS"
+    verification: Literal["UNVERIFIED"] = "UNVERIFIED"
+
+
+__all__ = [
+    "MAX_CERTIFIED_SNF_DIMENSION",
+    "MAX_CERTIFIED_SNF_INPUT_DIGITS",
+    "MAX_CERTIFIED_SNF_INPUT_DIMENSION",
+    "MAX_CERTIFIED_SNF_OUTPUT_DIGITS",
+    "CertifiedIntegerMatrix",
+    "CertifiedSmithNormalFormRequest",
+    "CertifiedSmithNormalFormResult",
+    "SmithNormalFormCertificate",
+]

--- a/src/jacobian/contracts/topology.py
+++ b/src/jacobian/contracts/topology.py
@@ -10,7 +10,12 @@ from typing import Annotated, Literal, Self
 from pydantic import Field, StrictInt, StringConstraints, model_validator
 
 from jacobian.canonical import canonicalize_json
+from jacobian.contracts.certified_snf import (
+    CertifiedIntegerMatrix,
+    SmithNormalFormCertificate,
+)
 from jacobian.contracts.common import Sha256Digest
+from jacobian.contracts.exact import CanonicalInteger
 from jacobian.contracts.results import ContractModel
 
 MAX_TOPOLOGY_VERTICES = 64
@@ -20,6 +25,10 @@ MAX_TOPOLOGY_FACES = 2048
 MAX_TOPOLOGY_CHAIN_GROUP = 512
 MAX_TOPOLOGY_MATRIX_CELLS = 131_072
 MAX_TOPOLOGY_PRIME = 251
+MAX_INTEGRAL_HOMOLOGY_CHAIN_GROUP = 16
+MAX_INTEGRAL_HOMOLOGY_TOTAL_CHAIN_RANK = 32
+MAX_INTEGRAL_HOMOLOGY_MATRIX_CELLS = 256
+MAX_INTEGRAL_HOMOLOGY_OUTPUT_DIGITS = 256
 
 VertexLabel = Annotated[
     str,
@@ -485,7 +494,205 @@ class SimplicialHomologyResult(TopologyExactResult):
         return self
 
 
+class IntegralSimplicialHomologyRequest(ContractModel):
+    complex: FiniteSimplicialComplex
+    convention: HomologyConvention = HomologyConvention.UNREDUCED
+
+    @model_validator(mode="after")
+    def require_integral_certificate_bounds(self) -> Self:
+        require_linear_algebra_bounds(self.complex)
+        if any(
+            size > MAX_INTEGRAL_HOMOLOGY_CHAIN_GROUP for size in self.complex.f_vector
+        ):
+            raise ValueError(
+                "integral homology requires at most "
+                f"{MAX_INTEGRAL_HOMOLOGY_CHAIN_GROUP} simplices in each chain group"
+            )
+        if sum(self.complex.f_vector) > MAX_INTEGRAL_HOMOLOGY_TOTAL_CHAIN_RANK:
+            raise ValueError(
+                "integral homology requires total chain rank at most "
+                f"{MAX_INTEGRAL_HOMOLOGY_TOTAL_CHAIN_RANK}"
+            )
+        padded = (0, *self.complex.f_vector)
+        if any(
+            rows * columns > MAX_INTEGRAL_HOMOLOGY_MATRIX_CELLS
+            for rows, columns in pairwise(padded)
+        ):
+            raise ValueError(
+                "integral homology boundary exceeds the "
+                f"{MAX_INTEGRAL_HOMOLOGY_MATRIX_CELLS}-cell bound"
+            )
+        return self
+
+
+class IntegralVector(ContractModel):
+    coefficients: tuple[CanonicalInteger, ...] = Field(
+        max_length=MAX_INTEGRAL_HOMOLOGY_CHAIN_GROUP
+    )
+
+    @model_validator(mode="after")
+    def require_output_digit_budget(self) -> Self:
+        if any(
+            len(value.lstrip("-")) > MAX_INTEGRAL_HOMOLOGY_OUTPUT_DIGITS
+            for value in self.coefficients
+        ):
+            raise ValueError("integral homology vector exceeds the output digit bound")
+        return self
+
+
+class IntegralFreeGenerator(ContractModel):
+    cycle: IntegralVector
+    cycle_coordinates: IntegralVector
+
+
+class IntegralTorsionGenerator(ContractModel):
+    order: CanonicalInteger
+    cycle: IntegralVector
+    cycle_coordinates: IntegralVector
+    bounding_chain: IntegralVector
+
+    @model_validator(mode="after")
+    def require_nontrivial_bounded_order(self) -> Self:
+        if (
+            int(self.order) <= 1
+            or len(self.order.lstrip("-")) > MAX_INTEGRAL_HOMOLOGY_OUTPUT_DIGITS
+        ):
+            raise ValueError("torsion generator order must be a bounded integer > 1")
+        return self
+
+
+class IntegralHomologyGroupResult(ContractModel):
+    dimension: StrictInt = Field(ge=0, le=MAX_TOPOLOGY_DIMENSION)
+    chain_dimension: StrictInt = Field(ge=1, le=MAX_INTEGRAL_HOMOLOGY_CHAIN_GROUP)
+    incoming_chain_dimension: StrictInt = Field(
+        ge=0, le=MAX_INTEGRAL_HOMOLOGY_CHAIN_GROUP
+    )
+    outgoing_boundary_rank: StrictInt = Field(
+        ge=0, le=MAX_INTEGRAL_HOMOLOGY_CHAIN_GROUP
+    )
+    cycle_rank: StrictInt = Field(ge=0, le=MAX_INTEGRAL_HOMOLOGY_CHAIN_GROUP)
+    incoming_boundary_rank: StrictInt = Field(
+        ge=0, le=MAX_INTEGRAL_HOMOLOGY_CHAIN_GROUP
+    )
+    betti_number: StrictInt = Field(ge=0, le=MAX_INTEGRAL_HOMOLOGY_CHAIN_GROUP)
+    torsion_coefficients: tuple[CanonicalInteger, ...] = Field(
+        max_length=MAX_INTEGRAL_HOMOLOGY_CHAIN_GROUP
+    )
+    free_generators: tuple[IntegralFreeGenerator, ...] = Field(
+        max_length=MAX_INTEGRAL_HOMOLOGY_CHAIN_GROUP
+    )
+    torsion_generators: tuple[IntegralTorsionGenerator, ...] = Field(
+        max_length=MAX_INTEGRAL_HOMOLOGY_CHAIN_GROUP
+    )
+    outgoing_smith_certificate: SmithNormalFormCertificate
+    boundary_in_cycle_coordinates: CertifiedIntegerMatrix
+    incoming_smith_certificate: SmithNormalFormCertificate
+    generator_basis: Literal[
+        "CANONICAL_SIMPLEX_BASIS_VIA_CERTIFIED_SMITH_TRANSFORMATIONS"
+    ] = "CANONICAL_SIMPLEX_BASIS_VIA_CERTIFIED_SMITH_TRANSFORMATIONS"
+
+    @model_validator(mode="after")
+    def require_complete_integral_group_ledger(self) -> Self:
+        outgoing = self.outgoing_smith_certificate
+        incoming = self.incoming_smith_certificate
+        if (
+            outgoing.source.column_count != self.chain_dimension
+            or outgoing.rank != self.outgoing_boundary_rank
+            or self.cycle_rank != self.chain_dimension - self.outgoing_boundary_rank
+            or (
+                self.boundary_in_cycle_coordinates.row_count,
+                self.boundary_in_cycle_coordinates.column_count,
+            )
+            != (self.cycle_rank, self.incoming_chain_dimension)
+            or incoming.source != self.boundary_in_cycle_coordinates
+            or incoming.rank != self.incoming_boundary_rank
+            or self.betti_number != self.cycle_rank - self.incoming_boundary_rank
+            or len(self.free_generators) != self.betti_number
+        ):
+            raise ValueError("integral homology rank and certificate ledger is invalid")
+        torsion = tuple(
+            factor for factor in incoming.invariant_factors if int(factor) > 1
+        )
+        if (
+            self.torsion_coefficients != torsion
+            or tuple(item.order for item in self.torsion_generators) != torsion
+        ):
+            raise ValueError(
+                "integral homology torsion generators must match Smith factors"
+            )
+        if any(
+            len(item.cycle.coefficients) != self.chain_dimension
+            or len(item.cycle_coordinates.coefficients) != self.cycle_rank
+            for item in self.free_generators
+        ) or any(
+            len(item.cycle.coefficients) != self.chain_dimension
+            or len(item.cycle_coordinates.coefficients) != self.cycle_rank
+            or len(item.bounding_chain.coefficients) != self.incoming_chain_dimension
+            for item in self.torsion_generators
+        ):
+            raise ValueError(
+                "integral homology generators must use the declared simplex bases"
+            )
+        matrices = (
+            outgoing.source,
+            outgoing.diagonal,
+            outgoing.left_transformation,
+            outgoing.right_transformation,
+            self.boundary_in_cycle_coordinates,
+            incoming.source,
+            incoming.diagonal,
+            incoming.left_transformation,
+            incoming.right_transformation,
+        )
+        scalar_values = (
+            value for matrix in matrices for row in matrix.entries for value in row
+        )
+        if any(
+            len(value.lstrip("-")) > MAX_INTEGRAL_HOMOLOGY_OUTPUT_DIGITS
+            for value in scalar_values
+        ):
+            raise ValueError(
+                "integral homology certificate exceeds the output digit bound"
+            )
+        return self
+
+
+class IntegralSimplicialHomologyResult(TopologyExactResult):
+    complex_digest: Sha256Digest
+    coefficient_ring: Literal["ZZ"] = "ZZ"
+    convention: HomologyConvention
+    orientation_convention: Literal["LEXICOGRAPHIC_VERTEX_ORDER"] = (
+        "LEXICOGRAPHIC_VERTEX_ORDER"
+    )
+    dimension_range: tuple[StrictInt, StrictInt]
+    groups: tuple[IntegralHomologyGroupResult, ...] = Field(
+        min_length=1,
+        max_length=MAX_TOPOLOGY_DIMENSION + 1,
+    )
+    completeness: Literal["FREE_TORSION_AND_BOUND_GENERATORS"] = (
+        "FREE_TORSION_AND_BOUND_GENERATORS"
+    )
+    decomposition: Literal["DIRECT_SUM_Z_AND_FINITE_CYCLIC_FACTORS"] = (
+        "DIRECT_SUM_Z_AND_FINITE_CYCLIC_FACTORS"
+    )
+
+    @model_validator(mode="after")
+    def require_complete_integral_dimension_range(self) -> Self:
+        dimensions = tuple(group.dimension for group in self.groups)
+        if dimensions != tuple(range(len(self.groups))):
+            raise ValueError(
+                "integral homology groups must cover contiguous dimensions"
+            )
+        if self.dimension_range != (0, len(self.groups) - 1):
+            raise ValueError("integral homology dimension_range must cover every group")
+        return self
+
+
 __all__ = [
+    "MAX_INTEGRAL_HOMOLOGY_CHAIN_GROUP",
+    "MAX_INTEGRAL_HOMOLOGY_MATRIX_CELLS",
+    "MAX_INTEGRAL_HOMOLOGY_OUTPUT_DIGITS",
+    "MAX_INTEGRAL_HOMOLOGY_TOTAL_CHAIN_RANK",
     "MAX_TOPOLOGY_CHAIN_GROUP",
     "MAX_TOPOLOGY_DIMENSION",
     "MAX_TOPOLOGY_FACES",
@@ -501,6 +708,12 @@ __all__ = [
     "FiniteSimplicialComplex",
     "HomologyConvention",
     "HomologyGroupResult",
+    "IntegralFreeGenerator",
+    "IntegralHomologyGroupResult",
+    "IntegralSimplicialHomologyRequest",
+    "IntegralSimplicialHomologyResult",
+    "IntegralTorsionGenerator",
+    "IntegralVector",
     "ModularVector",
     "Simplex",
     "SimplexBasis",

--- a/src/jacobian/domains/_certified_snf.py
+++ b/src/jacobian/domains/_certified_snf.py
@@ -1,0 +1,376 @@
+"""Bounded elementary-operation Smith reduction used by trusted producers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import pairwise
+from typing import Literal
+
+from jacobian.contracts.certified_snf import (
+    CertifiedIntegerMatrix,
+    SmithNormalFormCertificate,
+)
+
+Matrix = list[list[int]]
+
+
+@dataclass(frozen=True, slots=True)
+class SmithReduction:
+    source: Matrix
+    diagonal: Matrix
+    left: Matrix
+    right: Matrix
+    rank: int
+    invariant_factors: tuple[int, ...]
+    left_determinant: int
+    right_determinant: int
+
+
+def zero_matrix(rows: int, columns: int) -> Matrix:
+    return [[0 for _ in range(columns)] for _ in range(rows)]
+
+
+def identity_matrix(size: int) -> Matrix:
+    result = zero_matrix(size, size)
+    for index in range(size):
+        result[index][index] = 1
+    return result
+
+
+def matrix_shape(matrix: Matrix, *, columns_if_empty: int = 0) -> tuple[int, int]:
+    return len(matrix), len(matrix[0]) if matrix else columns_if_empty
+
+
+def matrix_multiply(
+    left: Matrix,
+    right: Matrix,
+    *,
+    right_columns_if_empty: int = 0,
+) -> Matrix:
+    left_rows = len(left)
+    middle = len(left[0]) if left else len(right)
+    right_rows = len(right)
+    right_columns = len(right[0]) if right else right_columns_if_empty
+    if middle != right_rows:
+        raise ValueError("integer matrices are not composable")
+    return [
+        [
+            sum(left[row][index] * right[index][column] for index in range(middle))
+            for column in range(right_columns)
+        ]
+        for row in range(left_rows)
+    ]
+
+
+def matrix_vector_multiply(matrix: Matrix, vector: list[int]) -> list[int]:
+    if matrix and len(matrix[0]) != len(vector):
+        raise ValueError("integer matrix and vector are not composable")
+    return [
+        sum(value * vector[index] for index, value in enumerate(row)) for row in matrix
+    ]
+
+
+def matrix_columns(matrix: Matrix, start: int = 0) -> Matrix:
+    if not matrix:
+        return []
+    return [
+        [matrix[row][column] for column in range(start, len(matrix[0]))]
+        for row in range(len(matrix))
+    ]
+
+
+def determinant(matrix: Matrix) -> int:
+    """Exact fraction-free Bareiss determinant."""
+
+    size = len(matrix)
+    if any(len(row) != size for row in matrix):
+        raise ValueError("determinant requires a square matrix")
+    if size == 0:
+        return 1
+    work = [row[:] for row in matrix]
+    sign = 1
+    previous = 1
+    for pivot_index in range(size - 1):
+        selected = next(
+            (row for row in range(pivot_index, size) if work[row][pivot_index] != 0),
+            None,
+        )
+        if selected is None:
+            return 0
+        if selected != pivot_index:
+            work[pivot_index], work[selected] = work[selected], work[pivot_index]
+            sign = -sign
+        pivot = work[pivot_index][pivot_index]
+        for row in range(pivot_index + 1, size):
+            for column in range(pivot_index + 1, size):
+                numerator = (
+                    work[row][column] * pivot
+                    - work[row][pivot_index] * work[pivot_index][column]
+                )
+                if numerator % previous:
+                    raise ArithmeticError("Bareiss division was not exact")
+                work[row][column] = numerator // previous
+        previous = pivot
+    return sign * work[-1][-1]
+
+
+def inverse_unimodular(matrix: Matrix) -> Matrix:
+    """Invert a unimodular integer matrix by exact Gauss-Jordan elimination."""
+
+    size = len(matrix)
+    if any(len(row) != size for row in matrix):
+        raise ValueError("unimodular inverse requires a square matrix")
+    if size == 0:
+        return []
+    augmented = [
+        [*row, *(1 if row_index == column else 0 for column in range(size))]
+        for row_index, row in enumerate(matrix)
+    ]
+    for column in range(size):
+        selected = next(
+            (row for row in range(column, size) if augmented[row][column] != 0),
+            None,
+        )
+        if selected is None:
+            raise ValueError("matrix is singular")
+        augmented[column], augmented[selected] = (
+            augmented[selected],
+            augmented[column],
+        )
+        while abs(augmented[column][column]) != 1:
+            selected = next(
+                (row for row in range(column + 1, size) if augmented[row][column] != 0),
+                None,
+            )
+            if selected is None:
+                raise ValueError("matrix is not unimodular")
+            quotient = augmented[column][column] // augmented[selected][column]
+            augmented[column] = [
+                value - quotient * other
+                for value, other in zip(
+                    augmented[column], augmented[selected], strict=True
+                )
+            ]
+            augmented[column], augmented[selected] = (
+                augmented[selected],
+                augmented[column],
+            )
+        pivot = augmented[column][column]
+        if pivot == -1:
+            augmented[column] = [-value for value in augmented[column]]
+        for row in range(size):
+            if row == column:
+                continue
+            factor = augmented[row][column]
+            if factor:
+                augmented[row] = [
+                    value - factor * pivot_value
+                    for value, pivot_value in zip(
+                        augmented[row], augmented[column], strict=True
+                    )
+                ]
+    return [row[size:] for row in augmented]
+
+
+def _swap_rows(matrix: Matrix, left: int, right: int) -> None:
+    matrix[left], matrix[right] = matrix[right], matrix[left]
+
+
+def _swap_columns(matrix: Matrix, left: int, right: int) -> None:
+    for row in matrix:
+        row[left], row[right] = row[right], row[left]
+
+
+def _add_row_multiple(
+    matrix: Matrix, target: int, source: int, multiplier: int
+) -> None:
+    matrix[target] = [
+        value + multiplier * other
+        for value, other in zip(matrix[target], matrix[source], strict=True)
+    ]
+
+
+def _add_column_multiple(
+    matrix: Matrix, target: int, source: int, multiplier: int
+) -> None:
+    for row in matrix:
+        row[target] += multiplier * row[source]
+
+
+def _negate_row(matrix: Matrix, row: int) -> None:
+    matrix[row] = [-value for value in matrix[row]]
+
+
+def smith_reduce(
+    source: Matrix,
+    *,
+    row_count: int | None = None,
+    column_count: int | None = None,
+) -> SmithReduction:
+    """Return a canonical Smith diagonal and explicit elementary transformations."""
+
+    rows = len(source) if row_count is None else row_count
+    columns = (
+        (len(source[0]) if source else 0) if column_count is None else column_count
+    )
+    if len(source) != rows or any(len(row) != columns for row in source):
+        raise ValueError("source entries do not match the declared matrix shape")
+    original = [row[:] for row in source]
+    matrix = [row[:] for row in source]
+    left = identity_matrix(rows)
+    right = identity_matrix(columns)
+    diagonal_count = min(rows, columns)
+
+    for pivot in range(diagonal_count):
+        selected = min(
+            (
+                (abs(matrix[row][column]), row, column)
+                for row in range(pivot, rows)
+                for column in range(pivot, columns)
+                if matrix[row][column] != 0
+            ),
+            default=None,
+        )
+        if selected is None:
+            break
+        _, selected_row, selected_column = selected
+        if selected_row != pivot:
+            _swap_rows(matrix, pivot, selected_row)
+            _swap_rows(left, pivot, selected_row)
+        if selected_column != pivot:
+            _swap_columns(matrix, pivot, selected_column)
+            _swap_columns(right, pivot, selected_column)
+
+        while True:
+            changed = False
+            for row in range(pivot + 1, rows):
+                while matrix[row][pivot] != 0:
+                    quotient = matrix[row][pivot] // matrix[pivot][pivot]
+                    _add_row_multiple(matrix, row, pivot, -quotient)
+                    _add_row_multiple(left, row, pivot, -quotient)
+                    if matrix[row][pivot] != 0 and abs(matrix[row][pivot]) < abs(
+                        matrix[pivot][pivot]
+                    ):
+                        _swap_rows(matrix, row, pivot)
+                        _swap_rows(left, row, pivot)
+                    changed = True
+            for column in range(pivot + 1, columns):
+                while matrix[pivot][column] != 0:
+                    quotient = matrix[pivot][column] // matrix[pivot][pivot]
+                    _add_column_multiple(matrix, column, pivot, -quotient)
+                    _add_column_multiple(right, column, pivot, -quotient)
+                    if matrix[pivot][column] != 0 and abs(matrix[pivot][column]) < abs(
+                        matrix[pivot][pivot]
+                    ):
+                        _swap_columns(matrix, column, pivot)
+                        _swap_columns(right, column, pivot)
+                    changed = True
+            offender = next(
+                (
+                    (row, column)
+                    for row in range(pivot + 1, rows)
+                    for column in range(pivot + 1, columns)
+                    if matrix[row][column] % matrix[pivot][pivot]
+                ),
+                None,
+            )
+            if offender is not None:
+                _add_row_multiple(matrix, pivot, offender[0], 1)
+                _add_row_multiple(left, pivot, offender[0], 1)
+                changed = True
+                continue
+            if not changed:
+                break
+            if all(matrix[row][pivot] == 0 for row in range(pivot + 1, rows)) and all(
+                matrix[pivot][column] == 0 for column in range(pivot + 1, columns)
+            ):
+                break
+        if matrix[pivot][pivot] < 0:
+            _negate_row(matrix, pivot)
+            _negate_row(left, pivot)
+
+    factors = tuple(
+        matrix[index][index]
+        for index in range(diagonal_count)
+        if matrix[index][index] != 0
+    )
+    if any(value <= 0 for value in factors) or any(
+        right_factor % left_factor for left_factor, right_factor in pairwise(factors)
+    ):
+        raise ArithmeticError("Smith reduction did not produce a canonical diagonal")
+    if matrix_multiply(matrix_multiply(left, original), right) != matrix:
+        raise ArithmeticError("Smith transformations do not bind the source")
+    left_determinant = determinant(left)
+    right_determinant = determinant(right)
+    if abs(left_determinant) != 1 or abs(right_determinant) != 1:
+        raise ArithmeticError("Smith transformations are not unimodular")
+    return SmithReduction(
+        source=original,
+        diagonal=matrix,
+        left=left,
+        right=right,
+        rank=len(factors),
+        invariant_factors=factors,
+        left_determinant=left_determinant,
+        right_determinant=right_determinant,
+    )
+
+
+def _contract_matrix(
+    entries: Matrix,
+    *,
+    rows: int,
+    columns: int,
+) -> CertifiedIntegerMatrix:
+    return CertifiedIntegerMatrix(
+        row_count=rows,
+        column_count=columns,
+        entries=tuple(tuple(str(value) for value in row) for row in entries),
+    )
+
+
+def certificate_from_reduction(
+    reduction: SmithReduction,
+) -> SmithNormalFormCertificate:
+    rows = len(reduction.source)
+    columns = len(reduction.source[0]) if reduction.source else len(reduction.right)
+    left_determinant: Literal["-1", "1"] = (
+        "1" if reduction.left_determinant == 1 else "-1"
+    )
+    right_determinant: Literal["-1", "1"] = (
+        "1" if reduction.right_determinant == 1 else "-1"
+    )
+    return SmithNormalFormCertificate(
+        source=_contract_matrix(reduction.source, rows=rows, columns=columns),
+        diagonal=_contract_matrix(reduction.diagonal, rows=rows, columns=columns),
+        left_transformation=_contract_matrix(
+            reduction.left,
+            rows=rows,
+            columns=rows,
+        ),
+        right_transformation=_contract_matrix(
+            reduction.right,
+            rows=columns,
+            columns=columns,
+        ),
+        rank=reduction.rank,
+        invariant_factors=tuple(str(value) for value in reduction.invariant_factors),
+        left_determinant=left_determinant,
+        right_determinant=right_determinant,
+    )
+
+
+__all__ = [
+    "Matrix",
+    "SmithReduction",
+    "certificate_from_reduction",
+    "determinant",
+    "identity_matrix",
+    "inverse_unimodular",
+    "matrix_columns",
+    "matrix_multiply",
+    "matrix_shape",
+    "matrix_vector_multiply",
+    "smith_reduce",
+    "zero_matrix",
+]

--- a/src/jacobian/domains/builtins.py
+++ b/src/jacobian/domains/builtins.py
@@ -2,6 +2,7 @@
 
 from jacobian.domains.analysis import REAL_ANALYSIS_BUNDLE
 from jacobian.domains.arithmetic import ARITHMETIC_BUNDLE
+from jacobian.domains.certified_snf import CERTIFIED_SNF_BUNDLE
 from jacobian.domains.combinatorics import COMBINATORICS_BUNDLE
 from jacobian.domains.finite_sets import FINITE_SET_BUNDLE
 from jacobian.domains.geometry import GEOMETRY_BUNDLE
@@ -31,6 +32,7 @@ BUILTIN_DOMAIN_BUNDLES = (
     GRAPH_OPTIMIZATION_BUNDLE,
     GRAPH_INVARIANT_BUNDLE,
     GRAPH_SYMMETRY_BUNDLE,
+    CERTIFIED_SNF_BUNDLE,
     MATRIX_BUNDLE,
     LATTICE_BUNDLE,
     POLYNOMIAL_BUNDLE,

--- a/src/jacobian/domains/certified_snf/__init__.py
+++ b/src/jacobian/domains/certified_snf/__init__.py
@@ -1,0 +1,5 @@
+"""Transformation-certified Smith normal forms."""
+
+from jacobian.domains.certified_snf.bundle import CERTIFIED_SNF_BUNDLE
+
+__all__ = ["CERTIFIED_SNF_BUNDLE"]

--- a/src/jacobian/domains/certified_snf/bundle.py
+++ b/src/jacobian/domains/certified_snf/bundle.py
@@ -1,0 +1,64 @@
+"""Explicit bundle for transformation-certified Smith normal forms."""
+
+from jacobian.contracts.capabilities import CapabilityDiagnostic
+from jacobian.domains.certified_snf.operations import CERTIFIED_SNF_CAPABILITIES
+from jacobian.operations import DomainBundle, DomainDiagnostics, DomainSemantics
+from jacobian.provider_runtime import known_provider_runtime
+
+CERTIFIED_SNF_BUNDLE = DomainBundle(
+    domain_id="certified_snf",
+    schema_namespace="jacobian.certified-snf",
+    semantics=DomainSemantics(
+        name="jacobian.transformation-certified-smith-normal-form",
+        version="1",
+        definition={
+            "domain": "ZZ",
+            "maximum_rows": 16,
+            "maximum_columns": 16,
+            "maximum_input_digits": 32,
+            "relation": "D = U A V",
+            "left_transformation": "square unimodular row-basis change",
+            "right_transformation": "square unimodular column-basis change",
+            "normalization": "positive nonzero diagonal with divisibility chain",
+            "excluded": (
+                "Hermite normal form, rational canonical form, modular normal "
+                "forms, and homology conclusions"
+            ),
+        },
+    ),
+    provider_runtime=known_provider_runtime(
+        "jacobian.certified-snf",
+        features=(
+            "exact-integer",
+            "elementary-row-operations",
+            "elementary-column-operations",
+            "left-unimodular-transformation",
+            "right-unimodular-transformation",
+            "smith-divisibility-chain",
+        ),
+    ),
+    backend_version="jacobian.certified-snf/1",
+    capabilities=CERTIFIED_SNF_CAPABILITIES,
+    diagnostics=DomainDiagnostics(
+        invalid_request=CapabilityDiagnostic(
+            code="INVALID_CERTIFIED_SMITH_REQUEST",
+            stage="certified_smith_input_validation",
+            message="Input does not satisfy the bounded certified-Smith contract.",
+            hint=(
+                "Supply a nonempty matrix of at most 16 by 16 canonical integer "
+                "strings, each containing at most 32 decimal digits."
+            ),
+        )
+    ),
+    scope_description="the complete supplied bounded integer matrix",
+    completeness_basis=(
+        "elementary row and column operations produced both full basis changes "
+        "and the complete canonical Smith diagonal"
+    ),
+    assurance_basis=(
+        "exact integer computation capped at COMPUTED; independent certificate "
+        "replay is available through matrix.normal_form.smith.certified.verify"
+    ),
+)
+
+__all__ = ["CERTIFIED_SNF_BUNDLE"]

--- a/src/jacobian/domains/certified_snf/checkers.py
+++ b/src/jacobian/domains/certified_snf/checkers.py
@@ -1,0 +1,35 @@
+"""Independent checker declaration for certified Smith normal forms."""
+
+from jacobian.checker_operations import ExactReplayCheckerDeclaration
+from jacobian.contracts.certified_snf import CertifiedSmithNormalFormRequest
+
+CERTIFIED_SNF_EXACT_REPLAY_CHECKERS = (
+    ExactReplayCheckerDeclaration(
+        "matrix.normal_form.smith.certified.compute",
+        CertifiedSmithNormalFormRequest,
+        "check_certified_smith_normal_form",
+        "matrix.smith-normal-form.transformation-certificate-v1",
+        entrypoint_module="jacobian_checkers.certified_snf",
+        replay_method="independent Smith transformation-certificate replay",
+        reason=(
+            "operator-authorized standard-library checker validates D=UAV, both "
+            "unimodular determinants, and the complete canonical divisibility chain"
+        ),
+        verification_capability_id="matrix.normal_form.smith.certified.verify",
+        verification_title="Verify a transformation-certified Smith normal form",
+        verification_description=(
+            "Independently verify the full Smith diagonal and both unimodular "
+            "basis transformations against the exact stored integer matrix."
+        ),
+        verification_tags=(
+            "verification",
+            "exact",
+            "matrix",
+            "integer",
+            "smith-normal-form",
+            "certificate",
+        ),
+    ),
+)
+
+__all__ = ["CERTIFIED_SNF_EXACT_REPLAY_CHECKERS"]

--- a/src/jacobian/domains/certified_snf/operations.py
+++ b/src/jacobian/domains/certified_snf/operations.py
@@ -1,0 +1,67 @@
+"""Transformation-certified Smith normal-form operation."""
+
+from __future__ import annotations
+
+from jacobian.contracts.certified_snf import (
+    CertifiedSmithNormalFormRequest,
+    CertifiedSmithNormalFormResult,
+)
+from jacobian.domains._certified_snf import certificate_from_reduction, smith_reduce
+from jacobian.domains._examples import example
+from jacobian.operations import ComputedOperation, ComputedSuccess
+
+
+def _certified_smith(
+    request: CertifiedSmithNormalFormRequest,
+) -> ComputedSuccess[CertifiedSmithNormalFormResult]:
+    source = [[int(value) for value in row] for row in request.matrix.entries]
+    reduction = smith_reduce(
+        source,
+        row_count=request.matrix.row_count,
+        column_count=request.matrix.column_count,
+    )
+    return ComputedSuccess(
+        CertifiedSmithNormalFormResult(
+            certificate=certificate_from_reduction(reduction)
+        )
+    )
+
+
+CERTIFIED_SNF_CAPABILITIES = (
+    ComputedOperation(
+        capability_id="matrix.normal_form.smith.certified.compute",
+        title="Compute a transformation-certified Smith normal form",
+        description=(
+            "Compute the canonical Smith diagonal D and explicit unimodular "
+            "matrices U and V satisfying D = U A V for one bounded integer matrix."
+        ),
+        request_model=CertifiedSmithNormalFormRequest,
+        result_model=CertifiedSmithNormalFormResult,
+        implementation=_certified_smith,
+        relation_id="matrix.normal_form.smith.certified.relation",
+        tags=(
+            "matrix",
+            "integer",
+            "smith-normal-form",
+            "unimodular-transformation",
+            "certificate",
+            "exact",
+            "bounded",
+        ),
+        invocation_examples=(
+            example(
+                "certified_smith_two_by_two",
+                "Compute D, U, and V for a two-by-two integer matrix.",
+                {
+                    "matrix": {
+                        "row_count": 2,
+                        "column_count": 2,
+                        "entries": [["2", "4"], ["6", "8"]],
+                    }
+                },
+            ),
+        ),
+    ),
+)
+
+__all__ = ["CERTIFIED_SNF_CAPABILITIES"]

--- a/src/jacobian/domains/topology/bundle.py
+++ b/src/jacobian/domains/topology/bundle.py
@@ -16,14 +16,18 @@ TOPOLOGY_BUNDLE = DomainBundle(
         definition={
             "description": (
                 "bounded finite abstract simplicial complexes, oriented chain "
-                "complexes, and homology over bounded prime fields"
+                "complexes, homology over bounded prime fields, and bounded "
+                "transformation-certified integral homology"
             ),
             "vertices": "canonical ASCII labels in lexicographic order",
             "orientation": "the increasing vertex order orients every simplex",
             "faces": "the empty simplex is not stored",
             "isolated_vertices": "represented by singleton maximal facets",
             "homology": "reduced or unreduced convention is explicit",
-            "integral_homology": "not provided",
+            "integral_homology": (
+                "free rank, torsion invariant factors, simplex-basis generators, "
+                "bounding chains, and full Smith transformation certificates"
+            ),
             "persistent_homology": "not provided",
         },
     ),
@@ -33,6 +37,9 @@ TOPOLOGY_BUNDLE = DomainBundle(
             "finite-simplicial-complex",
             "oriented-boundary-matrices",
             "prime-field-homology",
+            "integral-homology",
+            "torsion-invariant-factors",
+            "smith-transformation-certificates",
             "exact-modular-elimination",
         ),
     ),
@@ -45,18 +52,22 @@ TOPOLOGY_BUNDLE = DomainBundle(
             message="Input does not satisfy the bounded simplicial-topology contract.",
             hint=(
                 "Use unique declared vertices, distinct maximal facets, and a "
-                "bounded prime when requesting F_p homology."
+                "bounded prime when requesting F_p homology; integral homology "
+                "has tighter 16-simplex-per-chain-group and total-chain-rank-32 "
+                "bounds."
             ),
         )
     ),
     scope_description="the complete supplied bounded finite simplicial complex",
     completeness_basis=(
         "the finite facet closure, every oriented boundary entry, and every "
-        "requested finite-field chain dimension were computed exactly"
+        "requested finite-field or bounded integral chain dimension were "
+        "computed exactly"
     ),
     assurance_basis=(
         "exact deterministic finite computation; independent verification is "
-        "available through topology.result.verify"
+        "available through topology.result.verify or the dedicated integral "
+        "homology verifier"
     ),
 )
 

--- a/src/jacobian/domains/topology/checkers.py
+++ b/src/jacobian/domains/topology/checkers.py
@@ -3,6 +3,7 @@
 from jacobian.checker_operations import ExactReplayCheckerDeclaration
 from jacobian.contracts.topology import (
     ChainComplexRequest,
+    IntegralSimplicialHomologyRequest,
     SimplicialComplexRequest,
     SimplicialHomologyRequest,
 )
@@ -40,6 +41,36 @@ TOPOLOGY_EXACT_REPLAY_CHECKERS = (
         entrypoint_module=_ENTRYPOINT,
         replay_method="independent modular quotient replay",
         reason=_REASON,
+    ),
+    ExactReplayCheckerDeclaration(
+        "topology.simplicial_homology.integral.compute",
+        IntegralSimplicialHomologyRequest,
+        "check_integral_simplicial_homology",
+        "topology.simplicial-homology.integral-smith-certificate-v1",
+        entrypoint_module=_ENTRYPOINT,
+        replay_method=(
+            "independent integral chain and Smith transformation-certificate replay"
+        ),
+        reason=(
+            "operator-authorized clean-process checker reconstructs every integer "
+            "boundary, validates both Smith certificates per dimension, and binds "
+            "free and torsion generators to the canonical simplex bases"
+        ),
+        verification_capability_id="topology.simplicial_homology.integral.verify",
+        verification_title="Verify integral simplicial homology",
+        verification_description=(
+            "Independently verify every free rank, torsion factor, cycle generator, "
+            "bounding chain, and embedded Smith transformation certificate."
+        ),
+        verification_tags=(
+            "verification",
+            "exact",
+            "topology",
+            "simplicial-homology",
+            "integer",
+            "torsion",
+            "smith-normal-form",
+        ),
     ),
 )
 

--- a/src/jacobian/domains/topology/operations.py
+++ b/src/jacobian/domains/topology/operations.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
+from jacobian.contracts.certified_snf import CertifiedIntegerMatrix
 from jacobian.contracts.topology import (
     BoundarySquareLedgerEntry,
     ChainCoefficientRing,
@@ -13,6 +14,12 @@ from jacobian.contracts.topology import (
     FiniteSimplicialComplex,
     HomologyConvention,
     HomologyGroupResult,
+    IntegralFreeGenerator,
+    IntegralHomologyGroupResult,
+    IntegralSimplicialHomologyRequest,
+    IntegralSimplicialHomologyResult,
+    IntegralTorsionGenerator,
+    IntegralVector,
     ModularVector,
     SimplexBasis,
     SimplicialComplexMaterializationResult,
@@ -23,6 +30,14 @@ from jacobian.contracts.topology import (
     SparseMatrixEntry,
     face_closure,
     simplicial_complex_digest,
+)
+from jacobian.domains._certified_snf import (
+    certificate_from_reduction,
+    inverse_unimodular,
+    matrix_columns,
+    matrix_multiply,
+    matrix_vector_multiply,
+    smith_reduce,
 )
 from jacobian.domains._examples import example
 from jacobian.operations import ComputedOperation, ComputedSuccess
@@ -459,6 +474,160 @@ def _homology(
     )
 
 
+def _integer_matrix(
+    entries: list[list[int]],
+    *,
+    rows: int,
+    columns: int,
+) -> CertifiedIntegerMatrix:
+    return CertifiedIntegerMatrix(
+        row_count=rows,
+        column_count=columns,
+        entries=tuple(tuple(str(value) for value in row) for row in entries),
+    )
+
+
+def _integral_vector(values: list[int]) -> IntegralVector:
+    return IntegralVector(coefficients=tuple(str(value) for value in values))
+
+
+def _integral_homology(
+    request: IntegralSimplicialHomologyRequest,
+) -> ComputedSuccess[IntegralSimplicialHomologyResult]:
+    chain = _chain_result(
+        ChainComplexRequest(
+            complex=request.complex,
+            coefficient_ring=ChainCoefficientRing.INTEGER,
+            convention=request.convention,
+        )
+    )
+    boundaries = tuple(
+        _dense(matrix, modulus=None) for matrix in chain.boundary_matrices
+    )
+    groups: list[IntegralHomologyGroupResult] = []
+    for dimension, basis in enumerate(chain.simplex_bases):
+        chain_dimension = len(basis.simplices)
+        if dimension == 0 and chain.augmentation is not None:
+            outgoing = _dense(chain.augmentation, modulus=None)
+            outgoing_rows = 1
+        else:
+            outgoing = boundaries[dimension]
+            outgoing_rows = chain.boundary_matrices[dimension].rows
+        outgoing_reduction = smith_reduce(
+            outgoing,
+            row_count=outgoing_rows,
+            column_count=chain_dimension,
+        )
+        outgoing_rank = outgoing_reduction.rank
+        cycle_rank = chain_dimension - outgoing_rank
+        cycle_basis = matrix_columns(
+            outgoing_reduction.right,
+            start=outgoing_rank,
+        )
+        right_inverse = inverse_unimodular(outgoing_reduction.right)
+
+        if dimension < request.complex.dimension:
+            incoming = boundaries[dimension + 1]
+            incoming_chain_dimension = len(chain.simplex_bases[dimension + 1].simplices)
+        else:
+            incoming_chain_dimension = 0
+            incoming = [[] for _ in range(chain_dimension)]
+        all_cycle_coordinates = matrix_multiply(
+            right_inverse,
+            incoming,
+            right_columns_if_empty=incoming_chain_dimension,
+        )
+        if any(
+            value != 0 for row in all_cycle_coordinates[:outgoing_rank] for value in row
+        ):
+            raise ArithmeticError("incoming boundary is not in the outgoing kernel")
+        incoming_coordinates = all_cycle_coordinates[outgoing_rank:]
+        incoming_reduction = smith_reduce(
+            incoming_coordinates,
+            row_count=cycle_rank,
+            column_count=incoming_chain_dimension,
+        )
+        incoming_rank = incoming_reduction.rank
+        incoming_left_inverse = inverse_unimodular(incoming_reduction.left)
+
+        free_generators: list[IntegralFreeGenerator] = []
+        for index in range(incoming_rank, cycle_rank):
+            coordinate = [
+                incoming_left_inverse[row][index] for row in range(cycle_rank)
+            ]
+            free_generators.append(
+                IntegralFreeGenerator(
+                    cycle=_integral_vector(
+                        matrix_vector_multiply(cycle_basis, coordinate)
+                    ),
+                    cycle_coordinates=_integral_vector(coordinate),
+                )
+            )
+
+        torsion_generators: list[IntegralTorsionGenerator] = []
+        for index, factor in enumerate(incoming_reduction.invariant_factors):
+            if factor == 1:
+                continue
+            coordinate = [
+                incoming_left_inverse[row][index] for row in range(cycle_rank)
+            ]
+            cycle = matrix_vector_multiply(cycle_basis, coordinate)
+            bounding_chain = [
+                incoming_reduction.right[row][index]
+                for row in range(incoming_chain_dimension)
+            ]
+            if matrix_vector_multiply(incoming, bounding_chain) != [
+                factor * value for value in cycle
+            ]:
+                raise ArithmeticError("torsion bounding-chain relation is invalid")
+            torsion_generators.append(
+                IntegralTorsionGenerator(
+                    order=str(factor),
+                    cycle=_integral_vector(cycle),
+                    cycle_coordinates=_integral_vector(coordinate),
+                    bounding_chain=_integral_vector(bounding_chain),
+                )
+            )
+
+        groups.append(
+            IntegralHomologyGroupResult(
+                dimension=dimension,
+                chain_dimension=chain_dimension,
+                incoming_chain_dimension=incoming_chain_dimension,
+                outgoing_boundary_rank=outgoing_rank,
+                cycle_rank=cycle_rank,
+                incoming_boundary_rank=incoming_rank,
+                betti_number=cycle_rank - incoming_rank,
+                torsion_coefficients=tuple(
+                    str(factor)
+                    for factor in incoming_reduction.invariant_factors
+                    if factor > 1
+                ),
+                free_generators=tuple(free_generators),
+                torsion_generators=tuple(torsion_generators),
+                outgoing_smith_certificate=certificate_from_reduction(
+                    outgoing_reduction
+                ),
+                boundary_in_cycle_coordinates=_integer_matrix(
+                    incoming_coordinates,
+                    rows=cycle_rank,
+                    columns=incoming_chain_dimension,
+                ),
+                incoming_smith_certificate=certificate_from_reduction(
+                    incoming_reduction
+                ),
+            )
+        )
+    return ComputedSuccess(
+        IntegralSimplicialHomologyResult(
+            complex_digest=request.complex.complex_digest,
+            convention=request.convention,
+            dimension_range=(0, request.complex.dimension),
+            groups=tuple(groups),
+        )
+    )
+
+
 _CIRCLE = {
     "vertices": ["a", "b", "c"],
     "facets": [["a", "b"], ["b", "c"], ["a", "c"]],
@@ -530,6 +699,68 @@ TOPOLOGY_CAPABILITIES = (
             "cycle-basis",
             "prime-field",
             "exact",
+        ),
+    ),
+    ComputedOperation(
+        capability_id="topology.simplicial_homology.integral.compute",
+        title="Compute transformation-certified integral simplicial homology",
+        description=(
+            "Compute the free rank, torsion invariant factors, and simplex-basis "
+            "cycle generators of every integral homology group, with explicit "
+            "Smith transformations and bounding chains."
+        ),
+        request_model=IntegralSimplicialHomologyRequest,
+        result_model=IntegralSimplicialHomologyResult,
+        implementation=_integral_homology,
+        relation_id="topology.simplicial_homology.integral.relation",
+        tags=(
+            "topology",
+            "simplicial-homology",
+            "integer-homology",
+            "torsion",
+            "betti-number",
+            "cycle-generator",
+            "smith-normal-form",
+            "certificate",
+            "exact",
+        ),
+        invocation_examples=(
+            example(
+                "integral_circle_homology",
+                "Compute H_0 and H_1 over the integers for a triangle boundary.",
+                {
+                    "complex": {
+                        "vertices": ["a", "b", "c"],
+                        "maximal_simplices": [
+                            ["a", "b"],
+                            ["a", "c"],
+                            ["b", "c"],
+                        ],
+                        "faces_by_dimension": [
+                            {
+                                "dimension": 0,
+                                "faces": [["a"], ["b"], ["c"]],
+                            },
+                            {
+                                "dimension": 1,
+                                "faces": [
+                                    ["a", "b"],
+                                    ["a", "c"],
+                                    ["b", "c"],
+                                ],
+                            },
+                        ],
+                        "dimension": 1,
+                        "f_vector": [3, 3],
+                        "closure_size": 6,
+                        "complex_digest": (
+                            "sha256:"
+                            "6f797991bac967e2a8e572707df487061655df0f094c"
+                            "bde0f52f82c5401fc043"
+                        ),
+                    }
+                },
+            ),
         ),
     ),
 )

--- a/src/jacobian/exact_domain_checkers.py
+++ b/src/jacobian/exact_domain_checkers.py
@@ -37,6 +37,9 @@ from jacobian.contracts.results import (
     ExecutionStatus,
     Verification,
 )
+from jacobian.domains.certified_snf.checkers import (
+    CERTIFIED_SNF_EXACT_REPLAY_CHECKERS,
+)
 from jacobian.domains.combinatorics.checkers import (
     COMBINATORICS_EXACT_REPLAY_CHECKERS,
 )
@@ -59,6 +62,7 @@ from jacobian.domains.projective_geometry.checkers import (
 from jacobian.domains.topology.checkers import TOPOLOGY_EXACT_REPLAY_CHECKERS
 from jacobian.operation_installation import InstalledDomainBundle
 from jacobian.provider_runtime import (
+    certified_snf_checker_provider_runtime,
     combinatorics_exact_checker_provider_runtime,
     exact_domain_checker_provider_runtime,
     graded_syzygy_checker_provider_runtime,
@@ -110,6 +114,8 @@ def _provider_runtime_key(declaration: ExactReplayCheckerDeclaration) -> str:
         return "projective-arrangement"
     if declaration.entrypoint_module == "jacobian_checkers.simplicial_topology":
         return "topology"
+    if declaration.entrypoint_module == "jacobian_checkers.certified_snf":
+        return "certified-snf"
     if declaration.entrypoint_module == "jacobian_checkers.finite_posets":
         return "poset"
     raise ValueError(
@@ -122,6 +128,7 @@ def install_exact_domain_checkers(
     *,
     polynomial: InstalledDomainBundle | None = None,
     matrix: InstalledDomainBundle | None = None,
+    certified_snf: InstalledDomainBundle | None = None,
     graph: InstalledDomainBundle | None = None,
     graph_invariants: InstalledDomainBundle | None = None,
     graph_symmetry: InstalledDomainBundle | None = None,
@@ -138,6 +145,7 @@ def install_exact_domain_checkers(
     installer = CheckerInstaller(checkers)
     provider_runtimes = {
         "python-flint": exact_domain_checker_provider_runtime(),
+        "certified-snf": certified_snf_checker_provider_runtime(),
         "finite-graph": graph_exact_checker_provider_runtime(),
         "finite-probability": probability_exact_checker_provider_runtime(),
         "combinatorics": combinatorics_exact_checker_provider_runtime(),
@@ -158,6 +166,11 @@ def install_exact_domain_checkers(
             (matrix, item)
             for item in MATRIX_EXACT_REPLAY_CHECKERS
             if matrix is not None
+        ),
+        *(
+            (certified_snf, item)
+            for item in CERTIFIED_SNF_EXACT_REPLAY_CHECKERS
+            if certified_snf is not None
         ),
         *_available_graph_declaration_bundles(
             graph=graph,
@@ -230,6 +243,9 @@ def install_exact_domain_checkers(
             "python-flint": exact_domain_checker_provider_runtime(
                 checker_ids=authorized_ids["python-flint"]
             ),
+            "certified-snf": certified_snf_checker_provider_runtime(
+                checker_ids=authorized_ids["certified-snf"]
+            ),
             "finite-graph": graph_exact_checker_provider_runtime(
                 checker_ids=authorized_ids["finite-graph"]
             ),
@@ -266,6 +282,7 @@ def install_exact_domain_verification(
     *,
     polynomial: InstalledDomainBundle | None = None,
     matrix: InstalledDomainBundle | None = None,
+    certified_snf: InstalledDomainBundle | None = None,
     graph: InstalledDomainBundle | None = None,
     graph_invariants: InstalledDomainBundle | None = None,
     graph_symmetry: InstalledDomainBundle | None = None,
@@ -283,6 +300,7 @@ def install_exact_domain_verification(
         checkers,
         polynomial=polynomial,
         matrix=matrix,
+        certified_snf=certified_snf,
         graph=graph,
         graph_invariants=graph_invariants,
         graph_symmetry=graph_symmetry,
@@ -329,6 +347,15 @@ def install_exact_domain_verification(
             if installation.checker_ids.get(declaration.capability_id) is not None
         )
         if matrix is not None
+        else ()
+    )
+    certified_snf_declarations = (
+        tuple(
+            _installed_declaration(certified_snf, declaration, installation)
+            for declaration in CERTIFIED_SNF_EXACT_REPLAY_CHECKERS
+            if installation.checker_ids.get(declaration.capability_id) is not None
+        )
+        if certified_snf is not None
         else ()
     )
     graph_declarations = tuple(
@@ -396,7 +423,7 @@ def install_exact_domain_verification(
         if combinatorics is not None
         else ()
     )
-    topology_declarations = (
+    all_topology_declarations = (
         tuple(
             _installed_declaration(
                 topology,
@@ -408,6 +435,11 @@ def install_exact_domain_verification(
         )
         if topology is not None
         else ()
+    )
+    topology_declarations = tuple(
+        declaration
+        for declaration in all_topology_declarations
+        if declaration.declaration.verification_capability_id is None
     )
     poset_declarations = (
         tuple(
@@ -428,9 +460,15 @@ def install_exact_domain_verification(
             for declaration in all_polynomial_declarations
             if declaration.declaration.verification_capability_id is not None
         ),
+        *certified_snf_declarations,
         *graph_declarations,
         *number_theory_declarations,
         *projective_declarations,
+        *(
+            declaration
+            for declaration in all_topology_declarations
+            if declaration.declaration.verification_capability_id is not None
+        ),
     )
     dedicated_adapters: tuple[CapabilityAdapter, ...] = tuple(
         ExactDomainResultVerificationAdapter(

--- a/src/jacobian/portfolio/core_installation.py
+++ b/src/jacobian/portfolio/core_installation.py
@@ -223,6 +223,7 @@ class CoreApplicationInstaller:
         exact_bundles = {
             "polynomial": polynomial,
             "matrix": matrix,
+            "certified_snf": result.domain_bundles.get("certified_snf"),
             "graph": result.domain_bundles.get("graph_optimization"),
             "graph_invariants": result.domain_bundles.get("graph_invariants"),
             "graph_symmetry": result.domain_bundles.get("graph_symmetry"),
@@ -243,6 +244,7 @@ class CoreApplicationInstaller:
             ctx.checkers,
             polynomial=polynomial,
             matrix=matrix,
+            certified_snf=exact_bundles["certified_snf"],
             graph=exact_bundles["graph"],
             graph_invariants=exact_bundles["graph_invariants"],
             graph_symmetry=exact_bundles["graph_symmetry"],

--- a/src/jacobian/provider_runtime.py
+++ b/src/jacobian/provider_runtime.py
@@ -1286,6 +1286,49 @@ def topology_exact_checker_provider_runtime(
             "finite-face-closure-replay",
             "oriented-boundary-replay",
             "prime-field-quotient-replay",
+            "integral-smith-certificate-replay",
+            "free-and-torsion-generator-replay",
+            "standard-library-only",
+        ),
+        checker_ids=checker_ids,
+    )
+
+
+def certified_snf_checker_provider_runtime(
+    *,
+    checker_ids: tuple[str, ...] = (),
+) -> CapabilityProviderRuntime:
+    """Bind the independent transformation-certified Smith checker source."""
+
+    try:
+        version, _, license_files = _jacobian_identity()
+    except ProviderRuntimeError:
+        source = _unavailable_runtime(
+            provider="jacobian.certified-snf-checker-source",
+            install_tier=CapabilityInstallTier.T1,
+            license_id="MIT",
+            diagnostic="The certified-Smith checker source could not be identified.",
+        )
+    else:
+        source = source_provider_runtime(
+            "jacobian.certified-snf-checker-source",
+            version=version,
+            entrypoint=(
+                "jacobian_checkers.certified_snf:check_certified_smith_normal_form"
+            ),
+            install_tier=CapabilityInstallTier.T1,
+            license_id="MIT",
+            license_files=license_files,
+            features=("clean-process-replay", "standard-library-only"),
+        )
+    return composite_provider_runtime(
+        "jacobian.certified-snf-checkers",
+        components=(source,),
+        features=(
+            "clean-process-replay",
+            "full-transformation-relation-replay",
+            "bareiss-unimodularity-replay",
+            "smith-divisibility-chain-replay",
             "standard-library-only",
         ),
         checker_ids=checker_ids,

--- a/src/jacobian_checkers/certified_snf.py
+++ b/src/jacobian_checkers/certified_snf.py
@@ -1,0 +1,300 @@
+"""Independent Smith-certificate replay with no producer or contract imports."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from itertools import pairwise
+from typing import Any
+
+from jacobian_checkers.bound_artifacts import bound_request
+
+_INTEGER = re.compile(r"^(?:0|-?[1-9][0-9]*)$")
+_MAX_DIMENSION = 32
+_MAX_INPUT_DIMENSION = 16
+_MAX_INPUT_DIGITS = 32
+_MAX_OUTPUT_DIGITS = 4_096
+
+
+@dataclass(frozen=True, slots=True)
+class ParsedMatrix:
+    rows: int
+    columns: int
+    entries: list[list[int]]
+
+
+@dataclass(frozen=True, slots=True)
+class ParsedSmithCertificate:
+    source: ParsedMatrix
+    diagonal: ParsedMatrix
+    left: ParsedMatrix
+    right: ParsedMatrix
+    rank: int
+    factors: tuple[int, ...]
+
+
+def _reject(detail: str) -> dict[str, Any]:
+    return {
+        "accepted": False,
+        "conclusion": "UNKNOWN",
+        "arithmetic": "EXACT_INTEGER",
+        "method": "DIRECT_WITNESS",
+        "coverage": "NOT_APPLICABLE",
+        "detail": detail,
+    }
+
+
+def _accept(detail: str) -> dict[str, Any]:
+    return {
+        "accepted": True,
+        "conclusion": "TRUE",
+        "arithmetic": "EXACT_INTEGER",
+        "method": "EXHAUSTIVE_FINITE",
+        "coverage": "EXHAUSTIVE",
+        "detail": detail,
+    }
+
+
+def _strict_int(value: object, *, minimum: int, maximum: int) -> int:
+    if type(value) is not int or not minimum <= value <= maximum:
+        raise ValueError("integer lies outside the checker scope")
+    return value
+
+
+def _canonical_integer(value: object, *, maximum_digits: int) -> int:
+    if (
+        not isinstance(value, str)
+        or _INTEGER.fullmatch(value) is None
+        or len(value.lstrip("-")) > maximum_digits
+    ):
+        raise ValueError("integer encoding lies outside the checker scope")
+    return int(value)
+
+
+def parse_matrix(value: object, *, maximum_digits: int) -> ParsedMatrix:
+    if not isinstance(value, dict) or set(value) != {
+        "matrix_schema_version",
+        "domain",
+        "row_count",
+        "column_count",
+        "entries",
+    }:
+        raise ValueError("integer matrix payload is malformed")
+    if value["matrix_schema_version"] != "1" or value["domain"] != "ZZ":
+        raise ValueError("integer matrix semantics are unsupported")
+    rows = _strict_int(value["row_count"], minimum=0, maximum=_MAX_DIMENSION)
+    columns = _strict_int(value["column_count"], minimum=0, maximum=_MAX_DIMENSION)
+    entries = value["entries"]
+    if (
+        not isinstance(entries, list)
+        or len(entries) != rows
+        or any(not isinstance(row, list) or len(row) != columns for row in entries)
+    ):
+        raise ValueError("integer matrix shape is malformed")
+    return ParsedMatrix(
+        rows=rows,
+        columns=columns,
+        entries=[
+            [_canonical_integer(item, maximum_digits=maximum_digits) for item in row]
+            for row in entries
+        ],
+    )
+
+
+def _multiply(left: ParsedMatrix, right: ParsedMatrix) -> ParsedMatrix:
+    if left.columns != right.rows:
+        raise ValueError("integer matrices are not composable")
+    return ParsedMatrix(
+        rows=left.rows,
+        columns=right.columns,
+        entries=[
+            [
+                sum(
+                    left.entries[row][middle] * right.entries[middle][column]
+                    for middle in range(left.columns)
+                )
+                for column in range(right.columns)
+            ]
+            for row in range(left.rows)
+        ],
+    )
+
+
+def _determinant(matrix: ParsedMatrix) -> int:
+    if matrix.rows != matrix.columns:
+        raise ValueError("determinant requires a square matrix")
+    if matrix.rows == 0:
+        return 1
+    work = [row[:] for row in matrix.entries]
+    sign = 1
+    previous = 1
+    for pivot_index in range(matrix.rows - 1):
+        selected = next(
+            (
+                row
+                for row in range(pivot_index, matrix.rows)
+                if work[row][pivot_index] != 0
+            ),
+            None,
+        )
+        if selected is None:
+            return 0
+        if selected != pivot_index:
+            work[pivot_index], work[selected] = work[selected], work[pivot_index]
+            sign = -sign
+        pivot = work[pivot_index][pivot_index]
+        for row in range(pivot_index + 1, matrix.rows):
+            for column in range(pivot_index + 1, matrix.rows):
+                numerator = (
+                    work[row][column] * pivot
+                    - work[row][pivot_index] * work[pivot_index][column]
+                )
+                if numerator % previous:
+                    raise ValueError("fraction-free determinant replay failed")
+                work[row][column] = numerator // previous
+        previous = pivot
+    return sign * work[-1][-1]
+
+
+def validate_certificate(value: object) -> ParsedSmithCertificate:
+    if not isinstance(value, dict) or set(value) != {
+        "certificate_schema_version",
+        "source",
+        "diagonal",
+        "left_transformation",
+        "right_transformation",
+        "rank",
+        "invariant_factors",
+        "left_determinant",
+        "right_determinant",
+        "relation",
+        "transformation_scope",
+        "convention",
+    }:
+        raise ValueError("Smith certificate payload is malformed")
+    if (
+        value["certificate_schema_version"] != "1"
+        or value["relation"] != "DIAGONAL_EQUALS_LEFT_TIMES_SOURCE_TIMES_RIGHT"
+        or value["transformation_scope"] != "FULL_BASIS_BOTH_SIDES"
+        or value["convention"] != "POSITIVE_DIVISIBILITY_DIAGONAL"
+    ):
+        raise ValueError("Smith certificate semantics are unsupported")
+    source = parse_matrix(value["source"], maximum_digits=_MAX_OUTPUT_DIGITS)
+    diagonal = parse_matrix(value["diagonal"], maximum_digits=_MAX_OUTPUT_DIGITS)
+    left = parse_matrix(value["left_transformation"], maximum_digits=_MAX_OUTPUT_DIGITS)
+    right = parse_matrix(
+        value["right_transformation"], maximum_digits=_MAX_OUTPUT_DIGITS
+    )
+    if (
+        (diagonal.rows, diagonal.columns) != (source.rows, source.columns)
+        or (left.rows, left.columns) != (source.rows, source.rows)
+        or (right.rows, right.columns) != (source.columns, source.columns)
+    ):
+        raise ValueError("Smith certificate matrix shapes are incompatible")
+    rank = _strict_int(
+        value["rank"],
+        minimum=0,
+        maximum=min(source.rows, source.columns),
+    )
+    raw_factors = value["invariant_factors"]
+    if not isinstance(raw_factors, list):
+        raise ValueError("Smith invariant factors are malformed")
+    factors = tuple(
+        _canonical_integer(item, maximum_digits=_MAX_OUTPUT_DIGITS)
+        for item in raw_factors
+    )
+    diagonal_values = tuple(
+        diagonal.entries[index][index]
+        for index in range(min(source.rows, source.columns))
+    )
+    if (
+        rank != len(factors)
+        or any(value <= 0 for value in factors)
+        or diagonal_values[:rank] != factors
+        or any(value != 0 for value in diagonal_values[rank:])
+        or any(
+            diagonal.entries[row][column] != 0
+            for row in range(diagonal.rows)
+            for column in range(diagonal.columns)
+            if row != column
+        )
+        or any(
+            right_factor % left_factor
+            for left_factor, right_factor in pairwise(factors)
+        )
+    ):
+        raise ValueError("Smith diagonal is not canonical")
+    left_determinant = _determinant(left)
+    right_determinant = _determinant(right)
+    if (
+        abs(left_determinant) != 1
+        or abs(right_determinant) != 1
+        or value["left_determinant"] != str(left_determinant)
+        or value["right_determinant"] != str(right_determinant)
+    ):
+        raise ValueError("Smith transformations are not unimodular")
+    replayed = _multiply(_multiply(left, source), right)
+    if replayed.entries != diagonal.entries:
+        raise ValueError("Smith transformation relation does not hold")
+    return ParsedSmithCertificate(
+        source=source,
+        diagonal=diagonal,
+        left=left,
+        right=right,
+        rank=rank,
+        factors=factors,
+    )
+
+
+def check_certified_smith_normal_form(request: object) -> dict[str, Any]:
+    try:
+        source, result = bound_request(
+            request,
+            operation_id="matrix.normal_form.smith.certified.compute",
+            witness_format="matrix.smith-normal-form.transformation-certificate-v1",
+        )
+        if not isinstance(source, dict) or set(source) != {"matrix"}:
+            raise ValueError("certified Smith request is malformed")
+        source_matrix = parse_matrix(source["matrix"], maximum_digits=_MAX_INPUT_DIGITS)
+        if (
+            not 1 <= source_matrix.rows <= _MAX_INPUT_DIMENSION
+            or not 1 <= source_matrix.columns <= _MAX_INPUT_DIMENSION
+        ):
+            raise ValueError("certified Smith request lies outside checker scope")
+        if not isinstance(result, dict) or set(result) != {
+            "certificate",
+            "exactness",
+            "determinism",
+            "backend",
+            "backend_version",
+            "completeness",
+            "verification",
+        }:
+            raise ValueError("certified Smith result is malformed")
+        if (
+            result["exactness"] != "EXACT_INTEGER"
+            or result["determinism"] != "DETERMINISTIC"
+            or result["backend"] != "jacobian-stdlib-elementary-operations"
+            or result["backend_version"] != "1"
+            or result["completeness"] != "FULL_MATRIX_TRANSFORMATIONS"
+            or result["verification"] != "UNVERIFIED"
+        ):
+            raise ValueError("certified Smith result metadata is unsupported")
+        certificate = validate_certificate(result["certificate"])
+        if certificate.source != source_matrix:
+            raise ValueError("Smith certificate is rebound to another source matrix")
+        return _accept(
+            "independent Smith transformation-certificate replay accepted "
+            "matrix.normal_form.smith.certified.compute"
+        )
+    except (KeyError, TypeError, ValueError, OverflowError):
+        return _reject("malformed, unsupported, or mismatched checker request")
+
+
+__all__ = [
+    "ParsedMatrix",
+    "ParsedSmithCertificate",
+    "check_certified_smith_normal_form",
+    "parse_matrix",
+    "validate_certificate",
+]

--- a/src/jacobian_checkers/simplicial_topology.py
+++ b/src/jacobian_checkers/simplicial_topology.py
@@ -9,11 +9,22 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from collections.abc import Callable, Sequence
 from itertools import combinations
 from typing import Any
 
 from jacobian_checkers.bound_artifacts import bound_request as _bound_request
+from jacobian_checkers.certified_snf import (
+    ParsedMatrix,
+    ParsedSmithCertificate,
+)
+from jacobian_checkers.certified_snf import (
+    parse_matrix as _parse_integer_matrix,
+)
+from jacobian_checkers.certified_snf import (
+    validate_certificate as _validate_smith_certificate,
+)
 
 _MAX_VERTICES = 64
 _MAX_FACETS = 128
@@ -22,6 +33,11 @@ _MAX_FACES = 2048
 _MAX_CHAIN_GROUP = 512
 _MAX_MATRIX_CELLS = 131_072
 _MAX_PRIME = 251
+_MAX_INTEGRAL_CHAIN_GROUP = 16
+_MAX_INTEGRAL_TOTAL_CHAIN_RANK = 32
+_MAX_INTEGRAL_MATRIX_CELLS = 256
+_MAX_INTEGER_DIGITS = 256
+_INTEGER = re.compile(r"^(?:0|-?[1-9][0-9]*)$")
 _LABEL_CHARACTERS = frozenset(
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.:-"
 )
@@ -500,6 +516,93 @@ def _vectors(
     return vectors
 
 
+def _integer(value: object) -> int:
+    if (
+        not isinstance(value, str)
+        or _INTEGER.fullmatch(value) is None
+        or len(value.lstrip("-")) > _MAX_INTEGER_DIGITS
+    ):
+        raise ValueError("integral homology coefficient is noncanonical")
+    return int(value)
+
+
+def _integer_vector(value: object, *, length: int) -> list[int]:
+    if not isinstance(value, dict) or set(value) != {"coefficients"}:
+        raise ValueError("integral homology vector is malformed")
+    coefficients = value["coefficients"]
+    if not isinstance(coefficients, list) or len(coefficients) != length:
+        raise ValueError("integral homology vector has the wrong coordinate length")
+    return [_integer(coefficient) for coefficient in coefficients]
+
+
+def _parsed_matrix(
+    entries: list[list[int]], *, rows: int, columns: int
+) -> ParsedMatrix:
+    if len(entries) != rows or any(len(row) != columns for row in entries):
+        raise ValueError("reconstructed integer matrix has the wrong shape")
+    return ParsedMatrix(rows=rows, columns=columns, entries=entries)
+
+
+def _integer_matvec(matrix: ParsedMatrix, vector: Sequence[int]) -> list[int]:
+    if matrix.columns != len(vector):
+        raise ValueError("integer matrix and vector are not composable")
+    return [
+        sum(
+            matrix.entries[row][column] * vector[column]
+            for column in range(matrix.columns)
+        )
+        for row in range(matrix.rows)
+    ]
+
+
+def _integer_matmul(left: ParsedMatrix, right: ParsedMatrix) -> ParsedMatrix:
+    if left.columns != right.rows:
+        raise ValueError("integer matrices are not composable")
+    return ParsedMatrix(
+        rows=left.rows,
+        columns=right.columns,
+        entries=[
+            [
+                sum(
+                    left.entries[row][middle] * right.entries[middle][column]
+                    for middle in range(left.columns)
+                )
+                for column in range(right.columns)
+            ]
+            for row in range(left.rows)
+        ],
+    )
+
+
+def _matrix_tail_columns(matrix: ParsedMatrix, *, start: int) -> ParsedMatrix:
+    return ParsedMatrix(
+        rows=matrix.rows,
+        columns=matrix.columns - start,
+        entries=[row[start:] for row in matrix.entries],
+    )
+
+
+def _certificate_within_integral_digit_budget(
+    certificate: ParsedSmithCertificate,
+) -> bool:
+    matrices = (
+        certificate.source,
+        certificate.diagonal,
+        certificate.left,
+        certificate.right,
+    )
+    return all(
+        len(str(abs(value))) <= _MAX_INTEGER_DIGITS
+        for matrix in matrices
+        for row in matrix.entries
+        for value in row
+    )
+
+
+def _unit_vector(length: int, index: int) -> list[int]:
+    return [1 if position == index else 0 for position in range(length)]
+
+
 def _replay_materialization(source: dict[str, Any], result: dict[str, Any]) -> bool:
     expected_complex = _complex_from_request(source)
     return result == {
@@ -673,6 +776,219 @@ def _replay_homology(source: dict[str, Any], result: dict[str, Any]) -> bool:
     return True
 
 
+def _replay_integral_homology(
+    source: dict[str, Any],
+    result: dict[str, Any],
+) -> bool:
+    if set(source) != {"complex", "convention"}:
+        return False
+    complex_ = _parse_complex(source["complex"])
+    _require_linear_bounds(complex_)
+    if (
+        any(size > _MAX_INTEGRAL_CHAIN_GROUP for size in complex_["f_vector"])
+        or sum(complex_["f_vector"]) > _MAX_INTEGRAL_TOTAL_CHAIN_RANK
+        or any(
+            rows * columns > _MAX_INTEGRAL_MATRIX_CELLS
+            for rows, columns in zip(
+                (0, *complex_["f_vector"][:-1]),
+                complex_["f_vector"],
+                strict=True,
+            )
+        )
+    ):
+        return False
+    convention = source["convention"]
+    if convention not in {"REDUCED", "UNREDUCED"}:
+        return False
+    result_fields = {
+        *_META,
+        "complex_digest",
+        "coefficient_ring",
+        "convention",
+        "orientation_convention",
+        "dimension_range",
+        "groups",
+        "completeness",
+        "decomposition",
+    }
+    if (
+        set(result) != result_fields
+        or any(result[key] != value for key, value in _META.items())
+        or result["complex_digest"] != complex_["complex_digest"]
+        or result["coefficient_ring"] != "ZZ"
+        or result["convention"] != convention
+        or result["orientation_convention"] != "LEXICOGRAPHIC_VERTEX_ORDER"
+        or result["dimension_range"] != [0, complex_["dimension"]]
+        or result["completeness"] != "FREE_TORSION_AND_BOUND_GENERATORS"
+        or result["decomposition"] != "DIRECT_SUM_Z_AND_FINITE_CYCLIC_FACTORS"
+        or not isinstance(result["groups"], list)
+        or len(result["groups"]) != complex_["dimension"] + 1
+    ):
+        return False
+    raw_boundaries = [
+        _boundary(complex_, dimension, ring="INTEGER", prime=None)
+        for dimension in range(complex_["dimension"] + 1)
+    ]
+    boundaries = [_dense(matrix, prime=None) for matrix in raw_boundaries]
+    augmentation_raw = _augmentation(len(complex_["vertices"]))
+    augmentation = _dense(augmentation_raw, prime=None)
+    group_fields = {
+        "dimension",
+        "chain_dimension",
+        "incoming_chain_dimension",
+        "outgoing_boundary_rank",
+        "cycle_rank",
+        "incoming_boundary_rank",
+        "betti_number",
+        "torsion_coefficients",
+        "free_generators",
+        "torsion_generators",
+        "outgoing_smith_certificate",
+        "boundary_in_cycle_coordinates",
+        "incoming_smith_certificate",
+        "generator_basis",
+    }
+    for dimension, group in enumerate(result["groups"]):
+        if not isinstance(group, dict) or set(group) != group_fields:
+            return False
+        chain_dimension = complex_["f_vector"][dimension]
+        if dimension == 0 and convention == "REDUCED":
+            outgoing_entries = augmentation
+            outgoing_rows = 1
+        else:
+            outgoing_entries = boundaries[dimension]
+            outgoing_rows = raw_boundaries[dimension]["rows"]
+        outgoing = _parsed_matrix(
+            outgoing_entries,
+            rows=outgoing_rows,
+            columns=chain_dimension,
+        )
+        outgoing_certificate = _validate_smith_certificate(
+            group["outgoing_smith_certificate"]
+        )
+        if (
+            not _certificate_within_integral_digit_budget(outgoing_certificate)
+            or outgoing_certificate.source != outgoing
+        ):
+            return False
+        outgoing_rank = outgoing_certificate.rank
+        cycle_rank = chain_dimension - outgoing_rank
+        cycle_basis = _matrix_tail_columns(
+            outgoing_certificate.right,
+            start=outgoing_rank,
+        )
+        if dimension < complex_["dimension"]:
+            incoming_entries = boundaries[dimension + 1]
+            incoming_chain_dimension = complex_["f_vector"][dimension + 1]
+        else:
+            incoming_chain_dimension = 0
+            incoming_entries = [[] for _ in range(chain_dimension)]
+        incoming = _parsed_matrix(
+            incoming_entries,
+            rows=chain_dimension,
+            columns=incoming_chain_dimension,
+        )
+        coordinates = _parse_integer_matrix(
+            group["boundary_in_cycle_coordinates"],
+            maximum_digits=_MAX_INTEGER_DIGITS,
+        )
+        if (
+            coordinates.rows != cycle_rank
+            or coordinates.columns != incoming_chain_dimension
+            or _integer_matmul(cycle_basis, coordinates) != incoming
+        ):
+            return False
+        incoming_certificate = _validate_smith_certificate(
+            group["incoming_smith_certificate"]
+        )
+        if (
+            not _certificate_within_integral_digit_budget(incoming_certificate)
+            or incoming_certificate.source != coordinates
+        ):
+            return False
+        incoming_rank = incoming_certificate.rank
+        betti_number = cycle_rank - incoming_rank
+        torsion_positions = [
+            (index, factor)
+            for index, factor in enumerate(incoming_certificate.factors)
+            if factor > 1
+        ]
+        if (
+            group["dimension"] != dimension
+            or group["chain_dimension"] != chain_dimension
+            or group["incoming_chain_dimension"] != incoming_chain_dimension
+            or group["outgoing_boundary_rank"] != outgoing_rank
+            or group["cycle_rank"] != cycle_rank
+            or group["incoming_boundary_rank"] != incoming_rank
+            or group["betti_number"] != betti_number
+            or group["torsion_coefficients"]
+            != [str(factor) for _, factor in torsion_positions]
+            or group["generator_basis"]
+            != "CANONICAL_SIMPLEX_BASIS_VIA_CERTIFIED_SMITH_TRANSFORMATIONS"
+            or not isinstance(group["free_generators"], list)
+            or len(group["free_generators"]) != betti_number
+            or not isinstance(group["torsion_generators"], list)
+            or len(group["torsion_generators"]) != len(torsion_positions)
+        ):
+            return False
+        for offset, item in enumerate(group["free_generators"]):
+            if not isinstance(item, dict) or set(item) != {
+                "cycle",
+                "cycle_coordinates",
+            }:
+                return False
+            coordinate = _integer_vector(
+                item["cycle_coordinates"],
+                length=cycle_rank,
+            )
+            cycle = _integer_vector(item["cycle"], length=chain_dimension)
+            smith_index = incoming_rank + offset
+            if (
+                _integer_matvec(incoming_certificate.left, coordinate)
+                != _unit_vector(cycle_rank, smith_index)
+                or _integer_matvec(cycle_basis, coordinate) != cycle
+                or any(_integer_matvec(outgoing, cycle))
+            ):
+                return False
+        for item, (smith_index, factor) in zip(
+            group["torsion_generators"],
+            torsion_positions,
+            strict=True,
+        ):
+            if not isinstance(item, dict) or set(item) != {
+                "order",
+                "cycle",
+                "cycle_coordinates",
+                "bounding_chain",
+            }:
+                return False
+            coordinate = _integer_vector(
+                item["cycle_coordinates"],
+                length=cycle_rank,
+            )
+            cycle = _integer_vector(item["cycle"], length=chain_dimension)
+            bounding = _integer_vector(
+                item["bounding_chain"],
+                length=incoming_chain_dimension,
+            )
+            expected_bounding = [
+                incoming_certificate.right.entries[row][smith_index]
+                for row in range(incoming_chain_dimension)
+            ]
+            if (
+                item["order"] != str(factor)
+                or _integer_matvec(incoming_certificate.left, coordinate)
+                != _unit_vector(cycle_rank, smith_index)
+                or _integer_matvec(cycle_basis, coordinate) != cycle
+                or any(_integer_matvec(outgoing, cycle))
+                or bounding != expected_bounding
+                or _integer_matvec(incoming, bounding)
+                != [factor * value for value in cycle]
+            ):
+                return False
+    return True
+
+
 def _run(
     request: object,
     *,
@@ -720,7 +1036,17 @@ def check_simplicial_homology(request: object) -> dict[str, Any]:
     )
 
 
+def check_integral_simplicial_homology(request: object) -> dict[str, Any]:
+    return _run(
+        request,
+        operation_id="topology.simplicial_homology.integral.compute",
+        witness_format="topology.simplicial-homology.integral-smith-certificate-v1",
+        replay=_replay_integral_homology,
+    )
+
+
 __all__ = [
+    "check_integral_simplicial_homology",
     "check_simplicial_chain_complex",
     "check_simplicial_complex_materialization",
     "check_simplicial_homology",

--- a/tests/component/checkers/test_simplicial_topology_checker.py
+++ b/tests/component/checkers/test_simplicial_topology_checker.py
@@ -14,15 +14,18 @@ from jacobian.contracts.topology import (
     ChainCoefficientRing,
     ChainComplexRequest,
     HomologyConvention,
+    IntegralSimplicialHomologyRequest,
     SimplicialComplexRequest,
     SimplicialHomologyRequest,
 )
 from jacobian.domains.topology.operations import (
     _chain_result,
     _homology,
+    _integral_homology,
     _materialize,
 )
 from jacobian_checkers.simplicial_topology import (
+    check_integral_simplicial_homology,
     check_simplicial_chain_complex,
     check_simplicial_complex_materialization,
     check_simplicial_homology,
@@ -125,6 +128,10 @@ _REDUCED_HOMOLOGY_REQUEST = SimplicialHomologyRequest(
     prime=3,
     convention=HomologyConvention.REDUCED,
 )
+_INTEGRAL_HOMOLOGY_REQUEST = IntegralSimplicialHomologyRequest(
+    complex=_COMPLEX,
+    convention=HomologyConvention.UNREDUCED,
+)
 _HOMOLOGY_CASE = _request(
     "topology.simplicial_homology.compute",
     "topology.simplicial-homology.modular-replay",
@@ -175,6 +182,17 @@ _CASES: tuple[
             _homology(_REDUCED_HOMOLOGY_REQUEST).value.model_dump(mode="json"),
         ),
     ),
+    (
+        check_integral_simplicial_homology,
+        _request(
+            "topology.simplicial_homology.integral.compute",
+            "topology.simplicial-homology.integral-smith-certificate-v1",
+            _INTEGRAL_HOMOLOGY_REQUEST.model_dump(mode="json"),
+            _integral_homology(_INTEGRAL_HOMOLOGY_REQUEST).value.model_dump(
+                mode="json"
+            ),
+        ),
+    ),
 )
 
 
@@ -218,6 +236,26 @@ def test_homology_checker_rejects_a_noncycle_representative() -> None:
     candidate["payload_digest"] = _digest(candidate["payload"])
 
     checked = check_simplicial_homology(forged)
+
+    assert checked["accepted"] is False
+    assert checked["conclusion"] == "UNKNOWN"
+
+
+def test_integral_homology_checker_rejects_a_forged_unimodular_transform() -> None:
+    case = next(
+        request
+        for checker, request in _CASES
+        if checker is check_integral_simplicial_homology
+    )
+    forged = copy.deepcopy(case)
+    candidate = forged["candidate"]
+    transformation = candidate["payload"]["groups"][1]["outgoing_smith_certificate"][
+        "right_transformation"
+    ]["entries"]
+    transformation[0][0] = str(int(transformation[0][0]) + 1)
+    candidate["payload_digest"] = _digest(candidate["payload"])
+
+    checked = check_integral_simplicial_homology(forged)
 
     assert checked["accepted"] is False
     assert checked["conclusion"] == "UNKNOWN"

--- a/tests/composition/runtime/exact_verification/test_certified_snf_integral_homology_public_reproductions.py
+++ b/tests/composition/runtime/exact_verification/test_certified_snf_integral_homology_public_reproductions.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from jacobian.contracts.capabilities import (
+    CapabilityAssuranceLevel,
+    CapabilityMode,
+    CapabilityRequest,
+)
+from jacobian.contracts.results import ExecutionStatus
+
+PROJECT_ROOT = Path(__file__).resolve().parents[4]
+REPRODUCTIONS = (
+    PROJECT_ROOT
+    / "benchmarks"
+    / "reproduction_cases"
+    / "certified_snf_integral_homology_public.json"
+)
+
+
+def _suite() -> dict[str, Any]:
+    suite = json.loads(REPRODUCTIONS.read_text(encoding="utf-8"))
+    assert suite["scored"] is False
+    assert suite["held_out_evaluation"]["status"] == "READY_NOT_RUN"
+    return suite
+
+
+def test_public_certified_smith_cases_reach_checker_bound_results(
+    authorized_complete_runtime,
+) -> None:
+    for case in _suite()["smith_cases"]:
+        computed = authorized_complete_runtime.core.capabilities.invoke(
+            CapabilityRequest(
+                capability_id="matrix.normal_form.smith.certified.compute",
+                input={"matrix": case["matrix"]},
+            )
+        )
+        certificate = computed.output["result"]["certificate"]
+        assert certificate["rank"] == case["expected_rank"]
+        assert certificate["invariant_factors"] == case["expected_invariant_factors"]
+        assert computed.assurance.level is CapabilityAssuranceLevel.COMPUTED
+
+        verified = authorized_complete_runtime.core.capabilities.invoke(
+            CapabilityRequest(
+                capability_id="matrix.normal_form.smith.certified.verify",
+                mode=CapabilityMode.VERIFY,
+                input={"result_uri": computed.output["result_uri"]},
+            )
+        )
+        assert verified.execution.status is ExecutionStatus.COMPLETED
+        assert verified.output["status"] == "VERIFIED"
+        assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED
+
+
+def test_public_integral_homology_cases_bind_generators_and_torsion(
+    authorized_complete_runtime,
+) -> None:
+    for case in _suite()["homology_cases"]:
+        materialized = authorized_complete_runtime.core.capabilities.invoke(
+            CapabilityRequest(
+                capability_id="topology.simplicial_complex.materialize",
+                input=case["presentation"],
+            )
+        )
+        computed = authorized_complete_runtime.core.capabilities.invoke(
+            CapabilityRequest(
+                capability_id="topology.simplicial_homology.integral.compute",
+                input={
+                    "complex": materialized.output["result"]["complex"],
+                    "convention": case["convention"],
+                },
+            )
+        )
+        groups = computed.output["result"]["groups"]
+        assert [group["betti_number"] for group in groups] == (
+            case["expected_free_ranks"]
+        )
+        assert [group["torsion_coefficients"] for group in groups] == (
+            case["expected_torsion"]
+        )
+        assert computed.assurance.level is CapabilityAssuranceLevel.COMPUTED
+
+        verified = authorized_complete_runtime.core.capabilities.invoke(
+            CapabilityRequest(
+                capability_id="topology.simplicial_homology.integral.verify",
+                mode=CapabilityMode.VERIFY,
+                input={"result_uri": computed.output["result_uri"]},
+            )
+        )
+        assert verified.execution.status is ExecutionStatus.COMPLETED
+        assert verified.output["status"] == "VERIFIED"
+        assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED

--- a/tests/composition/runtime/exact_verification/test_certified_snf_verification.py
+++ b/tests/composition/runtime/exact_verification/test_certified_snf_verification.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from jacobian.contracts.capabilities import (
+    CapabilityAssuranceLevel,
+    CapabilityMode,
+    CapabilityRequest,
+)
+from jacobian.contracts.results import ExecutionStatus
+
+
+def _compute(authorized_complete_runtime):
+    return authorized_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="matrix.normal_form.smith.certified.compute",
+            input={
+                "matrix": {
+                    "row_count": 2,
+                    "column_count": 3,
+                    "entries": [["2", "4", "4"], ["6", "6", "12"]],
+                }
+            },
+        )
+    )
+
+
+def test_certified_smith_result_is_independently_verified(
+    authorized_complete_runtime,
+) -> None:
+    computed = _compute(authorized_complete_runtime)
+    verified = authorized_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="matrix.normal_form.smith.certified.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"result_uri": computed.output["result_uri"]},
+        )
+    )
+
+    assert computed.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert verified.execution.status is ExecutionStatus.COMPLETED
+    assert verified.output["status"] == "VERIFIED"
+    assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED
+    assert verified.output["verification_record_uri"] in verified.artifact_uris
+
+
+def test_certified_smith_checker_rejects_a_forged_relation(
+    authorized_complete_runtime,
+) -> None:
+    computed = _compute(authorized_complete_runtime)
+    artifact = authorized_complete_runtime.core.store.get(computed.output["result_uri"])
+    payload = dict(artifact.payload)
+    certificate = dict(payload["certificate"])
+    left = dict(certificate["left_transformation"])
+    entries = [list(row) for row in left["entries"]]
+    entries[0][0] = str(int(entries[0][0]) + 1)
+    left["entries"] = entries
+    certificate["left_transformation"] = left
+    payload["certificate"] = certificate
+    forged = authorized_complete_runtime.core.artifacts.put(
+        schema_uri=artifact.manifest.schema_uri,
+        semantics_uri=artifact.manifest.semantics_uri,
+        parents=artifact.manifest.parents,
+        payload=payload,
+        summary="adversarial rebound Smith transformation",
+    )
+
+    rejected = authorized_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="matrix.normal_form.smith.certified.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"result_uri": forged.artifact_uri},
+        )
+    )
+
+    assert rejected.execution.status is ExecutionStatus.COMPLETED
+    assert rejected.output["status"] == "REJECTED"
+    assert rejected.output["conclusion"] == "UNKNOWN"
+    assert rejected.output["verification_record_uri"] is None
+    assert rejected.assurance.level is CapabilityAssuranceLevel.COMPUTED

--- a/tests/composition/runtime/test_topology_capabilities.py
+++ b/tests/composition/runtime/test_topology_capabilities.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import pytest
 
+from jacobian.canonical import canonicalize_json
 from jacobian.contracts.capabilities import (
     CapabilityAssuranceLevel,
     CapabilityDiscoveryRequest,
@@ -69,7 +70,7 @@ def _betti(
     return tuple(group["betti_number"] for group in result.output["result"]["groups"])
 
 
-def test_topology_bundle_exposes_three_atomic_capabilities(
+def test_topology_bundle_exposes_four_atomic_capabilities(
     fresh_complete_runtime,
 ) -> None:
     ids = tuple(operation.capability_id for operation in TOPOLOGY_BUNDLE.capabilities)
@@ -78,6 +79,7 @@ def test_topology_bundle_exposes_three_atomic_capabilities(
         "topology.simplicial_complex.materialize",
         "topology.simplicial_complex.chain_complex.compute",
         "topology.simplicial_homology.compute",
+        "topology.simplicial_homology.integral.compute",
     )
     assert "topology" in fresh_complete_runtime.portfolio.domain_bundles
     catalog_ids = {
@@ -281,6 +283,89 @@ def test_torus_and_projective_plane_distinguish_coefficient_fields(
     assert _betti(fresh_complete_runtime, torus, prime=3) == (1, 2, 1)
     assert _betti(fresh_complete_runtime, projective_plane, prime=2) == (1, 1, 1)
     assert _betti(fresh_complete_runtime, projective_plane, prime=3) == (1, 0, 0)
+
+
+def test_integral_homology_exposes_free_and_torsion_generators(
+    fresh_complete_runtime,
+) -> None:
+    circle = _materialize(fresh_complete_runtime, _CIRCLE)
+    projective_plane = _materialize(
+        fresh_complete_runtime,
+        {
+            "vertices": [str(index) for index in range(6)],
+            "facets": _PROJECTIVE_PLANE_FACETS,
+        },
+    )
+
+    circle_result = fresh_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="topology.simplicial_homology.integral.compute",
+            input={"complex": circle, "convention": "UNREDUCED"},
+        )
+    )
+    projective_result = fresh_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="topology.simplicial_homology.integral.compute",
+            input={"complex": projective_plane, "convention": "UNREDUCED"},
+        )
+    )
+
+    assert circle_result.execution.status is ExecutionStatus.COMPLETED
+    assert circle_result.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    circle_groups = circle_result.output["result"]["groups"]
+    assert [group["betti_number"] for group in circle_groups] == [1, 1]
+    assert [group["torsion_coefficients"] for group in circle_groups] == [[], []]
+    assert all(
+        group["generator_basis"]
+        == "CANONICAL_SIMPLEX_BASIS_VIA_CERTIFIED_SMITH_TRANSFORMATIONS"
+        for group in circle_groups
+    )
+
+    assert projective_result.execution.status is ExecutionStatus.COMPLETED
+    projective_groups = projective_result.output["result"]["groups"]
+    assert [group["betti_number"] for group in projective_groups] == [1, 0, 0]
+    assert [group["torsion_coefficients"] for group in projective_groups] == [
+        [],
+        ["2"],
+        [],
+    ]
+    torsion = projective_groups[1]["torsion_generators"][0]
+    assert torsion["order"] == "2"
+    assert len(torsion["cycle"]["coefficients"]) == projective_plane["f_vector"][1]
+    assert (
+        len(torsion["bounding_chain"]["coefficients"])
+        == (projective_plane["f_vector"][2])
+    )
+    artifacts = [
+        fresh_complete_runtime.core.store.get(uri)
+        for uri in projective_result.artifact_uris
+    ]
+    sizes = [len(canonicalize_json(artifact.payload)) for artifact in artifacts]
+    assert all(size < 10 * 1024 * 1024 for size in sizes)
+    assert sum(sizes) < 8 * 1024 * 1024
+
+
+def test_reduced_integral_homology_uses_the_augmentation_kernel(
+    fresh_complete_runtime,
+) -> None:
+    points = _materialize(
+        fresh_complete_runtime,
+        {
+            "vertices": ["a", "b", "c"],
+            "facets": [["a"], ["b"], ["c"]],
+        },
+    )
+    result = fresh_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="topology.simplicial_homology.integral.compute",
+            input={"complex": points, "convention": "REDUCED"},
+        )
+    )
+
+    group = result.output["result"]["groups"][0]
+    assert group["outgoing_boundary_rank"] == 1
+    assert group["betti_number"] == 2
+    assert len(group["free_generators"]) == 2
 
 
 def test_reduced_homology_and_disjoint_union_are_explicit(

--- a/tests/composition/runtime/test_topology_verification.py
+++ b/tests/composition/runtime/test_topology_verification.py
@@ -110,6 +110,82 @@ def test_topology_checker_rejects_forged_cycle_evidence(
     assert rejected.assurance.level is CapabilityAssuranceLevel.COMPUTED
 
 
+def test_integral_homology_has_a_dedicated_independent_verifier(
+    authorized_complete_runtime,
+) -> None:
+    materialized = _computed_results(authorized_complete_runtime)[0]
+    computed = authorized_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="topology.simplicial_homology.integral.compute",
+            input={
+                "complex": materialized.output["result"]["complex"],
+                "convention": "UNREDUCED",
+            },
+        )
+    )
+    verified = authorized_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="topology.simplicial_homology.integral.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"result_uri": computed.output["result_uri"]},
+        )
+    )
+
+    assert computed.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert verified.execution.status is ExecutionStatus.COMPLETED
+    assert verified.output["status"] == "VERIFIED"
+    assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED
+    assert verified.output["verification_record_uri"] in verified.artifact_uris
+
+
+def test_integral_homology_checker_rejects_a_forged_free_generator(
+    authorized_complete_runtime,
+) -> None:
+    materialized = _computed_results(authorized_complete_runtime)[0]
+    computed = authorized_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="topology.simplicial_homology.integral.compute",
+            input={
+                "complex": materialized.output["result"]["complex"],
+                "convention": "UNREDUCED",
+            },
+        )
+    )
+    artifact = authorized_complete_runtime.core.store.get(computed.output["result_uri"])
+    payload = dict(artifact.payload)
+    groups = [dict(group) for group in payload["groups"]]
+    group = dict(groups[1])
+    generators = [dict(item) for item in group["free_generators"]]
+    cycle = dict(generators[0]["cycle"])
+    coefficients = list(cycle["coefficients"])
+    coefficients[0] = str(int(coefficients[0]) + 1)
+    cycle["coefficients"] = coefficients
+    generators[0]["cycle"] = cycle
+    group["free_generators"] = generators
+    groups[1] = group
+    payload["groups"] = groups
+    forged = authorized_complete_runtime.core.artifacts.put(
+        schema_uri=artifact.manifest.schema_uri,
+        semantics_uri=artifact.manifest.semantics_uri,
+        parents=artifact.manifest.parents,
+        payload=payload,
+        summary="adversarial integral-homology free generator",
+    )
+    rejected = authorized_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="topology.simplicial_homology.integral.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"result_uri": forged.artifact_uri},
+        )
+    )
+
+    assert rejected.execution.status is ExecutionStatus.COMPLETED
+    assert rejected.output["status"] == "REJECTED"
+    assert rejected.output["conclusion"] == "UNKNOWN"
+    assert rejected.output["verification_record_uri"] is None
+    assert rejected.assurance.level is CapabilityAssuranceLevel.COMPUTED
+
+
 def test_topology_checker_runtime_binds_only_independent_source(
     authorized_complete_runtime,
 ) -> None:

--- a/tests/domain/matrix/test_certified_snf.py
+++ b/tests/domain/matrix/test_certified_snf.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from itertools import combinations
+from math import gcd
+from pathlib import Path
+from random import Random
+
+import pytest
+from tests.support.services import DomainTestServices, open_domain_services
+
+from jacobian.canonical import canonicalize_json
+from jacobian.contracts.capabilities import (
+    CapabilityAssuranceLevel,
+    CapabilityRequest,
+)
+from jacobian.contracts.results import ExecutionStatus
+from jacobian.domains._certified_snf import smith_reduce
+from jacobian.domains.certified_snf import CERTIFIED_SNF_BUNDLE
+
+
+@pytest.fixture
+def domain_services(tmp_path: Path) -> Iterator[DomainTestServices]:
+    with open_domain_services(
+        tmp_path / "state",
+        CERTIFIED_SNF_BUNDLE,
+    ) as services:
+        yield services
+
+
+def _minor_determinant(matrix: list[list[int]]) -> int:
+    size = len(matrix)
+    if size == 0:
+        return 1
+    work = [row[:] for row in matrix]
+    sign = 1
+    previous = 1
+    for pivot_index in range(size - 1):
+        selected = next(
+            (row for row in range(pivot_index, size) if work[row][pivot_index] != 0),
+            None,
+        )
+        if selected is None:
+            return 0
+        if selected != pivot_index:
+            work[pivot_index], work[selected] = work[selected], work[pivot_index]
+            sign = -sign
+        pivot = work[pivot_index][pivot_index]
+        for row in range(pivot_index + 1, size):
+            for column in range(pivot_index + 1, size):
+                work[row][column] = (
+                    work[row][column] * pivot
+                    - work[row][pivot_index] * work[pivot_index][column]
+                ) // previous
+        previous = pivot
+    return sign * work[-1][-1]
+
+
+def _invariant_factors_from_determinantal_divisors(
+    source: list[list[int]],
+) -> tuple[int, ...]:
+    rows = len(source)
+    columns = len(source[0])
+    previous_divisor = 1
+    factors: list[int] = []
+    for size in range(1, min(rows, columns) + 1):
+        divisor = 0
+        for selected_rows in combinations(range(rows), size):
+            for selected_columns in combinations(range(columns), size):
+                minor = [
+                    [source[row][column] for column in selected_columns]
+                    for row in selected_rows
+                ]
+                divisor = gcd(divisor, abs(_minor_determinant(minor)))
+        if divisor == 0:
+            break
+        factors.append(divisor // previous_divisor)
+        previous_divisor = divisor
+    return tuple(factors)
+
+
+def test_certified_smith_materializes_both_full_basis_changes(
+    domain_services: DomainTestServices,
+) -> None:
+    result = domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="matrix.normal_form.smith.certified.compute",
+            input={
+                "matrix": {
+                    "row_count": 2,
+                    "column_count": 2,
+                    "entries": [["2", "4"], ["6", "8"]],
+                }
+            },
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    certificate = result.output["result"]["certificate"]
+    assert certificate["diagonal"]["entries"] == [["2", "0"], ["0", "4"]]
+    assert certificate["invariant_factors"] == ["2", "4"]
+    assert certificate["relation"] == ("DIAGONAL_EQUALS_LEFT_TIMES_SOURCE_TIMES_RIGHT")
+    assert certificate["left_determinant"] in {"-1", "1"}
+    assert certificate["right_determinant"] in {"-1", "1"}
+    assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert len(result.artifact_uris) == 2
+
+
+def test_elementary_reduction_matches_determinantal_divisors() -> None:
+    random = Random(20260730)
+    for _ in range(500):
+        rows = random.randint(1, 6)
+        columns = random.randint(1, 6)
+        source = [
+            [random.randint(-20, 20) for _ in range(columns)] for _ in range(rows)
+        ]
+
+        reduction = smith_reduce(source)
+
+        assert reduction.invariant_factors == (
+            _invariant_factors_from_determinantal_divisors(source)
+        )
+
+
+def test_maximum_certified_smith_payload_stays_within_artifact_budget(
+    domain_services: DomainTestServices,
+) -> None:
+    factor = "1" + "0" * 31
+    result = domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="matrix.normal_form.smith.certified.compute",
+            input={
+                "matrix": {
+                    "row_count": 16,
+                    "column_count": 16,
+                    "entries": [
+                        [factor if row == column else "0" for column in range(16)]
+                        for row in range(16)
+                    ],
+                }
+            },
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    artifacts = [domain_services.core.store.get(uri) for uri in result.artifact_uris]
+    sizes = [len(canonicalize_json(artifact.payload)) for artifact in artifacts]
+    assert all(size < 10 * 1024 * 1024 for size in sizes)
+    assert sum(sizes) < 8 * 1024 * 1024

--- a/tests/unit/contracts/test_certified_snf_contracts.py
+++ b/tests/unit/contracts/test_certified_snf_contracts.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.contracts.certified_snf import (
+    CertifiedIntegerMatrix,
+    CertifiedSmithNormalFormRequest,
+    SmithNormalFormCertificate,
+)
+
+
+def _matrix(entries: list[list[int | str]]) -> dict[str, object]:
+    return {
+        "row_count": len(entries),
+        "column_count": len(entries[0]),
+        "entries": [[str(value) for value in row] for row in entries],
+    }
+
+
+def test_certified_smith_request_accepts_a_bounded_integer_rectangle() -> None:
+    request = CertifiedSmithNormalFormRequest.model_validate(
+        {"matrix": _matrix([[2, 4, 6], [8, 10, 12]])}
+    )
+
+    assert request.matrix.row_count == 2
+    assert request.matrix.column_count == 3
+
+
+def test_certified_smith_request_rejects_large_input_scalars() -> None:
+    with pytest.raises(ValidationError, match="at most 32 decimal digits"):
+        CertifiedSmithNormalFormRequest.model_validate(
+            {"matrix": _matrix([["1" * 33]])}
+        )
+
+
+def test_certificate_contract_requires_a_canonical_divisibility_diagonal() -> None:
+    source = CertifiedIntegerMatrix.model_validate(_matrix([[2, 0], [0, 6]]))
+    identity = CertifiedIntegerMatrix.model_validate(_matrix([[1, 0], [0, 1]]))
+
+    with pytest.raises(ValidationError, match="positive divisibility diagonal"):
+        SmithNormalFormCertificate(
+            source=source,
+            diagonal=source,
+            left_transformation=identity,
+            right_transformation=identity,
+            rank=2,
+            invariant_factors=("2", "3"),
+            left_determinant="1",
+            right_determinant="1",
+        )
+
+
+def test_zero_dimensional_matrices_remain_explicit_for_chain_boundaries() -> None:
+    matrix = CertifiedIntegerMatrix(
+        row_count=0,
+        column_count=3,
+        entries=(),
+    )
+
+    assert matrix.model_dump(mode="json")["entries"] == []
+    assert matrix.column_count == 3

--- a/tests/unit/contracts/test_topology_contracts.py
+++ b/tests/unit/contracts/test_topology_contracts.py
@@ -6,6 +6,7 @@ from pydantic import ValidationError
 from jacobian.contracts.topology import (
     ChainCoefficientRing,
     ChainComplexRequest,
+    IntegralSimplicialHomologyRequest,
     SimplicialComplexRequest,
     SimplicialHomologyRequest,
 )
@@ -63,3 +64,36 @@ def test_chain_bounds_are_checked_after_materialization_but_before_computation()
     assert complex_.closure_size == 8 * 255
     with pytest.raises(ValidationError, match="chain group"):
         SimplicialHomologyRequest(complex=complex_, prime=2)
+
+
+def test_integral_homology_has_tighter_certificate_size_bounds() -> None:
+    too_many_vertices = tuple(f"v{index}" for index in range(17))
+    vertex_complex = _materialized_complex(
+        too_many_vertices,
+        tuple((vertex,) for vertex in too_many_vertices),
+    )
+    with pytest.raises(ValidationError, match="at most 16 simplices"):
+        IntegralSimplicialHomologyRequest(complex=vertex_complex)
+
+    projective_plane_facets = (
+        ("0", "1", "2"),
+        ("0", "1", "3"),
+        ("0", "2", "4"),
+        ("0", "3", "5"),
+        ("0", "4", "5"),
+        ("1", "2", "5"),
+        ("1", "3", "4"),
+        ("1", "4", "5"),
+        ("2", "3", "4"),
+        ("2", "3", "5"),
+        ("6",),
+        ("7",),
+    )
+    total_rank_too_large = _materialized_complex(
+        tuple(str(index) for index in range(8)),
+        projective_plane_facets,
+    )
+    assert max(total_rank_too_large.f_vector) <= 16
+    assert sum(total_rank_too_large.f_vector) == 33
+    with pytest.raises(ValidationError, match="total chain rank at most 32"):
+        IntegralSimplicialHomologyRequest(complex=total_rank_too_large)


### PR DESCRIPTION
## Problem

The existing Smith-normal-form outcome exposes only the diagonal, so agents cannot inspect or independently verify the basis changes needed for integral homology generators and torsion bounds. The topology bundle currently stops at prime-field homology.

## Result

- adds an atomic `matrix.normal_form.smith.certified.compute` outcome with explicit unimodular `U` and `V` satisfying `D = U A V`
- adds a dedicated clean-process verifier that independently checks both transformations, Bareiss determinants, and the canonical divisibility diagonal
- adds bounded integral simplicial homology with free/torsion decomposition, simplex-basis generators, torsion bounding chains, and two embedded Smith certificates per dimension
- adds a dedicated integral-homology verifier that reconstructs every boundary and checks kernel coordinates, quotient decomposition, generators, and bounding equations
- preserves the existing diagonal-only Smith capability, prime-field homology, and generic topology verifier unchanged
- adds answer-visible public reproductions and leaves the held-out comparison explicitly `READY_NOT_RUN`

## Bounds and compatibility

Standalone certified Smith input is at most 16 by 16 with 32 input digits. Integral homology is limited to 16 simplices per chain group, total chain rank 32, 256 boundary cells, and 256 output digits. Producers remain capped at `COMPUTED`; only operator-authorized replay can return `VERIFIED`. No new optional dependency or compatibility replacement is introduced.

## Handoff snapshot

- base tree: `ac790a141fd3a60d0353e49781f3c62c146e75fd`
- implementation head: `6170f24288d4d5b255cfd6c9503cb313c5b3bbc1`
- installed catalog: 290 capabilities, digest `sha256:5a21676a34334ccdd509ea0c4844a615639477dcecbad4aeb068d907fc2d504d`
- DEFAULT policy: `sha256:870a92b83d3e522e4015b6bb1cabda33086906f9de1c3c36e466251ea7ed1957`
- certified-SNF producer source digest: `sha256:d74f44dc1573eaca6bcd2fb0d77d25b674daeb0de1325714d8f01ba446cf98e1`
- certified-SNF checker composite digest: `sha256:58e614eafdef89be225e44aaae2a08f7b5403f8b49d0ce7e5d8ef1d22fcfa63b`
- topology checker composite digest: `sha256:698b485e72f08957817d469ebff1e0d99e89846581785d4f6d1f94f614c9f3f8`
- model, prompt, scorer, raw model trace: not applicable; held-out model evaluation was not run
- open obligation: run the frozen held-out baseline/treatment study before making portfolio-value claims
- next action: retain the bounded family and use new runtime/artifact evidence before expanding its scope

## Validation

`make test-affected BASE=origin/main` selected the full suite. Functional lanes produced 1,874 passed and 42 declared optional-runtime skips: unit 298, component 547, domain 160, composition 438/4 skipped, storage 90, process 139, MCP 21, provider 143/7 skipped, e2e 7/1 skipped, and Lean 31/30 skipped. The final tree also passes:

- `make check`
- `make check-static`
- `make test-domain`
- `make build`
- `make security-audit`
- `make duplicate-code`
- `make docs-linkcheck`
- `git diff --check`

The npm JavaScript suite passes 14/14. `npm pack --dry-run --prefix npm` fails under npm 10.8.2 because it reads the repository-root `package.json`; the identical failure was reproduced in a clean worktree at the base tree above, so it is not introduced by this PR.