### PR TITLE
fix(npm): allow pre-release resolution when installing through uv

### DIFF
--- a/npm/bin/launcher.cjs
+++ b/npm/bin/launcher.cjs
@@ -120,6 +120,29 @@ function packageNeedsRefresh(installedVersion) {
 }
 
 /**
+ * Build the uv arguments that install the pinned Python distribution.
+ *
+ * uv resolves pre-release dependencies only when they are explicitly allowed.
+ * While Jacobian is pre-stable its pinned distribution depends on pre-release
+ * packages, so the flag is required. pip accepts the same pins without it.
+ *
+ * @param {string} python
+ * @param {string} [spec]
+ * @returns {string[]}
+ */
+function uvInstallArgs(python, spec = PACKAGE_SPEC) {
+  return [
+    "pip",
+    "install",
+    "--upgrade",
+    "--prerelease=allow",
+    "--python",
+    python,
+    spec,
+  ];
+}
+
+/**
  * Ensure the shared virtual environment exists and the Jacobian package is
  * installed.  Returns the path to the venv Python executable.
  *
@@ -158,7 +181,7 @@ function ensureEnvironment(runtime) {
   const installedVersion = check.status === 0 ? check.stdout.trim() : null;
   if (packageNeedsRefresh(installedVersion)) {
     if (runtime.kind === "uv") {
-      const result = run(runtime.path, ["pip", "install", "--upgrade", "--python", python, PACKAGE_SPEC]);
+      const result = run(runtime.path, uvInstallArgs(python));
       if (result.error || result.status !== 0) {
         process.exitCode = 1;
         throw new Error(
@@ -263,6 +286,7 @@ module.exports = {
   VENV_NAME,
   packageNeedsRefresh,
   pythonVersionFromNpmVersion,
+  uvInstallArgs,
   venvRoot,
   venvPython,
   detectRuntime,

--- a/npm/bin/launcher.cjs
+++ b/npm/bin/launcher.cjs
@@ -122,9 +122,10 @@ function packageNeedsRefresh(installedVersion) {
 /**
  * Build the uv arguments that install the pinned Python distribution.
  *
- * uv resolves pre-release dependencies only when they are explicitly allowed.
- * While Jacobian is pre-stable its pinned distribution depends on pre-release
- * packages, so the flag is required. pip accepts the same pins without it.
+ * uv considers pre-release dependencies only when the resolver is allowed to
+ * do so. While Jacobian is pre-stable its pinned distribution depends on a
+ * pre-release package, so allow them only when necessary; ranged dependencies
+ * still prefer stable releases. pip accepts the same pins without this flag.
  *
  * @param {string} python
  * @param {string} [spec]
@@ -135,7 +136,7 @@ function uvInstallArgs(python, spec = PACKAGE_SPEC) {
     "pip",
     "install",
     "--upgrade",
-    "--prerelease=allow",
+    "--prerelease=if-necessary",
     "--python",
     python,
     spec,

--- a/npm/npm-packaging.test.mjs
+++ b/npm/npm-packaging.test.mjs
@@ -149,12 +149,12 @@ test("launcher pins and refreshes stale default Python packages", () => {
 test("launcher allows pre-release resolution when installing through uv", () => {
   const args = uvInstallArgs("/tmp/venv/bin/python");
 
-  assert.ok(args.includes("--prerelease=allow"));
+  assert.ok(args.includes("--prerelease=if-necessary"));
   assert.deepEqual(args, [
     "pip",
     "install",
     "--upgrade",
-    "--prerelease=allow",
+    "--prerelease=if-necessary",
     "--python",
     "/tmp/venv/bin/python",
     PACKAGE_SPEC,

--- a/npm/npm-packaging.test.mjs
+++ b/npm/npm-packaging.test.mjs
@@ -56,6 +56,7 @@ import {
   PYTHON_PACKAGE_VERSION,
   packageNeedsRefresh,
   pythonVersionFromNpmVersion,
+  uvInstallArgs,
 } from "./bin/launcher.cjs";
 import {
   EXPECTED_TOOLS,
@@ -143,6 +144,21 @@ test("launcher pins and refreshes stale default Python packages", () => {
   assert.equal(packageNeedsRefresh("0.4.0"), true);
   assert.equal(packageNeedsRefresh(null), true);
   assert.equal(packageNeedsRefresh(PYTHON_PACKAGE_VERSION), false);
+});
+
+test("launcher allows pre-release resolution when installing through uv", () => {
+  const args = uvInstallArgs("/tmp/venv/bin/python");
+
+  assert.ok(args.includes("--prerelease=allow"));
+  assert.deepEqual(args, [
+    "pip",
+    "install",
+    "--upgrade",
+    "--prerelease=allow",
+    "--python",
+    "/tmp/venv/bin/python",
+    PACKAGE_SPEC,
+  ]);
 });
 
 test("npm and Python packages publish the same release version", async () => {


### PR DESCRIPTION
## Problem

The launcher's uv path fails on a clean machine, so `jacobian doctor` / `jacobian setup` cannot bootstrap:

```
$ uv pip install --upgrade --python /tmp/v/bin/python jacobian==0.6.0a0
  Because jacobian==0.6.0a0 depends on mcp-types==2.0.0b2 and pre-releases
  weren't enabled ... hint: try `--prerelease=allow`
```

uv resolves pre-release dependencies only when explicitly allowed. The exact pin is not sufficient because the constraint applies to a transitive dependency (`mcp-types==2.0.0b2`).

## Behavior

Add `--prerelease=allow` to the uv invocation only. Verified that pip accepts the same pins unchanged (`python -m pip install jacobian==0.6.0a0` resolves `mcp-types-2.0.0b2` and imports fine), so the pip fallback is untouched.

The argument list is extracted into `uvInstallArgs` so the flag is covered by a test rather than being an unguarded literal.

## Compatibility

None. Same resolution when pre-releases are not involved, so this is a no-op once Jacobian ships a stable distribution.

## Validation

`npm test --prefix npm`: 16 passed, 0 failed. The new test fails (15 passed / 1 failed) when the flag is removed. `make npm-test` packs cleanly.

## Separate, needs your action

While checking this I hit a second bootstrap problem that a PR cannot fix. The npm `latest` tag is four releases behind:

```
$ npm view jacobian dist-tags
{ latest: '0.2.0-alpha.0', alpha: '0.6.0-alpha.0' }
```

`release.yml:118` publishes with `--tag alpha`, so `latest` still points at 0.2.0-alpha.0. The README quickstart `npm install -g jacobian` therefore installs the 0.2.0 launcher, which tries to install a PyPI package named `jacobian-research-kernel` (404) and dies with "package install failed". Either move the tag (`npm dist-tag add jacobian@0.6.0-alpha.0 latest`) or document `npm install -g jacobian@alpha`. Happy to send the README change if you prefer the second.