### PR TITLE
build(npm): make npm package dry-run work with npm 11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ duplicate-code: ## Run the CI duplicate-code detector locally.
 
 npm-test: ## Run the npm package tests and dry-run pack.
 	npm test --prefix npm
-	npm pack --dry-run --prefix npm
+	npm pack --dry-run ./npm
 
 todo-check: ## Fail on TODO comments that do not reference an issue.
 	@violations="$$(rg -n 'TODO' --type py src/ tests/ | rg -v 'TODO\(#\d+\)' || true)"; \


### PR DESCRIPTION
## Problem

`make npm-test` runs all 14 package tests successfully under npm 11, then fails during the packaging check. `npm pack --dry-run --prefix npm` does not apply `--prefix` to `pack` in npm 11, so npm looks for the repository-root `package.json` and exits with `ENOENT`.

## Solution

Pass the package directory as the positional pack target:

```sh
npm pack --dry-run ./npm
```

This keeps the command at the repository root and works with npm 11 without changing package contents or publication behavior.

## Testing

- Base reproduction: `make npm-test` — 14 tests passed, then `npm pack --dry-run --prefix npm` failed with `ENOENT` for the repository-root `package.json`.
- Final tree: `make npm-test` — 14 tests passed and the dry-run pack succeeded with the expected six package files.
- `git diff --check origin/main..HEAD` — passed.

## Trust & Compatibility Impact

No verification kernel, checker registry, artifact format, public API, or package contents change. This only corrects the local/CI npm packaging command.

## Checklist

- [x] Routine relevant validation passes (`make npm-test`)
- [x] Relevant focused tests are listed above