### PR TITLE
feat(math): add typed native Python API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,24 @@ MCP tools.
 Prefer thin adapters to maintained mathematical systems. Pin versions when
 reproducibility, certificates, or verification depend on them.
 
+The supported native Python API lives only under `jacobian.math`. Keep its
+public modules deliberately small, declare their supported symbols with
+explicit `__all__` values, and cover namespace and import isolation in the
+public-API tests. Do not re-export domain APIs from the root `jacobian`
+namespace. Native functions accept and return Python or maintained
+backend-native values and call typed mathematical kernels directly; they must
+not invoke `capability.invoke`, construct a capability runtime, or expose MCP,
+artifact, provider-loading, or installation objects.
+
+Keep Pydantic models authoritative at capability, persistence, artifact, and
+wire boundaries. Domain implementations and operation factories must preserve
+their concrete request, result, and obligation types: do not accept
+`Callable[[ContractModel], ContractModel]`, cast a validated request back to a
+domain model, or erase bounded-search obligation types. When a native API and a
+capability expose the same outcome, share one typed mathematical kernel and use
+explicit domain-owned conversions rather than duplicating the mathematics or
+introducing a generic conversion framework.
+
 Built-in mathematical producers belong in explicit domain bundles. Do not add
 global operation registries, recursive package discovery, import-time
 registration, or mechanical wrappers for backend functions. Producers remain

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,7 +59,9 @@ Reference documents define exact interfaces, records, gates, and test
 expectations. Start with the [tool surface](reference/tools.md) for the public
 MCP contract and the
 [domain operation library](reference/domain-operation-library.md) for the
-shared built-in operation contract. Use the runtime `capability://catalog` and
+shared built-in operation contract. The
+[native Python API](reference/python-api.md) documents the supported
+native-value modules. Use the runtime `capability://catalog` and
 `capability.describe` for the installed capability inventory and exact
 operation schemas.
 

--- a/docs/reference/domain-operation-library.md
+++ b/docs/reference/domain-operation-library.md
@@ -63,6 +63,47 @@ materializes input and result artifacts, records their lineage and relation,
 and returns `COMPLETE · COMPUTED`. Neither exact arithmetic nor deterministic
 execution grants `VERIFIED`.
 
+### Static type contract
+
+The generic operation layer preserves each domain contract through
+construction and installation:
+
+```python
+ComputedOperation[RequestT, ResultT]
+ComputedOperationFactory(
+    operation: Callable[[RequestT], ResultT],
+) -> ComputedOperation[RequestT, ResultT]
+BoundedSearchOperation[RequestT, ResultT, ObligationT]
+```
+
+Domain implementations accept their concrete validated request model and
+return their concrete result model. Bounded searches likewise return their
+declared obligation model from the obligation builder. A broad
+`Callable[[ContractModel], ContractModel]` boundary, or a cast from
+`ContractModel` to the declared request type inside an implementation, defeats
+this contract and is not supported.
+
+This static precision does not replace runtime validation. The installer still
+validates untrusted input with the declared Pydantic request model before it
+calls domain code, then validates returned result and obligation values before
+materializing artifacts.
+
+## Native Python relationship
+
+The supported native-value interface is the deliberately small
+[`jacobian.math`](python-api.md) namespace. Its functions accept Python,
+SymPy, or NetworkX values as documented and call typed mathematical kernels
+directly. They do not construct the capability runtime or route through
+`capability.invoke`.
+
+When a native function corresponds to a capability, both paths share the same
+domain-owned mathematical kernel. Explicit adapters translate between native
+values and the existing Pydantic request and result contracts. This keeps one
+mathematical implementation while preserving capability schemas, artifact
+lineage, completeness, provenance, and verification behavior. Generic
+reflection, automatic model generation, and universal value conversion are
+outside this library's contract.
+
 ## Bounded searches
 
 A `BoundedSearchOperation` adds a completion predicate, a typed scope
@@ -165,13 +206,17 @@ record.
 Keep additions domain-owned and follow the nearby bundle:
 
 1. define bounded Pydantic request, result, and, for search, obligation models;
-2. implement one mathematical outcome without store or envelope dependencies;
+2. implement one mathematical outcome with concrete request, result, and
+   obligation types and without store or envelope dependencies;
 3. declare a computed or bounded-search operation in a subject module;
 4. include it explicitly in the domain bundle and declare the maintained
    provider runtime and backend version;
 5. test request validation, artifacts and lineage, assurance, failure
    semantics, and catalog projection; and
-6. add an independent checker only when the exact relation has a separate,
+6. if the outcome belongs in the supported native Python API, share the typed
+   kernel, add explicit domain-owned conversions, and update the public symbol
+   manifest and import-isolation tests; and
+7. add an independent checker only when the exact relation has a separate,
    operator-authorized replay path.
 
 Do not add a mechanical wrapper for every backend function, hide a research

--- a/docs/reference/python-api.md
+++ b/docs/reference/python-api.md
@@ -1,0 +1,37 @@
+# Native Python API
+
+Jacobian provides a deliberately small native-value API for deterministic
+mathematical computations. It is independent of the MCP transport and does not
+construct a capability runtime.
+
+```python
+from fractions import Fraction
+
+import networkx as nx
+import sympy
+
+from jacobian.math import arithmetic, graphs, matrices
+
+half = arithmetic.sum_rationals(Fraction(1, 3), Fraction(1, 6))
+inverse = matrices.inverse(sympy.Matrix([[1, 2], [3, 4]]))
+triangles = graphs.triangle_count(nx.cycle_graph(3))
+```
+
+The supported modules and symbols are:
+
+- `jacobian.math.arithmetic`: `absolute_value`, `sign`, `reciprocal`,
+  `sum_rationals`, and `quotient`;
+- `jacobian.math.matrices`: `rref`, `inverse`, and `trace`; and
+- `jacobian.math.graphs`: `triangle_count`, `diameter`, and `is_eulerian`.
+
+Arithmetic functions return Python `int` or `fractions.Fraction` values. Matrix
+functions accept and return SymPy matrices and exact SymPy scalar values. Graph
+functions accept undirected simple NetworkX `Graph` objects. Each module's
+`__all__` is the authoritative public symbol manifest; other implementation
+modules remain internal.
+
+This API shares typed mathematical kernels with the corresponding capability
+implementations, but it is not a facade over `capability.invoke`. Capability
+requests, result contracts, artifacts, provenance, completeness, and
+verification remain available through the capability runtime and retain their
+existing wire semantics.

--- a/src/jacobian/domains/analysis/operations.py
+++ b/src/jacobian/domains/analysis/operations.py
@@ -12,7 +12,7 @@ from pydantic import ValidationError
 from jacobian.bounded_process import ProcessResourceLimits, run_bounded_process
 from jacobian.canonical import canonicalize_json, loads_strict_json
 from jacobian.contracts.capabilities import CapabilityDiagnostic
-from jacobian.contracts.results import ContractModel, ExecutionStatus
+from jacobian.contracts.results import ExecutionStatus
 from jacobian.contracts.validated_analysis import (
     ArbPointEnclosureObligation,
     ArbPointEnclosureRequest,
@@ -151,7 +151,7 @@ def _scope(
 def _obligation(
     request: ArbPointEnclosureRequest,
     result: ArbPointEnclosureResult,
-) -> ContractModel:
+) -> ArbPointEnclosureObligation:
     return ArbPointEnclosureObligation(
         function=request.function,
         argument=request.argument,

--- a/src/jacobian/domains/arithmetic/operations.py
+++ b/src/jacobian/domains/arithmetic/operations.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import math
 from fractions import Fraction
-from typing import Literal, cast
+from typing import Literal
 
 from jacobian.contracts.arithmetic import (
     IntegerBaseDigitsRequest,
@@ -34,7 +34,7 @@ from jacobian.contracts.rationals import (
     RationalValueRequest,
     RationalValueResult,
 )
-from jacobian.contracts.results import ContractModel
+from jacobian.math import arithmetic as native_arithmetic
 
 
 def _int(value: str) -> int:
@@ -50,14 +50,14 @@ def to_fraction(num: str, den: str) -> Fraction:
     return Fraction(int(num), int(den))
 
 
-def absolute_value(request: ContractModel) -> ContractModel:
-    req = cast(IntegerValueRequest, request)
-    return IntegerValueResult(value=_canonical(abs(_int(req.value))))
+def absolute_value(request: IntegerValueRequest) -> IntegerValueResult:
+    return IntegerValueResult(
+        value=_canonical(native_arithmetic.absolute_value(_int(request.value)))
+    )
 
 
-def sign(request: ContractModel) -> ContractModel:
-    req = cast(IntegerValueRequest, request)
-    value = _int(req.value)
+def sign(request: IntegerValueRequest) -> IntegerSignResult:
+    value = native_arithmetic.sign(_int(request.value))
     if value < 0:
         sign: Literal[-1, 0, 1] = -1
     elif value > 0:
@@ -67,24 +67,21 @@ def sign(request: ContractModel) -> ContractModel:
     return IntegerSignResult(sign=sign)
 
 
-def decimal_digit_sum(request: ContractModel) -> ContractModel:
-    req = cast(IntegerValueRequest, request)
+def decimal_digit_sum(request: IntegerValueRequest) -> IntegerValueResult:
     return IntegerValueResult(
-        value=_canonical(sum(int(digit) for digit in str(abs(_int(req.value)))))
+        value=_canonical(sum(int(digit) for digit in str(abs(_int(request.value)))))
     )
 
 
-def decimal_digit_count(request: ContractModel) -> ContractModel:
-    req = cast(IntegerValueRequest, request)
-    return IntegerValueResult(value=_canonical(len(str(abs(_int(req.value))))))
+def decimal_digit_count(request: IntegerValueRequest) -> IntegerValueResult:
+    return IntegerValueResult(value=_canonical(len(str(abs(_int(request.value))))))
 
 
-def base_digits(request: ContractModel) -> ContractModel:
+def base_digits(request: IntegerBaseDigitsRequest) -> IntegerBaseDigitsResult:
     from sympy.ntheory import digits as sympy_digits
 
-    req = cast(IntegerBaseDigitsRequest, request)
-    value = _int(req.value)
-    signed_base, *expanded = sympy_digits(value, req.base)
+    value = _int(request.value)
+    signed_base, *expanded = sympy_digits(value, request.base)
     sign: Literal[-1, 0, 1]
     if value == 0:
         sign = 0
@@ -99,15 +96,14 @@ def base_digits(request: ContractModel) -> ContractModel:
     )
 
 
-def nth_root(request: ContractModel) -> ContractModel:
+def nth_root(request: IntegerNthRootRequest) -> IntegerNthRootResult:
     from sympy import integer_nthroot
 
-    req = cast(IntegerNthRootRequest, request)
-    if req.value < 0 and req.degree % 2 == 0:
+    if request.value < 0 and request.degree % 2 == 0:
         raise ValueError("even root of a negative integer is not integral-real")
-    root, exact = integer_nthroot(abs(req.value), req.degree)
+    root, exact = integer_nthroot(abs(request.value), request.degree)
     return IntegerNthRootResult(
-        root=_canonical(-root if req.value < 0 else root),
+        root=_canonical(-root if request.value < 0 else root),
         exact=exact,
     )
 
@@ -123,88 +119,94 @@ def _wire(value: Fraction) -> CanonicalRational:
     )
 
 
-def reciprocal(request: ContractModel) -> ContractModel:
-    req = cast(RationalValueRequest, request)
-    value = _fraction(req.value)
-    if value == 0:
-        raise ValueError("zero has no reciprocal")
-    return RationalValueResult(value=_wire(Fraction(1, 1) / value))
+def reciprocal(request: RationalValueRequest) -> RationalValueResult:
+    try:
+        value = native_arithmetic.reciprocal(_fraction(request.value))
+    except ZeroDivisionError as exc:
+        raise ValueError(str(exc)) from exc
+    return RationalValueResult(value=_wire(value))
 
 
-def negation(request: ContractModel) -> ContractModel:
-    req = cast(RationalValueRequest, request)
-    return RationalValueResult(value=_wire(-_fraction(req.value)))
+def negation(request: RationalValueRequest) -> RationalValueResult:
+    return RationalValueResult(value=_wire(-_fraction(request.value)))
 
 
-def rational_absolute_value(request: ContractModel) -> ContractModel:
-    req = cast(RationalValueRequest, request)
-    return RationalValueResult(value=_wire(abs(_fraction(req.value))))
+def rational_absolute_value(request: RationalValueRequest) -> RationalValueResult:
+    return RationalValueResult(value=_wire(abs(_fraction(request.value))))
 
 
-def sum_rationals(request: ContractModel) -> ContractModel:
-    req = cast(RationalPairRequest, request)
-    return RationalValueResult(value=_wire(_fraction(req.left) + _fraction(req.right)))
-
-
-def difference(request: ContractModel) -> ContractModel:
-    req = cast(RationalPairRequest, request)
-    return RationalValueResult(value=_wire(_fraction(req.left) - _fraction(req.right)))
-
-
-def product(request: ContractModel) -> ContractModel:
-    req = cast(RationalPairRequest, request)
-    return RationalValueResult(value=_wire(_fraction(req.left) * _fraction(req.right)))
-
-
-def quotient(request: ContractModel) -> ContractModel:
-    req = cast(RationalPairRequest, request)
-    right = _fraction(req.right)
-    if right == 0:
-        raise ValueError("division by zero")
-    return RationalValueResult(value=_wire(_fraction(req.left) / right))
-
-
-def minimum(request: ContractModel) -> ContractModel:
-    req = cast(RationalPairRequest, request)
+def sum_rationals(request: RationalPairRequest) -> RationalValueResult:
     return RationalValueResult(
-        value=_wire(min(_fraction(req.left), _fraction(req.right)))
+        value=_wire(
+            native_arithmetic.sum_rationals(
+                _fraction(request.left), _fraction(request.right)
+            )
+        )
     )
 
 
-def maximum(request: ContractModel) -> ContractModel:
-    req = cast(RationalPairRequest, request)
+def difference(request: RationalPairRequest) -> RationalValueResult:
     return RationalValueResult(
-        value=_wire(max(_fraction(req.left), _fraction(req.right)))
+        value=_wire(_fraction(request.left) - _fraction(request.right))
     )
 
 
-def floor(request: ContractModel) -> ContractModel:
-    req = cast(RationalValueRequest, request)
-    return RationalIntegerResult(value=str(math.floor(_fraction(req.value))))
+def product(request: RationalPairRequest) -> RationalValueResult:
+    return RationalValueResult(
+        value=_wire(_fraction(request.left) * _fraction(request.right))
+    )
 
 
-def ceiling(request: ContractModel) -> ContractModel:
-    req = cast(RationalValueRequest, request)
-    return RationalIntegerResult(value=str(math.ceil(_fraction(req.value))))
+def quotient(request: RationalPairRequest) -> RationalValueResult:
+    try:
+        value = native_arithmetic.quotient(
+            _fraction(request.left), _fraction(request.right)
+        )
+    except ZeroDivisionError as exc:
+        raise ValueError(str(exc)) from exc
+    return RationalValueResult(value=_wire(value))
 
 
-def continued_fraction(request: ContractModel) -> ContractModel:
+def minimum(request: RationalPairRequest) -> RationalValueResult:
+    return RationalValueResult(
+        value=_wire(min(_fraction(request.left), _fraction(request.right)))
+    )
+
+
+def maximum(request: RationalPairRequest) -> RationalValueResult:
+    return RationalValueResult(
+        value=_wire(max(_fraction(request.left), _fraction(request.right)))
+    )
+
+
+def floor(request: RationalValueRequest) -> RationalIntegerResult:
+    return RationalIntegerResult(value=str(math.floor(_fraction(request.value))))
+
+
+def ceiling(request: RationalValueRequest) -> RationalIntegerResult:
+    return RationalIntegerResult(value=str(math.ceil(_fraction(request.value))))
+
+
+def continued_fraction(
+    request: RationalValueRequest,
+) -> RationalContinuedFractionResult:
     from sympy import Rational as SympyRational
     from sympy import continued_fraction as sympy_continued_fraction
 
-    req = cast(RationalValueRequest, request)
-    value = _fraction(req.value)
+    value = _fraction(request.value)
     terms = sympy_continued_fraction(SympyRational(value.numerator, value.denominator))
     return RationalContinuedFractionResult(
         terms=tuple(str(int(term)) for term in terms)
     )
 
 
-def equal(request: ContractModel) -> ContractModel:
-    req = cast(RationalPairRequest, request)
-    return RationalComparisonResult(holds=_fraction(req.left) == _fraction(req.right))
+def equal(request: RationalPairRequest) -> RationalComparisonResult:
+    return RationalComparisonResult(
+        holds=_fraction(request.left) == _fraction(request.right)
+    )
 
 
-def less_than(request: ContractModel) -> ContractModel:
-    req = cast(RationalPairRequest, request)
-    return RationalComparisonResult(holds=_fraction(req.left) < _fraction(req.right))
+def less_than(request: RationalPairRequest) -> RationalComparisonResult:
+    return RationalComparisonResult(
+        holds=_fraction(request.left) < _fraction(request.right)
+    )

--- a/src/jacobian/domains/combinatorics/operations.py
+++ b/src/jacobian/domains/combinatorics/operations.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from functools import reduce
 from operator import mul
-from typing import cast
 
 from jacobian.contracts.combinatorics import (
     FibonacciPairRequest,
@@ -18,101 +17,102 @@ from jacobian.contracts.combinatorics import (
     RationalResult,
 )
 from jacobian.contracts.exact import CanonicalRational
-from jacobian.contracts.results import ContractModel
 
 
 def _integer_result(value: int) -> IntegerResult:
     return IntegerResult(value=str(int(value)))
 
 
-def factorial(request: ContractModel) -> ContractModel:
+def factorial(request: NonnegativeIntegerRequest) -> IntegerResult:
     import math
 
-    n = cast(NonnegativeIntegerRequest, request).n
+    n = request.n
     return _integer_result(math.factorial(n))
 
 
-def double_factorial(request: ContractModel) -> ContractModel:
+def double_factorial(request: NonnegativeIntegerRequest) -> IntegerResult:
     import sympy
 
-    n = cast(NonnegativeIntegerRequest, request).n
+    n = request.n
     return _integer_result(sympy.factorial2(n))
 
 
-def derangements(request: ContractModel) -> ContractModel:
+def derangements(request: NonnegativeIntegerRequest) -> IntegerResult:
     import sympy
 
-    n = cast(NonnegativeIntegerRequest, request).n
+    n = request.n
     return _integer_result(sympy.subfactorial(n))
 
 
-def binomial(request: ContractModel) -> ContractModel:
+def binomial(request: NonnegativePairRequest) -> IntegerResult:
     import math
 
-    pair = cast(NonnegativePairRequest, request)
+    pair = request
     if pair.k > pair.n:
         return _integer_result(0)
     return _integer_result(math.comb(pair.n, pair.k))
 
 
-def multinomial(request: ContractModel) -> ContractModel:
+def multinomial(request: IntegerListRequest) -> IntegerResult:
     import math
 
-    values = [int(v) for v in cast(IntegerListRequest, request).values]
+    values = [int(v) for v in request.values]
     numerator = math.factorial(sum(values))
     denominator = reduce(mul, (math.factorial(v) for v in values), 1)
     return _integer_result(numerator // denominator)
 
 
-def permutations(request: ContractModel) -> ContractModel:
+def permutations(request: NonnegativePairRequest) -> IntegerResult:
     import math
 
-    pair = cast(NonnegativePairRequest, request)
+    pair = request
     if pair.k > pair.n:
         return _integer_result(0)
     return _integer_result(math.perm(pair.n, pair.k))
 
 
-def stirling_first(request: ContractModel) -> ContractModel:
+def stirling_first(request: NonnegativePairRequest) -> IntegerResult:
     from sympy.functions.combinatorial.numbers import stirling
 
-    pair = cast(NonnegativePairRequest, request)
+    pair = request
     return _integer_result(stirling(pair.n, pair.k, kind=1))
 
 
-def stirling_second(request: ContractModel) -> ContractModel:
+def stirling_second(request: NonnegativePairRequest) -> IntegerResult:
     from sympy.functions.combinatorial.numbers import stirling
 
-    pair = cast(NonnegativePairRequest, request)
+    pair = request
     return _integer_result(stirling(pair.n, pair.k, kind=2))
 
 
-def bell(request: ContractModel) -> ContractModel:
+def bell(request: NonnegativeIntegerRequest) -> IntegerResult:
     import sympy
 
-    n = cast(NonnegativeIntegerRequest, request).n
+    n = request.n
     return _integer_result(sympy.bell(n))
 
 
-def catalan(request: ContractModel) -> ContractModel:
+def catalan(request: NonnegativeIntegerRequest) -> IntegerResult:
     import sympy
 
-    n = cast(NonnegativeIntegerRequest, request).n
+    n = request.n
     return _integer_result(sympy.catalan(n))
 
 
-def partition_number(request: ContractModel) -> ContractModel:
+def partition_number(request: NonnegativeIntegerRequest) -> IntegerResult:
     import sympy
 
-    n = cast(NonnegativeIntegerRequest, request).n
+    n = request.n
     return _integer_result(sympy.partition(n))
 
 
-def enumerate_integer_partitions(request: ContractModel) -> ContractModel:
+def enumerate_integer_partitions(
+    request: IntegerPartitionEnumerationRequest,
+) -> IntegerPartitionEnumerationResult:
     """Enumerate all bounded partitions using ``sympy.utilities.partitions``."""
     from sympy.utilities.iterables import partitions
 
-    value = cast(IntegerPartitionEnumerationRequest, request)
+    value = request
     expanded_partitions: list[tuple[int, ...]] = []
     for multiplicities in partitions(value.n, m=value.max_parts):
         expanded_partitions.append(
@@ -129,18 +129,18 @@ def enumerate_integer_partitions(request: ContractModel) -> ContractModel:
     )
 
 
-def fibonacci(request: ContractModel) -> ContractModel:
+def fibonacci(request: NonnegativeIntegerRequest) -> IntegerResult:
     import sympy
 
-    n = cast(NonnegativeIntegerRequest, request).n
+    n = request.n
     return _integer_result(sympy.fibonacci(n))
 
 
-def fibonacci_pair(request: ContractModel) -> ContractModel:
+def fibonacci_pair(request: FibonacciPairRequest) -> FibonacciPairResult:
     """Compute two consecutive Fibonacci values."""
     import sympy
 
-    n = cast(FibonacciPairRequest, request).n
+    n = request.n
     return FibonacciPairResult(
         n=n,
         f_n=str(sympy.fibonacci(n)),
@@ -148,41 +148,41 @@ def fibonacci_pair(request: ContractModel) -> ContractModel:
     )
 
 
-def lucas(request: ContractModel) -> ContractModel:
+def lucas(request: NonnegativeIntegerRequest) -> IntegerResult:
     import sympy
 
-    n = cast(NonnegativeIntegerRequest, request).n
+    n = request.n
     return _integer_result(sympy.lucas(n))
 
 
-def motzkin(request: ContractModel) -> ContractModel:
+def motzkin(request: NonnegativeIntegerRequest) -> IntegerResult:
     import sympy
 
-    n = cast(NonnegativeIntegerRequest, request).n
+    n = request.n
     return _integer_result(sympy.motzkin(n))
 
 
-def bernoulli(request: ContractModel) -> ContractModel:
+def bernoulli(request: NonnegativeIntegerRequest) -> RationalResult:
     import sympy
 
-    n = cast(NonnegativeIntegerRequest, request).n
+    n = request.n
     value = sympy.bernoulli(n)
     return RationalResult(
         value=CanonicalRational(num=str(value.p), den=str(value.q)),
     )
 
 
-def central_binomial(request: ContractModel) -> ContractModel:
+def central_binomial(request: NonnegativeIntegerRequest) -> IntegerResult:
     import math
 
-    n = cast(NonnegativeIntegerRequest, request).n
+    n = request.n
     return _integer_result(math.comb(2 * n, n))
 
 
-def compositions(request: ContractModel) -> ContractModel:
+def compositions(request: NonnegativePairRequest) -> IntegerResult:
     import math
 
-    pair = cast(NonnegativePairRequest, request)
+    pair = request
     if pair.n == pair.k == 0:
         return _integer_result(1)
     if 0 < pair.k <= pair.n:

--- a/src/jacobian/domains/combinatorics/recurrence_series_operations.py
+++ b/src/jacobian/domains/combinatorics/recurrence_series_operations.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any
 
 from jacobian.canonical import format_canonical_integer
 from jacobian.contracts.combinatorics import (
@@ -13,7 +13,6 @@ from jacobian.contracts.combinatorics import (
     RationalGeneratingFunctionCoefficientsResult,
 )
 from jacobian.contracts.exact import CanonicalRational
-from jacobian.contracts.results import ContractModel
 
 
 def _sympy_rational(value: CanonicalRational) -> Any:
@@ -29,10 +28,12 @@ def _wire(value: Any) -> CanonicalRational:
     )
 
 
-def evaluate_linear_recurrence(request: ContractModel) -> ContractModel:
+def evaluate_linear_recurrence(
+    request: LinearRecurrenceEvaluationRequest,
+) -> LinearRecurrenceEvaluationResult:
     """Materialize the complete bounded replay prefix and requested projection."""
 
-    value = cast(LinearRecurrenceEvaluationRequest, request)
+    value = request
     requested_indices = (
         tuple(range(value.term_count))
         if value.scope == "PREFIX" and value.term_count is not None
@@ -67,11 +68,11 @@ def evaluate_linear_recurrence(request: ContractModel) -> ContractModel:
 
 
 def compute_rational_generating_function_coefficients(
-    request: ContractModel,
-) -> ContractModel:
+    request: RationalGeneratingFunctionCoefficientsRequest,
+) -> RationalGeneratingFunctionCoefficientsResult:
     """Expand N(x)/D(x) by exact coefficient recurrence through x^(k-1)."""
 
-    value = cast(RationalGeneratingFunctionCoefficientsRequest, request)
+    value = request
     numerator = tuple(_sympy_rational(item) for item in value.numerator)
     denominator = tuple(_sympy_rational(item) for item in value.denominator)
     zero = denominator[0] * 0

--- a/src/jacobian/domains/finite_sets/operations.py
+++ b/src/jacobian/domains/finite_sets/operations.py
@@ -2,19 +2,16 @@
 
 from __future__ import annotations
 
-from typing import cast
-
 from jacobian.contracts.finite_sets import (
     FiniteSetBooleanResult,
     FiniteSetCardinalityResult,
     FiniteSetElementListResult,
     FiniteSetPairRequest,
 )
-from jacobian.contracts.results import ContractModel
 
 
-def _pair(request: ContractModel) -> tuple[set[int], set[int]]:
-    pair = cast(FiniteSetPairRequest, request)
+def _pair(request: FiniteSetPairRequest) -> tuple[set[int], set[int]]:
+    pair = request
     return (
         {int(element) for element in pair.left.elements},
         {int(element) for element in pair.right.elements},
@@ -27,51 +24,55 @@ def _element_list(values: set[int]) -> FiniteSetElementListResult:
     )
 
 
-def set_union(request: ContractModel) -> ContractModel:
+def set_union(request: FiniteSetPairRequest) -> FiniteSetElementListResult:
     left, right = _pair(request)
     return _element_list(left | right)
 
 
-def set_intersection(request: ContractModel) -> ContractModel:
+def set_intersection(request: FiniteSetPairRequest) -> FiniteSetElementListResult:
     left, right = _pair(request)
     return _element_list(left & right)
 
 
-def set_difference(request: ContractModel) -> ContractModel:
+def set_difference(request: FiniteSetPairRequest) -> FiniteSetElementListResult:
     left, right = _pair(request)
     return _element_list(left - right)
 
 
-def set_symmetric_difference(request: ContractModel) -> ContractModel:
+def set_symmetric_difference(
+    request: FiniteSetPairRequest,
+) -> FiniteSetElementListResult:
     left, right = _pair(request)
     return _element_list(left ^ right)
 
 
-def decide_subset(request: ContractModel) -> ContractModel:
+def decide_subset(request: FiniteSetPairRequest) -> FiniteSetBooleanResult:
     left, right = _pair(request)
     return FiniteSetBooleanResult(holds=left <= right)
 
 
-def decide_proper_subset(request: ContractModel) -> ContractModel:
+def decide_proper_subset(request: FiniteSetPairRequest) -> FiniteSetBooleanResult:
     left, right = _pair(request)
     return FiniteSetBooleanResult(holds=left < right)
 
 
-def decide_disjoint(request: ContractModel) -> ContractModel:
+def decide_disjoint(request: FiniteSetPairRequest) -> FiniteSetBooleanResult:
     left, right = _pair(request)
     return FiniteSetBooleanResult(holds=left.isdisjoint(right))
 
 
-def left_cardinality(request: ContractModel) -> ContractModel:
+def left_cardinality(request: FiniteSetPairRequest) -> FiniteSetCardinalityResult:
     left, _ = _pair(request)
     return FiniteSetCardinalityResult(cardinality=len(left))
 
 
-def intersection_cardinality(request: ContractModel) -> ContractModel:
+def intersection_cardinality(
+    request: FiniteSetPairRequest,
+) -> FiniteSetCardinalityResult:
     left, right = _pair(request)
     return FiniteSetCardinalityResult(cardinality=len(left & right))
 
 
-def union_cardinality(request: ContractModel) -> ContractModel:
+def union_cardinality(request: FiniteSetPairRequest) -> FiniteSetCardinalityResult:
     left, right = _pair(request)
     return FiniteSetCardinalityResult(cardinality=len(left | right))

--- a/src/jacobian/domains/geometry/operations.py
+++ b/src/jacobian/domains/geometry/operations.py
@@ -32,9 +32,8 @@ from jacobian.contracts.geometry import (
     SimplePolygonDecisionResult,
     SimplePolygonPointRequest,
 )
-from jacobian.contracts.results import ContractModel
 
-Compute = Callable[[ContractModel], ContractModel]
+Compute = Callable[[LinePairRequest], GeometryBooleanResult]
 
 
 def _fraction(value: Any) -> Fraction:
@@ -106,8 +105,8 @@ def _on_segment(point: Any, start: Any, end: Any) -> bool:
     )
 
 
-def _pair_points(request: ContractModel) -> tuple[Any, Any]:
-    pair = cast(PointPairRequest, request)
+def _pair_points(request: PointPairRequest) -> tuple[Any, Any]:
+    pair = request
     return _point(pair.first), _point(pair.second)
 
 
@@ -117,21 +116,23 @@ def _line(value: LineRequest) -> Any:
     return Line2D(_point(value.first), _point(value.second))
 
 
-def squared_distance(request: ContractModel) -> ContractModel:
+def squared_distance(request: PointPairRequest) -> GeometryRationalResult:
     first, second = _pair_points(request)
     return GeometryRationalResult(value=_wire_rational(first.distance(second) ** 2))
 
 
-def midpoint(request: ContractModel) -> ContractModel:
+def midpoint(request: PointPairRequest) -> GeometryPointResult:
     first, second = _pair_points(request)
     return GeometryPointResult(point=_wire_point(first.midpoint(second)))
 
 
-def segment_intersection(request: ContractModel) -> ContractModel:
+def segment_intersection(
+    request: SegmentIntersectionRequest,
+) -> SegmentIntersectionResult:
     import sympy
     from sympy.geometry import Point2D
 
-    pair = cast(SegmentIntersectionRequest, request)
+    pair = request
     first_start, first_end = _closed_segment(pair.first)
     second_start, second_end = _closed_segment(pair.second)
     first_degenerate = first_start == first_end
@@ -206,10 +207,10 @@ def segment_intersection(request: ContractModel) -> ContractModel:
     )
 
 
-def collinear(request: ContractModel) -> ContractModel:
+def collinear(request: PointTripleRequest) -> GeometryBooleanResult:
     from sympy.geometry import Point2D
 
-    triple = cast(PointTripleRequest, request)
+    triple = request
     return GeometryBooleanResult(
         holds=Point2D.is_collinear(
             _point(triple.first),
@@ -219,10 +220,10 @@ def collinear(request: ContractModel) -> ContractModel:
     )
 
 
-def concyclic(request: ContractModel) -> ContractModel:
+def concyclic(request: PointQuadrupleRequest) -> GeometryBooleanResult:
     from sympy.geometry import Point2D
 
-    points = cast(PointQuadrupleRequest, request)
+    points = request
     return GeometryBooleanResult(
         holds=Point2D.is_concyclic(
             _point(points.first),
@@ -236,8 +237,8 @@ def concyclic(request: ContractModel) -> ContractModel:
 def line_predicate(
     predicate: Callable[[Any, Any], bool],
 ) -> Compute:
-    def compute(request: ContractModel) -> ContractModel:
-        pair = cast(LinePairRequest, request)
+    def compute(request: LinePairRequest) -> GeometryBooleanResult:
+        pair = request
         return GeometryBooleanResult(
             holds=predicate(_line(pair.first_line), _line(pair.second_line))
         )
@@ -245,10 +246,10 @@ def line_predicate(
     return compute
 
 
-def line_intersection(request: ContractModel) -> ContractModel:
+def line_intersection(request: LinePairRequest) -> GeometryLineIntersectionResult:
     from sympy.geometry import Point2D
 
-    pair = cast(LinePairRequest, request)
+    pair = request
     first, second = _line(pair.first_line), _line(pair.second_line)
     if first.equals(second):
         return GeometryLineIntersectionResult(status="COINCIDENT")
@@ -261,20 +262,20 @@ def line_intersection(request: ContractModel) -> ContractModel:
     return GeometryLineIntersectionResult(status="POINT", point=_wire_point(point))
 
 
-def projection(request: ContractModel) -> ContractModel:
+def projection(request: PointLineRequest) -> GeometryPointResult:
     from sympy.geometry import Point2D
 
-    value = cast(PointLineRequest, request)
+    value = request
     projected = _line(value.line).projection(_point(value.point))
     if not isinstance(projected, Point2D):
         raise ValueError("line projection did not produce one exact point")
     return GeometryPointResult(point=_wire_point(projected))
 
 
-def orientation(request: ContractModel) -> ContractModel:
+def orientation(request: PointTripleRequest) -> GeometryOrientationResult:
     import sympy
 
-    triple = cast(PointTripleRequest, request)
+    triple = request
     first, second, third = (
         _point(triple.first),
         _point(triple.second),
@@ -288,10 +289,10 @@ def orientation(request: ContractModel) -> ContractModel:
     )
 
 
-def centroid(request: ContractModel) -> ContractModel:
+def centroid(request: PointTripleRequest) -> GeometryPointResult:
     from sympy.geometry import Point2D
 
-    triple = cast(PointTripleRequest, request)
+    triple = request
     points = [_point(triple.first), _point(triple.second), _point(triple.third)]
     return GeometryPointResult(
         point=_wire_point(
@@ -303,10 +304,10 @@ def centroid(request: ContractModel) -> ContractModel:
     )
 
 
-def circumcircle(request: ContractModel) -> ContractModel:
+def circumcircle(request: PointTripleRequest) -> GeometryCircleResult:
     from sympy.geometry import Circle, Point2D
 
-    triple = cast(PointTripleRequest, request)
+    triple = request
     points = [_point(triple.first), _point(triple.second), _point(triple.third)]
     if Point2D.is_collinear(*points):
         raise ValueError("a circumcircle requires three noncollinear points")
@@ -317,35 +318,32 @@ def circumcircle(request: ContractModel) -> ContractModel:
     )
 
 
-def signed_area(request: ContractModel) -> ContractModel:
+def signed_area(request: PolygonRequest) -> GeometryRationalResult:
     from sympy.geometry import Polygon
 
-    polygon = cast(PolygonRequest, request)
+    polygon = request
     value = Polygon(*(_point(point) for point in polygon.points)).area
     return GeometryRationalResult(value=_wire_rational(value))
 
 
-def simple_polygon(request: ContractModel) -> ContractModel:
-    polygon = cast(PolygonRequest, request)
+def simple_polygon(request: PolygonRequest) -> SimplePolygonDecisionResult:
+    polygon = request
     points = polygon.points
     checked = 0
     for first in range(len(points)):
         for second in range(first + 1, len(points)):
             checked += 1
-            intersection = cast(
-                SegmentIntersectionResult,
-                segment_intersection(
-                    SegmentIntersectionRequest(
-                        first=ClosedSegment2D(
-                            start=points[first],
-                            end=points[(first + 1) % len(points)],
-                        ),
-                        second=ClosedSegment2D(
-                            start=points[second],
-                            end=points[(second + 1) % len(points)],
-                        ),
-                    )
-                ),
+            intersection = segment_intersection(
+                SegmentIntersectionRequest(
+                    first=ClosedSegment2D(
+                        start=points[first],
+                        end=points[(first + 1) % len(points)],
+                    ),
+                    second=ClosedSegment2D(
+                        start=points[second],
+                        end=points[(second + 1) % len(points)],
+                    ),
+                )
             )
             adjacent = (first - second) % len(points) in {1, len(points) - 1}
             shared = (
@@ -376,10 +374,12 @@ def simple_polygon(request: ContractModel) -> ContractModel:
     )
 
 
-def classify_polygon_point(request: ContractModel) -> ContractModel:
+def classify_polygon_point(
+    request: SimplePolygonPointRequest,
+) -> PolygonPointClassificationResult:
     from sympy.geometry import Polygon
 
-    value = cast(SimplePolygonPointRequest, request)
+    value = request
     point = _point(value.point)
     points = tuple(_point(item) for item in value.polygon.points)
     for index, start in enumerate(points):
@@ -396,11 +396,11 @@ def classify_polygon_point(request: ContractModel) -> ContractModel:
     )
 
 
-def convex_hull_points(request: ContractModel) -> ContractModel:
+def convex_hull_points(request: PointSetRequest) -> GeometryConvexHullResult:
     from sympy.geometry import Line2D, Point2D, Polygon, Segment2D
     from sympy.geometry.util import convex_hull
 
-    point_set = cast(PointSetRequest, request)
+    point_set = request
     hull = convex_hull(*(_point(point) for point in point_set.points))
     if isinstance(hull, Point2D):
         points = (hull,)

--- a/src/jacobian/domains/graph_optimization/chromatic_number.py
+++ b/src/jacobian/domains/graph_optimization/chromatic_number.py
@@ -9,7 +9,7 @@ from jacobian.contracts.graph_coloring import (
     GraphChromaticNumberOutput,
     GraphChromaticNumberRequest,
 )
-from jacobian.contracts.results import ContractModel, ExecutionStatus
+from jacobian.contracts.results import ExecutionStatus
 from jacobian.domains.graph_optimization.operations import (
     build_simple_graph,
     solve_chromatic_number,
@@ -100,7 +100,7 @@ def _chromatic_number_scope_parameters(
 def _chromatic_number_obligation(
     request: GraphChromaticNumberRequest,
     result: GraphChromaticNumberOutput,
-) -> ContractModel:
+) -> GraphChromaticNumberObligation:
     return GraphChromaticNumberObligation(
         graph=request.graph,
         status=result.status,

--- a/src/jacobian/domains/graph_optimization/finite_optimization.py
+++ b/src/jacobian/domains/graph_optimization/finite_optimization.py
@@ -149,7 +149,7 @@ def _scope(
     }
 
 
-def _vertex_obligation(
+def _vertex_obligation[ObligationT: ContractModel](
     request: GraphOptimizationRequest,
     result: (
         GraphDominationMinimumOutput
@@ -157,8 +157,8 @@ def _vertex_obligation(
         | GraphInducedTreeMaximumOutput
         | GraphInducedBipartiteMaximumOutput
     ),
-    model: type[ContractModel],
-) -> ContractModel:
+    model: type[ObligationT],
+) -> ObligationT:
     return model.model_validate(
         {
             "graph": request.graph,
@@ -175,7 +175,7 @@ def _vertex_obligation(
 def _matching_obligation(
     request: GraphOptimizationRequest,
     result: GraphMinimumMaximalMatchingOutput,
-) -> ContractModel:
+) -> GraphMinimumMaximalMatchingObligation:
     return GraphMinimumMaximalMatchingObligation(
         graph=request.graph,
         status=result.status,

--- a/src/jacobian/domains/graph_optimization/hamiltonian_path.py
+++ b/src/jacobian/domains/graph_optimization/hamiltonian_path.py
@@ -9,7 +9,6 @@ from jacobian.contracts.graph_optimization import (
     GraphHamiltonianPathRequest,
     GraphHamiltonianPathResult,
 )
-from jacobian.contracts.results import ContractModel
 from jacobian.domains.graph_optimization.operations import build_simple_graph
 from jacobian.operations import (
     ComputedNotApplicable,
@@ -22,8 +21,9 @@ if TYPE_CHECKING:
     import networkx as nx
 
 
-def decide_hamiltonian_path(request: ContractModel) -> ContractModel:
-    request = cast(GraphHamiltonianPathRequest, request)
+def decide_hamiltonian_path(
+    request: GraphHamiltonianPathRequest,
+) -> GraphHamiltonianPathResult:
     graph = cast("nx.Graph[str]", build_simple_graph(request.graph))
     vertices = tuple(sorted(graph))
     order = len(vertices)
@@ -84,9 +84,7 @@ def _execute(
     import networkx as nx
 
     try:
-        return ComputedSuccess(
-            cast(GraphHamiltonianPathResult, decide_hamiltonian_path(request))
-        )
+        return ComputedSuccess(decide_hamiltonian_path(request))
     except (
         ArithmeticError,
         nx.NetworkXError,

--- a/src/jacobian/domains/graph_optimization/invariants.py
+++ b/src/jacobian/domains/graph_optimization/invariants.py
@@ -140,6 +140,8 @@ def _distance_matrix(graph: Any) -> GraphDistanceMatrixResult:
 def _diameter(graph: Any) -> GraphDiameterResult:
     import networkx as nx
 
+    from jacobian.math.graphs import diameter
+
     if not graph or not nx.is_connected(graph):
         return GraphDiameterResult(
             status="NOT_APPLICABLE",
@@ -149,7 +151,7 @@ def _diameter(graph: Any) -> GraphDiameterResult:
         )
     return GraphDiameterResult(
         status="COMPUTED",
-        diameter=int(nx.diameter(graph)),
+        diameter=diameter(graph),
         connected=True,
         exactness="EXACT",
     )
@@ -170,9 +172,9 @@ def _vertex_connectivity(graph: Any) -> GraphVertexConnectivityResult:
 
 
 def _eulerian(graph: Any) -> GraphEulerianResult:
-    import networkx as nx
+    from jacobian.math.graphs import is_eulerian
 
-    return GraphEulerianResult(is_eulerian=bool(nx.is_eulerian(graph)))
+    return GraphEulerianResult(is_eulerian=is_eulerian(graph))
 
 
 def _spanning_tree_count(graph: Any) -> GraphSpanningTreeCountResult:
@@ -255,10 +257,9 @@ def _maximum_matching(graph: Any) -> GraphMaximumMatchingResult:
 
 
 def _triangle_count(graph: Any) -> GraphTriangleCountResult:
-    import networkx as nx
+    from jacobian.math.graphs import triangle_count
 
-    triangle_counts = cast(dict[str, int], nx.triangles(graph))
-    return GraphTriangleCountResult(triangle_count=sum(triangle_counts.values()) // 3)
+    return GraphTriangleCountResult(triangle_count=triangle_count(graph))
 
 
 def _radius(graph: Any) -> GraphRadiusResult:

--- a/src/jacobian/domains/matrix_lattice/capabilities.py
+++ b/src/jacobian/domains/matrix_lattice/capabilities.py
@@ -1,7 +1,6 @@
 """Exact matrix capability declarations."""
 
 from collections.abc import Callable
-from typing import Any
 
 from pydantic import ValidationError
 
@@ -45,18 +44,21 @@ from jacobian.operations import (
 )
 
 
-def matrix_operation(
+def matrix_operation[
+    RequestT: ContractModel,
+    ResultT: ContractModel,
+](
     capability_id: str,
     title: str,
     description: str,
-    request_model: type[ContractModel],
-    result_model: type[ContractModel],
-    operation: Callable[[Any], ContractModel],
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
     relation_id: str,
     *tags: str,
     invocation_examples: tuple[CapabilityInvocationExample, ...] = (),
-) -> ComputedOperation[Any, Any]:
-    def implementation(request: ContractModel) -> ComputedOutcome[Any]:
+) -> ComputedOperation[RequestT, ResultT]:
+    def implementation(request: RequestT) -> ComputedOutcome[ResultT]:
         try:
             return ComputedSuccess(operation(request))
         except ValidationError as exc:

--- a/src/jacobian/domains/matrix_lattice/operations.py
+++ b/src/jacobian/domains/matrix_lattice/operations.py
@@ -21,8 +21,10 @@ from jacobian.contracts.matrix_operations import (
     RationalOutputMatrix,
     RrefResult,
     SmithNormalFormResult,
+    SquareIntegerMatrixRequest,
     SquareRationalMatrixRequest,
 )
+from jacobian.math import matrices as native_matrices
 
 
 def _rational(value: Any) -> OutputRational:
@@ -45,7 +47,7 @@ def _qq_matrix(matrix: RationalMatrix) -> Any:
 
 
 def compute_rref(request: RationalMatrixRequest) -> RrefResult:
-    reduced, pivots = _qq_matrix(request.matrix).rref()
+    reduced, pivots = native_matrices.rref(_qq_matrix(request.matrix))
     columns = reduced.cols
     pivot_columns = tuple(int(column) for column in pivots)
     return RrefResult(
@@ -136,17 +138,13 @@ def compute_smith_normal_form(
     )
 
 
-def compute_inverse(request: IntegerMatrixRequest) -> MatrixInverseResult:
+def compute_inverse(request: SquareIntegerMatrixRequest) -> MatrixInverseResult:
     import sympy
 
     source = sympy.Matrix(
         [[int(value) for value in row] for row in request.matrix.entries]
     )
-    if source.rows != source.cols:
-        raise ValueError("inverse requires a square matrix")
-    if source.det() == 0:
-        raise ValueError("matrix is singular; inverse does not exist")
-    inverse = source.inv()
+    inverse = native_matrices.inverse(source)
     return MatrixInverseResult(
         inverse=RationalOutputMatrix(
             entries=tuple(
@@ -157,15 +155,13 @@ def compute_inverse(request: IntegerMatrixRequest) -> MatrixInverseResult:
     )
 
 
-def compute_trace(request: IntegerMatrixRequest) -> MatrixTraceResult:
+def compute_trace(request: SquareIntegerMatrixRequest) -> MatrixTraceResult:
     import sympy
 
     source = sympy.Matrix(
         [[int(value) for value in row] for row in request.matrix.entries]
     )
-    if source.rows != source.cols:
-        raise ValueError("trace requires a square matrix")
-    return MatrixTraceResult(trace=str(int(source.trace())))
+    return MatrixTraceResult(trace=str(int(native_matrices.trace(source))))
 
 
 def compute_rational_linear_solve(
@@ -185,7 +181,7 @@ def compute_rational_linear_solve(
     )
 
 
-def compute_adjugate(request: IntegerMatrixRequest) -> MatrixAdjugateResult:
+def compute_adjugate(request: SquareIntegerMatrixRequest) -> MatrixAdjugateResult:
     import sympy
 
     source = sympy.Matrix(

--- a/src/jacobian/domains/number_theory/factorization_worker.py
+++ b/src/jacobian/domains/number_theory/factorization_worker.py
@@ -25,16 +25,29 @@ from jacobian.domains.number_theory.operations import (
 
 PROTOCOL = "jacobian.number-theory.factorization.sympy.v1"
 
-_OPERATIONS: dict[
-    str,
-    tuple[type[ContractModel], Callable[[ContractModel], ContractModel]],
-] = {
-    "divisors": (FactorizationRequest, enumerate_divisors),
-    "proper_divisors": (FactorizationRequest, enumerate_proper_divisors),
-    "prime_factorization": (FactorizationRequest, factorize_primes),
-    "powerful": (PowerfulNumberRequest, decide_powerful),
-    "squarefree": (ArithmeticFunctionRequest, decide_squarefree),
-    "radical": (ArithmeticFunctionRequest, compute_radical),
+
+def _validated_operation[
+    RequestT: ContractModel,
+    ResultT: ContractModel,
+](
+    request_model: type[RequestT],
+    operation: Callable[[RequestT], ResultT],
+) -> Callable[[object], ResultT]:
+    def invoke(payload: object) -> ResultT:
+        return operation(request_model.model_validate(payload))
+
+    return invoke
+
+
+_OPERATIONS: dict[str, Callable[[object], ContractModel]] = {
+    "divisors": _validated_operation(FactorizationRequest, enumerate_divisors),
+    "proper_divisors": _validated_operation(
+        FactorizationRequest, enumerate_proper_divisors
+    ),
+    "prime_factorization": _validated_operation(FactorizationRequest, factorize_primes),
+    "powerful": _validated_operation(PowerfulNumberRequest, decide_powerful),
+    "squarefree": _validated_operation(ArithmeticFunctionRequest, decide_squarefree),
+    "radical": _validated_operation(ArithmeticFunctionRequest, compute_radical),
 }
 
 
@@ -49,9 +62,8 @@ def main() -> int:
             raise ValueError("unexpected worker request fields")
         if payload["protocol"] != PROTOCOL:
             raise ValueError("unsupported worker protocol")
-        request_model, operation = _OPERATIONS[payload["operation"]]
-        request = request_model.model_validate(payload["request"])
-        result = operation(request)
+        operation = _OPERATIONS[payload["operation"]]
+        result = operation(payload["request"])
         sys.stdout.buffer.write(
             canonicalize_json(
                 {

--- a/src/jacobian/domains/number_theory/operations.py
+++ b/src/jacobian/domains/number_theory/operations.py
@@ -54,26 +54,25 @@ from jacobian.contracts.number_theory import (
     QuadraticResiduesResult,
     ValuationRequest,
 )
-from jacobian.contracts.results import ContractModel
 
 
-def compute_gcd(request: ContractModel) -> ContractModel:
+def compute_gcd(request: IntegerPairRequest) -> IntegerValueResult:
     """Compute gcd(a, b) using ``math.gcd``."""
-    pair = cast(IntegerPairRequest, request)
+    pair = request
     return IntegerValueResult(value=str(math.gcd(int(pair.left), int(pair.right))))
 
 
-def compute_lcm(request: ContractModel) -> ContractModel:
+def compute_lcm(request: IntegerPairRequest) -> IntegerValueResult:
     """Compute lcm(a, b) using ``math.lcm``."""
-    pair = cast(IntegerPairRequest, request)
+    pair = request
     return IntegerValueResult(value=str(math.lcm(int(pair.left), int(pair.right))))
 
 
-def compute_jacobi_symbol(request: ContractModel) -> ContractModel:
+def compute_jacobi_symbol(request: JacobiSymbolRequest) -> JacobiSymbolResult:
     """Compute the Jacobi symbol using ``sympy.jacobi_symbol``."""
     from sympy import jacobi_symbol
 
-    value = cast(JacobiSymbolRequest, request)
+    value = request
     symbol = cast(Literal[-1, 0, 1], int(jacobi_symbol(int(value.a), value.n)))
     return JacobiSymbolResult(
         a=value.a,
@@ -82,11 +81,11 @@ def compute_jacobi_symbol(request: ContractModel) -> ContractModel:
     )
 
 
-def compute_extended_gcd(request: ContractModel) -> ContractModel:
+def compute_extended_gcd(request: IntegerPairRequest) -> ExtendedGcdResult:
     """Compute gcd and Bezout coefficients using ``sympy.gcdex``."""
     from sympy import gcdex
 
-    pair = cast(IntegerPairRequest, request)
+    pair = request
     x, y, divisor = gcdex(int(pair.left), int(pair.right))
     return ExtendedGcdResult(
         gcd=str(int(divisor)),
@@ -95,11 +94,11 @@ def compute_extended_gcd(request: ContractModel) -> ContractModel:
     )
 
 
-def enumerate_divisors(request: ContractModel) -> ContractModel:
+def enumerate_divisors(request: FactorizationRequest) -> DivisorListResult:
     """Enumerate all positive divisors using ``sympy.divisors``."""
     from sympy import divisors as sympy_divisors
 
-    value = int(cast(FactorizationRequest, request).value)
+    value = int(request.value)
     if value == 0:
         raise ValueError("zero has infinitely many divisors")
     return DivisorListResult(
@@ -107,11 +106,11 @@ def enumerate_divisors(request: ContractModel) -> ContractModel:
     )
 
 
-def enumerate_proper_divisors(request: ContractModel) -> ContractModel:
+def enumerate_proper_divisors(request: FactorizationRequest) -> DivisorListResult:
     """Enumerate all positive proper divisors using ``sympy.divisors(proper=True)``."""
     from sympy import divisors as sympy_divisors
 
-    value = int(cast(FactorizationRequest, request).value)
+    value = int(request.value)
     if value == 0:
         raise ValueError("zero has infinitely many divisors")
     return DivisorListResult(
@@ -119,11 +118,11 @@ def enumerate_proper_divisors(request: ContractModel) -> ContractModel:
     )
 
 
-def factorize_primes(request: ContractModel) -> ContractModel:
+def factorize_primes(request: FactorizationRequest) -> PrimeFactorizationResult:
     """Compute the complete prime-power factorization using ``sympy.factorint``."""
     from sympy import factorint
 
-    value = int(cast(FactorizationRequest, request).value)
+    value = int(request.value)
     if value == 0:
         raise ValueError("zero has no finite prime factorization")
     factors = tuple(
@@ -133,11 +132,11 @@ def factorize_primes(request: ContractModel) -> ContractModel:
     return PrimeFactorizationResult(factors=factors)
 
 
-def decide_powerful(request: ContractModel) -> ContractModel:
+def decide_powerful(request: PowerfulNumberRequest) -> PowerfulNumberResult:
     """Decide whether every prime exponent is at least two."""
     from sympy import factorint
 
-    value = int(cast(PowerfulNumberRequest, request).value)
+    value = int(request.value)
     factor_items = sorted(factorint(value).items())
     factors = tuple(
         PrimePower(prime=str(prime), power=int(power)) for prime, power in factor_items
@@ -153,156 +152,156 @@ def decide_powerful(request: ContractModel) -> ContractModel:
     )
 
 
-def compute_valuation(request: ContractModel) -> ContractModel:
+def compute_valuation(request: ValuationRequest) -> IntegerValueResult:
     """Compute the p-adic valuation using ``sympy.multiplicity``."""
     from sympy import isprime, multiplicity
 
-    req = cast(ValuationRequest, request)
+    req = request
     value, prime = int(req.value), int(req.prime)
     if value == 0 or abs(prime) < 2 or not isprime(abs(prime)):
         raise ValueError("valuation requires nonzero value and prime absolute base")
     return IntegerValueResult(value=str(multiplicity(abs(prime), abs(value))))
 
 
-def compute_divisor_count(request: ContractModel) -> ContractModel:
+def compute_divisor_count(request: PositiveIntegerRequest) -> IntegerValueResult:
     """Count positive divisors using ``sympy.divisor_count``."""
     from sympy import divisor_count
 
-    n = cast(PositiveIntegerRequest, request).n
+    n = request.n
     return IntegerValueResult(value=str(int(divisor_count(n))))
 
 
-def compute_divisor_sum(request: ContractModel) -> ContractModel:
+def compute_divisor_sum(request: PositiveIntegerRequest) -> IntegerValueResult:
     """Sum positive divisors using ``sympy.divisor_sigma``."""
     from sympy import divisor_sigma
 
-    n = cast(PositiveIntegerRequest, request).n
+    n = request.n
     return IntegerValueResult(value=str(int(divisor_sigma(n))))
 
 
-def compute_aliquot_sum(request: ContractModel) -> ContractModel:
+def compute_aliquot_sum(request: PositiveIntegerRequest) -> IntegerValueResult:
     """Sum positive proper divisors using ``sympy.divisor_sigma(n) - n``."""
     from sympy import divisor_sigma
 
-    n = cast(PositiveIntegerRequest, request).n
+    n = request.n
     return IntegerValueResult(value=str(int(divisor_sigma(n)) - n))
 
 
-def decide_coprime(request: ContractModel) -> ContractModel:
+def decide_coprime(request: IntegerPairRequest) -> BooleanResult:
     """Decide coprimality using ``math.gcd``."""
-    pair = cast(IntegerPairRequest, request)
+    pair = request
     return BooleanResult(holds=math.gcd(int(pair.left), int(pair.right)) == 1)
 
 
-def decide_divides(request: ContractModel) -> ContractModel:
+def decide_divides(request: DivisibilityRequest) -> BooleanResult:
     """Decide divisibility using the remainder operator."""
-    req = cast(DivisibilityRequest, request)
+    req = request
     divisor, dividend = int(req.divisor), int(req.dividend)
     if divisor == 0:
         raise ValueError("divisor must be nonzero")
     return BooleanResult(holds=dividend % divisor == 0)
 
 
-def decide_even(request: ContractModel) -> ContractModel:
+def decide_even(request: IntegerValueRequest) -> BooleanResult:
     """Decide evenness using the remainder operator."""
-    value = int(cast(IntegerValueRequest, request).value)
+    value = int(request.value)
     return BooleanResult(holds=value % 2 == 0)
 
 
-def decide_odd(request: ContractModel) -> ContractModel:
+def decide_odd(request: IntegerValueRequest) -> BooleanResult:
     """Decide oddness using the remainder operator."""
-    value = int(cast(IntegerValueRequest, request).value)
+    value = int(request.value)
     return BooleanResult(holds=value % 2 != 0)
 
 
-def decide_square(request: ContractModel) -> ContractModel:
+def decide_square(request: NonnegativeIntegerRequest) -> BooleanResult:
     """Decide perfect square using ``math.isqrt``."""
-    n = cast(NonnegativeIntegerRequest, request).n
+    n = request.n
     return BooleanResult(holds=math.isqrt(n) ** 2 == n)
 
 
-def decide_squarefree(request: ContractModel) -> ContractModel:
+def decide_squarefree(request: ArithmeticFunctionRequest) -> BooleanResult:
     """Decide squarefreeness using ``sympy.factorint``."""
     from sympy import factorint
 
-    n = cast(ArithmeticFunctionRequest, request).n
+    n = request.n
     if n == 0:
         return BooleanResult(holds=False)
     return BooleanResult(holds=all(power == 1 for power in factorint(n).values()))
 
 
-def decide_perfect(request: ContractModel) -> ContractModel:
+def decide_perfect(request: NonnegativeIntegerRequest) -> BooleanResult:
     """Decide perfect number using ``sympy.divisor_sigma``."""
     from sympy import divisor_sigma
 
-    n = cast(NonnegativeIntegerRequest, request).n
+    n = request.n
     return BooleanResult(holds=bool(n and int(divisor_sigma(n)) - n == n))
 
 
-def decide_abundant(request: ContractModel) -> ContractModel:
+def decide_abundant(request: NonnegativeIntegerRequest) -> BooleanResult:
     """Decide abundant number using ``sympy.divisor_sigma``."""
     from sympy import divisor_sigma
 
-    n = cast(NonnegativeIntegerRequest, request).n
+    n = request.n
     return BooleanResult(holds=bool(n and int(divisor_sigma(n)) - n > n))
 
 
-def decide_deficient(request: ContractModel) -> ContractModel:
+def decide_deficient(request: NonnegativeIntegerRequest) -> BooleanResult:
     """Decide deficient number using ``sympy.divisor_sigma``."""
     from sympy import divisor_sigma
 
-    n = cast(NonnegativeIntegerRequest, request).n
+    n = request.n
     return BooleanResult(holds=bool(n and int(divisor_sigma(n)) - n < n))
 
 
-def decide_prime(request: ContractModel) -> ContractModel:
+def decide_prime(request: IntegerValueRequest) -> BooleanResult:
     """Decide primality using ``sympy.isprime``."""
     from sympy import isprime
 
-    value = int(cast(IntegerValueRequest, request).value)
+    value = int(request.value)
     return BooleanResult(holds=bool(isprime(value)))
 
 
-def compute_next_prime(request: ContractModel) -> ContractModel:
+def compute_next_prime(request: NonnegativeIntegerRequest) -> IntegerValueResult:
     """Compute the next prime using ``sympy.nextprime``."""
     from sympy import nextprime
 
-    n = cast(NonnegativeIntegerRequest, request).n
+    n = request.n
     return IntegerValueResult(value=str(int(nextprime(n))))
 
 
-def compute_previous_prime(request: ContractModel) -> ContractModel:
+def compute_previous_prime(request: NonnegativeIntegerRequest) -> IntegerValueResult:
     """Compute the previous prime using ``sympy.prevprime``."""
     from sympy import prevprime
 
-    n = cast(NonnegativeIntegerRequest, request).n
+    n = request.n
     if n <= 2:
         raise ValueError("previous prime requires n greater than 2")
     return IntegerValueResult(value=str(int(prevprime(n))))
 
 
-def compute_prime_count(request: ContractModel) -> ContractModel:
+def compute_prime_count(request: NonnegativeIntegerRequest) -> IntegerValueResult:
     """Count primes through n using ``sympy.primepi``."""
     from sympy import primepi
 
-    n = cast(NonnegativeIntegerRequest, request).n
+    n = request.n
     return IntegerValueResult(value=str(int(primepi(n))))
 
 
-def compute_floor_square_root(request: ContractModel) -> ContractModel:
+def compute_floor_square_root(request: FloorSquareRootRequest) -> FloorSquareRootResult:
     """Return the exact floor square-root."""
     from sympy import integer_nthroot
 
-    n = cast(FloorSquareRootRequest, request).n
+    n = request.n
     root, _ = integer_nthroot(n, 2)
     return FloorSquareRootResult(root=int(root))
 
 
-def compute_legendre_symbol(request: ContractModel) -> ContractModel:
+def compute_legendre_symbol(request: LegendreSymbolRequest) -> LegendreSymbolResult:
     """Compute ``(a / p)`` after checking that ``p`` is prime."""
     from sympy import isprime, legendre_symbol
 
-    value = cast(LegendreSymbolRequest, request)
+    value = request
     if not isprime(value.prime):
         raise ValueError("Legendre denominator must be prime")
     return LegendreSymbolResult(
@@ -312,11 +311,13 @@ def compute_legendre_symbol(request: ContractModel) -> ContractModel:
     )
 
 
-def compute_factorial_valuation(request: ContractModel) -> ContractModel:
+def compute_factorial_valuation(
+    request: FactorialValuationRequest,
+) -> FactorialValuationResult:
     """Compute the valuation of ``n!`` at an arbitrary composite base."""
     from sympy.ntheory import multiplicity_in_factorial
 
-    value = cast(FactorialValuationRequest, request)
+    value = request
     return FactorialValuationResult(
         n=value.n,
         base=value.base,
@@ -324,81 +325,81 @@ def compute_factorial_valuation(request: ContractModel) -> ContractModel:
     )
 
 
-def compute_nth_prime(request: ContractModel) -> ContractModel:
+def compute_nth_prime(request: PositiveIntegerRequest) -> IntegerValueResult:
     """Compute the nth prime using ``sympy.prime``."""
     from sympy import prime
 
-    n = cast(PositiveIntegerRequest, request).n
+    n = request.n
     return IntegerValueResult(value=str(int(prime(n))))
 
 
-def compute_primorial(request: ContractModel) -> ContractModel:
+def compute_primorial(request: NonnegativeIntegerRequest) -> IntegerValueResult:
     """Compute the product of the first n primes using ``sympy.primorial``."""
     from sympy import primorial
 
-    n = cast(NonnegativeIntegerRequest, request).n
+    n = request.n
     return IntegerValueResult(value=str(int(primorial(n))))
 
 
-def compute_euler_totient(request: ContractModel) -> ContractModel:
+def compute_euler_totient(request: PositiveIntegerRequest) -> IntegerValueResult:
     """Count coprime residues using ``sympy.totient``."""
     from sympy import totient
 
-    n = cast(PositiveIntegerRequest, request).n
+    n = request.n
     return IntegerValueResult(value=str(int(totient(n))))
 
 
-def compute_mobius(request: ContractModel) -> ContractModel:
+def compute_mobius(request: PositiveIntegerRequest) -> IntegerValueResult:
     """Compute the Mobius function using ``sympy.mobius``."""
     from sympy import mobius
 
-    n = cast(PositiveIntegerRequest, request).n
+    n = request.n
     return IntegerValueResult(value=str(int(mobius(n))))
 
 
-def compute_radical(request: ContractModel) -> ContractModel:
+def compute_radical(request: ArithmeticFunctionRequest) -> IntegerValueResult:
     """Compute the product of distinct prime divisors using ``sympy.factorint``."""
     from sympy import factorint
 
-    n = cast(ArithmeticFunctionRequest, request).n
+    n = request.n
     return IntegerValueResult(value=str(math.prod(factorint(n))))
 
 
-def compute_modular_inverse(request: ContractModel) -> ContractModel:
+def compute_modular_inverse(request: ModularValueRequest) -> IntegerValueResult:
     """Compute the modular inverse using ``pow(value, -1, modulus)``."""
-    req = cast(ModularValueRequest, request)
+    req = request
     value, modulus = int(req.value), req.modulus
     return IntegerValueResult(value=str(pow(value, -1, modulus)))
 
 
-def compute_multiplicative_order(request: ContractModel) -> ContractModel:
+def compute_multiplicative_order(request: ModularValueRequest) -> IntegerValueResult:
     """Compute the multiplicative order using ``sympy.n_order``."""
     from sympy import n_order
 
-    req = cast(ModularValueRequest, request)
+    req = request
     value, modulus = int(req.value), req.modulus
     if math.gcd(value, modulus) != 1:
         raise ValueError("multiplicative order requires coprime value and modulus")
     return IntegerValueResult(value=str(int(n_order(value, modulus))))
 
 
-def enumerate_quadratic_residues(request: ContractModel) -> ContractModel:
+def enumerate_quadratic_residues(request: ModulusRequest) -> QuadraticResiduesResult:
     """Enumerate all quadratic residues using ``sympy.quadratic_residues``."""
     from sympy.ntheory.residue_ntheory import quadratic_residues
 
-    modulus = cast(ModulusRequest, request).modulus
+    modulus = request.modulus
     return QuadraticResiduesResult(
         residues=tuple(str(int(r)) for r in quadratic_residues(modulus)),
     )
 
 
 def compute_modular_polynomial_residue_image(
-    request: ContractModel,
-) -> ContractModel:
+    request: ModularPolynomialResidueImageRequest,
+) -> ModularPolynomialResidueImageResult:
     """Enumerate one sparse polynomial over its declared finite residue domains."""
     from itertools import product
 
-    polynomial = cast(ModularPolynomialResidueImageRequest, request)
+    polynomial = request
     normalized_terms = tuple(
         NormalizedModularPolynomialTerm(
             coefficient=int(term.coefficient) % polynomial.modulus,
@@ -471,11 +472,11 @@ def _evaluate_modular_polynomial(
     return value
 
 
-def solve_chinese_remainder(request: ContractModel) -> ContractModel:
+def solve_chinese_remainder(request: ChineseRemainderRequest) -> ChineseRemainderResult:
     """Solve a congruence system using ``sympy.solve_congruence``."""
     from sympy.ntheory.modular import solve_congruence
 
-    system = cast(ChineseRemainderRequest, request)
+    system = request
     result = solve_congruence(
         *zip(system.residues, system.moduli, strict=True),
         check=True,

--- a/src/jacobian/domains/optimization/operations.py
+++ b/src/jacobian/domains/optimization/operations.py
@@ -12,7 +12,7 @@ from pydantic import ValidationError
 from jacobian.bounded_process import ProcessResourceLimits, run_bounded_process
 from jacobian.canonical import canonicalize_json, loads_strict_json
 from jacobian.contracts.capabilities import CapabilityDiagnostic
-from jacobian.contracts.results import ContractModel, ExecutionStatus
+from jacobian.contracts.results import ExecutionStatus
 from jacobian.contracts.validated_analysis import (
     RationalLinearProgramObligation,
     RationalLinearProgramRequest,
@@ -124,7 +124,7 @@ def _scope(
 def _obligation(
     request: RationalLinearProgramRequest,
     result: RationalLinearProgramResult,
-) -> ContractModel:
+) -> RationalLinearProgramObligation:
     return RationalLinearProgramObligation(
         program=request.program,
         status=result.status,

--- a/src/jacobian/domains/polynomial/_support.py
+++ b/src/jacobian/domains/polynomial/_support.py
@@ -46,7 +46,7 @@ def polynomial_operation[
     description: str,
     request_model: type[RequestT],
     result_model: type[ResultT],
-    operation: Callable[[ContractModel], ContractModel],
+    operation: Callable[[RequestT], ResultT],
     *tags: str,
     invocation_examples: tuple[CapabilityInvocationExample, ...] = (),
     relation_id: str | None = None,

--- a/src/jacobian/domains/polynomial/elementary_operations.py
+++ b/src/jacobian/domains/polynomial/elementary_operations.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from functools import cache
-from typing import Any, cast
+from typing import Any
 
 from jacobian.contracts.polynomial_operations import (
     IntegerPolynomial,
@@ -29,7 +29,6 @@ from jacobian.contracts.polynomial_operations import (
     RationalPolynomialIntegralResult,
     RationalPolynomialRequest,
 )
-from jacobian.contracts.results import ContractModel
 from jacobian.domains.polynomial.operations import _poly, _rational, _wire
 
 
@@ -60,8 +59,9 @@ def _integer_wire(polynomial: Any) -> IntegerPolynomial:
     )
 
 
-def integer_polynomial_gcd(request: ContractModel) -> ContractModel:
-    request = cast(IntegerPolynomialPairRequest, request)
+def integer_polynomial_gcd(
+    request: IntegerPolynomialPairRequest,
+) -> IntegerPolynomialGcdResult:
     left = _integer_poly(request.left)
     right = _integer_poly(request.right)
     gcd = left.gcd(right)
@@ -73,15 +73,17 @@ def integer_polynomial_gcd(request: ContractModel) -> ContractModel:
     )
 
 
-def integer_polynomial_content(request: ContractModel) -> ContractModel:
-    request = cast(IntegerPolynomialRequest, request)
+def integer_polynomial_content(
+    request: IntegerPolynomialRequest,
+) -> IntegerPolynomialContentResult:
     return IntegerPolynomialContentResult(
         content=str(int(_integer_poly(request.polynomial).content()))
     )
 
 
-def integer_polynomial_primitive_part(request: ContractModel) -> ContractModel:
-    request = cast(IntegerPolynomialRequest, request)
+def integer_polynomial_primitive_part(
+    request: IntegerPolynomialRequest,
+) -> IntegerPolynomialPrimitivePartResult:
     source = _integer_poly(request.polynomial)
     content, primitive = source.primitive()
     reconstructed = primitive.mul_ground(content)
@@ -92,22 +94,25 @@ def integer_polynomial_primitive_part(request: ContractModel) -> ContractModel:
     )
 
 
-def integer_polynomial_evaluate(request: ContractModel) -> ContractModel:
-    request = cast(IntegerPolynomialEvaluationRequest, request)
+def integer_polynomial_evaluate(
+    request: IntegerPolynomialEvaluationRequest,
+) -> IntegerPolynomialEvaluationResult:
     point = int(request.point)
     value = _integer_poly(request.polynomial).eval(point)
     return IntegerPolynomialEvaluationResult(point=request.point, value=str(int(value)))
 
 
-def integer_polynomial_compose(request: ContractModel) -> ContractModel:
-    request = cast(IntegerPolynomialCompositionRequest, request)
+def integer_polynomial_compose(
+    request: IntegerPolynomialCompositionRequest,
+) -> IntegerPolynomialCompositionResult:
     composition = _integer_poly(request.outer).compose(_integer_poly(request.inner))
     return IntegerPolynomialCompositionResult(composition=_integer_wire(composition))
 
 
-def integer_polynomial_shift(request: ContractModel) -> ContractModel:
+def integer_polynomial_shift(
+    request: IntegerPolynomialShiftRequest,
+) -> IntegerPolynomialShiftResult:
     """Compute ``p(x + a)`` using SymPy's exact dense shift."""
-    request = cast(IntegerPolynomialShiftRequest, request)
     shifted = _integer_poly(request.polynomial).shift(request.shift)
     return IntegerPolynomialShiftResult(
         shift=request.shift,
@@ -115,8 +120,9 @@ def integer_polynomial_shift(request: ContractModel) -> ContractModel:
     )
 
 
-def rational_polynomial_division(request: ContractModel) -> ContractModel:
-    request = cast(RationalPolynomialDivisionRequest, request)
+def rational_polynomial_division(
+    request: RationalPolynomialDivisionRequest,
+) -> RationalPolynomialDivisionResult:
     left = _poly(request.left)
     right = _poly(request.right)
     quotient, remainder = left.div(right)
@@ -129,8 +135,9 @@ def rational_polynomial_division(request: ContractModel) -> ContractModel:
     )
 
 
-def rational_polynomial_evaluate(request: ContractModel) -> ContractModel:
-    request = cast(RationalPolynomialEvaluationRequest, request)
+def rational_polynomial_evaluate(
+    request: RationalPolynomialEvaluationRequest,
+) -> RationalPolynomialEvaluationResult:
     from sympy import Rational
 
     point = request.point.as_fraction()
@@ -141,8 +148,9 @@ def rational_polynomial_evaluate(request: ContractModel) -> ContractModel:
     )
 
 
-def rational_polynomial_derivative(request: ContractModel) -> ContractModel:
-    request = cast(RationalPolynomialRequest, request)
+def rational_polynomial_derivative(
+    request: RationalPolynomialRequest,
+) -> RationalPolynomialDerivativeResult:
     return RationalPolynomialDerivativeResult(
         derivative=_wire(
             _poly(request.polynomial).diff(),
@@ -151,8 +159,9 @@ def rational_polynomial_derivative(request: ContractModel) -> ContractModel:
     )
 
 
-def rational_polynomial_integral(request: ContractModel) -> ContractModel:
-    request = cast(RationalPolynomialRequest, request)
+def rational_polynomial_integral(
+    request: RationalPolynomialRequest,
+) -> RationalPolynomialIntegralResult:
     return RationalPolynomialIntegralResult(
         antiderivative=_wire(
             _poly(request.polynomial).integrate(),
@@ -200,9 +209,8 @@ def _partial_fraction_sort_key(
 
 
 def rational_partial_fraction_decomposition(
-    request: ContractModel,
-) -> ContractModel:
-    request = cast(RationalFunctionRequest, request)
+    request: RationalFunctionRequest,
+) -> RationalPartialFractionResult:
     from sympy import Add, Poly, apart, cancel, fraction, together
 
     variables = request.numerator.variables

--- a/src/jacobian/domains/polynomial/jacobian_syzygy.py
+++ b/src/jacobian/domains/polynomial/jacobian_syzygy.py
@@ -26,7 +26,6 @@ from jacobian.contracts.polynomials import (
     RationalPolynomialTerm,
     SparseRationalPolynomial,
 )
-from jacobian.contracts.results import ContractModel
 from jacobian.domains.polynomial._support import polynomial_operation
 from jacobian.domains.polynomial.operations import _poly, _rational, _symbols, _wire
 
@@ -153,8 +152,9 @@ def _coefficient_matrix(
     return source_basis, target_basis, matrix, entries
 
 
-def compute_graded_jacobian_syzygy(request: ContractModel) -> ContractModel:
-    request = cast(GradedJacobianSyzygyRequest, request)
+def compute_graded_jacobian_syzygy(
+    request: GradedJacobianSyzygyRequest,
+) -> GradedJacobianSyzygyResult:
     if request.polynomial is not None:
         variables = cast(tuple[str, str, str], request.polynomial.variables)
         source = _poly(request.polynomial)

--- a/src/jacobian/domains/polynomial/operations.py
+++ b/src/jacobian/domains/polynomial/operations.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from fractions import Fraction
-from typing import Any, cast
+from typing import Any
 
 from jacobian.contracts.exact import CanonicalRational
 from jacobian.contracts.polynomial_operations import (
@@ -28,7 +28,6 @@ from jacobian.contracts.polynomials import (
     RationalPolynomialTerm,
     SparseRationalPolynomial,
 )
-from jacobian.contracts.results import ContractModel
 
 _MAX_OUTPUT_TERMS = 1024
 
@@ -102,8 +101,7 @@ def _invariant_value(
     )
 
 
-def polynomial_gcd(request: ContractModel) -> ContractModel:
-    request = cast(PolynomialGcdRequest, request)
+def polynomial_gcd(request: PolynomialGcdRequest) -> PolynomialGcdResult:
     left = _poly(request.left)
     right = _poly(request.right)
     left_multiplier, right_multiplier, gcd = left.gcdex(right)
@@ -118,9 +116,8 @@ def polynomial_gcd(request: ContractModel) -> ContractModel:
 
 
 def polynomial_resultant(
-    request: ContractModel,
-) -> ContractModel:
-    request = cast(PolynomialResultantRequest, request)
+    request: PolynomialResultantRequest,
+) -> PolynomialResultantResult:
     from sympy import resultant
 
     variables = request.left.variables
@@ -139,9 +136,8 @@ def polynomial_resultant(
 
 
 def polynomial_discriminant(
-    request: ContractModel,
-) -> ContractModel:
-    request = cast(PolynomialDiscriminantRequest, request)
+    request: PolynomialDiscriminantRequest,
+) -> PolynomialDiscriminantResult:
     from sympy import discriminant
 
     variables = request.polynomial.variables
@@ -158,9 +154,8 @@ def polynomial_discriminant(
 
 
 def polynomial_square_free_decomposition(
-    request: ContractModel,
-) -> ContractModel:
-    request = cast(PolynomialSquareFreeRequest, request)
+    request: PolynomialSquareFreeRequest,
+) -> PolynomialSquareFreeDecompositionResult:
     from sympy import QQ, Poly
 
     source = _poly(request.polynomial)

--- a/src/jacobian/domains/projective_geometry/arrangements.py
+++ b/src/jacobian/domains/projective_geometry/arrangements.py
@@ -14,7 +14,6 @@ from jacobian.contracts.projective_geometry import (
     ProjectiveLineArrangementResult,
     ProjectiveMultiplicityCount,
 )
-from jacobian.contracts.results import ContractModel
 from jacobian.domains._examples import example
 from jacobian.operations import (
     ComputedOperation,
@@ -64,8 +63,9 @@ def _wire_triple(values: tuple[int, int, int]) -> PrimitiveProjectiveTriple:
     )
 
 
-def materialize_projective_line_flats(request: ContractModel) -> ContractModel:
-    request = cast(ProjectiveLineArrangementRequest, request)
+def materialize_projective_line_flats(
+    request: ProjectiveLineArrangementRequest,
+) -> ProjectiveLineArrangementResult:
     normalized = tuple(
         sorted(
             (

--- a/src/jacobian/domains/sequences/operations.py
+++ b/src/jacobian/domains/sequences/operations.py
@@ -7,10 +7,8 @@ from collections import Counter
 from fractions import Fraction
 from functools import reduce
 from itertools import pairwise
-from typing import cast
 
 from jacobian.contracts.exact import CanonicalRational
-from jacobian.contracts.results import ContractModel
 from jacobian.contracts.sequences import (
     FrequencyEntry,
     IntegerSequenceBooleanResult,
@@ -23,9 +21,8 @@ from jacobian.contracts.sequences import (
 )
 
 
-def _values(request: ContractModel) -> list[int]:
-    sequence = cast(IntegerSequenceRequest, request)
-    return [int(value) for value in sequence.values]
+def _values(request: IntegerSequenceRequest) -> list[int]:
+    return [int(value) for value in request.values]
 
 
 def _value_result(value: int) -> IntegerSequenceValueResult:
@@ -36,36 +33,36 @@ def _list_result(values: list[int]) -> IntegerSequenceListResult:
     return IntegerSequenceListResult(values=tuple(str(v) for v in values))
 
 
-def sequence_sum(request: ContractModel) -> ContractModel:
+def sequence_sum(request: IntegerSequenceRequest) -> IntegerSequenceValueResult:
     return _value_result(sum(_values(request)))
 
 
-def sequence_product(request: ContractModel) -> ContractModel:
+def sequence_product(request: IntegerSequenceRequest) -> IntegerSequenceValueResult:
     return _value_result(math.prod(_values(request)))
 
 
-def sequence_gcd(request: ContractModel) -> ContractModel:
+def sequence_gcd(request: IntegerSequenceRequest) -> IntegerSequenceValueResult:
     return _value_result(reduce(math.gcd, _values(request)))
 
 
-def sequence_lcm(request: ContractModel) -> ContractModel:
+def sequence_lcm(request: IntegerSequenceRequest) -> IntegerSequenceValueResult:
     return _value_result(reduce(math.lcm, _values(request), 1))
 
 
-def sequence_minimum(request: ContractModel) -> ContractModel:
+def sequence_minimum(request: IntegerSequenceRequest) -> IntegerSequenceValueResult:
     return _value_result(min(_values(request)))
 
 
-def sequence_maximum(request: ContractModel) -> ContractModel:
+def sequence_maximum(request: IntegerSequenceRequest) -> IntegerSequenceValueResult:
     return _value_result(max(_values(request)))
 
 
-def sequence_range(request: ContractModel) -> ContractModel:
+def sequence_range(request: IntegerSequenceRequest) -> IntegerSequenceValueResult:
     values = _values(request)
     return _value_result(max(values) - min(values))
 
 
-def sequence_mean(request: ContractModel) -> ContractModel:
+def sequence_mean(request: IntegerSequenceRequest) -> IntegerSequenceRationalResult:
     values = _values(request)
     fraction = Fraction(sum(values), len(values))
     return IntegerSequenceRationalResult(
@@ -76,7 +73,7 @@ def sequence_mean(request: ContractModel) -> ContractModel:
     )
 
 
-def sequence_median(request: ContractModel) -> ContractModel:
+def sequence_median(request: IntegerSequenceRequest) -> IntegerSequenceRationalResult:
     values = sorted(_values(request))
     middle = len(values) // 2
     if len(values) % 2:
@@ -91,11 +88,13 @@ def sequence_median(request: ContractModel) -> ContractModel:
     )
 
 
-def sequence_distinct_count(request: ContractModel) -> ContractModel:
+def sequence_distinct_count(
+    request: IntegerSequenceRequest,
+) -> IntegerSequenceValueResult:
     return _value_result(len(set(_values(request))))
 
 
-def prefix_sums(request: ContractModel) -> ContractModel:
+def prefix_sums(request: IntegerSequenceRequest) -> IntegerSequenceListResult:
     total = 0
     result: list[int] = []
     for value in _values(request):
@@ -104,18 +103,18 @@ def prefix_sums(request: ContractModel) -> ContractModel:
     return _list_result(result)
 
 
-def first_differences(request: ContractModel) -> ContractModel:
+def first_differences(request: IntegerSequenceRequest) -> IntegerSequenceListResult:
     values = _values(request)
     return _list_result([right - left for left, right in pairwise(values)])
 
 
-def second_differences(request: ContractModel) -> ContractModel:
+def second_differences(request: IntegerSequenceRequest) -> IntegerSequenceListResult:
     values = _values(request)
     first = [right - left for left, right in pairwise(values)]
     return _list_result([right - left for left, right in pairwise(first)])
 
 
-def prefix_products(request: ContractModel) -> ContractModel:
+def prefix_products(request: IntegerSequenceRequest) -> IntegerSequenceListResult:
     total = 1
     result: list[int] = []
     for value in _values(request):
@@ -124,7 +123,7 @@ def prefix_products(request: ContractModel) -> ContractModel:
     return _list_result(result)
 
 
-def prefix_minima(request: ContractModel) -> ContractModel:
+def prefix_minima(request: IntegerSequenceRequest) -> IntegerSequenceListResult:
     values = _values(request)
     result = [values[0]]
     for value in values[1:]:
@@ -132,7 +131,7 @@ def prefix_minima(request: ContractModel) -> ContractModel:
     return _list_result(result)
 
 
-def prefix_maxima(request: ContractModel) -> ContractModel:
+def prefix_maxima(request: IntegerSequenceRequest) -> IntegerSequenceListResult:
     values = _values(request)
     result = [values[0]]
     for value in values[1:]:
@@ -140,7 +139,7 @@ def prefix_maxima(request: ContractModel) -> ContractModel:
     return _list_result(result)
 
 
-def prefix_gcds(request: ContractModel) -> ContractModel:
+def prefix_gcds(request: IntegerSequenceRequest) -> IntegerSequenceListResult:
     values = _values(request)
     result = [values[0]]
     for value in values[1:]:
@@ -148,7 +147,7 @@ def prefix_gcds(request: ContractModel) -> ContractModel:
     return _list_result(result)
 
 
-def prefix_lcms(request: ContractModel) -> ContractModel:
+def prefix_lcms(request: IntegerSequenceRequest) -> IntegerSequenceListResult:
     values = _values(request)
     result = [values[0]]
     for value in values[1:]:
@@ -156,27 +155,27 @@ def prefix_lcms(request: ContractModel) -> ContractModel:
     return _list_result(result)
 
 
-def sorted_unique(request: ContractModel) -> ContractModel:
+def sorted_unique(request: IntegerSequenceRequest) -> IntegerSequenceListResult:
     return _list_result(sorted(set(_values(request))))
 
 
-def sort_sequence(request: ContractModel) -> ContractModel:
+def sort_sequence(request: IntegerSequenceRequest) -> IntegerSequenceListResult:
     return _list_result(sorted(_values(request)))
 
 
-def reverse_sequence(request: ContractModel) -> ContractModel:
+def reverse_sequence(request: IntegerSequenceRequest) -> IntegerSequenceListResult:
     return _list_result(list(reversed(_values(request))))
 
 
-def parities(request: ContractModel) -> ContractModel:
+def parities(request: IntegerSequenceRequest) -> IntegerSequenceListResult:
     return _list_result([value % 2 for value in _values(request)])
 
 
-def signs(request: ContractModel) -> ContractModel:
+def signs(request: IntegerSequenceRequest) -> IntegerSequenceListResult:
     return _list_result([(value > 0) - (value < 0) for value in _values(request)])
 
 
-def frequencies(request: ContractModel) -> ContractModel:
+def frequencies(request: IntegerSequenceRequest) -> IntegerSequenceFrequenciesResult:
     counts = Counter(_values(request))
     entries = tuple(
         FrequencyEntry(value=str(value), count=counts[value])
@@ -185,7 +184,7 @@ def frequencies(request: ContractModel) -> ContractModel:
     return IntegerSequenceFrequenciesResult(entries=entries)
 
 
-def zero_indices(request: ContractModel) -> ContractModel:
+def zero_indices(request: IntegerSequenceRequest) -> IntegerSequenceIndexListResult:
     return IntegerSequenceIndexListResult(
         indices=tuple(
             index for index, value in enumerate(_values(request)) if value == 0
@@ -193,7 +192,7 @@ def zero_indices(request: ContractModel) -> ContractModel:
     )
 
 
-def decide_arithmetic(request: ContractModel) -> ContractModel:
+def decide_arithmetic(request: IntegerSequenceRequest) -> IntegerSequenceBooleanResult:
     values = _values(request)
     if len(values) < 2:
         return IntegerSequenceBooleanResult(holds=True)
@@ -201,7 +200,7 @@ def decide_arithmetic(request: ContractModel) -> ContractModel:
     return IntegerSequenceBooleanResult(holds=len(differences) <= 1)
 
 
-def decide_geometric(request: ContractModel) -> ContractModel:
+def decide_geometric(request: IntegerSequenceRequest) -> IntegerSequenceBooleanResult:
     values = _values(request)
     if len(values) < 2:
         return IntegerSequenceBooleanResult(holds=True)
@@ -216,14 +215,18 @@ def decide_geometric(request: ContractModel) -> ContractModel:
     )
 
 
-def decide_nondecreasing(request: ContractModel) -> ContractModel:
+def decide_nondecreasing(
+    request: IntegerSequenceRequest,
+) -> IntegerSequenceBooleanResult:
     values = _values(request)
     return IntegerSequenceBooleanResult(
         holds=all(left <= right for left, right in pairwise(values))
     )
 
 
-def decide_strictly_increasing(request: ContractModel) -> ContractModel:
+def decide_strictly_increasing(
+    request: IntegerSequenceRequest,
+) -> IntegerSequenceBooleanResult:
     values = _values(request)
     return IntegerSequenceBooleanResult(
         holds=all(left < right for left, right in pairwise(values))

--- a/src/jacobian/math/__init__.py
+++ b/src/jacobian/math/__init__.py
@@ -1,0 +1,5 @@
+"""Native-value mathematical APIs supported by Jacobian."""
+
+from jacobian.math import arithmetic, graphs, matrices
+
+__all__ = ["arithmetic", "graphs", "matrices"]

--- a/src/jacobian/math/arithmetic.py
+++ b/src/jacobian/math/arithmetic.py
@@ -1,0 +1,43 @@
+"""Exact arithmetic on Python integers and fractions."""
+
+from fractions import Fraction
+from typing import SupportsIndex
+
+__all__ = ["absolute_value", "quotient", "reciprocal", "sign", "sum_rationals"]
+
+
+def absolute_value(value: SupportsIndex) -> int:
+    """Return the exact absolute value of an integer-like value."""
+
+    return abs(value.__index__())
+
+
+def sign(value: SupportsIndex) -> int:
+    """Return -1, 0, or 1 according to the sign of an integer."""
+
+    integer = value.__index__()
+    return (integer > 0) - (integer < 0)
+
+
+def reciprocal(value: Fraction | int) -> Fraction:
+    """Return the exact reciprocal, rejecting zero."""
+
+    rational = Fraction(value)
+    if not rational:
+        raise ZeroDivisionError("zero has no reciprocal")
+    return 1 / rational
+
+
+def sum_rationals(left: Fraction | int, right: Fraction | int) -> Fraction:
+    """Add two exact rational values."""
+
+    return Fraction(left) + Fraction(right)
+
+
+def quotient(left: Fraction | int, right: Fraction | int) -> Fraction:
+    """Divide two exact rational values."""
+
+    divisor = Fraction(right)
+    if not divisor:
+        raise ZeroDivisionError("division by zero")
+    return Fraction(left) / divisor

--- a/src/jacobian/math/graphs.py
+++ b/src/jacobian/math/graphs.py
@@ -1,0 +1,43 @@
+"""Deterministic algorithms on NetworkX undirected simple graphs."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import networkx as nx
+
+__all__ = ["diameter", "is_eulerian", "triangle_count"]
+
+
+def _simple_graph(graph: nx.Graph[Any]) -> nx.Graph[Any]:
+    if not isinstance(graph, nx.Graph):
+        raise TypeError("graph must be a NetworkX Graph")
+    if graph.is_directed() or graph.is_multigraph():
+        raise ValueError("graph must be undirected and simple")
+    if graph.number_of_nodes() > 32:
+        raise ValueError("graph may contain at most 32 vertices")
+    if nx.number_of_selfloops(graph):
+        raise ValueError("graph must not contain self-loops")
+    return graph
+
+
+def triangle_count(graph: nx.Graph[Any]) -> int:
+    """Count the triangles in an undirected simple graph."""
+
+    counts = cast(dict[Any, int], nx.triangles(_simple_graph(graph)))
+    return sum(counts.values()) // 3
+
+
+def diameter(graph: nx.Graph[Any]) -> int:
+    """Return graph diameter, requiring a nonempty connected graph."""
+
+    value = _simple_graph(graph)
+    if not value or not nx.is_connected(value):
+        raise ValueError("diameter requires a nonempty connected graph")
+    return int(nx.diameter(value))
+
+
+def is_eulerian(graph: nx.Graph[Any]) -> bool:
+    """Return whether the graph has an Eulerian circuit."""
+
+    return bool(nx.is_eulerian(_simple_graph(graph)))

--- a/src/jacobian/math/matrices.py
+++ b/src/jacobian/math/matrices.py
@@ -1,0 +1,47 @@
+"""Exact linear algebra on SymPy matrices."""
+
+from typing import Any
+
+import sympy
+from sympy.matrices.matrixbase import MatrixBase
+
+__all__ = ["inverse", "rref", "trace"]
+
+
+def _matrix(value: MatrixBase) -> MatrixBase:
+    if not isinstance(value, MatrixBase):
+        raise TypeError("matrix must be a SymPy MatrixBase")
+    if not 1 <= value.rows <= 32 or not 1 <= value.cols <= 32:
+        raise ValueError("matrix dimensions must be between 1 and 32")
+    if any(not entry.is_number or entry.is_finite is not True for entry in value):
+        raise ValueError("matrix entries must be finite exact numbers")
+    if any(entry.is_Float for entry in value):
+        raise ValueError("matrix entries must be exact; SymPy Float is not supported")
+    return value
+
+
+def rref(matrix: MatrixBase) -> tuple[MatrixBase, tuple[int, ...]]:
+    """Return exact reduced row-echelon form and pivot columns."""
+
+    reduced, pivots = _matrix(matrix).rref()
+    return reduced, tuple(int(pivot) for pivot in pivots)
+
+
+def inverse(matrix: MatrixBase) -> MatrixBase:
+    """Return the exact inverse of a square, nonsingular matrix."""
+
+    source = _matrix(matrix)
+    if source.rows != source.cols:
+        raise ValueError("inverse requires a square matrix")
+    if source.det() == 0:
+        raise ValueError("matrix is singular; inverse does not exist")
+    return source.inv()
+
+
+def trace(matrix: MatrixBase) -> Any:
+    """Return the exact trace of a square matrix."""
+
+    source = _matrix(matrix)
+    if source.rows != source.cols:
+        raise ValueError("trace requires a square matrix")
+    return sympy.simplify(source.trace())

--- a/src/jacobian/math/matrices.py
+++ b/src/jacobian/math/matrices.py
@@ -15,7 +15,7 @@ def _matrix(value: MatrixBase) -> MatrixBase:
         raise ValueError("matrix dimensions must be between 1 and 32")
     if any(not entry.is_number or entry.is_finite is not True for entry in value):
         raise ValueError("matrix entries must be finite exact numbers")
-    if any(entry.is_Float for entry in value):
+    if any(entry.has(sympy.Float) for entry in value):
         raise ValueError("matrix entries must be exact; SymPy Float is not supported")
     return value
 

--- a/src/jacobian/operation_installation.py
+++ b/src/jacobian/operation_installation.py
@@ -302,7 +302,7 @@ class BoundedSearchOperationAdapter:
 
     def __init__(
         self,
-        operation: BoundedSearchOperation[Any, Any],
+        operation: BoundedSearchOperation[Any, Any, Any],
         bundle: DomainBundle,
         resources: _OperationResources,
     ) -> None:

--- a/src/jacobian/operations.py
+++ b/src/jacobian/operations.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Protocol, cast
+from typing import TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:
     from jacobian.checker_operations import ExactReplayCheckerDeclaration
@@ -108,14 +108,14 @@ class ComputedOperationFactory:
         description: str,
         request_model: type[RequestT],
         result_model: type[ResultT],
-        operation: Callable[[ContractModel], ContractModel],
+        operation: Callable[[RequestT], ResultT],
         *tags: str,
         invocation_examples: tuple[CapabilityInvocationExample, ...] = (),
         relation_id: str | None = None,
     ) -> ComputedOperation[RequestT, ResultT]:
         def implementation(request: RequestT) -> ComputedOutcome[ResultT]:
             try:
-                return ComputedSuccess(cast(ResultT, operation(request)))
+                return ComputedSuccess(operation(request))
             except self.failure.exceptions as exc:
                 return ComputedNotApplicable(self.failure.diagnostic(exc))
 
@@ -195,6 +195,7 @@ type BoundedSearchOutcome[ResultT: ContractModel] = (
 class BoundedSearchOperation[
     RequestT: ContractModel,
     ResultT: ContractModel,
+    ObligationT: ContractModel,
 ]:
     """One budgeted producer with explicit partial-result semantics."""
 
@@ -207,8 +208,8 @@ class BoundedSearchOperation[
     relation_id: str
     scope_parameters: Callable[[RequestT, ResultT], dict[str, Any]]
     is_complete: Callable[[ResultT], bool]
-    obligation_model: type[ContractModel]
-    obligation: Callable[[RequestT, ResultT], ContractModel]
+    obligation_model: type[ObligationT]
+    obligation: Callable[[RequestT, ResultT], ObligationT]
     incomplete_basis: str
     tags: tuple[str, ...] = ()
     invocation_examples: tuple[CapabilityInvocationExample, ...] = ()
@@ -232,7 +233,9 @@ class DomainDiagnostics:
     invalid_request: CapabilityDiagnostic
 
 
-type DomainOperation = ComputedOperation[Any, Any] | BoundedSearchOperation[Any, Any]
+type DomainOperation = (
+    ComputedOperation[Any, Any] | BoundedSearchOperation[Any, Any, Any]
+)
 
 
 class ManagedDomainInstaller(Protocol):

--- a/tests/boundary/process/public_api/test_import_isolation.py
+++ b/tests/boundary/process/public_api/test_import_isolation.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_native_namespace_does_not_import_runtime_or_transport() -> None:
+    forbidden = (
+        "jacobian.runtime",
+        "jacobian.mcp",
+        "jacobian.operation_installation",
+        "jacobian.providers",
+    )
+    script = "import jacobian.math, sys; print('\\n'.join(sys.modules))"
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    imported = set(completed.stdout.splitlines())
+    assert not any(
+        name == prefix or name.startswith(f"{prefix}.")
+        for name in imported
+        for prefix in forbidden
+    )

--- a/tests/boundary/providers/graph/runtime/test_graph_public_api_bridges.py
+++ b/tests/boundary/providers/graph/runtime/test_graph_public_api_bridges.py
@@ -1,0 +1,73 @@
+import networkx as nx
+
+from jacobian.contracts.capabilities import (
+    CapabilityAssuranceLevel,
+    CapabilityCompletenessStatus,
+    CapabilityMode,
+    CapabilityRequest,
+)
+from jacobian.contracts.results import ExecutionStatus
+from jacobian.math import graphs
+
+
+def _assert_computed_lineage(runtime, result) -> None:
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert result.completeness.status is CapabilityCompletenessStatus.COMPLETE
+    assert len(result.artifact_uris) == 2
+    source_uri, result_uri = result.artifact_uris
+    assert runtime.core.store.get(result_uri).manifest.parents == (source_uri,)
+    assert result.relationships[0].source_artifact_uris == (source_uri,)
+    assert result.relationships[0].target_artifact_uris == (result_uri,)
+
+
+def test_native_graph_metric_agrees_and_capability_remains_verifiable(
+    authorized_complete_runtime,
+) -> None:
+    runtime = authorized_complete_runtime
+    graph = nx.path_graph(("a", "b", "c", "d"))
+    computed = runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.invariant.diameter.compute",
+            input={
+                "graph": {
+                    "vertices": list(graph.nodes),
+                    "edges": [list(edge) for edge in graph.edges],
+                }
+            },
+        )
+    )
+
+    assert computed.output["result"]["diameter"] == graphs.diameter(graph)
+    _assert_computed_lineage(runtime, computed)
+
+    verified = runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.invariant.diameter.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"result_uri": computed.output["result_uri"]},
+        )
+    )
+    assert verified.execution.status is ExecutionStatus.COMPLETED
+    assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED
+    assert verified.output["status"] == "VERIFIED"
+    assert verified.output["operation_id"] == "graph.invariant.diameter.compute"
+    assert verified.output["verification_record_uri"] in verified.artifact_uris
+
+
+def test_capability_provider_provenance_is_unchanged(
+    authorized_complete_runtime,
+) -> None:
+    providers = {
+        descriptor.capability_id: descriptor.provider
+        for descriptor in authorized_complete_runtime.core.capabilities.catalog().capabilities
+        if descriptor.capability_id
+        in {
+            "graph.invariant.diameter.compute",
+            "graph.invariant.diameter.verify",
+        }
+    }
+    assert providers == {
+        "graph.invariant.diameter.compute": "jacobian.graph-invariants",
+        "graph.invariant.diameter.verify": "jacobian.graph-exact-checkers",
+    }

--- a/tests/boundary/providers/sympy/runtime/test_sympy_public_api_bridges.py
+++ b/tests/boundary/providers/sympy/runtime/test_sympy_public_api_bridges.py
@@ -1,0 +1,85 @@
+from fractions import Fraction
+
+import sympy
+
+from jacobian.contracts.capabilities import (
+    CapabilityAssuranceLevel,
+    CapabilityCompletenessStatus,
+    CapabilityRequest,
+)
+from jacobian.contracts.results import ExecutionStatus
+from jacobian.math import arithmetic, matrices
+
+
+def _assert_computed_lineage(runtime, result) -> None:
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert result.completeness.status is CapabilityCompletenessStatus.COMPLETE
+    assert len(result.artifact_uris) == 2
+    source_uri, result_uri = result.artifact_uris
+    assert runtime.core.store.get(result_uri).manifest.parents == (source_uri,)
+    assert result.relationships[0].source_artifact_uris == (source_uri,)
+    assert result.relationships[0].target_artifact_uris == (result_uri,)
+
+
+def test_native_and_capability_arithmetic_agree(authorized_complete_runtime) -> None:
+    runtime = authorized_complete_runtime
+    result = runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="rational.compute.sum",
+            input={
+                "left": {"num": "1", "den": "3"},
+                "right": {"num": "1", "den": "6"},
+            },
+        )
+    )
+
+    native = arithmetic.sum_rationals(Fraction(1, 3), Fraction(1, 6))
+    assert result.output["result"]["value"] == {
+        "num": str(native.numerator),
+        "den": str(native.denominator),
+    }
+    _assert_computed_lineage(runtime, result)
+
+
+def test_native_and_capability_matrix_inverse_agree(
+    authorized_complete_runtime,
+) -> None:
+    runtime = authorized_complete_runtime
+    result = runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="matrix.inverse.compute",
+            input={
+                "matrix": {
+                    "domain": "ZZ",
+                    "entries": [["1", "2"], ["3", "4"]],
+                }
+            },
+        )
+    )
+
+    native = matrices.inverse(sympy.Matrix([[1, 2], [3, 4]]))
+    wire = result.output["result"]["inverse"]["entries"]
+    bridged = sympy.Matrix(
+        [
+            [sympy.Rational(int(value["num"]), int(value["den"])) for value in row]
+            for row in wire
+        ]
+    )
+    assert bridged == native
+    _assert_computed_lineage(runtime, result)
+
+
+def test_capability_provider_provenance_is_unchanged(
+    authorized_complete_runtime,
+) -> None:
+    providers = {
+        descriptor.capability_id: descriptor.provider
+        for descriptor in authorized_complete_runtime.core.capabilities.catalog().capabilities
+        if descriptor.capability_id
+        in {"rational.compute.sum", "matrix.inverse.compute"}
+    }
+    assert providers == {
+        "rational.compute.sum": "jacobian.sympy",
+        "matrix.inverse.compute": "jacobian.sympy",
+    }

--- a/tests/component/providers/public_api/test_graphs.py
+++ b/tests/component/providers/public_api/test_graphs.py
@@ -1,0 +1,20 @@
+import networkx as nx
+import pytest
+
+from jacobian.math import graphs
+
+
+def test_graph_algorithms_use_networkx_objects() -> None:
+    graph = nx.cycle_graph(3)
+    assert graphs.triangle_count(graph) == 1
+    assert graphs.diameter(graph) == 1
+    assert graphs.is_eulerian(graph)
+
+
+def test_graph_input_errors_are_stable() -> None:
+    with pytest.raises(TypeError, match="NetworkX Graph"):
+        graphs.triangle_count({0: [1]})  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="nonempty connected"):
+        graphs.diameter(nx.Graph([(0, 1), (2, 3)]))
+    with pytest.raises(ValueError, match="undirected and simple"):
+        graphs.triangle_count(nx.DiGraph([(0, 1)]))  # type: ignore[arg-type]

--- a/tests/component/providers/public_api/test_matrices.py
+++ b/tests/component/providers/public_api/test_matrices.py
@@ -1,0 +1,26 @@
+import pytest
+import sympy
+
+from jacobian.math import matrices
+
+
+def test_exact_matrix_operations() -> None:
+    source = sympy.Matrix([[1, 2], [3, 4]])
+    assert matrices.inverse(source) == sympy.Matrix(
+        [[-2, 1], [sympy.Rational(3, 2), sympy.Rational(-1, 2)]]
+    )
+    assert matrices.trace(source) == 5
+    reduced, pivots = matrices.rref(sympy.Matrix([[1, 2], [2, 4]]))
+    assert reduced == sympy.Matrix([[1, 2], [0, 0]])
+    assert pivots == (0,)
+
+
+def test_matrix_input_errors_are_stable() -> None:
+    with pytest.raises(TypeError, match="SymPy MatrixBase"):
+        matrices.trace([[1]])  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="square"):
+        matrices.inverse(sympy.Matrix([[1, 2]]))
+    with pytest.raises(ValueError, match="singular"):
+        matrices.inverse(sympy.zeros(2))
+    with pytest.raises(ValueError, match="exact"):
+        matrices.trace(sympy.Matrix([[1.5]]))

--- a/tests/component/providers/public_api/test_matrices.py
+++ b/tests/component/providers/public_api/test_matrices.py
@@ -24,3 +24,6 @@ def test_matrix_input_errors_are_stable() -> None:
         matrices.inverse(sympy.zeros(2))
     with pytest.raises(ValueError, match="exact"):
         matrices.trace(sympy.Matrix([[1.5]]))
+    nested_float = sympy.Add(sympy.Float("0.1"), sympy.Rational(1, 3), evaluate=False)
+    with pytest.raises(ValueError, match="exact"):
+        matrices.trace(sympy.Matrix([[nested_float]]))

--- a/tests/unit/public_api/test_arithmetic.py
+++ b/tests/unit/public_api/test_arithmetic.py
@@ -1,0 +1,27 @@
+from fractions import Fraction
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from jacobian.math import arithmetic
+
+
+@given(st.integers())
+def test_absolute_value_and_sign_preserve_integer_invariants(value: int) -> None:
+    assert arithmetic.absolute_value(value) >= 0
+    assert arithmetic.absolute_value(value) * arithmetic.sign(value) == value
+
+
+def test_exact_rational_operations() -> None:
+    assert arithmetic.sum_rationals(Fraction(1, 3), Fraction(1, 6)) == Fraction(1, 2)
+    assert arithmetic.quotient(Fraction(2, 3), 4) == Fraction(1, 6)
+    assert arithmetic.reciprocal(Fraction(-2, 3)) == Fraction(-3, 2)
+
+
+@pytest.mark.parametrize(
+    "operation", [arithmetic.reciprocal, lambda x: arithmetic.quotient(1, x)]
+)
+def test_zero_division_is_explicit(operation: object) -> None:
+    with pytest.raises(ZeroDivisionError, match=r"zero|division by zero"):
+        operation(0)  # type: ignore[operator]

--- a/tests/unit/public_api/test_namespace.py
+++ b/tests/unit/public_api/test_namespace.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import importlib
+
+import jacobian
+
+PUBLIC_API = {
+    "jacobian.math": ("arithmetic", "graphs", "matrices"),
+    "jacobian.math.arithmetic": (
+        "absolute_value",
+        "quotient",
+        "reciprocal",
+        "sign",
+        "sum_rationals",
+    ),
+    "jacobian.math.graphs": ("diameter", "is_eulerian", "triangle_count"),
+    "jacobian.math.matrices": ("inverse", "rref", "trace"),
+}
+
+
+def test_public_manifest_is_exact() -> None:
+    for module_name, names in PUBLIC_API.items():
+        module = importlib.import_module(module_name)
+        assert tuple(module.__all__) == names
+        assert len(names) == len(set(names))
+        assert all(not name.startswith("_") for name in names)
+        assert all(hasattr(module, name) for name in names)
+
+
+def test_functions_have_one_canonical_module() -> None:
+    function_locations: dict[object, list[str]] = {}
+    for module_name, names in PUBLIC_API.items():
+        module = importlib.import_module(module_name)
+        for name in names:
+            value = getattr(module, name)
+            if callable(value) and not isinstance(value, type(importlib)):
+                function_locations.setdefault(value, []).append(f"{module_name}.{name}")
+    assert all(len(locations) == 1 for locations in function_locations.values())
+
+
+def test_root_namespace_stays_minimal() -> None:
+    assert jacobian.__all__ == ["ResultEnvelope"]
+    assert "arithmetic" not in jacobian.__all__
+    assert "matrices" not in jacobian.__all__
+    assert "graphs" not in jacobian.__all__


### PR DESCRIPTION
## Problem

Jacobian's Python-facing mathematical implementations erased their domain types at the shared operation factory boundary. Implementations accepted `ContractModel`, cast requests back to their declared models, and bounded searches lost the concrete obligation type. Python callers also had no small native-value interface for deterministic computations without constructing the capability runtime.

## Solution

- preserve concrete request, result, and obligation types through `ComputedOperation`, `ComputedOperationFactory`, and `BoundedSearchOperation`
- migrate the built-in domain implementations away from `ContractModel` callables and request casts
- add the canonical `jacobian.math` namespace with small arithmetic, matrix, and graph slices using Python, SymPy, and NetworkX values
- share typed mathematical kernels between native functions and the corresponding capability implementations instead of routing through `capability.invoke`
- freeze the supported modules and symbols with explicit manifests, import-isolation coverage, native behavior tests, and installed-runtime bridge tests
- document the public namespace and contributor constraints

Existing capability IDs, request and result schemas, artifacts, provenance, completeness, provider loading, and verification authority remain unchanged. The package continues to ship the complete built-in dependency set.

### Suggested review order

1. `src/jacobian/operations.py` and `src/jacobian/operation_installation.py` for the generic typing invariant.
2. `src/jacobian/math/` and the arithmetic, matrix, and graph adapters for the native-value boundary.
3. The remaining domain signature migration, which is mechanical once the generic types are strict.
4. Public API and runtime bridge tests, then the reference documentation.

## Testing

- `make check` — Ruff, formatting, complexity, mypy, and 647 unit tests passed
- focused native API component tests — 7 passed
- focused native API process isolation — 1 passed
- focused number-theory, matrix, and graph domain tests — 26 passed
- focused native/capability provider bridge tests — 5 passed
- `make test-composition TESTS=tests/composition/portfolio/test_domain_bundles.py PYTEST_ARGS='-n 0'` — 7 passed
- `make check-static` — dependency, dead-code, architecture, typing, and package-build checks passed
- `make docs-linkcheck` — passed
- `git diff --check origin/main...HEAD` — clean

## Trust & Compatibility Impact

This adds a pre-stable native Python API but does not change the capability wire contract or artifact formats. Pydantic validation remains authoritative at capability, artifact, persistence, and wire boundaries. Native imports do not initialize MCP, construct the runtime, or load provider implementations. Producers remain capped at `COMPUTED`; independent checker authorization and `VERIFIED` behavior are unchanged and covered by the graph-diameter bridge test.

## Checklist

- [x] Routine local validation passes (`make check`)
- [x] Relevant focused tests are listed above
