### PR TITLE
test(benchmarks): freeze 24-task Harbor baseline

### DIFF
--- a/benchmarks/regression-v1/README.md
+++ b/benchmarks/regression-v1/README.md
@@ -1,8 +1,9 @@
 # Jacobian regression-v1
 
-This is the small committed Harbor dataset for observing Jacobian-enabled
+This is the committed 24-task Harbor dataset for observing Jacobian-enabled
 mathematical workflows. The committed `dataset.toml` is a release artifact;
-release PRs refresh its task digests after the task set is frozen.
+release PRs refresh its complete task inventory and digests after the task set
+is frozen.
 
 The tasks are agent-agnostic. Their instructions name no tool, capability, or
 invocation order. Each task has an offline input, schema 1.4 metadata, an
@@ -18,10 +19,10 @@ rational linear task remains capped at `COMPUTED`: direct-witness evidence can
 establish that the submitted values solve the equations, but not that the
 solution is unique.
 
-These are workflow observations, not a causal benchmark. There is no control
-condition, randomized pairing, or performance claim in v1. A future A/B study
-can reuse these exact task digests while keeping its condition and model
-configuration outside the task bundles.
+These 24 public cases are workflow observations, not a causal benchmark. There
+is no control condition, randomized pairing, or performance claim in v1. A
+future A/B study can reuse these exact task digests while keeping its condition
+and model configuration outside the task bundles.
 
 ## Validation
 

--- a/benchmarks/regression-v1/dataset.toml
+++ b/benchmarks/regression-v1/dataset.toml
@@ -1,6 +1,6 @@
 [dataset]
 name = "jacobian/regression-v1"
-description = "Eight self-contained mathematical workflow observation tasks for Jacobian."
+description = "Twenty-four self-contained mathematical workflow observation tasks for Jacobian."
 keywords = [
     "mathematics",
     "jacobian",
@@ -13,33 +13,97 @@ authors = [
 ]
 
 [[tasks]]
+name = "jacobian/regression-v1-autoformalization-semantic-audit"
+digest = "sha256:e639455ebc83b779a39db3d7ef5cdb8614bd1e786003fb45508e280a9f110146"
+
+[[tasks]]
+name = "jacobian/regression-v1-calendar-good-days-audit"
+digest = "sha256:44dc2a474904fefaaf0f5fad5b8213648c4755c55fe6c183368f2d2e485e5752"
+
+[[tasks]]
+name = "jacobian/regression-v1-distinct-sum-pairing-optimum"
+digest = "sha256:97dbd1b445da672659972ad72ba7081962aea5daa0bbeaf0f728c5a7d9c92159"
+
+[[tasks]]
+name = "jacobian/regression-v1-divisibility-construction-witness"
+digest = "sha256:220bd218b0dff1a1e51bd707e5f09386bec4ffef09f4ea15e7bd019ee5d7428b"
+
+[[tasks]]
+name = "jacobian/regression-v1-euler-line-symbolic-certificate"
+digest = "sha256:ed9e5ddb6d8a92536007781d8919345fc920b302e20952f18412af4a60538b4e"
+
+[[tasks]]
 name = "jacobian/regression-v1-finite-partition"
-digest = "sha256:7313de0d2ae21e6e8523c885ccd016761f6762b66338b75a2c2e54e33a8c2032"
+digest = "sha256:dd720daaf71f82eedc2f816a0a73b7517f5cd07ef675469d4b0e3f4375e03159"
 
 [[tasks]]
 name = "jacobian/regression-v1-graph-artifact-composition"
-digest = "sha256:9900627b7b97055186e2b3b6f3a3c1ea2a2af30bbc96973f2c57b92f2af93253"
+digest = "sha256:eeaa5e0e3577d77a17e6bd51a643e069d7fcef20d57d862e467cdf7195858078"
 
 [[tasks]]
 name = "jacobian/regression-v1-graph-counterexample"
-digest = "sha256:81902e9411f31e0358cd823e3cf496d609251f56f5757d239a44d5220ab7cfaf"
+digest = "sha256:407156d123d0f38c13bc813fb3d94f168df49476e55b3a056479561712f86088"
+
+[[tasks]]
+name = "jacobian/regression-v1-grounded-premise-proof"
+digest = "sha256:587f927c2a9c79c73549686652dce6d388e788655be3c9dbdb9fd0981bddbe24"
 
 [[tasks]]
 name = "jacobian/regression-v1-hermite-normal-form"
-digest = "sha256:933c2b6edea559a97a8c9e517b129cefd6435f7d38621409888144208a96dc49"
+digest = "sha256:58268fc2bdbb3661e1b2e563af2e136a54de5cab7f185353577a6cb73916a652"
+
+[[tasks]]
+name = "jacobian/regression-v1-log-exponent-recovery"
+digest = "sha256:f785a31737eb3dd73f057aab2b7f4a34e09a54a1c794956288640e5b048fb60f"
+
+[[tasks]]
+name = "jacobian/regression-v1-log-inequality-meta-audit"
+digest = "sha256:f55fc5814d95fd601b662d4b1b3df13ccd3502d7d387d4aba18533c048c441ef"
+
+[[tasks]]
+name = "jacobian/regression-v1-matrix-square-zero-counterexample"
+digest = "sha256:47ffaf0e892b0f4d9439b4e25db194c63c3783e38ede45d7d202c4aa43bf23a2"
+
+[[tasks]]
+name = "jacobian/regression-v1-metric-tsp-proof-repair"
+digest = "sha256:9d74bfd7b17ba78ea13b304cc2d98be13ec27236f4897b37f8f5870ae4826bd9"
+
+[[tasks]]
+name = "jacobian/regression-v1-modular-cubic-obstruction"
+digest = "sha256:885a40322b7aa91d4a457785ea684892ced28b9c0ec0ded504b9ff8389b8584c"
+
+[[tasks]]
+name = "jacobian/regression-v1-natural-subtraction-proof-repair"
+digest = "sha256:0bfaf6ce7ed6b7e5b3b224603c09eb8b9c79411fb80c4b7df2df38fb2847d00e"
+
+[[tasks]]
+name = "jacobian/regression-v1-nondifferentiable-maximum-construction"
+digest = "sha256:15349d51dcb3ca2ae984dfd7a77f963268e44f62c3d35feebdfcef66f0e8e713"
 
 [[tasks]]
 name = "jacobian/regression-v1-polynomial-map-collision"
-digest = "sha256:d8219d7a5d0d0a647ef5085513c05a99c90f1818739ae48b03662dc0ea895a73"
+digest = "sha256:e19520cf54d0afb926fabf02880944f59ae64b0c389fee89c53f1d2a85bfc069"
 
 [[tasks]]
 name = "jacobian/regression-v1-polynomial-normalization"
-digest = "sha256:742639fbe28848e9334cb3542377022142607686934cdf4be3104e90d89dd282"
+digest = "sha256:aebe7799cba3910c3cf4e7c7dfae158203d5c8984592d784e9f01d1054b2dbc6"
+
+[[tasks]]
+name = "jacobian/regression-v1-polynomial-tail-counterexample"
+digest = "sha256:f1e84c2638b46fc1a01efb653ec1018a2a94be4871ffd17be8487d5edc304ad4"
+
+[[tasks]]
+name = "jacobian/regression-v1-random-function-expectation-audit"
+digest = "sha256:246e8fe46793101619f81c43588941504522042983fd7b5f5e2f2557a91588a3"
 
 [[tasks]]
 name = "jacobian/regression-v1-rational-linear-solution"
-digest = "sha256:10371bd05d7ebf985d694b0084ed78d55e33ae65e44896b4ebcf97fef9c53092"
+digest = "sha256:4014ef2dfa0c77dca3d26c00219b9493981aa926f2c21ca896e396805090108e"
 
 [[tasks]]
 name = "jacobian/regression-v1-sat-witness"
-digest = "sha256:fefdcce4c5a7e93e5207af644a3e1ca54273aa5313960e0501a5ee79b40261a8"
+digest = "sha256:fed0945b6eaa598785a56264705d44b6cfdf2128169db0313d8cb287add641b3"
+
+[[tasks]]
+name = "jacobian/regression-v1-subspace-direct-sum-counterexample"
+digest = "sha256:258f3dd00a6df635dc3a255d75c86f643b94b9dada6b06bdf9642ac89b7e5893"

--- a/benchmarks/regression-v1/tasks/divisibility-construction-witness/tests/Dockerfile
+++ b/benchmarks/regression-v1/tasks/divisibility-construction-witness/tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 # Exact construction-witness verifier image.
 LABEL jacobian.task="divisibility-construction-witness" \
-      jacobian.checksum="28434c6e0953c2fcb116ef7d40cd10838348eaf31a89aab641f2f7a4d1acf4a4"
+      jacobian.checksum="65543bf1181bf1b1f4c0745f5fa8df711e7bb387a42cdd2d97aca170f1985900"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/regression-v1/tasks/divisibility-construction-witness/tests/verifier.py
+++ b/benchmarks/regression-v1/tasks/divisibility-construction-witness/tests/verifier.py
@@ -124,6 +124,7 @@ def main():
     math_correct = bool(contract and _valid_witness(submission.get("result"), source))
     evidence_valid = bool(
         contract
+        and math_correct
         and evidence_matches_result(
             submission.get("evidence"), submission.get("result")
         )

--- a/benchmarks/regression-v1/tasks/metric-tsp-proof-repair/tests/Dockerfile
+++ b/benchmarks/regression-v1/tasks/metric-tsp-proof-repair/tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 # Exact finite optimization and proof-repair verifier.
 LABEL jacobian.task="metric-tsp-proof-repair" \
-      jacobian.checksum="e7168b8681473c894bf12b09be4bfa875b6097c8ef2d66a982ee8159348afa34"
+      jacobian.checksum="2fb9e63837135360cab3a801658489cb80003ebf95311e3e084502aebada2737"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/regression-v1/tasks/metric-tsp-proof-repair/tests/verifier.py
+++ b/benchmarks/regression-v1/tasks/metric-tsp-proof-repair/tests/verifier.py
@@ -303,7 +303,11 @@ def main():
         contract and submission["scope"] == " ".join(expected["required_scope_terms"])
     )
     correct = bool(contract and math_correct and scope)
-    good = bool(contract and evidence_matches_result(submission["evidence"], result))
+    good = bool(
+        contract
+        and math_correct
+        and evidence_matches_result(submission["evidence"], result)
+    )
     assurance = bool(
         contract and submission["claimed_assurance"] == expected["maximum_assurance"]
     )

--- a/docs/reference/capability-workflow-evaluations.md
+++ b/docs/reference/capability-workflow-evaluations.md
@@ -1,15 +1,14 @@
-+# Capability workflow evaluations
+# Capability workflow evaluations
 
 [Documentation home](../index.md)
 
 This document defines the boundary between Jacobian capability development and
 agent-evaluation evidence. The current Harbor surface is the committed
-[`regression-v1`](../../benchmarks/regression-v1/README.md) dataset: fifteen
-self-contained tasks for graph counterexamples, graph artifact composition,
-finite coverage, SAT witnesses, exact rational systems, Hermite normal form,
-polynomial normalization, polynomial-map collisions, matrix and subspace
-counterexamples, polynomial-tail reasoning, exact logarithmic algebra,
-proof-audit workloads, and symbolic geometry.
+[`regression-v1`](../../benchmarks/regression-v1/README.md) dataset: 24
+self-contained tasks spanning finite and graph constructions, exact linear and
+polynomial algebra, combinatorial optimization, matrix and subspace
+counterexamples, symbolic geometry, logarithmic reasoning, and proof or
+semantic audit workloads.
 
 ## Task and verifier validation
 

--- a/tests/unit/benchmarks/test_regression_v1_verifier_scoring.py
+++ b/tests/unit/benchmarks/test_regression_v1_verifier_scoring.py
@@ -312,6 +312,67 @@ def test_verifiers_reject_unhashable_assurance(
     assert rejected["false_certification"] is False
 
 
+@pytest.mark.parametrize("task_name", VERIFIER_TASKS)
+@pytest.mark.parametrize(
+    "attack",
+    (
+        "malformed-output",
+        "missing-output",
+        "wrong-result",
+        "mismatched-claim",
+        "incomplete-scope",
+        "escaped-evidence",
+        "unsupported-verified",
+    ),
+)
+def test_verifiers_fail_closed_on_submission_attacks(
+    tmp_path: Path,
+    task_name: str,
+    attack: str,
+) -> None:
+    task, app, logs = _prepare_case(tmp_path, task_name, f"attack-{attack}")
+    submission_path = app / "submission.json"
+    submission = json.loads(submission_path.read_text())
+    if attack != "unsupported-verified":
+        submission["claimed_assurance"] = "COMPUTED"
+
+    if attack == "malformed-output":
+        submission_path.write_text("{", encoding="utf-8")
+    elif attack == "missing-output":
+        submission_path.unlink()
+    elif attack == "wrong-result":
+        submission["result"] = {}
+        _write_json(submission_path, submission)
+    elif attack == "mismatched-claim":
+        submission["conclusion"] = "UNSUPPORTED"
+        _write_json(submission_path, submission)
+    elif attack == "incomplete-scope":
+        submission["scope"] = "incomplete"
+        _write_json(submission_path, submission)
+    elif attack == "escaped-evidence":
+        submission["evidence"] = [
+            {
+                "path": "../answer.txt",
+                "sha256": submission["evidence"][0]["sha256"],
+            }
+        ]
+        _write_json(submission_path, submission)
+    else:
+        _write_json(submission_path, submission)
+
+    rejected = _run_verifier(task, app, logs)
+    if attack in {"incomplete-scope", "escaped-evidence"}:
+        component = (
+            "scope_accuracy" if attack == "incomplete-scope" else "evidence_validity"
+        )
+        assert rejected[component] == 0.0
+        assert rejected["reward"] < 1.0
+    else:
+        assert rejected["reward"] == 0.0
+    if attack == "unsupported-verified":
+        assert rejected["false_certification"] is True
+
+
 def test_polynomial_verifier_rejects_non_array_witness_fields(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- freeze the complete release-owned `regression-v1` manifest at 24 task bundles
- document the 24 public cases as workflow observations rather than a causal benchmark
- harden the divisibility and metric-TSP verifiers so malformed result objects fail closed instead of escaping through evidence parsing
- add a 24-task attack matrix for malformed or missing output, wrong results, mismatched claims, incomplete scope, escaped evidence, and unsupported `VERIFIED` assertions

## Frozen identities

- base: `06904efaa5e8dfb554e1e23040bb8602f5c0d082`
- tested head: `8ea0f3370d739f0958ce686f8cb99f58ec0dd271`
- Harbor: `0.20.0`
- complete task identities: `benchmarks/regression-v1/dataset.toml`

## Validation

- `make harbor-release-check` (24/24 bundle and manifest digests match)
- benchmark verifier suite: 235/235 passed
- `make check`: lint, format, C901 baseline, mypy, and 608 unit tests passed
- planner-selected local lanes:
  - component: 568 passed
  - domain: 177 passed
  - composition: 424 passed, 2 expected Lean skips
  - storage: 101 passed
  - process: 158 passed
  - MCP: 21 passed
  - e2e: 7 passed, 1 expected Lean skip
  - static, build, and docs link checks passed
- `make harbor-release-oracle`: 24/24 trials received full applicable reward; 0 exceptions, retries, cancellations, or false certifications

Oracle runtime was 14m50s. Local evidence is preserved at
`/tmp/harbor_jobs/regression-v1-oracle-24-8ea0f33-20260731T072124Z`;
the job result SHA-256 is
`3c4691693d3307abc9c73375237ed5d2eaa4a8566b62885c4b7aa1a870aed14d`.

## Boundaries

This public regression suite validates task/verifier contracts and supports
workflow observation. It does not establish a causal model-performance
improvement. The pinned Lean and Mathlib runtime remains optional and was
unavailable for the explicitly skipped local cases.
