### PR TITLE
test(evaluation): freeze capability gap scaffold

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -10,6 +10,7 @@ diagnostics only.
 | Path | Artifact class | What it proves | Authoritative for |
 | --- | --- | --- | --- |
 | [`regression-v1/`](regression-v1/) | Harbor workflow dataset | Offline Oracle contract + Jacobian observation on a release-frozen task set | Agent workflow observation (v1); `dataset.toml` is refreshed only by release PRs |
+| [`capability-evaluations/v1/`](capability-evaluations/v1/) | Gap ledger + C1/C2 evaluation scaffold | Public workflow classification and fail-closed comparison design | Discovery handoffs and future held-out configuration; **not** a model-performance claim |
 | [`research/`](research/) | Public research challenges + runner | Answer-visible composition diagnostics under no-retrieval policy | Capability discovery handoffs; **not** held-out model scores |
 | [`reproductions/`](reproductions/) | Public reproduction fixtures | Exact public case replay in composition/provider tests | Regression of known public mathematical episodes |
 | [`examples/`](examples/) | Pilot / documentation cases | Illustrative inputs only | Docs and local smoke |

--- a/benchmarks/capability-evaluations/v1/README.md
+++ b/benchmarks/capability-evaluations/v1/README.md
@@ -1,0 +1,29 @@
+# Capability evaluation v1
+
+This directory freezes the discovery handoff and comparison design derived
+from the public 24-task Harbor `regression-v1` suite. It does not contain a
+model result or a held-out score.
+
+The artifacts have three distinct roles:
+
+- `gap-ledger.json` classifies the mathematical moves and portfolio gaps
+  exposed by every public task. Its accepted candidates are discovery
+  handoffs, not performance claims.
+- `comparison-plan.json` fixes the C0/C1/C2 meanings, matched-condition
+  invariants, contamination boundary, and execution gate.
+- `job-public-c1-current.json` and `job-public-c2-treatment.json` are Harbor
+  configurations for answer-visible workflow reproduction only. They differ
+  only in their result directory and digest-pinned Jacobian image selection.
+
+The public jobs must never be cited as causal evidence. C1 is the frozen
+current catalog; C2 is the same catalog plus exactly one candidate delta. A
+future held-out run must supply a separately frozen task set whose Oracle
+material is stored outside the evaluated workspace, use at least two
+independent mathematical families, and bind every result to the exact
+catalog, policy, image, model, prompt, budget, seed, scorer, and task digests.
+
+No held-out fixtures or Oracle answers are committed here. Until those
+external identities are filled and a hard model-run budget is authorized,
+`comparison-plan.json` remains `SCAFFOLD_ONLY` and no model execution is
+allowed.
+

--- a/benchmarks/capability-evaluations/v1/comparison-plan.json
+++ b/benchmarks/capability-evaluations/v1/comparison-plan.json
@@ -1,0 +1,130 @@
+{
+  "schema_version": "1",
+  "plan_id": "jacobian.capability-comparison.v1",
+  "status": "SCAFFOLD_ONLY",
+  "captured_at": "2026-07-31",
+  "evidence_classes": [
+    "HARNESS_VALIDATION",
+    "PUBLIC_WORKFLOW_OBSERVATION",
+    "HELD_OUT_COMPARATIVE_EVALUATION"
+  ],
+  "public_reproduction": {
+    "path": "benchmarks/regression-v1/tasks",
+    "task_count": 24,
+    "manifest_digest": "sha256:e6feea1ad0c9640670107c51ede1c7df1eb20517b01e79bc04cc04d83702d2d8",
+    "contamination": "PUBLIC_ANSWER_VISIBLE",
+    "causal_claims_allowed": false
+  },
+  "held_out_boundary": {
+    "status": "NOT_MATERIALIZED",
+    "task_manifest_digest": null,
+    "oracle_manifest_digest": null,
+    "minimum_independent_families": 2,
+    "agent_visible": [
+      "task instruction",
+      "offline input",
+      "submission and evidence schemas"
+    ],
+    "agent_forbidden": [
+      "Oracle solution",
+      "expected result",
+      "verifier source and authorized verification records"
+    ],
+    "storage_rule": "ORACLE_OUTSIDE_EVALUATED_WORKSPACE"
+  },
+  "conditions": [
+    {
+      "condition_id": "C0",
+      "role": "CONTEXT_ONLY",
+      "portfolio": "No Jacobian MCP; optional broad toolbox-value context, never the primary candidate comparison.",
+      "public_job_config": null,
+      "image_environment_variable": null,
+      "catalog_digest": null,
+      "status": "NOT_CONFIGURED"
+    },
+    {
+      "condition_id": "C1",
+      "role": "PRIMARY_CONTROL",
+      "portfolio": "Frozen current Jacobian catalog.",
+      "public_job_config": "benchmarks/capability-evaluations/v1/job-public-c1-current.json",
+      "image_environment_variable": "JACOBIAN_C1_IMAGE",
+      "catalog_digest": "sha256:c9fd0f0e062312f1b466c08207b5fd1d2994bd6aee12b6a8c2f6d7bd876706bc",
+      "status": "FROZEN"
+    },
+    {
+      "condition_id": "C2",
+      "role": "PRIMARY_TREATMENT",
+      "portfolio": "The C1 catalog plus exactly one accepted candidate delta.",
+      "public_job_config": "benchmarks/capability-evaluations/v1/job-public-c2-treatment.json",
+      "image_environment_variable": "JACOBIAN_C2_IMAGE",
+      "catalog_digest": null,
+      "status": "BLOCKED_PENDING_SINGLE_DELTA"
+    }
+  ],
+  "matched_invariants": [
+    "task digests",
+    "visible prompt",
+    "agent implementation",
+    "model identifier",
+    "reasoning effort",
+    "token budget",
+    "wall-time budget",
+    "container base",
+    "shell and file access",
+    "MCP policy profile",
+    "random seed",
+    "scorer and verifier identities"
+  ],
+  "randomization": {
+    "unit": "CASE_REPETITION",
+    "strategy": "BLOCK_RANDOMIZED_C1_C2_ORDER",
+    "seed": 104729,
+    "paired": true
+  },
+  "budget_ladder": [
+    {
+      "stage": "SMOKE",
+      "cases": null,
+      "conditions": 0,
+      "repetitions": null,
+      "model_execution": false,
+      "interpretation": "Oracle, schema, and verifier-attack validation only."
+    },
+    {
+      "stage": "PILOT",
+      "cases": 3,
+      "conditions": 2,
+      "repetitions": 3,
+      "model_execution": true,
+      "interpretation": "Workflow and variance diagnosis only; no statistically strong portfolio claim."
+    },
+    {
+      "stage": "DECISION",
+      "cases": 5,
+      "conditions": 2,
+      "repetitions": 5,
+      "model_execution": true,
+      "interpretation": "Minimum target after sample size is preregistered from pilot variance."
+    }
+  ],
+  "execution_gate": {
+    "explicit_authorization": false,
+    "hard_run_budget": null,
+    "credentials_present": false,
+    "held_out_frozen": false,
+    "treatment_frozen": false,
+    "model_execution_allowed": false
+  },
+  "claim_policy": {
+    "public_jobs_causal_claims_allowed": false,
+    "pilot_decision_claims_allowed": false,
+    "held_out_decision_requires": [
+      "mathematically correct completion",
+      "valid and scope-bound evidence",
+      "no false-certification regression",
+      "discoverable and successfully invoked candidate",
+      "frozen paired C1/C2 identities"
+    ],
+    "false_certification_rule": "STOP_AND_REPAIR_ON_ANY_REGRESSION"
+  }
+}

--- a/benchmarks/capability-evaluations/v1/comparison-plan.schema.json
+++ b/benchmarks/capability-evaluations/v1/comparison-plan.schema.json
@@ -1,0 +1,357 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jacobian.invalid/schemas/capability-comparison-plan-v1.json",
+  "title": "Jacobian C1/C2 capability comparison plan",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "plan_id",
+    "status",
+    "captured_at",
+    "evidence_classes",
+    "public_reproduction",
+    "held_out_boundary",
+    "conditions",
+    "matched_invariants",
+    "randomization",
+    "budget_ladder",
+    "execution_gate",
+    "claim_policy"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "1"
+    },
+    "plan_id": {
+      "const": "jacobian.capability-comparison.v1"
+    },
+    "status": {
+      "const": "SCAFFOLD_ONLY"
+    },
+    "captured_at": {
+      "type": "string",
+      "format": "date"
+    },
+    "evidence_classes": {
+      "type": "array",
+      "prefixItems": [
+        {
+          "const": "HARNESS_VALIDATION"
+        },
+        {
+          "const": "PUBLIC_WORKFLOW_OBSERVATION"
+        },
+        {
+          "const": "HELD_OUT_COMPARATIVE_EVALUATION"
+        }
+      ],
+      "items": false
+    },
+    "public_reproduction": {
+      "$ref": "#/$defs/fixture"
+    },
+    "held_out_boundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "task_manifest_digest",
+        "oracle_manifest_digest",
+        "minimum_independent_families",
+        "agent_visible",
+        "agent_forbidden",
+        "storage_rule"
+      ],
+      "properties": {
+        "status": {
+          "const": "NOT_MATERIALIZED"
+        },
+        "task_manifest_digest": {
+          "type": "null"
+        },
+        "oracle_manifest_digest": {
+          "type": "null"
+        },
+        "minimum_independent_families": {
+          "type": "integer",
+          "minimum": 2
+        },
+        "agent_visible": {
+          "type": "array",
+          "minItems": 3,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "agent_forbidden": {
+          "type": "array",
+          "minItems": 3,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "storage_rule": {
+          "const": "ORACLE_OUTSIDE_EVALUATED_WORKSPACE"
+        }
+      }
+    },
+    "conditions": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "$ref": "#/$defs/condition"
+      }
+    },
+    "matched_invariants": {
+      "type": "array",
+      "minItems": 10,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "randomization": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "unit",
+        "strategy",
+        "seed",
+        "paired"
+      ],
+      "properties": {
+        "unit": {
+          "const": "CASE_REPETITION"
+        },
+        "strategy": {
+          "const": "BLOCK_RANDOMIZED_C1_C2_ORDER"
+        },
+        "seed": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "paired": {
+          "const": true
+        }
+      }
+    },
+    "budget_ladder": {
+      "type": "array",
+      "minItems": 3,
+      "items": {
+        "$ref": "#/$defs/budget"
+      }
+    },
+    "execution_gate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "explicit_authorization",
+        "hard_run_budget",
+        "credentials_present",
+        "held_out_frozen",
+        "treatment_frozen",
+        "model_execution_allowed"
+      ],
+      "properties": {
+        "explicit_authorization": {
+          "const": false
+        },
+        "hard_run_budget": {
+          "type": "null"
+        },
+        "credentials_present": {
+          "const": false
+        },
+        "held_out_frozen": {
+          "const": false
+        },
+        "treatment_frozen": {
+          "const": false
+        },
+        "model_execution_allowed": {
+          "const": false
+        }
+      }
+    },
+    "claim_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "public_jobs_causal_claims_allowed",
+        "pilot_decision_claims_allowed",
+        "held_out_decision_requires",
+        "false_certification_rule"
+      ],
+      "properties": {
+        "public_jobs_causal_claims_allowed": {
+          "const": false
+        },
+        "pilot_decision_claims_allowed": {
+          "const": false
+        },
+        "held_out_decision_requires": {
+          "type": "array",
+          "minItems": 5,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "false_certification_rule": {
+          "const": "STOP_AND_REPAIR_ON_ANY_REGRESSION"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "fixture": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "task_count",
+        "manifest_digest",
+        "contamination",
+        "causal_claims_allowed"
+      ],
+      "properties": {
+        "path": {
+          "const": "benchmarks/regression-v1/tasks"
+        },
+        "task_count": {
+          "const": 24
+        },
+        "manifest_digest": {
+          "$ref": "#/$defs/digest"
+        },
+        "contamination": {
+          "const": "PUBLIC_ANSWER_VISIBLE"
+        },
+        "causal_claims_allowed": {
+          "const": false
+        }
+      }
+    },
+    "condition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "condition_id",
+        "role",
+        "portfolio",
+        "public_job_config",
+        "image_environment_variable",
+        "catalog_digest",
+        "status"
+      ],
+      "properties": {
+        "condition_id": {
+          "enum": [
+            "C0",
+            "C1",
+            "C2"
+          ]
+        },
+        "role": {
+          "enum": [
+            "CONTEXT_ONLY",
+            "PRIMARY_CONTROL",
+            "PRIMARY_TREATMENT"
+          ]
+        },
+        "portfolio": {
+          "type": "string",
+          "minLength": 1
+        },
+        "public_job_config": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "image_environment_variable": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "catalog_digest": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/digest"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "status": {
+          "enum": [
+            "NOT_CONFIGURED",
+            "FROZEN",
+            "BLOCKED_PENDING_SINGLE_DELTA"
+          ]
+        }
+      }
+    },
+    "budget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "stage",
+        "cases",
+        "conditions",
+        "repetitions",
+        "model_execution",
+        "interpretation"
+      ],
+      "properties": {
+        "stage": {
+          "enum": [
+            "SMOKE",
+            "PILOT",
+            "DECISION"
+          ]
+        },
+        "cases": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "conditions": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "repetitions": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "model_execution": {
+          "type": "boolean"
+        },
+        "interpretation": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/benchmarks/capability-evaluations/v1/gap-ledger.json
+++ b/benchmarks/capability-evaluations/v1/gap-ledger.json
@@ -1,0 +1,1001 @@
+{
+  "schema_version": "1",
+  "ledger_id": "jacobian.regression-v1.capability-gap-ledger",
+  "captured_at": "2026-07-31",
+  "source_suite": {
+    "path": "benchmarks/regression-v1/dataset.toml",
+    "task_count": 24,
+    "manifest_sha256": "sha256:e6feea1ad0c9640670107c51ede1c7df1eb20517b01e79bc04cc04d83702d2d8",
+    "contamination": "PUBLIC_ANSWER_VISIBLE"
+  },
+  "runtime_snapshot": {
+    "repository_commit": "67a6152c54f0724883c47892987e1fa81e338057",
+    "repository_tree": "5299e06b87ff14dde793272dedb07637d791e44e",
+    "package_version": "0.6.0-alpha.0",
+    "harbor_version": "0.20.0",
+    "catalog_digest": "sha256:c9fd0f0e062312f1b466c08207b5fd1d2994bd6aee12b6a8c2f6d7bd876706bc",
+    "policy_profile": "DEFAULT",
+    "policy_digest": "sha256:870a92b83d3e522e4015b6bb1cabda33086906f9de1c3c36e466251ea7ed1957",
+    "provider_snapshots": [
+      {
+        "capability_id": "modular.enumerate.quadratic_residues",
+        "availability": "AVAILABLE",
+        "provider": "jacobian.sympy",
+        "provider_version": "1.14.0",
+        "runtime_digest": "sha256:073cc470f11e11a095f95d50f46b264145cea0598b42820321dc9005790358f9"
+      },
+      {
+        "capability_id": "linear.rational_solution.find",
+        "availability": "AVAILABLE",
+        "provider": "python-flint",
+        "provider_version": "0.9.0",
+        "runtime_digest": "sha256:8ade9b4c5c1972b029d9393bb2586e2097cc44149a84ef8ef9ef376d634c328f"
+      },
+      {
+        "capability_id": "lean.check",
+        "availability": "UNAVAILABLE",
+        "provider": "lean-runtime",
+        "provider_version": "Lean 4.31.0 required but not installed",
+        "runtime_digest": null
+      }
+    ],
+    "lean_available": false,
+    "model_execution": "NOT_RUN",
+    "oracle_evidence": {
+      "task_count": 24,
+      "result_sha256": "sha256:3c4691693d3307abc9c73375237ed5d2eaa4a8566b62885c4b7aa1a870aed14d",
+      "host_local_path": "/tmp/harbor_jobs/regression-v1-oracle-24-8ea0f33-20260731T072124Z"
+    }
+  },
+  "gap_taxonomy": [
+    "EXISTING_WORKS",
+    "WEAK_DISCOVERY",
+    "BAD_PARAMETERIZATION",
+    "MISSING_OPERATION",
+    "MISSING_ARTIFACT_HANDOFF",
+    "MISSING_CHECKER",
+    "PROVIDER_UNAVAILABLE",
+    "ENVIRONMENT_BUDGET_AUTH",
+    "MODEL_REASONING"
+  ],
+  "tasks": [
+    {
+      "task_id": "autoformalization-semantic-audit",
+      "mathematical_moves": [
+        "Compare formal statement semantics with an informal dimension and dot-product claim.",
+        "Produce exact rational vector counterexamples to two semantic substitutions."
+      ],
+      "current_capabilities": [
+        {
+          "capability_id": "lean.statement.compare",
+          "availability": "UNAVAILABLE",
+          "boundary": "The operation exists, but the pinned Lean runtime is absent from the current environment."
+        },
+        {
+          "capability_id": "linear.rational_solution.find",
+          "availability": "AVAILABLE",
+          "boundary": "Finds one Ax=b solution; it does not return a basis of all relations among named vectors."
+        }
+      ],
+      "gap_classes": [
+        "PROVIDER_UNAVAILABLE",
+        "MISSING_OPERATION"
+      ],
+      "contamination": "PUBLIC_ANSWER_VISIBLE",
+      "candidate_ids": [
+        "rational-relation-basis"
+      ],
+      "disposition": "ACCEPT_CANDIDATE",
+      "next_action": "Restore the pinned Lean profile separately; use this vector episode as one public reproduction for the rational-relation primitive."
+    },
+    {
+      "task_id": "calendar-good-days-audit",
+      "mathematical_moves": [
+        "Enumerate a declared finite calendar interval and test an exact digit predicate."
+      ],
+      "current_capabilities": [],
+      "gap_classes": [
+        "MODEL_REASONING"
+      ],
+      "contamination": "PUBLIC_ANSWER_VISIBLE",
+      "candidate_ids": [],
+      "disposition": "NO_NEW_CAPABILITY",
+      "next_action": "Keep the finite enumeration in agent-owned composition; do not add a calendar-task solver."
+    },
+    {
+      "task_id": "distinct-sum-pairing-optimum",
+      "mathematical_moves": [
+        "Search for disjoint pairs with distinct bounded sums and establish finite optimality."
+      ],
+      "current_capabilities": [
+        {
+          "capability_id": "optimization.linear.rational_optimum.compute",
+          "availability": "AVAILABLE",
+          "boundary": "The rational LP outcome does not encode the discrete all-different pairing semantics."
+        }
+      ],
+      "gap_classes": [
+        "MISSING_OPERATION"
+      ],
+      "contamination": "PUBLIC_ANSWER_VISIBLE",
+      "candidate_ids": [],
+      "disposition": "DEFER_RESEARCH",
+      "next_action": "Mine independent finite matching or all-different episodes before proposing a reusable bounded combinatorial contract."
+    },
+    {
+      "task_id": "divisibility-construction-witness",
+      "mathematical_moves": [
+        "Evaluate polynomial divisibility conditions over a bounded integer search scope.",
+        "Return a witness with exact quotient and remainder arithmetic."
+      ],
+      "current_capabilities": [
+        {
+          "capability_id": "modular.enumerate.quadratic_residues",
+          "availability": "AVAILABLE",
+          "boundary": "Enumerates squares modulo one modulus only; it cannot expose a general sparse polynomial residue image."
+        }
+      ],
+      "gap_classes": [
+        "MISSING_OPERATION",
+        "WEAK_DISCOVERY"
+      ],
+      "contamination": "PUBLIC_ANSWER_VISIBLE",
+      "candidate_ids": [
+        "modular-polynomial-residue-image"
+      ],
+      "disposition": "ACCEPT_CANDIDATE",
+      "next_action": "Use this as the second structurally distinct public episode for a complete polynomial residue-image producer."
+    },
+    {
+      "task_id": "euler-line-symbolic-certificate",
+      "mathematical_moves": [
+        "Derive exact sparse rational-function coordinates.",
+        "Find and replay a nonzero linear relation among three named points."
+      ],
+      "current_capabilities": [
+        {
+          "capability_id": "polynomial.identity.verify",
+          "availability": "AVAILABLE",
+          "boundary": "Can replay denominator-cleared identities but does not discover the relation coefficients."
+        },
+        {
+          "capability_id": "linear.rational_solution.find",
+          "availability": "AVAILABLE",
+          "boundary": "Solves Ax=b but loses named-vector relation-basis semantics."
+        }
+      ],
+      "gap_classes": [
+        "MISSING_OPERATION",
+        "MISSING_ARTIFACT_HANDOFF"
+      ],
+      "contamination": "PUBLIC_ANSWER_VISIBLE",
+      "candidate_ids": [
+        "rational-relation-basis"
+      ],
+      "disposition": "ACCEPT_CANDIDATE",
+      "next_action": "Preserve polynomial identity replay and evaluate whether a relation artifact composes cleanly after denominator clearing."
+    },
+    {
+      "task_id": "finite-partition",
+      "mathematical_moves": [
+        "Partition a finite universe by a residue predicate and certify disjoint exhaustive coverage."
+      ],
+      "current_capabilities": [
+        {
+          "capability_id": "case.partition.finite",
+          "availability": "AVAILABLE",
+          "boundary": "Matches the finite partition and exact coverage outcome."
+        }
+      ],
+      "gap_classes": [
+        "EXISTING_WORKS"
+      ],
+      "contamination": "PUBLIC_ANSWER_VISIBLE",
+      "candidate_ids": [],
+      "disposition": "USE_EXISTING",
+      "next_action": "Use trace evidence to diagnose discovery or payload failures; do not add a duplicate producer."
+    },
+    {
+      "task_id": "graph-artifact-composition",
+      "mathematical_moves": [
+        "Compute maximum-degree vertices and distances from every vertex to that set.",
+        "Compose graph artifacts while preserving labels and aggregate scope."
+      ],
+      "current_capabilities": [
+        {
+          "capability_id": "graph.compute.properties",
+          "availability": "AVAILABLE",
+          "boundary": "Provides graph properties and degrees."
+        },
+        {
+          "capability_id": "graph.distance_matrix.compute",
+          "availability": "AVAILABLE",
+          "boundary": "Provides all-pairs distances that the agent can compose with a chosen vertex set."
+        }
+      ],
+      "gap_classes": [
+        "EXISTING_WORKS",
+        "MODEL_REASONING"
+      ],
+      "contamination": "PUBLIC_ANSWER_VISIBLE",
+      "candidate_ids": [],
+      "disposition": "USE_EXISTING",
+      "next_action": "Inspect model traces for artifact handoff friction before changing the portfolio."
+    },
+    {
+      "task_id": "graph-counterexample",
+      "mathematical_moves": [
+        "Search finite simple graphs and return a hypothesis-satisfying counterexample."
+      ],
+      "current_capabilities": [
+        {
+          "capability_id": "graph.search.atlas",
+          "availability": "AVAILABLE",
+          "boundary": "Searches bounded graph atlases."
+        },
+        {
+          "capability_id": "graph.construct.explicit",
+          "availability": "AVAILABLE",
+          "boundary": "Materializes an inspectable labelled graph witness."
+        },
+        {
+          "capability_id": "graph.counterexample.shrink",
+          "availability": "AVAILABLE",
+          "boundary": "Shrinks an already identified graph counterexample."
+        }
+      ],
+      "gap_classes": [
+        "EXISTING_WORKS"
+      ],
+      "contamination": "PUBLIC_ANSWER_VISIBLE",
+      "candidate_ids": [],
+      "disposition": "USE_EXISTING",
+      "next_action": "Retain as a public composition regression and route any failures by trace category."
+    },
+    {
+      "task_id": "grounded-premise-proof",
+      "mathematical_moves": [
+        "Select a minimal premise set from a frozen library and replay a proof DAG."
+      ],
+      "current_capabilities": [
+        {
+          "capability_id": "lean.retrieve.premises",
+          "availability": "UNAVAILABLE",
+          "boundary": "The premise operation exists but the pinned Lean runtime is not installed."
+        }
+      ],
+      "gap_classes": [
+        "PROVIDER_UNAVAILABLE"
+      ],
+      "contamination": "PUBLIC_ANSWER_VISIBLE",
+      "candidate_ids": [],
+      "disposition": "RUNTIME_FIX",
+      "next_action": "Build and smoke the dedicated pinned Lean evaluation profile; do not add a monolithic proof-audit capability."
+    },
+    {
+      "task_id": "hermite-normal-form",
+      "mathematical_moves": [
+        "Compute row Hermite normal form and a unimodular transformation certificate."
+      ],
+      "current_capabilities": [
+        {
+          "capability_id": "matrix.normal_form.hermite",
+          "availability": "AVAILABLE",
+          "boundary": "Returns the exact normal form and transformation."
+        },
+        {
+          "capability_id": "matrix.normal_form.hermite.verify",
+          "availability": "AVAILABLE",
+          "boundary": "Independently replays the normal-form certificate."
+        }
+      ],
+      "gap_classes": [
+        "EXISTING_WORKS"
+      ],
+      "contamination": "PUBLIC_ANSWER_VISIBLE",
+      "candidate_ids": [],
+      "disposition": "USE_EXISTING",
+      "next_action": "Keep as a producer-to-checker discovery and artifact-flow regression."
+    },
+    {
+      "task_id": "log-exponent-recovery",
+      "mathematical_moves": [
+        "Reduce exact logarithmic identities to integer exponents and rational reciprocal-log contributions."
+      ],
+      "current_capabilities": [
+        {
+          "capability_id": "integer.compute.prime_factorization",
+          "availability": "AVAILABLE",
+          "boundary": "Supplies exact exponent data without prescribing the logarithmic derivation."
+        },
+        {
+          "capability_id": "rational.compute.sum",
+          "availability": "AVAILABLE",
+          "boundary": "Supports exact rational composition."
+        }
+      ],
+      "gap_classes": [
+        "EXISTING_WORKS",
+        "MODEL_REASONING"
+      ],
+      "contamination": "PUBLIC_ANSWER_VISIBLE",
+      "candidate_ids": [],
+      "disposition": "NO_NEW_CAPABILITY",
+      "next_action": "Measure whether agents compose factorization and rational arithmetic correctly; do not add a task-shaped logarithm solver."
+    },
+    {
+      "task_id": "log-inequality-meta-audit",
+      "mathematical_moves": [
+        "Separate mathematical truth from instruction following and evaluation correctness.",
+        "Replay an exact rational algebraic comparison."
+      ],
+      "current_capabilities": [
+        {
+          "capability_id": "rational.compute.product",
+          "availability": "AVAILABLE",
+          "boundary": "Supports the exact comparison arithmetic but not the meta-evaluation judgment."
+        },
+        {
+          "capability_id": "rational.decide.less_than",
+          "availability": "AVAILABLE",
+          "boundary": "Decides one exact rational order relation."
+        }
+      ],
+      "gap_classes": [
+        "EXISTING_WORKS",
+        "MODEL_REASONING"
+      ],
+      "contamination": "PUBLIC_ANSWER_VISIBLE",
+      "candidate_ids": [],
+      "disposition": "NO_NEW_CAPABILITY",
+      "next_action": "Keep strategy and rubric interpretation agent-owned; diagnose arithmetic failures separately."
+    },
+    {
+      "task_id": "matrix-square-zero-counterexample",
+      "mathematical_moves": [
+        "Multiply an exact integer matrix by itself and inspect zero/nonzero conditions."
+      ],
+      "current_capabilities": [
+        {
+          "capability_id": "matrix.rank.compute",
+          "availability": "AVAILABLE",
+          "boundary": "Computes rank but cannot produce the exact matrix product."
+        }
+      ],
+      "gap_classes": [
+        "MISSING_OPERATION"
+      ],
+      "contamination": "PUBLIC_ANSWER_VISIBLE",
+      "candidate_ids": [
+        "matrix-exact-product"
+      ],
+      "disposition": "ACCEPT_CANDIDATE",
+      "next_action": "Implement the fundamental exact product primitive as a separate atomic outcome; evaluate power only after product composition is observed."
+    },
+    {
+      "task_id": "metric-tsp-proof-repair",
+      "mathematical_moves": [
+        "Compute a weighted minimum spanning tree and double-tree trace.",
+        "Distinguish a generic approximation guarantee from exact tour optimality."
+      ],
+      "current_capabilities": [
+        {
+          "capability_id": "graph.invariant.spanning_tree_count.compute",
+          "availability": "AVAILABLE",
+          "boundary": "Counts spanning trees; it does not optimize a weighted tree or return one."
+        },
+        {
+          "capability_id": "graph.hamiltonian_path.decide",
+          "availability": "AVAILABLE",
+          "boundary": "Decides Hamiltonian path existence, not weighted tour optimality."
+        }
+      ],
+      "gap_classes": [
+        "MISSING_OPERATION"
+      ],
+      "contamination": "PUBLIC_ANSWER_VISIBLE",
+      "candidate_ids": [
+        "weighted-minimum-spanning-tree",
+        "bounded-metric-tsp-optimum"
+      ],
+      "disposition": "ACCEPT_CANDIDATE",
+      "next_action": "Implement weighted MST first; keep exact bounded TSP deferred until independent recurrence is observed."
+    },
+    {
+      "task_id": "modular-cubic-obstruction",
+      "mathematical_moves": [
+        "Enumerate a complete polynomial residue image and certify that a target residue is absent."
+      ],
+      "current_capabilities": [
+        {
+          "capability_id": "modular.enumerate.quadratic_residues",
+          "availability": "AVAILABLE",
+          "boundary": "Only squares modulo m are supported; cubic and multivariate sparse polynomial images are absent."
+        }
+      ],
+      "gap_classes": [
+        "MISSING_OPERATION",
+        "WEAK_DISCOVERY"
+      ],
+      "contamination": "PUBLIC_ANSWER_VISIBLE",
+      "candidate_ids": [
+        "modular-polynomial-residue-image"
+      ],
+      "disposition": "ACCEPT_CANDIDATE",
+      "next_action": "Use as the primary public reproduction for a complete residue image and independent obstruction replay."
+    },
+    {
+      "task_id": "natural-subtraction-proof-repair",
+      "mathematical_moves": [
+        "Inspect an expression subtree and replay an exact rational linear combination under a side condition."
+      ],
+      "current_capabilities": [
+        {
+          "capability_id": "lean.statement.compare",
+          "availability": "UNAVAILABLE",
+          "boundary": "Formal statement tooling exists but its runtime provider is absent."
+        },
+        {
+          "capability_id": "linear.rational_solution.find",
+          "availability": "AVAILABLE",
+          "boundary": "Can solve the coefficient system but does not interpret the Lean proof branch."
+        }
+      ],
+      "gap_classes": [
+        "PROVIDER_UNAVAILABLE",
+        "MODEL_REASONING"
+      ],
+      "contamination": "PUBLIC_ANSWER_VISIBLE",
+      "candidate_ids": [],
+      "disposition": "RUNTIME_FIX",
+      "next_action": "Restore Lean availability and retain exact linear arithmetic as a composable operation; do not add proof-repair policy."
+    },
+    {
+      "task_id": "nondifferentiable-maximum-construction",
+      "mathematical_moves": [
+        "Construct a continuous two-branch piecewise-linear function and compare one-sided slopes."
+      ],
+      "current_capabilities": [],
+      "gap_classes": [
+        "MISSING_OPERATION"
+      ],
+      "contamination": "PUBLIC_ANSWER_VISIBLE",
+      "candidate_ids": [
+        "piecewise-linear-local-certificate"
+      ],
+      "disposition": "DEFER_RESEARCH",
+      "next_action": "Mine independent piecewise-linear continuity and extremum episodes before fixing a domain contract."
+    },
+    {
+      "task_id": "polynomial-map-collision",
+      "mathematical_moves": [
+        "Evaluate a polynomial map at two points and replay a collision claim."
+      ],
+      "current_capabilities": [
+        {
+          "capability_id": "polynomial.map.evaluate",
+          "availability": "AVAILABLE",
+          "boundary": "Evaluates the exact map at a supplied point."
+        },
+        {
+          "capability_id": "polynomial.map.collision.verify",
+          "availability": "AVAILABLE",
+          "boundary": "Independently checks a supplied collision witness."
+        }
+      ],
+      "gap_classes": [
+        "EXISTING_WORKS"
+      ],
+      "contamination": "PUBLIC_ANSWER_VISIBLE",
+      "candidate_ids": [],
+      "disposition": "USE_EXISTING",
+      "next_action": "Keep as a producer/checker artifact-flow regression."
+    },
+    {
+      "task_id": "polynomial-normalization",
+      "mathematical_moves": [
+        "Combine sparse rational terms into a canonical polynomial representation."
+      ],
+      "current_capabilities": [
+        {
+          "capability_id": "polynomial.expression.normalize",
+          "availability": "AVAILABLE",
+          "boundary": "Returns the required canonical sparse expression."
+        },
+        {
+          "capability_id": "polynomial.expression_normalization.verify",
+          "availability": "AVAILABLE",
+          "boundary": "Replays normalization independently."
+        }
+      ],
+      "gap_classes": [
+        "EXISTING_WORKS"
+      ],
+      "contamination": "PUBLIC_ANSWER_VISIBLE",
+      "candidate_ids": [],
+      "disposition": "USE_EXISTING",
+      "next_action": "Use for discovery, parameterization, and checker-handoff diagnostics only."
+    },
+    {
+      "task_id": "polynomial-tail-counterexample",
+      "mathematical_moves": [
+        "Factor and evaluate exact rational polynomials beyond all listed roots.",
+        "Produce a finite counterexample to an eventual monotonicity claim."
+      ],
+      "current_capabilities": [
+        {
+          "capability_id": "polynomial.factor.compute",
+          "availability": "AVAILABLE",
+          "boundary": "Provides exact polynomial factorization."
+        },
+        {
+          "capability_id": "polynomial.rational.compute.evaluate",
+          "availability": "AVAILABLE",
+          "boundary": "Evaluates one rational polynomial at an exact point."
+        }
+      ],
+      "gap_classes": [
+        "EXISTING_WORKS",
+        "MODEL_REASONING"
+      ],
+      "contamination": "PUBLIC_ANSWER_VISIBLE",
+      "candidate_ids": [],
+      "disposition": "USE_EXISTING",
+      "next_action": "Observe whether agents compose factorization, root scope, and exact evaluation without inventing an eventual-tail solver."
+    },
+    {
+      "task_id": "random-function-expectation-audit",
+      "mathematical_moves": [
+        "Enumerate dependent random-mapping events and compute an exact expectation."
+      ],
+      "current_capabilities": [],
+      "gap_classes": [
+        "MISSING_OPERATION",
+        "MODEL_REASONING"
+      ],
+      "contamination": "PUBLIC_ANSWER_VISIBLE",
+      "candidate_ids": [
+        "dependent-random-mapping-expectation"
+      ],
+      "disposition": "DEFER_RESEARCH",
+      "next_action": "Collect another independent dependent finite-probability workflow before selecting an atomic distribution artifact."
+    },
+    {
+      "task_id": "rational-linear-solution",
+      "mathematical_moves": [
+        "Solve an exact rational linear system and replay substitution."
+      ],
+      "current_capabilities": [
+        {
+          "capability_id": "linear.rational_solution.find",
+          "availability": "AVAILABLE",
+          "boundary": "Returns one exact rational solution."
+        },
+        {
+          "capability_id": "linear.rational_solution.verify",
+          "availability": "AVAILABLE",
+          "boundary": "Checks the supplied solution but does not certify uniqueness."
+        }
+      ],
+      "gap_classes": [
+        "EXISTING_WORKS",
+        "MISSING_CHECKER"
+      ],
+      "contamination": "PUBLIC_ANSWER_VISIBLE",
+      "candidate_ids": [],
+      "disposition": "USE_EXISTING",
+      "next_action": "Keep assurance capped to the checked claim; uniqueness remains an explicit open obligation, not an inferred conclusion."
+    },
+    {
+      "task_id": "sat-witness",
+      "mathematical_moves": [
+        "Decide a CNF formula and replay a complete satisfying assignment or proof artifact."
+      ],
+      "current_capabilities": [
+        {
+          "capability_id": "sat.model.find",
+          "availability": "AVAILABLE",
+          "boundary": "Finds a bounded SAT model."
+        },
+        {
+          "capability_id": "sat.model.verify",
+          "availability": "AVAILABLE",
+          "boundary": "Independently replays a supplied assignment."
+        },
+        {
+          "capability_id": "sat.unsat_proof.verify",
+          "availability": "AVAILABLE",
+          "boundary": "Checks the supported unsatisfiability proof artifact."
+        }
+      ],
+      "gap_classes": [
+        "EXISTING_WORKS"
+      ],
+      "contamination": "PUBLIC_ANSWER_VISIBLE",
+      "candidate_ids": [],
+      "disposition": "USE_EXISTING",
+      "next_action": "Retain as a fail-closed assurance and producer-to-checker regression."
+    },
+    {
+      "task_id": "subspace-direct-sum-counterexample",
+      "mathematical_moves": [
+        "Compute rank and a nonzero rational dependence among named subspace generators.",
+        "Separate generator-family semantics from one Ax=b solution."
+      ],
+      "current_capabilities": [
+        {
+          "capability_id": "matrix.rank.compute",
+          "availability": "AVAILABLE",
+          "boundary": "Computes a matrix rank but does not return all named-vector relations."
+        },
+        {
+          "capability_id": "linear.rational_solution.find",
+          "availability": "AVAILABLE",
+          "boundary": "Returns one system solution without a canonical relation-basis artifact."
+        }
+      ],
+      "gap_classes": [
+        "MISSING_OPERATION",
+        "MISSING_ARTIFACT_HANDOFF"
+      ],
+      "contamination": "PUBLIC_ANSWER_VISIBLE",
+      "candidate_ids": [
+        "rational-relation-basis"
+      ],
+      "disposition": "ACCEPT_CANDIDATE",
+      "next_action": "Implement the smaller named-vector relation primitive first and derive direct-sum claims through agent composition."
+    }
+  ],
+  "handoffs": [
+    {
+      "stage": "discovery",
+      "status": "accepted",
+      "subject": {
+        "candidate_id": "modular-polynomial-residue-image",
+        "capability_ids": [
+          "modular.polynomial_residue_image.compute"
+        ]
+      },
+      "evidence_refs": [
+        {
+          "ref": "benchmarks/regression-v1/tasks/modular-cubic-obstruction"
+        },
+        {
+          "ref": "benchmarks/regression-v1/tasks/divisibility-construction-witness"
+        },
+        {
+          "ref": "MCP capability.describe capture on 2026-07-31: ONLY_WEAK_LEXICAL_MATCHES for a complete sparse polynomial residue image"
+        }
+      ],
+      "contract_ref": "planned:modular.polynomial_residue_image.compute",
+      "runtime_snapshot": "#/runtime_snapshot",
+      "assurance": "DISCOVERY_EVIDENCE_ONLY",
+      "open_obligations": [
+        "Validate modulus, sparse terms, variable order, finite domains, and an assignment bound before writes.",
+        "Return the complete normalized image, counts, witnesses, scope, and a table artifact while capping the producer at COMPUTED.",
+        "Implement an operator-authorized independent enumerating checker and incomplete-table attacks.",
+        "Create at least two held-out structural families before a benefit claim."
+      ],
+      "missing_evidence": [
+        "No held-out comparative model run has been authorized or executed."
+      ],
+      "decision": "IMPLEMENT",
+      "next_action": "Hand this bounded producer contract to implement-math-capability.",
+      "move_episodes": [
+        "modular-cubic-obstruction",
+        "divisibility-construction-witness"
+      ],
+      "candidate_gate": {
+        "basis": "RECURRENT",
+        "nonduplicative": true,
+        "bounded_typed_contract": true,
+        "honest_failure_semantics": true,
+        "maintained_backend": true,
+        "checker_or_obligation": true,
+        "public_reproduction": true,
+        "held_out_hypothesis": true
+      },
+      "portfolio_delta": "One modular-domain result computes the complete image of a bounded sparse integer polynomial over declared finite residue domains.",
+      "public_reproduction": [
+        "modular-cubic-obstruction",
+        "divisibility-construction-witness"
+      ],
+      "evaluation_hypothesis": "Adding the complete residue-image result reduces incomplete modular tables and unsupported obstruction claims relative to the current quadratic-residue-only catalog without increasing false VERIFIED claims."
+    },
+    {
+      "stage": "discovery",
+      "status": "accepted",
+      "subject": {
+        "candidate_id": "rational-relation-basis",
+        "capability_ids": [
+          "linear.rational_relations.compute"
+        ]
+      },
+      "evidence_refs": [
+        {
+          "ref": "benchmarks/regression-v1/tasks/subspace-direct-sum-counterexample"
+        },
+        {
+          "ref": "benchmarks/regression-v1/tasks/autoformalization-semantic-audit"
+        },
+        {
+          "ref": "benchmarks/regression-v1/tasks/euler-line-symbolic-certificate"
+        },
+        {
+          "ref": "MCP capability.describe capture on 2026-07-31: only Ax=b solution and inconsistency outcomes matched"
+        }
+      ],
+      "contract_ref": "planned:linear.rational_relations.compute",
+      "runtime_snapshot": "#/runtime_snapshot",
+      "assurance": "DISCOVERY_EVIDENCE_ONLY",
+      "open_obligations": [
+        "Freeze named-vector orientation, ambient-dimension validation, canonical rational normalization, and relation-basis normalization.",
+        "Return rank, a complete relation basis, a nontrivial witness when present, and explicit scope/completeness.",
+        "Implement an independent exact row-reduction checker with reorder, rescale, omission, and substitution attacks.",
+        "Confirm direct-sum conclusions compose without losing named-subspace semantics."
+      ],
+      "missing_evidence": [
+        "No held-out comparative model run has been authorized or executed."
+      ],
+      "decision": "IMPLEMENT",
+      "next_action": "Hand the smaller relation-basis producer to implement-math-capability before considering a broader direct-sum outcome.",
+      "move_episodes": [
+        "subspace-direct-sum-counterexample",
+        "autoformalization-semantic-audit",
+        "euler-line-symbolic-certificate"
+      ],
+      "candidate_gate": {
+        "basis": "RECURRENT",
+        "nonduplicative": true,
+        "bounded_typed_contract": true,
+        "honest_failure_semantics": true,
+        "maintained_backend": true,
+        "checker_or_obligation": true,
+        "public_reproduction": true,
+        "held_out_hypothesis": true
+      },
+      "portfolio_delta": "One linear-domain result returns rank and a canonical basis of all exact rational dependencies among named vectors.",
+      "public_reproduction": [
+        "subspace-direct-sum-counterexample",
+        "autoformalization-semantic-audit",
+        "euler-line-symbolic-certificate"
+      ],
+      "evaluation_hypothesis": "A named-vector relation artifact reduces ad hoc coefficient search and semantic loss relative to Ax=b-only access while preserving exact scope and assurance calibration."
+    },
+    {
+      "stage": "discovery",
+      "status": "accepted",
+      "subject": {
+        "candidate_id": "matrix-exact-product",
+        "capability_ids": [
+          "matrix.multiply.compute"
+        ]
+      },
+      "evidence_refs": [
+        {
+          "ref": "benchmarks/regression-v1/tasks/matrix-square-zero-counterexample"
+        },
+        {
+          "ref": "MCP capability.describe capture on 2026-07-31: determinant, rank, inverse, adjugate, trace, and normal forms matched but no matrix product"
+        }
+      ],
+      "contract_ref": "planned:matrix.multiply.compute",
+      "runtime_snapshot": "#/runtime_snapshot",
+      "assurance": "DISCOVERY_EVIDENCE_ONLY",
+      "open_obligations": [
+        "Bound dimensions and exact scalar representation before computation.",
+        "Return operands, shape binding, and the exact result artifact at COMPUTED assurance.",
+        "Add an independent bounded arithmetic replay before any VERIFIED path.",
+        "Evaluate whether a separate power outcome is justified after product composition traces exist."
+      ],
+      "missing_evidence": [
+        "Only one public Harbor episode currently exercises the primitive.",
+        "No held-out comparative model run has been authorized or executed."
+      ],
+      "decision": "IMPLEMENT",
+      "next_action": "Treat exact matrix multiplication as a documented fundamental-primitive exception and hand it to implement-math-capability.",
+      "move_episodes": [
+        "matrix-square-zero-counterexample"
+      ],
+      "candidate_gate": {
+        "basis": "FUNDAMENTAL_PRIMITIVE",
+        "nonduplicative": true,
+        "bounded_typed_contract": true,
+        "honest_failure_semantics": true,
+        "maintained_backend": true,
+        "checker_or_obligation": true,
+        "public_reproduction": true,
+        "held_out_hypothesis": true
+      },
+      "portfolio_delta": "One matrix-domain outcome computes the exact product of two bounded compatible matrices.",
+      "public_reproduction": [
+        "matrix-square-zero-counterexample"
+      ],
+      "evaluation_hypothesis": "An exact matrix product eliminates shell-side arithmetic for matrix identities without encouraging overbroad square-zero-specific tooling or false certification."
+    },
+    {
+      "stage": "discovery",
+      "status": "accepted",
+      "subject": {
+        "candidate_id": "weighted-minimum-spanning-tree",
+        "capability_ids": [
+          "graph.spanning_tree.minimum.compute"
+        ]
+      },
+      "evidence_refs": [
+        {
+          "ref": "benchmarks/regression-v1/tasks/metric-tsp-proof-repair"
+        },
+        {
+          "ref": "MCP capability.describe capture on 2026-07-31: spanning-tree count present, weighted minimum spanning tree absent"
+        }
+      ],
+      "contract_ref": "planned:graph.spanning_tree.minimum.compute",
+      "runtime_snapshot": "#/runtime_snapshot",
+      "assurance": "DISCOVERY_EVIDENCE_ONLY",
+      "open_obligations": [
+        "Freeze weighted labelled graph semantics, disconnected outcomes, parallel-edge policy, and deterministic tie handling.",
+        "Return an inspectable tree, total exact weight, scope, and optimality obligation at COMPUTED assurance.",
+        "Choose an independent bounded exhaustive or cut/cycle-certificate checker.",
+        "Add a second independent held-out family before a benefit claim."
+      ],
+      "missing_evidence": [
+        "Only one public Harbor episode currently exercises weighted MST.",
+        "No held-out comparative model run has been authorized or executed."
+      ],
+      "decision": "IMPLEMENT",
+      "next_action": "Use the fundamental graph-optimization exception to implement MST before any exact TSP capability.",
+      "move_episodes": [
+        "metric-tsp-proof-repair"
+      ],
+      "candidate_gate": {
+        "basis": "FUNDAMENTAL_PRIMITIVE",
+        "nonduplicative": true,
+        "bounded_typed_contract": true,
+        "honest_failure_semantics": true,
+        "maintained_backend": true,
+        "checker_or_obligation": true,
+        "public_reproduction": true,
+        "held_out_hypothesis": true
+      },
+      "portfolio_delta": "One graph-domain outcome returns a minimum-weight spanning tree and exact total weight for a bounded weighted labelled graph.",
+      "public_reproduction": [
+        "metric-tsp-proof-repair"
+      ],
+      "evaluation_hypothesis": "A weighted MST artifact reduces incorrect double-tree traces and unsupported exact-TSP inferences while leaving tour strategy to the agent."
+    },
+    {
+      "stage": "discovery",
+      "status": "needs_revision",
+      "subject": {
+        "candidate_id": "bounded-metric-tsp-optimum",
+        "capability_ids": []
+      },
+      "evidence_refs": [
+        {
+          "ref": "benchmarks/regression-v1/tasks/metric-tsp-proof-repair"
+        }
+      ],
+      "contract_ref": null,
+      "runtime_snapshot": "#/runtime_snapshot",
+      "assurance": "DISCOVERY_EVIDENCE_ONLY",
+      "open_obligations": [
+        "Keep optimum, approximation, and tour-witness outcomes separate.",
+        "Define interruption semantics that never turn incomplete search into optimality."
+      ],
+      "missing_evidence": [
+        "No second independent exact bounded metric-TSP workflow.",
+        "No accepted certificate and checker boundary.",
+        "No held-out comparative model run."
+      ],
+      "decision": "DEFER",
+      "next_action": "Reopen discovery only after MST is available and another exact-tour episode establishes recurrence.",
+      "move_episodes": [
+        "metric-tsp-proof-repair"
+      ],
+      "candidate_gate": {
+        "basis": "INSUFFICIENT",
+        "nonduplicative": true,
+        "bounded_typed_contract": false,
+        "honest_failure_semantics": false,
+        "maintained_backend": true,
+        "checker_or_obligation": false,
+        "public_reproduction": true,
+        "held_out_hypothesis": false
+      },
+      "portfolio_delta": "No portfolio delta is accepted at this stage.",
+      "public_reproduction": [
+        "metric-tsp-proof-repair"
+      ],
+      "evaluation_hypothesis": "A future bounded exact-tour result should improve correct optimality claims without converting interrupted searches into conclusions."
+    },
+    {
+      "stage": "discovery",
+      "status": "needs_revision",
+      "subject": {
+        "candidate_id": "dependent-random-mapping-expectation",
+        "capability_ids": []
+      },
+      "evidence_refs": [
+        {
+          "ref": "benchmarks/regression-v1/tasks/random-function-expectation-audit"
+        }
+      ],
+      "contract_ref": null,
+      "runtime_snapshot": "#/runtime_snapshot",
+      "assurance": "DISCOVERY_EVIDENCE_ONLY",
+      "open_obligations": [
+        "Identify a reusable finite probability artifact that exposes dependence rather than encoding one random-function formula."
+      ],
+      "missing_evidence": [
+        "No second independent dependent finite-probability episode.",
+        "No stable atomic output or checker boundary.",
+        "No held-out comparative model run."
+      ],
+      "decision": "DEFER",
+      "next_action": "Mine additional dependent finite-distribution workflows before choosing a contract.",
+      "move_episodes": [
+        "random-function-expectation-audit"
+      ],
+      "candidate_gate": {
+        "basis": "INSUFFICIENT",
+        "nonduplicative": true,
+        "bounded_typed_contract": false,
+        "honest_failure_semantics": false,
+        "maintained_backend": false,
+        "checker_or_obligation": false,
+        "public_reproduction": true,
+        "held_out_hypothesis": false
+      },
+      "portfolio_delta": "No portfolio delta is accepted at this stage.",
+      "public_reproduction": [
+        "random-function-expectation-audit"
+      ],
+      "evaluation_hypothesis": "A future dependency-aware artifact should reduce independence-assumption errors on structurally different finite distributions."
+    },
+    {
+      "stage": "discovery",
+      "status": "needs_revision",
+      "subject": {
+        "candidate_id": "piecewise-linear-local-certificate",
+        "capability_ids": []
+      },
+      "evidence_refs": [
+        {
+          "ref": "benchmarks/regression-v1/tasks/nondifferentiable-maximum-construction"
+        }
+      ],
+      "contract_ref": null,
+      "runtime_snapshot": "#/runtime_snapshot",
+      "assurance": "DISCOVERY_EVIDENCE_ONLY",
+      "open_obligations": [
+        "Decide whether continuity, extremum, and one-sided-slope evidence form one coherent local certificate or separate atomic outcomes."
+      ],
+      "missing_evidence": [
+        "No second independent piecewise-linear workflow.",
+        "No accepted artifact normalization or checker boundary.",
+        "No held-out comparative model run."
+      ],
+      "decision": "DEFER",
+      "next_action": "Mine additional local piecewise-linear analysis episodes and nearby portfolio overlap.",
+      "move_episodes": [
+        "nondifferentiable-maximum-construction"
+      ],
+      "candidate_gate": {
+        "basis": "INSUFFICIENT",
+        "nonduplicative": true,
+        "bounded_typed_contract": false,
+        "honest_failure_semantics": false,
+        "maintained_backend": true,
+        "checker_or_obligation": false,
+        "public_reproduction": true,
+        "held_out_hypothesis": false
+      },
+      "portfolio_delta": "No portfolio delta is accepted at this stage.",
+      "public_reproduction": [
+        "nondifferentiable-maximum-construction"
+      ],
+      "evaluation_hypothesis": "A future local certificate should reduce continuity and derivative-sign mistakes across more than one branch family."
+    }
+  ]
+}

--- a/benchmarks/capability-evaluations/v1/gap-ledger.schema.json
+++ b/benchmarks/capability-evaluations/v1/gap-ledger.schema.json
@@ -1,0 +1,481 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jacobian.invalid/schemas/capability-gap-ledger-v1.json",
+  "title": "Jacobian public workflow capability gap ledger",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "ledger_id",
+    "captured_at",
+    "source_suite",
+    "runtime_snapshot",
+    "gap_taxonomy",
+    "tasks",
+    "handoffs"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "1"
+    },
+    "ledger_id": {
+      "const": "jacobian.regression-v1.capability-gap-ledger"
+    },
+    "captured_at": {
+      "type": "string",
+      "format": "date"
+    },
+    "source_suite": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "task_count",
+        "manifest_sha256",
+        "contamination"
+      ],
+      "properties": {
+        "path": {
+          "const": "benchmarks/regression-v1/dataset.toml"
+        },
+        "task_count": {
+          "const": 24
+        },
+        "manifest_sha256": {
+          "$ref": "#/$defs/digest"
+        },
+        "contamination": {
+          "const": "PUBLIC_ANSWER_VISIBLE"
+        }
+      }
+    },
+    "runtime_snapshot": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "repository_commit",
+        "repository_tree",
+        "package_version",
+        "harbor_version",
+        "catalog_digest",
+        "policy_profile",
+        "policy_digest",
+        "provider_snapshots",
+        "lean_available",
+        "model_execution",
+        "oracle_evidence"
+      ],
+      "properties": {
+        "repository_commit": {
+          "$ref": "#/$defs/sha"
+        },
+        "repository_tree": {
+          "$ref": "#/$defs/sha"
+        },
+        "package_version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "harbor_version": {
+          "const": "0.20.0"
+        },
+        "catalog_digest": {
+          "$ref": "#/$defs/digest"
+        },
+        "policy_profile": {
+          "const": "DEFAULT"
+        },
+        "policy_digest": {
+          "$ref": "#/$defs/digest"
+        },
+        "provider_snapshots": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "capability_id",
+              "availability",
+              "provider",
+              "provider_version",
+              "runtime_digest"
+            ],
+            "properties": {
+              "capability_id": {
+                "$ref": "#/$defs/id"
+              },
+              "availability": {
+                "enum": [
+                  "AVAILABLE",
+                  "UNAVAILABLE"
+                ]
+              },
+              "provider": {
+                "type": "string",
+                "minLength": 1
+              },
+              "provider_version": {
+                "type": "string",
+                "minLength": 1
+              },
+              "runtime_digest": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/digest"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "lean_available": {
+          "const": false
+        },
+        "model_execution": {
+          "const": "NOT_RUN"
+        },
+        "oracle_evidence": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "task_count",
+            "result_sha256",
+            "host_local_path"
+          ],
+          "properties": {
+            "task_count": {
+              "const": 24
+            },
+            "result_sha256": {
+              "$ref": "#/$defs/digest"
+            },
+            "host_local_path": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
+    "gap_taxonomy": {
+      "type": "array",
+      "minItems": 9,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/gap"
+      }
+    },
+    "tasks": {
+      "type": "array",
+      "minItems": 24,
+      "maxItems": 24,
+      "items": {
+        "$ref": "#/$defs/task"
+      }
+    },
+    "handoffs": {
+      "type": "array",
+      "minItems": 7,
+      "items": {
+        "$ref": "#/$defs/handoff"
+      }
+    }
+  },
+  "$defs": {
+    "sha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_.-]+$"
+    },
+    "gap": {
+      "enum": [
+        "EXISTING_WORKS",
+        "WEAK_DISCOVERY",
+        "BAD_PARAMETERIZATION",
+        "MISSING_OPERATION",
+        "MISSING_ARTIFACT_HANDOFF",
+        "MISSING_CHECKER",
+        "PROVIDER_UNAVAILABLE",
+        "ENVIRONMENT_BUDGET_AUTH",
+        "MODEL_REASONING"
+      ]
+    },
+    "capability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "capability_id",
+        "availability",
+        "boundary"
+      ],
+      "properties": {
+        "capability_id": {
+          "$ref": "#/$defs/id"
+        },
+        "availability": {
+          "enum": [
+            "AVAILABLE",
+            "UNAVAILABLE"
+          ]
+        },
+        "boundary": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "task": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "task_id",
+        "mathematical_moves",
+        "current_capabilities",
+        "gap_classes",
+        "contamination",
+        "candidate_ids",
+        "disposition",
+        "next_action"
+      ],
+      "properties": {
+        "task_id": {
+          "$ref": "#/$defs/id"
+        },
+        "mathematical_moves": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "current_capabilities": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/capability"
+          }
+        },
+        "gap_classes": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/gap"
+          }
+        },
+        "contamination": {
+          "const": "PUBLIC_ANSWER_VISIBLE"
+        },
+        "candidate_ids": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/id"
+          }
+        },
+        "disposition": {
+          "enum": [
+            "USE_EXISTING",
+            "ACCEPT_CANDIDATE",
+            "RUNTIME_FIX",
+            "DEFER_RESEARCH",
+            "NO_NEW_CAPABILITY"
+          ]
+        },
+        "next_action": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "evidenceRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "ref"
+      ],
+      "properties": {
+        "ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "digest": {
+          "$ref": "#/$defs/digest"
+        }
+      }
+    },
+    "handoff": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "stage",
+        "status",
+        "subject",
+        "evidence_refs",
+        "contract_ref",
+        "runtime_snapshot",
+        "assurance",
+        "open_obligations",
+        "missing_evidence",
+        "decision",
+        "next_action",
+        "move_episodes",
+        "candidate_gate",
+        "portfolio_delta",
+        "public_reproduction",
+        "evaluation_hypothesis"
+      ],
+      "properties": {
+        "stage": {
+          "const": "discovery"
+        },
+        "status": {
+          "enum": [
+            "accepted",
+            "needs_revision"
+          ]
+        },
+        "subject": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "candidate_id",
+            "capability_ids"
+          ],
+          "properties": {
+            "candidate_id": {
+              "$ref": "#/$defs/id"
+            },
+            "capability_ids": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/id"
+              }
+            }
+          }
+        },
+        "evidence_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/evidenceRef"
+          }
+        },
+        "contract_ref": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "runtime_snapshot": {
+          "const": "#/runtime_snapshot"
+        },
+        "assurance": {
+          "const": "DISCOVERY_EVIDENCE_ONLY"
+        },
+        "open_obligations": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "missing_evidence": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "decision": {
+          "enum": [
+            "IMPLEMENT",
+            "DEFER"
+          ]
+        },
+        "next_action": {
+          "type": "string",
+          "minLength": 1
+        },
+        "move_episodes": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/id"
+          }
+        },
+        "candidate_gate": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "basis",
+            "nonduplicative",
+            "bounded_typed_contract",
+            "honest_failure_semantics",
+            "maintained_backend",
+            "checker_or_obligation",
+            "public_reproduction",
+            "held_out_hypothesis"
+          ],
+          "properties": {
+            "basis": {
+              "enum": [
+                "RECURRENT",
+                "FUNDAMENTAL_PRIMITIVE",
+                "INSUFFICIENT"
+              ]
+            },
+            "nonduplicative": {
+              "type": "boolean"
+            },
+            "bounded_typed_contract": {
+              "type": "boolean"
+            },
+            "honest_failure_semantics": {
+              "type": "boolean"
+            },
+            "maintained_backend": {
+              "type": "boolean"
+            },
+            "checker_or_obligation": {
+              "type": "boolean"
+            },
+            "public_reproduction": {
+              "type": "boolean"
+            },
+            "held_out_hypothesis": {
+              "type": "boolean"
+            }
+          }
+        },
+        "portfolio_delta": {
+          "type": "string",
+          "minLength": 1
+        },
+        "public_reproduction": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/id"
+          }
+        },
+        "evaluation_hypothesis": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/benchmarks/capability-evaluations/v1/job-public-c1-current.json
+++ b/benchmarks/capability-evaluations/v1/job-public-c1-current.json
@@ -1,0 +1,36 @@
+{
+  "jobs_dir": "benchmarks/results/capability-evaluation-v1/public-c1-current",
+  "n_attempts": 3,
+  "timeout_multiplier": 1.0,
+  "orchestrator": {
+    "type": "local",
+    "n_concurrent_trials": 1,
+    "quiet": false
+  },
+  "environment": {
+    "type": "docker",
+    "force_build": true,
+    "delete": true,
+    "extra_docker_compose": [
+      "benchmarks/capability-evaluations/v1/public-c1-current.compose.yaml"
+    ]
+  },
+  "agents": [
+    {
+      "name": "codex",
+      "model_name": "${JACOBIAN_MODEL}",
+      "mcp_servers": [
+        {
+          "name": "jacobian",
+          "transport": "streamable-http",
+          "url": "http://jacobian-auth-proxy:8080/mcp"
+        }
+      ]
+    }
+  ],
+  "datasets": [
+    {
+      "path": "benchmarks/regression-v1/tasks"
+    }
+  ]
+}

--- a/benchmarks/capability-evaluations/v1/job-public-c2-treatment.json
+++ b/benchmarks/capability-evaluations/v1/job-public-c2-treatment.json
@@ -1,0 +1,36 @@
+{
+  "jobs_dir": "benchmarks/results/capability-evaluation-v1/public-c2-treatment",
+  "n_attempts": 3,
+  "timeout_multiplier": 1.0,
+  "orchestrator": {
+    "type": "local",
+    "n_concurrent_trials": 1,
+    "quiet": false
+  },
+  "environment": {
+    "type": "docker",
+    "force_build": true,
+    "delete": true,
+    "extra_docker_compose": [
+      "benchmarks/capability-evaluations/v1/public-c2-treatment.compose.yaml"
+    ]
+  },
+  "agents": [
+    {
+      "name": "codex",
+      "model_name": "${JACOBIAN_MODEL}",
+      "mcp_servers": [
+        {
+          "name": "jacobian",
+          "transport": "streamable-http",
+          "url": "http://jacobian-auth-proxy:8080/mcp"
+        }
+      ]
+    }
+  ],
+  "datasets": [
+    {
+      "path": "benchmarks/regression-v1/tasks"
+    }
+  ]
+}

--- a/benchmarks/capability-evaluations/v1/public-c1-current.compose.yaml
+++ b/benchmarks/capability-evaluations/v1/public-c1-current.compose.yaml
@@ -1,0 +1,39 @@
+services:
+  jacobian:
+    image: ${JACOBIAN_C1_IMAGE:?JACOBIAN_C1_IMAGE must be digest-pinned}
+    command:
+      - --transport
+      - streamable-http
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8000"
+      - --auth-tokens-file
+      - /run/secrets/jacobian_tokens
+      - --stateless-http
+      - --capability-policy-profile
+      - COMPUTE_VERIFY_NO_RETRIEVAL
+      - --state-dir
+      - /state
+    secrets:
+      - jacobian_tokens
+    volumes:
+      - jacobian-state:/state
+  jacobian-auth-proxy:
+    image: caddy@sha256:4c6e91c6ed0e2fa03efd5b44747b625fec79bc9cd06ac5235a779726618e530d
+    depends_on:
+      - jacobian
+    command:
+      - caddy
+      - reverse-proxy
+      - --from
+      - :8080
+      - --to
+      - jacobian:8000
+      - --header-up
+      - "Authorization: Bearer ${JACOBIAN_MCP_TOKEN:?JACOBIAN_MCP_TOKEN is required}"
+secrets:
+  jacobian_tokens:
+    environment: JACOBIAN_AUTH_TOKENS_JSON
+volumes:
+  jacobian-state: {}

--- a/benchmarks/capability-evaluations/v1/public-c2-treatment.compose.yaml
+++ b/benchmarks/capability-evaluations/v1/public-c2-treatment.compose.yaml
@@ -1,0 +1,39 @@
+services:
+  jacobian:
+    image: ${JACOBIAN_C2_IMAGE:?JACOBIAN_C2_IMAGE must be digest-pinned}
+    command:
+      - --transport
+      - streamable-http
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8000"
+      - --auth-tokens-file
+      - /run/secrets/jacobian_tokens
+      - --stateless-http
+      - --capability-policy-profile
+      - COMPUTE_VERIFY_NO_RETRIEVAL
+      - --state-dir
+      - /state
+    secrets:
+      - jacobian_tokens
+    volumes:
+      - jacobian-state:/state
+  jacobian-auth-proxy:
+    image: caddy@sha256:4c6e91c6ed0e2fa03efd5b44747b625fec79bc9cd06ac5235a779726618e530d
+    depends_on:
+      - jacobian
+    command:
+      - caddy
+      - reverse-proxy
+      - --from
+      - :8080
+      - --to
+      - jacobian:8000
+      - --header-up
+      - "Authorization: Bearer ${JACOBIAN_MCP_TOKEN:?JACOBIAN_MCP_TOKEN is required}"
+secrets:
+  jacobian_tokens:
+    environment: JACOBIAN_AUTH_TOKENS_JSON
+volumes:
+  jacobian-state: {}

--- a/benchmarks/regression-v1/README.md
+++ b/benchmarks/regression-v1/README.md
@@ -22,7 +22,9 @@ solution is unique.
 These 24 public cases are workflow observations, not a causal benchmark. There
 is no control condition, randomized pairing, or performance claim in v1. A
 future A/B study can reuse these exact task digests while keeping its condition
-and model configuration outside the task bundles.
+and model configuration outside the task bundles. The versioned
+[`capability-evaluations/v1`](../capability-evaluations/v1/README.md) scaffold
+records the current gap ledger and the fail-closed C1/C2 comparison boundary.
 
 ## Validation
 

--- a/docs/reference/agent-evaluations.md
+++ b/docs/reference/agent-evaluations.md
@@ -4,11 +4,10 @@
 
 Jacobian’s current mathematical observation suite is the committed Harbor
 [`regression-v1`](../../benchmarks/regression-v1/README.md) dataset. It contains
-fifteen self-contained tasks covering graph counterexamples, graph artifact
-composition, exact finite partitions, SAT witnesses, rational linear systems,
-Hermite normal form, polynomial normalization, polynomial-map collisions,
-matrix and subspace counterexamples, polynomial-tail reasoning, exact
-logarithmic algebra, proof-audit workloads, and symbolic geometry.
+24 self-contained tasks covering exact finite enumeration and construction,
+graph workflows, matrix and linear algebra, modular and polynomial reasoning,
+SAT witnesses, proof repair, formal-semantics audits, finite probability, and
+symbolic geometry.
 
 The task bundles are agent-agnostic. A prompt says only that a mathematical
 toolbox may be available; it does not prescribe capability IDs, decomposition,
@@ -21,8 +20,8 @@ Task and verifier validation is separate from model observation. First parse and
 check the task bundles with Harbor, then run the Oracle job:
 
 ```sh
-harbor check benchmarks/regression-v1/tasks
-harbor run -c benchmarks/regression-v1/job-oracle.json
+make harbor-check
+make harbor-oracle
 ```
 
 The verifier emits `correctness`, `evidence_validity`, `scope_accuracy`,
@@ -66,3 +65,19 @@ job configuration, not in task bundles, and must reuse the exact task digests,
 agents, models, prompts, budgets, environments, and seeds. Held-out
 performance claims require a separately frozen task set and report every run;
 workflow observations must not be presented as comparative evidence.
+
+## Capability-delta scaffold
+
+The versioned
+[`capability-evaluations/v1`](../../benchmarks/capability-evaluations/v1/README.md)
+artifacts classify all 24 public cases, record accepted and deferred discovery
+handoffs, and freeze the primary comparison as current catalog C1 versus C1
+plus exactly one candidate delta C2. Its two Harbor jobs are public,
+answer-visible reproduction configurations only.
+
+The comparison remains fail closed: no held-out fixture or Oracle identity is
+committed, the treatment catalog is unset, and model execution is disabled
+until explicit authorization and a hard run budget are recorded. A future
+held-out evaluation must keep Oracle material outside the evaluated workspace
+and match task digests, model and reasoning settings, prompt, budgets, runtime,
+policy, seed, and scorer across the paired C1/C2 conditions.

--- a/tests/unit/benchmarks/test_capability_evaluation_v1.py
+++ b/tests/unit/benchmarks/test_capability_evaluation_v1.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from pathlib import Path
+
+from jsonschema import Draft202012Validator, FormatChecker
+
+ROOT = Path(__file__).parents[3]
+EVALUATION = ROOT / "benchmarks" / "capability-evaluations" / "v1"
+REGRESSION = ROOT / "benchmarks" / "regression-v1"
+
+
+def _load(name: str) -> dict[str, object]:
+    payload = json.loads((EVALUATION / name).read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def _validate(instance_name: str, schema_name: str) -> dict[str, object]:
+    instance = _load(instance_name)
+    schema = _load(schema_name)
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema, format_checker=FormatChecker()).validate(instance)
+    return instance
+
+
+def test_gap_ledger_covers_the_frozen_public_suite() -> None:
+    ledger = _validate("gap-ledger.json", "gap-ledger.schema.json")
+    tasks = ledger["tasks"]
+    assert isinstance(tasks, list)
+    ledger_task_ids = [entry["task_id"] for entry in tasks]
+    task_dirs = sorted(
+        path.name for path in (REGRESSION / "tasks").iterdir() if path.is_dir()
+    )
+
+    assert ledger_task_ids == task_dirs
+    assert len(ledger_task_ids) == len(set(ledger_task_ids)) == 24
+    manifest_bytes = (REGRESSION / "dataset.toml").read_bytes()
+    manifest_digest = "sha256:" + hashlib.sha256(manifest_bytes).hexdigest()
+    assert ledger["source_suite"]["manifest_sha256"] == manifest_digest
+
+
+def test_gap_ledger_handoffs_are_closed_over_task_candidates() -> None:
+    ledger = _load("gap-ledger.json")
+    tasks = ledger["tasks"]
+    handoffs = ledger["handoffs"]
+    assert isinstance(tasks, list)
+    assert isinstance(handoffs, list)
+    handoff_by_id = {entry["subject"]["candidate_id"]: entry for entry in handoffs}
+    task_candidates = {
+        candidate_id for task in tasks for candidate_id in task["candidate_ids"]
+    }
+
+    assert task_candidates == set(handoff_by_id)
+    for candidate_id, handoff in handoff_by_id.items():
+        if handoff["status"] == "accepted":
+            assert handoff["decision"] == "IMPLEMENT"
+            assert handoff["subject"]["capability_ids"]
+            assert handoff["candidate_gate"]["basis"] in {
+                "RECURRENT",
+                "FUNDAMENTAL_PRIMITIVE",
+            }
+        else:
+            assert handoff["decision"] == "DEFER"
+            assert handoff["missing_evidence"]
+        assert candidate_id not in {
+            "calendar-good-days-solver",
+            "proof-audit",
+            "distinct-sum-pairing-solver",
+        }
+
+
+def test_comparison_plan_is_fail_closed_until_treatment_and_held_out_freeze() -> None:
+    plan = _validate("comparison-plan.json", "comparison-plan.schema.json")
+    conditions = plan["conditions"]
+    assert isinstance(conditions, list)
+    assert [condition["condition_id"] for condition in conditions] == [
+        "C0",
+        "C1",
+        "C2",
+    ]
+    assert conditions[1]["role"] == "PRIMARY_CONTROL"
+    assert conditions[2]["role"] == "PRIMARY_TREATMENT"
+    assert conditions[2]["catalog_digest"] is None
+    assert plan["held_out_boundary"]["status"] == "NOT_MATERIALIZED"
+    assert plan["execution_gate"]["model_execution_allowed"] is False
+    assert plan["claim_policy"]["public_jobs_causal_claims_allowed"] is False
+
+    ledger = _load("gap-ledger.json")
+    assert (
+        conditions[1]["catalog_digest"] == ledger["runtime_snapshot"]["catalog_digest"]
+    )
+    assert (
+        plan["public_reproduction"]["manifest_digest"]
+        == ledger["source_suite"]["manifest_sha256"]
+    )
+
+
+def test_public_c1_and_c2_jobs_differ_only_by_condition_identity() -> None:
+    c1 = _load("job-public-c1-current.json")
+    c2 = _load("job-public-c2-treatment.json")
+
+    assert c1["agents"][0]["model_name"] == "${JACOBIAN_MODEL}"
+    assert c2["agents"][0]["model_name"] == "${JACOBIAN_MODEL}"
+    assert (
+        c1["datasets"] == c2["datasets"] == [{"path": "benchmarks/regression-v1/tasks"}]
+    )
+
+    normalized_c1 = deepcopy(c1)
+    normalized_c2 = deepcopy(c2)
+    normalized_c1["jobs_dir"] = normalized_c2["jobs_dir"] = "<condition-results>"
+    normalized_c1["environment"]["extra_docker_compose"] = ["<condition-compose>"]
+    normalized_c2["environment"]["extra_docker_compose"] = ["<condition-compose>"]
+    assert normalized_c1 == normalized_c2
+
+
+def test_public_condition_compose_files_differ_only_by_image_selection() -> None:
+    c1 = (EVALUATION / "public-c1-current.compose.yaml").read_text(encoding="utf-8")
+    c2 = (EVALUATION / "public-c2-treatment.compose.yaml").read_text(encoding="utf-8")
+
+    assert "JACOBIAN_C1_IMAGE must be digest-pinned" in c1
+    assert "JACOBIAN_C2_IMAGE must be digest-pinned" in c2
+    assert c1.replace("JACOBIAN_C1_IMAGE", "JACOBIAN_CONDITION_IMAGE") == c2.replace(
+        "JACOBIAN_C2_IMAGE", "JACOBIAN_CONDITION_IMAGE"
+    )
+    assert not (EVALUATION / "held-out").exists()


### PR DESCRIPTION
## Summary

- classify the mathematical moves and portfolio gaps across all 24 public Harbor tasks
- record four accepted discovery handoffs and three explicitly deferred candidates
- freeze fail-closed C0/C1/C2 semantics, public contamination boundaries, and matched-condition invariants
- add paired public C1/C2 Harbor job configurations without making a model-performance claim
- update the evaluation references from 15 to 24 tasks

## Evidence boundary

The public suite remains answer-visible workflow evidence only. C2 has no catalog digest, held-out fixtures and Oracle identities are unset, and model execution remains disabled until a single treatment delta, external held-out material, explicit authorization, credentials, and a hard budget are frozen.

## Validation

- `make harbor-release-check` (24 task digests match)
- `make test-unit` (613 passed)
- `make test-component` (568 passed)
- `make test-domain` (177 passed)
- `make test-composition` (424 passed, 2 expected Lean skips)
- `make test-storage` (101 passed)
- `make test-process` (158 passed)
- `make test-mcp` (21 passed)
- `make test-e2e` (7 passed, 1 expected Lean skip)
- `make check-static`
- `make build`
- `make docs-linkcheck`
