### PR TITLE
feat(matrix): expose exact rational relations

### DIFF
--- a/research/evaluations/capability-workflow-v1/gap-ledger.json
+++ b/research/evaluations/capability-workflow-v1/gap-ledger.json
@@ -72,21 +72,26 @@
           "boundary": "The operation exists, but the pinned Lean runtime is absent from the current environment."
         },
         {
-          "capability_id": "linear.rational_solution.find",
+          "capability_id": "matrix.nullspace.compute",
           "availability": "AVAILABLE",
-          "boundary": "Finds one Ax=b solution; it does not return a basis of all relations among named vectors."
+          "boundary": "Returns the complete canonical basis of exact rational dependencies among ordered matrix columns; the original audit missed this installed outcome because its descriptor exposed only nullspace terminology."
+        },
+        {
+          "capability_id": "matrix.result.verify",
+          "availability": "AVAILABLE",
+          "boundary": "Independently replays the complete nullspace basis with Python-FLINT, but the generic verifier is discovered after the producer rather than by relation intent."
         }
       ],
       "gap_classes": [
         "PROVIDER_UNAVAILABLE",
-        "MISSING_OPERATION"
+        "WEAK_DISCOVERY"
       ],
       "contamination": "PUBLIC_ANSWER_VISIBLE",
       "candidate_ids": [
         "rational-relation-basis"
       ],
-      "disposition": "ACCEPT_CANDIDATE",
-      "next_action": "Restore the pinned Lean profile separately; use this vector episode as one public reproduction for the rational-relation primitive."
+      "disposition": "USE_EXISTING",
+      "next_action": "Restore the pinned Lean profile separately; expose rational-relation terminology and an ordered-column example on matrix.nullspace.compute instead of adding a duplicate producer."
     },
     {
       "task_id": "calendar-good-days-audit",
@@ -159,21 +164,26 @@
           "boundary": "Can replay denominator-cleared identities but does not discover the relation coefficients."
         },
         {
-          "capability_id": "linear.rational_solution.find",
+          "capability_id": "matrix.nullspace.compute",
           "availability": "AVAILABLE",
-          "boundary": "Solves Ax=b but loses named-vector relation-basis semantics."
+          "boundary": "Returns the complete canonical coefficient basis for rational relations among ordered columns; denominator clearing and column-to-point naming remain explicit agent-owned preparation."
+        },
+        {
+          "capability_id": "matrix.result.verify",
+          "availability": "AVAILABLE",
+          "boundary": "Independently checks the complete stored nullspace result but does not verify the upstream denominator-clearing transformation."
         }
       ],
       "gap_classes": [
-        "MISSING_OPERATION",
+        "WEAK_DISCOVERY",
         "MISSING_ARTIFACT_HANDOFF"
       ],
       "contamination": "PUBLIC_ANSWER_VISIBLE",
       "candidate_ids": [
         "rational-relation-basis"
       ],
-      "disposition": "ACCEPT_CANDIDATE",
-      "next_action": "Preserve polynomial identity replay and evaluate whether a relation artifact composes cleanly after denominator clearing."
+      "disposition": "USE_EXISTING",
+      "next_action": "Preserve polynomial identity replay, use ordered columns with matrix.nullspace.compute, and evaluate the still-open denominator-clearing artifact handoff."
     },
     {
       "task_id": "finite-partition",
@@ -624,26 +634,26 @@
       ],
       "current_capabilities": [
         {
-          "capability_id": "matrix.rank.compute",
+          "capability_id": "matrix.nullspace.compute",
           "availability": "AVAILABLE",
-          "boundary": "Computes a matrix rank but does not return all named-vector relations."
+          "boundary": "Returns nullity and the complete canonical basis of exact rational dependencies among ordered generator columns; rank is determined by rank-nullity."
         },
         {
-          "capability_id": "linear.rational_solution.find",
+          "capability_id": "matrix.result.verify",
           "availability": "AVAILABLE",
-          "boundary": "Returns one system solution without a canonical relation-basis artifact."
+          "boundary": "Independently replays the exact stored nullspace basis and binds a verification record to the input and result."
         }
       ],
       "gap_classes": [
-        "MISSING_OPERATION",
-        "MISSING_ARTIFACT_HANDOFF"
+        "WEAK_DISCOVERY",
+        "MODEL_REASONING"
       ],
       "contamination": "PUBLIC_ANSWER_VISIBLE",
       "candidate_ids": [
         "rational-relation-basis"
       ],
-      "disposition": "ACCEPT_CANDIDATE",
-      "next_action": "Implement the smaller named-vector relation primitive first and derive direct-sum claims through agent composition."
+      "disposition": "USE_EXISTING",
+      "next_action": "Expose relation terminology on matrix.nullspace.compute and derive direct-sum claims from ordered generator columns through agent-owned composition."
     }
   ],
   "handoffs": [
@@ -704,11 +714,12 @@
     },
     {
       "stage": "discovery",
-      "status": "accepted",
+      "status": "needs_revision",
       "subject": {
         "candidate_id": "rational-relation-basis",
         "capability_ids": [
-          "linear.rational_relations.compute"
+          "matrix.nullspace.compute",
+          "matrix.result.verify"
         ]
       },
       "evidence_refs": [
@@ -723,22 +734,25 @@
         },
         {
           "ref": "MCP capability.describe capture on 2026-07-31: only Ax=b solution and inconsistency outcomes matched"
+        },
+        {
+          "ref": "MCP exact contract and independent replay audit on main@62bdb559: matrix.nullspace.compute already covers the complete ordered-column relation basis and matrix.result.verify accepts it with a bound Python-FLINT verification record"
         }
       ],
-      "contract_ref": "planned:linear.rational_relations.compute",
+      "contract_ref": "capability:matrix.nullspace.compute@2",
       "runtime_snapshot": "#/runtime_snapshot",
       "assurance": "DISCOVERY_EVIDENCE_ONLY",
       "open_obligations": [
-        "Freeze named-vector orientation, ambient-dimension validation, canonical rational normalization, and relation-basis normalization.",
-        "Return rank, a complete relation basis, a nontrivial witness when present, and explicit scope/completeness.",
-        "Implement an independent exact row-reduction checker with reorder, rescale, omission, and substitution attacks.",
-        "Confirm direct-sum conclusions compose without losing named-subspace semantics."
+        "Expose ordered-column relation terminology, an exact rank field, and a relation-oriented invocation example without adding a duplicate capability ID.",
+        "Retain the existing independent Python-FLINT replay while versioning the expanded result contract.",
+        "Measure whether direct-sum conclusions compose from the verified ordered-column basis without losing essential named-subspace semantics."
       ],
       "missing_evidence": [
-        "No held-out comparative model run has been authorized or executed."
+        "No held-out comparative model run has been authorized or executed.",
+        "No trace shows that explicit names inside the mathematical artifact improve outcomes beyond preserving the declared column order."
       ],
-      "decision": "IMPLEMENT",
-      "next_action": "Hand the smaller relation-basis producer to implement-math-capability before considering a broader direct-sum outcome.",
+      "decision": "DEFER",
+      "next_action": "Improve and version matrix.nullspace.compute for rational-relation discovery, then evaluate the existing producer/checker pair before reconsidering a named-vector alias or broader direct-sum outcome.",
       "move_episodes": [
         "subspace-direct-sum-counterexample",
         "autoformalization-semantic-audit",
@@ -746,7 +760,7 @@
       ],
       "candidate_gate": {
         "basis": "RECURRENT",
-        "nonduplicative": true,
+        "nonduplicative": false,
         "bounded_typed_contract": true,
         "honest_failure_semantics": true,
         "maintained_backend": true,
@@ -754,7 +768,7 @@
         "public_reproduction": true,
         "held_out_hypothesis": true
       },
-      "portfolio_delta": "One linear-domain result returns rank and a canonical basis of all exact rational dependencies among named vectors.",
+      "portfolio_delta": "No new capability ID: reuse the existing exact nullspace producer/checker pair, expose ordered-column rational-relation intent, and add explicit rank to the versioned result.",
       "public_reproduction": [
         "subspace-direct-sum-counterexample",
         "autoformalization-semantic-audit",

--- a/src/jacobian/contracts/matrix_operations.py
+++ b/src/jacobian/contracts/matrix_operations.py
@@ -169,6 +169,7 @@ class RrefResult(ContractModel):
 
 class NullspaceResult(ContractModel):
     ambient_dimension: int = Field(ge=1, le=MAX_MATRIX_DIMENSION)
+    rank: int = Field(ge=0, le=MAX_MATRIX_DIMENSION)
     nullity: int = Field(ge=0, le=MAX_MATRIX_DIMENSION)
     basis_vectors: tuple[tuple[OutputRational, ...], ...] = Field(
         max_length=MAX_MATRIX_DIMENSION
@@ -178,6 +179,8 @@ class NullspaceResult(ContractModel):
 
     @model_validator(mode="after")
     def require_basis_shape(self) -> Self:
+        if self.rank + self.nullity != self.ambient_dimension:
+            raise ValueError("rank plus nullity must equal the ambient dimension")
         if len(self.basis_vectors) != self.nullity:
             raise ValueError("basis vector count must equal nullity")
         if any(len(vector) != self.ambient_dimension for vector in self.basis_vectors):

--- a/src/jacobian/domains/matrix_lattice/capabilities.py
+++ b/src/jacobian/domains/matrix_lattice/capabilities.py
@@ -57,6 +57,7 @@ def matrix_operation[
     relation_id: str,
     *tags: str,
     invocation_examples: tuple[CapabilityInvocationExample, ...] = (),
+    version: str = "1",
 ) -> ComputedOperation[RequestT, ResultT]:
     def implementation(request: RequestT) -> ComputedOutcome[ResultT]:
         try:
@@ -89,6 +90,7 @@ def matrix_operation[
 
     return ComputedOperation(
         capability_id=capability_id,
+        version=version,
         title=title,
         description=description,
         request_model=request_model,
@@ -213,29 +215,45 @@ MATRIX_CAPABILITIES = (
     ),
     matrix_operation(
         "matrix.nullspace.compute",
-        "Compute a canonical exact nullspace basis",
-        "Compute the RREF fundamental basis of the right nullspace over QQ.",
+        "Compute a canonical exact nullspace or relation basis",
+        (
+            "Compute the RREF fundamental basis of the right nullspace over QQ. "
+            "When columns are ordered vectors, the result gives their rank and "
+            "every exact rational linear dependency coefficient."
+        ),
         RationalMatrixRequest,
         NullspaceResult,
         compute_nullspace,
         "matrix.relation.nullspace-of",
         "matrix",
         "nullspace",
+        "kernel",
+        "linear-dependence",
+        "rational-relations",
         "exact-rational",
         invocation_examples=(
             example(
-                "nullspace_two_by_two",
-                "Compute a nullspace basis for a dependent matrix.",
+                "rational_relation_among_columns",
+                ("Compute every rational relation among three ordered column vectors."),
                 {
                     "matrix": {
                         "entries": [
-                            [{"num": "1", "den": "1"}, {"num": "2", "den": "1"}],
-                            [{"num": "2", "den": "1"}, {"num": "4", "den": "1"}],
+                            [
+                                {"num": "1", "den": "1"},
+                                {"num": "0", "den": "1"},
+                                {"num": "1", "den": "1"},
+                            ],
+                            [
+                                {"num": "0", "den": "1"},
+                                {"num": "1", "den": "1"},
+                                {"num": "1", "den": "1"},
+                            ],
                         ]
                     }
                 },
             ),
         ),
+        version="2",
     ),
     matrix_operation(
         "matrix.characteristic_polynomial.compute",

--- a/src/jacobian/domains/matrix_lattice/operations.py
+++ b/src/jacobian/domains/matrix_lattice/operations.py
@@ -86,6 +86,7 @@ def compute_nullspace(request: RationalMatrixRequest) -> NullspaceResult:
         basis.append(tuple(_rational(value) for value in vector))
     return NullspaceResult(
         ambient_dimension=matrix.cols,
+        rank=len(pivot_columns),
         nullity=len(basis),
         basis_vectors=tuple(basis),
         free_columns=free_columns,

--- a/src/jacobian_checkers/exact_domain_operations.py
+++ b/src/jacobian_checkers/exact_domain_operations.py
@@ -802,6 +802,7 @@ def _nullspace(source: dict[str, Any], result: dict[str, Any]) -> bool:
         set(result)
         != {
             "ambient_dimension",
+            "rank",
             "nullity",
             "basis_vectors",
             "free_columns",
@@ -827,6 +828,7 @@ def _nullspace(source: dict[str, Any], result: dict[str, Any]) -> bool:
     declared = [[_q(item) for item in vector] for vector in result["basis_vectors"]]
     return (
         result["ambient_dimension"] == reduced.ncols()
+        and result["rank"] == rank
         and result["nullity"] == len(free)
         and tuple(result["free_columns"]) == free
         and declared == expected

--- a/tests/component/checkers/test_exact_domain_operation_checkers.py
+++ b/tests/component/checkers/test_exact_domain_operation_checkers.py
@@ -245,6 +245,7 @@ _CASES: tuple[
             {"matrix": _qq([[1, 2, 3], [2, 4, 6]])},
             {
                 "ambient_dimension": 3,
+                "rank": 1,
                 "nullity": 2,
                 "basis_vectors": [[_q(-2), _q(1), _q(0)], [_q(-3), _q(0), _q(1)]],
                 "free_columns": [1, 2],
@@ -667,6 +668,25 @@ def test_exact_domain_checker_rejects_changed_flint_runtime(
     assert decision["accepted"] is False
     assert decision["conclusion"] == "UNKNOWN"
     assert "runtime is unavailable" in decision["detail"]
+
+
+def test_matrix_nullspace_checker_rejects_wrong_rank() -> None:
+    checker_request = copy.deepcopy(
+        next(
+            checker_request
+            for checker, checker_request in _CASES
+            if checker is check_matrix_nullspace
+        )
+    )
+    checker_request["candidate"]["payload"]["rank"] = 2
+    checker_request["candidate"]["payload_digest"] = _digest(
+        checker_request["candidate"]["payload"]
+    )
+
+    decision = check_matrix_nullspace(checker_request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
 
 
 def _modular_checker_request() -> dict[str, Any]:

--- a/tests/domain/matrix/test_matrix_lattice_domain.py
+++ b/tests/domain/matrix/test_matrix_lattice_domain.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from collections.abc import Iterator
 from pathlib import Path
 
-from pytest import MonkeyPatch, fixture
+from pydantic import ValidationError
+from pytest import MonkeyPatch, fixture, raises
 from tests.support.rationals import rational_payload as _q
 from tests.support.services import (
     DomainTestServices,
@@ -13,6 +14,7 @@ from tests.support.services import (
 from jacobian.bounded_process import BoundedProcessResult
 from jacobian.contracts.capabilities import (
     CapabilityAssuranceLevel,
+    CapabilityDiscoveryRequest,
     CapabilityRequest,
 )
 from jacobian.contracts.matrix_operations import (
@@ -21,6 +23,7 @@ from jacobian.contracts.matrix_operations import (
     IntegerMatrixRequest,
     LatticeReductionRequest,
     MatrixTraceResult,
+    NullspaceResult,
     SquareIntegerMatrixRequest,
 )
 from jacobian.contracts.results import ExecutionStatus
@@ -106,6 +109,7 @@ def test_exact_matrix_domain_results_and_lineage(
             {"matrix": _qq([[1, 2, 3], [2, 4, 6]])},
             {
                 "ambient_dimension": 3,
+                "rank": 1,
                 "nullity": 2,
                 "basis_vectors": [
                     [_q(-2), _q(1), _q(0)],
@@ -160,6 +164,63 @@ def test_exact_matrix_domain_results_and_lineage(
         assert produced.manifest.parents == (source.artifact_uri,)
         assert result.relationships[0].source_artifact_uris == (source.artifact_uri,)
         assert result.relationships[0].target_artifact_uris == (produced.artifact_uri,)
+
+
+def test_rational_relation_intent_reuses_the_exact_nullspace_operation(
+    matrix_domain_services: DomainTestServices,
+) -> None:
+    discovered = matrix_domain_services.core.capabilities.discover(
+        CapabilityDiscoveryRequest(
+            query=(
+                "all exact rational dependencies among named vectors and a "
+                "normalized relation basis"
+            ),
+            limit=5,
+        )
+    )
+
+    assert discovered.matches[0].capability_id == "matrix.nullspace.compute"
+    assert discovered.matches[0].lexical_fit == "STRONG_CANDIDATE"
+    descriptor = next(
+        descriptor
+        for descriptor in matrix_domain_services.core.capabilities.catalog().capabilities
+        if descriptor.capability_id == "matrix.nullspace.compute"
+    )
+    assert descriptor.version == "2"
+    assert descriptor.invocation_examples[0].name == ("rational_relation_among_columns")
+
+    result = matrix_domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id=descriptor.capability_id,
+            input=descriptor.invocation_examples[0].input,
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output["result"] == {
+        "ambient_dimension": 3,
+        "rank": 2,
+        "nullity": 1,
+        "basis_vectors": [[_q(-1), _q(-1), _q(1)]],
+        "free_columns": [2],
+        "convention": "RREF_FUNDAMENTAL_BASIS",
+    }
+
+
+def test_nullspace_result_enforces_rank_nullity() -> None:
+    with raises(ValidationError, match="rank plus nullity"):
+        NullspaceResult.model_validate(
+            {
+                "ambient_dimension": 3,
+                "rank": 2,
+                "nullity": 2,
+                "basis_vectors": [
+                    [_q(-2), _q(1), _q(0)],
+                    [_q(-3), _q(0), _q(1)],
+                ],
+                "free_columns": [1, 2],
+            }
+        )
 
 
 def test_invalid_matrix_request_fails_before_operation_artifacts(


### PR DESCRIPTION
## Summary

- expose rational-relation intent through the existing complete
  `matrix.nullspace.compute` outcome instead of adding a duplicate capability;
- version that experimental contract to `2`, return exact `rank`, and validate
  rank-nullity in the result model;
- add relation-oriented discovery vocabulary and an ordered-column example;
- extend the already-authorized independent Python-FLINT replay to bind and
  verify the new rank field, including a wrong-rank adversarial test;
- correct the capability gap ledger: the earlier discovery audit missed this
  consequential catalog overlap, so the candidate is now `USE_EXISTING` /
  `DEFER`, not a new `linear.rational_relations.compute` implementation.

This intentionally collapses the planned producer/checker pair into one
non-duplicative vertical slice. The existing producer already returns the
complete canonical RREF fundamental basis, and `matrix.result.verify` already
provides an independent checker path.

## Evidence and handoff

- Base: `main@552b9099212f714ea6501625f3e212ee4e831aed`
- Tested head: `e612cae4c8eb8dbfa629c88114e385123abd5948`
- Package: `0.6.0a0`
- Installed catalog: 296 capabilities,
  `sha256:e77887f3eb23af27a6a72c3d199ecb24937518c24a4150983a8607f88ce9b210`
- Policy: `DEFAULT`,
  `sha256:870a92b83d3e522e4015b6bb1cabda33086906f9de1c3c36e466251ea7ed1957`
- Producer: `matrix.nullspace.compute@2`; SymPy `1.14.0`,
  provider digest
  `sha256:c4d811388627d8853cd0a17c03a79fc17e81242fd8622a53c65ffa983282fbeb`
- Verifier: `matrix.result.verify`; composite independent-checker digest
  `sha256:2358e2df9f4579231b0bbd7b065757d4456dfa4f7972f198f748dd4bdc3a4e87`;
  Python-FLINT `0.9.0`; nullspace checker
  `checker://sha256/f887d8b2700215eaf3137db3af9d746655e8a885eb824f6a99d846419b124983`
- Public reproductions:
  `subspace-direct-sum-counterexample`,
  `autoformalization-semantic-audit`, and
  `euler-line-symbolic-certificate`
- Runtime probe: the relation-intent query ranks the producer first with
  `STRONG_CANDIDATE`; ordered columns `(1,0),(0,1),(1,1)` produce rank 2,
  nullity 1, and basis `(-1,-1,1)` at `COMPUTED`; independent replay returns
  `COMPLETED` / `TRUE` / `VERIFIED` with its verification record included in
  `artifact_uris`.
- Lean 4.31.0 was unavailable as expected and unrelated capabilities remained
  available.
- No model or Oracle run was authorized or executed, so this makes no causal
  agent-performance claim. Model, prompt, cost, and raw model trace are N/A.

Stage: `implementation`; status: `complete`; subject:
`matrix.nullspace.compute@2` + `matrix.result.verify`; decision:
reuse/consolidate rather than add a new capability ID.

Open obligations:

- evaluate held-out direct-sum composition before reconsidering named-vector
  semantics or a broader direct-sum outcome;
- preserve and evaluate the denominator-clearing artifact handoff;
- restore the separately pinned Lean evaluation profile where formal
  observations require it.

Next action: audit the installed catalog for the planned exact matrix
product/power primitive before implementing any new matrix capability.

## Validation

`make test-plan BASE=origin/main` selected the full gate because the versioned
gap ledger has no exact Python ownership mapping.

- focused post-rebase tests: 176 passed;
- unit: 647 passed;
- component: 588 passed;
- domain: 188 passed;
- composition: 421 passed, 2 expected Lean skips;
- storage: 101 passed;
- process: 159 passed;
- MCP: 21 passed;
- provider: 154 passed, 7 expected external-proof-runtime skips;
- e2e: 7 passed, 1 expected Lean skip;
- Lean boundary: 31 passed, 28 expected unavailable-runtime skips;
- npm: 15 passed and package dry-run passed;
- Ruff, formatting, deptry, vulture, mypy (401 files), test architecture,
  package build, dependency security audit, duplicate-code scan, and
  documentation link check passed;
- C901 baseline remained unchanged at 128 known violations.

The complete gate was rerun after rebasing over PR #252; `origin/main` remained
at the tested base afterward, and `git diff --check` is clean.
