### PR TITLE
feat(modular): compute bounded polynomial residue images

### DIFF
--- a/src/jacobian/contracts/number_theory.py
+++ b/src/jacobian/contracts/number_theory.py
@@ -11,6 +11,9 @@ integer nth root).
 
 from __future__ import annotations
 
+import math
+from collections import Counter
+from itertools import product
 from typing import Annotated, Literal, Self
 
 from pydantic import Field, StrictBool, StrictInt, StringConstraints, model_validator
@@ -30,6 +33,12 @@ _MAX_MODULUS = 10_000
 _MAX_CRT_SIZE = 64
 _MAX_DIVISORS = 4_096
 _MAX_FACTOR_ENTRIES = 256
+_MAX_RESIDUE_VARIABLES = 6
+_MAX_RESIDUE_DOMAIN_SIZE = 32
+_MAX_RESIDUE_TERMS = 64
+_MAX_RESIDUE_EXPONENT = 32
+_MAX_RESIDUE_ASSIGNMENTS = 4_096
+_MAX_POLYNOMIAL_RESIDUE_MODULUS = 1_000_000
 
 BoundedInteger = Annotated[
     str,
@@ -38,6 +47,26 @@ BoundedInteger = Annotated[
         max_length=_MAX_INTEGER_LENGTH,
         strict=True,
     ),
+]
+ResidueVariableName = Annotated[
+    str,
+    StringConstraints(
+        pattern=r"^[a-z][a-z0-9_]{0,31}$",
+        max_length=32,
+        strict=True,
+    ),
+]
+ResidueDomain = Annotated[
+    tuple[StrictInt, ...],
+    Field(min_length=1, max_length=_MAX_RESIDUE_DOMAIN_SIZE),
+]
+ResidueAssignment = Annotated[
+    tuple[StrictInt, ...],
+    Field(min_length=1, max_length=_MAX_RESIDUE_VARIABLES),
+]
+CanonicalResidue = Annotated[
+    StrictInt,
+    Field(ge=0, lt=_MAX_POLYNOMIAL_RESIDUE_MODULUS),
 ]
 
 
@@ -182,6 +211,87 @@ class ModulusRequest(ContractModel):
     """A single bounded modulus (2 <= modulus <= 10 000)."""
 
     modulus: StrictInt = Field(ge=2, le=_MAX_MODULUS)
+
+
+class ModularPolynomialVariable(ContractModel):
+    """One named variable and its canonical finite residue domain."""
+
+    name: ResidueVariableName
+    residues: ResidueDomain
+
+    @model_validator(mode="after")
+    def require_canonical_domain(self) -> Self:
+        if any(residue < 0 for residue in self.residues):
+            raise ValueError("variable residues must be nonnegative")
+        if self.residues != tuple(sorted(set(self.residues))):
+            raise ValueError("variable residues must be strictly increasing")
+        return self
+
+
+class ModularPolynomialTerm(ContractModel):
+    """One nonzero sparse integer-polynomial term in canonical exponent order."""
+
+    coefficient: BoundedInteger
+    exponents: tuple[StrictInt, ...] = Field(
+        min_length=1,
+        max_length=_MAX_RESIDUE_VARIABLES,
+    )
+
+    @model_validator(mode="after")
+    def require_nonnegative_exponents(self) -> Self:
+        if any(
+            exponent < 0 or exponent > _MAX_RESIDUE_EXPONENT
+            for exponent in self.exponents
+        ):
+            raise ValueError(
+                f"term exponents must be between 0 and {_MAX_RESIDUE_EXPONENT}"
+            )
+        return self
+
+
+class ModularPolynomialResidueImageRequest(ContractModel):
+    """A bounded sparse polynomial over declared finite residue domains."""
+
+    modulus: StrictInt = Field(ge=2, le=_MAX_POLYNOMIAL_RESIDUE_MODULUS)
+    variables: tuple[ModularPolynomialVariable, ...] = Field(
+        min_length=1,
+        max_length=_MAX_RESIDUE_VARIABLES,
+    )
+    terms: tuple[ModularPolynomialTerm, ...] = Field(
+        min_length=0,
+        max_length=_MAX_RESIDUE_TERMS,
+    )
+
+    @model_validator(mode="after")
+    def require_canonical_bounded_polynomial(self) -> Self:
+        variable_names = [variable.name for variable in self.variables]
+        if len(variable_names) != len(set(variable_names)):
+            raise ValueError("polynomial variable names must be unique")
+        if any(
+            residue >= self.modulus
+            for variable in self.variables
+            for residue in variable.residues
+        ):
+            raise ValueError("every variable residue must be less than the modulus")
+        assignment_count = math.prod(
+            len(variable.residues) for variable in self.variables
+        )
+        if assignment_count > _MAX_RESIDUE_ASSIGNMENTS:
+            raise ValueError(
+                "declared residue domains exceed the 4,096-assignment bound"
+            )
+        if any(len(term.exponents) != len(self.variables) for term in self.terms):
+            raise ValueError("every term exponent vector must match the variable count")
+        exponent_vectors = [term.exponents for term in self.terms]
+        if exponent_vectors != sorted(set(exponent_vectors)):
+            raise ValueError(
+                "term exponent vectors must be unique and lexicographically increasing"
+            )
+        if any(int(term.coefficient) % self.modulus == 0 for term in self.terms):
+            raise ValueError(
+                "sparse polynomial terms must have nonzero coefficient modulo m"
+            )
+        return self
 
 
 class ChineseRemainderRequest(ContractModel):
@@ -353,6 +463,183 @@ class QuadraticResiduesResult(ContractModel):
     """All quadratic residues modulo one modulus."""
 
     residues: tuple[BoundedInteger, ...]
+
+
+class NormalizedModularPolynomialTerm(ContractModel):
+    """One sparse term with its coefficient reduced to the canonical residue."""
+
+    coefficient: StrictInt = Field(ge=1, lt=_MAX_POLYNOMIAL_RESIDUE_MODULUS)
+    exponents: tuple[StrictInt, ...] = Field(
+        min_length=1,
+        max_length=_MAX_RESIDUE_VARIABLES,
+    )
+
+
+class ModularPolynomialResidueCount(ContractModel):
+    """Multiplicity of one reachable residue in the declared assignment table."""
+
+    residue: CanonicalResidue
+    count: StrictInt = Field(ge=1, le=_MAX_RESIDUE_ASSIGNMENTS)
+
+
+class ModularPolynomialResidueWitness(ContractModel):
+    """The first lexicographic assignment reaching one residue."""
+
+    residue: CanonicalResidue
+    assignment: ResidueAssignment
+
+
+class ModularPolynomialResidueTableRow(ContractModel):
+    """One exact assignment-to-residue evaluation."""
+
+    assignment: ResidueAssignment
+    residue: CanonicalResidue
+
+
+class ModularPolynomialResidueImageResult(ContractModel):
+    """Complete image and exhaustive table for one bounded modular polynomial."""
+
+    semantics_version: Literal["modular-polynomial-residue-image.v1"]
+    modulus: StrictInt = Field(ge=2, le=_MAX_POLYNOMIAL_RESIDUE_MODULUS)
+    variable_order: tuple[ResidueVariableName, ...] = Field(
+        min_length=1,
+        max_length=_MAX_RESIDUE_VARIABLES,
+    )
+    domains: tuple[ResidueDomain, ...] = Field(
+        min_length=1,
+        max_length=_MAX_RESIDUE_VARIABLES,
+    )
+    normalized_terms: tuple[NormalizedModularPolynomialTerm, ...] = Field(
+        min_length=0,
+        max_length=_MAX_RESIDUE_TERMS,
+    )
+    enumeration_scope: Literal["COMPLETE_DECLARED_CARTESIAN_PRODUCT"]
+    total_assignments: StrictInt = Field(ge=1, le=_MAX_RESIDUE_ASSIGNMENTS)
+    image: tuple[CanonicalResidue, ...] = Field(
+        min_length=1,
+        max_length=_MAX_RESIDUE_ASSIGNMENTS,
+    )
+    residue_counts: tuple[ModularPolynomialResidueCount, ...] = Field(
+        min_length=1,
+        max_length=_MAX_RESIDUE_ASSIGNMENTS,
+    )
+    witnesses: tuple[ModularPolynomialResidueWitness, ...] = Field(
+        min_length=1,
+        max_length=_MAX_RESIDUE_ASSIGNMENTS,
+    )
+    table: tuple[ModularPolynomialResidueTableRow, ...] = Field(
+        min_length=1,
+        max_length=_MAX_RESIDUE_ASSIGNMENTS,
+    )
+
+    @model_validator(mode="after")
+    def bind_complete_residue_image(self) -> Self:
+        assignments = _validate_residue_image_shape(self)
+        residues = _validate_residue_image_table(self, assignments)
+        _validate_residue_image_summaries(self, assignments, residues)
+        return self
+
+
+def _evaluate_normalized_modular_polynomial(
+    terms: tuple[NormalizedModularPolynomialTerm, ...],
+    assignment: tuple[int, ...],
+    modulus: int,
+) -> int:
+    value = 0
+    for term in terms:
+        monomial = term.coefficient
+        for coordinate, exponent in zip(
+            assignment,
+            term.exponents,
+            strict=True,
+        ):
+            monomial = monomial * pow(coordinate, exponent, modulus) % modulus
+        value = (value + monomial) % modulus
+    return value
+
+
+def _validate_residue_image_shape(
+    result: ModularPolynomialResidueImageResult,
+) -> tuple[tuple[int, ...], ...]:
+    if len(set(result.variable_order)) != len(result.variable_order):
+        raise ValueError("result variable names must be unique")
+    if len(result.domains) != len(result.variable_order):
+        raise ValueError("result domains must match the variable count")
+    if any(
+        domain != tuple(sorted(set(domain)))
+        or any(residue < 0 or residue >= result.modulus for residue in domain)
+        for domain in result.domains
+    ):
+        raise ValueError("result domains must contain canonical increasing residues")
+    if any(
+        len(term.exponents) != len(result.variable_order)
+        or term.coefficient >= result.modulus
+        or any(
+            exponent < 0 or exponent > _MAX_RESIDUE_EXPONENT
+            for exponent in term.exponents
+        )
+        for term in result.normalized_terms
+    ):
+        raise ValueError("normalized terms do not match the result scope")
+    exponent_vectors = [term.exponents for term in result.normalized_terms]
+    if exponent_vectors != sorted(set(exponent_vectors)):
+        raise ValueError("normalized term exponents must be canonical")
+    assignments = tuple(product(*result.domains))
+    if result.total_assignments != len(assignments):
+        raise ValueError("total assignments do not match the declared domains")
+    if len(result.table) != len(assignments):
+        raise ValueError("complete table length does not match the declared domains")
+    return assignments
+
+
+def _validate_residue_image_table(
+    result: ModularPolynomialResidueImageResult,
+    assignments: tuple[tuple[int, ...], ...],
+) -> tuple[int, ...]:
+    if tuple(row.assignment for row in result.table) != assignments:
+        raise ValueError(
+            "complete table must enumerate the declared Cartesian product in order"
+        )
+    expected_residues = tuple(
+        _evaluate_normalized_modular_polynomial(
+            result.normalized_terms,
+            assignment,
+            result.modulus,
+        )
+        for assignment in assignments
+    )
+    if tuple(row.residue for row in result.table) != expected_residues:
+        raise ValueError("complete table contains an incorrect polynomial evaluation")
+    return expected_residues
+
+
+def _validate_residue_image_summaries(
+    result: ModularPolynomialResidueImageResult,
+    assignments: tuple[tuple[int, ...], ...],
+    residues: tuple[int, ...],
+) -> None:
+    image = tuple(sorted(set(residues)))
+    if result.image != image:
+        raise ValueError("residue image does not match the complete table")
+    counts = Counter(residues)
+    expected_counts = tuple(
+        ModularPolynomialResidueCount(residue=residue, count=counts[residue])
+        for residue in image
+    )
+    if result.residue_counts != expected_counts:
+        raise ValueError("residue counts do not match the complete table")
+    first_assignments: dict[int, tuple[int, ...]] = {}
+    for assignment, residue in zip(assignments, residues, strict=True):
+        first_assignments.setdefault(residue, assignment)
+    expected_witnesses = tuple(
+        ModularPolynomialResidueWitness(
+            residue=residue,
+            assignment=first_assignments[residue],
+        )
+        for residue in image
+    )
+    if result.witnesses != expected_witnesses:
+        raise ValueError("residue witnesses must be the first table assignments")
 
 
 class ChineseRemainderResult(ContractModel):

--- a/src/jacobian/domains/number_theory/modular.py
+++ b/src/jacobian/domains/number_theory/modular.py
@@ -6,6 +6,8 @@ from jacobian.contracts.number_theory import (
     IntegerValueResult,
     JacobiSymbolRequest,
     JacobiSymbolResult,
+    ModularPolynomialResidueImageRequest,
+    ModularPolynomialResidueImageResult,
     ModularValueRequest,
     ModulusRequest,
     QuadraticResiduesResult,
@@ -20,6 +22,7 @@ from jacobian.domains.number_theory.discrete_logarithm import (
 from jacobian.domains.number_theory.operations import (
     compute_jacobi_symbol,
     compute_modular_inverse,
+    compute_modular_polynomial_residue_image,
     compute_multiplicative_order,
     enumerate_quadratic_residues,
     solve_chinese_remainder,
@@ -93,6 +96,41 @@ MODULAR_CAPABILITIES = (
                 "quadratic_residues_mod_10",
                 "Enumerate quadratic residues modulo 10.",
                 {"modulus": 10},
+            ),
+        ),
+    ),
+    number_theory_operation(
+        "modular.polynomial_residue_image.compute",
+        "Compute modular polynomial residue image",
+        (
+            "Compute the complete image of a bounded sparse integer polynomial "
+            "over declared finite residue domains modulo m, including "
+            "multiplicities, witnesses, and the exhaustive assignment table."
+        ),
+        ModularPolynomialResidueImageRequest,
+        ModularPolynomialResidueImageResult,
+        compute_modular_polynomial_residue_image,
+        "number-theory",
+        "modular",
+        "polynomial",
+        "residue",
+        "enumeration",
+        "obstruction",
+        relation_id="modular.polynomial_residue_image.relation",
+        invocation_examples=(
+            example(
+                "cubic_residue_image_mod_7",
+                "Enumerate the complete image of four times x cubed modulo 7.",
+                {
+                    "modulus": 7,
+                    "variables": [
+                        {
+                            "name": "x",
+                            "residues": [0, 1, 2, 3, 4, 5, 6],
+                        }
+                    ],
+                    "terms": [{"coefficient": "4", "exponents": [3]}],
+                },
             ),
         ),
     ),

--- a/src/jacobian/domains/number_theory/operations.py
+++ b/src/jacobian/domains/number_theory/operations.py
@@ -37,9 +37,15 @@ from jacobian.contracts.number_theory import (
     JacobiSymbolResult,
     LegendreSymbolRequest,
     LegendreSymbolResult,
+    ModularPolynomialResidueCount,
+    ModularPolynomialResidueImageRequest,
+    ModularPolynomialResidueImageResult,
+    ModularPolynomialResidueTableRow,
+    ModularPolynomialResidueWitness,
     ModularValueRequest,
     ModulusRequest,
     NonnegativeIntegerRequest,
+    NormalizedModularPolynomialTerm,
     PositiveIntegerRequest,
     PowerfulNumberRequest,
     PowerfulNumberResult,
@@ -384,6 +390,85 @@ def enumerate_quadratic_residues(request: ContractModel) -> ContractModel:
     return QuadraticResiduesResult(
         residues=tuple(str(int(r)) for r in quadratic_residues(modulus)),
     )
+
+
+def compute_modular_polynomial_residue_image(
+    request: ContractModel,
+) -> ContractModel:
+    """Enumerate one sparse polynomial over its declared finite residue domains."""
+    from itertools import product
+
+    polynomial = cast(ModularPolynomialResidueImageRequest, request)
+    normalized_terms = tuple(
+        NormalizedModularPolynomialTerm(
+            coefficient=int(term.coefficient) % polynomial.modulus,
+            exponents=term.exponents,
+        )
+        for term in polynomial.terms
+    )
+    table: list[ModularPolynomialResidueTableRow] = []
+    counts: dict[int, int] = {}
+    first_assignments: dict[int, tuple[int, ...]] = {}
+    for assignment in product(
+        *(variable.residues for variable in polynomial.variables)
+    ):
+        residue = _evaluate_modular_polynomial(
+            normalized_terms,
+            assignment,
+            polynomial.modulus,
+        )
+        table.append(
+            ModularPolynomialResidueTableRow(
+                assignment=assignment,
+                residue=residue,
+            )
+        )
+        counts[residue] = counts.get(residue, 0) + 1
+        first_assignments.setdefault(residue, assignment)
+    image = tuple(sorted(counts))
+    return ModularPolynomialResidueImageResult(
+        semantics_version="modular-polynomial-residue-image.v1",
+        modulus=polynomial.modulus,
+        variable_order=tuple(variable.name for variable in polynomial.variables),
+        domains=tuple(variable.residues for variable in polynomial.variables),
+        normalized_terms=normalized_terms,
+        enumeration_scope="COMPLETE_DECLARED_CARTESIAN_PRODUCT",
+        total_assignments=len(table),
+        image=image,
+        residue_counts=tuple(
+            ModularPolynomialResidueCount(
+                residue=residue,
+                count=counts[residue],
+            )
+            for residue in image
+        ),
+        witnesses=tuple(
+            ModularPolynomialResidueWitness(
+                residue=residue,
+                assignment=first_assignments[residue],
+            )
+            for residue in image
+        ),
+        table=tuple(table),
+    )
+
+
+def _evaluate_modular_polynomial(
+    terms: tuple[NormalizedModularPolynomialTerm, ...],
+    assignment: tuple[int, ...],
+    modulus: int,
+) -> int:
+    value = 0
+    for term in terms:
+        monomial = term.coefficient
+        for coordinate, exponent in zip(
+            assignment,
+            term.exponents,
+            strict=True,
+        ):
+            monomial = monomial * pow(coordinate, exponent, modulus) % modulus
+        value = (value + monomial) % modulus
+    return value
 
 
 def solve_chinese_remainder(request: ContractModel) -> ContractModel:

--- a/tests/composition/portfolio/test_domain_bundles.py
+++ b/tests/composition/portfolio/test_domain_bundles.py
@@ -44,6 +44,7 @@ from jacobian.contracts.number_theory import (
     FloorSquareRootRequest,
     JacobiSymbolRequest,
     LegendreSymbolRequest,
+    ModularPolynomialResidueImageRequest,
     ModularValueRequest,
     ModulusRequest,
     PositiveIntegerRequest,
@@ -146,6 +147,7 @@ EXPECTED_IDS: frozenset[str] = frozenset(
         "modular.compute.discrete_logarithm",
         "modular.compute.multiplicative_order",
         "modular.enumerate.quadratic_residues",
+        "modular.polynomial_residue_image.compute",
         "modular.solve.chinese_remainder",
         "number_theory.compute.jacobi_symbol",
         "number_theory.compute.factorial_valuation",
@@ -269,6 +271,16 @@ _REPR: list[tuple[type[ContractModel], dict[str, object]]] = [
     (PositiveIntegerRequest, {"n": 10}),
     (ModularValueRequest, {"value": "3", "modulus": 7}),
     (ModulusRequest, {"modulus": 7}),
+    (
+        ModularPolynomialResidueImageRequest,
+        {
+            "modulus": 7,
+            "variables": [
+                {"name": "x", "residues": [0, 1, 2, 3, 4, 5, 6]},
+            ],
+            "terms": [{"coefficient": "4", "exponents": [3]}],
+        },
+    ),
     (ChineseRemainderRequest, {"residues": [2, 3], "moduli": [3, 5]}),
     (JacobiSymbolRequest, {"a": "10", "n": 21}),
     (FloorSquareRootRequest, {"n": 12}),

--- a/tests/domain/number_theory/test_domain_math_capabilities.py
+++ b/tests/domain/number_theory/test_domain_math_capabilities.py
@@ -1,12 +1,20 @@
 from collections.abc import Iterator
+from copy import deepcopy
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 from tests.support.services import DomainTestServices, open_domain_services
 
 from jacobian.contracts.capabilities import (
     CapabilityAssuranceLevel,
+    CapabilityCompletenessStatus,
+    CapabilityDiscoveryRequest,
     CapabilityRequest,
+)
+from jacobian.contracts.number_theory import (
+    ModularPolynomialResidueImageRequest,
+    ModularPolynomialResidueImageResult,
 )
 from jacobian.contracts.results import ExecutionStatus
 from jacobian.domains.arithmetic import build_arithmetic_bundle
@@ -144,3 +152,232 @@ def test_geometric_sequence_handles_zero_terms_exactly(domain_services) -> None:
         )
         assert result.execution.status is ExecutionStatus.COMPLETED
         assert result.output["result"] == {"holds": expected}
+
+
+def _cubic_residue_payload() -> dict[str, object]:
+    return {
+        "modulus": 7,
+        "variables": [
+            {"name": "x", "residues": [0, 1, 2, 3, 4, 5, 6]},
+        ],
+        "terms": [{"coefficient": "4", "exponents": [3]}],
+    }
+
+
+def test_modular_polynomial_residue_image_is_complete_and_materialized(
+    domain_services,
+) -> None:
+    result = domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="modular.polynomial_residue_image.compute",
+            input=_cubic_residue_payload(),
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert result.completeness.status is CapabilityCompletenessStatus.COMPLETE
+    assert result.obligations == ()
+    assert result.output["result"] == {
+        "semantics_version": "modular-polynomial-residue-image.v1",
+        "modulus": 7,
+        "variable_order": ["x"],
+        "domains": [[0, 1, 2, 3, 4, 5, 6]],
+        "normalized_terms": [{"coefficient": 4, "exponents": [3]}],
+        "enumeration_scope": "COMPLETE_DECLARED_CARTESIAN_PRODUCT",
+        "total_assignments": 7,
+        "image": [0, 3, 4],
+        "residue_counts": [
+            {"residue": 0, "count": 1},
+            {"residue": 3, "count": 3},
+            {"residue": 4, "count": 3},
+        ],
+        "witnesses": [
+            {"residue": 0, "assignment": [0]},
+            {"residue": 3, "assignment": [3]},
+            {"residue": 4, "assignment": [1]},
+        ],
+        "table": [
+            {"assignment": [0], "residue": 0},
+            {"assignment": [1], "residue": 4},
+            {"assignment": [2], "residue": 4},
+            {"assignment": [3], "residue": 3},
+            {"assignment": [4], "residue": 4},
+            {"assignment": [5], "residue": 3},
+            {"assignment": [6], "residue": 3},
+        ],
+    }
+    input_uri, result_uri = result.artifact_uris
+    stored_result = domain_services.core.store.get(result_uri)
+    assert stored_result.payload == result.output["result"]
+    assert stored_result.manifest.parents == (input_uri,)
+    assert result.relationships[0].relation_id == (
+        "modular.polynomial_residue_image.relation"
+    )
+    assert result.relationships[0].source_artifact_uris == (input_uri,)
+    assert result.relationships[0].target_artifact_uris == (result_uri,)
+
+
+def test_modular_polynomial_residue_image_handles_multivariate_domains(
+    domain_services,
+) -> None:
+    result = domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="modular.polynomial_residue_image.compute",
+            input={
+                "modulus": 5,
+                "variables": [
+                    {"name": "x", "residues": [0, 1, 2]},
+                    {"name": "y", "residues": [0, 2]},
+                ],
+                "terms": [
+                    {"coefficient": "-1", "exponents": [0, 1]},
+                    {"coefficient": "1", "exponents": [2, 0]},
+                ],
+            },
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    output = result.output["result"]
+    assert output["normalized_terms"] == [
+        {"coefficient": 4, "exponents": [0, 1]},
+        {"coefficient": 1, "exponents": [2, 0]},
+    ]
+    assert output["total_assignments"] == 6
+    assert output["table"] == [
+        {"assignment": [0, 0], "residue": 0},
+        {"assignment": [0, 2], "residue": 3},
+        {"assignment": [1, 0], "residue": 1},
+        {"assignment": [1, 2], "residue": 4},
+        {"assignment": [2, 0], "residue": 4},
+        {"assignment": [2, 2], "residue": 2},
+    ]
+    assert output["image"] == [0, 1, 2, 3, 4]
+
+
+def test_modular_polynomial_residue_result_rejects_an_incomplete_table(
+    domain_services,
+) -> None:
+    result = domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="modular.polynomial_residue_image.compute",
+            input=_cubic_residue_payload(),
+        )
+    )
+    corrupted = deepcopy(result.output["result"])
+    corrupted["table"].pop()
+
+    with pytest.raises(ValidationError, match="complete table length"):
+        ModularPolynomialResidueImageResult.model_validate(corrupted)
+
+
+def test_modular_polynomial_residue_image_reproduces_divisibility_polynomial(
+    domain_services,
+) -> None:
+    result = domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="modular.polynomial_residue_image.compute",
+            input={
+                "modulus": 7**7,
+                "variables": [
+                    {"name": "a", "residues": [18]},
+                    {"name": "b", "residues": [1]},
+                ],
+                "terms": [
+                    {"coefficient": "7", "exponents": [1, 6]},
+                    {"coefficient": "21", "exponents": [2, 5]},
+                    {"coefficient": "35", "exponents": [3, 4]},
+                    {"coefficient": "35", "exponents": [4, 3]},
+                    {"coefficient": "21", "exponents": [5, 2]},
+                    {"coefficient": "7", "exponents": [6, 1]},
+                ],
+            },
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    output = result.output["result"]
+    assert output["modulus"] == 823543
+    assert output["total_assignments"] == 1
+    assert output["image"] == [0]
+    assert output["witnesses"] == [{"residue": 0, "assignment": [18, 1]}]
+    assert output["table"] == [{"assignment": [18, 1], "residue": 0}]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "modulus": 7,
+            "variables": [{"name": "x", "residues": [0, 1]}],
+            "terms": [{"coefficient": "1", "exponents": [1, 0]}],
+        },
+        {
+            "modulus": 7,
+            "variables": [{"name": "x", "residues": [0, 1]}],
+            "terms": [{"coefficient": "7", "exponents": [1]}],
+        },
+        {
+            "modulus": 17,
+            "variables": [
+                {"name": "x", "residues": list(range(17))},
+                {"name": "y", "residues": list(range(17))},
+                {"name": "z", "residues": list(range(17))},
+            ],
+            "terms": [{"coefficient": "1", "exponents": [1, 1, 1]}],
+        },
+    ],
+)
+def test_modular_polynomial_residue_image_rejects_invalid_scope_before_writes(
+    domain_services,
+    payload: dict[str, object],
+) -> None:
+    result = domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="modular.polynomial_residue_image.compute",
+            input=payload,
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.diagnostics[0].code == "INVALID_NUMBER_THEORY_REQUEST"
+    assert result.artifact_uris == ()
+    assert result.episode_uri is None
+
+
+def test_modular_polynomial_residue_image_assignment_bound_is_exact() -> None:
+    accepted = ModularPolynomialResidueImageRequest.model_validate(
+        {
+            "modulus": 16,
+            "variables": [
+                {"name": "x", "residues": list(range(16))},
+                {"name": "y", "residues": list(range(16))},
+                {"name": "z", "residues": list(range(16))},
+            ],
+            "terms": [{"coefficient": "1", "exponents": [1, 1, 1]}],
+        }
+    )
+
+    assert len(accepted.variables) == 3
+    assert accepted.modulus == 16
+
+
+def test_modular_polynomial_residue_image_is_discoverable_by_intent(
+    domain_services,
+) -> None:
+    discovered = domain_services.core.capabilities.discover(
+        CapabilityDiscoveryRequest(
+            query=(
+                "complete sparse polynomial residue image modulo an integer "
+                "with witnesses and an exhaustive table"
+            ),
+            domain="modular",
+            limit=5,
+        )
+    )
+
+    assert discovered.matches[0].capability_id == (
+        "modular.polynomial_residue_image.compute"
+    )
+    assert discovered.matches[0].has_invocation_examples is True


### PR DESCRIPTION
## Summary

- add the EXPLORE-only `modular.polynomial_residue_image.compute` capability
- validate bounded sparse integer-polynomial inputs before artifact writes
- return the complete declared Cartesian assignment table, residue image, counts, and first witnesses
- reproduce the public cubic-residue obstruction and the `(a+b)^7-a^7-b^7` divisibility case

## Capability development handoff

- Stage/status: producer implementation complete; independent checker and held-out evaluation remain open
- Candidate/capability: `modular-polynomial-residue-image` / `modular.polynomial_residue_image.compute`
- Evidence: PR #247 gap ledger; `benchmarks/harbor/regression-v1/tasks/modular-polynomial-residue-obstruction`; `benchmarks/harbor/regression-v1/tasks/multinomial-divisibility`
- Contract: `ModularPolynomialResidueImageRequest` and `ModularPolynomialResidueImageResult` in `src/jacobian/contracts/number_theory.py`
- Runtime snapshot: base `443f00526ad3eeb1b2f56f205247434e6eca4840`; Python 3.12; SymPy 1.14.0; default policy; catalog 257 available entries; new catalog digest `sha256:a2daea2a2f64231e2ad0be963d99834bb6376a3ceaaf736135db3add19c4c127`; policy digest `sha256:870a92b83d3e522e4015b6bb1cabda33086906f9de1c3c36e466251ea7ed1957`
- Assurance: `COMPLETE · COMPUTED`; no checker declaration, no verification authority, no mathematical claim beyond the bounded declared table
- Artifacts: validated input plus a durable result artifact containing the exhaustive table; exact input-to-result relationship is recorded
- Open obligations: independent replay checker, adversarial false-certification tests, and frozen C1/C2 model-in-the-loop comparison
- Evaluation state: public reproductions covered; held-out cases and model execution intentionally not run
- Compatibility: experimental/pre-stable contract

## Validation

- `make test-plan BASE=origin/main`
- `make test-unit` (613 passed)
- `make test-component` (568 passed)
- `make test-domain` (186 passed)
- `make test-composition` (424 passed, 2 expected Lean skips)
- `make test-storage` (101 passed)
- `make test-process` (158 passed)
- `make test-mcp` (21 passed)
- `make test-e2e` (7 passed, 1 expected Lean skip)
- `make check-static`
- `make build`
- `make harbor-check` (24 tasks)

No model jobs were run.