### PR TITLE
feat(matrix): add exact multiplication

### DIFF
--- a/research/evaluations/capability-workflow-v1/gap-ledger.json
+++ b/research/evaluations/capability-workflow-v1/gap-ledger.json
@@ -367,20 +367,25 @@
       ],
       "current_capabilities": [
         {
-          "capability_id": "matrix.rank.compute",
+          "capability_id": "matrix.multiply.compute",
           "availability": "AVAILABLE",
-          "boundary": "Computes rank but cannot produce the exact matrix product."
+          "boundary": "Computes the complete exact row-by-column product of two compatible bounded matrices over QQ and binds the operand shapes."
+        },
+        {
+          "capability_id": "matrix.result.verify",
+          "availability": "AVAILABLE",
+          "boundary": "Independently replays the exact product with Python-FLINT when checker authority is installed."
         }
       ],
       "gap_classes": [
-        "MISSING_OPERATION"
+        "EXISTING_WORKS"
       ],
       "contamination": "PUBLIC_ANSWER_VISIBLE",
       "candidate_ids": [
         "matrix-exact-product"
       ],
-      "disposition": "ACCEPT_CANDIDATE",
-      "next_action": "Implement the fundamental exact product primitive as a separate atomic outcome; evaluate power only after product composition is observed."
+      "disposition": "USE_EXISTING",
+      "next_action": "Use and evaluate the exact product primitive; consider a separate power outcome only after repeated product-composition evidence."
     },
     {
       "task_id": "metric-tsp-proof-repair",
@@ -782,7 +787,8 @@
       "subject": {
         "candidate_id": "matrix-exact-product",
         "capability_ids": [
-          "matrix.multiply.compute"
+          "matrix.multiply.compute",
+          "matrix.result.verify"
         ]
       },
       "evidence_refs": [
@@ -791,15 +797,16 @@
         },
         {
           "ref": "MCP capability.describe capture on 2026-07-31: determinant, rank, inverse, adjugate, trace, and normal forms matched but no matrix product"
+        },
+        {
+          "ref": "MCP capability.describe audit on main@b7ace445: exact product and power queries returned only unrelated weak matrix matches"
         }
       ],
-      "contract_ref": "planned:matrix.multiply.compute",
+      "contract_ref": "capability:matrix.multiply.compute@1",
       "runtime_snapshot": "#/runtime_snapshot",
       "assurance": "DISCOVERY_EVIDENCE_ONLY",
       "open_obligations": [
-        "Bound dimensions and exact scalar representation before computation.",
-        "Return operands, shape binding, and the exact result artifact at COMPUTED assurance.",
-        "Add an independent bounded arithmetic replay before any VERIFIED path.",
+        "Measure whether the installed product and replay improve held-out matrix-identity work without increasing false certification.",
         "Evaluate whether a separate power outcome is justified after product composition traces exist."
       ],
       "missing_evidence": [
@@ -807,7 +814,7 @@
         "No held-out comparative model run has been authorized or executed."
       ],
       "decision": "IMPLEMENT",
-      "next_action": "Treat exact matrix multiplication as a documented fundamental-primitive exception and hand it to implement-math-capability.",
+      "next_action": "Freeze a held-out matrix-identity comparison for the product delta; keep matrix power deferred until composition traces justify it.",
       "move_episodes": [
         "matrix-square-zero-counterexample"
       ],

--- a/src/jacobian/contracts/matrix_operations.py
+++ b/src/jacobian/contracts/matrix_operations.py
@@ -104,6 +104,22 @@ class RationalMatrixRequest(ContractModel):
     matrix: RationalMatrix
 
 
+class RationalMatrixProductRequest(ContractModel):
+    """Two compatible bounded matrices over the exact rational domain."""
+
+    left: RationalMatrix
+    right: RationalMatrix
+
+    @model_validator(mode="after")
+    def require_compatible_shapes(self) -> Self:
+        if len(self.left.entries[0]) != len(self.right.entries):
+            raise ValueError(
+                "matrix multiplication requires the left column count to equal "
+                "the right row count"
+            )
+        return self
+
+
 class SquareRationalMatrixRequest(ContractModel):
     matrix: RationalMatrix
 
@@ -268,6 +284,24 @@ class MatrixTraceResult(ContractModel):
     def require_bounded_trace(cls, value: CanonicalInteger) -> CanonicalInteger:
         _check_integer_digits(value, maximum=MAX_OUTPUT_SCALAR_DIGITS)
         return value
+
+
+class MatrixProductResult(ContractModel):
+    product: RationalOutputMatrix
+    left_rows: int = Field(ge=1, le=MAX_MATRIX_DIMENSION)
+    inner_dimension: int = Field(ge=1, le=MAX_MATRIX_DIMENSION)
+    right_columns: int = Field(ge=1, le=MAX_MATRIX_DIMENSION)
+    convention: Literal["STANDARD_ROW_BY_COLUMN_PRODUCT_OVER_QQ"] = (
+        "STANDARD_ROW_BY_COLUMN_PRODUCT_OVER_QQ"
+    )
+
+    @model_validator(mode="after")
+    def require_product_shape(self) -> Self:
+        if len(self.product.entries) != self.left_rows:
+            raise ValueError("product row count must equal left_rows")
+        if len(self.product.entries[0]) != self.right_columns:
+            raise ValueError("product column count must equal right_columns")
+        return self
 
 
 class RationalLinearSolveResult(ContractModel):

--- a/src/jacobian/domains/matrix_lattice/bundle.py
+++ b/src/jacobian/domains/matrix_lattice/bundle.py
@@ -22,6 +22,7 @@ def build_matrix_bundle() -> DomainBundle:
                 "maximum_rows": 32,
                 "maximum_columns": 32,
                 "maximum_decimal_digits_per_scalar_component": 256,
+                "multiplication": "standard row-by-column product over QQ",
                 "rref": "unique reduced row echelon form over QQ",
                 "nullspace": "RREF fundamental basis ordered by ascending free column",
                 "characteristic_polynomial": "dense det(lambda I - A) coefficients",
@@ -35,6 +36,7 @@ def build_matrix_bundle() -> DomainBundle:
             "jacobian.sympy",
             features=(
                 "exact-rational-matrix",
+                "matrix-multiplication",
                 "rref",
                 "nullspace",
                 "characteristic-polynomial",

--- a/src/jacobian/domains/matrix_lattice/capabilities.py
+++ b/src/jacobian/domains/matrix_lattice/capabilities.py
@@ -13,10 +13,12 @@ from jacobian.contracts.matrix_operations import (
     IntegerMatrixRequest,
     MatrixAdjugateResult,
     MatrixInverseResult,
+    MatrixProductResult,
     MatrixTraceResult,
     NullspaceResult,
     RationalLinearSolveRequest,
     RationalLinearSolveResult,
+    RationalMatrixProductRequest,
     RationalMatrixRequest,
     RrefResult,
     SmithNormalFormResult,
@@ -30,6 +32,7 @@ from jacobian.domains.matrix_lattice.operations import (
     compute_characteristic_polynomial,
     compute_inverse,
     compute_nullspace,
+    compute_product,
     compute_rational_linear_solve,
     compute_rref,
     compute_smith_normal_form,
@@ -184,6 +187,65 @@ MATRIX_CAPABILITIES = (
                 "trace_two_by_two",
                 "Compute the trace of a 2x2 integer matrix.",
                 {"matrix": {"entries": [["1", "2"], ["3", "4"]]}},
+            ),
+        ),
+    ),
+    matrix_operation(
+        "matrix.multiply.compute",
+        "Multiply two exact rational matrices",
+        (
+            "Compute the standard row-by-column product of two compatible bounded "
+            "matrices over QQ, with the operand shapes bound in the result. Equal "
+            "operands give the exact self-product or matrix square."
+        ),
+        RationalMatrixProductRequest,
+        MatrixProductResult,
+        compute_product,
+        "matrix.relation.product-of",
+        "matrix",
+        "matrix-multiplication",
+        "product",
+        "self-product",
+        "matrix-square",
+        "zero-matrix",
+        "matrix-identity",
+        "exact-rational",
+        invocation_examples=(
+            example(
+                "multiply_rectangular_matrices",
+                "Multiply a 2x3 matrix by a 3x2 matrix over QQ.",
+                {
+                    "left": {
+                        "entries": [
+                            [
+                                {"num": "1", "den": "1"},
+                                {"num": "2", "den": "1"},
+                                {"num": "0", "den": "1"},
+                            ],
+                            [
+                                {"num": "0", "den": "1"},
+                                {"num": "1", "den": "1"},
+                                {"num": "1", "den": "1"},
+                            ],
+                        ]
+                    },
+                    "right": {
+                        "entries": [
+                            [
+                                {"num": "1", "den": "1"},
+                                {"num": "0", "den": "1"},
+                            ],
+                            [
+                                {"num": "0", "den": "1"},
+                                {"num": "1", "den": "1"},
+                            ],
+                            [
+                                {"num": "1", "den": "1"},
+                                {"num": "1", "den": "1"},
+                            ],
+                        ]
+                    },
+                },
             ),
         ),
     ),

--- a/src/jacobian/domains/matrix_lattice/checkers.py
+++ b/src/jacobian/domains/matrix_lattice/checkers.py
@@ -3,11 +3,18 @@
 from jacobian.checker_operations import ExactReplayCheckerDeclaration
 from jacobian.contracts.matrix_operations import (
     IntegerMatrixRequest,
+    RationalMatrixProductRequest,
     RationalMatrixRequest,
     SquareRationalMatrixRequest,
 )
 
 MATRIX_EXACT_REPLAY_CHECKERS = (
+    ExactReplayCheckerDeclaration(
+        "matrix.multiply.compute",
+        RationalMatrixProductRequest,
+        "check_matrix_product",
+        "matrix.product.flint-replay",
+    ),
     ExactReplayCheckerDeclaration(
         "matrix.normal_form.rref.compute",
         RationalMatrixRequest,

--- a/src/jacobian/domains/matrix_lattice/operations.py
+++ b/src/jacobian/domains/matrix_lattice/operations.py
@@ -11,12 +11,14 @@ from jacobian.contracts.matrix_operations import (
     IntegerOutputMatrix,
     MatrixAdjugateResult,
     MatrixInverseResult,
+    MatrixProductResult,
     MatrixTraceResult,
     NullspaceResult,
     OutputRational,
     RationalLinearSolveRequest,
     RationalLinearSolveResult,
     RationalMatrix,
+    RationalMatrixProductRequest,
     RationalMatrixRequest,
     RationalOutputMatrix,
     RrefResult,
@@ -163,6 +165,23 @@ def compute_trace(request: SquareIntegerMatrixRequest) -> MatrixTraceResult:
         [[int(value) for value in row] for row in request.matrix.entries]
     )
     return MatrixTraceResult(trace=str(int(native_matrices.trace(source))))
+
+
+def compute_product(request: RationalMatrixProductRequest) -> MatrixProductResult:
+    left = _qq_matrix(request.left)
+    right = _qq_matrix(request.right)
+    product = left * right
+    return MatrixProductResult(
+        product=RationalOutputMatrix(
+            entries=tuple(
+                tuple(_rational(product[row, column]) for column in range(product.cols))
+                for row in range(product.rows)
+            )
+        ),
+        left_rows=left.rows,
+        inner_dimension=left.cols,
+        right_columns=right.cols,
+    )
 
 
 def compute_rational_linear_solve(

--- a/src/jacobian_checkers/exact_domain_operations.py
+++ b/src/jacobian_checkers/exact_domain_operations.py
@@ -26,6 +26,9 @@ _MAX_RESIDUE_TERMS = 64
 _MAX_RESIDUE_EXPONENT = 32
 _MAX_RESIDUE_ASSIGNMENTS = 4_096
 _MAX_RESIDUE_MODULUS = 1_000_000
+_MAX_MATRIX_DIMENSION = 32
+_MAX_MATRIX_INPUT_DIGITS = 256
+_MAX_MATRIX_OUTPUT_DIGITS = 4_096
 
 
 def _reject(detail: str) -> dict[str, Any]:
@@ -202,6 +205,32 @@ def _integer_matrix(value: object) -> fmpz_mat:
     ):
         raise ValueError("integer matrix shape is malformed")
     return fmpz_mat([[_integer(item) for item in row] for row in entries])
+
+
+def _bounded_rational_matrix(value: object, *, maximum_digits: int) -> fmpq_mat:
+    if not isinstance(value, dict):
+        raise ValueError("rational matrix is malformed")
+    entries = value.get("entries")
+    if (
+        not isinstance(entries, list)
+        or not 1 <= len(entries) <= _MAX_MATRIX_DIMENSION
+        or not isinstance(entries[0], list)
+        or not 1 <= len(entries[0]) <= _MAX_MATRIX_DIMENSION
+    ):
+        raise ValueError("rational matrix exceeds the checker dimension bound")
+    for row in entries:
+        if not isinstance(row, list) or len(row) != len(entries[0]):
+            raise ValueError("rational matrix shape is malformed")
+        for item in row:
+            if not isinstance(item, dict) or set(item) != {"num", "den"}:
+                raise ValueError("rational matrix scalar is malformed")
+            for component in (item["num"], item["den"]):
+                if (
+                    not isinstance(component, str)
+                    or len(component.lstrip("-")) > maximum_digits
+                ):
+                    raise ValueError("rational matrix scalar exceeds the checker bound")
+    return _rational_matrix(value)
 
 
 def _run(
@@ -844,6 +873,52 @@ def check_matrix_nullspace(request: dict[str, Any]) -> dict[str, Any]:
     )
 
 
+def _matrix_product(source: dict[str, Any], result: dict[str, Any]) -> bool:
+    if set(source) != {"left", "right"} or set(result) != {
+        "product",
+        "left_rows",
+        "inner_dimension",
+        "right_columns",
+        "convention",
+    }:
+        return False
+    if result["convention"] != "STANDARD_ROW_BY_COLUMN_PRODUCT_OVER_QQ":
+        return False
+    left = _bounded_rational_matrix(
+        source["left"],
+        maximum_digits=_MAX_MATRIX_INPUT_DIGITS,
+    )
+    right = _bounded_rational_matrix(
+        source["right"],
+        maximum_digits=_MAX_MATRIX_INPUT_DIGITS,
+    )
+    if left.ncols() != right.nrows():
+        return False
+    expected = left * right
+    declared = _bounded_rational_matrix(
+        result["product"],
+        maximum_digits=_MAX_MATRIX_OUTPUT_DIGITS,
+    )
+    return (
+        type(result["left_rows"]) is int
+        and type(result["inner_dimension"]) is int
+        and type(result["right_columns"]) is int
+        and result["left_rows"] == left.nrows()
+        and result["inner_dimension"] == left.ncols()
+        and result["right_columns"] == right.ncols()
+        and declared == expected
+    )
+
+
+def check_matrix_product(request: dict[str, Any]) -> dict[str, Any]:
+    return _run(
+        request,
+        operation_id="matrix.multiply.compute",
+        witness_format="matrix.product.flint-replay",
+        replay=_matrix_product,
+    )
+
+
 def _characteristic_polynomial(source: dict[str, Any], result: dict[str, Any]) -> bool:
     if set(result) != {
         "variable",
@@ -920,6 +995,7 @@ __all__ = [
     "check_integer_prime_factorization",
     "check_matrix_characteristic_polynomial",
     "check_matrix_nullspace",
+    "check_matrix_product",
     "check_matrix_rref",
     "check_matrix_smith_normal_form",
     "check_polynomial_discriminant",

--- a/tests/component/checkers/test_exact_domain_checker_installation.py
+++ b/tests/component/checkers/test_exact_domain_checker_installation.py
@@ -12,6 +12,7 @@ from jacobian.contracts.graph_optimization import (
 from jacobian.contracts.jacobian_syzygy import GradedJacobianSyzygyRequest
 from jacobian.contracts.matrix_operations import (
     IntegerMatrixRequest,
+    RationalMatrixProductRequest,
     RationalMatrixRequest,
     SquareRationalMatrixRequest,
 )
@@ -91,6 +92,7 @@ def test_installer_authorizes_all_exact_domain_replays(tmp_path: Path) -> None:
         "polynomial.compute.square_free_decomposition",
     )
     matrix_ids = (
+        "matrix.multiply.compute",
         "matrix.normal_form.rref.compute",
         "matrix.nullspace.compute",
         "matrix.characteristic_polynomial.compute",
@@ -126,6 +128,7 @@ def test_installer_authorizes_all_exact_domain_replays(tmp_path: Path) -> None:
         ),
         matrix=_installed(
             (
+                RationalMatrixProductRequest,
                 RationalMatrixRequest,
                 SquareRationalMatrixRequest,
                 IntegerMatrixRequest,
@@ -220,11 +223,13 @@ def test_installer_preserves_operator_control(tmp_path: Path) -> None:
         ),
         matrix=_installed(
             (
+                RationalMatrixProductRequest,
                 RationalMatrixRequest,
                 SquareRationalMatrixRequest,
                 IntegerMatrixRequest,
             ),
             (
+                "matrix.multiply.compute",
                 "matrix.normal_form.rref.compute",
                 "matrix.nullspace.compute",
                 "matrix.characteristic_polynomial.compute",
@@ -260,11 +265,13 @@ def test_installer_skips_checkers_for_an_unavailable_graph_bundle(
     )
     matrix = _installed(
         (
+            RationalMatrixProductRequest,
             RationalMatrixRequest,
             SquareRationalMatrixRequest,
             IntegerMatrixRequest,
         ),
         (
+            "matrix.multiply.compute",
             "matrix.normal_form.rref.compute",
             "matrix.nullspace.compute",
             "matrix.characteristic_polynomial.compute",

--- a/tests/component/checkers/test_exact_domain_operation_checkers.py
+++ b/tests/component/checkers/test_exact_domain_operation_checkers.py
@@ -18,6 +18,7 @@ from jacobian_checkers.exact_domain_operations import (
     check_integer_prime_factorization,
     check_matrix_characteristic_polynomial,
     check_matrix_nullspace,
+    check_matrix_product,
     check_matrix_rref,
     check_matrix_smith_normal_form,
     check_modular_polynomial_residue_image,
@@ -219,6 +220,24 @@ _CASES: tuple[
                 ],
                 "reconstructed": _poly(-1, 1, 1, -1),
                 "normalization": "MONIC_FACTORS",
+            },
+        ),
+    ),
+    (
+        check_matrix_product,
+        _request(
+            "matrix.multiply.compute",
+            "matrix.product.flint-replay",
+            {
+                "left": _qq([[1, 2, 0], [0, 1, 1]]),
+                "right": _qq([[1, 0], [0, 1], [1, 1]]),
+            },
+            {
+                "product": _qq([[1, 2], [1, 2]]),
+                "left_rows": 2,
+                "inner_dimension": 3,
+                "right_columns": 2,
+                "convention": "STANDARD_ROW_BY_COLUMN_PRODUCT_OVER_QQ",
             },
         ),
     ),
@@ -684,6 +703,55 @@ def test_matrix_nullspace_checker_rejects_wrong_rank() -> None:
     )
 
     decision = check_matrix_nullspace(checker_request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+def _matrix_product_checker_request() -> dict[str, Any]:
+    return copy.deepcopy(
+        next(
+            checker_request
+            for checker, checker_request in _CASES
+            if checker is check_matrix_product
+        )
+    )
+
+
+def test_matrix_product_checker_rejects_wrong_entry() -> None:
+    checker_request = _matrix_product_checker_request()
+    checker_request["candidate"]["payload"]["product"]["entries"][0][0] = _q(2)
+    checker_request["candidate"]["payload_digest"] = _digest(
+        checker_request["candidate"]["payload"]
+    )
+
+    decision = check_matrix_product(checker_request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+def test_matrix_product_checker_rejects_wrong_shape_binding() -> None:
+    checker_request = _matrix_product_checker_request()
+    checker_request["candidate"]["payload"]["inner_dimension"] = 2
+    checker_request["candidate"]["payload_digest"] = _digest(
+        checker_request["candidate"]["payload"]
+    )
+
+    decision = check_matrix_product(checker_request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+def test_matrix_product_checker_rejects_oversized_source() -> None:
+    checker_request = _matrix_product_checker_request()
+    checker_request["claim"]["payload"]["left"] = _qq([[1]] * 33)
+    checker_request["claim"]["payload_digest"] = _digest(
+        checker_request["claim"]["payload"]
+    )
+
+    decision = check_matrix_product(checker_request)
 
     assert decision["accepted"] is False
     assert decision["conclusion"] == "UNKNOWN"

--- a/tests/composition/runtime/exact_verification/test_matrix_product_verification.py
+++ b/tests/composition/runtime/exact_verification/test_matrix_product_verification.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from tests.support.rationals import rational_payload as _q
+
+from jacobian.contracts.capabilities import (
+    CapabilityAssuranceLevel,
+    CapabilityMode,
+    CapabilityRequest,
+    CapabilityResult,
+)
+from jacobian.contracts.results import ExecutionStatus
+from jacobian.runtime.model import JacobianRuntime
+
+
+def _qq(entries: list[list[int]]) -> dict[str, object]:
+    return {
+        "domain": "QQ",
+        "entries": [[_q(value) for value in row] for row in entries],
+    }
+
+
+def _compute_square(
+    runtime: JacobianRuntime,
+) -> CapabilityResult:
+    matrix = _qq([[0, 1], [0, 0]])
+    return runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="matrix.multiply.compute",
+            input={"left": matrix, "right": matrix},
+        )
+    )
+
+
+def test_square_zero_product_is_computed_then_independently_verified(
+    authorized_complete_runtime: JacobianRuntime,
+) -> None:
+    computed = _compute_square(authorized_complete_runtime)
+
+    assert computed.execution.status is ExecutionStatus.COMPLETED
+    assert computed.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert computed.output["result"] == {
+        "product": _qq([[0, 0], [0, 0]]),
+        "left_rows": 2,
+        "inner_dimension": 2,
+        "right_columns": 2,
+        "convention": "STANDARD_ROW_BY_COLUMN_PRODUCT_OVER_QQ",
+    }
+
+    verified = authorized_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="matrix.result.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"result_uri": computed.output["result_uri"]},
+        )
+    )
+
+    assert verified.execution.status is ExecutionStatus.COMPLETED
+    assert verified.output["status"] == "VERIFIED"
+    assert verified.output["operation_id"] == "matrix.multiply.compute"
+    assert verified.output["result_uri"] == computed.output["result_uri"]
+    assert verified.output["verification_record_uri"] is not None
+    assert verified.output["verification_record_uri"] in verified.artifact_uris
+    assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED
+
+
+def test_matrix_product_verifier_rejects_a_false_product_without_a_record(
+    authorized_complete_runtime: JacobianRuntime,
+) -> None:
+    computed = _compute_square(authorized_complete_runtime)
+    installed = authorized_complete_runtime.portfolio.domain_bundles["matrix"]
+    false_result = authorized_complete_runtime.core.artifacts.put(
+        schema_uri=installed.result_schema_uris["matrix.multiply.compute"],
+        semantics_uri=installed.semantics_uri,
+        parents=(computed.output["input_uri"],),
+        payload={
+            "product": _qq([[1, 0], [0, 0]]),
+            "left_rows": 2,
+            "inner_dimension": 2,
+            "right_columns": 2,
+            "convention": "STANDARD_ROW_BY_COLUMN_PRODUCT_OVER_QQ",
+        },
+        summary="adversarial false matrix product",
+    )
+
+    rejected = authorized_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="matrix.result.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"result_uri": false_result.artifact_uri},
+        )
+    )
+
+    assert rejected.execution.status is ExecutionStatus.COMPLETED
+    assert rejected.output["status"] == "REJECTED"
+    assert rejected.output["conclusion"] == "UNKNOWN"
+    assert rejected.output["verification_record_uri"] is None
+    assert rejected.assurance.level is CapabilityAssuranceLevel.COMPUTED

--- a/tests/domain/matrix/test_matrix_lattice_domain.py
+++ b/tests/domain/matrix/test_matrix_lattice_domain.py
@@ -22,8 +22,10 @@ from jacobian.contracts.matrix_operations import (
     IntegerMatrix,
     IntegerMatrixRequest,
     LatticeReductionRequest,
+    MatrixProductResult,
     MatrixTraceResult,
     NullspaceResult,
+    RationalMatrixProductRequest,
     SquareIntegerMatrixRequest,
 )
 from jacobian.contracts.results import ExecutionStatus
@@ -85,6 +87,20 @@ def test_exact_matrix_domain_results_and_lineage(
             {
                 "trace": "5",
                 "convention": "SUM_OF_DIAGONAL_ENTRIES",
+            },
+        ),
+        (
+            "matrix.multiply.compute",
+            {
+                "left": _qq([[1, 2, 0], [0, 1, 1]]),
+                "right": _qq([[1, 0], [0, 1], [1, 1]]),
+            },
+            {
+                "product": _qq([[1, 2], [1, 2]]),
+                "left_rows": 2,
+                "inner_dimension": 3,
+                "right_columns": 2,
+                "convention": "STANDARD_ROW_BY_COLUMN_PRODUCT_OVER_QQ",
             },
         ),
         (
@@ -207,6 +223,65 @@ def test_rational_relation_intent_reuses_the_exact_nullspace_operation(
     }
 
 
+def test_matrix_multiplication_intent_is_discoverable(
+    matrix_domain_services: DomainTestServices,
+) -> None:
+    discovered = matrix_domain_services.core.capabilities.discover(
+        CapabilityDiscoveryRequest(
+            query=(
+                "multiply an exact matrix by itself and inspect whether its square "
+                "is zero"
+            ),
+            limit=5,
+        )
+    )
+
+    assert discovered.matches[0].capability_id == "matrix.multiply.compute"
+    assert discovered.matches[0].lexical_fit == "STRONG_CANDIDATE"
+    descriptor = next(
+        descriptor
+        for descriptor in matrix_domain_services.core.capabilities.catalog().capabilities
+        if descriptor.capability_id == "matrix.multiply.compute"
+    )
+    assert descriptor.invocation_examples[0].name == "multiply_rectangular_matrices"
+
+    result = matrix_domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id=descriptor.capability_id,
+            input=descriptor.invocation_examples[0].input,
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output["result"] == {
+        "product": _qq([[1, 2], [1, 2]]),
+        "left_rows": 2,
+        "inner_dimension": 3,
+        "right_columns": 2,
+        "convention": "STANDARD_ROW_BY_COLUMN_PRODUCT_OVER_QQ",
+    }
+
+
+def test_matrix_product_contracts_reject_incompatible_or_mismatched_shapes() -> None:
+    with raises(ValidationError, match="left column count"):
+        RationalMatrixProductRequest.model_validate(
+            {
+                "left": _qq([[1, 2]]),
+                "right": _qq([[1, 2]]),
+            }
+        )
+
+    with raises(ValidationError, match="product row count"):
+        MatrixProductResult.model_validate(
+            {
+                "product": _qq([[1, 2]]),
+                "left_rows": 2,
+                "inner_dimension": 1,
+                "right_columns": 2,
+            }
+        )
+
+
 def test_nullspace_result_enforces_rank_nullity() -> None:
     with raises(ValidationError, match="rank plus nullity"):
         NullspaceResult.model_validate(
@@ -237,6 +312,20 @@ def test_invalid_matrix_request_fails_before_operation_artifacts(
     assert result.execution.status is ExecutionStatus.ERROR
     assert result.diagnostics[0].code == "INVALID_EXACT_MATRIX_REQUEST"
     assert result.artifact_uris == ()
+
+    incompatible_product = runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="matrix.multiply.compute",
+            input={
+                "left": _qq([[1, 2]]),
+                "right": _qq([[1, 2]]),
+            },
+        )
+    )
+
+    assert incompatible_product.execution.status is ExecutionStatus.ERROR
+    assert incompatible_product.diagnostics[0].code == "INVALID_EXACT_MATRIX_REQUEST"
+    assert incompatible_product.artifact_uris == ()
 
 
 def test_singular_matrix_inverse_is_not_applicable(


### PR DESCRIPTION
## Summary

- add `matrix.multiply.compute@1`, a bounded exact row-by-column product over QQ with explicit shape binding and pre-computation cross-field validation
- expose self-product/matrix-square intent through discovery without adding a task-shaped square-zero capability or prescribing composition strategy
- add an operator-authorized independent Python-FLINT replay checker, with source/result size bounds and exact claim/semantics/candidate binding
- update the capability gap ledger for the public `matrix-square-zero-counterexample` reproduction while leaving held-out evaluation and a possible later power primitive as open obligations

## Portfolio audit and scope

An installed-catalog audit on `main@b7ace445` found no exact matrix product or power capability. The smaller fundamental primitive was selected: multiplication composes naturally to powers, while the present evidence for power comes from the same square-zero episode. This PR therefore deliberately defers `matrix.power.compute` pending broader evidence.

The new producer validates the complete Pydantic request, including `left.columns == right.rows`, before computation or artifact publication. It emits the exact product plus `left_rows`, `inner_dimension`, `right_columns`, and the `STANDARD_ROW_BY_COLUMN_PRODUCT_OVER_QQ` convention. Producer assurance remains capped at `COMPUTED`.

The checker imports neither SymPy nor producer implementation code. It independently replays the multiplication with Python-FLINT, verifies the exact result schema/key set, convention, shape binding, and all entries, and fails closed on malformed, mismatched, or oversized inputs/results. Tests cover false-entry, wrong-shape, binding, and oversized-source attacks.

## Final runtime snapshot

Exact tree: `00e65f486d3d23afa20d141b7a886385b2b7c41f`, rebased on `main@7319b7d9a49d3e472e70010cbdcb2e353b083211`.

- Jacobian package: `0.6.0a0`
- installed catalog: 297 capabilities, digest `sha256:a0e901dfa0af51006899eec10a6b006f6277d32633dec2b228d64d72275b02bd`
- policy: `DEFAULT`, digest `sha256:870a92b83d3e522e4015b6bb1cabda33086906f9de1c3c36e466251ea7ed1957`
- producer: SymPy `1.14.0`, digest `sha256:c41b6815a5dac02241976d7ae6fb15f657a80c1d0cd3bd4d461258f4b9ec2199`
- checker: `checker://sha256/108039f720235c2fc1e027b284ef925c12639134a58b344a93a3978b7b566362`
- independent replay runtime: Python-FLINT `0.9.0`, distribution digest `sha256:8ade9b4c5c1972b029d9393bb2586e2097cc44149a84ef8ef9ef376d634c328f`
- checker composite digest: `sha256:e43600cc4c7c2c25b66dc815f8ebfd500df02ce4d25684a2c5cdc432cc233325`

The query `exact square-zero matrix self-product matrix square` ranks `matrix.multiply.compute` first with `STRONG_CANDIDATE` fit. The public square-zero input completes with `COMPUTED`; `matrix.result.verify` independently returns `VERIFIED` / `TRUE`, and the verification record is included in `artifact_uris`.

## Validation

`make test-plan BASE=origin/main` selected the full repository gate because the gap-ledger JSON has no exact Python ownership mapping. The selected gate passed on the final rebased tree:

- unit: 647 passed
- component: 596 passed
- domain: 190 passed
- composition: 425 passed, 2 expected Lean skips
- storage: 101 passed
- process: 159 passed
- MCP: 21 passed
- provider: 154 passed, 7 expected optional-runtime skips
- e2e: 7 passed, 1 expected Lean skip
- Lean boundary: 31 passed, 28 expected runtime skips
- npm: 15 passed
- Ruff, format, complexity baseline, deptry, vulture, mypy, architecture, build, pip-audit, duplicate-code, and docs-linkcheck: passed

No model or Oracle run was performed, so this PR makes no causal model-performance claim. The implementation/checker handoff is complete; held-out evaluation remains the next evidence stage.
