### PR TITLE
fix(benchmarks): harden verifier evidence and fixture binding

### DIFF
--- a/benchmarks/regression-v1/tasks/autoformalization-semantic-audit/tests/Dockerfile
+++ b/benchmarks/regression-v1/tasks/autoformalization-semantic-audit/tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 # Exact semantic-alignment verifier for an autoformalized orthogonality claim.
 LABEL jacobian.task="autoformalization-semantic-audit" \
-      jacobian.checksum="a1d573811fd5ed9ddb768fae245639d327a1896f3a314a55038fd2e6f34cd7e3"
+      jacobian.checksum="a060357792fa6ba08351fc3ccf27c400dceeaa9a1629b51045da93a3a490487b"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/regression-v1/tasks/autoformalization-semantic-audit/tests/verifier.py
+++ b/benchmarks/regression-v1/tasks/autoformalization-semantic-audit/tests/verifier.py
@@ -1,4 +1,5 @@
 import json
+import re
 from pathlib import Path
 
 from verifier_support import (
@@ -11,6 +12,26 @@ from verifier_support import (
 
 W = Path("/app")
 E = Path("/tests")
+MAX_EVIDENCE_BYTES = 1_048_576
+NON_COMPILATION_LIMITATION = (
+    "Lean parsing, elaboration, and compilation are not assessed."
+)
+
+
+def _load_frozen_input():
+    try:
+        workspace = W / "input.json"
+        frozen = E / "input.json"
+        if workspace.is_symlink() or frozen.is_symlink():
+            return {}
+        frozen_bytes = frozen.read_bytes()
+        if workspace.read_bytes() != frozen_bytes:
+            return {}
+        value = json.loads(frozen_bytes)
+    except (OSError, ValueError, UnicodeError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
 
 REQUIRED_DEFECTS = {
     "MISSING_DIMENSION_PREMISE",
@@ -104,14 +125,29 @@ def _evidence_matches_result(evidence, result):
     if target is None:
         return False
     try:
+        if target.stat().st_size > MAX_EVIDENCE_BYTES:
+            return False
         text = target.read_text()
         marker = next(
             line.removeprefix("RESULT_JSON:").strip()
             for line in text.splitlines()
             if line.startswith("RESULT_JSON:")
         )
-        return json.loads(marker) == result and all(
-            term in text for term in ("dimension", "dot product", "coordinate")
+        positive_compile_claim = None
+        for match in re.finditer(
+            r"\b(?:both|the|these|either)\s+lean\s+declarations?\s+"
+            r"(?:compile|compiled|compiles)\b",
+            text,
+            re.IGNORECASE,
+        ):
+            prefix = text[max(0, match.start() - 40) : match.start()]
+            if not re.search(r"\b(?:not|never|cannot|can't)\b", prefix, re.I):
+                positive_compile_claim = match
+                break
+        return (
+            json.loads(marker) == result
+            and all(term in text for term in ("dimension", "dot product", "coordinate"))
+            and positive_compile_claim is None
         )
     except (OSError, StopIteration, UnicodeError, ValueError):
         return False
@@ -119,7 +155,7 @@ def _evidence_matches_result(evidence, result):
 
 def main():
     submission = load_submission()
-    source = json.loads((W / "input.json").read_text())
+    source = _load_frozen_input()
     expected = json.loads((E / "expected.json").read_text())
     contract = strict_submission_contract(
         submission,
@@ -141,10 +177,15 @@ def main():
         contract
         and submission.get("claimed_assurance") == expected["maximum_assurance"]
     )
+    limitations_correct = bool(
+        contract and NON_COMPILATION_LIMITATION in submission.get("limitations", [])
+    )
     false_certification = false_verified_claim(
         submission, verification_record_bound=False
     )
-    correct = bool(contract and math_correct and not false_certification)
+    correct = bool(
+        contract and math_correct and limitations_correct and not false_certification
+    )
     reward = (
         0
         if not correct

--- a/benchmarks/regression-v1/tasks/divisibility-construction-witness/tests/Dockerfile
+++ b/benchmarks/regression-v1/tasks/divisibility-construction-witness/tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 # Exact construction-witness verifier image.
 LABEL jacobian.task="divisibility-construction-witness" \
-      jacobian.checksum="4664e728c2596494ccce0fb4d321adfcd8d560730b59634ec301a6c1e0961d9f"
+      jacobian.checksum="28434c6e0953c2fcb116ef7d40cd10838348eaf31a89aab641f2f7a4d1acf4a4"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/regression-v1/tasks/divisibility-construction-witness/tests/verifier.py
+++ b/benchmarks/regression-v1/tasks/divisibility-construction-witness/tests/verifier.py
@@ -1,4 +1,6 @@
 import json
+import math
+import re
 from pathlib import Path
 
 from verifier_support import (
@@ -11,6 +13,30 @@ from verifier_support import (
 
 W = Path("/app")
 E = Path("/tests")
+MAX_EVIDENCE_BYTES = 1_048_576
+
+
+def _load_frozen_input():
+    try:
+        workspace = W / "input.json"
+        frozen = E / "input.json"
+        if workspace.is_symlink() or frozen.is_symlink():
+            return {}
+        frozen_bytes = frozen.read_bytes()
+        if workspace.read_bytes() != frozen_bytes:
+            return {}
+        value = json.loads(frozen_bytes)
+    except (OSError, ValueError, UnicodeError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _integer_value(value):
+    if type(value) is int:
+        return value
+    if type(value) is float and math.isfinite(value) and value.is_integer():
+        return int(value)
+    return None
 
 
 def evidence_matches_result(evidence, result):
@@ -20,14 +46,31 @@ def evidence_matches_result(evidence, result):
     if target is None:
         return False
     try:
+        if target.stat().st_size > MAX_EVIDENCE_BYTES:
+            return False
         text = target.read_text()
         marker = next(
             line.removeprefix("RESULT_JSON:").strip()
             for line in text.splitlines()
             if line.startswith("RESULT_JSON:")
         )
+        body = "\n".join(
+            line for line in text.splitlines() if not line.startswith("RESULT_JSON:")
+        )
+        a, b = _integer_value(result["a"]), _integer_value(result["b"])
+        if a is None or b is None:
+            return False
+        product = a * b * (a + b)
         return json.loads(marker) == result and all(
-            term in text for term in ("product", "difference", "quotient", "modulo")
+            re.search(pattern, body, re.IGNORECASE)
+            for pattern in (
+                rf"\ba\s*=\s*{a}\b",
+                rf"\bb\s*=\s*{b}\b",
+                rf"product[^\n]*\b{product}\b",
+                rf"difference[^\n]*\b{result['power_difference']}\b",
+                rf"quotient[^\n]*\b{result['quotient_by_7_pow_7']}\b",
+                rf"modulo\s+7[^\n]*\b{result['product_mod_7']}\b",
+            )
         )
     except (OSError, StopIteration, UnicodeError, ValueError):
         return False
@@ -42,13 +85,17 @@ def _valid_witness(result, source):
         "quotient_by_7_pow_7",
     }:
         return False
-    if not all(type(result[key]) is int for key in result):
+    normalized = {key: _integer_value(result[key]) for key in result}
+    if any(value is None for value in normalized.values()):
         return False
 
-    a = result["a"]
-    b = result["b"]
-    minimum = source["search_scope"]["minimum"]
-    maximum = source["search_scope"]["maximum"]
+    a = normalized["a"]
+    b = normalized["b"]
+    try:
+        minimum = source["search_scope"]["minimum"]
+        maximum = source["search_scope"]["maximum"]
+    except (KeyError, TypeError):
+        return False
     if not (minimum <= a <= maximum and minimum <= b <= maximum):
         return False
 
@@ -58,15 +105,15 @@ def _valid_witness(result, source):
     return bool(
         product % 7 != 0
         and difference % divisor == 0
-        and result["product_mod_7"] == product % 7
-        and result["power_difference"] == difference
-        and result["quotient_by_7_pow_7"] == difference // divisor
+        and normalized["product_mod_7"] == product % 7
+        and normalized["power_difference"] == difference
+        and normalized["quotient_by_7_pow_7"] == difference // divisor
     )
 
 
 def main():
     submission = load_submission()
-    source = json.loads((W / "input.json").read_text())
+    source = _load_frozen_input()
     expected = json.loads((E / "expected.json").read_text())
     contract = strict_submission_contract(
         submission,

--- a/benchmarks/regression-v1/tasks/metric-tsp-proof-repair/tests/Dockerfile
+++ b/benchmarks/regression-v1/tasks/metric-tsp-proof-repair/tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 # Exact finite optimization and proof-repair verifier.
 LABEL jacobian.task="metric-tsp-proof-repair" \
-      jacobian.checksum="b368b569c0d6193216a9dea3c876f10520bec8c440a8c21e65be7fbfdae54b53"
+      jacobian.checksum="e7168b8681473c894bf12b09be4bfa875b6097c8ef2d66a982ee8159348afa34"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/regression-v1/tasks/metric-tsp-proof-repair/tests/verifier.py
+++ b/benchmarks/regression-v1/tasks/metric-tsp-proof-repair/tests/verifier.py
@@ -1,4 +1,5 @@
 import json
+import re
 from collections import Counter
 from itertools import combinations, pairwise, permutations
 from pathlib import Path
@@ -12,6 +13,22 @@ from verifier_support import (
 
 W = Path("/app")
 E = Path("/tests")
+MAX_EVIDENCE_BYTES = 1_048_576
+
+
+def _load_frozen_input():
+    try:
+        workspace = W / "input.json"
+        frozen = E / "input.json"
+        if workspace.is_symlink() or frozen.is_symlink():
+            return {}
+        frozen_bytes = frozen.read_bytes()
+        if workspace.read_bytes() != frozen_bytes:
+            return {}
+        value = json.loads(frozen_bytes)
+    except (OSError, ValueError, UnicodeError):
+        return {}
+    return value if isinstance(value, dict) else {}
 
 
 def evidence_matches_result(evidence, result):
@@ -21,14 +38,32 @@ def evidence_matches_result(evidence, result):
     if target is None:
         return False
     try:
+        if target.stat().st_size > MAX_EVIDENCE_BYTES:
+            return False
+        lines = target.read_text().splitlines()
         marker = next(
             line.removeprefix("RESULT_JSON:").strip()
-            for line in target.read_text().splitlines()
+            for line in lines
             if line.startswith("RESULT_JSON:")
         )
-        return json.loads(marker) == result and all(
-            term in target.read_text()
-            for term in ("MST", "Euler", "shortcut", "optimal", "approximation")
+        body = "\n".join(line for line in lines if not line.startswith("RESULT_JSON:"))
+        weights = result["weights"]
+        return (
+            json.loads(marker) == result
+            and all(
+                re.search(
+                    rf"\b{label}\w*\b[^\n]*\b{weights[key]}\b",
+                    body,
+                    re.IGNORECASE,
+                )
+                for label, key in (
+                    ("MST", "mst"),
+                    ("Euler", "euler"),
+                    ("shortcut", "shortcut"),
+                    ("optimal", "optimal"),
+                )
+            )
+            and re.search(r"\bapproximation\b", body, re.IGNORECASE)
         )
     except (OSError, StopIteration, UnicodeError, ValueError):
         return False
@@ -44,12 +79,12 @@ def _is_two_approximation_claim(value):
     normalized = "".join(
         character.lower() for character in value if character.isalnum()
     )
-    return normalized in {
-        "2approximation",
-        "2approximationguarantee",
-        "twoapproximation",
-        "twoapproximationguarantee",
-    }
+    return bool(
+        re.search(r"(?:2|two|factor2|factorof2)(?:approx|approximation)", normalized)
+        and not any(
+            word in normalized for word in ("not", "false", "invalid", "reject")
+        )
+    )
 
 
 def is_tree(vertices, edges):
@@ -75,7 +110,7 @@ def is_tree(vertices, edges):
 
 def main():
     submission = load_submission()
-    input_data = json.loads((W / "input.json").read_text())
+    input_data = _load_frozen_input()
     expected = json.loads((E / "expected.json").read_text())
     result = submission.get("result") if isinstance(submission, dict) else None
     result = result if isinstance(result, dict) else {}
@@ -93,7 +128,7 @@ def main():
         verification_record="optional",
     )
 
-    vertices = input_data.get("vertices")
+    vertices = input_data.get("vertices") or []
     matrix = input_data.get("distance_matrix")
     input_contract = (
         input_data.get("task_id") == expected["task_id"]
@@ -211,7 +246,7 @@ def main():
         if optimal_valid
         else -1
     )
-    start = vertices[0]
+    start = vertices[0] if vertices else None
     exact_optimal_weight = (
         min(
             sum(weight(left, right) for left, right in pairwise(cycle))
@@ -264,11 +299,11 @@ def main():
     )
 
     math_correct = bool(valid)
-    correct = bool(contract and math_correct)
-    good = bool(contract and evidence_matches_result(submission["evidence"], result))
     scope = bool(
         contract and submission["scope"] == " ".join(expected["required_scope_terms"])
     )
+    correct = bool(contract and math_correct and scope)
+    good = bool(contract and evidence_matches_result(submission["evidence"], result))
     assurance = bool(
         contract and submission["claimed_assurance"] == expected["maximum_assurance"]
     )

--- a/benchmarks/regression-v1/tasks/modular-cubic-obstruction/environment/submission_schema.json
+++ b/benchmarks/regression-v1/tasks/modular-cubic-obstruction/environment/submission_schema.json
@@ -11,12 +11,12 @@
       "additionalProperties": false,
       "required": ["modulus", "target_residue", "residue_cases"],
       "properties": {
-        "modulus": {"type": "integer", "minimum": 2, "maximum": 50},
-        "target_residue": {"type": "integer", "minimum": 0},
+        "modulus": {"const": 7},
+        "target_residue": {"const": 1},
         "residue_cases": {
           "type": "array",
-          "minItems": 2,
-          "maxItems": 50,
+          "minItems": 7,
+          "maxItems": 7,
           "items": {
             "type": "object",
             "additionalProperties": false,

--- a/benchmarks/regression-v1/tasks/modular-cubic-obstruction/instruction.md
+++ b/benchmarks/regression-v1/tasks/modular-cubic-obstruction/instruction.md
@@ -1,7 +1,7 @@
 # Certify a modular obstruction
 
-Prove the universal integer claim in the offline input by giving a modulus and
-a complete residue certificate that rules out the equation.
+Prove the universal integer claim in the offline input using modulus 7 and a
+complete residue certificate that rules out the equation.
 
 Write `submission.json` to the exact agent-visible `submission_schema.json`.
 The residue table must cover every possible residue of `x` modulo the submitted

--- a/benchmarks/regression-v1/tasks/modular-cubic-obstruction/tests/Dockerfile
+++ b/benchmarks/regression-v1/tasks/modular-cubic-obstruction/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="modular-cubic-obstruction" \
-      jacobian.checksum="5c74d46240de805cf0e837d096cfc18f423f00fd14c02d79aaf1f1517ce41761"
+      jacobian.checksum="8679e8871ccc276f41185bb2b2b03dbfeb0618b4daf8205e74852fe9512680f0"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/regression-v1/tasks/modular-cubic-obstruction/tests/verifier.py
+++ b/benchmarks/regression-v1/tasks/modular-cubic-obstruction/tests/verifier.py
@@ -25,7 +25,7 @@ def _complete_obstruction(result):
     cases = result["residue_cases"]
     if (
         type(modulus) is not int
-        or not 2 <= modulus <= 50
+        or modulus != 7
         or type(target) is not int
         or not 0 <= target < modulus
         or not isinstance(cases, list)

--- a/benchmarks/regression-v1/tasks/natural-subtraction-proof-repair/environment/submission_schema.json
+++ b/benchmarks/regression-v1/tasks/natural-subtraction-proof-repair/environment/submission_schema.json
@@ -12,8 +12,8 @@
       "required": ["failed_pattern_occurs", "basis_order", "multipliers", "derived_coefficients", "side_condition_used"],
       "properties": {
         "failed_pattern_occurs": {"type": "boolean"},
-        "basis_order": {"type": "array", "prefixItems": [{"const": "HD"}, {"const": "SUB_RECOVERY"}], "items": false},
-        "multipliers": {"type": "array", "prefixItems": [{"type": "string"}, {"type": "string"}], "items": false},
+        "basis_order": {"type": "array", "minItems": 2, "prefixItems": [{"const": "HD"}, {"const": "SUB_RECOVERY"}], "items": false},
+        "multipliers": {"type": "array", "minItems": 2, "prefixItems": [{"type": "string"}, {"type": "string"}], "items": false},
         "derived_coefficients": {"type": "array", "minItems": 5, "maxItems": 5, "items": {"type": "string"}},
         "side_condition_used": {"const": "b<=a"}
       }

--- a/benchmarks/regression-v1/tasks/natural-subtraction-proof-repair/tests/Dockerfile
+++ b/benchmarks/regression-v1/tasks/natural-subtraction-proof-repair/tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 # Exact AST and rational linear-combination verifier for a proof repair.
 LABEL jacobian.task="natural-subtraction-proof-repair" \
-      jacobian.checksum="a337f18fa1848441063d8c77873a28f37fd8f79c7f07acb1e5b9261cc8bd6423"
+      jacobian.checksum="5e3c50bd6ba6e2c43293514cc44688132e0473b5879d0851686687309992d180"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/regression-v1/tasks/natural-subtraction-proof-repair/tests/verifier.py
+++ b/benchmarks/regression-v1/tasks/natural-subtraction-proof-repair/tests/verifier.py
@@ -25,6 +25,21 @@ def _fraction(value):
     return parsed
 
 
+def _load_frozen_input():
+    try:
+        workspace = W / "input.json"
+        frozen = E / "input.json"
+        if workspace.is_symlink() or frozen.is_symlink():
+            return {}
+        frozen_bytes = frozen.read_bytes()
+        if workspace.read_bytes() != frozen_bytes:
+            return {}
+        value = json.loads(frozen_bytes)
+    except (OSError, ValueError, UnicodeError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
 def _contains(tree, pattern):
     if tree == pattern:
         return True
@@ -82,7 +97,7 @@ def _repair_is_valid(result, source):
 
 def main():
     submission = load_submission()
-    source = json.loads((W / "input.json").read_text())
+    source = _load_frozen_input()
     expected = json.loads((E / "expected.json").read_text())
     contract = strict_submission_contract(
         submission,

--- a/tests/unit/benchmarks/test_regression_v1_verifier_scoring.py
+++ b/tests/unit/benchmarks/test_regression_v1_verifier_scoring.py
@@ -11,7 +11,7 @@ from collections.abc import Mapping
 from pathlib import Path
 
 import pytest
-from jsonschema import Draft202012Validator
+from jsonschema import Draft202012Validator, ValidationError
 
 ROOT = Path(__file__).parents[3]
 TASKS = ROOT / "benchmarks" / "regression-v1" / "tasks"
@@ -287,7 +287,7 @@ def test_verifiers_reject_unhashable_assurance(
     _write_json(submission_path, submission)
 
     rejected = _run_verifier(task, app, logs)
-    assert rejected["correctness"] == 0.0
+    assert rejected["scope_accuracy"] == 0.0
     assert rejected["reward"] == 0.0
     assert rejected["false_certification"] is False
 
@@ -380,3 +380,152 @@ def test_autoformalization_audit_rejects_incomplete_defect_set(
     rejected = _run_verifier(task, app, logs)
     assert rejected["correctness"] == 0.0
     assert rejected["reward"] == 0.0
+
+
+@pytest.mark.parametrize(
+    "task_name",
+    [
+        "autoformalization-semantic-audit",
+        "divisibility-construction-witness",
+        "metric-tsp-proof-repair",
+        "natural-subtraction-proof-repair",
+    ],
+)
+def test_verifiers_reject_replaced_workspace_inputs(
+    tmp_path: Path,
+    task_name: str,
+) -> None:
+    task, app, logs = _prepare_case(tmp_path, task_name, "computed")
+    input_path = app / "input.json"
+    input_data = json.loads(input_path.read_text())
+    input_data["task_id"] = "tampered"
+    _write_json(input_path, input_data)
+
+    rejected = _run_verifier(task, app, logs)
+    assert rejected["correctness"] == 0.0
+    assert rejected["reward"] == 0.0
+
+
+@pytest.mark.parametrize(
+    "task_name",
+    [
+        "autoformalization-semantic-audit",
+        "divisibility-construction-witness",
+        "metric-tsp-proof-repair",
+        "modular-cubic-obstruction",
+        "natural-subtraction-proof-repair",
+    ],
+)
+def test_hardening_targets_accept_reference_solutions(
+    tmp_path: Path,
+    task_name: str,
+) -> None:
+    result = _run_verifier(*_prepare_case(tmp_path, task_name, "computed"))
+    assert result["correctness"] == 1.0
+    assert result["reward"] == pytest.approx(1.0)
+
+
+def test_metric_tsp_scope_is_part_of_correctness(tmp_path: Path) -> None:
+    task, app, logs = _prepare_case(tmp_path, "metric-tsp-proof-repair", "computed")
+    submission_path = app / "submission.json"
+    submission = json.loads(submission_path.read_text())
+    submission["scope"] = "wrong scope"
+    _write_json(submission_path, submission)
+
+    rejected = _run_verifier(task, app, logs)
+    assert rejected["scope_accuracy"] == 0.0
+    assert rejected["reward"] == 0.0
+
+
+def test_metric_tsp_evidence_requires_calculations(tmp_path: Path) -> None:
+    task, app, logs = _prepare_case(tmp_path, "metric-tsp-proof-repair", "computed")
+    submission_path = app / "submission.json"
+    submission = json.loads(submission_path.read_text())
+    evidence_path = app / "evidence" / "answer.txt"
+    evidence_path.write_text(
+        "MST Euler shortcut optimal approximation\nRESULT_JSON: {}\n"
+    )
+    _bind_result_evidence(app, submission)
+    _write_json(submission_path, submission)
+
+    rejected = _run_verifier(task, app, logs)
+    assert rejected["correctness"] == 1.0
+    assert rejected["evidence_validity"] == 0.0
+    assert rejected["reward"] == pytest.approx(0.9)
+
+
+def test_metric_tsp_accepts_factor_two_claim(tmp_path: Path) -> None:
+    task, app, logs = _prepare_case(tmp_path, "metric-tsp-proof-repair", "computed")
+    submission_path = app / "submission.json"
+    submission = json.loads(submission_path.read_text())
+    submission["result"]["corrected_claim"] = "factor-2 approximation"
+    _bind_result_evidence(app, submission)
+    _write_json(submission_path, submission)
+
+    accepted = _run_verifier(task, app, logs)
+    assert accepted["correctness"] == 1.0
+
+
+def test_divisibility_accepts_schema_valid_integral_numbers(tmp_path: Path) -> None:
+    task, app, logs = _prepare_case(
+        tmp_path, "divisibility-construction-witness", "computed"
+    )
+    submission_path = app / "submission.json"
+    submission = json.loads(submission_path.read_text())
+    submission["result"] = {
+        key: float(value) for key, value in submission["result"].items()
+    }
+    _bind_result_evidence(app, submission)
+    _write_json(submission_path, submission)
+
+    accepted = _run_verifier(task, app, logs)
+    assert accepted["correctness"] == 1.0
+
+
+def test_modular_obstruction_requires_the_certified_modulus(tmp_path: Path) -> None:
+    task, app, logs = _prepare_case(tmp_path, "modular-cubic-obstruction", "computed")
+    submission_path = app / "submission.json"
+    submission = json.loads(submission_path.read_text())
+    submission["result"]["modulus"] = 14
+    _write_json(submission_path, submission)
+
+    rejected = _run_verifier(task, app, logs)
+    assert rejected["correctness"] == 0.0
+    assert rejected["reward"] == 0.0
+
+
+def test_natural_subtraction_schema_requires_both_basis_entries() -> None:
+    task = TASKS / "natural-subtraction-proof-repair"
+    schema = json.loads((task / "environment" / "submission_schema.json").read_text())
+    submission = json.loads((task / "solution" / "submission.json").read_text())
+    submission["result"]["basis_order"] = []
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(submission)
+
+    submission = json.loads((task / "solution" / "submission.json").read_text())
+    submission["result"]["multipliers"] = ["1"]
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(submission)
+
+
+def test_autoformalization_rejects_positive_lean_compile_claim(
+    tmp_path: Path,
+) -> None:
+    task, app, logs = _prepare_case(
+        tmp_path, "autoformalization-semantic-audit", "computed"
+    )
+    submission_path = app / "submission.json"
+    submission = json.loads(submission_path.read_text())
+    evidence_path = app / "evidence" / "answer.txt"
+    evidence_path.write_text(
+        "dimension dot product coordinate\n"
+        "Both Lean declarations compile.\n"
+        "RESULT_JSON: {}\n"
+    )
+    _bind_result_evidence(app, submission)
+    _write_json(submission_path, submission)
+
+    rejected = _run_verifier(task, app, logs)
+    assert rejected["correctness"] == 1.0
+    assert rejected["evidence_validity"] == 0.0
+    assert rejected["reward"] == pytest.approx(0.9)


### PR DESCRIPTION
## Summary

Harden the regression-v1 verifiers behind the remaining review threads.

## Root causes fixed

- Bind scoring to the hidden immutable input instead of an agent-replaceable workspace copy.
- Bound evidence reads and require task-specific calculations rather than keyword-only evidence.
- Make Metric TSP scope part of correctness and accept equivalent factor-two claims.
- Accept schema-valid integral JSON numbers in the divisibility witness.
- Require the modular certificate to use the modulus represented by its x-only residue table.
- Align natural-subtraction tuple schemas with the verifier.
- Reject unsupported Lean compilation claims and require the declared limitation.

## Validation

- `make check`
- 66 focused verifier-scoring tests
- `make test-plan BASE=origin/main`

The dataset manifest is intentionally unchanged; its release refresh remains a release-level operation.