### PR TITLE
feat(graph): add exact weighted MST

### DIFF
--- a/docs/reference/graph-minimum-spanning-tree.md
+++ b/docs/reference/graph-minimum-spanning-tree.md
@@ -1,0 +1,106 @@
+# Exact weighted minimum spanning tree
+
+[Documentation home](../index.md)
+
+`graph.spanning_tree.minimum.compute` returns one deterministic
+minimum-total-weight spanning tree of a bounded labelled simple graph with
+exact rational edge weights. The producer remains `COMPUTED`.
+When checker authority is installed,
+`graph.spanning_tree.minimum.verify` can promote one exact stored result to
+`VERIFIED` after independent connectivity, tree, arithmetic, and
+cycle-certificate replay.
+
+## Input and outcome
+
+The request contains at most 32 unique labelled vertices and at most 496
+simple undirected edges. Each undirected endpoint pair occurs at most once and
+has one reduced exact rational weight. Numerator and denominator components
+are limited to 256 decimal digits and the denominator is positive.
+
+For a connected nonempty graph the result contains:
+
+- the canonical vertex order and connected-component partition;
+- canonically oriented and sorted weighted tree edges;
+- their exact rational total weight; and
+- one fundamental-cycle check for every non-tree source edge.
+
+A disconnected graph returns `NO_SPANNING_TREE` with its complete component
+partition, no tree edges, and no total weight. The empty graph follows the same
+convention. A singleton graph is connected and has the exact empty tree of
+total weight zero.
+
+The producer inserts edges in exact `(weight, left endpoint, right endpoint)`
+order before calling NetworkX's maintained Kruskal implementation. This makes
+the selected witness deterministic under request edge orientation and order.
+Determinism chooses one optimum when ties exist; it does not claim uniqueness.
+
+## Optimality certificate
+
+For each non-tree edge \(e=uv\), the tree contains one unique \(u\)-to-\(v\)
+path. The result records that path, the source weight \(w(e)\), and the maximum
+tree-edge weight \(M_e\) on the path. The certificate requires
+
+\[
+w(e) \mathrel{\geq} M_e
+\]
+
+for every non-tree edge. If the inequality failed, replacing an edge attaining
+\(M_e\) by \(e\) would produce a lighter spanning tree. Conversely, the
+fundamental-cycle criterion for graphic matroid bases establishes that a
+spanning tree satisfying every recorded inequality is minimum weight.
+
+Certificate construction is untrusted. The producer cannot authorize its
+checker, and a contract-valid certificate is not `VERIFIED` until the
+operator-authorized replay succeeds.
+
+## Independent replay
+
+The checker imports neither NetworkX nor any Jacobian producer module. It uses
+only bounded Python standard-library data structures and `fractions.Fraction`.
+It independently parses the exact weighted graph, computes its connected
+components, checks tree membership and spanning connectivity, recomputes the
+total, reconstructs every unique tree path, and requires exact coverage of all
+non-tree source edges.
+
+| Obligation | Independent replay | Failure meaning |
+| --- | --- | --- |
+| Artifact binding | Recompute claim, semantics, candidate, lineage, witness-envelope, and payload bindings. | Reject this evidence; no mathematical conclusion. |
+| Weighted graph validity | Reject malformed labels, loops, undeclared endpoints, parallel undirected edges, noncanonical rationals, and values outside the declared bounds. | Reject malformed or unsupported evidence. |
+| Connectivity convention | Exhaust the supplied adjacency relation and compare the complete canonical component partition. | Reject a mismatched `EXACT` or `NO_SPANNING_TREE` outcome. |
+| Spanning-tree feasibility | Require exactly \(n-1\) distinct source edges and reach every source vertex. | Reject a non-tree candidate. |
+| Exact total | Sum the selected source weights with exact rational arithmetic. | Reject a forged total. |
+| Certificate coverage | Require one canonical check for every and only every non-tree source edge. | Reject missing, duplicated, or substituted checks. |
+| Cycle optimality | Independently reconstruct each tree path and its maximum edge weight, then check every non-improvement inequality. | Reject a feasible but nonminimum tree. |
+| Authorization and runtime | Dispatch only the operator-authorized checker matching the exact schemas, semantics, evidence format, source digest, and provider runtime. | Unavailable, timeout, cancellation, or error remains non-conclusive. |
+
+For a disconnected or empty graph, acceptance uses complete finite
+connectivity replay. For a connected result, acceptance uses a checked
+certificate. Every rejection returns `UNKNOWN`; it never identifies another
+tree as optimal.
+
+## Scope and remaining evidence
+
+One invocation covers only the supplied finite weighted graph. It does not
+certify a TSP tour, an approximation trace, a graph family, or an
+all-orders theorem. Exact bounded TSP remains a separate deferred capability.
+
+The public `metric-tsp-proof-repair` case motivated this fundamental primitive,
+but its answer is public and no model run was performed for this change. A
+held-out comparison across at least two independent weighted-graph families
+remains required before making a model-performance claim.
+
+## Capability-development handoff
+
+`stage=implementation/checker,status=complete`
+
+- Contract: `graph.spanning_tree.minimum.compute@1` and the optional
+  `graph.spanning_tree.minimum.verify` replay.
+- Provider: NetworkX constructs the tree over exact `Fraction` weights.
+- Assurance: the producer is capped at `COMPUTED`; only the independently
+  installed standard-library checker can return `VERIFIED`.
+- Failure semantics: malformed input is rejected before artifact writes;
+  disconnected and empty inputs return complete no-tree outcomes; checker
+  failure is non-conclusive.
+- Open obligation: run a frozen held-out control/treatment evaluation before
+  deciding portfolio benefit, and keep exact TSP deferred until independent
+  recurrence and checker evidence exist.

--- a/research/evaluations/capability-workflow-v1/gap-ledger.json
+++ b/research/evaluations/capability-workflow-v1/gap-ledger.json
@@ -403,18 +403,28 @@
           "capability_id": "graph.hamiltonian_path.decide",
           "availability": "AVAILABLE",
           "boundary": "Decides Hamiltonian path existence, not weighted tour optimality."
+        },
+        {
+          "capability_id": "graph.spanning_tree.minimum.compute",
+          "availability": "AVAILABLE",
+          "boundary": "Returns one deterministic exact rational minimum-weight spanning tree, its total weight, connected components, and complete fundamental-cycle optimality checks."
+        },
+        {
+          "capability_id": "graph.spanning_tree.minimum.verify",
+          "availability": "AVAILABLE",
+          "boundary": "Independently replays connectivity, tree feasibility, total weight, and the cycle-property certificate without NetworkX or producer imports."
         }
       ],
       "gap_classes": [
-        "MISSING_OPERATION"
+        "EXISTING_WORKS"
       ],
       "contamination": "PUBLIC_ANSWER_VISIBLE",
       "candidate_ids": [
         "weighted-minimum-spanning-tree",
         "bounded-metric-tsp-optimum"
       ],
-      "disposition": "ACCEPT_CANDIDATE",
-      "next_action": "Implement weighted MST first; keep exact bounded TSP deferred until independent recurrence is observed."
+      "disposition": "USE_EXISTING",
+      "next_action": "Evaluate the installed MST producer/checker on held-out weighted graph families; keep exact bounded TSP deferred until independent recurrence is observed."
     },
     {
       "task_id": "modular-cubic-obstruction",
@@ -840,7 +850,8 @@
       "subject": {
         "candidate_id": "weighted-minimum-spanning-tree",
         "capability_ids": [
-          "graph.spanning_tree.minimum.compute"
+          "graph.spanning_tree.minimum.compute",
+          "graph.spanning_tree.minimum.verify"
         ]
       },
       "evidence_refs": [
@@ -849,15 +860,16 @@
         },
         {
           "ref": "MCP capability.describe capture on 2026-07-31: spanning-tree count present, weighted minimum spanning tree absent"
+        },
+        {
+          "ref": "MCP capability.describe audit on main@ac4bd667: exact weighted MST queries returned only weak matches led by spanning-tree count"
         }
       ],
-      "contract_ref": "planned:graph.spanning_tree.minimum.compute",
+      "contract_ref": "capability:graph.spanning_tree.minimum.compute@1",
       "runtime_snapshot": "#/runtime_snapshot",
       "assurance": "DISCOVERY_EVIDENCE_ONLY",
       "open_obligations": [
-        "Freeze weighted labelled graph semantics, disconnected outcomes, parallel-edge policy, and deterministic tie handling.",
-        "Return an inspectable tree, total exact weight, scope, and optimality obligation at COMPUTED assurance.",
-        "Choose an independent bounded exhaustive or cut/cycle-certificate checker.",
+        "Measure whether the installed producer and cycle-certificate replay improve held-out weighted graph work without increasing false certification.",
         "Add a second independent held-out family before a benefit claim."
       ],
       "missing_evidence": [
@@ -865,7 +877,7 @@
         "No held-out comparative model run has been authorized or executed."
       ],
       "decision": "IMPLEMENT",
-      "next_action": "Use the fundamental graph-optimization exception to implement MST before any exact TSP capability.",
+      "next_action": "Freeze a held-out weighted-graph comparison for the MST delta; keep exact TSP deferred until recurrence and an independent checker boundary are established.",
       "move_episodes": [
         "metric-tsp-proof-repair"
       ],

--- a/src/jacobian/contracts/graph_optimization.py
+++ b/src/jacobian/contracts/graph_optimization.py
@@ -6,6 +6,7 @@ from typing import Literal, Self
 
 from pydantic import Field, StrictInt, model_validator
 
+from jacobian.contracts.exact import CanonicalRational
 from jacobian.contracts.graph_coloring import ChromaticGraph, GraphVertex
 from jacobian.contracts.results import ContractModel
 
@@ -18,6 +19,230 @@ OptimizationTermination = Literal[
     "SOLVER_UNKNOWN",
     "SPECIAL_CASE",
 ]
+MAX_GRAPH_WEIGHT_DIGITS = 256
+
+
+def _require_bounded_weight(value: CanonicalRational) -> None:
+    if (
+        len(value.num.lstrip("-")) > MAX_GRAPH_WEIGHT_DIGITS
+        or len(value.den) > MAX_GRAPH_WEIGHT_DIGITS
+    ):
+        raise ValueError(
+            f"graph weights are limited to {MAX_GRAPH_WEIGHT_DIGITS} decimal digits"
+        )
+
+
+class RationalWeightedEdge(ContractModel):
+    """One exact rational edge of a bounded simple undirected graph."""
+
+    endpoints: tuple[GraphVertex, GraphVertex]
+    weight: CanonicalRational
+
+    @model_validator(mode="after")
+    def require_distinct_endpoints_and_bounded_weight(self) -> Self:
+        if self.endpoints[0] == self.endpoints[1]:
+            raise ValueError("weighted graph edges must not contain self-loops")
+        _require_bounded_weight(self.weight)
+        return self
+
+
+class RationalWeightedGraph(ContractModel):
+    """A bounded labelled simple graph with one exact rational edge weight."""
+
+    weighted_graph_schema_version: Literal["1"] = "1"
+    vertices: tuple[GraphVertex, ...] = Field(max_length=32)
+    edges: tuple[RationalWeightedEdge, ...] = Field(max_length=496)
+
+    @model_validator(mode="after")
+    def require_simple_weighted_graph(self) -> Self:
+        vertex_set = set(self.vertices)
+        if len(vertex_set) != len(self.vertices):
+            raise ValueError("weighted graph vertices must be unique")
+        normalized_edges = {tuple(sorted(edge.endpoints)) for edge in self.edges}
+        if any(
+            endpoint not in vertex_set
+            for edge in self.edges
+            for endpoint in edge.endpoints
+        ):
+            raise ValueError("weighted graph edges must reference declared vertices")
+        if len(normalized_edges) != len(self.edges):
+            raise ValueError("weighted graph edges must be unique ignoring orientation")
+        return self
+
+
+class GraphMinimumSpanningTreeRequest(ContractModel):
+    """One complete exact minimum-spanning-tree request."""
+
+    graph: RationalWeightedGraph
+
+
+class CanonicalWeightedTreeEdge(ContractModel):
+    """One canonically oriented source edge selected for a spanning tree."""
+
+    endpoints: tuple[GraphVertex, GraphVertex]
+    weight: CanonicalRational
+
+    @model_validator(mode="after")
+    def require_canonical_edge(self) -> Self:
+        if self.endpoints[0] >= self.endpoints[1]:
+            raise ValueError(
+                "tree edge endpoints must be in strict lexicographic order"
+            )
+        _require_bounded_weight(self.weight)
+        return self
+
+
+class GraphMstCycleCheck(ContractModel):
+    """One non-tree edge's fundamental-cycle non-improvement check."""
+
+    non_tree_edge: tuple[GraphVertex, GraphVertex]
+    edge_weight: CanonicalRational
+    tree_path_vertices: tuple[GraphVertex, ...] = Field(
+        min_length=2,
+        max_length=32,
+    )
+    maximum_tree_path_weight: CanonicalRational
+    condition: Literal["EDGE_WEIGHT_GTE_MAXIMUM_TREE_PATH_WEIGHT"] = (
+        "EDGE_WEIGHT_GTE_MAXIMUM_TREE_PATH_WEIGHT"
+    )
+
+    @model_validator(mode="after")
+    def require_canonical_cycle_check(self) -> Self:
+        if self.non_tree_edge[0] >= self.non_tree_edge[1]:
+            raise ValueError(
+                "non-tree edge endpoints must be in strict lexicographic order"
+            )
+        if (
+            self.tree_path_vertices[0] != self.non_tree_edge[0]
+            or self.tree_path_vertices[-1] != self.non_tree_edge[1]
+            or len(set(self.tree_path_vertices)) != len(self.tree_path_vertices)
+        ):
+            raise ValueError(
+                "tree path must be simple and join the non-tree edge endpoints"
+            )
+        _require_bounded_weight(self.edge_weight)
+        _require_bounded_weight(self.maximum_tree_path_weight)
+        return self
+
+
+class GraphMstOptimalityCertificate(ContractModel):
+    """Inspectable cycle-property certificate for one selected tree."""
+
+    certificate_schema_version: Literal["1"] = "1"
+    method: Literal["ALL_FUNDAMENTAL_CYCLES_NON_IMPROVING"] = (
+        "ALL_FUNDAMENTAL_CYCLES_NON_IMPROVING"
+    )
+    checks: tuple[GraphMstCycleCheck, ...] = Field(max_length=496)
+    required_checks: tuple[
+        Literal[
+            "SOURCE_CONNECTIVITY",
+            "TREE_SPANNING_ACYCLIC",
+            "TOTAL_WEIGHT_EXACT",
+            "ALL_NON_TREE_EDGES_COVERED",
+            "CYCLE_NON_IMPROVEMENT",
+        ],
+        ...,
+    ] = (
+        "SOURCE_CONNECTIVITY",
+        "TREE_SPANNING_ACYCLIC",
+        "TOTAL_WEIGHT_EXACT",
+        "ALL_NON_TREE_EDGES_COVERED",
+        "CYCLE_NON_IMPROVEMENT",
+    )
+
+    @model_validator(mode="after")
+    def require_canonical_check_order(self) -> Self:
+        edges = tuple(check.non_tree_edge for check in self.checks)
+        if edges != tuple(sorted(edges)) or len(edges) != len(set(edges)):
+            raise ValueError(
+                "cycle checks must cover unique canonically sorted non-tree edges"
+            )
+        return self
+
+
+class GraphMinimumSpanningTreeResult(ContractModel):
+    """Complete weighted spanning-tree outcome on the supplied finite graph."""
+
+    result_schema_version: Literal["1"] = "1"
+    status: Literal["EXACT", "NO_SPANNING_TREE"]
+    vertices: tuple[GraphVertex, ...] = Field(max_length=32)
+    order: StrictInt = Field(ge=0, le=32)
+    connected: bool
+    component_count: StrictInt = Field(ge=0, le=32)
+    components: tuple[tuple[GraphVertex, ...], ...] = Field(max_length=32)
+    tree_edges: tuple[CanonicalWeightedTreeEdge, ...] = Field(max_length=31)
+    total_weight: CanonicalRational | None = None
+    optimality_certificate: GraphMstOptimalityCertificate
+    convention: Literal[
+        "MINIMUM_TOTAL_EDGE_WEIGHT_OVER_QQ_EMPTY_GRAPH_HAS_NO_SPANNING_TREE"
+    ] = "MINIMUM_TOTAL_EDGE_WEIGHT_OVER_QQ_EMPTY_GRAPH_HAS_NO_SPANNING_TREE"
+    completion: Literal["COMPLETE"] = "COMPLETE"
+
+    @model_validator(mode="after")
+    def require_canonical_partition(self) -> Self:
+        if (
+            self.vertices != tuple(sorted(self.vertices))
+            or len(self.vertices) != len(set(self.vertices))
+            or self.order != len(self.vertices)
+        ):
+            raise ValueError("result vertices must be unique and canonically sorted")
+        if self.component_count != len(self.components):
+            raise ValueError("component count must match the component partition")
+        if any(
+            not component
+            or component != tuple(sorted(component))
+            or len(component) != len(set(component))
+            for component in self.components
+        ):
+            raise ValueError(
+                "components must be nonempty sets in canonical vertex order"
+            )
+        if self.components != tuple(
+            sorted(self.components, key=lambda component: component[0])
+        ):
+            raise ValueError("components must be canonically ordered")
+        partition = tuple(
+            sorted(vertex for component in self.components for vertex in component)
+        )
+        if partition != self.vertices:
+            raise ValueError("components must partition the result vertices")
+        return self
+
+    @model_validator(mode="after")
+    def bind_tree_and_status(self) -> Self:
+        tree_endpoints = tuple(edge.endpoints for edge in self.tree_edges)
+        if tree_endpoints != tuple(sorted(tree_endpoints)) or len(
+            tree_endpoints
+        ) != len(set(tree_endpoints)):
+            raise ValueError("tree edges must be unique and canonically sorted")
+        if any(
+            endpoint not in set(self.vertices)
+            for edge in self.tree_edges
+            for endpoint in edge.endpoints
+        ):
+            raise ValueError("tree edges must reference result vertices")
+        if self.status == "EXACT":
+            if (
+                not self.vertices
+                or not self.connected
+                or self.component_count != 1
+                or len(self.tree_edges) != self.order - 1
+                or self.total_weight is None
+            ):
+                raise ValueError(
+                    "exact MST result requires a connected nonempty spanning tree"
+                )
+        elif (
+            self.connected
+            or self.component_count == 1
+            or self.tree_edges
+            or self.total_weight is not None
+            or self.optimality_certificate.checks
+        ):
+            raise ValueError(
+                "no-spanning-tree result must expose only the disconnected partition"
+            )
+        return self
 
 
 class GraphOptimizationBudget(ContractModel):

--- a/src/jacobian/domains/graph_optimization/bundle.py
+++ b/src/jacobian/domains/graph_optimization/bundle.py
@@ -18,6 +18,9 @@ from jacobian.domains.graph_optimization.hamiltonian_path import (
 from jacobian.domains.graph_optimization.invariants import (
     BOUNDED_GRAPH_INVARIANT_CAPABILITIES,
 )
+from jacobian.domains.graph_optimization.minimum_spanning_tree import (
+    MINIMUM_SPANNING_TREE_CAPABILITY,
+)
 from jacobian.operations import (
     DomainBundle,
     DomainDiagnostics,
@@ -53,6 +56,10 @@ def build_graph_optimization_bundle() -> DomainBundle:
                     "finite optimizers also bind max_order and max_solver_calls"
                 ),
                 "conventions": {
+                    "minimum_spanning_tree": (
+                        "minimum total exact rational edge weight; empty and "
+                        "disconnected graphs have no spanning tree"
+                    ),
                     "domination": "ordinary closed-neighborhood domination",
                     "saturation_number": "minimum cardinality maximal matching",
                     "induced_forest": "empty induced graph allowed",
@@ -69,6 +76,14 @@ def build_graph_optimization_bundle() -> DomainBundle:
                 "timeout_or_cancellation": (
                     "UNKNOWN partial result with preserved bounds and tested obligations"
                 ),
+                "minimum_spanning_tree_certificate": (
+                    "every non-tree edge is no lighter than the maximum-weight "
+                    "edge on its fundamental tree path"
+                ),
+                "minimum_spanning_tree_ties": (
+                    "canonical weight-and-endpoint edge insertion before maintained "
+                    "Kruskal selection"
+                ),
                 "assurance": "computed; incomplete search is never a conclusion",
             },
         ),
@@ -81,7 +96,11 @@ def build_graph_optimization_bundle() -> DomainBundle:
                 ),
                 known_provider_runtime(
                     "jacobian.networkx",
-                    features=("graph-witness-validation", "graph-approximations"),
+                    features=(
+                        "graph-witness-validation",
+                        "graph-approximations",
+                        "exact-rational-minimum-spanning-tree",
+                    ),
                 ),
                 known_provider_runtime(
                     "jacobian.sympy",
@@ -91,6 +110,7 @@ def build_graph_optimization_bundle() -> DomainBundle:
             features=(
                 "bounded-k-colorability",
                 "finite-graph-optimization",
+                "exact-rational-minimum-spanning-tree",
                 "timeout-aware",
             ),
         ),
@@ -102,6 +122,7 @@ def build_graph_optimization_bundle() -> DomainBundle:
             CHROMATIC_NUMBER_CAPABILITY,
             *FINITE_GRAPH_OPTIMIZATION_CAPABILITIES,
             HAMILTONIAN_PATH_CAPABILITY,
+            MINIMUM_SPANNING_TREE_CAPABILITY,
             *BOUNDED_GRAPH_INVARIANT_CAPABILITIES,
         ),
         diagnostics=DomainDiagnostics(

--- a/src/jacobian/domains/graph_optimization/checkers.py
+++ b/src/jacobian/domains/graph_optimization/checkers.py
@@ -4,6 +4,7 @@ from jacobian.checker_operations import ExactReplayCheckerDeclaration
 from jacobian.contracts.graph_invariant_operations import GraphInvariantRequest
 from jacobian.contracts.graph_optimization import (
     GraphHamiltonianPathRequest,
+    GraphMinimumSpanningTreeRequest,
     GraphOptimizationRequest,
 )
 
@@ -52,6 +53,33 @@ GRAPH_OPTIMIZATION_EXACT_REPLAY_CHECKERS = (
             "exact maximum induced-tree result and its graph binding."
         ),
         verification_tags=("verification", "exact", "graph", "induced-tree"),
+    ),
+    ExactReplayCheckerDeclaration(
+        "graph.spanning_tree.minimum.compute",
+        GraphMinimumSpanningTreeRequest,
+        "check_graph_minimum_spanning_tree",
+        "graph.minimum-spanning-tree.cycle-certificate-v1",
+        entrypoint_module=_GRAPH_ENTRYPOINT,
+        replay_method="fundamental-cycle optimality certificate replay",
+        reason=(
+            "operator-authorized standard-library exact-rational checker "
+            "independent of the NetworkX Kruskal producer"
+        ),
+        verification_capability_id="graph.spanning_tree.minimum.verify",
+        verification_title="Verify a weighted minimum spanning tree",
+        verification_description=(
+            "Independently verify source connectivity, spanning-tree feasibility, "
+            "exact total weight, and every fundamental-cycle non-improvement check "
+            "for one stored exact rational weighted-graph result."
+        ),
+        verification_tags=(
+            "verification",
+            "exact",
+            "graph",
+            "weighted-graph",
+            "minimum-spanning-tree",
+            "cycle-property",
+        ),
     ),
     ExactReplayCheckerDeclaration(
         "graph.invariant.diameter.compute",
@@ -156,8 +184,8 @@ GRAPH_OPTIMIZATION_EXACT_REPLAY_CHECKERS = (
     ),
 )
 
-GRAPH_SEARCH_EXACT_REPLAY_CHECKERS = GRAPH_OPTIMIZATION_EXACT_REPLAY_CHECKERS[:2]
-GRAPH_INVARIANT_EXACT_REPLAY_CHECKERS = GRAPH_OPTIMIZATION_EXACT_REPLAY_CHECKERS[2:]
+GRAPH_SEARCH_EXACT_REPLAY_CHECKERS = GRAPH_OPTIMIZATION_EXACT_REPLAY_CHECKERS[:3]
+GRAPH_INVARIANT_EXACT_REPLAY_CHECKERS = GRAPH_OPTIMIZATION_EXACT_REPLAY_CHECKERS[3:]
 
 __all__ = [
     "GRAPH_INVARIANT_EXACT_REPLAY_CHECKERS",

--- a/src/jacobian/domains/graph_optimization/minimum_spanning_tree.py
+++ b/src/jacobian/domains/graph_optimization/minimum_spanning_tree.py
@@ -1,0 +1,252 @@
+"""Exact rational minimum-spanning-tree computation."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from typing import TYPE_CHECKING
+
+from jacobian.contracts.capabilities import (
+    CapabilityDiagnostic,
+    CapabilityInvocationExample,
+    CapabilityMode,
+)
+from jacobian.contracts.exact import CanonicalRational
+from jacobian.contracts.graph_optimization import (
+    CanonicalWeightedTreeEdge,
+    GraphMinimumSpanningTreeRequest,
+    GraphMinimumSpanningTreeResult,
+    GraphMstCycleCheck,
+    GraphMstOptimalityCertificate,
+)
+from jacobian.operations import (
+    ComputedNotApplicable,
+    ComputedOperation,
+    ComputedOutcome,
+    ComputedSuccess,
+)
+
+if TYPE_CHECKING:
+    import networkx as nx
+
+_INVALID_REQUEST = CapabilityDiagnostic(
+    code="INVALID_MINIMUM_SPANNING_TREE_REQUEST",
+    stage="minimum_spanning_tree_input_validation",
+    message=(
+        "Input does not satisfy the bounded exact rational weighted-graph contract."
+    ),
+    hint=(
+        "Supply at most 32 unique labelled vertices and at most one exact rational "
+        "weight for each simple undirected edge."
+    ),
+)
+
+
+def _rational(value: Fraction) -> CanonicalRational:
+    return CanonicalRational(num=str(value.numerator), den=str(value.denominator))
+
+
+def _canonical_endpoints(left: str, right: str) -> tuple[str, str]:
+    return (left, right) if left < right else (right, left)
+
+
+def _canonical_components(graph: nx.Graph[str]) -> tuple[tuple[str, ...], ...]:
+    import networkx as nx
+
+    return tuple(
+        sorted(
+            (tuple(sorted(component)) for component in nx.connected_components(graph)),
+            key=lambda component: component[0],
+        )
+    )
+
+
+def compute_minimum_spanning_tree(
+    request: GraphMinimumSpanningTreeRequest,
+) -> GraphMinimumSpanningTreeResult:
+    """Compute one deterministic exact MST and its cycle-property certificate."""
+
+    import networkx as nx
+
+    graph: nx.Graph[str] = nx.Graph()
+    graph.add_nodes_from(sorted(request.graph.vertices))
+    ordered_edges = sorted(
+        request.graph.edges,
+        key=lambda edge: (
+            edge.weight.as_fraction(),
+            *_canonical_endpoints(*edge.endpoints),
+        ),
+    )
+    source_weights: dict[tuple[str, str], Fraction] = {}
+    for edge in ordered_edges:
+        endpoints = _canonical_endpoints(*edge.endpoints)
+        weight = edge.weight.as_fraction()
+        source_weights[endpoints] = weight
+        graph.add_edge(*endpoints, weight=weight)
+
+    vertices = tuple(sorted(graph))
+    components = _canonical_components(graph)
+    if not vertices or len(components) != 1:
+        return GraphMinimumSpanningTreeResult(
+            status="NO_SPANNING_TREE",
+            vertices=vertices,
+            order=len(vertices),
+            connected=False,
+            component_count=len(components),
+            components=components,
+            tree_edges=(),
+            total_weight=None,
+            optimality_certificate=GraphMstOptimalityCertificate(checks=()),
+        )
+
+    tree: nx.Graph[str] = nx.minimum_spanning_tree(
+        graph,
+        algorithm="kruskal",
+        weight="weight",
+    )
+    selected = {
+        _canonical_endpoints(str(left), str(right)) for left, right in tree.edges
+    }
+    tree_edges = tuple(
+        CanonicalWeightedTreeEdge(
+            endpoints=endpoints,
+            weight=_rational(source_weights[endpoints]),
+        )
+        for endpoints in sorted(selected)
+    )
+    checks: list[GraphMstCycleCheck] = []
+    for endpoints in sorted(set(source_weights) - selected):
+        left, right = endpoints
+        path = tuple(nx.shortest_path(tree, left, right))
+        path_weights = tuple(
+            source_weights[_canonical_endpoints(path[index], path[index + 1])]
+            for index in range(len(path) - 1)
+        )
+        maximum_path_weight = max(path_weights)
+        if source_weights[endpoints] < maximum_path_weight:
+            raise RuntimeError(
+                "maintained MST backend returned a cycle-improvable spanning tree"
+            )
+        checks.append(
+            GraphMstCycleCheck(
+                non_tree_edge=endpoints,
+                edge_weight=_rational(source_weights[endpoints]),
+                tree_path_vertices=path,
+                maximum_tree_path_weight=_rational(maximum_path_weight),
+            )
+        )
+    return GraphMinimumSpanningTreeResult(
+        status="EXACT",
+        vertices=vertices,
+        order=len(vertices),
+        connected=True,
+        component_count=1,
+        components=components,
+        tree_edges=tree_edges,
+        total_weight=_rational(
+            sum(
+                (source_weights[edge.endpoints] for edge in tree_edges),
+                start=Fraction(),
+            )
+        ),
+        optimality_certificate=GraphMstOptimalityCertificate(checks=tuple(checks)),
+    )
+
+
+def _execute(
+    request: GraphMinimumSpanningTreeRequest,
+) -> ComputedOutcome[GraphMinimumSpanningTreeResult]:
+    import networkx as nx
+
+    try:
+        return ComputedSuccess(compute_minimum_spanning_tree(request))
+    except (
+        ArithmeticError,
+        nx.NetworkXError,
+        RuntimeError,
+        TypeError,
+        ValueError,
+    ) as exc:
+        return ComputedNotApplicable(
+            CapabilityDiagnostic(
+                code="MINIMUM_SPANNING_TREE_NOT_APPLICABLE",
+                stage="minimum_spanning_tree_computation",
+                message=str(exc),
+                hint=(
+                    "Check the finite simple weighted-graph contract and exact "
+                    "rational edge weights."
+                ),
+            )
+        )
+
+
+MINIMUM_SPANNING_TREE_CAPABILITY: ComputedOperation[
+    GraphMinimumSpanningTreeRequest,
+    GraphMinimumSpanningTreeResult,
+] = ComputedOperation(
+    capability_id="graph.spanning_tree.minimum.compute",
+    title="Exact weighted minimum spanning tree",
+    description=(
+        "Compute one deterministic minimum-total-weight spanning tree of a bounded "
+        "labelled simple graph over exact rational edge weights. Return the selected "
+        "weighted edges, exact total, connected components, and all fundamental-cycle "
+        "non-improvement checks; disconnected or empty inputs return a complete "
+        "NO_SPANNING_TREE outcome."
+    ),
+    request_model=GraphMinimumSpanningTreeRequest,
+    result_model=GraphMinimumSpanningTreeResult,
+    implementation=_execute,
+    relation_id="graph.spanning_tree.minimum.relation",
+    tags=(
+        "graph",
+        "weighted-graph",
+        "minimum-spanning-tree",
+        "mst",
+        "spanning-tree",
+        "minimum-weight",
+        "exact-rational",
+        "cycle-property",
+    ),
+    invalid_request=_INVALID_REQUEST,
+    invocation_examples=(
+        CapabilityInvocationExample(
+            name="four_vertex_weighted_graph",
+            description=(
+                "Compute an exact minimum spanning tree and its cycle checks."
+            ),
+            mode=CapabilityMode.EXPLORE,
+            input={
+                "graph": {
+                    "vertices": ["a", "b", "c", "d"],
+                    "edges": [
+                        {
+                            "endpoints": ["a", "b"],
+                            "weight": {"num": "1", "den": "1"},
+                        },
+                        {
+                            "endpoints": ["b", "c"],
+                            "weight": {"num": "2", "den": "1"},
+                        },
+                        {
+                            "endpoints": ["c", "d"],
+                            "weight": {"num": "3", "den": "1"},
+                        },
+                        {
+                            "endpoints": ["a", "d"],
+                            "weight": {"num": "5", "den": "1"},
+                        },
+                        {
+                            "endpoints": ["a", "c"],
+                            "weight": {"num": "7", "den": "2"},
+                        },
+                    ],
+                }
+            },
+        ),
+    ),
+)
+
+
+__all__ = [
+    "MINIMUM_SPANNING_TREE_CAPABILITY",
+    "compute_minimum_spanning_tree",
+]

--- a/src/jacobian_checkers/graph_exact_operations.py
+++ b/src/jacobian_checkers/graph_exact_operations.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import re
 from collections import deque
 from collections.abc import Callable
+from fractions import Fraction
 from functools import cache
 from itertools import combinations, pairwise
-from typing import Any
+from typing import Any, cast
 
 from jacobian_checkers.bound_artifacts import bound_request
 
@@ -115,6 +117,387 @@ def _finite_simple_graph(
         adjacency[left].add(right)
         adjacency[right].add(left)
     return tuple(vertices), normalized_edges, adjacency
+
+
+def _parse_graph_rational(payload: object) -> Fraction:
+    if not isinstance(payload, dict) or set(payload) != {"num", "den"}:
+        raise ValueError("graph weight is malformed")
+    numerator = payload["num"]
+    denominator = payload["den"]
+    if (
+        not isinstance(numerator, str)
+        or not isinstance(denominator, str)
+        or len(numerator.lstrip("-")) > 256
+        or len(denominator) > 256
+        or re.fullmatch(r"(?:0|-?[1-9][0-9]*)", numerator) is None
+        or re.fullmatch(r"[1-9][0-9]*", denominator) is None
+    ):
+        raise ValueError("graph weight lies outside the checker scope")
+    value = Fraction(int(numerator), int(denominator))
+    if str(value.numerator) != numerator or str(value.denominator) != denominator:
+        raise ValueError("graph weight is not canonical")
+    return value
+
+
+def _parse_weighted_edge(
+    raw_edge: object,
+    vertex_set: set[str],
+) -> tuple[tuple[str, str], Fraction]:
+    if not isinstance(raw_edge, dict) or set(raw_edge) != {"endpoints", "weight"}:
+        raise ValueError("weighted edge is malformed")
+    endpoints = raw_edge["endpoints"]
+    if (
+        not isinstance(endpoints, list)
+        or len(endpoints) != 2
+        or not all(isinstance(endpoint, str) for endpoint in endpoints)
+        or endpoints[0] == endpoints[1]
+        or endpoints[0] not in vertex_set
+        or endpoints[1] not in vertex_set
+    ):
+        raise ValueError("weighted edge endpoints are malformed")
+    return _canonical_edge(endpoints[0], endpoints[1]), _parse_graph_rational(
+        raw_edge["weight"]
+    )
+
+
+def _finite_weighted_graph(
+    source: dict[str, Any],
+) -> tuple[
+    tuple[str, ...],
+    dict[tuple[str, str], Fraction],
+    dict[str, set[str]],
+]:
+    if set(source) != {"graph"}:
+        raise ValueError("weighted graph request is malformed")
+    graph = source["graph"]
+    if not isinstance(graph, dict) or set(graph) != {
+        "weighted_graph_schema_version",
+        "vertices",
+        "edges",
+    }:
+        raise ValueError("weighted graph input is malformed")
+    vertices = graph["vertices"]
+    raw_edges = graph["edges"]
+    if (
+        graph["weighted_graph_schema_version"] != "1"
+        or not isinstance(vertices, list)
+        or len(vertices) > 32
+        or len(vertices) != len(set(vertices))
+        or not all(
+            isinstance(vertex, str) and 0 < len(vertex) <= 256 for vertex in vertices
+        )
+        or not isinstance(raw_edges, list)
+        or len(raw_edges) > len(vertices) * (len(vertices) - 1) // 2
+    ):
+        raise ValueError("weighted graph lies outside the checker scope")
+    vertex_set = set(vertices)
+    weights = dict(_parse_weighted_edge(raw_edge, vertex_set) for raw_edge in raw_edges)
+    if len(weights) != len(raw_edges):
+        raise ValueError("weighted graph contains parallel undirected edges")
+    adjacency = {vertex: set[str]() for vertex in vertices}
+    for left, right in weights:
+        adjacency[left].add(right)
+        adjacency[right].add(left)
+    return tuple(vertices), weights, adjacency
+
+
+def _component_partition(
+    vertices: tuple[str, ...],
+    adjacency: dict[str, set[str]],
+) -> tuple[tuple[str, ...], ...]:
+    unseen = set(vertices)
+    components: list[tuple[str, ...]] = []
+    while unseen:
+        root = min(unseen)
+        unseen.remove(root)
+        component = {root}
+        frontier = [root]
+        while frontier:
+            current = frontier.pop()
+            for neighbor in adjacency[current] & unseen:
+                unseen.remove(neighbor)
+                component.add(neighbor)
+                frontier.append(neighbor)
+        components.append(tuple(sorted(component)))
+    return tuple(sorted(components, key=lambda component: component[0]))
+
+
+def _fraction_payload(value: Fraction) -> dict[str, str]:
+    return {"num": str(value.numerator), "den": str(value.denominator)}
+
+
+def _no_spanning_tree_payload(
+    vertices: tuple[str, ...],
+    components: tuple[tuple[str, ...], ...],
+) -> dict[str, Any]:
+    return {
+        "result_schema_version": "1",
+        "status": "NO_SPANNING_TREE",
+        "vertices": sorted(vertices),
+        "order": len(vertices),
+        "connected": False,
+        "component_count": len(components),
+        "components": [list(component) for component in components],
+        "tree_edges": [],
+        "total_weight": None,
+        "optimality_certificate": {
+            "certificate_schema_version": "1",
+            "method": "ALL_FUNDAMENTAL_CYCLES_NON_IMPROVING",
+            "checks": [],
+            "required_checks": [
+                "SOURCE_CONNECTIVITY",
+                "TREE_SPANNING_ACYCLIC",
+                "TOTAL_WEIGHT_EXACT",
+                "ALL_NON_TREE_EDGES_COVERED",
+                "CYCLE_NON_IMPROVEMENT",
+            ],
+        },
+        "convention": (
+            "MINIMUM_TOTAL_EDGE_WEIGHT_OVER_QQ_EMPTY_GRAPH_HAS_NO_SPANNING_TREE"
+        ),
+        "completion": "COMPLETE",
+    }
+
+
+def _parse_tree_edges(
+    raw_edges: object,
+    source_weights: dict[tuple[str, str], Fraction],
+    order: int,
+) -> tuple[
+    dict[tuple[str, str], Fraction],
+    dict[str, dict[str, Fraction]],
+]:
+    if not isinstance(raw_edges, list) or len(raw_edges) != order - 1:
+        raise ValueError("declared tree has the wrong edge count")
+    tree_weights: dict[tuple[str, str], Fraction] = {}
+    declared_endpoints: list[tuple[str, str]] = []
+    for raw_edge in raw_edges:
+        if not isinstance(raw_edge, dict) or set(raw_edge) != {
+            "endpoints",
+            "weight",
+        }:
+            raise ValueError("declared tree edge is malformed")
+        endpoints = raw_edge["endpoints"]
+        if (
+            not isinstance(endpoints, list)
+            or len(endpoints) != 2
+            or not all(isinstance(endpoint, str) for endpoint in endpoints)
+            or endpoints[0] >= endpoints[1]
+        ):
+            raise ValueError("declared tree edge orientation is not canonical")
+        edge = (endpoints[0], endpoints[1])
+        if edge not in source_weights or raw_edge["weight"] != _fraction_payload(
+            source_weights[edge]
+        ):
+            raise ValueError("declared tree edge does not match the source graph")
+        declared_endpoints.append(edge)
+        tree_weights[edge] = source_weights[edge]
+    if declared_endpoints != sorted(declared_endpoints) or len(tree_weights) != len(
+        raw_edges
+    ):
+        raise ValueError("declared tree edges are not unique and canonical")
+    adjacency: dict[str, dict[str, Fraction]] = {}
+    for (left, right), weight in tree_weights.items():
+        adjacency.setdefault(left, {})[right] = weight
+        adjacency.setdefault(right, {})[left] = weight
+    return tree_weights, adjacency
+
+
+def _tree_reaches_every_vertex(
+    vertices: tuple[str, ...],
+    adjacency: dict[str, dict[str, Fraction]],
+) -> bool:
+    reached = {vertices[0]}
+    frontier = [vertices[0]]
+    while frontier:
+        current = frontier.pop()
+        for neighbor in adjacency.get(current, {}):
+            if neighbor not in reached:
+                reached.add(neighbor)
+                frontier.append(neighbor)
+    return reached == set(vertices)
+
+
+def _tree_path(
+    adjacency: dict[str, dict[str, Fraction]],
+    source: str,
+    target: str,
+) -> tuple[str, ...]:
+    predecessor: dict[str, str | None] = {source: None}
+    frontier = deque([source])
+    while frontier and target not in predecessor:
+        current = frontier.popleft()
+        for neighbor in sorted(adjacency.get(current, {})):
+            if neighbor not in predecessor:
+                predecessor[neighbor] = current
+                frontier.append(neighbor)
+    if target not in predecessor:
+        raise ValueError("declared tree does not join a source edge's endpoints")
+    reversed_path = [target]
+    while predecessor[reversed_path[-1]] is not None:
+        reversed_path.append(cast(str, predecessor[reversed_path[-1]]))
+    return tuple(reversed(reversed_path))
+
+
+def _expected_mst_certificate(
+    source_weights: dict[tuple[str, str], Fraction],
+    tree_weights: dict[tuple[str, str], Fraction],
+    tree_adjacency: dict[str, dict[str, Fraction]],
+) -> dict[str, Any] | None:
+    checks: list[dict[str, Any]] = []
+    for edge in sorted(set(source_weights) - set(tree_weights)):
+        path = _tree_path(tree_adjacency, *edge)
+        maximum = max(
+            tree_adjacency[path[index]][path[index + 1]]
+            for index in range(len(path) - 1)
+        )
+        if source_weights[edge] < maximum:
+            return None
+        checks.append(
+            {
+                "non_tree_edge": list(edge),
+                "edge_weight": _fraction_payload(source_weights[edge]),
+                "tree_path_vertices": list(path),
+                "maximum_tree_path_weight": _fraction_payload(maximum),
+                "condition": "EDGE_WEIGHT_GTE_MAXIMUM_TREE_PATH_WEIGHT",
+            }
+        )
+    return {
+        "certificate_schema_version": "1",
+        "method": "ALL_FUNDAMENTAL_CYCLES_NON_IMPROVING",
+        "checks": checks,
+        "required_checks": [
+            "SOURCE_CONNECTIVITY",
+            "TREE_SPANNING_ACYCLIC",
+            "TOTAL_WEIGHT_EXACT",
+            "ALL_NON_TREE_EDGES_COVERED",
+            "CYCLE_NON_IMPROVEMENT",
+        ],
+    }
+
+
+def _connected_mst_result(
+    result: dict[str, Any],
+    *,
+    vertices: tuple[str, ...],
+    components: tuple[tuple[str, ...], ...],
+    source_weights: dict[tuple[str, str], Fraction],
+) -> bool:
+    if (
+        set(result)
+        != {
+            "result_schema_version",
+            "status",
+            "vertices",
+            "order",
+            "connected",
+            "component_count",
+            "components",
+            "tree_edges",
+            "total_weight",
+            "optimality_certificate",
+            "convention",
+            "completion",
+        }
+        or result["result_schema_version"] != "1"
+        or result["status"] != "EXACT"
+        or result["vertices"] != sorted(vertices)
+        or result["order"] != len(vertices)
+        or result["connected"] is not True
+        or result["component_count"] != 1
+        or result["components"] != [list(component) for component in components]
+        or result["convention"]
+        != ("MINIMUM_TOTAL_EDGE_WEIGHT_OVER_QQ_EMPTY_GRAPH_HAS_NO_SPANNING_TREE")
+        or result["completion"] != "COMPLETE"
+    ):
+        return False
+    tree_weights, tree_adjacency = _parse_tree_edges(
+        result["tree_edges"],
+        source_weights,
+        len(vertices),
+    )
+    if not _tree_reaches_every_vertex(vertices, tree_adjacency):
+        return False
+    if result["total_weight"] != _fraction_payload(
+        sum(tree_weights.values(), start=Fraction())
+    ):
+        return False
+    certificate = _expected_mst_certificate(
+        source_weights,
+        tree_weights,
+        tree_adjacency,
+    )
+    return certificate is not None and result["optimality_certificate"] == certificate
+
+
+def _minimum_spanning_tree(
+    source: dict[str, Any],
+    result: dict[str, Any],
+) -> bool:
+    vertices, source_weights, adjacency = _finite_weighted_graph(source)
+    components = _component_partition(vertices, adjacency)
+    if not vertices or len(components) != 1:
+        return result == _no_spanning_tree_payload(vertices, components)
+    return _connected_mst_result(
+        result,
+        vertices=vertices,
+        components=components,
+        source_weights=source_weights,
+    )
+
+
+def _mst_decision(
+    *,
+    accepted: bool,
+    detail: str,
+    disconnected: bool = False,
+) -> dict[str, Any]:
+    return {
+        "accepted": accepted,
+        "conclusion": "TRUE" if accepted else "UNKNOWN",
+        "arithmetic": "EXACT_RATIONAL",
+        "method": "EXHAUSTIVE_FINITE" if disconnected else "CHECKED_CERTIFICATE",
+        "coverage": "EXHAUSTIVE" if disconnected else "NOT_APPLICABLE",
+        "detail": detail,
+    }
+
+
+def check_graph_minimum_spanning_tree(
+    request: dict[str, Any],
+) -> dict[str, Any]:
+    try:
+        source, result = bound_request(
+            request,
+            operation_id="graph.spanning_tree.minimum.compute",
+            witness_format="graph.minimum-spanning-tree.cycle-certificate-v1",
+        )
+        if not _minimum_spanning_tree(source, result):
+            return _mst_decision(
+                accepted=False,
+                detail=(
+                    "declared result does not match independent exact rational "
+                    "spanning-tree and cycle-certificate replay"
+                ),
+            )
+        disconnected = result.get("status") == "NO_SPANNING_TREE"
+        return _mst_decision(
+            accepted=True,
+            disconnected=disconnected,
+            detail=(
+                "independent finite connectivity replay accepted "
+                "graph.spanning_tree.minimum.compute"
+                if disconnected
+                else (
+                    "independent fundamental-cycle optimality certificate replay "
+                    "accepted graph.spanning_tree.minimum.compute"
+                )
+            ),
+        )
+    except (KeyError, TypeError, ValueError, OverflowError):
+        return _mst_decision(
+            accepted=False,
+            detail="malformed, unsupported, or mismatched checker request",
+        )
 
 
 def _all_sources_distance_rows(
@@ -813,6 +1196,7 @@ __all__ = [
     "check_graph_hamiltonian_path",
     "check_graph_induced_tree_maximum",
     "check_graph_maximum_matching",
+    "check_graph_minimum_spanning_tree",
     "check_graph_radius",
     "check_graph_symmetry_generator_orbits",
 ]

--- a/tests/component/checkers/test_exact_domain_checker_installation.py
+++ b/tests/component/checkers/test_exact_domain_checker_installation.py
@@ -7,6 +7,7 @@ from tests.unit.contracts.artifacts import artifact_uri as _uri
 from jacobian.contracts.graph_invariant_operations import GraphInvariantRequest
 from jacobian.contracts.graph_optimization import (
     GraphHamiltonianPathRequest,
+    GraphMinimumSpanningTreeRequest,
     GraphOptimizationRequest,
 )
 from jacobian.contracts.jacobian_syzygy import GradedJacobianSyzygyRequest
@@ -101,6 +102,7 @@ def test_installer_authorizes_all_exact_domain_replays(tmp_path: Path) -> None:
     graph_ids = (
         "graph.hamiltonian_path.decide",
         "graph.induced_tree.maximum.compute",
+        "graph.spanning_tree.minimum.compute",
         "graph.invariant.diameter.compute",
         "graph.invariant.radius.compute",
         "graph.invariant.maximum_matching.compute",
@@ -137,13 +139,17 @@ def test_installer_authorizes_all_exact_domain_replays(tmp_path: Path) -> None:
             character="f",
         ),
         graph=_installed(
-            (GraphHamiltonianPathRequest, GraphOptimizationRequest),
-            graph_ids[:2],
+            (
+                GraphHamiltonianPathRequest,
+                GraphOptimizationRequest,
+                GraphMinimumSpanningTreeRequest,
+            ),
+            graph_ids[:3],
             character="7",
         ),
         graph_invariants=_installed(
             (GraphInvariantRequest,),
-            graph_ids[2:],
+            graph_ids[3:],
             character="8",
         ),
         number_theory=_installed(
@@ -280,10 +286,15 @@ def test_installer_skips_checkers_for_an_unavailable_graph_bundle(
         character="f",
     )
     graph = _installed(
-        (GraphHamiltonianPathRequest, GraphOptimizationRequest),
+        (
+            GraphHamiltonianPathRequest,
+            GraphOptimizationRequest,
+            GraphMinimumSpanningTreeRequest,
+        ),
         (
             "graph.hamiltonian_path.decide",
             "graph.induced_tree.maximum.compute",
+            "graph.spanning_tree.minimum.compute",
         ),
         character="7",
     )
@@ -304,6 +315,7 @@ def test_installer_skips_checkers_for_an_unavailable_graph_bundle(
             {
                 "graph.hamiltonian_path.decide",
                 "graph.induced_tree.maximum.compute",
+                "graph.spanning_tree.minimum.compute",
             },
         ),
         (

--- a/tests/component/checkers/test_exact_domain_operation_checkers.py
+++ b/tests/component/checkers/test_exact_domain_operation_checkers.py
@@ -32,6 +32,7 @@ from jacobian_checkers.graph_exact_operations import (
     check_graph_distance_matrix,
     check_graph_induced_tree_maximum,
     check_graph_maximum_matching,
+    check_graph_minimum_spanning_tree,
     check_graph_radius,
     check_graph_symmetry_generator_orbits,
 )
@@ -555,6 +556,77 @@ _CASES: tuple[
         ),
     ),
     (
+        check_graph_minimum_spanning_tree,
+        _request(
+            "graph.spanning_tree.minimum.compute",
+            "graph.minimum-spanning-tree.cycle-certificate-v1",
+            {
+                "graph": {
+                    "weighted_graph_schema_version": "1",
+                    "vertices": ["a", "b", "c"],
+                    "edges": [
+                        {
+                            "endpoints": ["a", "b"],
+                            "weight": _q(1),
+                        },
+                        {
+                            "endpoints": ["b", "c"],
+                            "weight": _q(2),
+                        },
+                        {
+                            "endpoints": ["a", "c"],
+                            "weight": _q(4),
+                        },
+                    ],
+                }
+            },
+            {
+                "result_schema_version": "1",
+                "status": "EXACT",
+                "vertices": ["a", "b", "c"],
+                "order": 3,
+                "connected": True,
+                "component_count": 1,
+                "components": [["a", "b", "c"]],
+                "tree_edges": [
+                    {
+                        "endpoints": ["a", "b"],
+                        "weight": _q(1),
+                    },
+                    {
+                        "endpoints": ["b", "c"],
+                        "weight": _q(2),
+                    },
+                ],
+                "total_weight": _q(3),
+                "optimality_certificate": {
+                    "certificate_schema_version": "1",
+                    "method": "ALL_FUNDAMENTAL_CYCLES_NON_IMPROVING",
+                    "checks": [
+                        {
+                            "non_tree_edge": ["a", "c"],
+                            "edge_weight": _q(4),
+                            "tree_path_vertices": ["a", "b", "c"],
+                            "maximum_tree_path_weight": _q(2),
+                            "condition": ("EDGE_WEIGHT_GTE_MAXIMUM_TREE_PATH_WEIGHT"),
+                        }
+                    ],
+                    "required_checks": [
+                        "SOURCE_CONNECTIVITY",
+                        "TREE_SPANNING_ACYCLIC",
+                        "TOTAL_WEIGHT_EXACT",
+                        "ALL_NON_TREE_EDGES_COVERED",
+                        "CYCLE_NON_IMPROVEMENT",
+                    ],
+                },
+                "convention": (
+                    "MINIMUM_TOTAL_EDGE_WEIGHT_OVER_QQ_EMPTY_GRAPH_HAS_NO_SPANNING_TREE"
+                ),
+                "completion": "COMPLETE",
+            },
+        ),
+    ),
+    (
         check_graph_maximum_matching,
         _request(
             "graph.invariant.maximum_matching.compute",
@@ -757,6 +829,70 @@ def test_matrix_product_checker_rejects_oversized_source() -> None:
     assert decision["conclusion"] == "UNKNOWN"
 
 
+def _minimum_spanning_tree_checker_request() -> dict[str, Any]:
+    return copy.deepcopy(
+        next(
+            checker_request
+            for checker, checker_request in _CASES
+            if checker is check_graph_minimum_spanning_tree
+        )
+    )
+
+
+def test_minimum_spanning_tree_checker_rejects_incomplete_cycle_coverage() -> None:
+    checker_request = _minimum_spanning_tree_checker_request()
+    checker_request["candidate"]["payload"]["optimality_certificate"]["checks"] = []
+    checker_request["candidate"]["payload_digest"] = _digest(
+        checker_request["candidate"]["payload"]
+    )
+
+    decision = check_graph_minimum_spanning_tree(checker_request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+def test_minimum_spanning_tree_checker_rejects_a_nonminimum_tree() -> None:
+    checker_request = _minimum_spanning_tree_checker_request()
+    result = checker_request["candidate"]["payload"]
+    result["tree_edges"] = [
+        {"endpoints": ["a", "b"], "weight": _q(1)},
+        {"endpoints": ["a", "c"], "weight": _q(4)},
+    ]
+    result["total_weight"] = _q(5)
+    result["optimality_certificate"]["checks"] = [
+        {
+            "non_tree_edge": ["b", "c"],
+            "edge_weight": _q(2),
+            "tree_path_vertices": ["b", "a", "c"],
+            "maximum_tree_path_weight": _q(4),
+            "condition": "EDGE_WEIGHT_GTE_MAXIMUM_TREE_PATH_WEIGHT",
+        }
+    ]
+    checker_request["candidate"]["payload_digest"] = _digest(result)
+
+    decision = check_graph_minimum_spanning_tree(checker_request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+def test_minimum_spanning_tree_checker_rejects_oversized_source_weight() -> None:
+    checker_request = _minimum_spanning_tree_checker_request()
+    checker_request["claim"]["payload"]["graph"]["edges"][0]["weight"] = {
+        "num": "1" * 257,
+        "den": "1",
+    }
+    checker_request["claim"]["payload_digest"] = _digest(
+        checker_request["claim"]["payload"]
+    )
+
+    decision = check_graph_minimum_spanning_tree(checker_request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
 def _modular_checker_request() -> dict[str, Any]:
     return copy.deepcopy(
         next(
@@ -902,7 +1038,9 @@ import jacobian_checkers.exact_domain_operations
 
 
 def test_graph_checker_reports_its_actual_exhaustive_replay_method() -> None:
-    checker, checker_request = _CASES[-2]
+    checker, checker_request = next(
+        case for case in _CASES if case[0] is check_graph_induced_tree_maximum
+    )
 
     decision = checker(checker_request)
 
@@ -917,7 +1055,9 @@ def test_graph_checker_reports_its_actual_exhaustive_replay_method() -> None:
 def test_graph_checker_does_not_require_the_unrelated_flint_runtime(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    checker, checker_request = _CASES[-2]
+    checker, checker_request = next(
+        case for case in _CASES if case[0] is check_graph_induced_tree_maximum
+    )
     monkeypatch.setattr(checker_module.flint, "__version__", "unexpected")
 
     decision = checker(checker_request)

--- a/tests/composition/runtime/exact_verification/test_minimum_spanning_tree_verification.py
+++ b/tests/composition/runtime/exact_verification/test_minimum_spanning_tree_verification.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from tests.support.rationals import rational_payload as _q
+
+from jacobian.contracts.capabilities import (
+    CapabilityAssuranceLevel,
+    CapabilityMode,
+    CapabilityRequest,
+)
+from jacobian.contracts.results import ExecutionStatus
+
+
+def _edge(
+    left: str,
+    right: str,
+    weight: int,
+) -> dict[str, object]:
+    return {
+        "endpoints": [left, right],
+        "weight": _q(weight),
+    }
+
+
+def _connected_payload() -> dict[str, object]:
+    return {
+        "graph": {
+            "vertices": ["a", "b", "c", "d"],
+            "edges": [
+                _edge("a", "b", 1),
+                _edge("b", "c", 1),
+                _edge("c", "d", 1),
+                _edge("a", "d", 4),
+                _edge("a", "c", 2),
+            ],
+        }
+    }
+
+
+def test_weighted_minimum_spanning_tree_is_independently_verified(
+    authorized_complete_runtime,
+) -> None:
+    computed = authorized_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.spanning_tree.minimum.compute",
+            input=_connected_payload(),
+        )
+    )
+    verified = authorized_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.spanning_tree.minimum.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"result_uri": computed.output["result_uri"]},
+        )
+    )
+
+    assert computed.execution.status is ExecutionStatus.COMPLETED
+    assert computed.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert computed.output["result"]["total_weight"] == _q(3)
+    assert verified.execution.status is ExecutionStatus.COMPLETED
+    assert verified.output["status"] == "VERIFIED"
+    assert verified.output["conclusion"] == "TRUE"
+    assert verified.output["operation_id"] == ("graph.spanning_tree.minimum.compute")
+    assert verified.output["verification_record_uri"] is not None
+    assert verified.output["verification_record_uri"] in verified.artifact_uris
+    assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED
+    assert verified.execution.detail == (
+        "independent fundamental-cycle optimality certificate replay accepted "
+        "graph.spanning_tree.minimum.compute"
+    )
+
+
+def test_minimum_spanning_tree_verifier_rejects_a_feasible_nonminimum_tree(
+    authorized_complete_runtime,
+) -> None:
+    computed = authorized_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.spanning_tree.minimum.compute",
+            input=_connected_payload(),
+        )
+    )
+    installed = authorized_complete_runtime.portfolio.domain_bundles[
+        "graph_optimization"
+    ]
+    false_result = authorized_complete_runtime.core.artifacts.put(
+        schema_uri=installed.result_schema_uris["graph.spanning_tree.minimum.compute"],
+        semantics_uri=installed.semantics_uri,
+        parents=(computed.output["input_uri"],),
+        payload={
+            "result_schema_version": "1",
+            "status": "EXACT",
+            "vertices": ["a", "b", "c", "d"],
+            "order": 4,
+            "connected": True,
+            "component_count": 1,
+            "components": [["a", "b", "c", "d"]],
+            "tree_edges": [
+                _edge("a", "b", 1),
+                _edge("a", "d", 4),
+                _edge("b", "c", 1),
+            ],
+            "total_weight": _q(6),
+            "optimality_certificate": {
+                "certificate_schema_version": "1",
+                "method": "ALL_FUNDAMENTAL_CYCLES_NON_IMPROVING",
+                "checks": [
+                    {
+                        "non_tree_edge": ["a", "c"],
+                        "edge_weight": _q(2),
+                        "tree_path_vertices": ["a", "b", "c"],
+                        "maximum_tree_path_weight": _q(1),
+                        "condition": "EDGE_WEIGHT_GTE_MAXIMUM_TREE_PATH_WEIGHT",
+                    },
+                    {
+                        "non_tree_edge": ["c", "d"],
+                        "edge_weight": _q(1),
+                        "tree_path_vertices": ["c", "b", "a", "d"],
+                        "maximum_tree_path_weight": _q(4),
+                        "condition": "EDGE_WEIGHT_GTE_MAXIMUM_TREE_PATH_WEIGHT",
+                    },
+                ],
+                "required_checks": [
+                    "SOURCE_CONNECTIVITY",
+                    "TREE_SPANNING_ACYCLIC",
+                    "TOTAL_WEIGHT_EXACT",
+                    "ALL_NON_TREE_EDGES_COVERED",
+                    "CYCLE_NON_IMPROVEMENT",
+                ],
+            },
+            "convention": (
+                "MINIMUM_TOTAL_EDGE_WEIGHT_OVER_QQ_EMPTY_GRAPH_HAS_NO_SPANNING_TREE"
+            ),
+            "completion": "COMPLETE",
+        },
+        summary="adversarial feasible but nonminimum spanning tree",
+    )
+
+    rejected = authorized_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.spanning_tree.minimum.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"result_uri": false_result.artifact_uri},
+        )
+    )
+
+    assert rejected.execution.status is ExecutionStatus.COMPLETED
+    assert rejected.output["status"] == "REJECTED"
+    assert rejected.output["conclusion"] == "UNKNOWN"
+    assert rejected.output["verification_record_uri"] is None
+    assert rejected.assurance.level is CapabilityAssuranceLevel.COMPUTED
+
+
+def test_disconnected_no_spanning_tree_result_is_completely_replayed(
+    authorized_complete_runtime,
+) -> None:
+    computed = authorized_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.spanning_tree.minimum.compute",
+            input={
+                "graph": {
+                    "vertices": ["a", "b", "c"],
+                    "edges": [_edge("a", "b", -1)],
+                }
+            },
+        )
+    )
+    verified = authorized_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.spanning_tree.minimum.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"result_uri": computed.output["result_uri"]},
+        )
+    )
+
+    assert computed.output["result"]["status"] == "NO_SPANNING_TREE"
+    assert verified.output["status"] == "VERIFIED"
+    assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED
+    assert verified.execution.detail == (
+        "independent finite connectivity replay accepted "
+        "graph.spanning_tree.minimum.compute"
+    )

--- a/tests/domain/graph/test_graph_minimum_spanning_tree.py
+++ b/tests/domain/graph/test_graph_minimum_spanning_tree.py
@@ -1,0 +1,297 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+from pydantic import ValidationError
+from pytest import fixture, raises
+from tests.support.rationals import rational_payload as _q
+from tests.support.services import DomainTestServices, open_domain_services
+
+from jacobian.contracts.capabilities import (
+    CapabilityAssuranceLevel,
+    CapabilityDiscoveryRequest,
+    CapabilityRequest,
+)
+from jacobian.contracts.graph_optimization import (
+    GraphMinimumSpanningTreeRequest,
+    GraphMinimumSpanningTreeResult,
+)
+from jacobian.contracts.results import ExecutionStatus
+from jacobian.domains.graph_optimization.bundle import (
+    build_graph_optimization_bundle,
+)
+
+
+@fixture
+def graph_optimization_services(
+    tmp_path: Path,
+) -> Iterator[DomainTestServices]:
+    with open_domain_services(
+        tmp_path,
+        build_graph_optimization_bundle(),
+    ) as services:
+        yield services
+
+
+def _edge(
+    left: str,
+    right: str,
+    numerator: int | str,
+    denominator: int | str = 1,
+) -> dict[str, object]:
+    return {
+        "endpoints": [left, right],
+        "weight": _q(numerator, denominator),
+    }
+
+
+def _weighted_graph(
+    *,
+    vertices: list[str],
+    edges: list[dict[str, object]],
+) -> dict[str, object]:
+    return {"vertices": vertices, "edges": edges}
+
+
+def test_exact_weighted_minimum_spanning_tree_and_lineage(
+    graph_optimization_services: DomainTestServices,
+) -> None:
+    result = graph_optimization_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.spanning_tree.minimum.compute",
+            input={
+                "graph": _weighted_graph(
+                    vertices=["d", "c", "b", "a"],
+                    edges=[
+                        _edge("d", "a", 5),
+                        _edge("c", "a", 7, 2),
+                        _edge("d", "c", 3),
+                        _edge("c", "b", 2),
+                        _edge("b", "a", 1),
+                    ],
+                )
+            },
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert result.output["result"] == {
+        "result_schema_version": "1",
+        "status": "EXACT",
+        "vertices": ["a", "b", "c", "d"],
+        "order": 4,
+        "connected": True,
+        "component_count": 1,
+        "components": [["a", "b", "c", "d"]],
+        "tree_edges": [
+            _edge("a", "b", 1),
+            _edge("b", "c", 2),
+            _edge("c", "d", 3),
+        ],
+        "total_weight": _q(6),
+        "optimality_certificate": {
+            "certificate_schema_version": "1",
+            "method": "ALL_FUNDAMENTAL_CYCLES_NON_IMPROVING",
+            "checks": [
+                {
+                    "non_tree_edge": ["a", "c"],
+                    "edge_weight": _q(7, 2),
+                    "tree_path_vertices": ["a", "b", "c"],
+                    "maximum_tree_path_weight": _q(2),
+                    "condition": "EDGE_WEIGHT_GTE_MAXIMUM_TREE_PATH_WEIGHT",
+                },
+                {
+                    "non_tree_edge": ["a", "d"],
+                    "edge_weight": _q(5),
+                    "tree_path_vertices": ["a", "b", "c", "d"],
+                    "maximum_tree_path_weight": _q(3),
+                    "condition": "EDGE_WEIGHT_GTE_MAXIMUM_TREE_PATH_WEIGHT",
+                },
+            ],
+            "required_checks": [
+                "SOURCE_CONNECTIVITY",
+                "TREE_SPANNING_ACYCLIC",
+                "TOTAL_WEIGHT_EXACT",
+                "ALL_NON_TREE_EDGES_COVERED",
+                "CYCLE_NON_IMPROVEMENT",
+            ],
+        },
+        "convention": (
+            "MINIMUM_TOTAL_EDGE_WEIGHT_OVER_QQ_EMPTY_GRAPH_HAS_NO_SPANNING_TREE"
+        ),
+        "completion": "COMPLETE",
+    }
+    assert len(result.artifact_uris) == 2
+    source = graph_optimization_services.core.store.get(result.artifact_uris[0])
+    produced = graph_optimization_services.core.store.get(result.artifact_uris[1])
+    assert produced.manifest.parents == (source.artifact_uri,)
+    assert result.relationships[0].source_artifact_uris == (source.artifact_uri,)
+    assert result.relationships[0].target_artifact_uris == (produced.artifact_uri,)
+
+
+def test_disconnected_and_empty_graphs_have_complete_no_tree_outcomes(
+    graph_optimization_services: DomainTestServices,
+) -> None:
+    for graph, expected_components in (
+        (
+            _weighted_graph(
+                vertices=["a", "b", "c"],
+                edges=[_edge("a", "b", -2)],
+            ),
+            [["a", "b"], ["c"]],
+        ),
+        (_weighted_graph(vertices=[], edges=[]), []),
+    ):
+        result = graph_optimization_services.core.capabilities.invoke(
+            CapabilityRequest(
+                capability_id="graph.spanning_tree.minimum.compute",
+                input={"graph": graph},
+            )
+        )
+
+        assert result.execution.status is ExecutionStatus.COMPLETED
+        assert result.output["result"]["status"] == "NO_SPANNING_TREE"
+        assert result.output["result"]["components"] == expected_components
+        assert result.output["result"]["tree_edges"] == []
+        assert result.output["result"]["total_weight"] is None
+        assert result.output["result"]["completion"] == "COMPLETE"
+
+
+def test_equal_weight_ties_are_deterministic_under_input_reordering(
+    graph_optimization_services: DomainTestServices,
+) -> None:
+    first = _weighted_graph(
+        vertices=["d", "c", "b", "a"],
+        edges=[
+            _edge("d", "a", 1),
+            _edge("c", "d", 1),
+            _edge("b", "c", 1),
+            _edge("a", "b", 1),
+        ],
+    )
+    second = _weighted_graph(
+        vertices=["a", "b", "c", "d"],
+        edges=[
+            _edge("b", "a", 1),
+            _edge("c", "b", 1),
+            _edge("d", "c", 1),
+            _edge("a", "d", 1),
+        ],
+    )
+
+    outputs = [
+        graph_optimization_services.core.capabilities.invoke(
+            CapabilityRequest(
+                capability_id="graph.spanning_tree.minimum.compute",
+                input={"graph": graph},
+            )
+        ).output["result"]
+        for graph in (first, second)
+    ]
+
+    assert outputs[0] == outputs[1]
+    assert outputs[0]["tree_edges"] == [
+        _edge("a", "b", 1),
+        _edge("a", "d", 1),
+        _edge("b", "c", 1),
+    ]
+
+
+def test_weighted_mst_intent_is_discoverable_and_example_is_valid(
+    graph_optimization_services: DomainTestServices,
+) -> None:
+    discovered = graph_optimization_services.core.capabilities.discover(
+        CapabilityDiscoveryRequest(
+            query=(
+                "compute an exact weighted minimum spanning tree with total "
+                "weight and inspectable cycle optimality evidence"
+            ),
+            domain="graph",
+            limit=5,
+        )
+    )
+
+    assert discovered.matches[0].capability_id == (
+        "graph.spanning_tree.minimum.compute"
+    )
+    assert discovered.matches[0].lexical_fit == "STRONG_CANDIDATE"
+    descriptor = next(
+        descriptor
+        for descriptor in graph_optimization_services.core.capabilities.catalog().capabilities
+        if descriptor.capability_id == "graph.spanning_tree.minimum.compute"
+    )
+    assert descriptor.invocation_examples[0].name == "four_vertex_weighted_graph"
+
+    result = graph_optimization_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id=descriptor.capability_id,
+            input=descriptor.invocation_examples[0].input,
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output["result"]["total_weight"] == _q(6)
+
+
+def test_weighted_graph_contract_rejects_parallel_edges_and_oversized_weights() -> None:
+    with raises(ValidationError, match="unique ignoring orientation"):
+        GraphMinimumSpanningTreeRequest.model_validate(
+            {
+                "graph": _weighted_graph(
+                    vertices=["a", "b"],
+                    edges=[
+                        _edge("a", "b", 1),
+                        _edge("b", "a", 2),
+                    ],
+                )
+            }
+        )
+
+    with raises(ValidationError, match="256 decimal digits"):
+        GraphMinimumSpanningTreeRequest.model_validate(
+            {
+                "graph": _weighted_graph(
+                    vertices=["a", "b"],
+                    edges=[_edge("a", "b", "1" * 257)],
+                )
+            }
+        )
+
+
+def test_invalid_weighted_graph_fails_before_artifact_writes(
+    graph_optimization_services: DomainTestServices,
+) -> None:
+    result = graph_optimization_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.spanning_tree.minimum.compute",
+            input={
+                "graph": _weighted_graph(
+                    vertices=["a", "b"],
+                    edges=[_edge("a", "missing", 1)],
+                )
+            },
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.diagnostics[0].code == "INVALID_MINIMUM_SPANNING_TREE_REQUEST"
+    assert result.artifact_uris == ()
+
+
+def test_minimum_spanning_tree_result_rejects_inconsistent_status() -> None:
+    with raises(ValidationError, match="connected nonempty spanning tree"):
+        GraphMinimumSpanningTreeResult.model_validate(
+            {
+                "status": "EXACT",
+                "vertices": ["a", "b"],
+                "order": 2,
+                "connected": False,
+                "component_count": 2,
+                "components": [["a"], ["b"]],
+                "tree_edges": [],
+                "total_weight": None,
+                "optimality_certificate": {"checks": []},
+            }
+        )


### PR DESCRIPTION
## Summary

- add `graph.spanning_tree.minimum.compute` for bounded simple undirected graphs with exact rational edge weights
- return canonical tree edges, exact total weight, complete connectivity/components, and an inspectable fundamental-cycle optimality certificate
- add operator-authorized `graph.spanning_tree.minimum.verify`, implemented independently with stdlib rational arithmetic and graph replay
- document empty, singleton, disconnected, negative-weight, and deterministic tie behavior
- update the capability gap ledger while keeping exact TSP explicitly deferred

## Portfolio and design evidence

A pre-change `capability.describe` audit on `main@ac4bd667` found no weighted-MST optimizer; the closest installed result was only the unweighted spanning-tree-count capability. This is a reusable graph primitive rather than task-specific research policy.

The producer uses NetworkX Kruskal selection with exact `Fraction` weights and is capped at `COMPUTED`. The verifier does not import NetworkX or producer code. It independently checks the source graph, connectivity/components, source-edge membership, tree shape, exact total, complete non-tree-edge coverage, fundamental paths, path maxima, and every cycle non-improvement inequality. Only the operator-authorized checker can promote the exact claim to `VERIFIED`.

Runtime snapshot on commit `02736934ef5d281ab5c9954e3dac61911992fe38`:

- package: `0.6.0a0`
- catalog: 299 capabilities, digest `sha256:8a7671a6db098b46383a79f22b48c7bb65ee5255e317aaa469501b81ec89bbaa`
- policy: `sha256:870a92b83d3e522e4015b6bb1cabda33086906f9de1c3c36e466251ea7ed1957`
- producer runtime: `jacobian.graph-optimization:composite-1`, digest `sha256:70a6994056fcbad5b210e005a1d21d0e243dac733f7e2687376d0721345a1ea6`
- checker: `checker://sha256/7da5f46dcc2466f3deee142462eda3056ff657efec9efabb9c44ffb7378cc728`
- checker runtime: `jacobian.graph-exact-checkers:composite-1`, digest `sha256:ca9d971c34687f53288ede33410536ccb745afbf828af3ee89975daee00d58aa`
- connected probe: exact weight 6, two cycle checks, independently `VERIFIED/TRUE`
- disconnected probe: complete `NO_SPANNING_TREE`, independently `VERIFIED/TRUE`

The Harbor case is a public reproduction/design signal only. No model/Oracle run or causal outcome claim is included; held-out comparative evaluation remains open.

## Validation

`make test-plan BASE=origin/main` selected the full gate. All commands passed on exact commit `02736934ef5d281ab5c9954e3dac61911992fe38` against `origin/main@ac4bd6677482eaa55e6af2c5c0b2e6652075c7ea`:

- unit: 647 passed
- component: 604 passed
- domain: 197 passed
- composition: 428 passed, 2 expected Lean skips
- storage: 101 passed
- process: 159 passed
- MCP: 21 passed
- provider: 154 passed, 7 expected optional-provider skips
- end-to-end: 7 passed, 1 expected Lean skip
- Lean: 31 passed, 28 expected missing-runtime skips
- npm: 15 passed
- Ruff, formatting, complexity baseline, deptry, vulture, mypy (408 files), architecture (297 tests), and build: passed
- security audit: no known vulnerabilities
- duplicate-code check: passed
- documentation link check: passed
