### PR TITLE
feat(benchmarks): add Regina outcome provider spike

### DIFF
--- a/benchmarks/regina_outcomes_pin.json
+++ b/benchmarks/regina_outcomes_pin.json
@@ -1,0 +1,70 @@
+{
+  "adapter_source_sha256": "sha256:5fbf704064e24ce68805699f20758b360a936c4483ca3a0c547b15423c958032",
+  "contract": "jacobian.regina-outcomes-spike/v1",
+  "distribution_version": "7.4.1",
+  "documentation_url": "https://regina-normal.github.io/engine-docs/",
+  "engine_version": "7.4",
+  "licensing_url": "https://regina-normal.github.io/engine-docs/#copying",
+  "provider": "regina",
+  "reproduction": {
+    "cases": [
+      {
+        "case_id": "three_sphere",
+        "iso_sig": "cPcbbbaaa",
+        "maximum_tetrahedra": 2
+      },
+      {
+        "case_id": "lens_l2_1",
+        "iso_sig": "cMcabbgqw",
+        "maximum_tetrahedra": 2
+      },
+      {
+        "case_id": "s2_cross_s1",
+        "iso_sig": "cMcabbjaj",
+        "maximum_tetrahedra": 2
+      },
+      {
+        "case_id": "three_ball",
+        "iso_sig": "baa",
+        "maximum_tetrahedra": 1
+      }
+    ],
+    "expected_mathematical_output_sha256": "sha256:5937e30dcc04370a2d7201ada568f8fdaac46906d4234d75d580fc80a68cc2a8",
+    "expected_provider_output": {"cases":[{"canonical_iso_sig":"cPcbbbaaa","case_id":"three_sphere","closed":true,"connected":true,"f_vector":[4,6,4,2],"facet_gluings":[[{"facet":0,"permutation":[0,1,2,3],"tetrahedron":1},{"facet":1,"permutation":[0,1,2,3],"tetrahedron":1},{"facet":2,"permutation":[0,1,2,3],"tetrahedron":1},{"facet":3,"permutation":[0,1,2,3],"tetrahedron":1}],[{"facet":0,"permutation":[0,1,2,3],"tetrahedron":0},{"facet":1,"permutation":[0,1,2,3],"tetrahedron":0},{"facet":2,"permutation":[0,1,2,3],"tetrahedron":0},{"facet":3,"permutation":[0,1,2,3],"tetrahedron":0}]],"homology_1":{"free_rank":0,"torsion_invariant_factors":[]},"input_iso_sig":"cPcbbbaaa","orientable":true,"recognition":{"is_three_ball":false,"is_three_sphere":true},"tetrahedra":2,"valid":true},{"canonical_iso_sig":"cMcabbgqw","case_id":"lens_l2_1","closed":true,"connected":true,"f_vector":[1,3,4,2],"facet_gluings":[[{"facet":1,"permutation":[1,0,2,3],"tetrahedron":0},{"facet":0,"permutation":[1,0,2,3],"tetrahedron":0},{"facet":2,"permutation":[0,1,2,3],"tetrahedron":1},{"facet":1,"permutation":[2,3,0,1],"tetrahedron":1}],[{"facet":3,"permutation":[3,2,0,1],"tetrahedron":1},{"facet":3,"permutation":[2,3,0,1],"tetrahedron":0},{"facet":2,"permutation":[0,1,2,3],"tetrahedron":0},{"facet":0,"permutation":[2,3,1,0],"tetrahedron":1}]],"homology_1":{"free_rank":0,"torsion_invariant_factors":["2"]},"input_iso_sig":"cMcabbgqw","orientable":true,"recognition":{"is_three_ball":false,"is_three_sphere":false},"tetrahedra":2,"valid":true},{"canonical_iso_sig":"cMcabbjaj","case_id":"s2_cross_s1","closed":true,"connected":true,"f_vector":[1,3,4,2],"facet_gluings":[[{"facet":1,"permutation":[1,2,3,0],"tetrahedron":0},{"facet":0,"permutation":[3,0,1,2],"tetrahedron":0},{"facet":2,"permutation":[0,1,2,3],"tetrahedron":1},{"facet":3,"permutation":[0,1,2,3],"tetrahedron":1}],[{"facet":1,"permutation":[1,2,3,0],"tetrahedron":1},{"facet":0,"permutation":[3,0,1,2],"tetrahedron":1},{"facet":2,"permutation":[0,1,2,3],"tetrahedron":0},{"facet":3,"permutation":[0,1,2,3],"tetrahedron":0}]],"homology_1":{"free_rank":1,"torsion_invariant_factors":[]},"input_iso_sig":"cMcabbjaj","orientable":true,"recognition":{"is_three_ball":false,"is_three_sphere":false},"tetrahedra":2,"valid":true},{"canonical_iso_sig":"baa","case_id":"three_ball","closed":false,"connected":true,"f_vector":[4,6,4,1],"facet_gluings":[[null,null,null,null]],"homology_1":{"free_rank":0,"torsion_invariant_factors":[]},"input_iso_sig":"baa","orientable":true,"recognition":{"is_three_ball":true,"is_three_sphere":false},"tetrahedra":1,"valid":true}],"contract":"jacobian.regina-outcomes-spike/v1","distribution_version":"7.4.1","normal_surfaces":{"coordinate_system":"STANDARD_7N","list_kind":"VERTEX_EMBEDDED_ONLY","observed_algorithm_flags":"0x0011","surface_count":4,"surfaces":[{"compact":true,"connected":true,"coordinates":["0","0","0","0","1","0","0","0","0","0","0","1","0","0"],"euler_characteristic":-1,"has_real_boundary":false,"orientable":false},{"compact":true,"connected":true,"coordinates":["0","0","1","1","0","0","0","0","0","0","0","1","0","0"],"euler_characteristic":1,"has_real_boundary":false,"orientable":false},{"compact":true,"connected":true,"coordinates":["1","1","0","0","1","0","0","1","1","1","1","0","0","0"],"euler_characteristic":0,"has_real_boundary":false,"orientable":true},{"compact":true,"connected":true,"coordinates":["1","1","1","1","0","0","0","1","1","1","1","0","0","0"],"euler_characteristic":2,"has_real_boundary":false,"orientable":true}],"triangulation_case_id":"lens_l2_1"},"provider":"regina"},
+    "normal_surface_case_id": "lens_l2_1",
+    "scope": "four answer-visible valid orientable 3-dimensional triangulations of at most two tetrahedra, plus standard-coordinate embedded vertex normal surfaces for L(2,1)"
+  },
+  "source": {
+    "archive_sha256": "sha256:74131014099b77083dd1d09004fd6bc972421c792d188cdf43f0fd11ca6cb2ed",
+    "download_url": "https://github.com/regina-normal/regina/releases/download/regina-7.4.1/regina-7.4.1.tar.gz",
+    "members": {
+      "core": {
+        "path": "regina-7.4.1/engine/regina-core.h",
+        "sha256": "sha256:0a2426e36fbe59aacf6632d3b0132a03fbf03a2111a234e2a5de7d632b10cfed"
+      },
+      "license": {
+        "path": "regina-7.4.1/LICENSE.txt",
+        "sha256": "sha256:5b57bb4d76ae689adfbb8edf6adf709b5cea589deebb9ac167c958b5c3283cc7"
+      },
+      "normal_surfaces": {
+        "path": "regina-7.4.1/engine/surface/normalsurfaces.h",
+        "sha256": "sha256:d5d1a0ea4dfc97b71baba5933fc529cb824bdf13731b6036cbdc0b18e878531c"
+      },
+      "triangulation": {
+        "path": "regina-7.4.1/engine/triangulation/dim3/triangulation3.h",
+        "sha256": "sha256:9e0081bfd19b454dbadb87f76acd8689dd28d5f721ff8d175410fe9aa88f753a"
+      }
+    },
+    "signed_checksums_url": "https://github.com/regina-normal/regina/releases/download/regina-7.4.1/SHA256SUMS-signed.txt"
+  },
+  "wheel": {
+    "download_url": "https://files.pythonhosted.org/packages/68/42/b4a994e393298c08c361342ee19bf240b7b16f155c492ce0631082c14e66/regina-7.4.1-cp312-cp312-manylinux_2_28_x86_64.whl",
+    "filename": "regina-7.4.1-cp312-cp312-manylinux_2_28_x86_64.whl",
+    "license_members": [],
+    "metadata_member": "regina-7.4.1.dist-info/METADATA",
+    "metadata_sha256": "sha256:e22af4f16a8a67c82831d02958999e2ae231015b2765dadb4af05a370be12a27",
+    "sha256": "sha256:d33ccc69697ec680a8dcf8f0c663428853da44f3578898ad9b908e4669e83c71",
+    "wheel_member": "regina-7.4.1.dist-info/WHEEL",
+    "wheel_sha256": "sha256:557bcd2a7ea715e08ce3918452b34b24e3bf27f7be70d269846b7dad6171c84d"
+  }
+}

--- a/benchmarks/regina_outcomes_spike.py
+++ b/benchmarks/regina_outcomes_spike.py
@@ -1,0 +1,848 @@
+"""Probe Regina as an isolated producer for bounded 3-manifold outcomes."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.metadata
+import json
+import math
+import re
+import sys
+import tarfile
+import zipfile
+from collections.abc import Callable, Mapping, Sequence
+from itertools import combinations
+from pathlib import Path
+from typing import Any
+
+PIN_PATH = Path(__file__).with_name("regina_outcomes_pin.json")
+ADAPTER_SOURCE = Path(__file__)
+_SOURCE_ROOT = "regina-7.4.1"
+_SOURCE_MEMBERS = {
+    "license": f"{_SOURCE_ROOT}/LICENSE.txt",
+    "core": f"{_SOURCE_ROOT}/engine/regina-core.h",
+    "triangulation": (f"{_SOURCE_ROOT}/engine/triangulation/dim3/triangulation3.h"),
+    "normal_surfaces": f"{_SOURCE_ROOT}/engine/surface/normalsurfaces.h",
+}
+_ENVIRONMENT = {"LANG": "C", "LC_ALL": "C", "TZ": "UTC"}
+_INTEGER = re.compile(r"^(?:0|[1-9][0-9]*)$")
+ProcessRunner = Callable[..., Any]
+
+
+def _default_runner(*args: object, **kwargs: object) -> Any:
+    from jacobian.bounded_process import run_bounded_process
+
+    return run_bounded_process(*args, **kwargs)
+
+
+class ReginaSpikeError(RuntimeError):
+    """A typed non-conclusion from the optional-provider spike."""
+
+    def __init__(self, status: str, code: str, detail: str) -> None:
+        super().__init__(detail)
+        self.status = status
+        self.code = code
+        self.detail = detail
+
+
+def _sha256_bytes(payload: bytes) -> str:
+    return f"sha256:{hashlib.sha256(payload).hexdigest()}"
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def _canonical_json(payload: object) -> bytes:
+    return (
+        json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+        + "\n"
+    ).encode("ascii")
+
+
+def _load_pin(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ReginaSpikeError(
+            "ERROR", "INVALID_SPIKE_PIN", "The Regina spike pin is unavailable."
+        ) from exc
+    if (
+        not isinstance(payload, dict)
+        or payload.get("contract") != "jacobian.regina-outcomes-spike/v1"
+    ):
+        raise ReginaSpikeError(
+            "ERROR", "INVALID_SPIKE_PIN", "The Regina spike pin is malformed."
+        )
+    return payload
+
+
+def _resolve_file(path: Path, role: str) -> Path:
+    try:
+        resolved = path.expanduser().resolve(strict=True)
+        if not resolved.is_file():
+            raise OSError
+    except OSError as exc:
+        raise ReginaSpikeError(
+            "UNAVAILABLE",
+            "PROVIDER_FILE_UNAVAILABLE",
+            f"The explicitly selected {role} file is unavailable.",
+        ) from exc
+    return resolved
+
+
+def _resolve_interpreter(path: Path) -> Path:
+    selected = path.expanduser().absolute()
+    try:
+        target = selected.resolve(strict=True)
+        if not selected.is_file() or not target.is_file():
+            raise OSError
+    except OSError as exc:
+        raise ReginaSpikeError(
+            "UNAVAILABLE",
+            "PROVIDER_FILE_UNAVAILABLE",
+            "The explicitly selected Regina Python interpreter is unavailable.",
+        ) from exc
+    return selected
+
+
+def _inspect_source_archive(path: Path, pin: Mapping[str, Any]) -> dict[str, Any]:
+    resolved = _resolve_file(path, "Regina source archive")
+    source_pin = pin["source"]
+    digest = _sha256_file(resolved)
+    if digest != source_pin["archive_sha256"]:
+        raise ReginaSpikeError(
+            "REJECTED",
+            "SOURCE_VERSION_MISMATCH",
+            "The Regina source archive differs from the frozen 7.4.1 digest.",
+        )
+    try:
+        with tarfile.open(resolved, mode="r:gz") as archive:
+            contents: dict[str, bytes] = {}
+            for role, member_name in _SOURCE_MEMBERS.items():
+                member = archive.getmember(member_name)
+                if not member.isfile() or member.size > 2 * 1024 * 1024:
+                    raise ValueError("source identity member is invalid")
+                stream = archive.extractfile(member)
+                if stream is None:
+                    raise ValueError("source identity member is unreadable")
+                contents[role] = stream.read()
+    except (KeyError, OSError, tarfile.TarError, ValueError) as exc:
+        raise ReginaSpikeError(
+            "REJECTED",
+            "SOURCE_ARCHIVE_MALFORMED",
+            "The pinned Regina source archive could not be inspected safely.",
+        ) from exc
+    expected = source_pin["members"]
+    if any(
+        _sha256_bytes(payload) != expected[role]["sha256"]
+        for role, payload in contents.items()
+    ) or not all(
+        b"GNU General Public License" in contents[role][:2048]
+        for role in ("core", "triangulation", "normal_surfaces")
+    ):
+        raise ReginaSpikeError(
+            "REJECTED",
+            "SOURCE_METADATA_MISMATCH",
+            "The Regina source or license slice differs from the pin.",
+        )
+    return {
+        "archive": str(resolved),
+        "archive_sha256": digest,
+        "download_url": source_pin["download_url"],
+        "signed_checksums_url": source_pin["signed_checksums_url"],
+        "license_id": "GPL-2.0-or-later",
+        "members": expected,
+    }
+
+
+def _inspect_wheel(path: Path, pin: Mapping[str, Any]) -> dict[str, Any]:
+    resolved = _resolve_file(path, "Regina CPython 3.12 wheel")
+    wheel_pin = pin["wheel"]
+    digest = _sha256_file(resolved)
+    if resolved.name != wheel_pin["filename"] or digest != wheel_pin["sha256"]:
+        raise ReginaSpikeError(
+            "REJECTED",
+            "WHEEL_VERSION_MISMATCH",
+            "The Regina wheel filename or digest differs from the pin.",
+        )
+    try:
+        with zipfile.ZipFile(resolved) as archive:
+            metadata = archive.read(wheel_pin["metadata_member"])
+            wheel_metadata = archive.read(wheel_pin["wheel_member"])
+            license_members = sorted(
+                name
+                for name in archive.namelist()
+                if ".dist-info/" in name and "license" in name.lower()
+            )
+    except (KeyError, OSError, zipfile.BadZipFile, RuntimeError) as exc:
+        raise ReginaSpikeError(
+            "REJECTED",
+            "WHEEL_MALFORMED",
+            "The pinned Regina wheel could not be inspected safely.",
+        ) from exc
+    if (
+        _sha256_bytes(metadata) != wheel_pin["metadata_sha256"]
+        or _sha256_bytes(wheel_metadata) != wheel_pin["wheel_sha256"]
+        or b"Name: regina\n" not in metadata
+        or f"Version: {pin['distribution_version']}\n".encode() not in metadata
+        or b"License: GPLv2+\n" not in metadata
+        or b"Requires-Python: >=3.6\n" not in metadata
+        or license_members != wheel_pin["license_members"]
+    ):
+        raise ReginaSpikeError(
+            "REJECTED",
+            "WHEEL_METADATA_MISMATCH",
+            "The Regina wheel metadata or license inventory differs from the pin.",
+        )
+    return {
+        "path": str(resolved),
+        "filename": resolved.name,
+        "sha256": digest,
+        "download_url": wheel_pin["download_url"],
+        "python_tag": "cp312",
+        "platform_tag": "manylinux_2_28_x86_64",
+        "license_metadata": "GPLv2+",
+        "license_members": license_members,
+        "license_file_present": bool(license_members),
+    }
+
+
+def _validate_reproduction(pin: Mapping[str, Any]) -> list[dict[str, Any]]:
+    reproduction = pin.get("reproduction")
+    if not isinstance(reproduction, dict):
+        raise ReginaSpikeError(
+            "ERROR", "INVALID_SPIKE_PIN", "The Regina reproduction is missing."
+        )
+    cases = reproduction.get("cases")
+    if not isinstance(cases, list) or not 1 <= len(cases) <= 8:
+        raise ReginaSpikeError(
+            "ERROR", "INVALID_SPIKE_PIN", "The Regina case list is malformed."
+        )
+    identifiers: set[str] = set()
+    for case in cases:
+        if (
+            not isinstance(case, dict)
+            or set(case) != {"case_id", "iso_sig", "maximum_tetrahedra"}
+            or not isinstance(case["case_id"], str)
+            or not case["case_id"]
+            or case["case_id"] in identifiers
+            or not isinstance(case["iso_sig"], str)
+            or not 1 <= len(case["iso_sig"]) <= 128
+            or type(case["maximum_tetrahedra"]) is not int
+            or not 1 <= case["maximum_tetrahedra"] <= 8
+        ):
+            raise ReginaSpikeError(
+                "ERROR", "INVALID_SPIKE_PIN", "A Regina case is malformed."
+            )
+        identifiers.add(case["case_id"])
+    normal_case = reproduction.get("normal_surface_case_id")
+    if normal_case not in identifiers:
+        raise ReginaSpikeError(
+            "ERROR",
+            "INVALID_SPIKE_PIN",
+            "The normal-surface case is not in the frozen case list.",
+        )
+    return cases
+
+
+def _run_checked(
+    runner: ProcessRunner,
+    command: Sequence[str],
+    *,
+    timeout_seconds: float,
+) -> bytes:
+    try:
+        completed = runner(
+            command,
+            input_bytes=b"",
+            timeout_seconds=timeout_seconds,
+            environment=_ENVIRONMENT,
+            stdout_limit=256 * 1024,
+            stderr_limit=32 * 1024,
+        )
+    except OSError as exc:
+        raise ReginaSpikeError(
+            "ERROR", "PROVIDER_LAUNCH_ERROR", "The Regina spike could not be launched."
+        ) from exc
+    if completed.cancelled:
+        raise ReginaSpikeError(
+            "CANCELLED", "PROVIDER_CANCELLED", "The Regina spike was cancelled."
+        )
+    if completed.timed_out:
+        raise ReginaSpikeError(
+            "TIMEOUT", "PROVIDER_TIMEOUT", "The Regina spike timed out."
+        )
+    if completed.stdout_exceeded or completed.stderr_exceeded:
+        raise ReginaSpikeError(
+            "ERROR", "PROVIDER_OUTPUT_LIMIT", "The Regina spike exceeded output bounds."
+        )
+    if completed.returncode != 0:
+        raise ReginaSpikeError(
+            "ERROR", "PROVIDER_CRASH", "The Regina spike exited unsuccessfully."
+        )
+    return completed.stdout
+
+
+def _parse_provider_output(output: bytes, pin: Mapping[str, Any]) -> dict[str, Any]:
+    try:
+        payload = json.loads(output.decode("ascii"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ReginaSpikeError(
+            "ERROR",
+            "PROVIDER_OUTPUT_MALFORMED",
+            "The Regina provider output is not canonical ASCII JSON.",
+        ) from exc
+    if not isinstance(payload, dict):
+        raise ReginaSpikeError(
+            "ERROR", "PROVIDER_OUTPUT_MALFORMED", "The Regina output is not an object."
+        )
+    runtime = payload.get("runtime")
+    if (
+        not isinstance(runtime, dict)
+        or runtime.get("distribution") != pin["distribution_version"]
+        or runtime.get("engine") != pin["engine_version"]
+        or not isinstance(runtime.get("python"), str)
+        or not runtime["python"].startswith("3.12.")
+    ):
+        raise ReginaSpikeError(
+            "REJECTED",
+            "PROVIDER_RUNTIME_MISMATCH",
+            "The worker is not running in the pinned Regina CPython boundary.",
+        )
+    mathematical = {key: value for key, value in payload.items() if key != "runtime"}
+    expected = pin["reproduction"]["expected_provider_output"]
+    if (
+        mathematical != expected
+        or _sha256_bytes(_canonical_json(mathematical))
+        != pin["reproduction"]["expected_mathematical_output_sha256"]
+    ):
+        raise ReginaSpikeError(
+            "REJECTED",
+            "REPRODUCTION_MISMATCH",
+            "Regina did not reproduce the frozen bounded outcomes.",
+        )
+    return payload
+
+
+class _UnionFind:
+    def __init__(self, values: Sequence[tuple[int, int, tuple[int, ...]]]) -> None:
+        self.parent = {value: value for value in values}
+
+    def find(
+        self, value: tuple[int, int, tuple[int, ...]]
+    ) -> tuple[int, int, tuple[int, ...]]:
+        parent = self.parent[value]
+        if parent != value:
+            self.parent[value] = self.find(parent)
+        return self.parent[value]
+
+    def union(
+        self,
+        left: tuple[int, int, tuple[int, ...]],
+        right: tuple[int, int, tuple[int, ...]],
+    ) -> None:
+        left_root = self.find(left)
+        right_root = self.find(right)
+        if left_root != right_root:
+            self.parent[right_root] = left_root
+
+
+def _replay_triangulation(case: Mapping[str, Any]) -> dict[str, Any]:
+    tetrahedra = case.get("tetrahedra")
+    gluings = case.get("facet_gluings")
+    if (
+        type(tetrahedra) is not int
+        or not 1 <= tetrahedra <= 8
+        or not isinstance(gluings, list)
+        or len(gluings) != tetrahedra
+        or any(not isinstance(row, list) or len(row) != 4 for row in gluings)
+    ):
+        raise ReginaSpikeError(
+            "REJECTED",
+            "INDEPENDENT_REPLAY_MISMATCH",
+            "The Regina gluing table has an invalid bounded shape.",
+        )
+    for source, row in enumerate(gluings):
+        for facet, gluing in enumerate(row):
+            if gluing is None:
+                continue
+            if not isinstance(gluing, dict) or set(gluing) != {
+                "tetrahedron",
+                "facet",
+                "permutation",
+            }:
+                raise ReginaSpikeError(
+                    "REJECTED",
+                    "INDEPENDENT_REPLAY_MISMATCH",
+                    "A Regina facet gluing is malformed.",
+                )
+            target = gluing["tetrahedron"]
+            target_facet = gluing["facet"]
+            permutation = gluing["permutation"]
+            if (
+                type(target) is not int
+                or not 0 <= target < tetrahedra
+                or type(target_facet) is not int
+                or not 0 <= target_facet < 4
+                or not isinstance(permutation, list)
+                or sorted(permutation) != [0, 1, 2, 3]
+                or permutation[facet] != target_facet
+            ):
+                raise ReginaSpikeError(
+                    "REJECTED",
+                    "INDEPENDENT_REPLAY_MISMATCH",
+                    "A Regina facet gluing lies outside the replay scope.",
+                )
+            reverse = gluings[target][target_facet]
+            if (
+                not isinstance(reverse, dict)
+                or reverse.get("tetrahedron") != source
+                or reverse.get("facet") != facet
+                or not isinstance(reverse.get("permutation"), list)
+                or any(
+                    reverse["permutation"][permutation[vertex]] != vertex
+                    for vertex in range(4)
+                )
+            ):
+                raise ReginaSpikeError(
+                    "REJECTED",
+                    "INDEPENDENT_REPLAY_MISMATCH",
+                    "The Regina facet gluings are not reciprocal.",
+                )
+
+    nodes = [
+        (tetrahedron, dimension, vertices)
+        for tetrahedron in range(tetrahedra)
+        for dimension in range(3)
+        for vertices in combinations(range(4), dimension + 1)
+    ]
+    components = _UnionFind(nodes)
+    for source, row in enumerate(gluings):
+        for facet, gluing in enumerate(row):
+            if gluing is None:
+                continue
+            target = gluing["tetrahedron"]
+            permutation = gluing["permutation"]
+            for dimension in range(3):
+                for vertices in combinations(
+                    [vertex for vertex in range(4) if vertex != facet],
+                    dimension + 1,
+                ):
+                    image = tuple(sorted(permutation[vertex] for vertex in vertices))
+                    components.union(
+                        (source, dimension, vertices),
+                        (target, dimension, image),
+                    )
+    f_vector = [
+        len({components.find(node) for node in nodes if node[1] == dimension})
+        for dimension in range(3)
+    ]
+    f_vector.append(tetrahedra)
+    if case.get("f_vector") != f_vector:
+        raise ReginaSpikeError(
+            "REJECTED",
+            "INDEPENDENT_REPLAY_MISMATCH",
+            "Independent face-quotient replay rejects the Regina f-vector.",
+        )
+    return {
+        "case_id": case.get("case_id"),
+        "computed_f_vector": f_vector,
+        "facet_gluing_involution": "MATCH",
+    }
+
+
+def _replay_normal_surfaces(
+    normal: Mapping[str, Any],
+    case_by_id: Mapping[str, Mapping[str, Any]],
+) -> dict[str, Any]:
+    case_id = normal.get("triangulation_case_id")
+    case = case_by_id.get(case_id) if isinstance(case_id, str) else None
+    surfaces = normal.get("surfaces")
+    if (
+        case is None
+        or normal.get("coordinate_system") != "STANDARD_7N"
+        or normal.get("list_kind") != "VERTEX_EMBEDDED_ONLY"
+        or not isinstance(surfaces, list)
+        or normal.get("surface_count") != len(surfaces)
+        or len(surfaces) > 128
+    ):
+        raise ReginaSpikeError(
+            "REJECTED",
+            "INDEPENDENT_REPLAY_MISMATCH",
+            "The normal-surface ledger is malformed.",
+        )
+    tetrahedra = case["tetrahedra"]
+    for surface in surfaces:
+        if not isinstance(surface, dict) or set(surface) != {
+            "compact",
+            "connected",
+            "coordinates",
+            "euler_characteristic",
+            "has_real_boundary",
+            "orientable",
+        }:
+            raise ReginaSpikeError(
+                "REJECTED",
+                "INDEPENDENT_REPLAY_MISMATCH",
+                "A normal-surface record is malformed.",
+            )
+        raw = surface["coordinates"]
+        if (
+            not isinstance(raw, list)
+            or len(raw) != 7 * tetrahedra
+            or any(
+                not isinstance(value, str)
+                or _INTEGER.fullmatch(value) is None
+                or len(value) > 256
+                for value in raw
+            )
+        ):
+            raise ReginaSpikeError(
+                "REJECTED",
+                "INDEPENDENT_REPLAY_MISMATCH",
+                "A normal coordinate vector is noncanonical or out of bounds.",
+            )
+        coordinates = [int(value) for value in raw]
+        if not any(coordinates) or math.gcd(*coordinates) != 1:
+            raise ReginaSpikeError(
+                "REJECTED",
+                "INDEPENDENT_REPLAY_MISMATCH",
+                "A normal coordinate vector is not primitive.",
+            )
+        if any(
+            sum(value > 0 for value in coordinates[offset + 4 : offset + 7]) > 1
+            for offset in range(0, len(coordinates), 7)
+        ):
+            raise ReginaSpikeError(
+                "REJECTED",
+                "INDEPENDENT_REPLAY_MISMATCH",
+                "A normal surface violates the quadrilateral constraints.",
+            )
+    return {
+        "triangulation_case_id": case_id,
+        "surface_count": len(surfaces),
+        "nonnegative_primitive_vectors": "MATCH",
+        "quadrilateral_constraints": "MATCH",
+    }
+
+
+def _independent_replay(payload: Mapping[str, Any]) -> dict[str, Any]:
+    cases = payload.get("cases")
+    normal = payload.get("normal_surfaces")
+    if not isinstance(cases, list) or not isinstance(normal, dict):
+        raise ReginaSpikeError(
+            "REJECTED",
+            "INDEPENDENT_REPLAY_MISMATCH",
+            "The Regina mathematical output is incomplete.",
+        )
+    triangulations = [_replay_triangulation(case) for case in cases]
+    by_id = {
+        case["case_id"]: case
+        for case in cases
+        if isinstance(case, dict) and isinstance(case.get("case_id"), str)
+    }
+    normal_replay = _replay_normal_surfaces(normal, by_id)
+    return {
+        "status": "PARTIAL_MATCH",
+        "imports_provider": False,
+        "triangulations": triangulations,
+        "normal_surface_local_constraints": normal_replay,
+        "not_established": [
+            "isomorphism-signature canonicality",
+            "integral homology from independently reconstructed chain matrices",
+            "normal matching equations, vertex extremality, or enumeration completeness",
+            "portable certificates for sphere or ball recognition",
+        ],
+    }
+
+
+def run_spike(
+    *,
+    python_executable: Path,
+    wheel: Path,
+    source_archive: Path,
+    timeout_seconds: float = 20,
+    runner: ProcessRunner = _default_runner,
+    pin_path: Path = PIN_PATH,
+    adapter_source: Path = ADAPTER_SOURCE,
+) -> dict[str, Any]:
+    """Run the bounded Regina reproduction and partial independent replay."""
+    try:
+        pin = _load_pin(pin_path)
+        _validate_reproduction(pin)
+        resolved_python = _resolve_interpreter(python_executable)
+        source = _inspect_source_archive(source_archive, pin)
+        wheel_identity = _inspect_wheel(wheel, pin)
+        resolved_adapter = _resolve_file(adapter_source, "Regina spike adapter")
+        adapter_digest = _sha256_file(resolved_adapter)
+        if adapter_digest != pin["adapter_source_sha256"]:
+            raise ReginaSpikeError(
+                "REJECTED",
+                "ADAPTER_SOURCE_MISMATCH",
+                "The Regina adapter source differs from the frozen digest.",
+            )
+        output = _run_checked(
+            runner,
+            [
+                str(resolved_python),
+                str(resolved_adapter),
+                "--worker",
+                "--pin",
+                str(pin_path.resolve()),
+            ],
+            timeout_seconds=timeout_seconds,
+        )
+        provider_output = _parse_provider_output(output, pin)
+        mathematical = {
+            key: value for key, value in provider_output.items() if key != "runtime"
+        }
+        replay = _independent_replay(mathematical)
+        return {
+            "contract": pin["contract"],
+            "status": "COMPLETED",
+            "conclusion": "SPIKE_PASSED_PRODUCTION_DEFERRED",
+            "assurance": "OBSERVED_PROVIDER_BEHAVIOR_WITH_PARTIAL_INDEPENDENT_REPLAY",
+            "provider": {
+                "name": pin["provider"],
+                "distribution_version": pin["distribution_version"],
+                "engine_version": pin["engine_version"],
+                "install_tier": "T1",
+                "deployment": "operator-installed isolated CPython wheel",
+                "distribution_decision": (
+                    "GPL_OPTIONAL_PROVIDER_OPERATOR_APPROVAL_REQUIRED"
+                ),
+                "source": source,
+                "wheel": wheel_identity,
+                "adapter_source_sha256": adapter_digest,
+                "python_executable": str(resolved_python),
+                "runtime": provider_output["runtime"],
+            },
+            "reproduction": {
+                "scope": pin["reproduction"]["scope"],
+                "provider_output_sha256": _sha256_bytes(output),
+                "cases": provider_output["cases"],
+                "normal_surfaces": provider_output["normal_surfaces"],
+            },
+            "independent_replay": replay,
+            "outcome_gates": {
+                "triangulation_materialize": {
+                    "decision": "REVISE",
+                    "evidence": "facet involution and quotient f-vector replayed",
+                    "open_obligation": (
+                        "define domain-owned gluing semantics and bind or independently "
+                        "recompute canonical isomorphism signatures"
+                    ),
+                },
+                "three_manifold_homology": {
+                    "decision": "REVISE",
+                    "evidence": "frozen H_1 groups reproduced",
+                    "open_obligation": (
+                        "expose cellular chain matrices and reuse independent certified "
+                        "Smith replay instead of trusting invariant factors alone"
+                    ),
+                },
+                "normal_surface_enumeration": {
+                    "decision": "REVISE",
+                    "evidence": (
+                        "bounded vectors, primitivity, and quadrilateral constraints replayed"
+                    ),
+                    "open_obligation": (
+                        "check matching equations, vertex or fundamental extremality, "
+                        "enumeration completeness, and algorithm scope independently"
+                    ),
+                },
+                "sphere_ball_recognition": {
+                    "decision": "RESEARCH_ONLY",
+                    "evidence": "frozen exact Regina decisions reproduced",
+                    "open_obligation": (
+                        "define separate decision contracts and portable certificates; "
+                        "provider booleans alone cannot support VERIFIED"
+                    ),
+                },
+            },
+            "capability_ids_registered": [],
+            "limitations": [
+                "the PyPI wheel metadata has no bundled dist-info license file",
+                "the wheel distribution is 7.4.1 while the engine reports major.minor 7.4",
+                "normal-surface enumeration may be extremely slow beyond tiny cases",
+                "all reproductions are answer-visible and are not held-out evaluation",
+            ],
+        }
+    except ReginaSpikeError as exc:
+        return {
+            "contract": "jacobian.regina-outcomes-spike/v1",
+            "status": exc.status,
+            "conclusion": "NO_CONCLUSION",
+            "diagnostic": {"code": exc.code, "detail": exc.detail},
+            "capability_ids_registered": [],
+        }
+
+
+def _group_payload(group: Any) -> dict[str, Any]:
+    return {
+        "free_rank": group.rank(),
+        "torsion_invariant_factors": [
+            str(group.invariantFactor(index))
+            for index in range(group.countInvariantFactors())
+        ],
+    }
+
+
+def _gluing_payload(triangulation: Any) -> list[list[dict[str, Any] | None]]:
+    result: list[list[dict[str, Any] | None]] = []
+    for tetrahedron_index in range(triangulation.size()):
+        tetrahedron = triangulation.tetrahedron(tetrahedron_index)
+        row: list[dict[str, Any] | None] = []
+        for facet in range(4):
+            adjacent = tetrahedron.adjacentTetrahedron(facet)
+            if adjacent is None:
+                row.append(None)
+                continue
+            permutation = tetrahedron.adjacentGluing(facet)
+            row.append(
+                {
+                    "tetrahedron": adjacent.index(),
+                    "facet": permutation[facet],
+                    "permutation": [permutation[index] for index in range(4)],
+                }
+            )
+        result.append(row)
+    return result
+
+
+def _worker(pin_path: Path) -> int:
+    """Run only inside the explicitly selected Regina interpreter."""
+    pin = _load_pin(pin_path)
+    cases = _validate_reproduction(pin)
+    try:
+        import regina
+    except ImportError as exc:
+        raise ReginaSpikeError(
+            "UNAVAILABLE", "PROVIDER_IMPORT_ERROR", "Regina is unavailable."
+        ) from exc
+    distribution_version = importlib.metadata.version("regina")
+    engine_version = regina.versionString()
+    payload_cases = []
+    triangulations: dict[str, Any] = {}
+    for case in cases:
+        triangulation = regina.Triangulation3.fromIsoSig(case["iso_sig"])
+        if triangulation.size() > case["maximum_tetrahedra"]:
+            raise ReginaSpikeError(
+                "REJECTED",
+                "REPRODUCTION_SCOPE_EXCEEDED",
+                "A frozen Regina triangulation exceeds its tetrahedron bound.",
+            )
+        triangulations[case["case_id"]] = triangulation
+        payload_cases.append(
+            {
+                "case_id": case["case_id"],
+                "input_iso_sig": case["iso_sig"],
+                "canonical_iso_sig": triangulation.isoSig(),
+                "tetrahedra": triangulation.size(),
+                "f_vector": [
+                    triangulation.countFaces(dimension) for dimension in range(4)
+                ],
+                "valid": triangulation.isValid(),
+                "closed": triangulation.isClosed(),
+                "connected": triangulation.isConnected(),
+                "orientable": triangulation.isOrientable(),
+                "homology_1": _group_payload(triangulation.homology()),
+                "recognition": {
+                    "is_three_sphere": triangulation.isSphere(),
+                    "is_three_ball": triangulation.isBall(),
+                },
+                "facet_gluings": _gluing_payload(triangulation),
+            }
+        )
+
+    normal_case_id = pin["reproduction"]["normal_surface_case_id"]
+    normal_triangulation = triangulations[normal_case_id]
+    normal_list = regina.NormalSurfaces(
+        normal_triangulation,
+        regina.NormalCoords.Standard,
+        regina.NormalList.Vertex | regina.NormalList.EmbeddedOnly,
+    )
+    surfaces = []
+    for surface in normal_list:
+        coordinates = []
+        for tetrahedron in range(normal_triangulation.size()):
+            coordinates.extend(
+                str(surface.triangles(tetrahedron, vertex)) for vertex in range(4)
+            )
+            coordinates.extend(
+                str(surface.quads(tetrahedron, quad_type)) for quad_type in range(3)
+            )
+        surfaces.append(
+            {
+                "coordinates": coordinates,
+                "euler_characteristic": int(str(surface.eulerChar())),
+                "orientable": surface.isOrientable(),
+                "compact": surface.isCompact(),
+                "connected": surface.isConnected(),
+                "has_real_boundary": surface.hasRealBoundary(),
+            }
+        )
+    surfaces.sort(key=lambda surface: surface["coordinates"])
+    payload = {
+        "contract": pin["contract"],
+        "provider": pin["provider"],
+        "distribution_version": distribution_version,
+        "cases": payload_cases,
+        "normal_surfaces": {
+            "triangulation_case_id": normal_case_id,
+            "coordinate_system": "STANDARD_7N",
+            "list_kind": "VERTEX_EMBEDDED_ONLY",
+            "observed_algorithm_flags": str(normal_list.algorithm()),
+            "surface_count": len(surfaces),
+            "surfaces": surfaces,
+        },
+        "runtime": {
+            "distribution": distribution_version,
+            "engine": engine_version,
+            "python": sys.version.split()[0],
+        },
+    }
+    sys.stdout.buffer.write(_canonical_json(payload))
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--python-executable", type=Path)
+    parser.add_argument("--wheel", type=Path)
+    parser.add_argument("--source-archive", type=Path)
+    parser.add_argument("--pin", type=Path, default=PIN_PATH)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--worker", action="store_true")
+    args = parser.parse_args(argv)
+    if args.worker:
+        return _worker(args.pin)
+    if (
+        args.python_executable is None
+        or args.wheel is None
+        or args.source_archive is None
+        or args.output is None
+    ):
+        parser.error(
+            "--python-executable, --wheel, --source-archive, and --output are required"
+        )
+    report = run_spike(
+        python_executable=args.python_executable,
+        wheel=args.wheel,
+        source_archive=args.source_archive,
+        pin_path=args.pin,
+    )
+    args.output.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return 0 if report["status"] == "COMPLETED" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/contributing/regina-outcomes-provider-spike.md
+++ b/docs/contributing/regina-outcomes-provider-spike.md
@@ -1,0 +1,188 @@
+# Regina low-dimensional-topology optional-provider spike
+
+[Documentation home](../index.md)
+
+- Status: provider and outcome-gate evidence; production deferred
+- Frozen report contract: `jacobian.regina-outcomes-spike/v1`
+- Registered capability IDs: none
+- Provider: Regina wheel distribution 7.4.1, engine-reported version 7.4
+
+## Decision
+
+Regina is viable as an isolated producer for bounded 3-manifold
+triangulations, algebraic invariants, normal surfaces, and exact recognition
+algorithms. This spike does not register a capability. Every examined outcome
+still needs a domain-owned contract or stronger independent evidence:
+
+| Candidate outcome | Decision | Evidence obtained | Missing production evidence |
+| --- | --- | --- | --- |
+| 3-manifold triangulation materialization | `REVISE` | facet gluings are reciprocal and independently reproduce quotient face counts | versioned gluing semantics and an independent binding for canonical isomorphism signatures |
+| \(H_1\) of a 3-manifold triangulation | `REVISE` | trivial, \(\mathbb Z/2\), and \(\mathbb Z\) groups reproduce | explicit cellular chain matrices and independent certified-Smith replay |
+| embedded vertex normal-surface enumeration | `REVISE` | bounded primitive vectors and quadrilateral constraints replay | matching equations, vertex extremality, completeness, coordinate/list/algorithm scope |
+| 3-sphere and 3-ball recognition | `RESEARCH_ONLY` | Regina's exact booleans reproduce on frozen cases | separate decision contracts and portable certificates; a provider boolean cannot establish `VERIFIED` |
+
+Regina remains an operator-installed T1 provider. The upstream engine and
+Python-wheel metadata declare GPL-2.0-or-later/GPLv2+. Redistribution,
+third-party-library obligations, and operator approval are separate from
+provider availability and checker authority. The CPython wheel contains no
+license file beneath its `.dist-info` directory, so the spike binds both the
+wheel metadata and the upstream source license; this is an observed packaging
+fact, not a license exception.
+
+Primary upstream boundaries are the
+[Regina 7.4.1 release](https://regina-normal.github.io/),
+[calculation-engine documentation](https://regina-normal.github.io/engine-docs/),
+[`Triangulation<3>` API](https://regina-normal.github.io/engine-docs/classregina_1_1Triangulation_3_013_01_4.html),
+[`NormalSurfaces` API](https://regina-normal.github.io/engine-docs/classregina_1_1NormalSurfaces.html),
+[`AbelianGroup` API](https://regina-normal.github.io/engine-docs/classregina_1_1AbelianGroup.html),
+and the
+[Regina 7.4.1 PyPI files](https://pypi.org/project/regina/7.4.1/).
+
+## Pinned provider identity
+
+[`benchmarks/regina_outcomes_pin.json`](../../benchmarks/regina_outcomes_pin.json)
+binds:
+
+- the 7.4.1 upstream source archive and the upstream signed-checksum location;
+- the upstream license, core, 3-dimensional triangulation, and normal-surface
+  header digests;
+- the CPython 3.12 manylinux wheel filename and SHA-256 digest;
+- the wheel `METADATA` and `WHEEL` member digests and empty `.dist-info`
+  license-file inventory;
+- the exact adapter source;
+- four isomorphism signatures and per-case tetrahedron bounds; and
+- the complete expected mathematical output and digest.
+
+The PyPI distribution version is `7.4.1`, while `regina.versionString()` returns
+the engine's major/minor string `7.4`. The worker checks both values instead of
+silently treating either as the other.
+
+## Reproduction
+
+Create a separate Python 3.12 environment and install only the pinned wheel:
+
+```sh
+uv venv /tmp/jcb-regina-venv --python 3.12
+uv pip install \
+  --python /tmp/jcb-regina-venv/bin/python \
+  /path/to/regina-7.4.1-cp312-cp312-manylinux_2_28_x86_64.whl
+```
+
+Run the controller from the locked Jacobian environment:
+
+```sh
+uv run python benchmarks/regina_outcomes_spike.py \
+  --python-executable /tmp/jcb-regina-venv/bin/python \
+  --wheel /path/to/regina-7.4.1-cp312-cp312-manylinux_2_28_x86_64.whl \
+  --source-archive /path/to/regina-7.4.1.tar.gz \
+  --output /tmp/jcb-regina-outcomes-spike.json
+```
+
+The controller hashes and safely inspects the source archive and wheel before
+launch. It preserves the selected virtual-environment launcher, runs the
+adapter in a bounded process with a sanitized environment, limits stdout and
+stderr, and strictly compares the mathematical output with the frozen digest.
+
+The answer-visible cases are:
+
+| Case | Isomorphism signature | Tetrahedra | f-vector | \(H_1\) | Recognition |
+| --- | --- | ---: | --- | --- | --- |
+| \(S^3\) | `cPcbbbaaa` | 2 | `(4, 6, 4, 2)` | `0` | sphere |
+| \(L(2,1)\) | `cMcabbgqw` | 2 | `(1, 3, 4, 2)` | \(\mathbb Z/2\) | neither sphere nor ball |
+| \(S^2\times S^1\) | `cMcabbjaj` | 2 | `(1, 3, 4, 2)` | \(\mathbb Z\) | neither sphere nor ball |
+| \(B^3\) | `baa` | 1 | `(4, 6, 4, 1)` | `0` | ball |
+
+For \(L(2,1)\), Regina also enumerates four embedded vertex normal surfaces in
+standard `7n` coordinates. The observed provider-output digest on CPython
+3.12.13 is
+`sha256:20276b2bd3df9dc95b78cda265114862f9690280b702f00964c8cc80e8d4a8a4`.
+The stable mathematical-output digest, which excludes the Python patch
+version, is stored in the pin.
+
+Missing files, source/wheel/adapter mismatch, malformed archives or wheel
+metadata, wrong distribution/engine/Python version, timeout, cancellation,
+process crash, output overflow, reproduction drift, and independent replay
+disagreement are all non-conclusions. They register no capability and produce
+no mathematical negation.
+
+## Independent replay boundary
+
+Without importing Regina, the controller:
+
+1. validates every local tetrahedron, facet index, and vertex permutation;
+2. checks that every internal facet gluing has the exact inverse gluing;
+3. independently forms equivalence classes of local vertices, edges, and
+   triangles and compares the quotient f-vector;
+4. parses bounded nonnegative normal-coordinate vectors;
+5. checks that every vector is primitive; and
+6. checks the per-tetrahedron quadrilateral constraints.
+
+This is intentionally `PARTIAL_MATCH`, not verification. It does not establish:
+
+- that an isomorphism signature is canonical or bound to the only possible
+  triangulation;
+- that Regina's reported \(H_1\) arose from independently reconstructed
+  boundary matrices;
+- the normal matching equations, surface topology, vertex-ray extremality, or
+  completeness of enumeration; or
+- a portable proof certificate for either recognition result.
+
+Same-provider round trips, known example names, or frozen expected answers
+cannot close these obligations.
+
+## Production contract gates
+
+The first production prerequisite should be one atomic
+3-manifold-triangulation artifact, not a generic `regina.call`. It must declare
+tetrahedron and local-vertex bases, partial facet pairings, exact permutations,
+boundary/ideal semantics, validity scope, orientation, connectedness, and
+content identity. Complete cross-field validation must precede provider
+execution or artifact writes.
+
+A later homology outcome should expose the exact cellular boundary matrices
+and their bases. It can then reuse the transformation-certified Smith
+certificate format and an independent checker, while keeping Regina's
+invariant factors as producer evidence only. This is adjacent to but not a
+replacement for simplicial-complex integral homology: Regina triangulations
+permit face identifications that are not finite abstract simplicial complexes.
+
+A normal-surface outcome must choose exactly one coordinate system and list
+class per capability. It must bound tetrahedra, coordinate digits, number of
+surfaces, runtime, and output size; expose matching equations and algorithm
+flags; distinguish complete enumeration from interruption; and retain vectors
+already found after timeout only as incomplete evidence. An independent
+checker must validate matching and admissibility and must not infer vertex or
+fundamental completeness from the absence of more provider output.
+
+Recognition outcomes must remain separate decisions such as 3-sphere or
+3-ball recognition. Timeout, cancellation, error, or an unavailable provider
+returns no conclusion. Until portable certificates and an independent checker
+exist, a successful exact Regina decision can be `COMPUTED` at most and never
+`VERIFIED`.
+
+## Handoff
+
+- Baseline tree: `59a51d2c59256a2e17bab811ec3be831d4b3cce4`.
+- Candidate stage: discovery/provider gate complete; all production outcomes
+  require revision.
+- Provider state: absent from the locked Jacobian environment; Regina 7.4.1
+  was installed only in the isolated reproduction venv.
+- Public/held-out role: every case and answer is visible; no model evaluation,
+  prompt, scorer run, or raw model trace exists.
+- Raw report: `/tmp/jcb-regina-outcomes-spike.json` on the reproducing host.
+  Its canonical pretty-printed report SHA-256 is
+  `b5c9bdcce35a873b0d38e0443ca4a98dcad299b41cbc1678845f869e0fc53e05`.
+- Validation run: the real isolated-provider reproduction; 7 focused
+  fail-closed tests; the complete planner-selected unit, component, domain,
+  composition, storage, process, MCP, and end-to-end lanes (1,707 passed and 5
+  optional Lean skips); Ruff, formatting, dependency, dead-code, type,
+  architecture, build, and documentation-link checks.
+- Producer maximum: `COMPUTED`.
+- Checker evidence: partial standard-library gluing and local normal-coordinate
+  replay; no checker was authorized.
+- Decision: retain the spike, register no capability, and begin with the
+  domain-owned triangulation contract if a later batch accepts the GPL
+  deployment boundary.
+- Next action: design and adversarially test the triangulation/gluing artifact,
+  then separately revisit cellular homology, normal enumeration, and each
+  recognition decision.

--- a/docs/index.md
+++ b/docs/index.md
@@ -137,6 +137,10 @@ reproduction, and independent modular-reduction obligations.
 The [cddlib exact H/V optional-provider spike](contributing/cddlib-hv-provider-spike.md)
 records the GPL source-build boundary, exact GMP-rational reproduction,
 homogeneous representation semantics, and the unresolved completeness gate.
+The [Regina low-dimensional-topology optional-provider spike](contributing/regina-outcomes-provider-spike.md)
+records the isolated GPL wheel/source boundary, bounded 3-manifold and
+normal-surface reproductions, partial independent replay, and outcome-specific
+production gates.
 
 Recurring agent work is encoded in the repository-local skills under
 `.agents/skills/`. Start with `develop-math-capabilities` for a complete

--- a/tests/boundary/process/providers/test_regina_outcomes_spike.py
+++ b/tests/boundary/process/providers/test_regina_outcomes_spike.py
@@ -1,0 +1,347 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import runpy
+import tarfile
+import zipfile
+from collections.abc import Callable, Sequence
+from io import BytesIO
+from pathlib import Path
+from typing import Any, cast
+
+from jacobian.bounded_process import BoundedProcessResult
+
+PROJECT_ROOT = Path(__file__).resolve().parents[4]
+SPIKE = runpy.run_path(str(PROJECT_ROOT / "benchmarks" / "regina_outcomes_spike.py"))
+BASE_PIN = json.loads(
+    (PROJECT_ROOT / "benchmarks" / "regina_outcomes_pin.json").read_text(
+        encoding="utf-8"
+    )
+)
+RunSpike = Callable[..., dict[str, Any]]
+RUN_SPIKE = cast(RunSpike, SPIKE["run_spike"])
+
+
+def _sha256(payload: bytes) -> str:
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def _canonical(payload: object) -> bytes:
+    return (
+        json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+        + "\n"
+    ).encode("ascii")
+
+
+def _result(
+    *,
+    stdout: bytes = b"",
+    returncode: int | None = 0,
+    timed_out: bool = False,
+) -> BoundedProcessResult:
+    return BoundedProcessResult(
+        returncode=returncode,
+        stdout=stdout,
+        stderr=b"",
+        stdout_exceeded=False,
+        stderr_exceeded=False,
+        timed_out=timed_out,
+    )
+
+
+def _runner(
+    outcomes: Sequence[BoundedProcessResult],
+) -> Callable[..., BoundedProcessResult]:
+    remaining = iter(outcomes)
+
+    def run(*_args: object, **_kwargs: object) -> BoundedProcessResult:
+        return next(remaining)
+
+    return run
+
+
+def _provider_output(
+    mathematical: dict[str, Any] | None = None,
+    *,
+    distribution_version: str = "7.4.1",
+    engine_version: str = "7.4",
+    python_version: str = "3.12.13",
+) -> bytes:
+    payload = {
+        **(mathematical or BASE_PIN["reproduction"]["expected_provider_output"]),
+        "runtime": {
+            "distribution": distribution_version,
+            "engine": engine_version,
+            "python": python_version,
+        },
+    }
+    return _canonical(payload)
+
+
+def _fixture(tmp_path: Path) -> tuple[Path, Path, Path, Path, Path]:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    python = tmp_path / "regina-python"
+    adapter = tmp_path / "regina-spike.py"
+    python.touch()
+    adapter.write_text("# fixture\n", encoding="utf-8")
+
+    source_payloads = {
+        "license": b"fixture GPL license\n",
+        "core": b"GNU General Public License\nfixture core\n",
+        "triangulation": b"GNU General Public License\nfixture triangulation\n",
+        "normal_surfaces": b"GNU General Public License\nfixture surfaces\n",
+    }
+    source = tmp_path / "regina-7.4.1.tar.gz"
+    members = {
+        "license": "regina-7.4.1/LICENSE.txt",
+        "core": "regina-7.4.1/engine/regina-core.h",
+        "triangulation": ("regina-7.4.1/engine/triangulation/dim3/triangulation3.h"),
+        "normal_surfaces": "regina-7.4.1/engine/surface/normalsurfaces.h",
+    }
+    with tarfile.open(source, mode="w:gz") as archive:
+        for role, name in members.items():
+            payload = source_payloads[role]
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            info.mtime = 0
+            archive.addfile(info, BytesIO(payload))
+
+    metadata = (
+        b"Name: regina\nVersion: 7.4.1\nLicense: GPLv2+\nRequires-Python: >=3.6\n"
+    )
+    wheel_metadata = b"Wheel-Version: 1.0\nTag: cp312-cp312-manylinux_2_28_x86_64\n"
+    wheel = tmp_path / BASE_PIN["wheel"]["filename"]
+    with zipfile.ZipFile(wheel, mode="w") as archive:
+        archive.writestr(BASE_PIN["wheel"]["metadata_member"], metadata)
+        archive.writestr(BASE_PIN["wheel"]["wheel_member"], wheel_metadata)
+
+    pin = {
+        **BASE_PIN,
+        "adapter_source_sha256": _sha256(adapter.read_bytes()),
+        "source": {
+            **BASE_PIN["source"],
+            "archive_sha256": _sha256(source.read_bytes()),
+            "members": {
+                role: {
+                    "path": members[role],
+                    "sha256": _sha256(source_payloads[role]),
+                }
+                for role in members
+            },
+        },
+        "wheel": {
+            **BASE_PIN["wheel"],
+            "sha256": _sha256(wheel.read_bytes()),
+            "metadata_sha256": _sha256(metadata),
+            "wheel_sha256": _sha256(wheel_metadata),
+        },
+    }
+    pin_path = tmp_path / "pin.json"
+    pin_path.write_text(json.dumps(pin), encoding="utf-8")
+    return python, wheel, source, adapter, pin_path
+
+
+def test_regina_spike_replays_partial_evidence_and_defers_production(
+    tmp_path: Path,
+) -> None:
+    python, wheel, source, adapter, pin = _fixture(tmp_path)
+
+    report = RUN_SPIKE(
+        python_executable=python,
+        wheel=wheel,
+        source_archive=source,
+        adapter_source=adapter,
+        pin_path=pin,
+        runner=_runner([_result(stdout=_provider_output())]),
+    )
+
+    assert report["status"] == "COMPLETED"
+    assert report["conclusion"] == "SPIKE_PASSED_PRODUCTION_DEFERRED"
+    assert report["provider"]["install_tier"] == "T1"
+    assert report["provider"]["distribution_decision"] == (
+        "GPL_OPTIONAL_PROVIDER_OPERATOR_APPROVAL_REQUIRED"
+    )
+    assert report["independent_replay"]["status"] == "PARTIAL_MATCH"
+    assert len(report["independent_replay"]["triangulations"]) == 4
+    assert (
+        report["independent_replay"]["normal_surface_local_constraints"][
+            "surface_count"
+        ]
+        == 4
+    )
+    assert {gate["decision"] for gate in report["outcome_gates"].values()} == {
+        "REVISE",
+        "RESEARCH_ONLY",
+    }
+    assert report["capability_ids_registered"] == []
+
+
+def test_absent_regina_is_an_explicit_non_conclusion(tmp_path: Path) -> None:
+    _python, wheel, source, adapter, pin = _fixture(tmp_path)
+
+    report = RUN_SPIKE(
+        python_executable=tmp_path / "absent-regina-python",
+        wheel=wheel,
+        source_archive=source,
+        adapter_source=adapter,
+        pin_path=pin,
+    )
+
+    assert report["status"] == "UNAVAILABLE"
+    assert report["conclusion"] == "NO_CONCLUSION"
+    assert report["diagnostic"]["code"] == "PROVIDER_FILE_UNAVAILABLE"
+    assert report["capability_ids_registered"] == []
+
+
+def test_source_and_wheel_mismatch_fail_before_execution(tmp_path: Path) -> None:
+    python, wheel, source, adapter, pin = _fixture(tmp_path)
+    source.write_bytes(b"not the pinned source")
+    source_report = RUN_SPIKE(
+        python_executable=python,
+        wheel=wheel,
+        source_archive=source,
+        adapter_source=adapter,
+        pin_path=pin,
+    )
+    assert source_report["status"] == "REJECTED"
+    assert source_report["diagnostic"]["code"] == "SOURCE_VERSION_MISMATCH"
+
+    python, wheel, source, adapter, pin = _fixture(tmp_path / "wheel")
+    wheel.write_bytes(b"not the pinned wheel")
+    wheel_report = RUN_SPIKE(
+        python_executable=python,
+        wheel=wheel,
+        source_archive=source,
+        adapter_source=adapter,
+        pin_path=pin,
+    )
+    assert wheel_report["status"] == "REJECTED"
+    assert wheel_report["diagnostic"]["code"] == "WHEEL_VERSION_MISMATCH"
+
+
+def test_malformed_source_and_wheel_are_typed_non_conclusions(
+    tmp_path: Path,
+) -> None:
+    python, wheel, source, adapter, pin_path = _fixture(tmp_path)
+    source.write_bytes(b"not-a-tar")
+    pin = json.loads(pin_path.read_text(encoding="utf-8"))
+    pin["source"]["archive_sha256"] = _sha256(source.read_bytes())
+    pin_path.write_text(json.dumps(pin), encoding="utf-8")
+
+    source_report = RUN_SPIKE(
+        python_executable=python,
+        wheel=wheel,
+        source_archive=source,
+        adapter_source=adapter,
+        pin_path=pin_path,
+    )
+
+    python, wheel, source, adapter, pin_path = _fixture(tmp_path / "wheel")
+    wheel.write_bytes(b"not-a-wheel")
+    pin = json.loads(pin_path.read_text(encoding="utf-8"))
+    pin["wheel"]["sha256"] = _sha256(wheel.read_bytes())
+    pin_path.write_text(json.dumps(pin), encoding="utf-8")
+
+    wheel_report = RUN_SPIKE(
+        python_executable=python,
+        wheel=wheel,
+        source_archive=source,
+        adapter_source=adapter,
+        pin_path=pin_path,
+    )
+
+    assert (source_report["status"], source_report["diagnostic"]["code"]) == (
+        "REJECTED",
+        "SOURCE_ARCHIVE_MALFORMED",
+    )
+    assert (wheel_report["status"], wheel_report["diagnostic"]["code"]) == (
+        "REJECTED",
+        "WHEEL_MALFORMED",
+    )
+    assert source_report["capability_ids_registered"] == []
+    assert wheel_report["capability_ids_registered"] == []
+
+
+def test_runtime_malformed_output_timeout_and_crash_fail_closed(
+    tmp_path: Path,
+) -> None:
+    python, wheel, source, adapter, pin = _fixture(tmp_path)
+    wrong_runtime = RUN_SPIKE(
+        python_executable=python,
+        wheel=wheel,
+        source_archive=source,
+        adapter_source=adapter,
+        pin_path=pin,
+        runner=_runner(
+            [_result(stdout=_provider_output(distribution_version="7.3.1.1"))]
+        ),
+    )
+    malformed = RUN_SPIKE(
+        python_executable=python,
+        wheel=wheel,
+        source_archive=source,
+        adapter_source=adapter,
+        pin_path=pin,
+        runner=_runner([_result(stdout=b"partial Regina output\n")]),
+    )
+    timed_out = RUN_SPIKE(
+        python_executable=python,
+        wheel=wheel,
+        source_archive=source,
+        adapter_source=adapter,
+        pin_path=pin,
+        runner=_runner([_result(timed_out=True)]),
+    )
+    crashed = RUN_SPIKE(
+        python_executable=python,
+        wheel=wheel,
+        source_archive=source,
+        adapter_source=adapter,
+        pin_path=pin,
+        runner=_runner([_result(returncode=9)]),
+    )
+
+    assert wrong_runtime["diagnostic"]["code"] == "PROVIDER_RUNTIME_MISMATCH"
+    assert malformed["diagnostic"]["code"] == "PROVIDER_OUTPUT_MALFORMED"
+    assert (timed_out["status"], timed_out["diagnostic"]["code"]) == (
+        "TIMEOUT",
+        "PROVIDER_TIMEOUT",
+    )
+    assert (crashed["status"], crashed["diagnostic"]["code"]) == (
+        "ERROR",
+        "PROVIDER_CRASH",
+    )
+    assert all(
+        report["conclusion"] == "NO_CONCLUSION"
+        for report in (wrong_runtime, malformed, timed_out, crashed)
+    )
+
+
+def test_independent_replay_rejects_a_reciprocal_gluing_forgery(
+    tmp_path: Path,
+) -> None:
+    python, wheel, source, adapter, pin_path = _fixture(tmp_path)
+    mathematical = copy.deepcopy(BASE_PIN["reproduction"]["expected_provider_output"])
+    mathematical["cases"][0]["facet_gluings"][0][0]["tetrahedron"] = 0
+    pin = json.loads(pin_path.read_text(encoding="utf-8"))
+    pin["reproduction"]["expected_provider_output"] = mathematical
+    pin["reproduction"]["expected_mathematical_output_sha256"] = _sha256(
+        _canonical(mathematical)
+    )
+    pin_path.write_text(json.dumps(pin), encoding="utf-8")
+
+    report = RUN_SPIKE(
+        python_executable=python,
+        wheel=wheel,
+        source_archive=source,
+        adapter_source=adapter,
+        pin_path=pin_path,
+        runner=_runner([_result(stdout=_provider_output(mathematical))]),
+    )
+
+    assert report["status"] == "REJECTED"
+    assert report["conclusion"] == "NO_CONCLUSION"
+    assert report["diagnostic"]["code"] == "INDEPENDENT_REPLAY_MISMATCH"
+    assert report["capability_ids_registered"] == []

--- a/tests/composition/runtime/test_regina_outcomes_spike_isolation.py
+++ b/tests/composition/runtime/test_regina_outcomes_spike_isolation.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import runpy
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, cast
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+SPIKE = runpy.run_path(str(PROJECT_ROOT / "benchmarks" / "regina_outcomes_spike.py"))
+RunSpike = Callable[..., dict[str, Any]]
+RUN_SPIKE = cast(RunSpike, SPIKE["run_spike"])
+
+
+def test_absent_regina_does_not_change_complete_runtime_catalog(
+    fresh_complete_runtime,
+    tmp_path: Path,
+) -> None:
+    before = fresh_complete_runtime.core.capabilities.catalog().model_dump(mode="json")
+
+    report = RUN_SPIKE(
+        python_executable=tmp_path / "absent-regina-python",
+        wheel=tmp_path / "absent-regina.whl",
+        source_archive=tmp_path / "absent-regina-source.tar.gz",
+    )
+
+    after = fresh_complete_runtime.core.capabilities.catalog().model_dump(mode="json")
+    assert report["status"] == "UNAVAILABLE"
+    assert report["capability_ids_registered"] == []
+    assert after == before


### PR DESCRIPTION
## Summary

- add a pinned, isolated Regina 7.4.1 provider spike for bounded 3-manifold and normal-surface outcomes
- independently replay reciprocal facet gluings, quotient f-vectors, primitive normal coordinates, and quadrilateral constraints without importing Regina
- record outcome-specific gates: triangulation, H1, and normal enumeration are REVISE; sphere/ball recognition is RESEARCH_ONLY
- register no capability and keep all timeout, crash, mismatch, malformed-artifact, and unavailable-provider paths as typed non-conclusions

## Evidence and handoff

- base tree: `59a51d2c59256a2e17bab811ec3be831d4b3cce4`
- commit/head: `9fd7eecd96e29235ddc6e13377bcd5acde39f749`
- provider: Regina wheel distribution 7.4.1, engine version 7.4, isolated CPython 3.12.13
- source archive SHA-256: `74131014099b77083dd1d09004fd6bc972421c792d188cdf43f0fd11ca6cb2ed`
- wheel SHA-256: `d33ccc69697ec680a8dcf8f0c663428853da44f3578898ad9b908e4669e83c71`
- stable mathematical output SHA-256: `5937e30dcc04370a2d7201ada568f8fdaac46906d4234d75d580fc80a68cc2a8`
- real pretty-printed report SHA-256: `b5c9bdcce35a873b0d38e0443ca4a98dcad299b41cbc1678845f869e0fc53e05`
- no model evaluation, prompt, scorer, or checker authorization was used

## Validation

- real isolated-provider reproduction: COMPLETED / PARTIAL_MATCH / no registered capability
- focused tests: 7 passed
- `make test-process TESTS=tests/boundary/process/providers/test_regina_outcomes_spike.py`
- `make test-composition TESTS=tests/composition/runtime/test_regina_outcomes_spike_isolation.py`
- `make check`
- `make check-static`
- `make test-plan BASE=origin/main`
- `make test-affected BASE=origin/main`: 1,707 passed, 5 optional Lean skips
- `make docs-linkcheck`

## Open obligations

No production capability is proposed. A later batch must first define a domain-owned triangulation/gluing artifact. H1 additionally needs exposed cellular boundary matrices and independent certified Smith replay; normal enumeration needs matching/extremality/completeness evidence; recognition needs portable certificates and an independent checker before any VERIFIED claim.