### PR TITLE
fix(runtime): harden MCP, plugin, persistence, and provider boundaries

### DIFF
--- a/docs/explanation/adr/0001-python-first-control-plane.md
+++ b/docs/explanation/adr/0001-python-first-control-plane.md
@@ -80,7 +80,7 @@ Python runtime
 | CLI | Typer |
 | Tests | pytest, Hypothesis, and `jsonschema` |
 | Performance benchmarks | pyperf |
-| MCP | Official Python MCP SDK `2.0.0b2` |
+| MCP | Official Python MCP SDK `2.0.0` |
 | Local execution | Sequential orchestration with bounded child processes |
 
 Pydantic validates data but does not define canonical cross-language bytes.
@@ -96,15 +96,16 @@ certificates, but it does not authorize their mathematical conclusions. The
 independent checker replays those artifacts with `fractions.Fraction` and does
 not import Z3.
 
-At the user's explicit request, v0.2 pins the current v2 beta exactly:
+The pre-stable control plane pins the released MCP v2 packages exactly:
 
 ```toml
-mcp = "==2.0.0b2"
+mcp = "==2.0.0"
+mcp-types = "==2.0.0"
 ```
 
-The exact prerelease pin prevents an unreviewed beta upgrade. The MCP package
-is isolated under `adapters/mcp` so SDK migration does not affect mathematical
-schemas or verification code.
+The exact pins prevent an unreviewed SDK drift. The MCP adapter is isolated
+under `adapters/mcp` so protocol changes do not affect mathematical schemas or
+verification code.
 
 ## Specialized backends
 

--- a/docs/explanation/adr/0009-bounded-lrat-authority.md
+++ b/docs/explanation/adr/0009-bounded-lrat-authority.md
@@ -1,0 +1,32 @@
+# ADR 0009: Keep bounded LRAT replay experimental
+
+Status: Accepted, pre-stable
+
+## Decision
+
+Jacobian keeps `sat.lrat.verify` as an explicitly bounded experimental checker.
+Its v1 dialect is `jacobian.lrat.rup/v1`: ASCII proof bytes containing clause
+additions with positive ordered RUP hints, followed by the empty clause. RAT
+hints, clause deletions, alternate encodings, and parser extensions are
+unsupported and fail closed. The checker binds the exact CNF, proof bytes,
+limits, parser/checker identity, and provider runtime before replay.
+
+The current handwritten replay is verification-only; Jacobian does not claim to
+produce LRAT certificates. A `VERIFIED` result remains available only through
+the operator-authorized independent checker path and is limited to this exact
+dialect and scope.
+
+## Authority gate
+
+A broader stable LRAT checker may be authorized only after a maintained backend
+is selected through a recorded comparison of independent implementation,
+supported dialect, deterministic replay, invalid-proof rejection, bounded
+resources, reproducible release and artifact identity, license, and operation
+without Jacobian's SAT producer. The candidates to evaluate are the current
+bounded checker, CakeLPR, and an available pinned Lean LRAT checker. Until one
+candidate passes every gate, no broader LRAT authority is implied.
+
+The required corpus includes valid proofs, malformed and truncated proofs,
+wrong-CNF bindings, altered hints, unsupported steps, and resource-limit
+failures. Rejection or an unavailable backend remains `UNKNOWN` and creates no
+verification record.

--- a/docs/explanation/adr/index.md
+++ b/docs/explanation/adr/index.md
@@ -17,6 +17,7 @@ stable public contract.
 | [0006](0006-semantic-test-topology.md) | Isolate tests by semantic depth and resource ownership | Accepted, pre-stable |
 | [0007](0007-benchmark-and-package-layout.md) | Organize benchmarks by artifact class; package domain adapters without shims | Accepted, pre-stable |
 | [0008](0008-harbor-native-benchmark-datasets.md) | Package every executable benchmark case in claim-specific Harbor datasets | Accepted, pre-stable |
+| [0009](0009-bounded-lrat-authority.md) | Keep LRAT replay experimental and addition-only until an independent backend passes the authority gate | Accepted, pre-stable |
 
 Add an ADR when a decision changes a trust boundary, durable data model,
 cross-component contract, dependency strategy, or other choice that would be

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -549,6 +549,20 @@ surface is deliberately small:
 - Scope and archive artifacts are immutable; the experiment snapshot is a
   durable lifecycle record.
 
+The released MCP Python SDK `2.0.0` owns validation for statically declared
+tool arguments. Jacobian retains descriptor-selected validation for the
+dynamic `capability.invoke` payload, because the selected mathematical schema
+is not known when the MCP tool is registered. User-correctable application
+failures are projected as `CallToolResult(is_error=True)`; protocol-state
+failures remain MCP errors. Successful capability calls keep the canonical
+`CapabilityResult` in `structured_content` and a compact text projection.
+
+When a result has a durable episode URI, the adapter additionally emits an
+MCP `ResourceLink` with the result's JSON media type and known size. The link
+is additive: clients that ignore it still receive the text and structured
+result, and tenant/resource authorization follows the direct resource-read
+path.
+
 The Python SDK advertises these stable tools and static resources through the
 `io.jacobian/core` v1 extension. They remain ordinary MCP tools and resources:
 clients do not need to advertise a matching client extension to invoke them.

--- a/docs/reference/conformance-v0.2.md
+++ b/docs/reference/conformance-v0.2.md
@@ -181,7 +181,7 @@ implementation.
 
 | ID | Scenario | Required result |
 | --- | --- | --- |
-| `ADP-001` | List MCP tools using SDK `2.0.0b2` | Exactly `capability.describe` and `capability.invoke`; installed mathematical operations are capability IDs, not top-level tools |
+| `ADP-001` | List MCP tools using SDK `2.0.0` | Exactly `capability.describe` and `capability.invoke`; installed mathematical operations are capability IDs, not top-level tools |
 | `ADP-002` | Read `experiment://<id>` | Latest durable snapshot |
 | `ADP-003` | Read experiment accounting, scope, or archive resources | Compact metadata and artifact handles; large pages remain artifact resources |
 | `ADP-004` | Describe and invoke an installed capability through MCP | The descriptor schema is enforced and the result preserves execution, assurance, evidence, artifact, and provenance fields |

--- a/docs/reference/graph-counterexample-shrinking.md
+++ b/docs/reference/graph-counterexample-shrinking.md
@@ -19,7 +19,9 @@ and `graph.property.non_bipartite.preservation` format.
 
 The result records every attempted reduction in execution order. Each attempt
 identifies the source graph, proposed graph, exact deleted vertex or edge,
-outcome, and—only for accepted steps—the independent verification record.
+candidate digest, outcome, and—only for accepted steps—the independent
+verification record. The local-minimality scope also records the expected and
+completed attempt counts, completeness status, and remaining obligations.
 Possible outcomes distinguish verified acceptance, mathematical property
 rejection, checker failure, and invalid reduction.
 
@@ -37,6 +39,10 @@ graph. It sets `one_step_locally_minimal` only when:
 3. every such deletion was mathematically rejected by the checker; and
 4. execution completed without a timeout, checker error, invalid proposal, or
    budget omission.
+
+An incomplete enumeration, cancellation, unavailable checker, or worker error
+leaves minimality unknown. This evidence is local to the declared reducer
+family; it does not imply global minimality.
 
 The result separately lists tested and untested deletions. It never claims
 global minimality. Restricting the reducer set restricts the meaning of the

--- a/docs/reference/provider-runtime.md
+++ b/docs/reference/provider-runtime.md
@@ -45,6 +45,14 @@ invocation to the exact descriptor runtime without repeating all discovery
 metadata in every response. Provider metadata remains separate from execution
 status, conclusion, evidence type, and assurance.
 
+Identity revalidation and first-use readiness are separate checks. The former
+remeasures the declared executable, source tree, distribution RECORD, or every
+component of a composite runtime and fails closed with a stable provider error
+code when identity is incomplete, unavailable, malformed, or changed. The
+latter imports a declared Python module and checks its required attributes (or
+checks executable readiness) immediately before first use. A missing callable
+is `READINESS_FAILED`; it does not change the import-free availability probe.
+
 ## Availability
 
 `CapabilityService.register` rejects descriptors without runtime identity and

--- a/docs/reference/sat-artifacts.md
+++ b/docs/reference/sat-artifacts.md
@@ -24,11 +24,12 @@ operator may separately authorize the bundled assignment checker and expose
 DRAT-trim executable with operator-supplied provenance.
 
 `sat.lrat.verify` is deliberately separate from the DRAT operation. Its
-bounded v1 accepts ASCII LRAT additions with ordered positive RUP hints and
-deletions. It binds the exact CNF object, variable map, DIMACS projection,
-proof bytes, limits, checker, and certificate. Negative RAT hints are
-`UNSUPPORTED`; malformed, truncated, timed-out, cancelled, or rejected proofs
-return `UNKNOWN` and never provide evidence that the formula is satisfiable.
+bounded v1 accepts only ASCII LRAT additions with ordered positive RUP hints.
+RAT hints, deletions, and other LRAT dialect extensions are unsupported and
+rejected. It binds the exact CNF object, variable map, DIMACS projection, proof
+bytes, limits, checker, and certificate. Malformed, truncated, timed-out,
+cancelled, or rejected proofs return `UNKNOWN` and never provide evidence that
+the formula is satisfiable.
 
 ## Registered descriptors
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,8 @@ authors = [{ name = "Jacobian contributors" }]
 dependencies = [
     "filelock>=3.20,<4",
     "jsonschema>=4.23,<5",
-    "mcp==2.0.0b2",
-    "mcp-types==2.0.0b2",
+    "mcp==2.0.0",
+    "mcp-types==2.0.0",
     "networkx>=3.4,<4",
     "pydantic>=2.12,<3",
     "pydantic-core>=2.41,<3",

--- a/src/jacobian/adapters/mcp/context.py
+++ b/src/jacobian/adapters/mcp/context.py
@@ -67,7 +67,7 @@ def _resource_runtime(
 ) -> JacobianRuntime:
     """Route resources through the same auth context as tools.
 
-    MCP 2.0.0b2 does not inject ``Context`` into static resources, but its HTTP
+    MCP 2.0.0 does not inject ``Context`` into static resources, but its HTTP
     authentication middleware still scopes the access token with a contextvar.
     """
 
@@ -92,8 +92,14 @@ def _configured_root(state_dir: str | Path | None) -> Path:
 
 
 def _unwrap_tool_error(exc: Exception) -> Exception:
-    tool_error = exc.__cause__ if isinstance(exc, ToolError) else exc
-    return tool_error if isinstance(tool_error, Exception) else exc
+    current = exc
+    for _ in range(4):
+        if not isinstance(current, ToolError) or not isinstance(
+            current.__cause__, Exception
+        ):
+            return current
+        current = current.__cause__
+    return current
 
 
 def _classify_public_tool_error(

--- a/src/jacobian/adapters/mcp/projections.py
+++ b/src/jacobian/adapters/mcp/projections.py
@@ -10,7 +10,7 @@ import threading
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any, Literal, cast
 
-from mcp_types import CallToolResult, TextContent
+from mcp_types import CallToolResult, ContentBlock, ResourceLink, TextContent
 
 from jacobian.adapters.mcp.constants import (
     CAPABILITY_DISCOVERY_RESPONSE_BYTE_LIMIT,
@@ -166,6 +166,21 @@ def _capability_call_tool_result(
     projected, projection = _invocation_text_projection(result, view=view)
     text = _compact_json(canonical if view == "FULL" else projected)
     model_visible_bytes = len(text.encode("utf-8"))
+    content: list[ContentBlock] = [TextContent(type="text", text=text)]
+    if result.episode_uri is not None:
+        content.append(
+            ResourceLink(
+                name="jacobian-capability-result",
+                title="Durable capability result",
+                uri=result.episode_uri,
+                description=(
+                    "Read the durable canonical capability result when the text "
+                    "projection omits output fields."
+                ),
+                mime_type="application/json",
+                size=len(_json_bytes(canonical)),
+            )
+        )
     return CallToolResult(
         _meta={
             "jacobian": {
@@ -177,7 +192,7 @@ def _capability_call_tool_result(
                 "output_complete": projection["output_complete"],
             }
         },
-        content=[TextContent(type="text", text=text)],
+        content=content,
         structured_content=canonical,
         is_error=False,
     )

--- a/src/jacobian/adapters/mcp/server.py
+++ b/src/jacobian/adapters/mcp/server.py
@@ -1,4 +1,4 @@
-"""Thin MCP 2.0.0b2 adapter over the tested Python runtime."""
+"""Thin MCP 2.0.0 adapter over the tested Python runtime."""
 
 from __future__ import annotations
 
@@ -12,7 +12,6 @@ from functools import wraps
 from pathlib import Path
 from typing import Any
 
-from jsonschema import Draft202012Validator
 from mcp.server import MCPServer
 from mcp.server.extension import Extension, ResourceBinding, ToolBinding
 from mcp.server.mcpserver.exceptions import ToolError
@@ -64,7 +63,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class JacobianMCPServer(MCPServer[AppState]):
-    """MCP server with strict validation at the public invocation boundary."""
+    """MCP server with SDK-owned static argument validation."""
 
     async def call_tool(
         self,
@@ -72,26 +71,18 @@ class JacobianMCPServer(MCPServer[AppState]):
         arguments: dict[str, Any],
         context: Any | None = None,
     ) -> Any:
-        tool = next(
-            (tool for tool in await self.list_tools() if tool.name == name), None
-        )
-        if tool is not None:
-            schema = {**tool.input_schema, "additionalProperties": False}
-            errors = list(Draft202012Validator(schema).iter_errors(arguments))
-            if errors:
-                return CallToolResult(
-                    content=[
-                        TextContent(
-                            type="text",
-                            text=_public_tool_error(
-                                name,
-                                ValueError("tool arguments failed schema validation"),
-                            ),
-                        )
-                    ],
-                    is_error=True,
-                )
-        return await super().call_tool(name, arguments, context)
+        try:
+            return await super().call_tool(name, arguments, context)
+        except ToolError as exc:
+            return CallToolResult(
+                content=[
+                    TextContent(
+                        type="text",
+                        text=_public_tool_error(name, exc),
+                    )
+                ],
+                is_error=True,
+            )
 
 
 class JacobianCoreExtension(Extension):
@@ -235,6 +226,11 @@ class JacobianCoreExtension(Extension):
         arguments = params.arguments or {}
         argument_digest = _argument_digest(arguments)
         try:
+            # MCP 2.0.0 validates declared parameter values through the generated
+            # Pydantic model, but that model intentionally ignores unknown keys.
+            # Keep this narrow adapter check so the public tool boundary remains
+            # closed; domain-selected capability payloads are validated later by
+            # Jacobian's descriptor contract.
             binding = next(
                 binding
                 for binding in self.tools()

--- a/src/jacobian/capabilities.py
+++ b/src/jacobian/capabilities.py
@@ -43,6 +43,10 @@ from jacobian.contracts.memory import ResearchEpisode
 from jacobian.contracts.results import Coverage, Execution, ExecutionStatus
 from jacobian.contracts.verification import VerificationRecord
 from jacobian.memory import ResearchMemory
+from jacobian.provider_runtime import (
+    ProviderRuntimeError,
+    require_provider_runtime_ready,
+)
 from jacobian.schema_validation import check_draft202012_schema
 from jacobian.store import ArtifactStore, StoreError
 
@@ -553,7 +557,11 @@ class CapabilityService:
             return result
         normalized_request = request.model_copy(update={"input": normalized_input})
         try:
-            result = CapabilityResult.model_validate(adapter.invoke(normalized_request))
+            result = _invoke_ready_adapter(
+                adapter=adapter,
+                descriptor=descriptor,
+                request=normalized_request,
+            )
         except CapabilityInvocationError as exc:
             result = _failed_result(
                 descriptor=descriptor,
@@ -1077,6 +1085,37 @@ def _failed_result(
         provider=provenance["provider"],
         provider_digest=provenance["provider_digest"],
     )
+
+
+def _invoke_ready_adapter(
+    *,
+    adapter: CapabilityAdapter,
+    descriptor: CapabilityDescriptor,
+    request: CapabilityRequest,
+) -> CapabilityResult:
+    runtime = descriptor.provider_runtime
+    if runtime is None:
+        raise CapabilityError(
+            f"capability {descriptor.capability_id} has no provider runtime identity"
+        )
+    try:
+        require_provider_runtime_ready(runtime)
+    except ProviderRuntimeError as exc:
+        return _failed_result(
+            descriptor=descriptor,
+            request=request,
+            diagnostic=CapabilityDiagnostic(
+                code="PROVIDER_READINESS_FAILED",
+                stage="provider_readiness",
+                message="The declared capability provider is not ready for first use.",
+                hint=(
+                    "Repair or reinstall the declared provider, then retry the "
+                    "capability invocation."
+                ),
+                details={"provider_failure_code": exc.code.value},
+            ),
+        )
+    return CapabilityResult.model_validate(adapter.invoke(request))
 
 
 def _provider_provenance(

--- a/src/jacobian/checker_worker.py
+++ b/src/jacobian/checker_worker.py
@@ -10,7 +10,13 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any, cast
 
-from jacobian.canonical import canonicalize_json, loads_strict_json
+from pydantic import ValidationError
+
+from jacobian.canonical import (
+    CanonicalizationError,
+    canonicalize_json,
+    loads_strict_json,
+)
 from jacobian.contracts.capabilities import (
     CapabilityProviderDigestKind,
     CapabilityProviderRuntime,
@@ -21,8 +27,17 @@ from jacobian.implementation import (
 )
 from jacobian.provider_runtime import (
     ProviderRuntimeError,
+    ProviderRuntimeErrorCode,
     require_provider_runtime_unchanged,
 )
+
+
+class _CheckerWorkerFailureError(ValueError):
+    """A bounded failure classification for checker-owned runtime parsing."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
 
 
 def _resolve(entrypoint: str) -> Callable[[dict[str, Any]], dict[str, Any]]:
@@ -43,13 +58,20 @@ def _measure_runtime(
     os.environ.pop("JACOBIAN_CHECKER_RUNTIME_DIGEST", None)
     if encoded is None:
         return None, None
-    runtime = CapabilityProviderRuntime.model_validate(loads_strict_json(encoded))
     try:
+        runtime = CapabilityProviderRuntime.model_validate(loads_strict_json(encoded))
         require_provider_runtime_unchanged(runtime)
-    except (OSError, ProviderRuntimeError, ValueError) as exc:
-        raise ValueError(
-            "checker runtime differs from its authorized identity"
-        ) from exc
+    except (CanonicalizationError, ValidationError) as exc:
+        raise _CheckerWorkerFailureError("MALFORMED_RUNTIME") from exc
+    except ProviderRuntimeError as exc:
+        code = (
+            "MALFORMED_RUNTIME"
+            if exc.code is ProviderRuntimeErrorCode.MALFORMED_RUNTIME
+            else "EXECUTION_FAILED"
+        )
+        raise _CheckerWorkerFailureError(code) from exc
+    except (OSError, ValueError) as exc:
+        raise _CheckerWorkerFailureError("MALFORMED_RUNTIME") from exc
     if runtime.digest_kind is CapabilityProviderDigestKind.EXECUTABLE:
         executable = runtime.configuration.get("executable")
         if not isinstance(executable, str):
@@ -72,8 +94,13 @@ def main() -> int:
         )
         return 2
     error_code = "EXECUTION_FAILED"
+    request_decoded = False
     try:
         request = loads_strict_json(sys.stdin.buffer.read())
+        request_decoded = True
+        if not isinstance(request, dict):
+            error_code = "INVALID_REQUEST"
+            raise _CheckerWorkerFailureError(error_code)
         measured_before = package_source_digest(sys.argv[1])
         if measured_before != sys.argv[2]:
             error_code = "SOURCE_CHANGED"
@@ -108,12 +135,20 @@ def main() -> int:
         )
         sys.stdout.buffer.write(b"\n")
         return 0
-    except Exception as exc:  # checker isolation turns all failures into ERROR
+    except _CheckerWorkerFailureError as exc:
+        error = {"error_code": exc.code}
+        sys.stdout.buffer.write(canonicalize_json(error))
+        sys.stdout.buffer.write(b"\n")
+        return 1
+    except CanonicalizationError:
         error = {
-            "error": type(exc).__name__,
-            "error_code": error_code,
-            "detail": str(exc),
+            "error_code": "RESPONSE_INVALID" if request_decoded else "INVALID_REQUEST"
         }
+        sys.stdout.buffer.write(canonicalize_json(error))
+        sys.stdout.buffer.write(b"\n")
+        return 1
+    except Exception:  # checker isolation turns all failures into ERROR
+        error = {"error_code": error_code}
         sys.stdout.buffer.write(canonicalize_json(error))
         sys.stdout.buffer.write(b"\n")
         return 1

--- a/src/jacobian/contracts/graph_shrinking.py
+++ b/src/jacobian/contracts/graph_shrinking.py
@@ -7,7 +7,7 @@ from typing import Literal, Self
 
 from pydantic import Field, StrictBool, StrictInt, model_validator
 
-from jacobian.contracts.common import ArtifactUri, CheckerUri
+from jacobian.contracts.common import ArtifactUri, CheckerUri, Sha256Digest
 from jacobian.contracts.results import ContractModel, ExecutionStatus
 
 
@@ -53,6 +53,7 @@ class GraphReductionAttempt(ContractModel):
     outcome: GraphReductionOutcome
     verification_record_uri: ArtifactUri | None = None
     detail: str
+    candidate_digest: Sha256Digest | None = None
 
     @model_validator(mode="after")
     def require_one_deletion_target(self) -> Self:
@@ -80,6 +81,10 @@ class GraphLocalMinimalityScope(ContractModel):
     one_step_locally_minimal: StrictBool
     global_minimality_claimed: Literal[False] = False
     basis: str
+    expected_attempt_count: StrictInt = Field(default=0, ge=0)
+    completed_attempt_count: StrictInt = Field(default=0, ge=0)
+    completeness_status: Literal["COMPLETE", "INCOMPLETE", "UNKNOWN"] = "UNKNOWN"
+    remaining_obligations: tuple[str, ...] = ()
 
     @model_validator(mode="after")
     def keep_scope_claim_fail_closed(self) -> Self:

--- a/src/jacobian/contracts/lean_artifacts.py
+++ b/src/jacobian/contracts/lean_artifacts.py
@@ -1,0 +1,54 @@
+"""Durable, environment-bound Lean proof-state and edit artifacts."""
+
+from __future__ import annotations
+
+from pydantic import Field, StrictInt, model_validator
+
+from jacobian.contracts.common import ArtifactUri, Sha256Digest
+from jacobian.contracts.lean_exploration import LeanLocalDeclaration, LeanTypedGoal
+from jacobian.contracts.results import ContractModel, ExecutionStatus
+
+
+class LeanEnvironmentIdentity(ContractModel):
+    lean_toolchain_version: str = Field(min_length=1, max_length=128)
+    project_source_digest: Sha256Digest
+    provider_runtime_digest: Sha256Digest
+
+
+class LeanProofState(ContractModel):
+    """A replayable state is valid only under its exact environment identity."""
+
+    source_artifact_uri: ArtifactUri
+    declaration_or_command_position: StrictInt = Field(ge=0)
+    typed_goals: tuple[LeanTypedGoal, ...] = Field(max_length=128)
+    local_hypotheses: tuple[LeanLocalDeclaration, ...] = Field(max_length=256)
+    metavariable_identifiers: tuple[str, ...] = Field(max_length=256)
+    dependency_references: tuple[ArtifactUri, ...] = Field(max_length=256)
+    environment_identity: LeanEnvironmentIdentity
+
+
+class LeanProofEdit(ContractModel):
+    """One requested edit and its bounded replay outcome."""
+
+    before_state_uri: ArtifactUri
+    requested_edit: str = Field(min_length=1, max_length=20_000)
+    after_state_uri: ArtifactUri | None = None
+    diagnostics: tuple[str, ...] = Field(max_length=64)
+    execution_status: ExecutionStatus
+    environment_identity: LeanEnvironmentIdentity
+
+    @model_validator(mode="after")
+    def bind_after_state_to_success(self) -> LeanProofEdit:
+        if self.execution_status is ExecutionStatus.COMPLETED:
+            if self.after_state_uri is None:
+                raise ValueError("completed Lean proof edits require an after-state")
+        elif self.after_state_uri is not None:
+            raise ValueError("only completed Lean proof edits may have an after-state")
+        return self
+
+
+__all__ = [
+    "LeanEnvironmentIdentity",
+    "LeanProofEdit",
+    "LeanProofState",
+]

--- a/src/jacobian/contracts/memory.py
+++ b/src/jacobian/contracts/memory.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Annotated, Any, Literal, Self
 
-from pydantic import Field, StrictInt, model_validator
+from pydantic import Field, RootModel, StrictInt, StrictStr, model_validator
 
 from jacobian.contracts.capabilities import (
     CapabilityAssuranceLevel,
@@ -16,6 +16,10 @@ from jacobian.contracts.common import ArtifactUri, Sha256Digest
 from jacobian.contracts.results import ContractModel
 
 MemoryFilterValue = Annotated[str, Field(min_length=1, max_length=128)]
+
+
+class PersistedTags(RootModel[tuple[StrictStr, ...]]):
+    """Canonical JSON array stored in the research-memory index."""
 
 
 class ResearchEpisode(ContractModel):

--- a/src/jacobian/contracts/plugin_inputs.py
+++ b/src/jacobian/contracts/plugin_inputs.py
@@ -1,0 +1,391 @@
+"""Strict request contracts for the maintained reference plugins.
+
+These models are intentionally domain-specific. They keep plugin adapters
+from passing unparsed JSON shapes into mathematical kernels while preserving
+the existing compact reference-plugin projections.
+"""
+
+from __future__ import annotations
+
+from itertools import pairwise
+from typing import Any, Literal, Self
+
+from pydantic import Field, StrictBool, StrictInt, StrictStr, model_validator
+
+from jacobian.contracts.claims import ClaimSpec
+from jacobian.contracts.results import ContractModel
+
+
+def _flatten_claim(value: object) -> object:
+    if not isinstance(value, dict) or not isinstance(value.get("predicate"), dict):
+        return value
+    claim = ClaimSpec.model_validate(value)
+    return {
+        "predicate": claim.predicate.name,
+        **claim.predicate.parameters,
+        **claim.bounds,
+    }
+
+
+class PluginRequestContext(ContractModel):
+    """Known execution metadata carried by the local plugin protocol."""
+
+    request_version: Literal["1"] | None = None
+    profile: StrictStr | None = None
+    seed: StrictInt | None = None
+    bindings: dict[str, Any] = Field(default_factory=dict)
+
+
+class GraphPathClaim(ContractModel):
+    predicate: Literal["intended_paths_complete", "is_bipartite"]
+    simple: StrictBool | None = None
+    max_path_length: StrictInt | None = Field(default=None, ge=1)
+
+    @model_validator(mode="before")
+    @classmethod
+    def flatten_generic_claim(cls, value: object) -> object:
+        return _flatten_claim(value)
+
+    @model_validator(mode="after")
+    def validate_predicate_fields(self) -> Self:
+        if self.predicate == "intended_paths_complete" and self.simple is not True:
+            raise ValueError("intended_paths_complete requires simple=True")
+        if self.predicate == "is_bipartite" and (
+            self.simple is not None or self.max_path_length is not None
+        ):
+            raise ValueError("is_bipartite does not accept path-bound fields")
+        return self
+
+
+class GraphPathCandidate(ContractModel):
+    vertices: tuple[str, ...] = Field(min_length=1, max_length=256)
+    arcs: tuple[tuple[str, str], ...] = Field(max_length=65_536)
+    source: str | None = None
+    terminals: tuple[str, ...] | None = Field(default=None, min_length=1)
+    intended_paths: tuple[tuple[str, ...], ...] | None = None
+
+    @model_validator(mode="after")
+    def validate_graph_shape(self) -> Self:
+        vertices = set(self.vertices)
+        if len(vertices) != len(self.vertices):
+            raise ValueError("vertices must be unique strings")
+        if any(
+            left not in vertices or right not in vertices for left, right in self.arcs
+        ):
+            raise ValueError("arcs must reference declared vertices")
+        if len(set(self.arcs)) != len(self.arcs):
+            raise ValueError("arcs must be unique")
+        if self.source is not None and self.source not in vertices:
+            raise ValueError("source is not a graph vertex")
+        if self.terminals is not None and (
+            not set(self.terminals) <= vertices
+            or len(set(self.terminals)) != len(self.terminals)
+        ):
+            raise ValueError("terminals must be unique graph vertices")
+        arc_set = set(self.arcs)
+        terminals = self.terminals or ()
+        for path in self.intended_paths or ():
+            if (
+                len(path) < 2
+                or len(set(path)) != len(path)
+                or any(vertex not in vertices for vertex in path)
+                or self.source is None
+                or path[0] != self.source
+                or path[-1] not in terminals
+                or any(pair not in arc_set for pair in pairwise(path))
+            ):
+                raise ValueError(
+                    "intended_paths must contain legal source-terminal paths"
+                )
+        return self
+
+
+class GraphPathEvaluationRequest(PluginRequestContext):
+    claim: GraphPathClaim
+    candidate: GraphPathCandidate | None = None
+    candidates: tuple[GraphPathCandidate, ...] | None = None
+
+    @model_validator(mode="after")
+    def require_candidates(self) -> Self:
+        if self.candidate is not None and self.candidates is not None:
+            raise ValueError("candidate and candidates cannot be combined")
+        if self.candidate is None and not self.candidates:
+            raise ValueError("at least one candidate is required")
+        candidates = (
+            (self.candidate,) if self.candidate is not None else self.candidates or ()
+        )
+        if self.claim.predicate == "intended_paths_complete":
+            for candidate in candidates:
+                if candidate.source is None or not candidate.terminals:
+                    raise ValueError(
+                        "intended_paths_complete requires source and terminals"
+                    )
+                if candidate.source in candidate.terminals:
+                    raise ValueError("source cannot also be a terminal")
+        return self
+
+
+class GraphPathCapabilityRequest(PluginRequestContext):
+    claim: GraphPathClaim
+    candidate: GraphPathCandidate
+    witness_role: Literal["DEFEATS_CANDIDATE", "SUPPORTS_CLAIM"] = "DEFEATS_CANDIDATE"
+
+    @model_validator(mode="after")
+    def require_path_roles(self) -> Self:
+        if self.claim.predicate == "intended_paths_complete":
+            if self.candidate.source is None or not self.candidate.terminals:
+                raise ValueError(
+                    "intended_paths_complete requires source and terminals"
+                )
+            if self.candidate.source in self.candidate.terminals:
+                raise ValueError("source cannot also be a terminal")
+        return self
+
+
+class GraphPathReductionRequest(PluginRequestContext):
+    target_kind: Literal["candidate", "witness"] = "candidate"
+    target: GraphPathCandidate
+    claim: GraphPathClaim
+    reducers: tuple[Literal["delete_vertex", "delete_edge"], ...] = ()
+    objectives: tuple[Literal["vertices", "edges"], ...] = ()
+
+    @model_validator(mode="after")
+    def require_path_target_for_candidate(self) -> Self:
+        if (
+            self.target_kind == "candidate"
+            and self.claim.predicate == "intended_paths_complete"
+            and (self.target.source is None or not self.target.terminals)
+        ):
+            raise ValueError("path claims require source and terminals")
+        if (
+            self.target_kind == "candidate"
+            and self.claim.predicate == "intended_paths_complete"
+            and self.target.terminals is not None
+            and self.target.source in self.target.terminals
+        ):
+            raise ValueError("source cannot also be a terminal")
+        return self
+
+
+class GraphCursor(ContractModel):
+    offset: StrictInt = Field(ge=0)
+
+
+class GraphEnumerationRequest(PluginRequestContext):
+    bounds: dict[str, StrictInt]
+    page_size: StrictInt = Field(ge=1)
+    cursor: GraphCursor | None = None
+
+    @model_validator(mode="after")
+    def validate_bounds(self) -> Self:
+        if set(self.bounds) != {"vertices"} or not 1 <= self.bounds["vertices"] <= 8:
+            raise ValueError("graph bounds require vertices from one through eight")
+        return self
+
+
+class GraphCanonicalizeRequest(PluginRequestContext):
+    structure: GraphPathCandidate
+
+
+class MatrixScope(ContractModel):
+    rows: StrictInt = Field(ge=1, le=32)
+    cols: StrictInt = Field(ge=1, le=32)
+    entries: tuple[StrictInt | StrictStr, ...] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def validate_entries(self) -> Self:
+        for value in self.entries:
+            if isinstance(value, str) and (
+                not value or not value.lstrip("-").isdigit()
+            ):
+                raise ValueError("scope entries must be exact integers")
+        return self
+
+
+class MatrixClaim(ContractModel):
+    predicate: Literal["is_nonsingular", "maximize_absolute_determinant"]
+    scope: MatrixScope | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def flatten_generic_claim(cls, value: object) -> object:
+        return _flatten_claim(value)
+
+    @model_validator(mode="after")
+    def validate_scope_for_predicate(self) -> Self:
+        if self.predicate == "maximize_absolute_determinant":
+            if self.scope is None:
+                raise ValueError("maximize_absolute_determinant requires a scope")
+            if self.scope.rows != self.scope.cols:
+                raise ValueError("determinant scope must be square")
+        return self
+
+
+class MatrixCandidate(ContractModel):
+    rows: StrictInt = Field(ge=1, le=32)
+    cols: StrictInt = Field(ge=1, le=32)
+    entries: tuple[tuple[StrictInt | StrictStr, ...], ...]
+
+    @model_validator(mode="after")
+    def validate_matrix_shape(self) -> Self:
+        if len(self.entries) != self.rows or any(
+            len(row) != self.cols for row in self.entries
+        ):
+            raise ValueError("matrix entries must match rows and cols")
+        for value in (item for row in self.entries for item in row):
+            if (
+                isinstance(value, bool)
+                or (
+                    isinstance(value, str)
+                    and (not value or not value.lstrip("-").isdigit())
+                )
+                or not isinstance(value, (int, str))
+            ):
+                raise ValueError("matrix entries must be exact integers")
+        return self
+
+
+class MatrixEvaluationRequest(PluginRequestContext):
+    claim: MatrixClaim
+    candidate: MatrixCandidate | None = None
+    candidates: tuple[MatrixCandidate, ...] | None = None
+
+    @model_validator(mode="after")
+    def require_candidates(self) -> Self:
+        if self.candidate is not None and self.candidates is not None:
+            raise ValueError("candidate and candidates cannot be combined")
+        if self.candidate is None and not self.candidates:
+            raise ValueError("at least one candidate is required")
+        return self
+
+
+class MatrixCapabilityRequest(PluginRequestContext):
+    claim: MatrixClaim
+    candidate: MatrixCandidate | None = None
+    witness_role: Literal["DEFEATS_CANDIDATE", "SUPPORTS_CLAIM"] = "DEFEATS_CANDIDATE"
+
+
+class MatrixReductionRequest(PluginRequestContext):
+    target_kind: Literal["candidate"] = "candidate"
+    target: MatrixCandidate
+    claim: MatrixClaim
+    reducers: tuple[Literal["delete_row_column", "zero_entry"], ...] = ()
+    objectives: tuple[Literal["elements", "max_abs_entry"], ...] = ()
+
+
+class MatrixCursor(ContractModel):
+    offset: StrictInt = Field(ge=0)
+
+
+class MatrixEnumerationRequest(PluginRequestContext):
+    bounds: MatrixScope
+    page_size: StrictInt = Field(ge=1)
+    cursor: MatrixCursor | None = None
+
+
+class MatrixTransformRequest(PluginRequestContext):
+    requested_relation: Literal[
+        "EQUIVALENT",
+        "OVER_APPROXIMATION",
+        "UNDER_APPROXIMATION",
+        "HEURISTIC",
+    ] = "EQUIVALENT"
+    target_schema_uri: StrictStr | None = None
+    target_semantics_uri: StrictStr | None = None
+    source: MatrixCandidate
+
+
+class MatrixMaterializeRequest(PluginRequestContext):
+    claim: MatrixClaim
+
+
+class ErdosStrausClaim(ContractModel):
+    predicate: Literal["erdos_straus_range"]
+    lower_bound: StrictInt = Field(ge=2, le=10_000)
+    upper_bound: StrictInt = Field(ge=2, le=10_000)
+
+    @model_validator(mode="before")
+    @classmethod
+    def flatten_generic_claim(cls, value: object) -> object:
+        return _flatten_claim(value)
+
+    @model_validator(mode="after")
+    def require_ordered_range(self) -> Self:
+        if self.upper_bound < self.lower_bound:
+            raise ValueError("upper_bound must be at least lower_bound")
+        return self
+
+
+class ErdosStrausCandidate(ContractModel):
+    lower_bound: StrictInt = Field(ge=2, le=10_000)
+    upper_bound: StrictInt = Field(ge=2, le=10_000)
+
+    @model_validator(mode="after")
+    def require_ordered_range(self) -> Self:
+        if self.upper_bound < self.lower_bound:
+            raise ValueError("upper_bound must be at least lower_bound")
+        return self
+
+
+class ErdosStrausCapabilityRequest(PluginRequestContext):
+    claim: ErdosStrausClaim
+    candidate: ErdosStrausCandidate
+    witness_role: Literal["DEFEATS_CANDIDATE", "SUPPORTS_CLAIM"] = "SUPPORTS_CLAIM"
+
+
+class GraphShrinkTarget(ContractModel):
+    graph_schema_version: Literal["1"] = "1"
+    vertices: tuple[str, ...] = Field(min_length=1, max_length=256)
+    edges: tuple[tuple[str, str], ...] = Field(max_length=32_640)
+
+    @model_validator(mode="after")
+    def validate_simple_graph(self) -> Self:
+        vertices = set(self.vertices)
+        if len(vertices) != len(self.vertices):
+            raise ValueError("graph vertices must be unique")
+        if any(left == right for left, right in self.edges):
+            raise ValueError("graph edges must not contain self-loops")
+        if any(
+            left not in vertices or right not in vertices for left, right in self.edges
+        ):
+            raise ValueError("graph edges must reference declared vertices")
+        normalized = {tuple(sorted(edge)) for edge in self.edges}
+        if len(normalized) != len(self.edges):
+            raise ValueError("graph edges must be unique ignoring orientation")
+        return self
+
+
+class GraphShrinkRequest(PluginRequestContext):
+    target_kind: Literal["candidate"] = "candidate"
+    target: GraphShrinkTarget
+    reducers: tuple[Literal["delete_vertex", "delete_edge"], ...]
+    objectives: tuple[Literal["vertices", "edges"], ...]
+    claim: dict[str, Any] = Field(default_factory=dict)
+
+
+__all__ = [
+    "ErdosStrausCandidate",
+    "ErdosStrausCapabilityRequest",
+    "ErdosStrausClaim",
+    "GraphCanonicalizeRequest",
+    "GraphCursor",
+    "GraphEnumerationRequest",
+    "GraphPathCandidate",
+    "GraphPathCapabilityRequest",
+    "GraphPathClaim",
+    "GraphPathEvaluationRequest",
+    "GraphPathReductionRequest",
+    "GraphShrinkRequest",
+    "GraphShrinkTarget",
+    "MatrixCandidate",
+    "MatrixCapabilityRequest",
+    "MatrixClaim",
+    "MatrixCursor",
+    "MatrixEnumerationRequest",
+    "MatrixEvaluationRequest",
+    "MatrixMaterializeRequest",
+    "MatrixReductionRequest",
+    "MatrixScope",
+    "MatrixTransformRequest",
+    "PluginRequestContext",
+]

--- a/src/jacobian/contracts/proof_ir.py
+++ b/src/jacobian/contracts/proof_ir.py
@@ -1,0 +1,64 @@
+"""Bounded logical-claim artifacts for the implemented decomposition operations."""
+
+from __future__ import annotations
+
+from typing import Literal, Self
+
+from pydantic import Field, model_validator
+
+from jacobian.contracts.common import ArtifactUri, Sha256Digest
+from jacobian.contracts.results import ContractModel
+
+
+class AtomicClaimRef(ContractModel):
+    """An immutable reference to one claim artifact and its two identities."""
+
+    claim_artifact_uri: ArtifactUri
+    schema_digest: Sha256Digest
+    semantics_digest: Sha256Digest
+
+
+class ConjunctionClaim(ContractModel):
+    """A finite ordered conjunction of atomic claim references."""
+
+    claim_refs: tuple[AtomicClaimRef, ...] = Field(min_length=1, max_length=256)
+
+
+class ImplicationClaim(ContractModel):
+    """A finite implication with explicit premises and one conclusion."""
+
+    premises: tuple[AtomicClaimRef, ...] = Field(min_length=1, max_length=256)
+    conclusion: AtomicClaimRef
+
+
+LogicalClaim = AtomicClaimRef | ConjunctionClaim | ImplicationClaim
+
+
+class ProofObligationSet(ContractModel):
+    """Decomposition structure, not proof authority."""
+
+    source_logical_claim: LogicalClaim
+    obligation_refs: tuple[AtomicClaimRef, ...] = Field(
+        min_length=1,
+        max_length=256,
+    )
+    decomposition_semantics: Sha256Digest
+    completeness_status: Literal["COMPLETE", "INCOMPLETE"]
+
+    @model_validator(mode="after")
+    def require_distinct_obligations(self) -> Self:
+        uris = tuple(item.claim_artifact_uri for item in self.obligation_refs)
+        if len(set(uris)) != len(uris):
+            raise ValueError(
+                "proof obligations must reference distinct claim artifacts"
+            )
+        return self
+
+
+__all__ = [
+    "AtomicClaimRef",
+    "ConjunctionClaim",
+    "ImplicationClaim",
+    "LogicalClaim",
+    "ProofObligationSet",
+]

--- a/src/jacobian/domains/analysis/operations.py
+++ b/src/jacobian/domains/analysis/operations.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import subprocess
 import sys
 from typing import Any
@@ -10,7 +9,11 @@ from typing import Any
 from pydantic import ValidationError
 
 from jacobian.bounded_process import ProcessResourceLimits, run_bounded_process
-from jacobian.canonical import canonicalize_json, loads_strict_json
+from jacobian.canonical import (
+    CanonicalizationError,
+    canonicalize_json,
+    loads_strict_json,
+)
 from jacobian.contracts.capabilities import CapabilityDiagnostic
 from jacobian.contracts.results import ExecutionStatus
 from jacobian.contracts.validated_analysis import (
@@ -123,7 +126,7 @@ def _point_enclosure(
             status=ExecutionStatus.TIMEOUT,
             diagnostic=_diagnostic("ARB_POINT_ENCLOSURE_TIMEOUT", detail),
         )
-    except (OSError, RuntimeError, json.JSONDecodeError, ValidationError):
+    except (OSError, RuntimeError, CanonicalizationError, ValidationError):
         detail = (
             "The Arb worker failed or returned malformed output; "
             "no enclosure conclusion is available."

--- a/src/jacobian/domains/analysis/worker.py
+++ b/src/jacobian/domains/analysis/worker.py
@@ -2,9 +2,16 @@
 
 from __future__ import annotations
 
-import json
 import sys
 from typing import Any
+
+from pydantic import ValidationError
+
+from jacobian.canonical import (
+    CanonicalizationError,
+    canonicalize_json,
+    loads_strict_json,
+)
 
 
 def _point_enclosure(payload: dict[str, Any]) -> dict[str, Any]:
@@ -37,14 +44,15 @@ def _point_enclosure(payload: dict[str, Any]) -> dict[str, Any]:
 
 
 def main() -> int:
-    payload = json.loads(sys.stdin.read())
-    sys.stdout.write(
-        json.dumps(
-            _point_enclosure(payload),
-            sort_keys=True,
-            separators=(",", ":"),
-        )
-    )
+    try:
+        payload = loads_strict_json(sys.stdin.buffer.read())
+        if not isinstance(payload, dict):
+            raise ValueError("analysis worker request must be an object")
+        result = _point_enclosure(payload)
+    except (CanonicalizationError, TypeError, ValueError, ValidationError):
+        sys.stderr.write("validated analysis worker request or execution failed\n")
+        return 2
+    sys.stdout.buffer.write(canonicalize_json(result))
     return 0
 
 

--- a/src/jacobian/domains/matrix_lattice/lll_worker.py
+++ b/src/jacobian/domains/matrix_lattice/lll_worker.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 import importlib
-import json
 import re
 import sys
 from typing import Any
 
+from jacobian.canonical import (
+    CanonicalizationError,
+    canonicalize_json,
+    loads_strict_json,
+)
 from jacobian.contracts.matrix_operations import (
     MAX_OUTPUT_SCALAR_DIGITS,
     MAX_SCALAR_DIGITS,
@@ -38,9 +42,9 @@ def _read() -> list[list[int]]:
     if len(encoded) > INPUT_LIMIT:
         raise WorkerError("FLINT_LLL_INPUT_LIMIT_EXCEEDED")
     try:
-        payload = json.loads(encoded)
-    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-        raise WorkerError("FLINT_LLL_INPUT_INVALID") from exc
+        payload = loads_strict_json(encoded)
+    except CanonicalizationError as exc:
+        raise WorkerError("INVALID_REQUEST") from exc
     if (
         not isinstance(payload, dict)
         or set(payload) != {"protocol", "basis"}
@@ -118,7 +122,7 @@ def main() -> int:
         code = 2
     else:
         code = 0
-    sys.stdout.write(json.dumps(output, sort_keys=True, separators=(",", ":")) + "\n")
+    sys.stdout.buffer.write(canonicalize_json(output) + b"\n")
     return code
 
 

--- a/src/jacobian/domains/optimization/operations.py
+++ b/src/jacobian/domains/optimization/operations.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import subprocess
 import sys
 from typing import Any
@@ -10,7 +9,11 @@ from typing import Any
 from pydantic import ValidationError
 
 from jacobian.bounded_process import ProcessResourceLimits, run_bounded_process
-from jacobian.canonical import canonicalize_json, loads_strict_json
+from jacobian.canonical import (
+    CanonicalizationError,
+    canonicalize_json,
+    loads_strict_json,
+)
 from jacobian.contracts.capabilities import CapabilityDiagnostic
 from jacobian.contracts.results import ExecutionStatus
 from jacobian.contracts.validated_analysis import (
@@ -87,7 +90,7 @@ def _linear_program(
                 message=detail,
             ),
         )
-    except (OSError, RuntimeError, json.JSONDecodeError, ValidationError):
+    except (OSError, RuntimeError, CanonicalizationError, ValidationError):
         detail = (
             "The exact rational LP worker failed or returned malformed "
             "output; no feasibility or optimality conclusion is available."

--- a/src/jacobian/experiments/errors.py
+++ b/src/jacobian/experiments/errors.py
@@ -7,5 +7,13 @@ class ExperimentError(RuntimeError):
     """A requested experiment is missing or invalid."""
 
 
+class ExperimentCorruptionError(ExperimentError):
+    """A persisted experiment snapshot cannot be reconstructed safely."""
+
+    def __init__(self, corruption: object) -> None:
+        self.corruption = corruption
+        super().__init__(str(corruption))
+
+
 class ExperimentNotFoundError(ExperimentError):
     """A requested enumeration experiment does not exist."""

--- a/src/jacobian/experiments/service.py
+++ b/src/jacobian/experiments/service.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from pydantic import ValidationError
 
-from jacobian.canonical import canonicalize_json, loads_strict_json
+from jacobian.canonical import canonicalize_json
 from jacobian.claims import ClaimValidationService
 from jacobian.contracts.artifacts import ArtifactPutResult
 from jacobian.contracts.discovery import (
@@ -45,7 +45,12 @@ from jacobian.experiments._helpers import (
     _now,
     _updated,
 )
-from jacobian.experiments.errors import ExperimentError, ExperimentNotFoundError
+from jacobian.experiments.errors import (
+    ExperimentCorruptionError,
+    ExperimentError,
+    ExperimentNotFoundError,
+)
+from jacobian.persistence import PersistenceCorruptionError, decode_persisted_model
 from jacobian.plugin_execution import PluginExecutor
 from jacobian.plugins.registry import PluginRegistry, PluginRegistryError
 from jacobian.schema_registry import SchemaRegistry, SchemaRegistryError, model_schema
@@ -64,6 +69,22 @@ _EXPERIMENT_NOT_FOUND = (
     "The experiment was not found. Check the URI returned by search.run or "
     "search.enumerate, or start a new experiment."
 )
+
+
+def _decode_experiment_snapshot(
+    encoded: str | bytes | bytearray,
+    experiment_uri: str,
+) -> ExperimentSnapshot:
+    try:
+        return decode_persisted_model(
+            ExperimentSnapshot,
+            encoded,
+            record_kind="experiment_snapshot",
+            record_id=experiment_uri,
+            field="snapshot_json",
+        )
+    except PersistenceCorruptionError as exc:
+        raise ExperimentCorruptionError(exc) from exc
 
 
 class ExperimentService:
@@ -159,10 +180,15 @@ class ExperimentService:
             ).fetchall()
             for row in rows:
                 try:
-                    snapshot = ExperimentSnapshot.model_validate(
-                        loads_strict_json(row["snapshot_json"])
+                    snapshot = _decode_experiment_snapshot(
+                        row["snapshot_json"], str(row["experiment_uri"])
                     )
-                except (TypeError, ValidationError, ValueError) as exc:
+                except (
+                    TypeError,
+                    ValidationError,
+                    ValueError,
+                    ExperimentCorruptionError,
+                ) as exc:
                     self._quarantine_recovery_snapshot(connection, row, exc)
                     continue
                 if snapshot.experiment_uri != str(
@@ -323,10 +349,8 @@ class ExperimentService:
             _LOGGER.warning("experiment not found: %s", experiment_uri)
             raise ExperimentNotFoundError(_EXPERIMENT_NOT_FOUND)
         try:
-            return ExperimentSnapshot.model_validate(
-                loads_strict_json(row["snapshot_json"])
-            )
-        except (ValidationError, ValueError) as exc:
+            return _decode_experiment_snapshot(row["snapshot_json"], experiment_uri)
+        except (ValidationError, ValueError, ExperimentCorruptionError) as exc:
             raise ExperimentError("stored experiment snapshot is invalid") from exc
 
     def contains(self, experiment_uri: str) -> bool:
@@ -388,9 +412,7 @@ class ExperimentService:
                     experiment_uri,
                 )
                 raise ExperimentNotFoundError(_EXPERIMENT_NOT_FOUND)
-            snapshot = ExperimentSnapshot.model_validate(
-                loads_strict_json(row["snapshot_json"])
-            )
+            snapshot = _decode_experiment_snapshot(row["snapshot_json"], experiment_uri)
             if snapshot.state in _TERMINAL_STATES:
                 return ExperimentCancelResult(
                     experiment_uri=experiment_uri,
@@ -935,9 +957,7 @@ class ExperimentService:
                     experiment_uri,
                 )
                 raise ExperimentNotFoundError(_EXPERIMENT_NOT_FOUND)
-            current = ExperimentSnapshot.model_validate(
-                loads_strict_json(row["snapshot_json"])
-            )
+            current = _decode_experiment_snapshot(row["snapshot_json"], experiment_uri)
             if current.state in _TERMINAL_STATES:
                 return
             terminal = _updated(
@@ -995,9 +1015,7 @@ class ExperimentService:
             if row is None:
                 _LOGGER.warning("experiment not found: %s", experiment_uri)
                 raise ExperimentNotFoundError(_EXPERIMENT_NOT_FOUND)
-            snapshot = ExperimentSnapshot.model_validate(
-                loads_strict_json(row["snapshot_json"])
-            )
+            snapshot = _decode_experiment_snapshot(row["snapshot_json"], experiment_uri)
             if snapshot.state == ExperimentState.CANCEL_REQUESTED:
                 return False
             if snapshot.state != ExperimentState.PENDING:
@@ -1060,8 +1078,8 @@ class ExperimentService:
                     snapshot.experiment_uri,
                 )
                 raise ExperimentNotFoundError(_EXPERIMENT_NOT_FOUND)
-            current = ExperimentSnapshot.model_validate(
-                loads_strict_json(row["snapshot_json"])
+            current = _decode_experiment_snapshot(
+                row["snapshot_json"], snapshot.experiment_uri
             )
             if current.state == ExperimentState.CANCEL_REQUESTED:
                 return False
@@ -1099,8 +1117,8 @@ class ExperimentService:
             if row is None:
                 _LOGGER.warning("experiment not found: %s", snapshot.experiment_uri)
                 raise ExperimentError(_EXPERIMENT_NOT_FOUND)
-            current = ExperimentSnapshot.model_validate(
-                loads_strict_json(row["snapshot_json"])
+            current = _decode_experiment_snapshot(
+                row["snapshot_json"], snapshot.experiment_uri
             )
             terminal = snapshot
             if current.state == ExperimentState.CANCEL_REQUESTED:

--- a/src/jacobian/graphs/shrinking.py
+++ b/src/jacobian/graphs/shrinking.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 from jacobian.artifacts import ArtifactService
 from jacobian.capabilities import CapabilityInvocationError
@@ -414,6 +414,11 @@ class GraphCounterexampleShrinkAdapter:
             outcome=outcome,
             verification_record_uri=step.verification_record_uri,
             detail=step.detail,
+            candidate_digest=(
+                "sha256:" + step.proposed_uri.removeprefix("artifact://sha256/")
+                if step.proposed_uri is not None
+                else None
+            ),
         )
 
 
@@ -525,6 +530,31 @@ def _local_scope(
         and len(final_attempts) == len(expected_vertices) + len(expected_edges)
         and all_rejected
     )
+    expected_attempt_count = len(expected_vertices) + len(expected_edges)
+    completeness_status: Literal["COMPLETE", "INCOMPLETE", "UNKNOWN"] = (
+        "COMPLETE"
+        if complete
+        else (
+            "INCOMPLETE"
+            if untested_vertices
+            or untested_edges
+            or len(final_attempts) != expected_attempt_count
+            else "UNKNOWN"
+        )
+    )
+    obligations = (
+        "attempt every supported immediate vertex deletion"
+        if untested_vertices
+        else "",
+        "attempt every supported immediate edge deletion" if untested_edges else "",
+        "obtain acceptable rejection evidence for every attempted deletion"
+        if not all_rejected
+        else "",
+        "complete the final property check before claiming local minimality"
+        if not final_property_verified
+        else "",
+    )
+    remaining_obligations: tuple[str, ...] = tuple(item for item in obligations if item)
     return GraphLocalMinimalityScope(
         requested_reducers=reducers,
         tested_vertex_deletions=tested_vertices,
@@ -533,6 +563,10 @@ def _local_scope(
         untested_edge_deletions=untested_edges,
         complete_for_requested_reducers=complete,
         one_step_locally_minimal=complete,
+        expected_attempt_count=expected_attempt_count,
+        completed_attempt_count=len(final_attempts),
+        completeness_status=completeness_status,
+        remaining_obligations=remaining_obligations,
         basis=(
             "every requested single deletion from the final graph was tested "
             "exactly once and mathematically rejected by the registered checker"

--- a/src/jacobian/lean_frontend/declarations.py
+++ b/src/jacobian/lean_frontend/declarations.py
@@ -15,7 +15,11 @@ from typing import Any, Protocol
 
 from pydantic import ValidationError
 
-from jacobian.canonical import canonicalize_json, loads_strict_json
+from jacobian.canonical import (
+    CanonicalizationError,
+    canonicalize_json,
+    loads_strict_json,
+)
 from jacobian.contracts.capabilities import CapabilityProviderRuntime
 from jacobian.contracts.lean import (
     LeanDeclarationInspectOutput,
@@ -697,7 +701,7 @@ def _parse_session_response(
         raise _protocol_error()
     try:
         envelope = loads_strict_json(serialized)
-    except ValueError as exc:
+    except CanonicalizationError as exc:
         raise _protocol_error() from exc
     if not isinstance(envelope, dict) or envelope.get("request_id") != (
         expected_request_id

--- a/src/jacobian/lean_frontend/exploration.py
+++ b/src/jacobian/lean_frontend/exploration.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import hashlib
-import json
 import os
 import queue
 import re
@@ -24,7 +23,11 @@ from typing import Any
 from pydantic import ValidationError
 
 from jacobian.artifacts import ArtifactService
-from jacobian.canonical import canonicalize_json, loads_strict_json
+from jacobian.canonical import (
+    CanonicalizationError,
+    canonicalize_json,
+    loads_strict_json,
+)
 from jacobian.capabilities import CapabilityInvocationError
 from jacobian.contracts.capabilities import (
     CapabilityAssurance,
@@ -239,7 +242,7 @@ class PersistentLeanRepl:
         if process is None or process.stdin is None:
             raise RuntimeError("Lean REPL is unavailable")
         try:
-            process.stdin.write(json.dumps(request, sort_keys=True) + "\n\n")
+            process.stdin.write(canonicalize_json(request).decode("utf-8") + "\n\n")
             process.stdin.flush()
         except (BrokenPipeError, OSError) as exc:
             self._stop_process()
@@ -284,7 +287,7 @@ class PersistentLeanRepl:
                     continue
                 if not block:
                     continue
-                value = json.loads("".join(block))
+                value = loads_strict_json("".join(block))
                 if not isinstance(value, dict):
                     raise RuntimeError("Lean REPL returned a non-object response")
                 responses.put(value)
@@ -292,7 +295,7 @@ class PersistentLeanRepl:
             if block:
                 raise RuntimeError("Lean REPL returned an unterminated response")
             responses.put(RuntimeError("Lean REPL exited"))
-        except (json.JSONDecodeError, OSError, RuntimeError) as exc:
+        except (CanonicalizationError, OSError, RuntimeError) as exc:
             responses.put(exc)
 
     def _stop_process(self) -> None:
@@ -532,7 +535,7 @@ def install_lean_exploration_capabilities(
         version="2",
         schema=LeanPremiseRetrievalArtifact.model_json_schema(),
     )
-    runtime = Path(__file__).resolve().parents[2] / "lean"
+    runtime = Path(__file__).resolve().parents[3] / "lean"
     repl = LeanExplorationReplRuntime(runtime, installations)
     resources = _Resources(
         store=store,
@@ -1333,11 +1336,17 @@ def _extract_typed_goals(
     except (OSError, subprocess.TimeoutExpired) as exc:
         raise RuntimeError("Lean typed proof-state extraction failed") from exc
     marker = "JACOBIAN_PROOF_STATE_RESULT "
-    lines = completed.stdout.decode("utf-8", errors="strict").splitlines()
+    try:
+        lines = completed.stdout.decode("utf-8", errors="strict").splitlines()
+    except UnicodeDecodeError as exc:
+        raise RuntimeError("Lean typed proof-state extraction failed") from exc
     responses = [line for line in lines if line.startswith(marker)]
     if completed.returncode != 0 or len(responses) != 1:
         raise RuntimeError("Lean typed proof-state extraction failed")
-    envelope = loads_strict_json(responses[0].removeprefix(marker))
+    try:
+        envelope = loads_strict_json(responses[0].removeprefix(marker))
+    except CanonicalizationError as exc:
+        raise RuntimeError("Lean typed proof-state extraction failed") from exc
     if (
         not isinstance(envelope, dict)
         or envelope.get("request_id") != request_id

--- a/src/jacobian/lean_frontend/statement.py
+++ b/src/jacobian/lean_frontend/statement.py
@@ -341,7 +341,7 @@ def _require_current_runtime(
 
     try:
         require_provider_runtime_unchanged(provider_runtime)
-    except (OSError, ProviderRuntimeError) as exc:
+    except (OSError, ProviderRuntimeError, ValidationError) as exc:
         raise _LeanUnavailableError(
             "The pinned Lean executable identity changed or became unavailable."
         ) from exc

--- a/src/jacobian/matrices/flint_hnf_worker.py
+++ b/src/jacobian/matrices/flint_hnf_worker.py
@@ -3,10 +3,15 @@
 from __future__ import annotations
 
 import importlib
-import json
 import re
 import sys
 from typing import Any
+
+from jacobian.canonical import (
+    CanonicalizationError,
+    canonicalize_json,
+    loads_strict_json,
+)
 
 FLINT_HNF_WORKER_PROTOCOL = "jacobian.flint-hnf-worker/v1"
 FLINT_HNF_INPUT_LIMIT = 1_000_000
@@ -22,24 +27,10 @@ class FlintHnfWorkerError(RuntimeError):
 
 
 def _emit(payload: dict[str, object]) -> None:
-    sys.stdout.write(
-        json.dumps(
-            {"protocol": FLINT_HNF_WORKER_PROTOCOL, **payload},
-            sort_keys=True,
-            separators=(",", ":"),
-        )
-        + "\n"
+    sys.stdout.buffer.write(
+        canonicalize_json({"protocol": FLINT_HNF_WORKER_PROTOCOL, **payload}) + b"\n"
     )
     sys.stdout.flush()
-
-
-def _strict_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
-    result: dict[str, Any] = {}
-    for key, value in pairs:
-        if key in result:
-            raise ValueError("duplicate JSON key")
-        result[key] = value
-    return result
 
 
 def _read_request() -> dict[str, Any]:
@@ -47,8 +38,8 @@ def _read_request() -> dict[str, Any]:
     if len(encoded) > FLINT_HNF_INPUT_LIMIT:
         raise FlintHnfWorkerError("FLINT_HNF_INPUT_LIMIT_EXCEEDED")
     try:
-        payload = json.loads(encoded, object_pairs_hook=_strict_object)
-    except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+        payload = loads_strict_json(encoded)
+    except CanonicalizationError as exc:
         raise FlintHnfWorkerError("FLINT_HNF_INPUT_INVALID") from exc
     if not isinstance(payload, dict):
         raise FlintHnfWorkerError("FLINT_HNF_INPUT_INVALID")

--- a/src/jacobian/matrices/flint_linear_worker.py
+++ b/src/jacobian/matrices/flint_linear_worker.py
@@ -3,11 +3,16 @@
 from __future__ import annotations
 
 import importlib
-import json
 import re
 import sys
 from fractions import Fraction
 from typing import Any
+
+from jacobian.canonical import (
+    CanonicalizationError,
+    canonicalize_json,
+    loads_strict_json,
+)
 
 FLINT_LINEAR_WORKER_PROTOCOL = "jacobian.flint-linear-worker/v1"
 FLINT_LINEAR_INCONSISTENCY_WORKER_PROTOCOL = (
@@ -34,23 +39,9 @@ def _emit(
     protocol: str = FLINT_LINEAR_WORKER_PROTOCOL,
 ) -> None:
     sys.stdout.write(
-        json.dumps(
-            {"protocol": protocol, **payload},
-            sort_keys=True,
-            separators=(",", ":"),
-        )
-        + "\n"
+        canonicalize_json({"protocol": protocol, **payload}).decode("utf-8") + "\n"
     )
     sys.stdout.flush()
-
-
-def _strict_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
-    result: dict[str, Any] = {}
-    for key, value in pairs:
-        if key in result:
-            raise ValueError("duplicate JSON key")
-        result[key] = value
-    return result
 
 
 def _read_request() -> dict[str, Any]:
@@ -58,8 +49,8 @@ def _read_request() -> dict[str, Any]:
     if len(encoded) > FLINT_LINEAR_INPUT_LIMIT:
         raise FlintLinearWorkerError("FLINT_LINEAR_INPUT_LIMIT_EXCEEDED")
     try:
-        payload = json.loads(encoded, object_pairs_hook=_strict_object)
-    except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+        payload = loads_strict_json(encoded)
+    except CanonicalizationError as exc:
         raise FlintLinearWorkerError("FLINT_LINEAR_INPUT_INVALID") from exc
     if not isinstance(payload, dict):
         raise FlintLinearWorkerError("FLINT_LINEAR_INPUT_INVALID")

--- a/src/jacobian/memory.py
+++ b/src/jacobian/memory.py
@@ -12,9 +12,47 @@ from jacobian.contracts.capabilities import (
     CapabilityAssuranceLevel,
     CapabilityMode,
 )
-from jacobian.contracts.memory import MemoryHit, MemorySearchResult, ResearchEpisode
+from jacobian.contracts.memory import (
+    MemoryHit,
+    MemorySearchResult,
+    PersistedTags,
+    ResearchEpisode,
+)
+from jacobian.persistence import PersistenceCorruptionError, decode_persisted_model
 from jacobian.schema_registry import SchemaRegistry, model_schema
-from jacobian.store import ArtifactStore
+from jacobian.store import ArtifactStore, StoreCorruptionError
+
+
+def _decode_memory_hits(
+    rows: list[Any],
+    *,
+    terms: tuple[str, ...],
+    matched_filters: tuple[str, ...],
+) -> tuple[MemoryHit, ...]:
+    try:
+        return tuple(
+            MemoryHit(
+                episode_uri=row["episode_uri"],
+                capability_id=row["capability_id"],
+                mode=CapabilityMode(row["mode"]),
+                assurance_level=CapabilityAssuranceLevel(row["assurance_level"]),
+                summary=row["summary"],
+                tags=decode_persisted_model(
+                    PersistedTags,
+                    row["tags_json"],
+                    record_kind="research_episode",
+                    record_id=row["episode_uri"],
+                    field="tags_json",
+                ).root,
+                created_at=datetime.fromisoformat(row["created_at"]),
+                score=(1000 if terms else 500),
+                matched_query_terms=terms,
+                matched_filters=matched_filters,
+            )
+            for row in rows
+        )
+    except PersistenceCorruptionError as exc:
+        raise StoreCorruptionError(exc) from exc
 
 
 class ResearchMemory:
@@ -55,7 +93,17 @@ class ResearchMemory:
                 """
             ).fetchall()
             for row in existing:
-                for tag in json.loads(row["tags_json"]):
+                try:
+                    tags = decode_persisted_model(
+                        PersistedTags,
+                        row["tags_json"],
+                        record_kind="research_episode",
+                        record_id=row["episode_uri"],
+                        field="tags_json",
+                    ).root
+                except PersistenceCorruptionError as exc:
+                    raise StoreCorruptionError(exc) from exc
+                for tag in tags:
                     connection.execute(
                         """
                         INSERT OR IGNORE INTO research_episode_tags(episode_uri, tag)
@@ -136,7 +184,7 @@ class ResearchMemory:
                     episode.mode.value,
                     episode.assurance_level.value,
                     episode.summary,
-                    json.dumps(list(episode.tags), sort_keys=True),
+                    canonicalize_json(list(episode.tags)).decode("utf-8"),
                     search_text,
                 ),
             )
@@ -310,20 +358,10 @@ class ResearchMemory:
             assurance_level=assurance_level,
             cutoff=cutoff,
         )
-        hits = tuple(
-            MemoryHit(
-                episode_uri=row["episode_uri"],
-                capability_id=row["capability_id"],
-                mode=CapabilityMode(row["mode"]),
-                assurance_level=CapabilityAssuranceLevel(row["assurance_level"]),
-                summary=row["summary"],
-                tags=tuple(json.loads(row["tags_json"])),
-                created_at=datetime.fromisoformat(row["created_at"]),
-                score=(1000 if terms else 500),
-                matched_query_terms=tuple(terms),
-                matched_filters=matched_filters,
-            )
-            for row in rows
+        hits = _decode_memory_hits(
+            rows,
+            terms=tuple(terms),
+            matched_filters=matched_filters,
         )
         return MemorySearchResult(
             query=query,

--- a/src/jacobian/persistence/__init__.py
+++ b/src/jacobian/persistence/__init__.py
@@ -1,6 +1,18 @@
 """Internal ownership boundary for Jacobian's local persistent state."""
 
 from jacobian.persistence.database import StateDatabase, StateDatabaseError
+from jacobian.persistence.decoding import (
+    PersistenceCorruptionCode,
+    PersistenceCorruptionError,
+    decode_persisted_model,
+)
 from jacobian.persistence.locking import PersistenceLock
 
-__all__ = ["PersistenceLock", "StateDatabase", "StateDatabaseError"]
+__all__ = [
+    "PersistenceCorruptionCode",
+    "PersistenceCorruptionError",
+    "PersistenceLock",
+    "StateDatabase",
+    "StateDatabaseError",
+    "decode_persisted_model",
+]

--- a/src/jacobian/persistence/decoding.py
+++ b/src/jacobian/persistence/decoding.py
@@ -1,0 +1,110 @@
+"""Fail-closed reconstruction of typed models from persisted JSON."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel, ValidationError
+
+from jacobian.canonical import (
+    CanonicalizationError,
+    canonicalize_json,
+    loads_strict_json,
+)
+
+
+class PersistenceCorruptionCode(StrEnum):
+    """Stable classifications for invalid persisted model bytes."""
+
+    INVALID_UTF8 = "INVALID_UTF8"
+    INVALID_JSON = "INVALID_JSON"
+    NON_CANONICAL_JSON = "NON_CANONICAL_JSON"
+    INVALID_MODEL = "INVALID_MODEL"
+
+
+class PersistenceCorruptionError(RuntimeError):
+    """A persisted record cannot be reconstructed without guessing."""
+
+    def __init__(
+        self,
+        *,
+        record_kind: str,
+        record_id: str,
+        field: str,
+        failure_code: PersistenceCorruptionCode,
+    ) -> None:
+        self.record_kind = record_kind
+        self.record_id = record_id
+        self.field = field
+        self.failure_code = failure_code
+        super().__init__(
+            f"persisted {record_kind} {record_id} field {field} is invalid "
+            f"({failure_code.value})"
+        )
+
+
+def decode_persisted_model[ModelT: BaseModel](
+    model_type: type[ModelT],
+    encoded: str | bytes | bytearray,
+    *,
+    record_kind: str,
+    record_id: str,
+    field: str,
+) -> ModelT:
+    """Decode canonical JSON and reconstruct one contract model.
+
+    The context is supplied by the owning persistence adapter. Raw row values
+    never enter the exception or diagnostic, and no repair or partial recovery
+    is attempted.
+    """
+
+    raw = encoded.encode("utf-8") if isinstance(encoded, str) else bytes(encoded)
+    try:
+        payload = loads_strict_json(raw)
+    except CanonicalizationError as exc:
+        message = str(exc)
+        code = (
+            PersistenceCorruptionCode.INVALID_UTF8
+            if "valid UTF-8" in message
+            else PersistenceCorruptionCode.INVALID_JSON
+        )
+        raise PersistenceCorruptionError(
+            record_kind=record_kind,
+            record_id=record_id,
+            field=field,
+            failure_code=code,
+        ) from exc
+
+    try:
+        canonical = canonicalize_json(payload)
+    except CanonicalizationError as exc:
+        raise PersistenceCorruptionError(
+            record_kind=record_kind,
+            record_id=record_id,
+            field=field,
+            failure_code=PersistenceCorruptionCode.INVALID_JSON,
+        ) from exc
+    if canonical != raw:
+        raise PersistenceCorruptionError(
+            record_kind=record_kind,
+            record_id=record_id,
+            field=field,
+            failure_code=PersistenceCorruptionCode.NON_CANONICAL_JSON,
+        )
+
+    try:
+        return model_type.model_validate(payload)
+    except ValidationError as exc:
+        raise PersistenceCorruptionError(
+            record_kind=record_kind,
+            record_id=record_id,
+            field=field,
+            failure_code=PersistenceCorruptionCode.INVALID_MODEL,
+        ) from exc
+
+
+__all__ = [
+    "PersistenceCorruptionCode",
+    "PersistenceCorruptionError",
+    "decode_persisted_model",
+]

--- a/src/jacobian/plugin_execution.py
+++ b/src/jacobian/plugin_execution.py
@@ -6,10 +6,15 @@ import logging
 import sys
 import time
 from dataclasses import dataclass
-from typing import Any
+from enum import StrEnum
+from typing import Any, cast
 
 from jacobian.bounded_process import run_bounded_process
-from jacobian.canonical import canonicalize_json, loads_strict_json
+from jacobian.canonical import (
+    CanonicalizationError,
+    canonicalize_json,
+    loads_strict_json,
+)
 from jacobian.contracts.results import ExecutionStatus
 from jacobian.implementation import package_source_digest
 from jacobian.worker_environment import worker_environment
@@ -41,6 +46,44 @@ _PLUGIN_STOPPED = (
 )
 
 
+class _PluginWorkerFailureCode(StrEnum):
+    """Bounded operational failures emitted by the plugin worker."""
+
+    INVALID_REQUEST = "INVALID_REQUEST"
+    SOURCE_CHANGED = "SOURCE_CHANGED"
+    RESPONSE_INVALID = "RESPONSE_INVALID"
+    EXECUTION_FAILED = "EXECUTION_FAILED"
+    PROVIDER_UNAVAILABLE = "PROVIDER_UNAVAILABLE"
+
+
+class PluginInputError(ValueError):
+    """A plugin request cannot be parsed into its domain contract."""
+
+    def __init__(
+        self,
+        *,
+        path: str,
+        expected: str,
+        actual_type: str,
+    ) -> None:
+        self.path = path
+        self.expected = expected
+        self.actual_type = actual_type
+        super().__init__(
+            f"invalid plugin input at {path or '/'}: expected {expected} "
+            f"(received {actual_type})"
+        )
+
+
+class PluginResponseError(ValueError):
+    """A plugin worker response is not a safe typed response envelope."""
+
+    def __init__(self, *, failure_code: _PluginWorkerFailureCode, message: str) -> None:
+        self.failure_code = failure_code
+        self.safe_message = message
+        super().__init__(message)
+
+
 @dataclass(frozen=True, slots=True)
 class PluginExecutionResult:
     """Operational result from one local plugin worker invocation."""
@@ -50,6 +93,10 @@ class PluginExecutionResult:
     diagnostics: str
     detail: str | None
     runtime_ms: int
+    failure_code: _PluginWorkerFailureCode | None = None
+    path: str | None = None
+    expected: str | None = None
+    actual_type: str | None = None
 
 
 class PluginExecutor:
@@ -107,6 +154,7 @@ class PluginExecutor:
                 diagnostics=diagnostics,
                 detail=_PLUGIN_TIMEOUT,
                 runtime_ms=_elapsed_ms(started),
+                failure_code=_PluginWorkerFailureCode.EXECUTION_FAILED,
             )
 
         if completed.stdout_exceeded:
@@ -116,6 +164,7 @@ class PluginExecutor:
                 diagnostics=diagnostics,
                 detail=_PLUGIN_OUTPUT_TOO_LARGE,
                 runtime_ms=_elapsed_ms(started),
+                failure_code=_PluginWorkerFailureCode.RESPONSE_INVALID,
             )
         if completed.stderr_exceeded:
             return PluginExecutionResult(
@@ -124,16 +173,18 @@ class PluginExecutor:
                 diagnostics=diagnostics,
                 detail=_PLUGIN_DIAGNOSTICS_TOO_LARGE,
                 runtime_ms=_elapsed_ms(started),
+                failure_code=_PluginWorkerFailureCode.RESPONSE_INVALID,
             )
         try:
             output = loads_strict_json(completed.stdout)
-        except ValueError:
+        except CanonicalizationError:
             return PluginExecutionResult(
                 status=ExecutionStatus.ERROR,
                 output=None,
                 diagnostics=diagnostics,
                 detail=_PLUGIN_UNREADABLE_RESPONSE,
                 runtime_ms=_elapsed_ms(started),
+                failure_code=_PluginWorkerFailureCode.RESPONSE_INVALID,
             )
         if completed.returncode != 0:
             _LOGGER.warning(
@@ -141,12 +192,17 @@ class PluginExecutor:
                 output,
                 diagnostics,
             )
+            code = _failure_code(output)
             return PluginExecutionResult(
                 status=ExecutionStatus.ERROR,
                 output=None,
                 diagnostics=diagnostics,
                 detail=_plugin_failure_detail(output),
                 runtime_ms=_elapsed_ms(started),
+                failure_code=code,
+                path=_optional_string(output, "path"),
+                expected=_optional_string(output, "expected"),
+                actual_type=_optional_string(output, "actual_type"),
             )
         if not isinstance(output, dict):
             return PluginExecutionResult(
@@ -155,6 +211,7 @@ class PluginExecutor:
                 diagnostics=diagnostics,
                 detail=_PLUGIN_UNREADABLE_RESPONSE,
                 runtime_ms=_elapsed_ms(started),
+                failure_code=_PluginWorkerFailureCode.RESPONSE_INVALID,
             )
         if output.get("measured_implementation_digest") != expected_digest:
             _LOGGER.warning(
@@ -167,6 +224,7 @@ class PluginExecutor:
                 diagnostics=diagnostics,
                 detail=_PLUGIN_CHANGED,
                 runtime_ms=_elapsed_ms(started),
+                failure_code=_PluginWorkerFailureCode.SOURCE_CHANGED,
             )
         response = output.get("response")
         if not isinstance(response, dict):
@@ -191,9 +249,32 @@ def _elapsed_ms(started: float) -> int:
 
 
 def _plugin_failure_detail(output: Any) -> str:
-    if isinstance(output, dict) and output.get("error_code") == "SOURCE_CHANGED":
+    code = _failure_code(output)
+    if code is _PluginWorkerFailureCode.SOURCE_CHANGED:
         return _PLUGIN_CHANGED
+    if code is _PluginWorkerFailureCode.INVALID_REQUEST:
+        return "The plugin rejected its request. Check the capability input contract and retry."
+    if code is _PluginWorkerFailureCode.PROVIDER_UNAVAILABLE:
+        return "The plugin provider is unavailable. Install or repair the declared provider, then retry."
     return _PLUGIN_STOPPED
+
+
+def _failure_code(value: Any) -> _PluginWorkerFailureCode:
+    if isinstance(value, dict):
+        raw_code = value.get("error_code")
+        if not isinstance(raw_code, str):
+            return _PluginWorkerFailureCode.EXECUTION_FAILED
+        try:
+            return _PluginWorkerFailureCode(raw_code)
+        except ValueError:
+            pass
+    return _PluginWorkerFailureCode.EXECUTION_FAILED
+
+
+def _optional_string(value: Any, key: str) -> str | None:
+    if isinstance(value, dict) and isinstance(value.get(key), str):
+        return cast(str, value[key])
+    return None
 
 
 def _bounded_text(value: bytes | str | None, *, limit: int) -> str:

--- a/src/jacobian/plugin_worker.py
+++ b/src/jacobian/plugin_worker.py
@@ -8,7 +8,11 @@ import sys
 from collections.abc import Callable
 from typing import Any, cast
 
-from jacobian.canonical import canonicalize_json, loads_strict_json
+from jacobian.canonical import (
+    CanonicalizationError,
+    canonicalize_json,
+    loads_strict_json,
+)
 from jacobian.implementation import (
     install_source_only_importer,
     package_source_digest,
@@ -34,9 +38,18 @@ def main() -> int:
         )
         return 2
     error_code = "EXECUTION_FAILED"
+    failure_fields: dict[str, str] = {}
+    request_decoded = False
     try:
         request = loads_strict_json(sys.stdin.buffer.read())
+        request_decoded = True
         if not isinstance(request, dict):
+            error_code = "INVALID_REQUEST"
+            failure_fields = {
+                "path": "/",
+                "expected": "object",
+                "actual_type": type(request).__name__,
+            }
             raise TypeError("plugin request must be a JSON object")
         measured_before = package_source_digest(sys.argv[1])
         if measured_before != sys.argv[2]:
@@ -47,6 +60,12 @@ def main() -> int:
             operation = _resolve(sys.argv[1])
             response = operation(request)
         if not isinstance(response, dict):
+            error_code = "RESPONSE_INVALID"
+            failure_fields = {
+                "path": "/response",
+                "expected": "object",
+                "actual_type": type(response).__name__,
+            }
             raise TypeError("plugin response must be a JSON object")
         measured_after = package_source_digest(sys.argv[1])
         if measured_after != measured_before:
@@ -62,11 +81,21 @@ def main() -> int:
         )
         sys.stdout.buffer.write(b"\n")
         return 0
-    except Exception as exc:  # untrusted failures are operational, never logical
+    except CanonicalizationError:
+        error_code = "RESPONSE_INVALID" if request_decoded else "INVALID_REQUEST"
+        failure_fields = {
+            "path": "/response" if request_decoded else "/",
+            "expected": "canonical JSON object",
+            "actual_type": "response" if request_decoded else "bytes",
+        }
+        error = {"error_code": error_code, **failure_fields}
+        sys.stdout.buffer.write(canonicalize_json(error))
+        sys.stdout.buffer.write(b"\n")
+        return 1
+    except Exception:  # untrusted failures are operational, never logical
         error = {
-            "error": type(exc).__name__,
             "error_code": error_code,
-            "detail": str(exc),
+            **failure_fields,
         }
         sys.stdout.buffer.write(canonicalize_json(error))
         sys.stdout.buffer.write(b"\n")

--- a/src/jacobian/plugins/erdos_straus.py
+++ b/src/jacobian/plugins/erdos_straus.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 from fractions import Fraction
 from typing import Any, TypeGuard
 
+from pydantic import ValidationError
+
+from jacobian.contracts.plugin_inputs import ErdosStrausCapabilityRequest
+
 _MIN_N = 2
 _MAX_N = 10_000
 
@@ -97,8 +101,12 @@ def _decomposition_table(
 def evaluate_capability(request: dict[str, Any]) -> dict[str, Any]:
     """Evaluate a bounded range without granting verification authority."""
 
-    claim = _claim_view(request.get("claim", {}))
-    candidate = request.get("candidate")
+    try:
+        selected = ErdosStrausCapabilityRequest.model_validate(request)
+    except ValidationError as exc:
+        raise ValueError("Erdős-Straus request does not match its contract") from exc
+    claim = selected.claim.model_dump(mode="python")
+    candidate = selected.candidate.model_dump(mode="python")
     errors = validate_claim(claim)
     if not isinstance(candidate, dict):
         errors.append("candidate must be an object")
@@ -139,9 +147,13 @@ def evaluate_capability(request: dict[str, Any]) -> dict[str, Any]:
 def find_witness_capability(request: dict[str, Any]) -> dict[str, Any]:
     """Propose a complete bounded decomposition table as unverified evidence."""
 
-    claim = _claim_view(request.get("claim", {}))
-    candidate = request.get("candidate")
-    role = request.get("witness_role")
+    try:
+        selected = ErdosStrausCapabilityRequest.model_validate(request)
+    except ValidationError as exc:
+        raise ValueError("Erdős-Straus request does not match its contract") from exc
+    claim = selected.claim.model_dump(mode="python")
+    candidate = selected.candidate.model_dump(mode="python")
+    role = selected.witness_role
     errors = validate_claim(claim)
     if role != "SUPPORTS_CLAIM":
         errors.append("erdos_straus_range supports only SUPPORTS_CLAIM witnesses")

--- a/src/jacobian/plugins/graph_paths.py
+++ b/src/jacobian/plugins/graph_paths.py
@@ -15,8 +15,16 @@ from itertools import pairwise, permutations
 from typing import Any, cast
 
 import networkx as nx
+from pydantic import ValidationError
 
 from jacobian.canonical import canonicalize_json
+from jacobian.contracts.plugin_inputs import (
+    GraphCanonicalizeRequest,
+    GraphEnumerationRequest,
+    GraphPathCapabilityRequest,
+    GraphPathEvaluationRequest,
+    GraphPathReductionRequest,
+)
 
 # ---------------------------------------------------------------------------
 # Validation helpers
@@ -178,7 +186,9 @@ def _as_digraph(payload: dict[str, Any]) -> nx.DiGraph[str]:
 
 
 def _max_path_length(claim: dict[str, Any], candidate: dict[str, Any]) -> int:
-    value = claim.get("max_path_length", len(candidate.get("vertices", [])))
+    value = claim.get("max_path_length")
+    if value is None:
+        value = len(candidate.get("vertices", []))
     return cast(int, value)
 
 
@@ -281,8 +291,21 @@ def _claim_view(payload: dict[str, Any]) -> dict[str, Any]:
 def evaluate(request: dict[str, Any]) -> dict[str, Any]:
     """Evaluate graph candidates for a claim.  Results are unverified."""
     start = time.monotonic()
-    claim = request.get("claim", {})
-    candidate_list = request.get("candidates", [request.get("candidate")])
+    try:
+        selected = GraphPathEvaluationRequest.model_validate(request)
+    except ValidationError:
+        return _rejected(
+            ["graph evaluation request does not match its contract"], start
+        )
+    claim = selected.claim.model_dump(mode="json", exclude_none=True)
+    candidate_list = (
+        [selected.candidate.model_dump(mode="json", exclude_none=True)]
+        if selected.candidate is not None
+        else [
+            candidate.model_dump(mode="json", exclude_none=True)
+            for candidate in selected.candidates or ()
+        ]
+    )
 
     claim_errors = validate_claim(claim)
     if claim_errors:
@@ -374,13 +397,35 @@ def evaluate(request: dict[str, Any]) -> dict[str, Any]:
     return response
 
 
+def _graph_capability_request(request: dict[str, Any]) -> GraphPathCapabilityRequest:
+    try:
+        return GraphPathCapabilityRequest.model_validate(request)
+    except ValidationError as exc:
+        raise ValueError(
+            "graph capability request does not match its contract"
+        ) from exc
+
+
+def _graph_reduction_request(request: dict[str, Any]) -> GraphPathReductionRequest:
+    try:
+        return GraphPathReductionRequest.model_validate(request)
+    except ValidationError as exc:
+        raise ValueError("graph reduction request does not match its contract") from exc
+
+
 def evaluate_capability(request: dict[str, Any]) -> dict[str, Any]:
     """Return one graph evaluation in the generic evaluator contract."""
 
+    try:
+        selected = GraphPathCapabilityRequest.model_validate(request)
+    except ValidationError as exc:
+        raise ValueError(
+            "graph evaluation request does not match its contract"
+        ) from exc
     response = evaluate(
         {
-            "claim": _claim_view(request.get("claim", {})),
-            "candidate": request.get("candidate"),
+            "claim": selected.claim.model_dump(mode="json", exclude_none=True),
+            "candidate": selected.candidate.model_dump(mode="json", exclude_none=True),
         }
     )
     if response["input"]["status"] != "ACCEPTED":
@@ -418,9 +463,13 @@ def evaluate_capability(request: dict[str, Any]) -> dict[str, Any]:
 def find_witness(request: dict[str, Any]) -> dict[str, Any]:
     """Search for a graph witness.  Result is unverified."""
     start = time.monotonic()
-    claim = request.get("claim", {})
-    candidate = request.get("candidate", {})
-    role = request.get("witness_role", "DEFEATS_CANDIDATE")
+    try:
+        selected = _graph_capability_request(request)
+    except ValueError as exc:
+        return _rejected([str(exc)], start)
+    claim = selected.claim.model_dump(mode="json", exclude_none=True)
+    candidate = selected.candidate.model_dump(mode="json", exclude_none=True)
+    role = selected.witness_role
 
     claim_errors = validate_claim(claim)
     if claim_errors:
@@ -554,16 +603,7 @@ def find_witness(request: dict[str, Any]) -> dict[str, Any]:
 def find_witness_capability(request: dict[str, Any]) -> dict[str, Any]:
     """Return graph witness search in the generic oracle contract."""
 
-    response = find_witness(
-        {
-            "claim": _claim_view(request.get("claim", {})),
-            "candidate": request.get("candidate", {}),
-            "witness_role": request.get(
-                "witness_role",
-                "DEFEATS_CANDIDATE",
-            ),
-        }
-    )
+    response = find_witness(request)
     if response["input"]["status"] != "ACCEPTED":
         raise ValueError("; ".join(response["input"]["errors"]))
     return {
@@ -586,8 +626,14 @@ def find_witness_capability(request: dict[str, Any]) -> dict[str, Any]:
 def materialize(request: dict[str, Any]) -> dict[str, Any]:
     """Materialize a complete bounded family for a graph claim."""
     start = time.monotonic()
-    claim = request.get("claim", {})
-    candidate = request.get("candidate", {})
+    try:
+        selected = GraphPathCapabilityRequest.model_validate(request)
+    except ValidationError:
+        return _rejected(
+            ["graph materialization request does not match its contract"], start
+        )
+    claim = selected.claim.model_dump(mode="json", exclude_none=True)
+    candidate = selected.candidate.model_dump(mode="json", exclude_none=True)
 
     claim_errors = validate_claim(claim)
     if claim_errors:
@@ -614,9 +660,10 @@ def materialize(request: dict[str, Any]) -> dict[str, Any]:
 def reductions(request: dict[str, Any]) -> dict[str, Any]:
     """Propose candidate reductions that preserve the attacked predicate."""
     start = time.monotonic()
-    target_kind = request.get("target_kind", "candidate")
-    target = request.get("target", {})
-    claim = request.get("claim", {})
+    selected = _graph_reduction_request(request)
+    target_kind = selected.target_kind
+    target = selected.target.model_dump(mode="json", exclude_none=True)
+    claim = selected.claim.model_dump(mode="json", exclude_none=True)
 
     claim_errors = validate_claim(claim)
     if claim_errors:
@@ -707,18 +754,19 @@ def reductions(request: dict[str, Any]) -> dict[str, Any]:
 def reductions_capability(request: dict[str, Any]) -> dict[str, Any]:
     """Return complete reduced payloads for the generic shrinker."""
 
-    target = request.get("target", {})
+    selected = _graph_reduction_request(request)
+    target = selected.target.model_dump(mode="json", exclude_none=True)
     response = reductions(
         {
-            "target_kind": request.get("target_kind", "candidate"),
+            "target_kind": selected.target_kind,
             "target": target,
-            "claim": _claim_view(request.get("claim", {})),
+            "claim": selected.claim.model_dump(mode="json", exclude_none=True),
         }
     )
     if response["input"]["status"] != "ACCEPTED":
         raise ValueError("; ".join(response["input"]["errors"]))
-    requested = set(request.get("reducers", ()))
-    objective_names = tuple(request.get("objectives", ()))
+    requested = set(selected.reducers)
+    objective_names = tuple(selected.objectives)
     proposals: list[dict[str, Any]] = []
     for operation in response["reductions"]:
         reducer = operation["reduction_kind"]
@@ -784,9 +832,13 @@ def canonicalize_capability(request: dict[str, Any]) -> dict[str, Any]:
     the same capability contract.
     """
 
-    structure = request.get("structure")
-    if not isinstance(structure, dict):
-        raise ValueError("structure must be an object")
+    try:
+        selected = GraphCanonicalizeRequest.model_validate(request)
+    except ValidationError as exc:
+        raise ValueError(
+            "graph canonicalization request does not match its contract"
+        ) from exc
+    structure = selected.structure.model_dump(mode="json", exclude_none=True)
     errors = validate_candidate(structure)
     if errors:
         raise ValueError("; ".join(errors))
@@ -867,34 +919,15 @@ def _relabel_graph_payload(
 def enumerate_candidates_capability(request: dict[str, Any]) -> dict[str, Any]:
     """Page through labeled DAGs whose arcs respect the vertex index order."""
 
-    bounds = request.get("bounds")
-    cursor = request.get("cursor")
-    page_size = request.get("page_size")
-    if not isinstance(bounds, dict):
-        raise ValueError("bounds must be an object")
-    if set(bounds) != {"vertices"}:
-        raise ValueError("graph bounds require exactly vertices")
-    vertex_count = bounds["vertices"]
-    if (
-        not isinstance(vertex_count, int)
-        or isinstance(vertex_count, bool)
-        or vertex_count < 1
-        or vertex_count > 8
-    ):
-        raise ValueError("vertices must be an integer from one through eight")
-    if not isinstance(page_size, int) or isinstance(page_size, bool) or page_size < 1:
-        raise ValueError("page_size must be a positive integer")
-    offset = 0
-    if cursor is not None:
-        if (
-            not isinstance(cursor, dict)
-            or set(cursor) != {"offset"}
-            or not isinstance(cursor["offset"], int)
-            or isinstance(cursor["offset"], bool)
-            or cursor["offset"] < 0
-        ):
-            raise ValueError("cursor must contain a nonnegative integer offset")
-        offset = cursor["offset"]
+    try:
+        selected = GraphEnumerationRequest.model_validate(request)
+    except ValidationError as exc:
+        raise ValueError(
+            "graph enumeration request does not match its contract"
+        ) from exc
+    vertex_count = selected.bounds["vertices"]
+    page_size = selected.page_size
+    offset = selected.cursor.offset if selected.cursor is not None else 0
 
     vertices = [f"v{index}" for index in range(vertex_count)]
     possible_arcs = [

--- a/src/jacobian/plugins/graph_shrinking.py
+++ b/src/jacobian/plugins/graph_shrinking.py
@@ -4,15 +4,24 @@ from __future__ import annotations
 
 from typing import Any
 
+from pydantic import ValidationError
+
+from jacobian.contracts.plugin_inputs import GraphShrinkRequest
+
 
 def reduce_simple_graph(request: dict[str, Any]) -> dict[str, Any]:
     """Propose every requested single deletion in canonical order."""
 
-    target = request["target"]
-    vertices = tuple(target["vertices"])
-    edges = tuple(tuple(edge) for edge in target["edges"])
-    requested = tuple(request["reducers"])
-    objectives = tuple(request["objectives"])
+    try:
+        selected = GraphShrinkRequest.model_validate(request)
+    except ValidationError as exc:
+        raise ValueError("graph shrinking request does not match its contract") from exc
+
+    target = selected.target
+    vertices = target.vertices
+    edges = target.edges
+    requested = selected.reducers
+    objectives = selected.objectives
     proposals: list[dict[str, Any]] = []
 
     if "delete_vertex" in requested:

--- a/src/jacobian/plugins/matrices.py
+++ b/src/jacobian/plugins/matrices.py
@@ -17,6 +17,17 @@ from copy import deepcopy
 from fractions import Fraction
 from typing import Any, cast
 
+from pydantic import ValidationError
+
+from jacobian.contracts.plugin_inputs import (
+    MatrixCapabilityRequest,
+    MatrixEnumerationRequest,
+    MatrixEvaluationRequest,
+    MatrixMaterializeRequest,
+    MatrixReductionRequest,
+    MatrixTransformRequest,
+)
+
 MAX_SEARCHED_MATRICES = 65_536
 
 # ---------------------------------------------------------------------------
@@ -67,27 +78,18 @@ def _canonical_rational(frac: Fraction) -> dict[str, str]:
 def enumerate_candidates_capability(request: dict[str, Any]) -> dict[str, Any]:
     """Page through a finite rectangular integer-matrix scope."""
 
-    bounds = request.get("bounds")
-    cursor = request.get("cursor")
-    page_size = request.get("page_size")
-    if not isinstance(bounds, dict):
-        raise ValueError("bounds must be an object")
+    try:
+        selected = MatrixEnumerationRequest.model_validate(request)
+    except ValidationError as exc:
+        raise ValueError(
+            "matrix enumeration request does not match its contract"
+        ) from exc
+    bounds = selected.bounds.model_dump(mode="json")
+    page_size = selected.page_size
+    offset = selected.cursor.offset if selected.cursor is not None else 0
     errors = _validate_scope(bounds)
     if errors:
         raise ValueError("; ".join(errors))
-    if not isinstance(page_size, int) or isinstance(page_size, bool) or page_size < 1:
-        raise ValueError("page_size must be a positive integer")
-    offset = 0
-    if cursor is not None:
-        if (
-            not isinstance(cursor, dict)
-            or set(cursor) != {"offset"}
-            or not isinstance(cursor["offset"], int)
-            or isinstance(cursor["offset"], bool)
-            or cursor["offset"] < 0
-        ):
-            raise ValueError("cursor must contain a nonnegative integer offset")
-        offset = cursor["offset"]
 
     rows = cast(int, bounds["rows"])
     cols = cast(int, bounds["cols"])
@@ -123,9 +125,13 @@ def enumerate_candidates_capability(request: dict[str, Any]) -> dict[str, Any]:
 def transform_row_major_capability(request: dict[str, Any]) -> dict[str, Any]:
     """Propose a row-major representation of one integer matrix."""
 
-    source = request.get("source")
-    if not isinstance(source, dict):
-        raise ValueError("source must be an object")
+    try:
+        selected = MatrixTransformRequest.model_validate(request)
+    except ValidationError as exc:
+        raise ValueError(
+            "matrix transform request does not match its contract"
+        ) from exc
+    source = selected.source.model_dump(mode="json")
     errors = validate_candidate(source)
     if errors:
         raise ValueError("; ".join(errors))
@@ -419,11 +425,41 @@ def _claim_view(payload: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _matrix_capability_request(request: dict[str, Any]) -> MatrixCapabilityRequest:
+    try:
+        return MatrixCapabilityRequest.model_validate(request)
+    except ValidationError as exc:
+        raise ValueError(
+            "matrix capability request does not match its contract"
+        ) from exc
+
+
+def _matrix_reduction_request(request: dict[str, Any]) -> MatrixReductionRequest:
+    try:
+        return MatrixReductionRequest.model_validate(request)
+    except ValidationError as exc:
+        raise ValueError(
+            "matrix reduction request does not match its contract"
+        ) from exc
+
+
 def evaluate(request: dict[str, Any]) -> dict[str, Any]:
     """Evaluate integer-matrix candidates for a claim.  Results are unverified."""
     start = time.monotonic()
-    claim = request.get("claim", {})
-    candidate_list = request.get("candidates", [request.get("candidate")])
+    try:
+        selected = MatrixEvaluationRequest.model_validate(request)
+    except ValidationError:
+        return _rejected(
+            ["matrix evaluation request does not match its contract"], start
+        )
+    claim = selected.claim.model_dump(mode="json")
+    candidate_list = (
+        [selected.candidate.model_dump(mode="json")]
+        if selected.candidate is not None
+        else [
+            candidate.model_dump(mode="json") for candidate in selected.candidates or ()
+        ]
+    )
 
     claim_errors = validate_claim(claim)
     if claim_errors:
@@ -498,13 +534,18 @@ def evaluate(request: dict[str, Any]) -> dict[str, Any]:
 def evaluate_capability(request: dict[str, Any]) -> dict[str, Any]:
     """Return one matrix evaluation in the generic evaluator contract."""
 
-    claim = _claim_view(request.get("claim", {}))
-    response = evaluate(
-        {
-            "claim": claim,
-            "candidate": request.get("candidate"),
-        }
+    try:
+        selected = MatrixCapabilityRequest.model_validate(request)
+    except ValidationError as exc:
+        raise ValueError(
+            "matrix evaluation request does not match its contract"
+        ) from exc
+    claim = selected.claim.model_dump(mode="json")
+    candidate_model = selected.candidate
+    candidate = (
+        candidate_model.model_dump(mode="json") if candidate_model is not None else None
     )
+    response = evaluate({"claim": claim, "candidate": candidate})
     if response["input"]["status"] != "ACCEPTED":
         raise ValueError("; ".join(response["input"]["errors"]))
     result = response["results"][0]
@@ -527,10 +568,14 @@ def evaluate_capability(request: dict[str, Any]) -> dict[str, Any]:
         "method": method,
         "coverage": coverage,
         "objectives": {objective["name"]: objective["value"]},
-        "features": {
-            "rows": str(request["candidate"]["rows"]),
-            "cols": str(request["candidate"]["cols"]),
-        },
+        "features": (
+            {
+                "rows": str(candidate_model.rows),
+                "cols": str(candidate_model.cols),
+            }
+            if candidate_model is not None
+            else {}
+        ),
         "failure_classifications": (
             ["nontrivial_kernel"] if result.get("is_singular") else []
         ),
@@ -541,14 +586,19 @@ def evaluate_capability(request: dict[str, Any]) -> dict[str, Any]:
 def find_witness(request: dict[str, Any]) -> dict[str, Any]:
     """Search for a matrix witness.  Result is unverified."""
     start = time.monotonic()
-    claim = request.get("claim", {})
-    candidate = request.get("candidate")
+    selected = _matrix_capability_request(request)
+    claim = selected.claim.model_dump(mode="json")
+    candidate = (
+        selected.candidate.model_dump(mode="json")
+        if selected.candidate is not None
+        else None
+    )
     claim_errors = validate_claim(claim)
     if claim_errors:
         return _rejected(claim_errors, start)
 
     predicate = claim.get("predicate")
-    requested_role = request.get("witness_role", "DEFEATS_CANDIDATE")
+    requested_role = selected.witness_role
 
     if predicate == "is_nonsingular":
         if requested_role != "DEFEATS_CANDIDATE":
@@ -658,16 +708,7 @@ def find_witness(request: dict[str, Any]) -> dict[str, Any]:
 def find_witness_capability(request: dict[str, Any]) -> dict[str, Any]:
     """Return matrix witness search in the generic oracle contract."""
 
-    domain_request: dict[str, Any] = {
-        "claim": _claim_view(request.get("claim", {})),
-        "witness_role": request.get(
-            "witness_role",
-            "DEFEATS_CANDIDATE",
-        ),
-    }
-    if request.get("candidate") is not None:
-        domain_request["candidate"] = request["candidate"]
-    response = find_witness(domain_request)
+    response = find_witness(request)
     if response["input"]["status"] != "ACCEPTED":
         raise ValueError("; ".join(response["input"]["errors"]))
     return {
@@ -690,7 +731,13 @@ def find_witness_capability(request: dict[str, Any]) -> dict[str, Any]:
 def materialize(request: dict[str, Any]) -> dict[str, Any]:
     """Materialize a complete bounded family for a matrix claim."""
     start = time.monotonic()
-    claim = request.get("claim", {})
+    try:
+        selected = MatrixMaterializeRequest.model_validate(request)
+    except ValidationError:
+        return _rejected(
+            ["matrix materialization request does not match its contract"], start
+        )
+    claim = selected.claim.model_dump(mode="json")
 
     claim_errors = validate_claim(claim)
     if claim_errors:
@@ -707,6 +754,14 @@ def materialize(request: dict[str, Any]) -> dict[str, Any]:
     scope_errors = _validate_scope(scope)
     if scope_errors:
         return _rejected(scope_errors, start)
+    if _scope_total(scope) > MAX_SEARCHED_MATRICES:
+        return _rejected(
+            [
+                "matrix materialization scope exceeds the bounded search limit "
+                f"of {MAX_SEARCHED_MATRICES} candidates"
+            ],
+            start,
+        )
 
     family: list[dict[str, Any]] = []
     for index, mat in _scope_iterator(scope):
@@ -732,9 +787,10 @@ def materialize(request: dict[str, Any]) -> dict[str, Any]:
 def reductions(request: dict[str, Any]) -> dict[str, Any]:
     """Propose candidate reductions that preserve the attacked predicate."""
     start = time.monotonic()
-    target_kind = request.get("target_kind", "candidate")
-    target = request.get("target", {})
-    claim = request.get("claim", {})
+    selected = _matrix_reduction_request(request)
+    target_kind = selected.target_kind
+    target = selected.target.model_dump(mode="json")
+    claim = selected.claim.model_dump(mode="json")
 
     claim_errors = validate_claim(claim)
     if claim_errors:
@@ -817,18 +873,19 @@ def reductions(request: dict[str, Any]) -> dict[str, Any]:
 def reductions_capability(request: dict[str, Any]) -> dict[str, Any]:
     """Return complete reduced payloads for the generic shrinker."""
 
-    target = request.get("target", {})
+    selected = _matrix_reduction_request(request)
+    target = selected.target.model_dump(mode="json")
     response = reductions(
         {
-            "target_kind": request.get("target_kind", "candidate"),
+            "target_kind": selected.target_kind,
             "target": target,
-            "claim": _claim_view(request.get("claim", {})),
+            "claim": selected.claim.model_dump(mode="json"),
         }
     )
     if response["input"]["status"] != "ACCEPTED":
         raise ValueError("; ".join(response["input"]["errors"]))
-    requested = set(request.get("reducers", ()))
-    objective_names = tuple(request.get("objectives", ()))
+    requested = set(selected.reducers)
+    objective_names = tuple(selected.objectives)
     proposals: list[dict[str, Any]] = []
     for operation in response["reductions"]:
         reducer = operation["reduction_kind"]

--- a/src/jacobian/provider_measurements.py
+++ b/src/jacobian/provider_measurements.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import importlib
 import importlib.metadata
-import json
 import os
 import shutil
 import subprocess
@@ -13,6 +12,7 @@ import tempfile
 import time
 from pathlib import Path
 
+from jacobian.canonical import CanonicalizationError, loads_strict_json
 from jacobian.contracts.capabilities import CapabilityProviderRuntime
 from jacobian.contracts.provider_measurements import (
     ProviderMeasurement,
@@ -95,7 +95,7 @@ elapsed = time.perf_counter() - started
 rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
 if sys.platform != "darwin":
     rss *= 1024
-print(json.dumps({"seconds": elapsed, "peak_rss_bytes": rss}))
+print(json.dumps({"seconds": format(elapsed, ".17g"), "peak_rss_bytes": rss}))
 """
 _EXTERNAL_PROBE = r"""
 import json
@@ -116,7 +116,7 @@ rss = resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss
 if sys.platform != "darwin":
     rss *= 1024
 print(json.dumps({
-    "seconds": elapsed,
+    "seconds": format(elapsed, ".17g"),
     "peak_rss_bytes": rss,
     "output_bytes": len(process.stdout) + len(process.stderr),
 }))
@@ -155,7 +155,9 @@ def _measure_command(command: list[str]) -> ProviderMeasurementSample:
         )
         if len(process.stdout.encode()) > _MAX_DIAGNOSTIC_BYTES:
             raise RuntimeError("provider probe output exceeded 64 KiB")
-        payload = json.loads(process.stdout)
+        payload = loads_strict_json(process.stdout)
+        if not isinstance(payload, dict):
+            raise ValueError("provider measurement returned a non-object")
         return ProviderMeasurementSample(
             status=ProviderMeasurementStatus.COMPLETED,
             seconds=float(payload["seconds"]),
@@ -171,7 +173,7 @@ def _measure_command(command: list[str]) -> ProviderMeasurementSample:
         OSError,
         RuntimeError,
         ValueError,
-        json.JSONDecodeError,
+        CanonicalizationError,
         subprocess.SubprocessError,
     ):
         return ProviderMeasurementSample(

--- a/src/jacobian/provider_runtime.py
+++ b/src/jacobian/provider_runtime.py
@@ -7,9 +7,12 @@ import importlib
 import importlib.metadata
 import sysconfig
 from collections.abc import Mapping
+from enum import StrEnum
 from functools import cache
 from pathlib import Path
 from typing import Any
+
+from pydantic import ValidationError
 
 from jacobian.canonical import canonicalize_json
 from jacobian.contracts.capabilities import (
@@ -41,8 +44,38 @@ SYMPY_POLYNOMIAL_WORKER_PROTOCOL = "jacobian.sympy-polynomial-normalization/v1"
 Z3_SOLVER_VERSION = "5.0.0.0"
 
 
+class ProviderRuntimeErrorCode(StrEnum):
+    """Stable classifications for provider identity and readiness failures."""
+
+    IDENTITY_INCOMPLETE = "IDENTITY_INCOMPLETE"
+    MALFORMED_RUNTIME = "MALFORMED_RUNTIME"
+    UNAVAILABLE = "UNAVAILABLE"
+    IDENTITY_CHANGED = "IDENTITY_CHANGED"
+    READINESS_FAILED = "READINESS_FAILED"
+
+
 class ProviderRuntimeError(RuntimeError):
     """Raised when a required provider identity cannot be inspected safely."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: ProviderRuntimeErrorCode | None = None,
+    ) -> None:
+        self.code = code or _infer_provider_error_code(message)
+        super().__init__(message[:512])
+
+
+def _infer_provider_error_code(message: str) -> ProviderRuntimeErrorCode:
+    lowered = message.casefold()
+    if "incomplete" in lowered:
+        return ProviderRuntimeErrorCode.IDENTITY_INCOMPLETE
+    if "malformed" in lowered or "invalid" in lowered:
+        return ProviderRuntimeErrorCode.MALFORMED_RUNTIME
+    if "changed" in lowered:
+        return ProviderRuntimeErrorCode.IDENTITY_CHANGED
+    return ProviderRuntimeErrorCode.UNAVAILABLE
 
 
 @cache
@@ -74,7 +107,8 @@ def _distribution_record_digest(
         rows.append(f"{package_path}\0{hash_value}\0{size}\n")
     if not rows or not hashed:
         raise ProviderRuntimeError(
-            "the installed Python distribution has no hashed RECORD manifest"
+            "the installed Python distribution has no hashed RECORD manifest",
+            code=ProviderRuntimeErrorCode.MALFORMED_RUNTIME,
         )
     digest = hashlib.sha256("".join(rows).encode()).hexdigest()
     return f"sha256:{digest}"
@@ -99,7 +133,8 @@ def _jacobian_identity() -> tuple[str, str, tuple[str, ...]]:
         digest = package_source_digest("jacobian.capabilities:CapabilityService")
     except (importlib.metadata.PackageNotFoundError, ImplementationError) as exc:
         raise ProviderRuntimeError(
-            "the Jacobian source runtime could not be identified"
+            "the Jacobian source runtime could not be identified",
+            code=ProviderRuntimeErrorCode.UNAVAILABLE,
         ) from exc
     return distribution.version, digest, _license_files(distribution)
 
@@ -121,7 +156,8 @@ def _inspect_python_distribution_identity(
     try:
         if importlib.util.find_spec(import_name) is None:
             raise ProviderRuntimeError(
-                f"the {distribution_name} import target is unavailable"
+                f"the {distribution_name} import target is unavailable",
+                code=ProviderRuntimeErrorCode.UNAVAILABLE,
             )
         distribution = importlib.metadata.distribution(distribution_name)
         digest = _distribution_record_digest(distribution)
@@ -131,7 +167,8 @@ def _inspect_python_distribution_identity(
         ProviderRuntimeError,
     ) as exc:
         raise ProviderRuntimeError(
-            f"the {distribution_name} distribution identity is unavailable"
+            f"the {distribution_name} distribution identity is unavailable",
+            code=ProviderRuntimeErrorCode.UNAVAILABLE,
         ) from exc
     return distribution.version, digest, _license_files(distribution)
 
@@ -354,59 +391,109 @@ def python_distribution_provider_runtime(
     )
 
 
-def require_provider_runtime_unchanged(
+def _validated_provider_runtime(
     runtime: CapabilityProviderRuntime,
-) -> None:
-    """Remeasure every immutable component of an authorized provider runtime."""
+) -> CapabilityProviderRuntime:
+    try:
+        return CapabilityProviderRuntime.model_validate(runtime.model_dump(mode="json"))
+    except (AttributeError, TypeError, ValidationError) as exc:
+        raise ProviderRuntimeError(
+            "provider runtime is malformed",
+            code=ProviderRuntimeErrorCode.MALFORMED_RUNTIME,
+        ) from exc
 
-    if (
-        runtime.availability is not CapabilityProviderAvailability.AVAILABLE
-        or runtime.digest is None
-        or runtime.digest_kind is None
-    ):
-        raise ProviderRuntimeError("provider runtime identity is incomplete")
 
-    if runtime.digest_kind is CapabilityProviderDigestKind.EXECUTABLE:
-        executable = runtime.configuration.get("executable")
-        if (
-            not isinstance(executable, str)
-            or _sha256_file(Path(executable)) != runtime.digest
-        ):
-            raise ProviderRuntimeError("provider executable identity changed")
-        return
+def _require_executable_identity(runtime: CapabilityProviderRuntime) -> None:
+    executable = runtime.configuration.get("executable")
+    if not isinstance(executable, str):
+        raise ProviderRuntimeError(
+            "provider executable identity is incomplete",
+            code=ProviderRuntimeErrorCode.IDENTITY_INCOMPLETE,
+        )
+    try:
+        measured = _sha256_file(Path(executable))
+    except OSError as exc:
+        raise ProviderRuntimeError(
+            "provider executable is unavailable",
+            code=ProviderRuntimeErrorCode.UNAVAILABLE,
+        ) from exc
+    if measured != runtime.digest:
+        raise ProviderRuntimeError(
+            "provider executable identity changed",
+            code=ProviderRuntimeErrorCode.IDENTITY_CHANGED,
+        )
 
-    if runtime.digest_kind is CapabilityProviderDigestKind.SOURCE_TREE:
-        entrypoint = runtime.configuration.get("entrypoint")
-        if not isinstance(entrypoint, str):
-            raise ProviderRuntimeError("provider source identity is incomplete")
-        try:
-            measured_source = package_source_digest(entrypoint)
-        except ImplementationError as exc:
-            raise ProviderRuntimeError("provider source is unavailable") from exc
-        if measured_source != runtime.digest:
-            raise ProviderRuntimeError("provider source identity changed")
-        return
 
-    if runtime.digest_kind is CapabilityProviderDigestKind.PYTHON_DISTRIBUTION_RECORD:
-        distribution = runtime.configuration.get("distribution")
-        import_name = runtime.distribution_import_name
-        if not isinstance(distribution, str) or import_name is None:
-            raise ProviderRuntimeError("Python distribution identity is incomplete")
+def _require_source_identity(runtime: CapabilityProviderRuntime) -> None:
+    entrypoint = runtime.configuration.get("entrypoint")
+    if not isinstance(entrypoint, str):
+        raise ProviderRuntimeError(
+            "provider source identity is incomplete",
+            code=ProviderRuntimeErrorCode.IDENTITY_INCOMPLETE,
+        )
+    try:
+        measured_source = package_source_digest(entrypoint)
+    except ImplementationError as exc:
+        raise ProviderRuntimeError(
+            "provider source is unavailable",
+            code=ProviderRuntimeErrorCode.UNAVAILABLE,
+        ) from exc
+    if measured_source != runtime.digest:
+        raise ProviderRuntimeError(
+            "provider source identity changed",
+            code=ProviderRuntimeErrorCode.IDENTITY_CHANGED,
+        )
+
+
+def _require_python_identity(runtime: CapabilityProviderRuntime) -> None:
+    distribution = runtime.configuration.get("distribution")
+    import_name = runtime.distribution_import_name
+    if not isinstance(distribution, str) or import_name is None:
+        raise ProviderRuntimeError(
+            "Python distribution identity is incomplete",
+            code=ProviderRuntimeErrorCode.IDENTITY_INCOMPLETE,
+        )
+    try:
         version, digest, _license_files = _inspect_python_distribution_identity(
             distribution,
             import_name,
             runtime.distribution_required_attributes,
         )
-        if version != runtime.version or digest != runtime.digest:
-            raise ProviderRuntimeError("Python distribution identity changed")
-        return
+    except ProviderRuntimeError as exc:
+        raise ProviderRuntimeError(
+            "Python distribution identity is unavailable",
+            code=ProviderRuntimeErrorCode.UNAVAILABLE,
+        ) from exc
+    if version != runtime.version or digest != runtime.digest:
+        raise ProviderRuntimeError(
+            "Python distribution identity changed",
+            code=ProviderRuntimeErrorCode.IDENTITY_CHANGED,
+        )
 
+
+def _component_runtimes(
+    runtime: CapabilityProviderRuntime,
+) -> tuple[CapabilityProviderRuntime, ...]:
     components = runtime.configuration.get("components")
     if not isinstance(components, list) or not components:
-        raise ProviderRuntimeError("composite provider identity is incomplete")
-    component_runtimes = tuple(
-        CapabilityProviderRuntime.model_validate(component) for component in components
-    )
+        raise ProviderRuntimeError(
+            "composite provider identity is incomplete",
+            code=ProviderRuntimeErrorCode.IDENTITY_INCOMPLETE,
+        )
+    try:
+        return tuple(
+            CapabilityProviderRuntime.model_validate(component)
+            for component in components
+        )
+    except ValidationError as exc:
+        raise ProviderRuntimeError(
+            "composite provider runtime is malformed",
+            code=ProviderRuntimeErrorCode.MALFORMED_RUNTIME,
+        ) from exc
+
+
+def _require_composite_identity(runtime: CapabilityProviderRuntime) -> None:
+    component_runtimes = _component_runtimes(runtime)
     for component in component_runtimes:
         require_provider_runtime_unchanged(component)
     measured = composite_provider_runtime(
@@ -421,7 +508,89 @@ def require_provider_runtime_unchanged(
         },
     )
     if measured.digest != runtime.digest:
-        raise ProviderRuntimeError("composite provider identity changed")
+        raise ProviderRuntimeError(
+            "composite provider identity changed",
+            code=ProviderRuntimeErrorCode.IDENTITY_CHANGED,
+        )
+
+
+def require_provider_runtime_unchanged(
+    runtime: CapabilityProviderRuntime,
+) -> None:
+    """Remeasure every immutable component of an authorized provider runtime."""
+
+    runtime = _validated_provider_runtime(runtime)
+
+    if (
+        runtime.availability is not CapabilityProviderAvailability.AVAILABLE
+        or runtime.digest is None
+        or runtime.digest_kind is None
+    ):
+        raise ProviderRuntimeError(
+            "provider runtime identity is incomplete",
+            code=ProviderRuntimeErrorCode.IDENTITY_INCOMPLETE,
+        )
+
+    if runtime.digest_kind is CapabilityProviderDigestKind.EXECUTABLE:
+        _require_executable_identity(runtime)
+        return
+
+    if runtime.digest_kind is CapabilityProviderDigestKind.SOURCE_TREE:
+        _require_source_identity(runtime)
+        return
+
+    if runtime.digest_kind is CapabilityProviderDigestKind.PYTHON_DISTRIBUTION_RECORD:
+        _require_python_identity(runtime)
+        return
+
+    _require_composite_identity(runtime)
+
+
+def require_provider_runtime_ready(runtime: CapabilityProviderRuntime) -> None:
+    """Check first-use callable availability without changing identity policy."""
+
+    runtime = _validated_provider_runtime(runtime)
+    if runtime.availability is not CapabilityProviderAvailability.AVAILABLE:
+        raise ProviderRuntimeError(
+            "provider runtime is unavailable",
+            code=ProviderRuntimeErrorCode.UNAVAILABLE,
+        )
+    if runtime.digest_kind is CapabilityProviderDigestKind.PYTHON_DISTRIBUTION_RECORD:
+        _require_python_ready(runtime)
+        return
+    if runtime.digest_kind is CapabilityProviderDigestKind.EXECUTABLE:
+        _require_executable_ready(runtime)
+        return
+    if runtime.digest_kind is CapabilityProviderDigestKind.COMPOSITE:
+        for component in _component_runtimes(runtime):
+            require_provider_runtime_ready(component)
+
+
+def _require_python_ready(runtime: CapabilityProviderRuntime) -> None:
+    import_name = runtime.distribution_import_name
+    if import_name is None:
+        raise ProviderRuntimeError(
+            "Python provider readiness identity is incomplete",
+            code=ProviderRuntimeErrorCode.IDENTITY_INCOMPLETE,
+        )
+    try:
+        module = importlib.import_module(import_name)
+        for attribute in runtime.distribution_required_attributes:
+            getattr(module, attribute)
+    except (AttributeError, ImportError, OSError, RuntimeError) as exc:
+        raise ProviderRuntimeError(
+            "Python provider required attributes are not ready",
+            code=ProviderRuntimeErrorCode.READINESS_FAILED,
+        ) from exc
+
+
+def _require_executable_ready(runtime: CapabilityProviderRuntime) -> None:
+    executable = runtime.configuration.get("executable")
+    if not isinstance(executable, str) or not Path(executable).is_file():
+        raise ProviderRuntimeError(
+            "provider executable is not ready",
+            code=ProviderRuntimeErrorCode.READINESS_FAILED,
+        )
 
 
 def known_provider_runtime(

--- a/src/jacobian/providers/lean_runtime.py
+++ b/src/jacobian/providers/lean_runtime.py
@@ -47,7 +47,10 @@ def lean_provider_runtime(
         license_id="Apache-2.0",
         features=tuple(sorted(profiles)),
         checker_ids=checker_ids,
-        configuration={"profiles": dict(profiles)},
+        configuration={
+            "executable": str(executable),
+            "profiles": dict(profiles),
+        },
     )
 
 

--- a/src/jacobian/registry.py
+++ b/src/jacobian/registry.py
@@ -9,7 +9,7 @@ import threading
 from collections.abc import Iterator
 from contextlib import contextmanager
 
-from jacobian.canonical import canonicalize_json, loads_strict_json
+from jacobian.canonical import canonicalize_json
 from jacobian.contracts.capabilities import (
     CapabilityProviderAvailability,
     CapabilityProviderRuntime,
@@ -20,7 +20,11 @@ from jacobian.contracts.checkers import (
     EvidenceKind,
 )
 from jacobian.implementation import ImplementationError, package_source_digest
-from jacobian.persistence import PersistenceLock
+from jacobian.persistence import (
+    PersistenceCorruptionError,
+    PersistenceLock,
+    decode_persisted_model,
+)
 from jacobian.provider_runtime import (
     ProviderRuntimeError,
     require_provider_runtime_unchanged,
@@ -340,10 +344,14 @@ class CheckerRegistry:
                 "an authorized checker_id, and retry."
             )
         try:
-            data = loads_strict_json(bytes(row["registration_json"]))
-            data["authorized"] = bool(row["authorized"])
-            registration = CheckerRegistration.model_validate(data)
-        except (TypeError, ValueError) as exc:
+            registration = decode_persisted_model(
+                CheckerRegistration,
+                bytes(row["registration_json"]),
+                record_kind="checker_registration",
+                record_id=checker_id,
+                field="registration_json",
+            ).model_copy(update={"authorized": bool(row["authorized"])})
+        except PersistenceCorruptionError as exc:
             raise CheckerRegistryError(
                 "Checker registry data is invalid. Restore the Jacobian state "
                 "directory from a trusted copy before retrying."

--- a/src/jacobian/search/errors.py
+++ b/src/jacobian/search/errors.py
@@ -7,5 +7,13 @@ class SearchError(RuntimeError):
     """A requested search experiment is missing or invalid."""
 
 
+class SearchCorruptionError(SearchError):
+    """A persisted search record cannot be reconstructed safely."""
+
+    def __init__(self, corruption: object) -> None:
+        self.corruption = corruption
+        super().__init__(str(corruption))
+
+
 class _SearchBudgetExhaustedError(SearchError):
     """The durable wall-clock budget was exhausted between checkpoints."""

--- a/src/jacobian/search/service.py
+++ b/src/jacobian/search/service.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from pydantic import ValidationError
 
-from jacobian.canonical import canonicalize_json, loads_strict_json
+from jacobian.canonical import canonicalize_json
 from jacobian.claims import ClaimValidationService
 from jacobian.contracts.artifacts import ArtifactPutResult
 from jacobian.contracts.discovery import ExperimentHandle, ExperimentState
@@ -39,6 +39,7 @@ from jacobian.evaluation import (
     EvaluationService,
 )
 from jacobian.experiment_identity import new_experiment_uri
+from jacobian.persistence import PersistenceCorruptionError, decode_persisted_model
 from jacobian.persistence.recovery import (
     put_internal_artifact,
     quarantine_recovery_snapshot,
@@ -58,7 +59,7 @@ from jacobian.search._helpers import (
     _updated_accounting,
     _updated_snapshot,
 )
-from jacobian.search.errors import SearchError
+from jacobian.search.errors import SearchCorruptionError, SearchError
 from jacobian.store import ArtifactStore, StoreError
 from jacobian.verification import VerificationService
 from jacobian.witnesses import WitnessSearchService
@@ -218,10 +219,14 @@ class SearchService:
             ).fetchall()
             for row in rows:
                 try:
-                    snapshot = SearchExperimentSnapshot.model_validate(
-                        loads_strict_json(row["snapshot_json"])
+                    snapshot = decode_persisted_model(
+                        SearchExperimentSnapshot,
+                        row["snapshot_json"],
+                        record_kind="search_snapshot",
+                        record_id=str(row["experiment_uri"]),
+                        field="snapshot_json",
                     )
-                except (TypeError, ValidationError, ValueError) as exc:
+                except PersistenceCorruptionError as exc:
                     self._quarantine_recovery_snapshot(connection, row, exc)
                     continue
                 if snapshot.experiment_uri != str(
@@ -669,17 +674,26 @@ class SearchService:
                 )
             rows = connection.execute(
                 """
-                SELECT event_json
+                SELECT sequence, event_json
                 FROM search_events
                 WHERE experiment_uri = ?
                 ORDER BY sequence
                 """,
                 (experiment_uri,),
             ).fetchall()
-        events = tuple(
-            SearchLifecycleEvent.model_validate(loads_strict_json(row["event_json"]))
-            for row in rows
-        )
+        try:
+            events = tuple(
+                decode_persisted_model(
+                    SearchLifecycleEvent,
+                    row["event_json"],
+                    record_kind="search_event",
+                    record_id=f"{experiment_uri}:{row['sequence']}",
+                    field="event_json",
+                )
+                for row in rows
+            )
+        except PersistenceCorruptionError as exc:
+            raise SearchCorruptionError(exc) from exc
         previous: str | None = None
         for event in events:
             if event.previous_event_digest != previous:
@@ -1226,9 +1240,15 @@ class SearchService:
                 "or search.enumerate, or start a new experiment."
             )
         try:
-            return SearchExperimentSnapshot.model_validate(
-                loads_strict_json(row["snapshot_json"])
+            return decode_persisted_model(
+                SearchExperimentSnapshot,
+                row["snapshot_json"],
+                record_kind="search_snapshot",
+                record_id=experiment_uri,
+                field="snapshot_json",
             )
+        except PersistenceCorruptionError as exc:
+            raise SearchCorruptionError(exc) from exc
         except (ValidationError, ValueError) as exc:
             raise SearchError("stored search snapshot is invalid") from exc
 

--- a/src/jacobian/store.py
+++ b/src/jacobian/store.py
@@ -21,9 +21,11 @@ from jacobian.canonical import (
 )
 from jacobian.contracts.artifacts import ArtifactManifest, ArtifactPutResult
 from jacobian.persistence import (
+    PersistenceCorruptionError,
     PersistenceLock,
     StateDatabase,
     StateDatabaseError,
+    decode_persisted_model,
 )
 from jacobian.persistence.migrations import STATE_MIGRATIONS
 
@@ -45,6 +47,14 @@ _BOOTSTRAP_SEMANTICS_URI: Final = (
 
 class StoreError(RuntimeError):
     """Base class for bounded artifact-store failures."""
+
+
+class StoreCorruptionError(StoreError):
+    """A persisted store record cannot be decoded without repair."""
+
+    def __init__(self, corruption: object) -> None:
+        self.corruption = corruption
+        super().__init__(str(corruption))
 
 
 class ArtifactNotFoundError(StoreError):
@@ -975,11 +985,16 @@ class ArtifactStore:
             raise ArtifactNotFoundError(f"artifact is not committed: {artifact_uri}")
 
         manifest_bytes = self._read_blob(manifest_digest)
-        manifest_data = loads_strict_json(
-            manifest_bytes,
-            limits=self.canonical_limits,
-        )
-        manifest = ArtifactManifest.model_validate(manifest_data)
+        try:
+            manifest = decode_persisted_model(
+                ArtifactManifest,
+                manifest_bytes,
+                record_kind="artifact_manifest",
+                record_id=artifact_uri,
+                field="manifest_json",
+            )
+        except PersistenceCorruptionError as exc:
+            raise StoreCorruptionError(exc) from exc
         database_parents = tuple(parent["parent_uri"] for parent in parent_rows)
         if any(parent["committed_parent_uri"] is None for parent in parent_rows):
             raise ArtifactIntegrityError("manifest parent is not committed")

--- a/src/jacobian/verification/service.py
+++ b/src/jacobian/verification/service.py
@@ -11,7 +11,11 @@ from typing import Any
 from pydantic import ValidationError
 
 from jacobian.bounded_process import ProcessResourceLimits, run_bounded_process
-from jacobian.canonical import canonicalize_json, loads_strict_json
+from jacobian.canonical import (
+    CanonicalizationError,
+    canonicalize_json,
+    loads_strict_json,
+)
 from jacobian.contracts.artifacts import ArtifactPutResult
 from jacobian.contracts.capabilities import CapabilityProviderRuntime
 from jacobian.contracts.checkers import CheckerDecision, EvidenceKind
@@ -193,7 +197,7 @@ class VerificationService:
             raise CheckerExecutionError(_CHECKER_DIAGNOSTICS_TOO_LARGE)
         try:
             response = loads_strict_json(completed.stdout)
-        except ValueError as exc:
+        except CanonicalizationError as exc:
             raise CheckerExecutionError(_CHECKER_UNREADABLE_RESPONSE) from exc
         if completed.returncode != 0:
             _LOGGER.warning(

--- a/src/jacobian/workspaces/_helpers.py
+++ b/src/jacobian/workspaces/_helpers.py
@@ -7,7 +7,7 @@ import uuid
 from collections.abc import Iterable
 from datetime import UTC, datetime
 
-from jacobian.canonical import canonicalize_json, loads_strict_json
+from jacobian.canonical import canonicalize_json
 from jacobian.contracts.results import ContractModel
 from jacobian.contracts.workspaces import (
     WorkspaceAttempt,
@@ -20,7 +20,12 @@ from jacobian.contracts.workspaces import (
     WorkspaceScratchEntry,
     WorkspaceScratchSummary,
 )
-from jacobian.workspaces.errors import WorkspaceError, WorkspaceReferenceError
+from jacobian.persistence import PersistenceCorruptionError, decode_persisted_model
+from jacobian.workspaces.errors import (
+    WorkspaceCorruptionError,
+    WorkspaceError,
+    WorkspaceReferenceError,
+)
 
 
 def _dependency_postorder(
@@ -160,8 +165,21 @@ def _now() -> datetime:
 def _model_from_json[ModelT: ContractModel](
     model_type: type[ModelT],
     payload: bytes,
+    *,
+    record_kind: str | None = None,
+    record_id: str = "workspace",
+    field: str = "payload_json",
 ) -> ModelT:
-    return model_type.model_validate(loads_strict_json(payload))
+    try:
+        return decode_persisted_model(
+            model_type,
+            payload,
+            record_kind=record_kind or model_type.__name__,
+            record_id=record_id,
+            field=field,
+        )
+    except PersistenceCorruptionError as exc:
+        raise WorkspaceCorruptionError(exc) from exc
 
 
 def _finding_summary(

--- a/src/jacobian/workspaces/errors.py
+++ b/src/jacobian/workspaces/errors.py
@@ -7,6 +7,14 @@ class WorkspaceError(RuntimeError):
     """Base error for invalid or unavailable workspace operations."""
 
 
+class WorkspaceCorruptionError(WorkspaceError):
+    """A persisted workspace payload cannot be reconstructed safely."""
+
+    def __init__(self, corruption: object) -> None:
+        self.corruption = corruption
+        super().__init__(str(corruption))
+
+
 class WorkspaceNotFoundError(WorkspaceError):
     """The requested workspace, branch, revision, or item does not exist."""
 

--- a/src/jacobian_checkers/sat_lrat.py
+++ b/src/jacobian_checkers/sat_lrat.py
@@ -113,16 +113,7 @@ def _replay(
         if clause_id <= 0:
             raise ValueError(f"line {number}: invalid clause id")
         if len(fields) > 1 and fields[1] == "d":
-            deleted_ids = _integers(fields[2:], number, "deletion")
-            if not deleted_ids or deleted_ids[-1] != 0:
-                raise ValueError(f"line {number}: malformed deletion")
-            for deleted in deleted_ids[:-1]:
-                if deleted not in active:
-                    raise ValueError(
-                        f"line {number}: deletion references inactive clause"
-                    )
-                del active[deleted]
-            continue
+            raise NotImplementedError("unsupported LRAT feature: deletions")
         values = _integers(fields, number)
         if clause_id <= last_id or values.count(0) != 2:
             raise ValueError(f"line {number}: invalid addition framing")

--- a/tests/boundary/process/test_worker_error_protocol.py
+++ b/tests/boundary/process/test_worker_error_protocol.py
@@ -90,3 +90,25 @@ def test_worker_code_cannot_self_report_a_source_change(
 
     assert completed.returncode == 1
     assert response["error_code"] == "EXECUTION_FAILED"
+
+
+def test_checker_worker_classifies_malformed_provider_runtime() -> None:
+    entrypoint = "tests.component.checkers._fixture_checkers:check_fixture_value"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "jacobian.checker_worker",
+            entrypoint,
+            package_source_digest(entrypoint),
+            "{malformed",
+        ],
+        input=b"{}",
+        capture_output=True,
+        check=False,
+        timeout=10,
+    )
+    response = loads_strict_json(completed.stdout)
+
+    assert completed.returncode == 1
+    assert response == {"error_code": "MALFORMED_RUNTIME"}

--- a/tests/boundary/providers/external_sat/startup/test_carcara.py
+++ b/tests/boundary/providers/external_sat/startup/test_carcara.py
@@ -42,7 +42,7 @@ def carcara_runtime(
     installed = create_runtime(
         root, checker_authority=CheckerAuthorityMode.INSTALL_BUNDLED
     )
-    assert installed.carcara_runtime == runtime
+    assert installed.portfolio.carcara_runtime == runtime
     return installed
 
 

--- a/tests/boundary/providers/external_sat/test_cadical_external_backend.py
+++ b/tests/boundary/providers/external_sat/test_cadical_external_backend.py
@@ -7,7 +7,6 @@ from jacobian.contracts.capabilities import CapabilityMode, CapabilityRequest
 from jacobian.contracts.results import ExecutionStatus
 from jacobian.providers.external_solver_runtime import (
     CADICAL_VERSION,
-    cadical_provider_runtime,
 )
 
 pytestmark = [
@@ -22,14 +21,14 @@ pytestmark = [
 def test_pinned_cadical_produces_a_model_and_text_drat_proof(
     attached_complete_runtime,
 ) -> None:
-    _ = attached_complete_runtime
-    provider_runtime = cadical_provider_runtime()
+    runtime = attached_complete_runtime
+    provider_runtime = runtime.portfolio.cadical_runtime
+    assert provider_runtime is not None
     if provider_runtime.version != CADICAL_VERSION:
         pytest.skip(f"requires pinned CaDiCaL {CADICAL_VERSION}")
-    runtime = provider_runtime
     capability_ids = {
         descriptor.capability_id
-        for descriptor in provider_runtime.core.capabilities.catalog().capabilities
+        for descriptor in runtime.core.capabilities.catalog().capabilities
     }
     assert {"sat.model.find", "sat.unsat_proof.find"}.issubset(capability_ids)
 

--- a/tests/boundary/providers/external_sat/test_sat_public_reproductions.py
+++ b/tests/boundary/providers/external_sat/test_sat_public_reproductions.py
@@ -14,7 +14,7 @@ from jacobian.contracts.capabilities import (
 )
 from jacobian.contracts.results import ExecutionStatus
 
-PROJECT_ROOT = Path(__file__).resolve().parents[3]
+PROJECT_ROOT = Path(__file__).resolve().parents[4]
 TASK_ROOT = (
     PROJECT_ROOT
     / "benchmarks"

--- a/tests/component/capabilities/test_mcp_invocation_projection.py
+++ b/tests/component/capabilities/test_mcp_invocation_projection.py
@@ -51,6 +51,18 @@ def test_standard_invocation_projection_is_compact_and_recoverable() -> None:
     assert metadata["omitted_output_fields"][0]["byte_count"] > 8_192
     assert metadata["omitted_output_fields"][0]["sha256"].startswith("sha256:")
     assert call_result.structured_content == result.model_dump(mode="json")
+    assert len(call_result.content) == 2
+    link = call_result.content[1]
+    assert link.type == "resource_link"
+    assert link.uri == result.episode_uri
+    assert link.mime_type == "application/json"
+    assert link.size == len(
+        json.dumps(
+            result.model_dump(mode="json"),
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode()
+    )
     result_meta = call_result.meta["jacobian"]
     assert (
         result_meta["logical_payload_bytes"]
@@ -66,3 +78,4 @@ def test_standard_invocation_does_not_drop_large_undurable_output() -> None:
 
     assert projection["output"] == result.output
     assert projection["mcp_projection"]["output_complete"] is True
+    assert len(call_result.content) == 1

--- a/tests/composition/runtime/test_capability_service.py
+++ b/tests/composition/runtime/test_capability_service.py
@@ -47,6 +47,20 @@ TEST_RUNTIME = CapabilityProviderRuntime(
     license_id="MIT",
 )
 
+NOT_READY_RUNTIME = CapabilityProviderRuntime(
+    provider="tests-python",
+    availability=CapabilityProviderAvailability.AVAILABLE,
+    version="1",
+    digest="sha256:" + "b" * 64,
+    digest_kind=CapabilityProviderDigestKind.PYTHON_DISTRIBUTION_RECORD,
+    platform="any",
+    install_tier=CapabilityInstallTier.T0,
+    license_id="MIT",
+    configuration={"distribution": "tests-fixture"},
+    distribution_import_name="tests.component.plugins._fixture_plugins",
+    distribution_required_attributes=("missing_first_use_attribute",),
+)
+
 
 @dataclass(frozen=True)
 class ComputedAdapter:
@@ -85,6 +99,24 @@ class ComputedAdapter:
                 basis="deterministic integer arithmetic",
             ),
         )
+
+
+@dataclass(frozen=True)
+class NotReadyProviderAdapter:
+    descriptor = CapabilityDescriptor(
+        capability_id="example.not-ready-provider",
+        version="1",
+        title="Provider readiness fixture",
+        description="Fixture for the first-use provider readiness boundary.",
+        provider="tests-python",
+        provider_runtime=NOT_READY_RUNTIME,
+        modes=(CapabilityMode.EXPLORE,),
+        input_schema={"type": "object"},
+        output_schema={"type": "object"},
+    )
+
+    def invoke(self, _request: CapabilityRequest) -> CapabilityResult:
+        raise AssertionError("provider must be rejected before adapter invocation")
 
 
 @dataclass(frozen=True)
@@ -315,6 +347,27 @@ def test_external_adapter_invocation_is_recorded_and_retrievable(
     assert episode.payload["result"]["completeness"]["status"] == "NOT_APPLICABLE"
     hits = core.memory.search(query="double computed").hits
     assert [hit.episode_uri for hit in hits] == [result.episode_uri]
+
+
+def test_provider_required_attributes_are_checked_before_first_use(
+    capability_core_services: DomainTestServices,
+) -> None:
+    core = capability_core_services.core
+    capability_core_services.installation.register_capability(NotReadyProviderAdapter())
+
+    result = core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="example.not-ready-provider",
+            input={},
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.diagnostics[0].code == "PROVIDER_READINESS_FAILED"
+    assert result.diagnostics[0].stage == "provider_readiness"
+    assert result.diagnostics[0].details == {
+        "provider_failure_code": "READINESS_FAILED"
+    }
 
 
 def test_installed_capability_discovery_is_compact_deterministic_and_transparent(

--- a/tests/composition/runtime/test_graph_counterexample_shrinking.py
+++ b/tests/composition/runtime/test_graph_counterexample_shrinking.py
@@ -54,6 +54,15 @@ def test_graph_counterexample_shrink_records_verified_steps_and_exact_local_scop
     assert scope["complete_for_requested_reducers"] is True
     assert scope["one_step_locally_minimal"] is True
     assert scope["global_minimality_claimed"] is False
+    assert scope["expected_attempt_count"] == 6
+    assert scope["completed_attempt_count"] == 6
+    assert scope["completeness_status"] == "COMPLETE"
+    assert scope["remaining_obligations"] == []
+    assert all(
+        attempt["candidate_digest"] is not None
+        for attempt in result.output["attempts"]
+        if attempt["proposed_graph_uri"] is not None
+    )
     trace = runtime.core.store.get(result.output["trace_uri"])
     assert trace.payload["attempts"] == result.output["attempts"]
     assert trace.payload["local_minimality_scope"] == scope

--- a/tests/support/provider_external_sat.py
+++ b/tests/support/provider_external_sat.py
@@ -8,13 +8,14 @@ def external_sat_toolchain_available() -> bool:
     probes also validate version, provenance, and the checker health command.
     """
 
+    from jacobian.contracts.capabilities import CapabilityProviderAvailability
     from jacobian.providers.external_solver_runtime import (
         cadical_provider_runtime,
         drat_trim_provider_runtime,
     )
 
     return all(
-        runtime.availability.value == "available"
+        runtime.availability is CapabilityProviderAvailability.AVAILABLE
         for runtime in (
             cadical_provider_runtime(),
             drat_trim_provider_runtime(),
@@ -25,14 +26,22 @@ def external_sat_toolchain_available() -> bool:
 def cadical_runtime_available() -> bool:
     """Return whether the pinned CaDiCaL executable passes readiness."""
 
+    from jacobian.contracts.capabilities import CapabilityProviderAvailability
     from jacobian.providers.external_solver_runtime import cadical_provider_runtime
 
-    return cadical_provider_runtime().availability.value == "available"
+    return (
+        cadical_provider_runtime().availability
+        is CapabilityProviderAvailability.AVAILABLE
+    )
 
 
 def drat_trim_runtime_available() -> bool:
     """Return whether the pinned DRAT-trim checker passes readiness."""
 
+    from jacobian.contracts.capabilities import CapabilityProviderAvailability
     from jacobian.providers.external_solver_runtime import drat_trim_provider_runtime
 
-    return drat_trim_provider_runtime().availability.value == "available"
+    return (
+        drat_trim_provider_runtime().availability
+        is CapabilityProviderAvailability.AVAILABLE
+    )

--- a/tests/support/provider_lean.py
+++ b/tests/support/provider_lean.py
@@ -11,9 +11,13 @@ PINNED_LEAN_CORE_RUNTIME_UNAVAILABLE_REASON = (
 def pinned_lean_core_runtime_available() -> bool:
     """Return whether the production pinned Lean CORE frontend probe succeeds."""
 
+    from jacobian.contracts.capabilities import CapabilityProviderAvailability
     from jacobian.providers.lean_runtime import lean_frontend_provider_runtime
 
-    return lean_frontend_provider_runtime().availability.value == "available"
+    return (
+        lean_frontend_provider_runtime().availability
+        is CapabilityProviderAvailability.AVAILABLE
+    )
 
 
 def pinned_mathlib_runtime_available() -> bool:
@@ -23,10 +27,11 @@ def pinned_mathlib_runtime_available() -> bool:
     during collection of unit and component tests.
     """
 
+    from jacobian.contracts.capabilities import CapabilityProviderAvailability
     from jacobian.providers.lean_runtime import lean_provider_runtime
 
     runtime = lean_provider_runtime(
         profiles={"mathlib": {"mathlib_commit": "pinned"}},
         checker_ids=(),
     )
-    return runtime.availability.value == "available"
+    return runtime.availability is CapabilityProviderAvailability.AVAILABLE

--- a/tests/unit/contracts/test_plugin_inputs.py
+++ b/tests/unit/contracts/test_plugin_inputs.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.contracts.plugin_inputs import (
+    ErdosStrausCapabilityRequest,
+    GraphPathCapabilityRequest,
+    GraphPathReductionRequest,
+    GraphShrinkRequest,
+    MatrixCapabilityRequest,
+    MatrixReductionRequest,
+    MatrixTransformRequest,
+)
+
+
+def _matrix_candidate() -> dict[str, object]:
+    return {"rows": 1, "cols": 1, "entries": [["1"]]}
+
+
+def test_plugin_contracts_reject_non_object_nested_payloads() -> None:
+    with pytest.raises(ValidationError):
+        GraphPathReductionRequest.model_validate(
+            {
+                "target": "a",
+                "claim": {"predicate": "is_bipartite"},
+            }
+        )
+    with pytest.raises(ValidationError):
+        MatrixReductionRequest.model_validate(
+            {
+                "target": _matrix_candidate(),
+                "claim": "is_nonsingular",
+            }
+        )
+
+
+def test_plugin_contracts_reject_scalar_collections_and_unknown_fields() -> None:
+    with pytest.raises(ValidationError):
+        GraphShrinkRequest.model_validate(
+            {
+                "target": {"vertices": ["a"], "edges": []},
+                "reducers": "delete_vertex",
+                "objectives": [],
+            }
+        )
+    with pytest.raises(ValidationError):
+        MatrixReductionRequest.model_validate(
+            {
+                "target": _matrix_candidate(),
+                "claim": {"predicate": "is_nonsingular"},
+                "reducers": [],
+                "objectives": [],
+                "unexpected": True,
+            }
+        )
+
+
+def test_plugin_contracts_accept_known_worker_metadata_without_opening_the_boundary() -> (
+    None
+):
+    request = GraphPathCapabilityRequest.model_validate(
+        {
+            "request_version": "1",
+            "profile": "FAST",
+            "seed": 0,
+            "bindings": {"claim_digest": "sha256:" + "a" * 64},
+            "claim": {"predicate": "is_bipartite"},
+            "candidate": {
+                "vertices": ["a", "b"],
+                "arcs": [["a", "b"]],
+            },
+        }
+    )
+    assert request.request_version == "1"
+    assert request.profile == "FAST"
+    assert request.seed == 0
+
+    with pytest.raises(ValidationError):
+        MatrixTransformRequest.model_validate(
+            {
+                "request_version": "1",
+                "source": _matrix_candidate(),
+                "unexpected": True,
+            }
+        )
+
+
+def test_erdos_straus_contract_enforces_range_and_role_domain() -> None:
+    with pytest.raises(ValidationError):
+        ErdosStrausCapabilityRequest.model_validate(
+            {
+                "claim": {
+                    "predicate": "erdos_straus_range",
+                    "lower_bound": 100,
+                    "upper_bound": 2,
+                },
+                "candidate": {"lower_bound": 100, "upper_bound": 2},
+            }
+        )
+
+
+def test_nested_matrix_scope_is_typed_and_bounded() -> None:
+    with pytest.raises(ValidationError):
+        MatrixCapabilityRequest.model_validate(
+            {
+                "claim": {
+                    "predicate": "maximize_absolute_determinant",
+                    "scope": {
+                        "rows": 2,
+                        "cols": 3,
+                        "entries": [-1, 1],
+                        "unexpected": True,
+                    },
+                }
+            }
+        )
+    with pytest.raises(ValidationError):
+        MatrixCapabilityRequest.model_validate(
+            {
+                "claim": {
+                    "predicate": "maximize_absolute_determinant",
+                    "scope": {"rows": 2, "cols": 3, "entries": [-1, 1]},
+                }
+            }
+        )
+    with pytest.raises(ValidationError):
+        ErdosStrausCapabilityRequest.model_validate(
+            {
+                "claim": {
+                    "predicate": "erdos_straus_range",
+                    "lower_bound": 2,
+                    "upper_bound": 3,
+                },
+                "candidate": {"lower_bound": 2, "upper_bound": 3},
+                "witness_role": "unsupported",
+            }
+        )

--- a/tests/unit/contracts/test_proof_ir_and_lean_artifacts.py
+++ b/tests/unit/contracts/test_proof_ir_and_lean_artifacts.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.contracts.lean_artifacts import (
+    LeanEnvironmentIdentity,
+    LeanProofEdit,
+    LeanProofState,
+)
+from jacobian.contracts.proof_ir import (
+    AtomicClaimRef,
+    ConjunctionClaim,
+    ImplicationClaim,
+    ProofObligationSet,
+)
+from jacobian.contracts.results import ExecutionStatus
+
+
+def _ref(index: str) -> AtomicClaimRef:
+    return AtomicClaimRef(
+        claim_artifact_uri=f"artifact://sha256/{index * 64}",
+        schema_digest=f"sha256/{index * 64}".replace("sha256/", "sha256:"),
+        semantics_digest=f"sha256/{index * 64}".replace("sha256/", "sha256:"),
+    )
+
+
+def test_bounded_claim_ir_preserves_order_and_direction() -> None:
+    first = _ref("a")
+    second = _ref("b")
+
+    assert ConjunctionClaim(claim_refs=(first, second)).claim_refs == (first, second)
+    assert ImplicationClaim(premises=(first,), conclusion=second).conclusion == second
+    with pytest.raises(ValidationError):
+        ProofObligationSet(
+            source_logical_claim=first,
+            obligation_refs=(second, second),
+            decomposition_semantics=first.semantics_digest,
+            completeness_status="COMPLETE",
+        )
+
+
+def test_lean_artifacts_bind_state_to_environment_identity() -> None:
+    environment = LeanEnvironmentIdentity(
+        lean_toolchain_version="4.31.0",
+        project_source_digest="sha256:" + "a" * 64,
+        provider_runtime_digest="sha256:" + "b" * 64,
+    )
+    state = LeanProofState(
+        source_artifact_uri="artifact://sha256/" + "c" * 64,
+        declaration_or_command_position=3,
+        typed_goals=(),
+        local_hypotheses=(),
+        metavariable_identifiers=(),
+        dependency_references=(),
+        environment_identity=environment,
+    )
+    edit = LeanProofEdit(
+        before_state_uri=state.source_artifact_uri,
+        requested_edit="rfl",
+        diagnostics=(),
+        execution_status=ExecutionStatus.ERROR,
+        environment_identity=environment,
+    )
+
+    assert edit.before_state_uri == state.source_artifact_uri

--- a/tests/unit/contracts/test_provider_runtime.py
+++ b/tests/unit/contracts/test_provider_runtime.py
@@ -22,8 +22,10 @@ from jacobian.contracts.provider_measurements import (
 )
 from jacobian.provider_runtime import (
     ProviderRuntimeError,
+    ProviderRuntimeErrorCode,
     composite_provider_runtime,
     python_distribution_provider_runtime,
+    require_provider_runtime_ready,
     require_provider_runtime_unchanged,
 )
 from jacobian.providers.flint_runtime import (
@@ -254,6 +256,43 @@ def test_python_distribution_unchanged_check_does_not_import_implementation(
 
     monkeypatch.setattr(provider_runtime.importlib, "import_module", fail_import)
     require_provider_runtime_unchanged(runtime)
+
+
+def test_python_provider_readiness_checks_required_attributes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = python_distribution_provider_runtime(
+        "pydantic",
+        distribution_name="pydantic",
+        import_name="pydantic",
+        required_attributes=("missing_required_attribute",),
+        install_tier=CapabilityInstallTier.T1,
+        license_id="MIT",
+        refresh=True,
+    )
+    assert runtime.availability is CapabilityProviderAvailability.AVAILABLE
+    monkeypatch.setattr(
+        provider_runtime.importlib,
+        "import_module",
+        lambda _name: SimpleNamespace(),
+    )
+
+    with pytest.raises(ProviderRuntimeError) as raised:
+        require_provider_runtime_ready(runtime)
+
+    assert raised.value.code is ProviderRuntimeErrorCode.READINESS_FAILED
+
+
+def test_disappeared_executable_is_unavailable(tmp_path: Path) -> None:
+    runtime = _runtime(
+        digest_kind=CapabilityProviderDigestKind.EXECUTABLE,
+        configuration={"executable": str(tmp_path / "gone")},
+    )
+
+    with pytest.raises(ProviderRuntimeError) as raised:
+        require_provider_runtime_unchanged(runtime)
+
+    assert raised.value.code is ProviderRuntimeErrorCode.UNAVAILABLE
 
 
 def test_lean_frontend_runtime_binds_the_pinned_executable(

--- a/tests/unit/persistence/test_decoding.py
+++ b/tests/unit/persistence/test_decoding.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import StrictInt
+
+from jacobian.canonical import canonicalize_json
+from jacobian.contracts.results import ContractModel
+from jacobian.persistence import (
+    PersistenceCorruptionCode,
+    PersistenceCorruptionError,
+    decode_persisted_model,
+)
+
+
+class _PersistedRecord(ContractModel):
+    value: StrictInt
+
+
+def _decode(encoded: str | bytes) -> _PersistedRecord:
+    return decode_persisted_model(
+        _PersistedRecord,
+        encoded,
+        record_kind="test_record",
+        record_id="record://one",
+        field="payload_json",
+    )
+
+
+def test_decode_persisted_model_accepts_canonical_model() -> None:
+    encoded = canonicalize_json({"value": 7})
+
+    assert _decode(encoded).value == 7
+
+
+@pytest.mark.parametrize(
+    ("encoded", "code"),
+    (
+        (b'{"value":1,"value":2}', PersistenceCorruptionCode.INVALID_JSON),
+        (b"{\xff", PersistenceCorruptionCode.INVALID_UTF8),
+        (b'{"value": 1}', PersistenceCorruptionCode.NON_CANONICAL_JSON),
+        (b'{"other":1}', PersistenceCorruptionCode.INVALID_MODEL),
+    ),
+)
+def test_decode_persisted_model_classifies_corruption(
+    encoded: bytes,
+    code: PersistenceCorruptionCode,
+) -> None:
+    with pytest.raises(PersistenceCorruptionError) as raised:
+        _decode(encoded)
+
+    error = raised.value
+    assert error.failure_code == code
+    assert error.record_kind == "test_record"
+    assert error.record_id == "record://one"
+    assert "value" not in str(error)

--- a/tools/c901-baseline.json
+++ b/tools/c901-baseline.json
@@ -263,11 +263,6 @@
       "complexity": 13
     },
     {
-      "path": "src/jacobian/provider_runtime.py",
-      "symbol": "require_provider_runtime_unchanged",
-      "complexity": 14
-    },
-    {
       "path": "src/jacobian/sat_smt/cadical.py",
       "symbol": "_parse_solver_output",
       "complexity": 11
@@ -575,7 +570,7 @@
     {
       "path": "src/jacobian_checkers/sat_lrat.py",
       "symbol": "_replay",
-      "complexity": 26
+      "complexity": 23
     },
     {
       "path": "src/jacobian_checkers/sat_lrat.py",

--- a/tools/c901-baseline.json
+++ b/tools/c901-baseline.json
@@ -220,7 +220,7 @@
     {
       "path": "src/jacobian/plugins/graph_paths.py",
       "symbol": "find_witness",
-      "complexity": 13
+      "complexity": 14
     },
     {
       "path": "src/jacobian/plugins/graph_paths.py",

--- a/uv.lock
+++ b/uv.lock
@@ -533,8 +533,8 @@ requires-dist = [
     { name = "cvc5", marker = "extra == 'smt'", specifier = "==1.3.4" },
     { name = "filelock", specifier = ">=3.20,<4" },
     { name = "jsonschema", specifier = ">=4.23,<5" },
-    { name = "mcp", specifier = "==2.0.0b2" },
-    { name = "mcp-types", specifier = "==2.0.0b2" },
+    { name = "mcp", specifier = "==2.0.0" },
+    { name = "mcp-types", specifier = "==2.0.0" },
     { name = "networkx", specifier = ">=3.4,<4" },
     { name = "pydantic", specifier = ">=2.12,<3" },
     { name = "pydantic-core", specifier = ">=2.41,<3" },
@@ -658,7 +658,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "2.0.0b2"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -667,7 +667,6 @@ dependencies = [
     { name = "mcp-types" },
     { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -677,22 +676,22 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/aa/c5d38e0199304494be6370667d04d93d8681d9bdc864d56678250dbd3f3b/mcp-2.0.0b2.tar.gz", hash = "sha256:0528d0d38ae798fbff251616ec687faaaa8f5309571e0b2bc553c530fa10b8b1", size = 1590650, upload-time = "2026-07-14T16:47:57.897Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284, upload-time = "2026-07-28T13:45:32.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/90/187d6283a304acc6954987992ef17e2515739a649f148dc8b67b302e1bbd/mcp-2.0.0b2-py3-none-any.whl", hash = "sha256:9c50ae5afa08960ab76d50aa3adab3184952d9bea7ef87f4a4a5ba68bdefcf0a", size = 334286, upload-time = "2026-07-14T16:47:54.768Z" },
+    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980, upload-time = "2026-07-28T13:45:28.853Z" },
 ]
 
 [[package]]
 name = "mcp-types"
-version = "2.0.0b2"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ad/21/db529130ac8edd1d844fc322862afeceaf2b7f610a591fa528002b022e07/mcp_types-2.0.0b2.tar.gz", hash = "sha256:094fa7160106819ab39a1586179c3a9f070bfd833d0a6f8fcb30a54a986cc402", size = 65877, upload-time = "2026-07-14T16:47:59.198Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632, upload-time = "2026-07-28T13:45:33.804Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/e1/c466ceacdaa929396d35ad45176398acd0c416fead0970d3ad22618a19d7/mcp_types-2.0.0b2-py3-none-any.whl", hash = "sha256:35c9c33abb90a77dc6ad1daecaa6407c788c2f32d14d52dad8f843c4f008eae2", size = 68944, upload-time = "2026-07-14T16:47:56.493Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649, upload-time = "2026-07-28T13:45:30.713Z" },
 ]
 
 [[package]]
@@ -1062,20 +1061,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pydantic-settings"
-version = "2.14.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
-]
-
-[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1221,15 +1206,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f1/51/276f964496a5714ab9f320896195639086881c2b39c03b5ad13de84acbb8/python_discovery-1.5.0.tar.gz", hash = "sha256:3e014c6327154d3dda27939a9a0dc9c5c000439f1906d3f303b48f984bd2ecef", size = 72483, upload-time = "2026-07-21T13:14:14.641Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/7b/14882602ddee241d7984a742fcb423cb4a30fb0d6efc546ac3129fba475a/python_discovery-1.5.0-py3-none-any.whl", hash = "sha256:70c4fc61b4e7404e44f01d6fc44a715c4d685ca6cea83d295922f05891877c98", size = 34205, upload-time = "2026-07-21T13:14:13.398Z" },
-]
-
-[[package]]
-name = "python-dotenv"
-version = "1.2.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

Jacobian’s pre-stable control plane was still pinned to the MCP 2.0 beta and several plugin, process, persistence, and provider boundaries accepted loosely typed or non-canonical payloads. That made operational failures harder to classify consistently and left durable evidence handoffs and minimality scope less explicit.

Related issue clusters: #94–#98, #120, #125, #195, #228, and #257–#280. The issue disposition below distinguishes changes this PR can close after merge from work that still needs follow-up evidence or implementation.

## Solution

This branch delivers the reliability boundary work as seven reviewable commits:

1. `feat(mcp): align adapter with released SDK` — pins `mcp==2.0.0` and `mcp-types==2.0.0`, adopts released SDK error ownership, and adds additive `ResourceLink` handoffs with text and structured-result fallbacks.
2. `feat(plugins): enforce typed request contracts` — adds strict Pydantic request models for graph paths, matrices, Erdős–Straus, and graph shrinking; public plugin entrypoints validate before kernel execution.
3. `feat(process): enforce canonical worker protocols` — routes worker and subprocess JSON through strict canonical decoding and preserves bounded structured failure codes.
4. `feat(storage): centralize persisted model decoding` — adds one fail-closed persisted-model reconstruction boundary and translates corruption into owning service error families.
5. `feat(provider): separate identity and readiness checks` — keeps provider identity measurement import-free and adds explicit first-use required-attribute/executable readiness checks.
6. `feat(graph): record complete local minimality evidence` — records deterministic attempt counts, candidate digests, outcomes, completeness, and remaining obligations without claiming global minimality.
7. `feat(verification): bound proof artifacts and LRAT authority` — adds bounded logical-claim and environment-bound Lean artifacts, and records the current addition-only LRAT replay as experimental.

Review order should follow the commit order above. The mathematical producer/checker authority boundary remains unchanged: producers stay `COMPUTED`, decomposition and Lean artifacts are structure rather than proof authority, and broader stable LRAT authority remains gated on an independent backend decision.

## Testing

- `uv sync --locked` — passed; installed `mcp 2.0.0` and `mcp-types 2.0.0`.
- `make test-plan BASE=origin/main` — passed; classified `full` and selected all affected lanes.
- `make check` — passed; Ruff, complexity, mypy, and 661 unit tests.
- `make check-static` — passed; full static checks and package build.
- `make test-component` — 596 passed.
- `make test-domain` — 190 passed.
- `make test-composition` — 426 passed, 2 expected Lean-environment skips.
- `make test-storage` — 101 passed.
- `make test-process` — 160 passed.
- `make test-mcp` — 21 passed.
- `make test-e2e` — 7 passed, 1 expected Lean-environment skip.
- `PATH=/home/morluto/.elan/bin:$PATH make test-lean` — 59 passed with Lean 4.31.0.
- `PATH=/home/morluto/.local/bin:/home/morluto/.elan/bin:$PATH make test-provider` — 161 passed with the prepared SAT/Lean runtimes.
- `make npm-test` — passed.
- `make harbor-check` — passed for all six maintained datasets/verifiers.
- `make security-audit`, `make duplicate-code`, and `make docs-linkcheck` — passed.
- `git diff --check` — passed.

## Issue disposition

This PR remains draft and does not change issue state. After merge, the following issues are intended to close from this change:

Closes #257, closes #258, closes #260, closes #262, closes #264, and closes #280.

The following areas have implementation coverage in this PR but should remain related until explicit caller-facing acceptance evidence is linked:

- #259 and #263 — provider/Lean runtime and typed-goal extraction failure normalization.
- #265–#268 — persisted search, experiment, workspace, and memory corruption boundaries.
- #270–#279 — strict plugin request contracts and entrypoint validation.
- #97 — complete local-minimality evidence; explicit omission, timeout, and checker-error regression cases remain useful closure evidence.

Keep open after this PR:

- #94 — polynomial-map composition and inverse contracts are not changed here.
- #95 — durable Lean artifact models are added, but durable capability/lifecycle and trust inspection are not integrated.
- #96 — the PR adds only the bounded decomposition IR v1, not the broader logical-claim language described by the issue.
- #98 and #120 — bounded addition-only LRAT replay remains experimental; no stable external backend was selected.
- #125 — Harbor validation passes, but the Harbor parity pilot and migration decision are not part of this diff.
- #195 — ResourceLink is additive and tested at the projection boundary, but host evaluation and authenticated `resources/read` evidence remain outstanding.

#228 is not claimed by this PR: the graph split is already present on `main` through PR #256 and can be reconciled against that change. #261 and #269 are already closed.

## Trust & Compatibility Impact

- Public capability IDs and mathematical result semantics remain unchanged.
- The MCP dependency moves from the beta pin to exact released `2.0.0` packages. Static tool arguments remain SDK-validated; descriptor-selected capability inputs remain Jacobian-validated.
- User-correctable tool failures remain `CallToolResult(is_error=True)`; protocol failures remain MCP errors.
- `ResourceLink` is additive and is emitted only when a durable result URI exists; text and structured content remain available to clients that ignore links.
- Corrupt persisted data, unavailable or changed providers, incomplete enumeration, unsupported proof formats, timeouts, and worker failures remain non-conclusive and unverified.
- No stable broader LRAT backend was selected in this change; the bounded handwritten checker remains explicitly experimental.

## Checklist
- [x] Routine local validation passes (`make check`)
- [x] Relevant focused tests and environment-dependent lanes are listed above.
- [x] Issue disposition is recorded without claiming unsupported closures.