### PR TITLE
fix(checkers): omit exact replay when its provider is unavailable

### DIFF
--- a/src/jacobian/exact_domain_checkers.py
+++ b/src/jacobian/exact_domain_checkers.py
@@ -46,6 +46,7 @@ from jacobian.providers.flint_runtime import (
     certified_snf_checker_provider_runtime,
     combinatorics_exact_checker_provider_runtime,
     exact_domain_checker_provider_runtime,
+    exact_domain_checker_source_provider_runtime,
     graded_syzygy_checker_provider_runtime,
     graph_exact_checker_provider_runtime,
     poset_exact_checker_provider_runtime,
@@ -59,15 +60,17 @@ from jacobian.store import ArtifactStore, StoredArtifact, StoreError
 from jacobian.verification import VerificationService
 
 _LOGGER = logging.getLogger(__name__)
+_OPTIONAL_EXACT_REPLAY_PROVIDER_KEYS = frozenset({"python-flint"})
 
 
 @dataclass(frozen=True, slots=True)
 class ExactDomainCheckerInstallation:
-    """Authorized checker identities keyed by producer capability ID."""
+    """Exact replay identities and non-conclusive installation diagnostics."""
 
     checker_ids: dict[str, str | None]
     provider_runtimes: dict[str, CapabilityProviderRuntime]
     witness_schema_uri: str | None = None
+    diagnostics: tuple[CapabilityDiagnostic, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -128,21 +131,15 @@ def install_exact_domain_checkers(
     }
     checker_ids: dict[str, str | None] = {}
     declarations_by_id: dict[str, ExactReplayCheckerDeclaration] = {}
+    diagnostics: list[CapabilityDiagnostic] = []
+    exact_checker_source_available = (
+        exact_domain_checker_source_provider_runtime().availability
+        is CapabilityProviderAvailability.AVAILABLE
+    )
     for installed, declaration in _available_declaration_bundles(bundles):
         declarations_by_id[declaration.capability_id] = declaration
         runtime_key = _provider_runtime_key(declaration)
         provider_runtime = provider_runtimes[runtime_key]
-        if (
-            provider_runtime.availability
-            is not CapabilityProviderAvailability.AVAILABLE
-        ):
-            _LOGGER.warning(
-                "%s independent replay is not installed: %s",
-                declaration.capability_id,
-                provider_runtime.diagnostic,
-            )
-            checker_ids[declaration.capability_id] = None
-            continue
         operation = CheckerOperation(
             name=f"{declaration.capability_id} independent {declaration.replay_method}",
             entrypoint=(f"{declaration.entrypoint_module}:{declaration.function}"),
@@ -157,6 +154,41 @@ def install_exact_domain_checkers(
             reason=declaration.reason,
             provider_runtime=provider_runtime,
         )
+        if (
+            provider_runtime.availability
+            is not CapabilityProviderAvailability.AVAILABLE
+        ):
+            can_omit = (
+                runtime_key in _OPTIONAL_EXACT_REPLAY_PROVIDER_KEYS
+                and exact_checker_source_available
+            )
+            if not can_omit:
+                checker_ids[declaration.capability_id] = installer.install(
+                    operation,
+                    authorize=authorize,
+                ).checker_id
+                continue
+            diagnostic = CapabilityDiagnostic(
+                code="EXACT_REPLAY_PROVIDER_UNAVAILABLE",
+                stage="provider_availability",
+                message=(
+                    f"Independent replay for {declaration.capability_id!r} is "
+                    "not installed: "
+                    f"{provider_runtime.diagnostic or 'the provider is unavailable.'}"
+                ),
+                hint=(
+                    "Install or repair the optional python-flint backend, then retry."
+                ),
+                details={
+                    "capability_id": declaration.capability_id,
+                    "provider": provider_runtime.provider,
+                    "checker_authorization_affected": True,
+                },
+            )
+            diagnostics.append(diagnostic)
+            _LOGGER.warning("%s", diagnostic.message)
+            checker_ids[declaration.capability_id] = None
+            continue
         checker_ids[declaration.capability_id] = installer.install(
             operation,
             authorize=authorize,
@@ -172,6 +204,7 @@ def install_exact_domain_checkers(
     }
     return ExactDomainCheckerInstallation(
         checker_ids=checker_ids,
+        diagnostics=tuple(diagnostics),
         provider_runtimes={
             "python-flint": exact_domain_checker_provider_runtime(
                 checker_ids=authorized_ids["python-flint"]
@@ -231,6 +264,7 @@ def install_exact_domain_verification(
     installation = ExactDomainCheckerInstallation(
         checker_ids=installed.checker_ids,
         witness_schema_uri=witness_schema_uri,
+        diagnostics=installed.diagnostics,
         provider_runtimes=installed.provider_runtimes,
     )
     if not any(

--- a/src/jacobian/exact_domain_checkers.py
+++ b/src/jacobian/exact_domain_checkers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Literal
@@ -21,6 +22,7 @@ from jacobian.contracts.capabilities import (
     CapabilityDescriptor,
     CapabilityDiagnostic,
     CapabilityMode,
+    CapabilityProviderAvailability,
     CapabilityProviderRuntime,
     CapabilityRequest,
     CapabilityResult,
@@ -55,6 +57,8 @@ from jacobian.registry import CheckerRegistry
 from jacobian.schema_registry import SchemaRegistry, SchemaRegistryError, model_schema
 from jacobian.store import ArtifactStore, StoredArtifact, StoreError
 from jacobian.verification import VerificationService
+
+_LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -127,6 +131,18 @@ def install_exact_domain_checkers(
     for installed, declaration in _available_declaration_bundles(bundles):
         declarations_by_id[declaration.capability_id] = declaration
         runtime_key = _provider_runtime_key(declaration)
+        provider_runtime = provider_runtimes[runtime_key]
+        if (
+            provider_runtime.availability
+            is not CapabilityProviderAvailability.AVAILABLE
+        ):
+            _LOGGER.warning(
+                "%s independent replay is not installed: %s",
+                declaration.capability_id,
+                provider_runtime.diagnostic,
+            )
+            checker_ids[declaration.capability_id] = None
+            continue
         operation = CheckerOperation(
             name=f"{declaration.capability_id} independent {declaration.replay_method}",
             entrypoint=(f"{declaration.entrypoint_module}:{declaration.function}"),
@@ -139,7 +155,7 @@ def install_exact_domain_checkers(
                 installed.result_schema_uris[declaration.capability_id],
             ),
             reason=declaration.reason,
-            provider_runtime=provider_runtimes[runtime_key],
+            provider_runtime=provider_runtime,
         )
         checker_ids[declaration.capability_id] = installer.install(
             operation,

--- a/src/jacobian/providers/flint_runtime.py
+++ b/src/jacobian/providers/flint_runtime.py
@@ -202,6 +202,28 @@ def python_flint_probability_provider_runtime(
     return runtime
 
 
+def exact_domain_checker_source_provider_runtime() -> CapabilityProviderRuntime:
+    """Identify the bundled source used by exact-domain replay checkers."""
+
+    try:
+        version, _, _ = _jacobian_identity()
+    except ProviderRuntimeError:
+        return _unavailable_runtime(
+            provider="jacobian.exact-domain-checker-source",
+            install_tier=CapabilityInstallTier.T1,
+            license_id="MIT",
+            diagnostic="The exact-domain checker source could not be identified.",
+        )
+    return source_provider_runtime(
+        "jacobian.exact-domain-checker-source",
+        version=version,
+        entrypoint=("jacobian_checkers.exact_domain_operations:check_polynomial_gcd"),
+        install_tier=CapabilityInstallTier.T1,
+        license_id="MIT",
+        features=("clean-process-replay",),
+    )
+
+
 def exact_domain_checker_provider_runtime(
     *,
     checker_ids: tuple[str, ...] = (),
@@ -209,30 +231,10 @@ def exact_domain_checker_provider_runtime(
 ) -> CapabilityProviderRuntime:
     """Bind independent checker source and its pinned FLINT replay backend."""
 
-    try:
-        version, _, _ = _jacobian_identity()
-    except ProviderRuntimeError:
-        source = _unavailable_runtime(
-            provider="jacobian.exact-domain-checker-source",
-            install_tier=CapabilityInstallTier.T1,
-            license_id="MIT",
-            diagnostic="The exact-domain checker source could not be identified.",
-        )
-    else:
-        source = source_provider_runtime(
-            "jacobian.exact-domain-checker-source",
-            version=version,
-            entrypoint=(
-                "jacobian_checkers.exact_domain_operations:check_polynomial_gcd"
-            ),
-            install_tier=CapabilityInstallTier.T1,
-            license_id="MIT",
-            features=("clean-process-replay",),
-        )
     return composite_provider_runtime(
         "jacobian.exact-domain-checkers",
         components=(
-            source,
+            exact_domain_checker_source_provider_runtime(),
             python_flint_exact_checker_provider_runtime(refresh=refresh),
         ),
         features=("clean-process-replay", "python-flint"),

--- a/tests/component/checkers/test_exact_domain_checker_installation.py
+++ b/tests/component/checkers/test_exact_domain_checker_installation.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 from tests.unit.contracts.artifacts import artifact_uri as _uri
 
+import jacobian.exact_domain_checkers as exact_domain_checkers
 from jacobian.contracts.capabilities import CapabilityProviderAvailability
 from jacobian.contracts.graph_invariant_operations import GraphInvariantRequest
 from jacobian.contracts.graph_optimization import (
@@ -35,8 +36,11 @@ from jacobian.exact_domain_checkers import (
 )
 from jacobian.operation_installation import InstalledDomainBundle
 from jacobian.portfolio import build_builtin_portfolio
-from jacobian.providers.flint_runtime import exact_domain_checker_provider_runtime
-from jacobian.registry import CheckerRegistry
+from jacobian.providers.flint_runtime import (
+    exact_domain_checker_provider_runtime,
+    exact_domain_checker_source_provider_runtime,
+)
+from jacobian.registry import CheckerExecutableChangedError, CheckerRegistry
 from jacobian.store import ArtifactStore
 
 
@@ -374,3 +378,67 @@ def test_installer_omits_exact_replay_when_its_provider_is_unavailable(
 
     assert set(installation.checker_ids) == set(matrix_ids)
     assert all(installation.checker_ids[name] is None for name in matrix_ids)
+    assert {
+        diagnostic.details["capability_id"] for diagnostic in installation.diagnostics
+    } == set(matrix_ids)
+    assert all(
+        diagnostic.code == "EXACT_REPLAY_PROVIDER_UNAVAILABLE"
+        for diagnostic in installation.diagnostics
+    )
+
+
+def test_installer_does_not_omit_replay_when_bundled_source_is_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    unavailable_source = exact_domain_checker_source_provider_runtime().model_copy(
+        update={
+            "availability": CapabilityProviderAvailability.UNAVAILABLE,
+            "version": None,
+            "digest": None,
+            "digest_kind": None,
+            "diagnostic": "The exact-domain checker source could not be identified.",
+        }
+    )
+    unavailable_provider = exact_domain_checker_provider_runtime().model_copy(
+        update={
+            "availability": CapabilityProviderAvailability.UNAVAILABLE,
+            "version": None,
+            "digest": None,
+            "digest_kind": None,
+            "diagnostic": (
+                "Required composite provider components are unavailable: "
+                "jacobian.exact-domain-checker-source."
+            ),
+        }
+    )
+    monkeypatch.setattr(
+        exact_domain_checkers,
+        "exact_domain_checker_source_provider_runtime",
+        lambda: unavailable_source,
+    )
+    monkeypatch.setattr(
+        exact_domain_checkers,
+        "exact_domain_checker_provider_runtime",
+        lambda **_: unavailable_provider,
+    )
+
+    with pytest.raises(CheckerExecutableChangedError):
+        install_exact_domain_checkers(
+            CheckerRegistry(ArtifactStore(tmp_path / "store")),
+            matrix=_installed(
+                (
+                    RationalMatrixRequest,
+                    SquareRationalMatrixRequest,
+                    IntegerMatrixRequest,
+                ),
+                (
+                    "matrix.normal_form.rref.compute",
+                    "matrix.nullspace.compute",
+                    "matrix.characteristic_polynomial.compute",
+                    "matrix.normal_form.smith.compute",
+                ),
+                character="f",
+            ),
+            authorize=True,
+        )

--- a/tests/component/checkers/test_exact_domain_checker_installation.py
+++ b/tests/component/checkers/test_exact_domain_checker_installation.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from tests.unit.contracts.artifacts import artifact_uri as _uri
 
+from jacobian.contracts.capabilities import CapabilityProviderAvailability
 from jacobian.contracts.graph_invariant_operations import GraphInvariantRequest
 from jacobian.contracts.graph_optimization import (
     GraphHamiltonianPathRequest,
@@ -33,6 +35,7 @@ from jacobian.exact_domain_checkers import (
 )
 from jacobian.operation_installation import InstalledDomainBundle
 from jacobian.portfolio import build_builtin_portfolio
+from jacobian.providers.flint_runtime import exact_domain_checker_provider_runtime
 from jacobian.registry import CheckerRegistry
 from jacobian.store import ArtifactStore
 
@@ -324,3 +327,50 @@ def test_installer_skips_checkers_for_an_unavailable_graph_bundle(
             if capability_id.startswith("graph.")
         }
         assert graph_ids == expected_graph_ids
+
+
+def test_installer_omits_exact_replay_when_its_provider_is_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unavailable optional backend omits its replay instead of failing install.
+
+    Without an authorized checker the affected capabilities cannot reach
+    ``VERIFIED``; they stay producer-only. Installation must still complete.
+    """
+
+    unavailable = exact_domain_checker_provider_runtime().model_copy(
+        update={
+            "availability": CapabilityProviderAvailability.UNAVAILABLE,
+            "digest": None,
+            "digest_kind": None,
+            "diagnostic": "python-flint is not installed.",
+        }
+    )
+    monkeypatch.setattr(
+        "jacobian.exact_domain_checkers.exact_domain_checker_provider_runtime",
+        lambda **_: unavailable,
+    )
+    matrix_ids = (
+        "matrix.normal_form.rref.compute",
+        "matrix.nullspace.compute",
+        "matrix.characteristic_polynomial.compute",
+        "matrix.normal_form.smith.compute",
+    )
+
+    installation = install_exact_domain_checkers(
+        CheckerRegistry(ArtifactStore(tmp_path / "store")),
+        matrix=_installed(
+            (
+                RationalMatrixRequest,
+                SquareRationalMatrixRequest,
+                IntegerMatrixRequest,
+            ),
+            matrix_ids,
+            character="f",
+        ),
+        authorize=True,
+    )
+
+    assert set(installation.checker_ids) == set(matrix_ids)
+    assert all(installation.checker_ids[name] is None for name in matrix_ids)

--- a/tests/composition/runtime/exact_verification/test_authority_and_installation.py
+++ b/tests/composition/runtime/exact_verification/test_authority_and_installation.py
@@ -1,7 +1,15 @@
 from __future__ import annotations
 
+from pathlib import Path
+
+import pytest
+
+import jacobian.exact_domain_checkers as exact_domain_checkers
+from jacobian.contracts.capabilities import CapabilityProviderAvailability
 from jacobian.exact_domain_checkers import install_exact_domain_verification
 from jacobian.portfolio.builtin import build_builtin_portfolio
+from jacobian.providers.flint_runtime import exact_domain_checker_provider_runtime
+from jacobian.runtime import CheckerAuthorityMode, create_runtime
 from jacobian.runtime.model import JacobianRuntime
 
 
@@ -67,3 +75,45 @@ def test_operator_can_leave_exact_result_verification_unavailable(
             for descriptor in fresh_complete_runtime.core.capabilities.catalog().capabilities
         }
     )
+
+
+def test_unavailable_flint_replay_preserves_runtime_and_reports_diagnostics(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    unavailable = exact_domain_checker_provider_runtime().model_copy(
+        update={
+            "availability": CapabilityProviderAvailability.UNAVAILABLE,
+            "version": None,
+            "digest": None,
+            "digest_kind": None,
+            "diagnostic": "The optional python-flint backend is unavailable.",
+        }
+    )
+    monkeypatch.setattr(
+        exact_domain_checkers,
+        "exact_domain_checker_provider_runtime",
+        lambda **_: unavailable,
+    )
+
+    runtime = create_runtime(
+        tmp_path / "state",
+        checker_authority=CheckerAuthorityMode.INSTALL_BUNDLED,
+    )
+    try:
+        capability_ids = {
+            descriptor.capability_id
+            for descriptor in runtime.core.capabilities.catalog().capabilities
+        }
+        assert "matrix.normal_form.rref.compute" in capability_ids
+        assert "matrix.result.verify" not in capability_ids
+        assert "graph.hamiltonian_path.verify" in capability_ids
+
+        installation = runtime.portfolio.exact_domain_checkers
+        assert installation is not None
+        assert any(
+            diagnostic.details.get("capability_id") == "matrix.normal_form.rref.compute"
+            for diagnostic in installation.diagnostics
+        )
+    finally:
+        runtime.close()


### PR DESCRIPTION
## Problem

Without the optional `flint` extra, `jacobian init` fails under the default `--checker-authority INSTALL_BUNDLED`:

```
$ uv pip install --prerelease=allow jacobian   # no [flint]
$ jacobian --state-dir /tmp/s init
{"error": {"code": "VERIFICATION_UNAVAILABLE", "message": "Jacobian stopped because trusted data or code changed."}}
```

`install_exact_domain_checkers` authorizes every declared checker unconditionally. With the backend absent the provider runtime is `UNAVAILABLE` with no digest, so `CheckerRegistry.authorize` raises `CheckerExecutableChangedError` from `_require_runtime_unchanged` and aborts installation.

That contradicts the documented contract: the README lists flint under "Optional backends", and the architecture notes that built-in producer bundles install independently of checker authorization. It is also inconsistent within one run, where an absent Lean runtime degrades gracefully (`lean.check is not installed: ...`).

## Behavior

Skip declarations whose provider runtime is not `AVAILABLE`, record `checker_id = None`, and warn with the provider diagnostic, matching `reference_installation` (Lean) and `foundation_installation` (CaDiCaL). The authorized-id projection already filters `None`, so no other call site changes.

Affected capabilities keep their producers and lose only their `VERIFY` capability, so nothing there can reach `VERIFIED` without an authorized checker.

## Compatibility

None when the backend is present. Verified on this tree: 291 capabilities with flint before and after. With the provider forced unavailable, 286, and the 5 omitted are all `.verify` (`integer.powerful.verify`, `integer.prime_factorization.verify`, `matrix.result.verify`, `modular.polynomial_residue_image.verify`, `polynomial.result.verify`).

## Validation

- New component test fails on `main` with the production error (`CheckerExecutableChangedError`, `registry.py:81`) and passes here.
- `make test-unit` 647 passed; `make test-component` 586 passed, 3 skipped; `make lint` clean.
- End to end without the extra: `init` now succeeds at 8 reference domains / 273 capabilities and reports each skipped replay.

Note: `make typecheck` fails on macOS on this tree before my change too (`bounded_process.py:94`, `resource.prlimit` is Linux-only). Unrelated, happy to file separately.

If you would rather keep flint effectively required, the narrower alternative is to leave the abort in place and replace the opaque message with one naming the `[flint]` extra. Glad to switch.