### PR TITLE
feat(modular): independently verify residue images

### DIFF
--- a/src/jacobian/domains/number_theory/checkers.py
+++ b/src/jacobian/domains/number_theory/checkers.py
@@ -3,6 +3,7 @@
 from jacobian.checker_operations import ExactReplayCheckerDeclaration
 from jacobian.contracts.number_theory import (
     FactorizationRequest,
+    ModularPolynomialResidueImageRequest,
     PowerfulNumberRequest,
 )
 
@@ -57,6 +58,34 @@ NUMBER_THEORY_EXACT_REPLAY_CHECKERS = (
             "integer",
             "number-theory",
             "powerful-number",
+        ),
+    ),
+    ExactReplayCheckerDeclaration(
+        "modular.polynomial_residue_image.compute",
+        ModularPolynomialResidueImageRequest,
+        "check_modular_polynomial_residue_image",
+        "modular.polynomial-residue-image.flint-replay",
+        entrypoint_module=_EXACT_DOMAIN_ENTRYPOINT,
+        replay_method="Python-FLINT exhaustive modular-polynomial replay",
+        reason=(
+            "operator-authorized Python-FLINT checker independently reconstructs "
+            "the declared Cartesian product and replays every modular-polynomial "
+            "evaluation without importing the stdlib producer"
+        ),
+        verification_capability_id="modular.polynomial_residue_image.verify",
+        verification_title="Verify a modular polynomial residue image",
+        verification_description=(
+            "Independently verify one complete bounded modular-polynomial residue "
+            "image, including every assignment, multiplicity, and first witness."
+        ),
+        verification_tags=(
+            "verification",
+            "exact",
+            "number-theory",
+            "modular",
+            "polynomial",
+            "residue",
+            "enumeration",
         ),
     ),
 )

--- a/src/jacobian_checkers/exact_domain_operations.py
+++ b/src/jacobian_checkers/exact_domain_operations.py
@@ -19,6 +19,13 @@ from jacobian_checkers.bound_artifacts import bound_request as _bound_request
 _INTEGER = re.compile(r"^-?(?:0|[1-9][0-9]*)$")
 _PYTHON_FLINT_VERSION = "0.9.0"
 _FLINT_VERSION = "3.6.0"
+_RESIDUE_VARIABLE = re.compile(r"^[a-z][a-z0-9_]{0,31}$")
+_MAX_RESIDUE_VARIABLES = 6
+_MAX_RESIDUE_DOMAIN_SIZE = 32
+_MAX_RESIDUE_TERMS = 64
+_MAX_RESIDUE_EXPONENT = 32
+_MAX_RESIDUE_ASSIGNMENTS = 4_096
+_MAX_RESIDUE_MODULUS = 1_000_000
 
 
 def _reject(detail: str) -> dict[str, Any]:
@@ -39,6 +46,28 @@ def _accept(detail: str) -> dict[str, Any]:
         "arithmetic": "EXACT_RATIONAL",
         "method": "DIRECT_WITNESS",
         "coverage": "NOT_APPLICABLE",
+        "detail": detail,
+    }
+
+
+def _reject_exact_integer(detail: str) -> dict[str, Any]:
+    return {
+        "accepted": False,
+        "conclusion": "UNKNOWN",
+        "arithmetic": "EXACT_INTEGER",
+        "method": "DIRECT_WITNESS",
+        "coverage": "NOT_APPLICABLE",
+        "detail": detail,
+    }
+
+
+def _accept_exhaustive_integer(detail: str) -> dict[str, Any]:
+    return {
+        "accepted": True,
+        "conclusion": "TRUE",
+        "arithmetic": "EXACT_INTEGER",
+        "method": "EXHAUSTIVE_FINITE",
+        "coverage": "EXHAUSTIVE",
         "detail": detail,
     }
 
@@ -303,6 +332,278 @@ def check_integer_powerful_number(request: dict[str, Any]) -> dict[str, Any]:
         witness_format="integer.powerful.flint-replay",
         replay=_powerful_number,
     )
+
+
+def _strict_integer(value: object, *, minimum: int, maximum: int) -> int:
+    if type(value) is not int or not minimum <= value <= maximum:
+        raise ValueError("bounded integer is malformed")
+    return value
+
+
+def _modular_residue_source(
+    source: dict[str, Any],
+) -> tuple[
+    int,
+    list[str],
+    list[list[int]],
+    list[tuple[int, list[int]]],
+]:
+    if set(source) != {"modulus", "variables", "terms"}:
+        raise ValueError("modular-polynomial source is malformed")
+    modulus = _strict_integer(
+        source["modulus"],
+        minimum=2,
+        maximum=_MAX_RESIDUE_MODULUS,
+    )
+    names, domains = _modular_residue_variables(source["variables"], modulus)
+    terms = _modular_residue_terms(source["terms"], len(names), modulus)
+    return modulus, names, domains, terms
+
+
+def _modular_residue_variables(
+    value: object,
+    modulus: int,
+) -> tuple[list[str], list[list[int]]]:
+    if not isinstance(value, list) or not 1 <= len(value) <= _MAX_RESIDUE_VARIABLES:
+        raise ValueError("modular-polynomial variables are malformed")
+    names: list[str] = []
+    domains: list[list[int]] = []
+    assignment_count = 1
+    for variable in value:
+        if not isinstance(variable, dict) or set(variable) != {"name", "residues"}:
+            raise ValueError("modular-polynomial variable is malformed")
+        name = variable["name"]
+        residues = variable["residues"]
+        if (
+            not isinstance(name, str)
+            or _RESIDUE_VARIABLE.fullmatch(name) is None
+            or not isinstance(residues, list)
+            or not 1 <= len(residues) <= _MAX_RESIDUE_DOMAIN_SIZE
+            or any(
+                type(residue) is not int or not 0 <= residue < modulus
+                for residue in residues
+            )
+            or residues != sorted(set(residues))
+        ):
+            raise ValueError("modular-polynomial variable domain is noncanonical")
+        names.append(name)
+        domains.append(residues)
+        assignment_count *= len(residues)
+    if len(names) != len(set(names)):
+        raise ValueError("modular-polynomial variable names are not unique")
+    if assignment_count > _MAX_RESIDUE_ASSIGNMENTS:
+        raise ValueError("modular-polynomial assignment scope is too large")
+    return names, domains
+
+
+def _modular_residue_terms(
+    value: object,
+    variable_count: int,
+    modulus: int,
+) -> list[tuple[int, list[int]]]:
+    if not isinstance(value, list) or len(value) > _MAX_RESIDUE_TERMS:
+        raise ValueError("modular-polynomial terms are malformed")
+    terms: list[tuple[int, list[int]]] = []
+    for term in value:
+        if not isinstance(term, dict) or set(term) != {"coefficient", "exponents"}:
+            raise ValueError("modular-polynomial term is malformed")
+        coefficient_text = term["coefficient"]
+        exponents = term["exponents"]
+        if (
+            not isinstance(coefficient_text, str)
+            or len(coefficient_text) > 256
+            or not isinstance(exponents, list)
+            or len(exponents) != variable_count
+            or any(
+                type(exponent) is not int or not 0 <= exponent <= _MAX_RESIDUE_EXPONENT
+                for exponent in exponents
+            )
+        ):
+            raise ValueError("modular-polynomial sparse term is malformed")
+        coefficient = _integer(coefficient_text) % modulus
+        if coefficient == 0:
+            raise ValueError("modular-polynomial sparse term is zero modulo m")
+        terms.append((coefficient, exponents))
+    exponent_vectors = [tuple(exponents) for _, exponents in terms]
+    if exponent_vectors != sorted(set(exponent_vectors)):
+        raise ValueError("modular-polynomial terms are not in canonical order")
+    return terms
+
+
+def _cartesian_assignments(domains: list[list[int]]) -> list[list[int]]:
+    assignments: list[list[int]] = [[]]
+    for domain in domains:
+        assignments = [
+            [*prefix, residue] for prefix in assignments for residue in domain
+        ]
+    return assignments
+
+
+def _evaluate_modular_polynomial_with_flint(
+    terms: list[tuple[int, list[int]]],
+    assignment: list[int],
+    modulus: int,
+) -> int:
+    modulus_value = flint.fmpz(modulus)
+    value = flint.fmpz(0)
+    for coefficient, exponents in terms:
+        monomial = flint.fmpz(coefficient)
+        for coordinate, exponent in zip(assignment, exponents, strict=True):
+            monomial *= pow(flint.fmpz(coordinate), exponent, modulus_value)
+            monomial %= modulus_value
+        value += monomial
+        value %= modulus_value
+    return int(value)
+
+
+def _strict_result_integer(value: object) -> int:
+    if type(value) is not int:
+        raise ValueError("modular-polynomial result integer is malformed")
+    return value
+
+
+def _modular_residue_result_shape(result: dict[str, Any]) -> None:
+    if set(result) != {
+        "semantics_version",
+        "modulus",
+        "variable_order",
+        "domains",
+        "normalized_terms",
+        "enumeration_scope",
+        "total_assignments",
+        "image",
+        "residue_counts",
+        "witnesses",
+        "table",
+    }:
+        raise ValueError("modular-polynomial result is malformed")
+    _strict_result_integer(result["modulus"])
+    _strict_result_integer(result["total_assignments"])
+    if not isinstance(result["variable_order"], list) or not all(
+        isinstance(name, str) for name in result["variable_order"]
+    ):
+        raise ValueError("modular-polynomial result variable order is malformed")
+    if not isinstance(result["domains"], list) or any(
+        not isinstance(domain, list)
+        or any(type(residue) is not int for residue in domain)
+        for domain in result["domains"]
+    ):
+        raise ValueError("modular-polynomial result domains are malformed")
+    if not isinstance(result["normalized_terms"], list) or any(
+        not isinstance(term, dict)
+        or set(term) != {"coefficient", "exponents"}
+        or type(term["coefficient"]) is not int
+        or not isinstance(term["exponents"], list)
+        or any(type(exponent) is not int for exponent in term["exponents"])
+        for term in result["normalized_terms"]
+    ):
+        raise ValueError("normalized modular-polynomial terms are malformed")
+    if not isinstance(result["image"], list) or any(
+        type(residue) is not int for residue in result["image"]
+    ):
+        raise ValueError("modular-polynomial image is malformed")
+    if not isinstance(result["residue_counts"], list) or any(
+        not isinstance(item, dict)
+        or set(item) != {"residue", "count"}
+        or type(item["residue"]) is not int
+        or type(item["count"]) is not int
+        for item in result["residue_counts"]
+    ):
+        raise ValueError("modular-polynomial residue counts are malformed")
+    if not isinstance(result["witnesses"], list) or any(
+        not isinstance(item, dict)
+        or set(item) != {"residue", "assignment"}
+        or type(item["residue"]) is not int
+        or not isinstance(item["assignment"], list)
+        or any(type(value) is not int for value in item["assignment"])
+        for item in result["witnesses"]
+    ):
+        raise ValueError("modular-polynomial witnesses are malformed")
+    if not isinstance(result["table"], list) or any(
+        not isinstance(row, dict)
+        or set(row) != {"assignment", "residue"}
+        or type(row["residue"]) is not int
+        or not isinstance(row["assignment"], list)
+        or any(type(value) is not int for value in row["assignment"])
+        for row in result["table"]
+    ):
+        raise ValueError("modular-polynomial assignment table is malformed")
+
+
+def _modular_polynomial_residue_image(
+    source: dict[str, Any],
+    result: dict[str, Any],
+) -> bool:
+    modulus, names, domains, terms = _modular_residue_source(source)
+    _modular_residue_result_shape(result)
+    normalized_terms = [
+        {"coefficient": coefficient, "exponents": exponents}
+        for coefficient, exponents in terms
+    ]
+    assignments = _cartesian_assignments(domains)
+    residues = [
+        _evaluate_modular_polynomial_with_flint(terms, assignment, modulus)
+        for assignment in assignments
+    ]
+    image = sorted(set(residues))
+    counts = [
+        {"residue": residue, "count": residues.count(residue)} for residue in image
+    ]
+    first_assignments: dict[int, list[int]] = {}
+    for assignment, residue in zip(assignments, residues, strict=True):
+        first_assignments.setdefault(residue, assignment)
+    witnesses = [
+        {"residue": residue, "assignment": first_assignments[residue]}
+        for residue in image
+    ]
+    table = [
+        {"assignment": assignment, "residue": residue}
+        for assignment, residue in zip(assignments, residues, strict=True)
+    ]
+    return bool(
+        result["semantics_version"] == "modular-polynomial-residue-image.v1"
+        and result["modulus"] == modulus
+        and result["variable_order"] == names
+        and result["domains"] == domains
+        and result["normalized_terms"] == normalized_terms
+        and result["enumeration_scope"] == "COMPLETE_DECLARED_CARTESIAN_PRODUCT"
+        and result["total_assignments"] == len(assignments)
+        and result["image"] == image
+        and result["residue_counts"] == counts
+        and result["witnesses"] == witnesses
+        and result["table"] == table
+    )
+
+
+def check_modular_polynomial_residue_image(
+    request: dict[str, Any],
+) -> dict[str, Any]:
+    operation_id = "modular.polynomial_residue_image.compute"
+    try:
+        if (
+            flint.__version__ != _PYTHON_FLINT_VERSION
+            or flint.__FLINT_VERSION__ != _FLINT_VERSION
+        ):
+            return _reject_exact_integer(
+                "authorized Python-FLINT runtime is unavailable"
+            )
+        source, result = _bound_request(
+            request,
+            operation_id=operation_id,
+            witness_format="modular.polynomial-residue-image.flint-replay",
+        )
+        if not _modular_polynomial_residue_image(source, result):
+            return _reject_exact_integer(
+                "declared result does not match independent Python-FLINT "
+                "exhaustive modular-polynomial replay"
+            )
+        return _accept_exhaustive_integer(
+            f"independent Python-FLINT exhaustive replay accepted {operation_id}"
+        )
+    except (KeyError, TypeError, ValueError, OverflowError):
+        return _reject_exact_integer(
+            "malformed, unsupported, or mismatched checker request"
+        )
 
 
 def _gcd(source: dict[str, Any], result: dict[str, Any]) -> bool:

--- a/tests/component/checkers/test_exact_domain_checker_installation.py
+++ b/tests/component/checkers/test_exact_domain_checker_installation.py
@@ -17,6 +17,7 @@ from jacobian.contracts.matrix_operations import (
 )
 from jacobian.contracts.number_theory import (
     FactorizationRequest,
+    ModularPolynomialResidueImageRequest,
     PowerfulNumberRequest,
 )
 from jacobian.contracts.polynomial_operations import (
@@ -105,6 +106,7 @@ def test_installer_authorizes_all_exact_domain_replays(tmp_path: Path) -> None:
     number_theory_ids = (
         "integer.compute.prime_factorization",
         "integer.decide.powerful",
+        "modular.polynomial_residue_image.compute",
     )
     projective_ids = ("geometry.projective_line_arrangement.flats.materialize",)
     registry = CheckerRegistry(ArtifactStore(tmp_path / "store"))
@@ -142,7 +144,11 @@ def test_installer_authorizes_all_exact_domain_replays(tmp_path: Path) -> None:
             character="8",
         ),
         number_theory=_installed(
-            (FactorizationRequest, PowerfulNumberRequest),
+            (
+                FactorizationRequest,
+                PowerfulNumberRequest,
+                ModularPolynomialResidueImageRequest,
+            ),
             number_theory_ids,
             character="6",
         ),

--- a/tests/component/checkers/test_exact_domain_operation_checkers.py
+++ b/tests/component/checkers/test_exact_domain_operation_checkers.py
@@ -4,6 +4,7 @@ import copy
 import subprocess
 import sys
 from collections.abc import Callable
+from itertools import product
 from typing import Any
 
 import pytest
@@ -19,6 +20,7 @@ from jacobian_checkers.exact_domain_operations import (
     check_matrix_nullspace,
     check_matrix_rref,
     check_matrix_smith_normal_form,
+    check_modular_polynomial_residue_image,
     check_polynomial_discriminant,
     check_polynomial_gcd,
     check_polynomial_resultant,
@@ -317,6 +319,49 @@ _CASES: tuple[
                     {"prime": "3", "power": 2},
                 ],
                 "violating_primes": [],
+            },
+        ),
+    ),
+    (
+        check_modular_polynomial_residue_image,
+        _request(
+            "modular.polynomial_residue_image.compute",
+            "modular.polynomial-residue-image.flint-replay",
+            {
+                "modulus": 7,
+                "variables": [
+                    {"name": "x", "residues": [0, 1, 2, 3, 4, 5, 6]},
+                ],
+                "terms": [{"coefficient": "4", "exponents": [3]}],
+            },
+            {
+                "semantics_version": "modular-polynomial-residue-image.v1",
+                "modulus": 7,
+                "variable_order": ["x"],
+                "domains": [[0, 1, 2, 3, 4, 5, 6]],
+                "normalized_terms": [{"coefficient": 4, "exponents": [3]}],
+                "enumeration_scope": "COMPLETE_DECLARED_CARTESIAN_PRODUCT",
+                "total_assignments": 7,
+                "image": [0, 3, 4],
+                "residue_counts": [
+                    {"residue": 0, "count": 1},
+                    {"residue": 3, "count": 3},
+                    {"residue": 4, "count": 3},
+                ],
+                "witnesses": [
+                    {"residue": 0, "assignment": [0]},
+                    {"residue": 3, "assignment": [3]},
+                    {"residue": 4, "assignment": [1]},
+                ],
+                "table": [
+                    {"assignment": [0], "residue": 0},
+                    {"assignment": [1], "residue": 4},
+                    {"assignment": [2], "residue": 4},
+                    {"assignment": [3], "residue": 3},
+                    {"assignment": [4], "residue": 4},
+                    {"assignment": [5], "residue": 3},
+                    {"assignment": [6], "residue": 3},
+                ],
             },
         ),
     ),
@@ -622,6 +667,150 @@ def test_exact_domain_checker_rejects_changed_flint_runtime(
     assert decision["accepted"] is False
     assert decision["conclusion"] == "UNKNOWN"
     assert "runtime is unavailable" in decision["detail"]
+
+
+def _modular_checker_request() -> dict[str, Any]:
+    return copy.deepcopy(
+        next(
+            checker_request
+            for checker, checker_request in _CASES
+            if checker is check_modular_polynomial_residue_image
+        )
+    )
+
+
+def test_modular_residue_checker_reports_exhaustive_integer_replay() -> None:
+    decision = check_modular_polynomial_residue_image(_modular_checker_request())
+
+    assert decision["accepted"] is True
+    assert decision["arithmetic"] == "EXACT_INTEGER"
+    assert decision["method"] == "EXHAUSTIVE_FINITE"
+    assert decision["coverage"] == "EXHAUSTIVE"
+
+
+def test_modular_residue_checker_accepts_exact_assignment_bound() -> None:
+    assignments = [list(values) for values in product(range(16), repeat=3)]
+    residues = [
+        assignment[0] * assignment[1] * assignment[2] % 16 for assignment in assignments
+    ]
+    image = sorted(set(residues))
+    first_assignments: dict[int, list[int]] = {}
+    for assignment, residue in zip(assignments, residues, strict=True):
+        first_assignments.setdefault(residue, assignment)
+    checker_request = _request(
+        "modular.polynomial_residue_image.compute",
+        "modular.polynomial-residue-image.flint-replay",
+        {
+            "modulus": 16,
+            "variables": [
+                {"name": "x", "residues": list(range(16))},
+                {"name": "y", "residues": list(range(16))},
+                {"name": "z", "residues": list(range(16))},
+            ],
+            "terms": [{"coefficient": "1", "exponents": [1, 1, 1]}],
+        },
+        {
+            "semantics_version": "modular-polynomial-residue-image.v1",
+            "modulus": 16,
+            "variable_order": ["x", "y", "z"],
+            "domains": [list(range(16)), list(range(16)), list(range(16))],
+            "normalized_terms": [{"coefficient": 1, "exponents": [1, 1, 1]}],
+            "enumeration_scope": "COMPLETE_DECLARED_CARTESIAN_PRODUCT",
+            "total_assignments": 4_096,
+            "image": image,
+            "residue_counts": [
+                {"residue": residue, "count": residues.count(residue)}
+                for residue in image
+            ],
+            "witnesses": [
+                {
+                    "residue": residue,
+                    "assignment": first_assignments[residue],
+                }
+                for residue in image
+            ],
+            "table": [
+                {"assignment": assignment, "residue": residue}
+                for assignment, residue in zip(assignments, residues, strict=True)
+            ],
+        },
+    )
+
+    decision = check_modular_polynomial_residue_image(checker_request)
+
+    assert decision["accepted"] is True
+    assert decision["method"] == "EXHAUSTIVE_FINITE"
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    (
+        lambda result: result["table"].pop(),
+        lambda result: result["table"][1].update(residue=3),
+        lambda result: result["residue_counts"][1].update(count=2),
+        lambda result: result["witnesses"][2].update(assignment=[2]),
+        lambda result: result.update(variable_order=["y"]),
+        lambda result: result["normalized_terms"][0].update(coefficient=3),
+    ),
+    ids=(
+        "partial-table",
+        "wrong-evaluation",
+        "wrong-multiplicity",
+        "nonfirst-witness",
+        "wrong-variable-order",
+        "wrong-normalization",
+    ),
+)
+def test_modular_residue_checker_rejects_one_obligation_mutation(
+    mutate: Callable[[dict[str, Any]], object],
+) -> None:
+    checker_request = _modular_checker_request()
+    mutate(checker_request["candidate"]["payload"])
+    checker_request["candidate"]["payload_digest"] = _digest(
+        checker_request["candidate"]["payload"]
+    )
+
+    decision = check_modular_polynomial_residue_image(checker_request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+def test_modular_residue_checker_rejects_wrong_bound_scope() -> None:
+    checker_request = _modular_checker_request()
+    checker_request["scope"] = {
+        "assignment_count": 7,
+        "enumeration": "COMPLETE_DECLARED_CARTESIAN_PRODUCT",
+    }
+
+    decision = check_modular_polynomial_residue_image(checker_request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+def test_exact_domain_checker_import_boundary_excludes_producer_modules() -> None:
+    script = """
+import builtins
+real_import = builtins.__import__
+blocked = {"jacobian", "sympy"}
+def guarded(name, *args, **kwargs):
+    if name.split(".", 1)[0] in blocked:
+        raise RuntimeError(f"forbidden checker import: {name}")
+    return real_import(name, *args, **kwargs)
+builtins.__import__ = guarded
+import jacobian_checkers.exact_domain_operations
+"""
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert completed.returncode == 0, completed.stderr
 
 
 def test_graph_checker_reports_its_actual_exhaustive_replay_method() -> None:

--- a/tests/composition/runtime/exact_verification/test_number_theory_verification.py
+++ b/tests/composition/runtime/exact_verification/test_number_theory_verification.py
@@ -10,6 +10,16 @@ from jacobian.contracts.capabilities import (
 from jacobian.contracts.results import ExecutionStatus
 
 
+def _modular_residue_payload(*, coefficient: str = "4") -> dict[str, object]:
+    return {
+        "modulus": 7,
+        "variables": [
+            {"name": "x", "residues": [0, 1, 2, 3, 4, 5, 6]},
+        ],
+        "terms": [{"coefficient": coefficient, "exponents": [3]}],
+    }
+
+
 @pytest.mark.parametrize("value", ("360", "-360", "1", "-1", "101"))
 def test_prime_factorization_result_uses_independent_python_flint_replay(
     authorized_complete_runtime,
@@ -155,3 +165,86 @@ def test_powerful_number_verifier_rejects_schema_valid_wrong_factor_product(
     assert rejected.output["status"] == "REJECTED"
     assert rejected.output["conclusion"] == "UNKNOWN"
     assert rejected.output["verification_record_uri"] is None
+
+
+def test_modular_residue_image_uses_independent_python_flint_replay(
+    authorized_complete_runtime,
+) -> None:
+    producer_id = "modular.polynomial_residue_image.compute"
+    verifier_id = "modular.polynomial_residue_image.verify"
+    computed = authorized_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id=producer_id,
+            input=_modular_residue_payload(),
+        )
+    )
+
+    verified = authorized_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id=verifier_id,
+            mode=CapabilityMode.VERIFY,
+            input={"result_uri": computed.output["result_uri"]},
+        )
+    )
+
+    assert verified.execution.status is ExecutionStatus.COMPLETED
+    assert verified.output["status"] == "VERIFIED"
+    assert verified.output["operation_id"] == producer_id
+    assert verified.output["verification_record_uri"] is not None
+    assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED
+    assert verified.output["verification_record_uri"] in verified.artifact_uris
+    provider_runtime = next(
+        descriptor.provider_runtime
+        for descriptor in authorized_complete_runtime.core.capabilities.catalog().capabilities
+        if descriptor.capability_id == verifier_id
+    )
+    assert provider_runtime is not None
+    assert provider_runtime.provider == "jacobian.exact-domain-checkers"
+    assert {
+        component["provider"]
+        for component in provider_runtime.configuration["components"]
+    } == {"jacobian.exact-domain-checker-source", "python-flint"}
+
+
+def test_modular_residue_verifier_rejects_source_result_substitution(
+    authorized_complete_runtime,
+) -> None:
+    source_result = authorized_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="modular.polynomial_residue_image.compute",
+            input=_modular_residue_payload(),
+        )
+    )
+    substituted_result = authorized_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="modular.polynomial_residue_image.compute",
+            input=_modular_residue_payload(coefficient="3"),
+        )
+    )
+    source_artifact = authorized_complete_runtime.core.store.get(
+        source_result.output["result_uri"]
+    )
+    candidate_artifact = authorized_complete_runtime.core.store.get(
+        substituted_result.output["result_uri"]
+    )
+    rebound_candidate = authorized_complete_runtime.core.artifacts.put(
+        schema_uri=candidate_artifact.manifest.schema_uri,
+        semantics_uri=candidate_artifact.manifest.semantics_uri,
+        parents=source_artifact.manifest.parents,
+        payload=candidate_artifact.payload,
+        summary="adversarial modular residue source-result substitution",
+    )
+
+    rejected = authorized_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="modular.polynomial_residue_image.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"result_uri": rebound_candidate.artifact_uri},
+        )
+    )
+
+    assert rejected.execution.status is ExecutionStatus.COMPLETED
+    assert rejected.output["status"] == "REJECTED"
+    assert rejected.output["conclusion"] == "UNKNOWN"
+    assert rejected.output["verification_record_uri"] is None
+    assert rejected.assurance.level is CapabilityAssuranceLevel.COMPUTED


### PR DESCRIPTION
## Summary

- add operator-authorized `modular.polynomial_residue_image.verify`
- independently replay the complete declared residue table with Python-FLINT
- bind exact semantics, normalized polynomial, variable order/domains, exhaustive scope, image, multiplicities, and first witnesses
- keep all rejected, malformed, unavailable, timed-out, cancelled, and errored paths non-conclusive

## Capability-development handoff

- Stage/status: checker / complete
- Subject: `modular.polynomial_residue_image.compute` → `modular.polynomial_residue_image.verify`
- Producer evidence: #249
- Discovery evidence: #247 and `research/evaluations/capability-workflow-v1/gap-ledger.json`
- Public reproduction: `benchmarks/datasets/agent-workflow-v1/tasks/mathematical-sciences/number-theory/modular-cubic-obstruction`
- Exact claim: the complete bounded table is the declared modular polynomial evaluated over every declared assignment, and the image, counts, and first witnesses are exactly derived from that table.
- Checker format: `modular.polynomial-residue-image.flint-replay`
- Authorization: the existing operator-owned bundled exact-domain checker registry; callers cannot supply code or authorize checkers.

### Obligation ledger

The checker independently binds and checks:

1. artifact, input, result, and semantics identities;
2. the canonical request and semantics version;
3. normalized coefficients/exponents and declared variable order/domains;
4. complete Cartesian-product scope and assignment count;
5. every assignment and polynomial evaluation;
6. the exact image, multiplicities, and lexicographically first witnesses;
7. the verification record to the claim, candidate, scope, checker identity, and evidence.

### Independence

The producer enumerates with the Python standard library and evaluates with built-in integer arithmetic. The checker runs in a clean process, reconstructs the product itself, and evaluates every row with Python-FLINT 0.9.0 / FLINT 3.6.0. Passive JSON and artifact bindings cross the boundary. Shared schema validation may reject malformed input but cannot certify the claim.

### Adversarial coverage

Tests reject candidate mutation, semantics substitution, claim-binding substitution, forged semantics digests, partial tables, wrong evaluations, wrong multiplicities, non-first witnesses, wrong variable order, wrong normalization, wrong scope, and schema-valid source/result substitution. A subprocess import-boundary test blocks both `jacobian` and `sympy` from the checker process.

All non-accepted outcomes remain `UNKNOWN` and publish no verification record. The treatment is the unchanged producer plus this independently authorized verifier; no model evaluation was run and no model-outcome claim is made. Held-out C1/C2 evaluation remains a later stage.

## Runtime snapshot

Tested tree: `074ad1aeb7296afca5620132d34a239740857134` on `main@4d12c45f9216248653d7a853df96159b15553433`.

- package: `0.6.0a0`
- installed catalog: 296 capabilities, digest `sha256:8973a48742080a13f3a581bcbf6414bcfb276aeb6927484887bebdfb05914e91`
- policy: `DEFAULT`, digest `sha256:870a92b83d3e522e4015b6bb1cabda33086906f9de1c3c36e466251ea7ed1957`
- provider: `jacobian.exact-domain-checkers`, available
- runtime components: `jacobian.exact-domain-checker-source`, `python-flint`
- sample replay: `COMPLETED/COMPUTED` → `VERIFIED/VERIFIED`
- checker: `checker://sha256/d73dffae3035c0a3b72a7bc1c5f183848a16091b2798362718e86be7fb67e792`
- verification record present in `artifact_uris`

## Validation

`make test-plan BASE=origin/main` selected unit, component, domain, composition, storage, process, MCP, e2e, static, and build lanes.

- `make test-unit` — 640 passed
- `make test-component` — 583 passed
- `make test-domain` — 186 passed
- `make test-composition` — 421 passed, 2 expected Lean skips
- `make test-storage` — 101 passed
- `make test-process` — 158 passed
- `make test-mcp` — 21 passed
- `make test-e2e` — 7 passed, 1 expected Lean skip
- `make check-static` — green; C901 baseline unchanged at 128
- `make build` — sdist and wheel built
- `make harbor-check` — verifier support and all 6 Harbor datasets match
- `git diff --check origin/main...HEAD` — clean
