### PR TITLE
refactor(plugins): consolidate reference kernels on typed contracts

### DIFF
--- a/src/jacobian/contracts/claims.py
+++ b/src/jacobian/contracts/claims.py
@@ -94,6 +94,19 @@ class ClaimSpec(ContractModel):
         return self
 
 
+def flatten_claim_spec(value: object) -> object:
+    """Project a generic claim artifact into a plugin request claim shape."""
+
+    if not isinstance(value, dict) or not isinstance(value.get("predicate"), dict):
+        return value
+    claim = ClaimSpec.model_validate(value)
+    return {
+        "predicate": claim.predicate.name,
+        **claim.predicate.parameters,
+        **claim.bounds,
+    }
+
+
 class ClaimValidationResult(ContractModel):
     schema_version: Literal["1"] = "1"
     execution: Execution

--- a/src/jacobian/contracts/plugin_graphs.py
+++ b/src/jacobian/contracts/plugin_graphs.py
@@ -7,20 +7,9 @@ from typing import Any, Literal, Self
 
 from pydantic import Field, StrictBool, StrictInt, model_validator
 
-from jacobian.contracts.claims import ClaimSpec
+from jacobian.contracts.claims import flatten_claim_spec
 from jacobian.contracts.plugin_protocol import PluginRequestContext
 from jacobian.contracts.results import ContractModel
-
-
-def _flatten_claim(value: object) -> object:
-    if not isinstance(value, dict) or not isinstance(value.get("predicate"), dict):
-        return value
-    claim = ClaimSpec.model_validate(value)
-    return {
-        "predicate": claim.predicate.name,
-        **claim.predicate.parameters,
-        **claim.bounds,
-    }
 
 
 class GraphPathClaim(ContractModel):
@@ -31,7 +20,7 @@ class GraphPathClaim(ContractModel):
     @model_validator(mode="before")
     @classmethod
     def flatten_generic_claim(cls, value: object) -> object:
-        return _flatten_claim(value)
+        return flatten_claim_spec(value)
 
     @model_validator(mode="after")
     def validate_predicate_fields(self) -> Self:
@@ -84,31 +73,6 @@ class GraphPathCandidate(ContractModel):
                 raise ValueError(
                     "intended_paths must contain legal source-terminal paths"
                 )
-        return self
-
-
-class GraphPathEvaluationRequest(PluginRequestContext):
-    claim: GraphPathClaim
-    candidate: GraphPathCandidate | None = None
-    candidates: tuple[GraphPathCandidate, ...] | None = None
-
-    @model_validator(mode="after")
-    def require_candidates(self) -> Self:
-        if self.candidate is not None and self.candidates is not None:
-            raise ValueError("candidate and candidates cannot be combined")
-        if self.candidate is None and not self.candidates:
-            raise ValueError("at least one candidate is required")
-        candidates = (
-            (self.candidate,) if self.candidate is not None else self.candidates or ()
-        )
-        if self.claim.predicate == "intended_paths_complete":
-            for candidate in candidates:
-                if candidate.source is None or not candidate.terminals:
-                    raise ValueError(
-                        "intended_paths_complete requires source and terminals"
-                    )
-                if candidate.source in candidate.terminals:
-                    raise ValueError("source cannot also be a terminal")
         return self
 
 
@@ -211,7 +175,6 @@ __all__ = [
     "GraphPathCandidate",
     "GraphPathCapabilityRequest",
     "GraphPathClaim",
-    "GraphPathEvaluationRequest",
     "GraphPathReductionRequest",
     "GraphShrinkRequest",
     "GraphShrinkTarget",

--- a/src/jacobian/contracts/plugin_matrices.py
+++ b/src/jacobian/contracts/plugin_matrices.py
@@ -6,35 +6,16 @@ from typing import Literal, Self
 
 from pydantic import Field, StrictInt, StrictStr, model_validator
 
-from jacobian.contracts.claims import ClaimSpec
+from jacobian.contracts.claims import flatten_claim_spec
+from jacobian.contracts.exact import CanonicalInteger
 from jacobian.contracts.plugin_protocol import PluginRequestContext
 from jacobian.contracts.results import ContractModel
-
-
-def _flatten_claim(value: object) -> object:
-    if not isinstance(value, dict) or not isinstance(value.get("predicate"), dict):
-        return value
-    claim = ClaimSpec.model_validate(value)
-    return {
-        "predicate": claim.predicate.name,
-        **claim.predicate.parameters,
-        **claim.bounds,
-    }
 
 
 class MatrixScope(ContractModel):
     rows: StrictInt = Field(ge=1, le=32)
     cols: StrictInt = Field(ge=1, le=32)
-    entries: tuple[StrictInt | StrictStr, ...] = Field(min_length=1)
-
-    @model_validator(mode="after")
-    def validate_entries(self) -> Self:
-        for value in self.entries:
-            if isinstance(value, str) and (
-                not value or not value.lstrip("-").isdigit()
-            ):
-                raise ValueError("scope entries must be exact integers")
-        return self
+    entries: tuple[StrictInt | CanonicalInteger, ...] = Field(min_length=1)
 
 
 class MatrixClaim(ContractModel):
@@ -44,7 +25,7 @@ class MatrixClaim(ContractModel):
     @model_validator(mode="before")
     @classmethod
     def flatten_generic_claim(cls, value: object) -> object:
-        return _flatten_claim(value)
+        return flatten_claim_spec(value)
 
     @model_validator(mode="after")
     def validate_scope_for_predicate(self) -> Self:
@@ -59,7 +40,7 @@ class MatrixClaim(ContractModel):
 class MatrixCandidate(ContractModel):
     rows: StrictInt = Field(ge=1, le=32)
     cols: StrictInt = Field(ge=1, le=32)
-    entries: tuple[tuple[StrictInt | StrictStr, ...], ...]
+    entries: tuple[tuple[StrictInt | CanonicalInteger, ...], ...]
 
     @model_validator(mode="after")
     def validate_matrix_shape(self) -> Self:
@@ -67,37 +48,35 @@ class MatrixCandidate(ContractModel):
             len(row) != self.cols for row in self.entries
         ):
             raise ValueError("matrix entries must match rows and cols")
-        for value in (item for row in self.entries for item in row):
-            if (
-                isinstance(value, bool)
-                or (
-                    isinstance(value, str)
-                    and (not value or not value.lstrip("-").isdigit())
-                )
-                or not isinstance(value, (int, str))
-            ):
-                raise ValueError("matrix entries must be exact integers")
         return self
 
-
-class MatrixEvaluationRequest(PluginRequestContext):
-    claim: MatrixClaim
-    candidate: MatrixCandidate | None = None
-    candidates: tuple[MatrixCandidate, ...] | None = None
-
-    @model_validator(mode="after")
-    def require_candidates(self) -> Self:
-        if self.candidate is not None and self.candidates is not None:
-            raise ValueError("candidate and candidates cannot be combined")
-        if self.candidate is None and not self.candidates:
-            raise ValueError("at least one candidate is required")
-        return self
+    def validate_for_claim(self, claim: MatrixClaim) -> None:
+        if (
+            claim.predicate in {"is_nonsingular", "maximize_absolute_determinant"}
+            and self.rows != self.cols
+        ):
+            raise ValueError("determinant predicates require a square matrix")
+        if claim.predicate == "maximize_absolute_determinant":
+            assert claim.scope is not None
+            if self.rows != claim.scope.rows or self.cols != claim.scope.cols:
+                raise ValueError("candidate dimensions do not match claim scope")
+            allowed = {int(value) for value in claim.scope.entries}
+            if any(int(entry) not in allowed for row in self.entries for entry in row):
+                raise ValueError("candidate entry is outside claim scope")
 
 
 class MatrixCapabilityRequest(PluginRequestContext):
     claim: MatrixClaim
     candidate: MatrixCandidate | None = None
     witness_role: Literal["DEFEATS_CANDIDATE", "SUPPORTS_CLAIM"] = "DEFEATS_CANDIDATE"
+
+    @model_validator(mode="after")
+    def validate_candidate_for_claim(self) -> Self:
+        if self.claim.predicate == "is_nonsingular" and self.candidate is None:
+            raise ValueError("is_nonsingular capability requires a candidate")
+        if self.candidate is not None:
+            self.candidate.validate_for_claim(self.claim)
+        return self
 
 
 class MatrixReductionRequest(PluginRequestContext):
@@ -106,6 +85,11 @@ class MatrixReductionRequest(PluginRequestContext):
     claim: MatrixClaim
     reducers: tuple[Literal["delete_row_column", "zero_entry"], ...] = ()
     objectives: tuple[Literal["elements", "max_abs_entry"], ...] = ()
+
+    @model_validator(mode="after")
+    def validate_target_for_claim(self) -> Self:
+        self.target.validate_for_claim(self.claim)
+        return self
 
 
 class MatrixCursor(ContractModel):
@@ -137,7 +121,6 @@ __all__ = [
     "MatrixClaim",
     "MatrixCursor",
     "MatrixEnumerationRequest",
-    "MatrixEvaluationRequest",
     "MatrixMaterializeRequest",
     "MatrixReductionRequest",
     "MatrixScope",

--- a/src/jacobian/contracts/plugin_number_theory.py
+++ b/src/jacobian/contracts/plugin_number_theory.py
@@ -6,20 +6,9 @@ from typing import Literal, Self
 
 from pydantic import Field, StrictInt, model_validator
 
-from jacobian.contracts.claims import ClaimSpec
+from jacobian.contracts.claims import flatten_claim_spec
 from jacobian.contracts.plugin_protocol import PluginRequestContext
 from jacobian.contracts.results import ContractModel
-
-
-def _flatten_claim(value: object) -> object:
-    if not isinstance(value, dict) or not isinstance(value.get("predicate"), dict):
-        return value
-    claim = ClaimSpec.model_validate(value)
-    return {
-        "predicate": claim.predicate.name,
-        **claim.predicate.parameters,
-        **claim.bounds,
-    }
 
 
 class ErdosStrausClaim(ContractModel):
@@ -30,7 +19,7 @@ class ErdosStrausClaim(ContractModel):
     @model_validator(mode="before")
     @classmethod
     def flatten_generic_claim(cls, value: object) -> object:
-        return _flatten_claim(value)
+        return flatten_claim_spec(value)
 
     @model_validator(mode="after")
     def require_ordered_range(self) -> Self:
@@ -54,6 +43,15 @@ class ErdosStrausCapabilityRequest(PluginRequestContext):
     claim: ErdosStrausClaim
     candidate: ErdosStrausCandidate
     witness_role: Literal["DEFEATS_CANDIDATE", "SUPPORTS_CLAIM"] = "SUPPORTS_CLAIM"
+
+    @model_validator(mode="after")
+    def require_matching_range(self) -> Self:
+        if (
+            self.candidate.lower_bound != self.claim.lower_bound
+            or self.candidate.upper_bound != self.claim.upper_bound
+        ):
+            raise ValueError("candidate range must exactly match the claim range")
+        return self
 
 
 __all__ = [

--- a/src/jacobian/plugins/erdos_straus.py
+++ b/src/jacobian/plugins/erdos_straus.py
@@ -3,68 +3,15 @@
 from __future__ import annotations
 
 from fractions import Fraction
-from typing import Any, TypeGuard
+from typing import Any
 
 from pydantic import ValidationError
 
-from jacobian.contracts.plugin_number_theory import ErdosStrausCapabilityRequest
-
-_MIN_N = 2
-_MAX_N = 10_000
-
-
-def _is_int(value: object) -> TypeGuard[int]:
-    return isinstance(value, int) and not isinstance(value, bool)
-
-
-def _claim_view(payload: dict[str, Any]) -> dict[str, Any]:
-    predicate = payload.get("predicate")
-    if not isinstance(predicate, dict):
-        return payload
-    parameters = predicate.get("parameters", {})
-    return {
-        "predicate": predicate.get("name"),
-        **(parameters if isinstance(parameters, dict) else {}),
-    }
-
-
-def _validate_range(payload: dict[str, Any]) -> list[str]:
-    lower = payload.get("lower_bound")
-    upper = payload.get("upper_bound")
-    if not _is_int(lower) or not _is_int(upper):
-        return ["lower_bound and upper_bound must be integers"]
-    if lower < _MIN_N:
-        return [f"lower_bound must be at least {_MIN_N}"]
-    if upper < lower:
-        return ["upper_bound must be at least lower_bound"]
-    if upper > _MAX_N:
-        return [f"upper_bound exceeds the reference limit of {_MAX_N}"]
-    return []
-
-
-def validate_claim(payload: dict[str, Any]) -> list[str]:
-    if payload.get("predicate") != "erdos_straus_range":
-        return ["unsupported Erdős-Straus claim predicate"]
-    return _validate_range(payload)
-
-
-def validate_candidate(payload: dict[str, Any]) -> list[str]:
-    return _validate_range(payload)
-
-
-def _validate_candidate_for_claim(
-    claim: dict[str, Any],
-    candidate: dict[str, Any],
-) -> list[str]:
-    errors = validate_candidate(candidate)
-    if errors:
-        return errors
-    if (
-        candidate["lower_bound"] != claim["lower_bound"]
-        or candidate["upper_bound"] != claim["upper_bound"]
-    ):
-        return ["candidate range must exactly match the claim range"]
-    return []
+from jacobian.contracts.plugin_number_theory import (
+    ErdosStrausCandidate,
+    ErdosStrausCapabilityRequest,
+    ErdosStrausClaim,
+)
 
 
 def _decompose(n: int) -> tuple[int, int, int] | None:
@@ -98,27 +45,12 @@ def _decomposition_table(
     return table, None
 
 
-def evaluate_capability(request: dict[str, Any]) -> dict[str, Any]:
-    """Evaluate a bounded range without granting verification authority."""
-
-    try:
-        selected = ErdosStrausCapabilityRequest.model_validate(request)
-    except ValidationError as exc:
-        raise ValueError("Erdős-Straus request does not match its contract") from exc
-    claim = selected.claim.model_dump(mode="python")
-    candidate = selected.candidate.model_dump(mode="python")
-    errors = validate_claim(claim)
-    if not isinstance(candidate, dict):
-        errors.append("candidate must be an object")
-    elif not errors:
-        errors.extend(_validate_candidate_for_claim(claim, candidate))
-    if errors:
-        raise ValueError("; ".join(errors))
-    if not isinstance(candidate, dict):
-        raise ValueError("candidate must be an object")
-
-    lower = candidate["lower_bound"]
-    upper = candidate["upper_bound"]
+def _evaluate_typed(
+    claim: ErdosStrausClaim,
+    candidate: ErdosStrausCandidate,
+) -> dict[str, Any]:
+    lower = candidate.lower_bound
+    upper = candidate.upper_bound
     table, missing = _decomposition_table(lower, upper)
     complete = missing is None
     return {
@@ -144,30 +76,26 @@ def evaluate_capability(request: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def find_witness_capability(request: dict[str, Any]) -> dict[str, Any]:
-    """Propose a complete bounded decomposition table as unverified evidence."""
+def evaluate_capability(request: dict[str, Any]) -> dict[str, Any]:
+    """Evaluate a bounded range without granting verification authority."""
 
     try:
         selected = ErdosStrausCapabilityRequest.model_validate(request)
     except ValidationError as exc:
         raise ValueError("Erdős-Straus request does not match its contract") from exc
-    claim = selected.claim.model_dump(mode="python")
-    candidate = selected.candidate.model_dump(mode="python")
-    role = selected.witness_role
-    errors = validate_claim(claim)
-    if role != "SUPPORTS_CLAIM":
-        errors.append("erdos_straus_range supports only SUPPORTS_CLAIM witnesses")
-    if not isinstance(candidate, dict):
-        errors.append("candidate must be an object")
-    elif not errors:
-        errors.extend(_validate_candidate_for_claim(claim, candidate))
-    if errors:
-        raise ValueError("; ".join(errors))
-    if not isinstance(candidate, dict):
-        raise ValueError("candidate must be an object")
+    return _evaluate_typed(selected.claim, selected.candidate)
 
-    lower = candidate["lower_bound"]
-    upper = candidate["upper_bound"]
+
+def _find_witness_typed(
+    claim: ErdosStrausClaim,
+    candidate: ErdosStrausCandidate,
+    role: str,
+) -> dict[str, Any]:
+    if role != "SUPPORTS_CLAIM":
+        raise ValueError("erdos_straus_range supports only SUPPORTS_CLAIM witnesses")
+
+    lower = candidate.lower_bound
+    upper = candidate.upper_bound
     table, missing = _decomposition_table(lower, upper)
     if missing is not None:
         return {
@@ -191,3 +119,17 @@ def find_witness_capability(request: dict[str, Any]) -> dict[str, Any]:
         "coverage": "EXHAUSTIVE",
         "detail": f"complete proposed decomposition table for [{lower}, {upper}]",
     }
+
+
+def find_witness_capability(request: dict[str, Any]) -> dict[str, Any]:
+    """Propose a complete bounded decomposition table as unverified evidence."""
+
+    try:
+        selected = ErdosStrausCapabilityRequest.model_validate(request)
+    except ValidationError as exc:
+        raise ValueError("Erdős-Straus request does not match its contract") from exc
+    return _find_witness_typed(
+        selected.claim,
+        selected.candidate,
+        selected.witness_role,
+    )

--- a/src/jacobian/plugins/graph_paths.py
+++ b/src/jacobian/plugins/graph_paths.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import time
 from copy import deepcopy
 from itertools import pairwise, permutations
-from typing import Any, cast
+from typing import Any
 
 import networkx as nx
 from pydantic import ValidationError
@@ -21,153 +21,17 @@ from jacobian.canonical import canonicalize_json
 from jacobian.contracts.plugin_graphs import (
     GraphCanonicalizeRequest,
     GraphEnumerationRequest,
+    GraphPathCandidate,
     GraphPathCapabilityRequest,
-    GraphPathEvaluationRequest,
+    GraphPathClaim,
     GraphPathReductionRequest,
 )
 
-# ---------------------------------------------------------------------------
-# Validation helpers
-# ---------------------------------------------------------------------------
 
-
-def _is_positive_int(value: Any) -> bool:
-    return isinstance(value, int) and not isinstance(value, bool) and value > 0
-
-
-def _is_valid_path(
-    path: Any,
-    *,
-    vertex_set: set[str],
-    arc_set: set[tuple[str, str]],
-    source: str,
-    terminals: set[str],
-) -> bool:
-    if (
-        not isinstance(path, list)
-        or len(path) < 2
-        or not all(isinstance(v, str) for v in path)
-        or path[0] != source
-        or path[-1] not in terminals
-        or len(path) != len(set(path))
-        or any(v not in vertex_set for v in path)
-    ):
-        return False
-    return all((left, right) in arc_set for left, right in pairwise(path))
-
-
-def validate_candidate(payload: dict[str, Any]) -> list[str]:
-    """Return a list of validation errors for a graph candidate payload."""
-    errors: list[str] = []
-    vertices = payload.get("vertices")
-    arcs = payload.get("arcs")
-    source = payload.get("source")
-    terminals = payload.get("terminals")
-    intended_paths = payload.get("intended_paths")
-
-    if not isinstance(vertices, list) or not vertices:
-        errors.append("vertices must be a non-empty list")
-        return errors
-    if len(vertices) != len(set(vertices)) or not all(
-        isinstance(v, str) for v in vertices
-    ):
-        errors.append("vertices must be unique strings")
-        return errors
-
-    vertex_set = set(vertices)
-
-    if source is not None and source not in vertex_set:
-        errors.append("source is not a graph vertex")
-
-    if terminals is not None:
-        if not isinstance(terminals, list):
-            errors.append("terminals must be a list")
-        elif not terminals or any(t not in vertex_set for t in terminals):
-            errors.append("terminals are invalid")
-
-    if arcs is not None:
-        if not isinstance(arcs, list):
-            errors.append("arcs must be a list")
-        else:
-            seen: set[tuple[str, str]] = set()
-            for arc in arcs:
-                if (
-                    not isinstance(arc, list)
-                    or len(arc) != 2
-                    or arc[0] not in vertex_set
-                    or arc[1] not in vertex_set
-                ):
-                    errors.append(f"arc {arc} is malformed or out of domain")
-                    break
-                pair = (arc[0], arc[1])
-                if pair in seen:
-                    errors.append(f"duplicate arc {arc}")
-                    break
-                seen.add(pair)
-
-    if intended_paths is not None and not errors:
-        if not isinstance(intended_paths, list):
-            errors.append("intended_paths must be a list")
-        else:
-            arc_set = {tuple(a) for a in arcs} if isinstance(arcs, list) else set()
-            term_set = set(terminals) if isinstance(terminals, list) else set()
-            default_source = source if isinstance(source, str) else vertices[0]
-            for path in intended_paths:
-                if not _is_valid_path(
-                    path,
-                    vertex_set=vertex_set,
-                    arc_set=arc_set,
-                    source=default_source,
-                    terminals=term_set,
-                ):
-                    errors.append(f"intended path {path} is invalid")
-                    break
-
-    return errors
-
-
-def validate_claim(payload: dict[str, Any]) -> list[str]:
-    """Return a list of validation errors for a graph claim payload."""
-    errors: list[str] = []
-    predicate = payload.get("predicate")
-    if predicate == "intended_paths_complete":
-        if payload.get("simple") is not True:
-            errors.append("intended_paths_complete requires simple=True")
-        max_len = payload.get("max_path_length")
-        if max_len is not None and not _is_positive_int(max_len):
-            errors.append("max_path_length must be a positive integer")
-    elif predicate == "is_bipartite":
-        pass
-    else:
-        errors.append(f"unsupported graph claim predicate: {predicate}")
-    return errors
-
-
-def _validate_candidate_for_claim(
-    claim: dict[str, Any], candidate: dict[str, Any]
-) -> list[str]:
-    errors = validate_candidate(candidate)
-    if errors or claim.get("predicate") != "intended_paths_complete":
-        return errors
-
-    source = candidate.get("source")
-    terminals = candidate.get("terminals")
-    intended_paths = candidate.get("intended_paths")
-    if not isinstance(source, str):
-        errors.append("intended_paths_complete requires a source vertex")
-    if not isinstance(terminals, list) or not terminals:
-        errors.append("intended_paths_complete requires non-empty terminals")
-    elif isinstance(source, str) and source in terminals:
-        errors.append("source cannot also be a terminal")
-    if not isinstance(intended_paths, list):
-        errors.append("intended_paths_complete requires intended_paths")
-    return errors
-
-
-def _path_coverage(claim: dict[str, Any], candidate: dict[str, Any]) -> str:
+def _path_coverage(claim: GraphPathClaim, candidate: GraphPathCandidate) -> str:
     return (
         "EXHAUSTIVE"
-        if _max_path_length(claim, candidate) >= len(candidate["vertices"])
+        if _max_path_length(claim, candidate) >= len(candidate.vertices)
         else "BOUNDED"
     )
 
@@ -177,48 +41,47 @@ def _path_coverage(claim: dict[str, Any], candidate: dict[str, Any]) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _as_digraph(payload: dict[str, Any]) -> nx.DiGraph[str]:
+def _as_digraph(candidate: GraphPathCandidate) -> nx.DiGraph[str]:
     g: nx.DiGraph[str] = nx.DiGraph()
-    g.add_nodes_from(payload.get("vertices", []))
-    for arc in payload.get("arcs", []):
-        g.add_edge(arc[0], arc[1])
+    g.add_nodes_from(candidate.vertices)
+    g.add_edges_from(candidate.arcs)
     return g
 
 
-def _max_path_length(claim: dict[str, Any], candidate: dict[str, Any]) -> int:
-    value = claim.get("max_path_length")
+def _max_path_length(claim: GraphPathClaim, candidate: GraphPathCandidate) -> int:
+    value = claim.max_path_length
     if value is None:
-        value = len(candidate.get("vertices", []))
-    return cast(int, value)
+        return len(candidate.vertices)
+    return value
 
 
 def _enumerate_simple_paths(
-    candidate: dict[str, Any], max_length: int
+    candidate: GraphPathCandidate, max_length: int
 ) -> set[tuple[str, ...]]:
     """Enumerate all simple source-terminal paths with at most max_length vertices."""
     g = _as_digraph(candidate)
-    source = candidate.get("source")
-    terminals = candidate.get("terminals") or []
-    if source is None or not terminals:
+    if candidate.source is None or not candidate.terminals:
         return set()
     cutoff = max(1, max_length - 1)
     paths: set[tuple[str, ...]] = set()
-    for target in terminals:
-        for path in nx.all_simple_paths(g, source, target, cutoff=cutoff):
-            paths.add(tuple(cast(list[str], path)))
+    for target in candidate.terminals:
+        for path in nx.all_simple_paths(g, candidate.source, target, cutoff=cutoff):
+            paths.add(tuple(path))
     return paths
 
 
-def _find_omitted_path(candidate: dict[str, Any], max_length: int) -> list[str] | None:
+def _find_omitted_path(
+    candidate: GraphPathCandidate, max_length: int
+) -> list[str] | None:
     actual = _enumerate_simple_paths(candidate, max_length)
-    intended = {tuple(p) for p in candidate.get("intended_paths", [])}
+    intended = set(candidate.intended_paths or ())
     for path in sorted(actual):
         if path not in intended:
             return list(path)
     return None
 
 
-def _find_odd_cycle(candidate: dict[str, Any]) -> list[str] | None:
+def _find_odd_cycle(candidate: GraphPathCandidate) -> list[str] | None:
     """Return an odd cycle in the underlying graph, or None if none exists."""
     g = _as_digraph(candidate)
     ug = g.to_undirected()
@@ -230,7 +93,7 @@ def _find_odd_cycle(candidate: dict[str, Any]) -> list[str] | None:
     return None
 
 
-def _two_coloring(candidate: dict[str, Any]) -> dict[str, int] | None:
+def _two_coloring(candidate: GraphPathCandidate) -> dict[str, int] | None:
     ug = _as_digraph(candidate).to_undirected()
     if not nx.is_bipartite(ug):
         return None
@@ -273,128 +136,70 @@ def _rejected(errors: list[str], start: float) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def _claim_view(payload: dict[str, Any]) -> dict[str, Any]:
-    """Project a generic ClaimSpec into this plugin's compact domain view."""
-
-    predicate = payload.get("predicate")
-    if not isinstance(predicate, dict):
-        return payload
-    parameters = predicate.get("parameters", {})
-    bounds = payload.get("bounds", {})
-    return {
-        "predicate": predicate.get("name"),
-        **(parameters if isinstance(parameters, dict) else {}),
-        **(bounds if isinstance(bounds, dict) else {}),
-    }
-
-
-def evaluate(request: dict[str, Any]) -> dict[str, Any]:
-    """Evaluate graph candidates for a claim.  Results are unverified."""
-    start = time.monotonic()
-    try:
-        selected = GraphPathEvaluationRequest.model_validate(request)
-    except ValidationError:
-        return _rejected(
-            ["graph evaluation request does not match its contract"], start
-        )
-    claim = selected.claim.model_dump(mode="json", exclude_none=True)
-    candidate_list = (
-        [selected.candidate.model_dump(mode="json", exclude_none=True)]
-        if selected.candidate is not None
-        else [
-            candidate.model_dump(mode="json", exclude_none=True)
-            for candidate in selected.candidates or ()
-        ]
-    )
-
-    claim_errors = validate_claim(claim)
-    if claim_errors:
-        return _rejected(claim_errors, start)
-
-    results: list[dict[str, Any]] = []
-    for idx, candidate in enumerate(candidate_list):
-        if candidate is None:
-            results.append({"candidate_index": idx, "error": "missing candidate"})
-            continue
-        cand_errors = _validate_candidate_for_claim(claim, candidate)
-        if cand_errors:
-            return _rejected(cand_errors, start)
-
-        predicate = claim.get("predicate")
-        max_len = _max_path_length(claim, candidate)
-
-        if predicate == "intended_paths_complete":
-            actual = _enumerate_simple_paths(candidate, max_len)
-            intended = {tuple(p) for p in candidate.get("intended_paths", [])}
-            omitted = [list(p) for p in sorted(actual) if p not in intended]
-            result: dict[str, Any] = {
-                "candidate_index": idx,
-                "objective": {
-                    "name": "path_family_complete",
-                    "value": len(omitted) == 0,
-                    "num_actual": len(actual),
-                    "num_intended": len(intended),
-                },
-                "proposed_witness": None,
-                "coverage": _path_coverage(claim, candidate),
-                "arithmetic": "EXACT_INTEGER",
-                "detail": (
-                    "intended family complete"
-                    if not omitted
-                    else f"{len(omitted)} omitted path(s)"
-                ),
+def _evaluate_typed(
+    claim: GraphPathClaim,
+    candidate: GraphPathCandidate,
+) -> dict[str, Any]:
+    max_len = _max_path_length(claim, candidate)
+    if claim.predicate == "intended_paths_complete":
+        actual = _enumerate_simple_paths(candidate, max_len)
+        intended = set(candidate.intended_paths or ())
+        omitted = [list(path) for path in sorted(actual) if path not in intended]
+        result: dict[str, Any] = {
+            "objective": {
+                "name": "path_family_complete",
+                "value": not omitted,
+                "num_actual": len(actual),
+                "num_intended": len(intended),
+            },
+            "proposed_witness": None,
+            "coverage": _path_coverage(claim, candidate),
+            "arithmetic": "EXACT_INTEGER",
+            "detail": (
+                "intended family complete"
+                if not omitted
+                else f"{len(omitted)} omitted path(s)"
+            ),
+        }
+        if omitted:
+            result["proposed_witness"] = {
+                "witness_format": "graph.omitted_path",
+                "format_version": "1",
+                "role": "DEFEATS_CANDIDATE",
+                "payload": {"path": omitted[0]},
             }
-            if omitted:
-                result["proposed_witness"] = {
-                    "witness_format": "graph.omitted_path",
+        return result
+
+    if claim.predicate == "is_bipartite":
+        odd_cycle = _find_odd_cycle(candidate)
+        if odd_cycle:
+            return {
+                "objective": {"name": "is_bipartite", "value": False},
+                "proposed_witness": {
+                    "witness_format": "graph.odd_cycle",
                     "format_version": "1",
                     "role": "DEFEATS_CANDIDATE",
-                    "payload": {"path": omitted[0]},
-                }
-            results.append(result)
+                    "payload": {"cycle": odd_cycle},
+                },
+                "coverage": "EXHAUSTIVE",
+                "arithmetic": "EXACT_INTEGER",
+                "detail": f"odd cycle of length {len(odd_cycle)}",
+            }
+        coloring = _two_coloring(candidate)
+        return {
+            "objective": {"name": "is_bipartite", "value": True},
+            "proposed_witness": {
+                "witness_format": "graph.2coloring",
+                "format_version": "1",
+                "role": "SUPPORTS_CLAIM",
+                "payload": {"coloring": coloring},
+            },
+            "coverage": "EXHAUSTIVE",
+            "arithmetic": "EXACT_INTEGER",
+            "detail": "graph is bipartite",
+        }
 
-        elif predicate == "is_bipartite":
-            odd_cycle = _find_odd_cycle(candidate)
-            if odd_cycle:
-                results.append(
-                    {
-                        "candidate_index": idx,
-                        "objective": {"name": "is_bipartite", "value": False},
-                        "proposed_witness": {
-                            "witness_format": "graph.odd_cycle",
-                            "format_version": "1",
-                            "role": "DEFEATS_CANDIDATE",
-                            "payload": {"cycle": odd_cycle},
-                        },
-                        "coverage": "EXHAUSTIVE",
-                        "arithmetic": "EXACT_INTEGER",
-                        "detail": f"odd cycle of length {len(odd_cycle)}",
-                    }
-                )
-            else:
-                coloring = _two_coloring(candidate)
-                results.append(
-                    {
-                        "candidate_index": idx,
-                        "objective": {"name": "is_bipartite", "value": True},
-                        "proposed_witness": {
-                            "witness_format": "graph.2coloring",
-                            "format_version": "1",
-                            "role": "SUPPORTS_CLAIM",
-                            "payload": {"coloring": coloring},
-                        },
-                        "coverage": "EXHAUSTIVE",
-                        "arithmetic": "EXACT_INTEGER",
-                        "detail": "graph is bipartite",
-                    }
-                )
-
-    response = _ok(start)
-    response["results"] = results
-    response["coverage"] = "EXHAUSTIVE"
-    response["arithmetic"] = "EXACT_INTEGER"
-    response["detail"] = "graph search-side evaluation"
-    return response
+    raise ValueError("unsupported graph claim predicate")
 
 
 def _graph_capability_request(request: dict[str, Any]) -> GraphPathCapabilityRequest:
@@ -422,17 +227,7 @@ def evaluate_capability(request: dict[str, Any]) -> dict[str, Any]:
         raise ValueError(
             "graph evaluation request does not match its contract"
         ) from exc
-    response = evaluate(
-        {
-            "claim": selected.claim.model_dump(mode="json", exclude_none=True),
-            "candidate": selected.candidate.model_dump(mode="json", exclude_none=True),
-        }
-    )
-    if response["input"]["status"] != "ACCEPTED":
-        raise ValueError("; ".join(response["input"]["errors"]))
-    result = response["results"][0]
-    if "error" in result:
-        raise ValueError(result["error"])
+    result = _evaluate_typed(selected.claim, selected.candidate)
     objective = result["objective"]
     coverage = result["coverage"]
     proposed = result.get("proposed_witness")
@@ -460,167 +255,122 @@ def evaluate_capability(request: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def find_witness(request: dict[str, Any]) -> dict[str, Any]:
-    """Search for a graph witness.  Result is unverified."""
-    start = time.monotonic()
-    try:
-        selected = _graph_capability_request(request)
-    except ValueError as exc:
-        return _rejected([str(exc)], start)
-    claim = selected.claim.model_dump(mode="json", exclude_none=True)
-    candidate = selected.candidate.model_dump(mode="json", exclude_none=True)
-    role = selected.witness_role
-
-    claim_errors = validate_claim(claim)
-    if claim_errors:
-        return _rejected(claim_errors, start)
-    cand_errors = _validate_candidate_for_claim(claim, candidate)
-    if cand_errors:
-        return _rejected(cand_errors, start)
-
-    predicate = claim.get("predicate")
+def _find_path_witness_typed(
+    claim: GraphPathClaim,
+    candidate: GraphPathCandidate,
+    role: str,
+) -> dict[str, Any]:
     max_len = _max_path_length(claim, candidate)
 
-    if predicate == "intended_paths_complete":
-        if role == "DEFEATS_CANDIDATE":
-            omitted = _find_omitted_path(candidate, max_len)
-            if omitted:
-                response = _ok(start)
-                response.update(
-                    {
-                        "status": "FOUND",
-                        "witness": {"path": omitted},
-                        "witness_format": "graph.omitted_path",
-                        "format_version": "1",
-                        "role": "DEFEATS_CANDIDATE",
-                        "coverage": "NOT_APPLICABLE",
-                        "arithmetic": "EXACT_INTEGER",
-                        "detail": "legal source-terminal path omitted from intended family",
-                    }
-                )
-                return response
-            response = _ok(start)
-            response.update(
-                {
-                    "status": "SEARCH_EXHAUSTED",
-                    "witness": None,
-                    "coverage": _path_coverage(claim, candidate),
-                    "arithmetic": "EXACT_INTEGER",
-                    "detail": "no omitted path found within bounded scope",
-                }
-            )
-            return response
+    if role == "DEFEATS_CANDIDATE":
+        omitted = _find_omitted_path(candidate, max_len)
+        if omitted:
+            return {
+                "status": "FOUND",
+                "witness": {"path": omitted},
+                "witness_format": "graph.omitted_path",
+                "format_version": "1",
+                "role": "DEFEATS_CANDIDATE",
+                "coverage": "NOT_APPLICABLE",
+                "arithmetic": "EXACT_INTEGER",
+                "detail": "legal source-terminal path omitted from intended family",
+            }
+        return {
+            "status": "SEARCH_EXHAUSTED",
+            "witness": None,
+            "coverage": _path_coverage(claim, candidate),
+            "arithmetic": "EXACT_INTEGER",
+            "detail": "no omitted path found within bounded scope",
+        }
 
-        if role == "SUPPORTS_CLAIM":
-            actual = _enumerate_simple_paths(candidate, max_len)
-            intended = {tuple(p) for p in candidate.get("intended_paths", [])}
-            if actual == intended:
-                response = _ok(start)
-                response.update(
-                    {
-                        "status": "SEARCH_EXHAUSTED",
-                        "witness": None,
-                        "coverage": _path_coverage(claim, candidate),
-                        "arithmetic": "EXACT_INTEGER",
-                        "detail": "intended family matches actual family",
-                    }
-                )
-                return response
-            response = _ok(start)
-            response.update(
-                {
-                    "status": "NOT_FOUND_WITHIN_SCOPE",
-                    "witness": None,
-                    "coverage": _path_coverage(claim, candidate),
-                    "arithmetic": "EXACT_INTEGER",
-                    "detail": "intended family does not match actual family",
-                }
-            )
-            return response
+    if role == "SUPPORTS_CLAIM":
+        actual = _enumerate_simple_paths(candidate, max_len)
+        intended = set(candidate.intended_paths or ())
+        return {
+            "status": "SEARCH_EXHAUSTED"
+            if actual == intended
+            else "NOT_FOUND_WITHIN_SCOPE",
+            "witness": None,
+            "coverage": _path_coverage(claim, candidate),
+            "arithmetic": "EXACT_INTEGER",
+            "detail": (
+                "intended family matches actual family"
+                if actual == intended
+                else "intended family does not match actual family"
+            ),
+        }
 
-    if predicate == "is_bipartite":
-        if role == "DEFEATS_CANDIDATE":
-            odd_cycle = _find_odd_cycle(candidate)
-            if odd_cycle:
-                response = _ok(start)
-                response.update(
-                    {
-                        "status": "FOUND",
-                        "witness": {"cycle": odd_cycle},
-                        "witness_format": "graph.odd_cycle",
-                        "format_version": "1",
-                        "role": "DEFEATS_CANDIDATE",
-                        "coverage": "EXHAUSTIVE",
-                        "arithmetic": "EXACT_INTEGER",
-                        "detail": f"odd cycle of length {len(odd_cycle)}",
-                    }
-                )
-                return response
-            response = _ok(start)
-            response.update(
-                {
-                    "status": "SEARCH_EXHAUSTED",
-                    "witness": None,
-                    "coverage": "EXHAUSTIVE",
-                    "arithmetic": "EXACT_INTEGER",
-                    "detail": "no odd cycle found",
-                }
-            )
-            return response
+    raise ValueError("unsupported witness role")
 
-        if role == "SUPPORTS_CLAIM":
-            coloring = _two_coloring(candidate)
-            if coloring:
-                response = _ok(start)
-                response.update(
-                    {
-                        "status": "FOUND",
-                        "witness": {"coloring": coloring},
-                        "witness_format": "graph.2coloring",
-                        "format_version": "1",
-                        "role": "SUPPORTS_CLAIM",
-                        "coverage": "EXHAUSTIVE",
-                        "arithmetic": "EXACT_INTEGER",
-                        "detail": "2-coloring witness",
-                    }
-                )
-                return response
-            response = _ok(start)
-            response.update(
-                {
-                    "status": "SEARCH_EXHAUSTED",
-                    "witness": None,
-                    "coverage": "EXHAUSTIVE",
-                    "arithmetic": "EXACT_INTEGER",
-                    "detail": "graph is not bipartite",
-                }
-            )
-            return response
 
-    return _rejected(["unsupported witness role or claim predicate"], start)
+def _find_bipartite_witness_typed(
+    candidate: GraphPathCandidate,
+    role: str,
+) -> dict[str, Any]:
+    if role == "DEFEATS_CANDIDATE":
+        odd_cycle = _find_odd_cycle(candidate)
+        if odd_cycle:
+            return {
+                "status": "FOUND",
+                "witness": {"cycle": odd_cycle},
+                "witness_format": "graph.odd_cycle",
+                "format_version": "1",
+                "role": "DEFEATS_CANDIDATE",
+                "coverage": "EXHAUSTIVE",
+                "arithmetic": "EXACT_INTEGER",
+                "detail": f"odd cycle of length {len(odd_cycle)}",
+            }
+        return {
+            "status": "SEARCH_EXHAUSTED",
+            "witness": None,
+            "coverage": "EXHAUSTIVE",
+            "arithmetic": "EXACT_INTEGER",
+            "detail": "no odd cycle found",
+        }
+
+    if role == "SUPPORTS_CLAIM":
+        coloring = _two_coloring(candidate)
+        return {
+            "status": "FOUND" if coloring else "SEARCH_EXHAUSTED",
+            "witness": {"coloring": coloring} if coloring else None,
+            **(
+                {
+                    "witness_format": "graph.2coloring",
+                    "format_version": "1",
+                    "role": "SUPPORTS_CLAIM",
+                }
+                if coloring
+                else {}
+            ),
+            "coverage": "EXHAUSTIVE",
+            "arithmetic": "EXACT_INTEGER",
+            "detail": "2-coloring witness" if coloring else "graph is not bipartite",
+        }
+
+    raise ValueError("unsupported witness role")
+
+
+def _find_witness_typed(
+    claim: GraphPathClaim,
+    candidate: GraphPathCandidate,
+    role: str,
+) -> dict[str, Any]:
+    if claim.predicate == "intended_paths_complete":
+        return _find_path_witness_typed(claim, candidate, role)
+    if claim.predicate == "is_bipartite":
+        return _find_bipartite_witness_typed(candidate, role)
+    raise ValueError("unsupported graph claim predicate")
 
 
 def find_witness_capability(request: dict[str, Any]) -> dict[str, Any]:
     """Return graph witness search in the generic oracle contract."""
 
-    response = find_witness(request)
-    if response["input"]["status"] != "ACCEPTED":
-        raise ValueError("; ".join(response["input"]["errors"]))
-    return {
-        key: value
-        for key, value in response.items()
-        if key
-        in {
-            "status",
-            "witness",
-            "witness_format",
-            "format_version",
-            "role",
-            "arithmetic",
-            "coverage",
-            "detail",
-        }
-    }
+    selected = _graph_capability_request(request)
+    return _find_witness_typed(
+        selected.claim,
+        selected.candidate,
+        selected.witness_role,
+    )
 
 
 def materialize(request: dict[str, Any]) -> dict[str, Any]:
@@ -632,58 +382,34 @@ def materialize(request: dict[str, Any]) -> dict[str, Any]:
         return _rejected(
             ["graph materialization request does not match its contract"], start
         )
-    claim = selected.claim.model_dump(mode="json", exclude_none=True)
-    candidate = selected.candidate.model_dump(mode="json", exclude_none=True)
-
-    claim_errors = validate_claim(claim)
-    if claim_errors:
-        return _rejected(claim_errors, start)
-    cand_errors = _validate_candidate_for_claim(claim, candidate)
-    if cand_errors:
-        return _rejected(cand_errors, start)
-
-    predicate = claim.get("predicate")
+    predicate = selected.claim.predicate
     if predicate != "intended_paths_complete":
         return _rejected(["materialize supports intended_paths_complete only"], start)
 
-    max_len = _max_path_length(claim, candidate)
-    paths = sorted(_enumerate_simple_paths(candidate, max_len))
+    max_len = _max_path_length(selected.claim, selected.candidate)
+    paths = sorted(_enumerate_simple_paths(selected.candidate, max_len))
 
     response = _ok(start)
     response["family"] = [list(p) for p in paths]
-    response["coverage"] = _path_coverage(claim, candidate)
+    response["coverage"] = _path_coverage(selected.claim, selected.candidate)
     response["arithmetic"] = "EXACT_INTEGER"
     response["detail"] = "all simple source-terminal paths within bound"
     return response
 
 
-def reductions(request: dict[str, Any]) -> dict[str, Any]:
-    """Propose candidate reductions that preserve the attacked predicate."""
-    start = time.monotonic()
-    selected = _graph_reduction_request(request)
-    target_kind = selected.target_kind
-    target = selected.target.model_dump(mode="json", exclude_none=True)
-    claim = selected.claim.model_dump(mode="json", exclude_none=True)
-
-    claim_errors = validate_claim(claim)
-    if claim_errors:
-        return _rejected(claim_errors, start)
-    cand_errors = (
-        _validate_candidate_for_claim(claim, target)
-        if target_kind == "candidate"
-        else []
-    )
-    if cand_errors:
-        return _rejected(cand_errors, start)
-
-    predicate = claim.get("predicate")
-    max_len = _max_path_length(claim, target)
+def _reductions_typed(
+    selected: GraphPathReductionRequest,
+    *,
+    start: float,
+) -> dict[str, Any]:
+    predicate = selected.claim.predicate
+    max_len = _max_path_length(selected.claim, selected.target)
 
     protected_vertices: set[str] = set()
     protected_arcs: set[tuple[str, str]] = set()
 
     if predicate == "intended_paths_complete":
-        omitted = _find_omitted_path(target, max_len)
+        omitted = _find_omitted_path(selected.target, max_len)
         if omitted is None:
             response = _ok(start)
             response["reductions"] = []
@@ -692,7 +418,7 @@ def reductions(request: dict[str, Any]) -> dict[str, Any]:
         protected_vertices = set(omitted)
         protected_arcs = set(pairwise(omitted))
     elif predicate == "is_bipartite":
-        cycle = _find_odd_cycle(target)
+        cycle = _find_odd_cycle(selected.target)
         if cycle is None:
             response = _ok(start)
             response["reductions"] = []
@@ -707,8 +433,8 @@ def reductions(request: dict[str, Any]) -> dict[str, Any]:
     else:
         return _rejected(["unsupported predicate for reductions"], start)
 
-    vertices = target.get("vertices", [])
-    arcs = target.get("arcs", [])
+    vertices = selected.target.vertices
+    arcs = selected.target.arcs
     current_vertices = len(vertices)
     current_edges = len(arcs)
 
@@ -756,13 +482,7 @@ def reductions_capability(request: dict[str, Any]) -> dict[str, Any]:
 
     selected = _graph_reduction_request(request)
     target = selected.target.model_dump(mode="json", exclude_none=True)
-    response = reductions(
-        {
-            "target_kind": selected.target_kind,
-            "target": target,
-            "claim": selected.claim.model_dump(mode="json", exclude_none=True),
-        }
-    )
+    response = _reductions_typed(selected, start=time.monotonic())
     if response["input"]["status"] != "ACCEPTED":
         raise ValueError("; ".join(response["input"]["errors"]))
     requested = set(selected.reducers)
@@ -839,9 +559,6 @@ def canonicalize_capability(request: dict[str, Any]) -> dict[str, Any]:
             "graph canonicalization request does not match its contract"
         ) from exc
     structure = selected.structure.model_dump(mode="json", exclude_none=True)
-    errors = validate_candidate(structure)
-    if errors:
-        raise ValueError("; ".join(errors))
     vertices = structure["vertices"]
     if len(vertices) > 9:
         raise ValueError("reference canonicalizer is limited to nine vertices")

--- a/src/jacobian/plugins/matrices.py
+++ b/src/jacobian/plugins/matrices.py
@@ -10,21 +10,22 @@ All outputs are unverified search results; checkers replay evidence separately.
 from __future__ import annotations
 
 import itertools
-import re
 import time
 from collections.abc import Iterator
 from copy import deepcopy
 from fractions import Fraction
-from typing import Any, cast
+from typing import Any
 
 from pydantic import ValidationError
 
 from jacobian.contracts.plugin_matrices import (
+    MatrixCandidate,
     MatrixCapabilityRequest,
+    MatrixClaim,
     MatrixEnumerationRequest,
-    MatrixEvaluationRequest,
     MatrixMaterializeRequest,
     MatrixReductionRequest,
+    MatrixScope,
     MatrixTransformRequest,
 )
 
@@ -35,65 +36,38 @@ MAX_SEARCHED_MATRICES = 65_536
 # ---------------------------------------------------------------------------
 
 
-_INTEGER_RE = re.compile(r"^-?(?:0|[1-9][0-9]*)$")
-
-
-def _is_exact_integer(value: Any) -> bool:
-    if isinstance(value, bool):
-        return False
-    if isinstance(value, int):
-        return True
-    if isinstance(value, str):
-        return bool(_INTEGER_RE.match(value))
-    return False
-
-
 def _to_int(value: Any) -> int:
-    if isinstance(value, bool):
-        raise ValueError("boolean is not an exact integer")
-    if isinstance(value, int):
-        return value
-    if isinstance(value, str):
-        if not _INTEGER_RE.match(value):
-            raise ValueError(f"not an exact integer: {value!r}")
-        return int(value)
-    raise ValueError(f"not an exact integer: {value!r}")
+    return int(value)
 
 
 def _to_int_matrix(entries: Any) -> list[list[int]]:
-    if not isinstance(entries, list):
+    if not isinstance(entries, (list, tuple)):
         raise ValueError("entries must be a list of rows")
     matrix: list[list[int]] = []
     for row in entries:
-        if not isinstance(row, list):
+        if not isinstance(row, (list, tuple)):
             raise ValueError("each row must be a list")
         matrix.append([_to_int(x) for x in row])
     return matrix
+
+
+def _candidate_matrix(candidate: MatrixCandidate) -> list[list[int]]:
+    return _to_int_matrix(candidate.entries)
 
 
 def _canonical_rational(frac: Fraction) -> dict[str, str]:
     return {"num": str(frac.numerator), "den": str(frac.denominator)}
 
 
-def enumerate_candidates_capability(request: dict[str, Any]) -> dict[str, Any]:
-    """Page through a finite rectangular integer-matrix scope."""
-
-    try:
-        selected = MatrixEnumerationRequest.model_validate(request)
-    except ValidationError as exc:
-        raise ValueError(
-            "matrix enumeration request does not match its contract"
-        ) from exc
-    bounds = selected.bounds.model_dump(mode="json")
-    page_size = selected.page_size
-    offset = selected.cursor.offset if selected.cursor is not None else 0
-    errors = _validate_scope(bounds)
-    if errors:
-        raise ValueError("; ".join(errors))
-
-    rows = cast(int, bounds["rows"])
-    cols = cast(int, bounds["cols"])
-    values = [_to_int(value) for value in cast(list[Any], bounds["entries"])]
+def _enumerate_typed(
+    bounds: MatrixScope,
+    *,
+    page_size: int,
+    offset: int,
+) -> dict[str, Any]:
+    rows = bounds.rows
+    cols = bounds.cols
+    values = _scope_values(bounds)
     total = len(values) ** (rows * cols)
     stop = min(offset + page_size, total)
     candidates: list[dict[str, Any]] = []
@@ -122,6 +96,22 @@ def enumerate_candidates_capability(request: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def enumerate_candidates_capability(request: dict[str, Any]) -> dict[str, Any]:
+    """Page through a finite rectangular integer-matrix scope."""
+
+    try:
+        selected = MatrixEnumerationRequest.model_validate(request)
+    except ValidationError as exc:
+        raise ValueError(
+            "matrix enumeration request does not match its contract"
+        ) from exc
+    return _enumerate_typed(
+        selected.bounds,
+        page_size=selected.page_size,
+        offset=selected.cursor.offset if selected.cursor is not None else 0,
+    )
+
+
 def transform_row_major_capability(request: dict[str, Any]) -> dict[str, Any]:
     """Propose a row-major representation of one integer matrix."""
 
@@ -131,17 +121,9 @@ def transform_row_major_capability(request: dict[str, Any]) -> dict[str, Any]:
         raise ValueError(
             "matrix transform request does not match its contract"
         ) from exc
-    source = selected.source.model_dump(mode="json")
-    errors = validate_candidate(source)
-    if errors:
-        raise ValueError("; ".join(errors))
-    rows = cast(int, source["rows"])
-    cols = cast(int, source["cols"])
-    values = [
-        str(_to_int(value))
-        for row in cast(list[list[Any]], source["entries"])
-        for value in row
-    ]
+    rows = selected.source.rows
+    cols = selected.source.cols
+    values = [str(value) for row in _candidate_matrix(selected.source) for value in row]
     return {
         "response_version": "1",
         "transform_format": "matrix.row_major",
@@ -249,135 +231,28 @@ def _is_singular(matrix: list[list[int]]) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _validate_scope(scope: dict[str, Any]) -> list[str]:
-    errors: list[str] = []
-    rows = scope.get("rows")
-    cols = scope.get("cols")
-    entries = scope.get("entries")
-    if not isinstance(rows, int) or isinstance(rows, bool) or rows <= 0:
-        errors.append("scope.rows must be a positive integer")
-    if not isinstance(cols, int) or isinstance(cols, bool) or cols <= 0:
-        errors.append("scope.cols must be a positive integer")
-    if not isinstance(entries, list) or not entries:
-        errors.append("scope.entries must be a non-empty list of allowed integers")
-    else:
-        for e in entries:
-            if not _is_exact_integer(e):
-                errors.append(f"scope entry {e!r} is not an exact integer")
-                break
-    return errors
+def _scope_values(scope: MatrixScope) -> list[int]:
+    return [_to_int(value) for value in scope.entries]
 
 
-def _scope_iterator(
-    scope: dict[str, Any],
-) -> Iterator[tuple[int, list[list[int]]]]:
-    rows = cast(int, scope["rows"])
-    cols = cast(int, scope["cols"])
-    values = [_to_int(e) for e in scope["entries"]]
+def _scope_iterator(scope: MatrixScope) -> Iterator[tuple[int, list[list[int]]]]:
+    rows = scope.rows
+    cols = scope.cols
+    values = _scope_values(scope)
     positions = rows * cols
     for index, combo in enumerate(itertools.product(values, repeat=positions)):
         mat = [list(combo[i * cols : (i + 1) * cols]) for i in range(rows)]
         yield index, mat
 
 
-def _scope_total(scope: dict[str, Any]) -> int:
-    values = [_to_int(e) for e in scope["entries"]]
-    rows = cast(int, scope["rows"])
-    cols = cast(int, scope["cols"])
-    return cast(int, len(values) ** (rows * cols))
+def _scope_total(scope: MatrixScope) -> int:
+    values = _scope_values(scope)
+    return int(len(values) ** (int(scope.rows) * int(scope.cols)))
 
 
 # ---------------------------------------------------------------------------
 # Validation
 # ---------------------------------------------------------------------------
-
-
-def validate_candidate(payload: dict[str, Any]) -> list[str]:
-    """Return a list of validation errors for a matrix candidate payload."""
-    errors: list[str] = []
-    rows = payload.get("rows")
-    cols = payload.get("cols")
-    entries = payload.get("entries")
-
-    if not isinstance(rows, int) or isinstance(rows, bool) or rows <= 0:
-        errors.append("rows must be a positive integer")
-    if not isinstance(cols, int) or isinstance(cols, bool) or cols <= 0:
-        errors.append("cols must be a positive integer")
-    if not isinstance(entries, list):
-        errors.append("entries must be a list of rows")
-        return errors
-
-    if rows is not None and len(entries) != rows:
-        errors.append(f"entries has {len(entries)} rows, expected {rows}")
-
-    for i, row in enumerate(entries):
-        if not isinstance(row, list):
-            errors.append(f"row {i} is not a list")
-            continue
-        if cols is not None and len(row) != cols:
-            errors.append(f"row {i} has {len(row)} columns, expected {cols}")
-        for j, val in enumerate(row):
-            if not _is_exact_integer(val):
-                errors.append(f"entry ({i},{j}) is not an exact integer")
-
-    if not errors:
-        try:
-            _to_int_matrix(entries)
-        except ValueError as exc:
-            errors.append(str(exc))
-
-    return errors
-
-
-def validate_claim(payload: dict[str, Any]) -> list[str]:
-    """Return a list of validation errors for a matrix claim payload."""
-    errors: list[str] = []
-    predicate = payload.get("predicate")
-    if predicate == "is_nonsingular":
-        pass
-    elif predicate == "maximize_absolute_determinant":
-        scope = payload.get("scope")
-        if not isinstance(scope, dict):
-            errors.append("maximize_absolute_determinant requires a scope")
-        else:
-            errors.extend(_validate_scope(scope))
-            if (
-                isinstance(scope.get("rows"), int)
-                and isinstance(scope.get("cols"), int)
-                and scope["rows"] != scope["cols"]
-            ):
-                errors.append("determinant scope must be square")
-    else:
-        errors.append(f"unsupported matrix claim predicate: {predicate}")
-    return errors
-
-
-def _validate_candidate_for_claim(
-    claim: dict[str, Any], candidate: dict[str, Any]
-) -> list[str]:
-    errors = validate_candidate(candidate)
-    if (
-        not errors
-        and claim.get("predicate")
-        in {"is_nonsingular", "maximize_absolute_determinant"}
-        and candidate.get("rows") != candidate.get("cols")
-    ):
-        errors.append("determinant predicates require a square matrix")
-    if not errors and claim.get("predicate") == "maximize_absolute_determinant":
-        scope = claim.get("scope")
-        if not isinstance(scope, dict):
-            errors.append("maximize_absolute_determinant requires a scope")
-        else:
-            if candidate.get("rows") != scope.get("rows") or candidate.get(
-                "cols"
-            ) != scope.get("cols"):
-                errors.append("candidate dimensions do not match claim scope")
-            else:
-                allowed = {_to_int(value) for value in scope["entries"]}
-                matrix = _to_int_matrix(candidate["entries"])
-                if any(entry not in allowed for row in matrix for entry in row):
-                    errors.append("candidate entry is outside claim scope")
-    return errors
 
 
 # ---------------------------------------------------------------------------
@@ -410,21 +285,6 @@ def _rejected(errors: list[str], start: float) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def _claim_view(payload: dict[str, Any]) -> dict[str, Any]:
-    """Project a generic ClaimSpec into this plugin's compact domain view."""
-
-    predicate = payload.get("predicate")
-    if not isinstance(predicate, dict):
-        return payload
-    parameters = predicate.get("parameters", {})
-    bounds = payload.get("bounds", {})
-    return {
-        "predicate": predicate.get("name"),
-        **(parameters if isinstance(parameters, dict) else {}),
-        **(bounds if isinstance(bounds, dict) else {}),
-    }
-
-
 def _matrix_capability_request(request: dict[str, Any]) -> MatrixCapabilityRequest:
     try:
         return MatrixCapabilityRequest.model_validate(request)
@@ -443,92 +303,50 @@ def _matrix_reduction_request(request: dict[str, Any]) -> MatrixReductionRequest
         ) from exc
 
 
-def evaluate(request: dict[str, Any]) -> dict[str, Any]:
-    """Evaluate integer-matrix candidates for a claim.  Results are unverified."""
-    start = time.monotonic()
-    try:
-        selected = MatrixEvaluationRequest.model_validate(request)
-    except ValidationError:
-        return _rejected(
-            ["matrix evaluation request does not match its contract"], start
-        )
-    claim = selected.claim.model_dump(mode="json")
-    candidate_list = (
-        [selected.candidate.model_dump(mode="json")]
-        if selected.candidate is not None
-        else [
-            candidate.model_dump(mode="json") for candidate in selected.candidates or ()
-        ]
-    )
-
-    claim_errors = validate_claim(claim)
-    if claim_errors:
-        return _rejected(claim_errors, start)
-
-    predicate = claim.get("predicate")
-    results: list[dict[str, Any]] = []
-
-    for idx, candidate in enumerate(candidate_list):
-        if candidate is None:
-            results.append({"candidate_index": idx, "error": "missing candidate"})
-            continue
-        cand_errors = _validate_candidate_for_claim(claim, candidate)
-        if cand_errors:
-            return _rejected(cand_errors, start)
-
-        matrix = _to_int_matrix(candidate["entries"])
-        det = _det_fraction(matrix)
-
-        if predicate == "is_nonsingular":
-            result: dict[str, Any] = {
-                "candidate_index": idx,
-                "objective": {
-                    "name": "determinant",
-                    "value": _canonical_rational(det),
-                },
-                "is_singular": det == 0,
-                "proposed_witness": None,
-                "coverage": "EXHAUSTIVE",
-                "arithmetic": "EXACT_RATIONAL",
-                "detail": "exact rational determinant",
-            }
-            if det == 0:
-                vec = _kernel_vector(matrix)
-                if vec is not None:
-                    result["proposed_witness"] = {
-                        "witness_format": "matrix.kernel_vector",
-                        "format_version": "1",
-                        "role": "DEFEATS_CANDIDATE",
-                        "payload": {"vector": [_canonical_rational(v) for v in vec]},
-                    }
-                    result["detail"] = (
-                        "matrix is singular with a non-zero kernel vector"
-                    )
-            results.append(result)
-
-        elif predicate == "maximize_absolute_determinant":
-            abs_det = abs(det)
-            results.append(
-                {
-                    "candidate_index": idx,
-                    "objective": {
-                        "name": "abs_determinant",
-                        "value": _canonical_rational(abs_det),
-                    },
-                    "is_singular": det == 0,
-                    "proposed_witness": None,
-                    "coverage": "EXHAUSTIVE",
-                    "arithmetic": "EXACT_RATIONAL",
-                    "detail": "exact rational absolute determinant",
+def _evaluate_typed(
+    claim: MatrixClaim,
+    candidate: MatrixCandidate,
+) -> dict[str, Any]:
+    matrix = _candidate_matrix(candidate)
+    det = _det_fraction(matrix)
+    if claim.predicate == "is_nonsingular":
+        result: dict[str, Any] = {
+            "objective": {
+                "name": "determinant",
+                "value": _canonical_rational(det),
+            },
+            "is_singular": det == 0,
+            "proposed_witness": None,
+            "coverage": "EXHAUSTIVE",
+            "arithmetic": "EXACT_RATIONAL",
+            "detail": "exact rational determinant",
+        }
+        if det == 0:
+            vec = _kernel_vector(matrix)
+            if vec is not None:
+                result["proposed_witness"] = {
+                    "witness_format": "matrix.kernel_vector",
+                    "format_version": "1",
+                    "role": "DEFEATS_CANDIDATE",
+                    "payload": {"vector": [_canonical_rational(v) for v in vec]},
                 }
-            )
+                result["detail"] = "matrix is singular with a non-zero kernel vector"
+        return result
 
-    response = _ok(start)
-    response["results"] = results
-    response["coverage"] = "EXHAUSTIVE"
-    response["arithmetic"] = "EXACT_RATIONAL"
-    response["detail"] = "matrix search-side evaluation"
-    return response
+    if claim.predicate == "maximize_absolute_determinant":
+        return {
+            "objective": {
+                "name": "abs_determinant",
+                "value": _canonical_rational(abs(det)),
+            },
+            "is_singular": det == 0,
+            "proposed_witness": None,
+            "coverage": "EXHAUSTIVE",
+            "arithmetic": "EXACT_RATIONAL",
+            "detail": "exact rational absolute determinant",
+        }
+
+    raise ValueError("unsupported matrix claim predicate")
 
 
 def evaluate_capability(request: dict[str, Any]) -> dict[str, Any]:
@@ -540,19 +358,12 @@ def evaluate_capability(request: dict[str, Any]) -> dict[str, Any]:
         raise ValueError(
             "matrix evaluation request does not match its contract"
         ) from exc
-    claim = selected.claim.model_dump(mode="json")
     candidate_model = selected.candidate
-    candidate = (
-        candidate_model.model_dump(mode="json") if candidate_model is not None else None
-    )
-    response = evaluate({"claim": claim, "candidate": candidate})
-    if response["input"]["status"] != "ACCEPTED":
-        raise ValueError("; ".join(response["input"]["errors"]))
-    result = response["results"][0]
-    if "error" in result:
-        raise ValueError(result["error"])
+    if candidate_model is None:
+        raise ValueError("matrix evaluation request requires a candidate")
+    result = _evaluate_typed(selected.claim, candidate_model)
     objective = result["objective"]
-    predicate = claim.get("predicate")
+    predicate = selected.claim.predicate
     if predicate == "is_nonsingular":
         conclusion = "FALSE" if result["is_singular"] else "TRUE"
         method = "EXHAUSTIVE_FINITE"
@@ -583,149 +394,104 @@ def evaluate_capability(request: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def find_witness(request: dict[str, Any]) -> dict[str, Any]:
-    """Search for a matrix witness.  Result is unverified."""
-    start = time.monotonic()
-    selected = _matrix_capability_request(request)
-    claim = selected.claim.model_dump(mode="json")
-    candidate = (
-        selected.candidate.model_dump(mode="json")
-        if selected.candidate is not None
-        else None
-    )
-    claim_errors = validate_claim(claim)
-    if claim_errors:
-        return _rejected(claim_errors, start)
+def _find_kernel_witness_typed(
+    candidate: MatrixCandidate | None,
+) -> dict[str, Any]:
+    if candidate is None:
+        raise ValueError("is_nonsingular witness requires a candidate")
+    matrix = _candidate_matrix(candidate)
+    vec = _kernel_vector(matrix)
+    if vec is None:
+        return {
+            "status": "SEARCH_EXHAUSTED",
+            "witness": None,
+            "coverage": "EXHAUSTIVE",
+            "arithmetic": "EXACT_RATIONAL",
+            "detail": "matrix has trivial kernel only",
+        }
+    return {
+        "status": "FOUND",
+        "witness": {"vector": [_canonical_rational(v) for v in vec]},
+        "witness_format": "matrix.kernel_vector",
+        "format_version": "1",
+        "role": "DEFEATS_CANDIDATE",
+        "coverage": "EXHAUSTIVE",
+        "arithmetic": "EXACT_RATIONAL",
+        "detail": "non-zero kernel vector found",
+    }
 
-    predicate = claim.get("predicate")
-    requested_role = selected.witness_role
 
-    if predicate == "is_nonsingular":
+def _find_maxdet_witness_typed(
+    claim: MatrixClaim,
+) -> dict[str, Any]:
+    scope = claim.scope
+    if scope is None:
+        raise ValueError("maximize_absolute_determinant witness requires a scope")
+    if _scope_total(scope) > MAX_SEARCHED_MATRICES:
+        raise ValueError(
+            f"scope exceeds witness search limit of {MAX_SEARCHED_MATRICES} candidates"
+        )
+
+    best_value = Fraction(-1)
+    best_index = -1
+    best_matrix: list[list[int]] = []
+    for index, mat in _scope_iterator(scope):
+        det = abs(_det_fraction(mat))
+        if det > best_value:
+            best_value = det
+            best_index = index
+            best_matrix = mat
+
+    if best_index < 0:
+        raise ValueError("scope contains no candidates")
+
+    return {
+        "status": "FOUND",
+        "witness": {
+            "matrix": {
+                "rows": scope.rows,
+                "cols": scope.cols,
+                "entries": best_matrix,
+            },
+            "objective_value": _canonical_rational(best_value),
+            "index": best_index,
+        },
+        "witness_format": "matrix.maximizer",
+        "format_version": "1",
+        "role": "SUPPORTS_CLAIM",
+        "coverage": "EXHAUSTIVE",
+        "arithmetic": "EXACT_RATIONAL",
+        "detail": f"maximizer with |det| = {best_value}",
+    }
+
+
+def _find_witness_typed(
+    claim: MatrixClaim,
+    candidate: MatrixCandidate | None,
+    requested_role: str,
+) -> dict[str, Any]:
+    if claim.predicate == "is_nonsingular":
         if requested_role != "DEFEATS_CANDIDATE":
-            return _rejected(
-                ["is_nonsingular supports only DEFEATS_CANDIDATE witnesses"],
-                start,
-            )
-        if candidate is None:
-            return _rejected(["is_nonsingular witness requires a candidate"], start)
-        cand_errors = _validate_candidate_for_claim(claim, candidate)
-        if cand_errors:
-            return _rejected(cand_errors, start)
-        matrix = _to_int_matrix(candidate["entries"])
-        vec = _kernel_vector(matrix)
-        if vec is None:
-            response = _ok(start)
-            response.update(
-                {
-                    "status": "SEARCH_EXHAUSTED",
-                    "witness": None,
-                    "coverage": "EXHAUSTIVE",
-                    "arithmetic": "EXACT_RATIONAL",
-                    "detail": "matrix has trivial kernel only",
-                }
-            )
-            return response
-        response = _ok(start)
-        response.update(
-            {
-                "status": "FOUND",
-                "witness": {"vector": [_canonical_rational(v) for v in vec]},
-                "witness_format": "matrix.kernel_vector",
-                "format_version": "1",
-                "role": "DEFEATS_CANDIDATE",
-                "coverage": "EXHAUSTIVE",
-                "arithmetic": "EXACT_RATIONAL",
-                "detail": "non-zero kernel vector found",
-            }
-        )
-        return response
-
-    if predicate == "maximize_absolute_determinant":
+            raise ValueError("is_nonsingular supports only DEFEATS_CANDIDATE witnesses")
+        return _find_kernel_witness_typed(candidate)
+    if claim.predicate == "maximize_absolute_determinant":
         if requested_role != "SUPPORTS_CLAIM":
-            return _rejected(
-                [
-                    "maximize_absolute_determinant supports only "
-                    "SUPPORTS_CLAIM witnesses"
-                ],
-                start,
+            raise ValueError(
+                "maximize_absolute_determinant supports only SUPPORTS_CLAIM witnesses"
             )
-        scope = claim.get("scope")
-        if scope is None:
-            return _rejected(
-                ["maximize_absolute_determinant witness requires a scope"], start
-            )
-        scope_errors = _validate_scope(scope)
-        if scope_errors:
-            return _rejected(scope_errors, start)
-        if _scope_total(scope) > MAX_SEARCHED_MATRICES:
-            return _rejected(
-                [
-                    "scope exceeds witness search limit of "
-                    f"{MAX_SEARCHED_MATRICES} candidates"
-                ],
-                start,
-            )
-
-        best_value = Fraction(-1)
-        best_index = -1
-        best_matrix: list[list[int]] = []
-        for index, mat in _scope_iterator(scope):
-            det = abs(_det_fraction(mat))
-            if det > best_value:
-                best_value = det
-                best_index = index
-                best_matrix = mat
-
-        if best_index < 0:
-            return _rejected(["scope contains no candidates"], start)
-
-        response = _ok(start)
-        response.update(
-            {
-                "status": "FOUND",
-                "witness": {
-                    "matrix": {
-                        "rows": scope["rows"],
-                        "cols": scope["cols"],
-                        "entries": best_matrix,
-                    },
-                    "objective_value": _canonical_rational(best_value),
-                    "index": best_index,
-                },
-                "witness_format": "matrix.maximizer",
-                "format_version": "1",
-                "role": "SUPPORTS_CLAIM",
-                "coverage": "EXHAUSTIVE",
-                "arithmetic": "EXACT_RATIONAL",
-                "detail": f"maximizer with |det| = {best_value}",
-            }
-        )
-        return response
-
-    return _rejected(["unsupported matrix claim predicate for witness search"], start)
+        return _find_maxdet_witness_typed(claim)
+    raise ValueError("unsupported matrix claim predicate for witness search")
 
 
 def find_witness_capability(request: dict[str, Any]) -> dict[str, Any]:
     """Return matrix witness search in the generic oracle contract."""
 
-    response = find_witness(request)
-    if response["input"]["status"] != "ACCEPTED":
-        raise ValueError("; ".join(response["input"]["errors"]))
-    return {
-        key: value
-        for key, value in response.items()
-        if key
-        in {
-            "status",
-            "witness",
-            "witness_format",
-            "format_version",
-            "role",
-            "arithmetic",
-            "coverage",
-            "detail",
-        }
-    }
+    selected = _matrix_capability_request(request)
+    return _find_witness_typed(
+        selected.claim,
+        selected.candidate,
+        selected.witness_role,
+    )
 
 
 def materialize(request: dict[str, Any]) -> dict[str, Any]:
@@ -737,23 +503,14 @@ def materialize(request: dict[str, Any]) -> dict[str, Any]:
         return _rejected(
             ["matrix materialization request does not match its contract"], start
         )
-    claim = selected.claim.model_dump(mode="json")
-
-    claim_errors = validate_claim(claim)
-    if claim_errors:
-        return _rejected(claim_errors, start)
-
-    if claim.get("predicate") != "maximize_absolute_determinant":
+    if selected.claim.predicate != "maximize_absolute_determinant":
         return _rejected(
             ["matrix materialize supports maximize_absolute_determinant only"], start
         )
 
-    scope = claim.get("scope")
+    scope = selected.claim.scope
     if scope is None:
         return _rejected(["missing scope"], start)
-    scope_errors = _validate_scope(scope)
-    if scope_errors:
-        return _rejected(scope_errors, start)
     if _scope_total(scope) > MAX_SEARCHED_MATRICES:
         return _rejected(
             [
@@ -769,8 +526,8 @@ def materialize(request: dict[str, Any]) -> dict[str, Any]:
             {
                 "index": index,
                 "candidate": {
-                    "rows": scope["rows"],
-                    "cols": scope["cols"],
+                    "rows": scope.rows,
+                    "cols": scope.cols,
                     "entries": mat,
                 },
             }
@@ -784,83 +541,67 @@ def materialize(request: dict[str, Any]) -> dict[str, Any]:
     return response
 
 
-def reductions(request: dict[str, Any]) -> dict[str, Any]:
-    """Propose candidate reductions that preserve the attacked predicate."""
-    start = time.monotonic()
-    selected = _matrix_reduction_request(request)
-    target_kind = selected.target_kind
-    target = selected.target.model_dump(mode="json")
-    claim = selected.claim.model_dump(mode="json")
+def _singular_reduction_proposals(matrix: list[list[int]]) -> list[dict[str, Any]]:
+    n = len(matrix)
+    proposed: list[dict[str, Any]] = []
 
-    claim_errors = validate_claim(claim)
-    if claim_errors:
-        return _rejected(claim_errors, start)
+    for i in range(n):
+        reduced = [
+            [matrix[r][c] for c in range(n) if c != i] for r in range(n) if r != i
+        ]
+        if reduced and _is_singular(reduced) and _kernel_vector(reduced) is not None:
+            proposed.append(
+                {
+                    "reduction_kind": "delete_row_column",
+                    "index": i,
+                    "objectives": {
+                        "elements": (n - 1) * (n - 1),
+                        "max_abs_entry": max(abs(x) for row in reduced for x in row),
+                    },
+                }
+            )
 
-    if target_kind != "candidate":
+    for i in range(n):
+        for j in range(n):
+            reduced = [row[:] for row in matrix]
+            reduced[i][j] = 0
+            if _is_singular(reduced) and _kernel_vector(reduced) is not None:
+                proposed.append(
+                    {
+                        "reduction_kind": "zero_entry",
+                        "row": i,
+                        "col": j,
+                        "objectives": {
+                            "elements": n * n,
+                            "max_abs_entry": max(
+                                abs(x) for row in reduced for x in row
+                            ),
+                        },
+                    }
+                )
+
+    proposed.sort(
+        key=lambda r: (r["objectives"]["elements"], r["objectives"]["max_abs_entry"])
+    )
+    return proposed
+
+
+def _reductions_typed(
+    selected: MatrixReductionRequest,
+    *,
+    start: float,
+) -> dict[str, Any]:
+    if selected.target_kind != "candidate":
         response = _ok(start)
         response["reductions"] = []
         response["detail"] = "matrix plugin only supports candidate reduction"
         return response
 
-    cand_errors = _validate_candidate_for_claim(claim, target)
-    if cand_errors:
-        return _rejected(cand_errors, start)
-
-    predicate = claim.get("predicate")
-    matrix = _to_int_matrix(target["entries"])
-    n = len(matrix)
-
-    proposed: list[dict[str, Any]] = []
-
-    if predicate == "is_nonsingular" and _is_singular(matrix):
-        # Try deleting matching row and column.
-        for i in range(n):
-            reduced = [
-                [matrix[r][c] for c in range(n) if c != i] for r in range(n) if r != i
-            ]
-            if reduced and _is_singular(reduced):
-                vec = _kernel_vector(reduced)
-                if vec is not None:
-                    proposed.append(
-                        {
-                            "reduction_kind": "delete_row_column",
-                            "index": i,
-                            "objectives": {
-                                "elements": (n - 1) * (n - 1),
-                                "max_abs_entry": max(
-                                    abs(x) for row in reduced for x in row
-                                ),
-                            },
-                        }
-                    )
-
-        # Try zeroing a single entry.
-        for i in range(n):
-            for j in range(n):
-                reduced = [row[:] for row in matrix]
-                reduced[i][j] = 0
-                if _is_singular(reduced):
-                    vec = _kernel_vector(reduced)
-                    if vec is not None:
-                        proposed.append(
-                            {
-                                "reduction_kind": "zero_entry",
-                                "row": i,
-                                "col": j,
-                                "objectives": {
-                                    "elements": n * n,
-                                    "max_abs_entry": max(
-                                        abs(x) for row in reduced for x in row
-                                    ),
-                                },
-                            }
-                        )
-
-    # maximize_absolute_determinant has no candidate reductions in the
-    # maintained reference profile.
-
-    proposed.sort(
-        key=lambda r: (r["objectives"]["elements"], r["objectives"]["max_abs_entry"])
+    matrix = _candidate_matrix(selected.target)
+    proposed = (
+        _singular_reduction_proposals(matrix)
+        if selected.claim.predicate == "is_nonsingular" and _is_singular(matrix)
+        else []
     )
 
     response = _ok(start)
@@ -876,13 +617,7 @@ def reductions_capability(request: dict[str, Any]) -> dict[str, Any]:
 
     selected = _matrix_reduction_request(request)
     target = selected.target.model_dump(mode="json")
-    response = reductions(
-        {
-            "target_kind": selected.target_kind,
-            "target": target,
-            "claim": selected.claim.model_dump(mode="json"),
-        }
-    )
+    response = _reductions_typed(selected, start=time.monotonic())
     if response["input"]["status"] != "ACCEPTED":
         raise ValueError("; ".join(response["input"]["errors"]))
     requested = set(selected.reducers)

--- a/tests/domain/graph/test_graph_paths_plugin.py
+++ b/tests/domain/graph/test_graph_paths_plugin.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
+import pytest
+
 from jacobian.plugins.graph_paths import (
-    evaluate,
-    find_witness,
+    evaluate_capability,
+    find_witness_capability,
     materialize,
-    reductions,
     reductions_capability,
-    validate_candidate,
-    validate_claim,
 )
 
 
@@ -41,55 +40,22 @@ def _bipartite_candidate() -> dict:
     }
 
 
-def test_validate_candidate_accepts_path_closure_fixture() -> None:
-    assert validate_candidate(_path_closure_candidate()) == []
-
-
-def test_validate_candidate_rejects_duplicate_vertices() -> None:
-    cand = _path_closure_candidate()
-    cand["vertices"] = ["s", "a", "a", "x", "t1", "t2"]
-    assert any("unique" in e for e in validate_candidate(cand))
-
-
-def test_validate_candidate_rejects_out_of_domain_arc() -> None:
-    cand = _path_closure_candidate()
-    cand["arcs"].append(["s", "z"])
-    assert any("out of domain" in e for e in validate_candidate(cand))
-
-
-def test_validate_claim_accepts_supported_predicates() -> None:
-    assert (
-        validate_claim({"predicate": "intended_paths_complete", "simple": True}) == []
-    )
-    assert validate_claim({"predicate": "is_bipartite"}) == []
-
-
-def test_validate_claim_rejects_unknown_predicate() -> None:
-    errors = validate_claim({"predicate": "has_hamiltonian_path"})
-    assert errors
-
-
 def test_evaluate_path_closure_is_incomplete() -> None:
     claim = {"predicate": "intended_paths_complete", "simple": True}
-    resp = evaluate({"claim": claim, "candidate": _path_closure_candidate()})
-    assert resp["input"]["status"] == "ACCEPTED"
-    result = resp["results"][0]
-    assert result["objective"]["value"] is False
-    assert result["objective"]["num_actual"] == 4
-    assert result["objective"]["num_intended"] == 2
-    assert result["proposed_witness"]["payload"]["path"] not in [
-        ["s", "a", "x", "t1"],
-        ["s", "b", "x", "t2"],
-    ]
+    response = evaluate_capability(
+        {"claim": claim, "candidate": _path_closure_candidate()}
+    )
+    assert response["conclusion"] == "FALSE"
+    assert response["failure_classifications"] == ["omitted_semantic_object"]
+    assert response["features"] == {"num_actual": "4", "num_intended": "2"}
 
 
 def test_path_closure_rejects_candidate_without_semantic_roles() -> None:
     claim = {"predicate": "intended_paths_complete", "simple": True}
     candidate = {"vertices": ["s", "t"], "arcs": [["s", "t"]]}
 
-    resp = evaluate({"claim": claim, "candidate": candidate})
-
-    assert resp["input"]["status"] == "REJECTED"
+    with pytest.raises(ValueError, match="graph evaluation request does not match"):
+        evaluate_capability({"claim": claim, "candidate": candidate})
 
 
 def test_bounded_path_search_does_not_claim_exhaustive_coverage() -> None:
@@ -106,7 +72,7 @@ def test_bounded_path_search_does_not_claim_exhaustive_coverage() -> None:
         "intended_paths": [],
     }
 
-    resp = find_witness(
+    resp = find_witness_capability(
         {
             "claim": claim,
             "candidate": candidate,
@@ -120,7 +86,7 @@ def test_bounded_path_search_does_not_claim_exhaustive_coverage() -> None:
 
 def test_negative_support_search_keeps_assurance_metadata() -> None:
     claim = {"predicate": "is_bipartite"}
-    resp = find_witness(
+    resp = find_witness_capability(
         {
             "claim": claim,
             "candidate": _bipartite_candidate(),
@@ -143,15 +109,14 @@ def test_path_claim_rejects_source_as_terminal() -> None:
         "intended_paths": [["s", "t"]],
     }
 
-    resp = find_witness(
-        {
-            "claim": claim,
-            "candidate": candidate,
-            "witness_role": "DEFEATS_CANDIDATE",
-        }
-    )
-
-    assert resp["input"]["status"] == "REJECTED"
+    with pytest.raises(ValueError, match="graph capability request does not match"):
+        find_witness_capability(
+            {
+                "claim": claim,
+                "candidate": candidate,
+                "witness_role": "DEFEATS_CANDIDATE",
+            }
+        )
 
 
 def test_evaluate_bipartite_true() -> None:
@@ -160,24 +125,20 @@ def test_evaluate_bipartite_true() -> None:
         "arcs": [["a", "b"], ["b", "c"]],
     }
     claim = {"predicate": "is_bipartite"}
-    resp = evaluate({"claim": claim, "candidate": cand})
-    assert resp["results"][0]["objective"]["value"] is True
-    assert resp["results"][0]["proposed_witness"]["witness_format"] == "graph.2coloring"
+    resp = evaluate_capability({"claim": claim, "candidate": cand})
+    assert resp["conclusion"] == "TRUE"
 
 
 def test_evaluate_bipartite_false_for_triangle() -> None:
     claim = {"predicate": "is_bipartite"}
-    resp = evaluate({"claim": claim, "candidate": _bipartite_candidate()})
-    result = resp["results"][0]
-    assert result["objective"]["value"] is False
-    assert result["proposed_witness"]["witness_format"] == "graph.odd_cycle"
-    cycle = result["proposed_witness"]["payload"]["cycle"]
-    assert len(cycle) == 3
+    resp = evaluate_capability({"claim": claim, "candidate": _bipartite_candidate()})
+    assert resp["conclusion"] == "FALSE"
+    assert resp["objectives"] == {"is_bipartite": False}
 
 
 def test_find_witness_returns_omitted_path() -> None:
     claim = {"predicate": "intended_paths_complete", "simple": True}
-    resp = find_witness(
+    resp = find_witness_capability(
         {
             "claim": claim,
             "candidate": _path_closure_candidate(),
@@ -195,7 +156,7 @@ def test_find_witness_returns_omitted_path() -> None:
 
 def test_find_witness_returns_odd_cycle() -> None:
     claim = {"predicate": "is_bipartite"}
-    resp = find_witness(
+    resp = find_witness_capability(
         {
             "claim": claim,
             "candidate": _bipartite_candidate(),
@@ -219,23 +180,26 @@ def test_materialize_enumerates_all_four_paths() -> None:
     }
 
 
-def test_reductions_for_path_closure() -> None:
+def test_reduction_capability_for_path_closure() -> None:
     claim = {"predicate": "intended_paths_complete", "simple": True}
-    resp = reductions(
+    response = reductions_capability(
         {
             "target_kind": "candidate",
             "target": _path_closure_candidate(),
             "claim": claim,
         }
     )
-    assert resp["input"]["status"] == "ACCEPTED"
-    kinds = {r["reduction_kind"] for r in resp["reductions"]}
-    assert "delete_vertex" in kinds
+    assert response["current_objectives"] == {}
     # Deleting vertices b and t1 (outside the chosen omitted path) must be proposed.
     vertices_to_delete = {
-        r["vertex"]
-        for r in resp["reductions"]
-        if r["reduction_kind"] == "delete_vertex"
+        next(
+            iter(
+                set(_path_closure_candidate()["vertices"])
+                - set(item["payload"]["vertices"])
+            )
+        )
+        for item in response["reductions"]
+        if item["reducer"] == "delete_vertex"
     }
     assert {"b", "t1"}.issubset(vertices_to_delete) or {"b", "t2"}.issubset(
         vertices_to_delete
@@ -261,26 +225,32 @@ def test_reduction_capability_projects_requested_objectives() -> None:
 
 def test_reductions_for_bipartite_triangle() -> None:
     claim = {"predicate": "is_bipartite"}
-    resp = reductions(
+    response = reductions_capability(
         {"target_kind": "candidate", "target": _bipartite_candidate(), "claim": claim}
     )
-    assert resp["input"]["status"] == "ACCEPTED"
     vertices_to_delete = {
-        r["vertex"]
-        for r in resp["reductions"]
-        if r["reduction_kind"] == "delete_vertex"
+        next(
+            iter(
+                set(_bipartite_candidate()["vertices"])
+                - set(item["payload"]["vertices"])
+            )
+        )
+        for item in response["reductions"]
+        if item["reducer"] == "delete_vertex"
     }
     assert {"u0", "u1", "u2"}.issubset(vertices_to_delete)
     # No triangle edge or vertex should be proposed for deletion.
-    for r in resp["reductions"]:
-        if r["reduction_kind"] == "delete_vertex":
-            assert r["vertex"] in {"u0", "u1", "u2"}
-        if r["reduction_kind"] == "delete_edge":
-            assert tuple(r["edge"]) not in {("v0", "v1"), ("v1", "v2"), ("v2", "v0")}
+    for item in response["reductions"]:
+        if item["reducer"] == "delete_vertex":
+            deleted = set(_bipartite_candidate()["vertices"]) - set(
+                item["payload"]["vertices"]
+            )
+            assert deleted <= {"u0", "u1", "u2"}
+    assert all(item["reducer"] != "delete_edge" for item in response["reductions"])
 
 
-def test_results_are_unverified() -> None:
-    resp = evaluate(
+def test_evaluation_does_not_grant_verification_authority() -> None:
+    response = evaluate_capability(
         {"claim": {"predicate": "is_bipartite"}, "candidate": _bipartite_candidate()}
     )
-    assert resp["verified"] is False
+    assert "verified" not in response

--- a/tests/domain/matrix/test_matrix_plugin.py
+++ b/tests/domain/matrix/test_matrix_plugin.py
@@ -7,14 +7,11 @@ from typing import Any
 
 import pytest
 
-from jacobian.plugins import matrices as matrix_plugin
 from jacobian.plugins.matrices import (
-    evaluate,
-    find_witness,
+    evaluate_capability,
+    find_witness_capability,
     materialize,
-    reductions,
-    validate_candidate,
-    validate_claim,
+    reductions_capability,
 )
 
 
@@ -46,28 +43,6 @@ def _maxdet_maximizer() -> dict:
     }
 
 
-def test_validate_candidate_accepts_kernel_fixture() -> None:
-    assert validate_candidate(_kernel_candidate()) == []
-
-
-def test_validate_candidate_rejects_floats() -> None:
-    cand = _kernel_candidate()
-    cand["entries"] = [[2.0, 4], [1, 2]]
-    assert validate_candidate(cand)
-
-
-def test_validate_candidate_rejects_bools() -> None:
-    cand = _kernel_candidate()
-    cand["entries"] = [[True, 4], [1, 2]]
-    assert validate_candidate(cand)
-
-
-def test_validate_candidate_rejects_non_rectangular() -> None:
-    cand = _kernel_candidate()
-    cand["entries"] = [[2, 4, 0], [1, 2]]
-    assert validate_candidate(cand)
-
-
 def test_determinant_predicate_rejects_rectangular_matrix() -> None:
     candidate = {
         "rows": 2,
@@ -75,9 +50,10 @@ def test_determinant_predicate_rejects_rectangular_matrix() -> None:
         "entries": [[1, 0, 0], [0, 1, 0]],
     }
 
-    resp = evaluate({"claim": {"predicate": "is_nonsingular"}, "candidate": candidate})
-
-    assert resp["input"]["status"] == "REJECTED"
+    with pytest.raises(ValueError, match="matrix evaluation request does not match"):
+        evaluate_capability(
+            {"claim": {"predicate": "is_nonsingular"}, "candidate": candidate}
+        )
 
 
 def test_maxdet_rejects_rectangular_scope() -> None:
@@ -86,41 +62,21 @@ def test_maxdet_rejects_rectangular_scope() -> None:
         "scope": {"rows": 2, "cols": 3, "entries": [-1, 1]},
     }
 
-    assert validate_claim(claim)
-
-
-def test_validate_claim_accepts_supported_predicates() -> None:
-    assert validate_claim({"predicate": "is_nonsingular"}) == []
-    assert (
-        validate_claim(
-            {"predicate": "maximize_absolute_determinant", "scope": _maxdet_scope()}
-        )
-        == []
-    )
-
-
-def test_validate_claim_rejects_missing_scope() -> None:
-    errors = validate_claim({"predicate": "maximize_absolute_determinant"})
-    assert errors
+    with pytest.raises(ValueError, match="matrix evaluation request does not match"):
+        evaluate_capability({"claim": claim, "candidate": _kernel_candidate()})
 
 
 def test_evaluate_kernel_matrix_is_singular() -> None:
     claim = {"predicate": "is_nonsingular"}
-    resp = evaluate({"claim": claim, "candidate": _kernel_candidate()})
-    assert resp["input"]["status"] == "ACCEPTED"
-    result = resp["results"][0]
-    assert result["is_singular"] is True
-    assert result["objective"]["value"] == {"num": "0", "den": "1"}
-    vec = result["proposed_witness"]["payload"]["vector"]
-    assert _matrix_times_vector(_kernel_candidate()["entries"], vec) == [
-        Fraction(0),
-        Fraction(0),
-    ]
+    response = evaluate_capability({"claim": claim, "candidate": _kernel_candidate()})
+    assert response["conclusion"] == "FALSE"
+    assert response["objectives"] == {"determinant": {"num": "0", "den": "1"}}
+    assert response["failure_classifications"] == ["nontrivial_kernel"]
 
 
 def test_find_witness_kernel_vector() -> None:
     claim = {"predicate": "is_nonsingular"}
-    resp = find_witness(
+    resp = find_witness_capability(
         {
             "claim": claim,
             "candidate": _kernel_candidate(),
@@ -138,22 +94,21 @@ def test_find_witness_kernel_vector() -> None:
 
 
 def test_find_witness_rejects_unsupported_role() -> None:
-    resp = find_witness(
-        {
-            "claim": {"predicate": "is_nonsingular"},
-            "candidate": _kernel_candidate(),
-            "witness_role": "SUPPORTS_CLAIM",
-        }
-    )
-
-    assert resp["input"]["status"] == "REJECTED"
+    with pytest.raises(ValueError, match="supports only DEFEATS_CANDIDATE"):
+        find_witness_capability(
+            {
+                "claim": {"predicate": "is_nonsingular"},
+                "candidate": _kernel_candidate(),
+                "witness_role": "SUPPORTS_CLAIM",
+            }
+        )
 
 
 def test_evaluate_maxdet_maximizer() -> None:
     claim = {"predicate": "maximize_absolute_determinant", "scope": _maxdet_scope()}
-    resp = evaluate({"claim": claim, "candidate": _maxdet_maximizer()})
-    result = resp["results"][0]
-    assert result["objective"]["value"] == {"num": "4", "den": "1"}
+    response = evaluate_capability({"claim": claim, "candidate": _maxdet_maximizer()})
+    assert response["conclusion"] == "UNKNOWN"
+    assert response["objectives"] == {"abs_determinant": {"num": "4", "den": "1"}}
 
 
 def test_evaluate_maxdet_rejects_candidate_outside_scope() -> None:
@@ -161,15 +116,13 @@ def test_evaluate_maxdet_rejects_candidate_outside_scope() -> None:
     candidate = _maxdet_maximizer()
     candidate["entries"][0][0] = 100
 
-    resp = evaluate({"claim": claim, "candidate": candidate})
-
-    assert resp["input"]["status"] == "REJECTED"
-    assert "outside claim scope" in resp["input"]["errors"][0]
+    with pytest.raises(ValueError, match="matrix evaluation request does not match"):
+        evaluate_capability({"claim": claim, "candidate": candidate})
 
 
 def test_find_witness_maxdet_returns_maximizer() -> None:
     claim = {"predicate": "maximize_absolute_determinant", "scope": _maxdet_scope()}
-    resp = find_witness({"claim": claim, "witness_role": "SUPPORTS_CLAIM"})
+    resp = find_witness_capability({"claim": claim, "witness_role": "SUPPORTS_CLAIM"})
     assert resp["status"] == "FOUND"
     assert resp["witness_format"] == "matrix.maximizer"
     mat = resp["witness"]["matrix"]
@@ -181,34 +134,23 @@ def test_find_witness_maxdet_returns_maximizer() -> None:
 def test_find_witness_maxdet_requires_supporting_role() -> None:
     claim = {"predicate": "maximize_absolute_determinant", "scope": _maxdet_scope()}
 
-    resp = find_witness(
-        {
-            "claim": claim,
-            "witness_role": "DEFEATS_CANDIDATE",
-        }
-    )
+    with pytest.raises(ValueError, match="supports only SUPPORTS_CLAIM"):
+        find_witness_capability(
+            {
+                "claim": claim,
+                "witness_role": "DEFEATS_CANDIDATE",
+            }
+        )
 
-    assert resp["input"]["status"] == "REJECTED"
 
-
-def test_find_witness_maxdet_rejects_over_budget_before_search(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    def unexpected_iterator(_: dict[str, object]) -> object:
-        raise AssertionError("over-budget scope must not be enumerated")
-
-    monkeypatch.setattr(matrix_plugin, "_scope_iterator", unexpected_iterator)
+def test_find_witness_maxdet_rejects_over_budget_before_search() -> None:
     claim = {
         "predicate": "maximize_absolute_determinant",
         "scope": {"rows": 5, "cols": 5, "entries": [-1, 1]},
     }
 
-    response = find_witness({"claim": claim, "witness_role": "SUPPORTS_CLAIM"})
-
-    assert response["input"]["status"] == "REJECTED"
-    assert response["input"]["errors"] == [
-        "scope exceeds witness search limit of 65536 candidates"
-    ]
+    with pytest.raises(ValueError, match="scope exceeds witness search limit"):
+        find_witness_capability({"claim": claim, "witness_role": "SUPPORTS_CLAIM"})
 
 
 def test_materialize_maxdet_scope_count() -> None:
@@ -222,10 +164,9 @@ def test_materialize_maxdet_scope_count() -> None:
 
 def test_reductions_kernel_fixture_is_minimal() -> None:
     claim = {"predicate": "is_nonsingular"}
-    resp = reductions(
+    resp = reductions_capability(
         {"target_kind": "candidate", "target": _kernel_candidate(), "claim": claim}
     )
-    assert resp["input"]["status"] == "ACCEPTED"
     assert resp["reductions"] == []
 
 
@@ -241,16 +182,18 @@ def test_reductions_finds_singular_principal_submatrix() -> None:
         ],
     }
     claim = {"predicate": "is_nonsingular"}
-    resp = reductions({"target_kind": "candidate", "target": cand, "claim": claim})
-    kinds = {r["reduction_kind"] for r in resp["reductions"]}
+    resp = reductions_capability(
+        {"target_kind": "candidate", "target": cand, "claim": claim}
+    )
+    kinds = {r["reducer"] for r in resp["reductions"]}
     assert "delete_row_column" in kinds
 
 
-def test_results_are_unverified() -> None:
-    resp = evaluate(
+def test_evaluation_does_not_grant_verification_authority() -> None:
+    response = evaluate_capability(
         {"claim": {"predicate": "is_nonsingular"}, "candidate": _kernel_candidate()}
     )
-    assert resp["verified"] is False
+    assert "verified" not in response
 
 
 # ---------------------------------------------------------------------------

--- a/tests/domain/number_theory/test_erdos_straus_plugin.py
+++ b/tests/domain/number_theory/test_erdos_straus_plugin.py
@@ -7,8 +7,6 @@ import pytest
 from jacobian.plugins.erdos_straus import (
     evaluate_capability,
     find_witness_capability,
-    validate_candidate,
-    validate_claim,
 )
 
 
@@ -24,12 +22,19 @@ def _candidate(lower: int = 2, upper: int = 100) -> dict[str, int]:
     return {"lower_bound": lower, "upper_bound": upper}
 
 
-def test_validate_bounded_range() -> None:
-    assert validate_claim(_claim()) == []
-    assert validate_candidate(_candidate()) == []
-    assert validate_claim(_claim(1, 100))
-    assert validate_candidate(_candidate(10, 9))
-    assert validate_candidate(_candidate(2, 10_001))
+@pytest.mark.parametrize(
+    ("claim", "candidate"),
+    (
+        (_claim(1, 100), _candidate()),
+        (_claim(), _candidate(10, 9)),
+        (_claim(), _candidate(2, 10_001)),
+    ),
+)
+def test_capability_rejects_invalid_ranges(
+    claim: dict[str, object], candidate: dict[str, int]
+) -> None:
+    with pytest.raises(ValueError):
+        evaluate_capability({"claim": claim, "candidate": candidate})
 
 
 def test_evaluate_finds_every_decomposition_through_1000() -> None:
@@ -85,7 +90,7 @@ def test_find_witness_returns_complete_exact_table() -> None:
                 "candidate": _candidate(2, 99),
                 "witness_role": "SUPPORTS_CLAIM",
             },
-            "candidate range must exactly match the claim range",
+            "Erdős-Straus request does not match its contract",
         ),
     ),
 )

--- a/tests/unit/contracts/test_plugin_inputs.py
+++ b/tests/unit/contracts/test_plugin_inputs.py
@@ -138,3 +138,13 @@ def test_nested_matrix_scope_is_typed_and_bounded() -> None:
                 "witness_role": "unsupported",
             }
         )
+
+
+def test_matrix_candidate_rejects_noncanonical_integer_strings() -> None:
+    with pytest.raises(ValidationError):
+        MatrixCapabilityRequest.model_validate(
+            {
+                "claim": {"predicate": "is_nonsingular"},
+                "candidate": {"rows": 1, "cols": 1, "entries": [["01"]]},
+            }
+        )

--- a/tools/c901-baseline.json
+++ b/tools/c901-baseline.json
@@ -218,39 +218,9 @@
       "complexity": 12
     },
     {
-      "path": "src/jacobian/plugins/graph_paths.py",
-      "symbol": "find_witness",
-      "complexity": 14
-    },
-    {
-      "path": "src/jacobian/plugins/graph_paths.py",
-      "symbol": "reductions",
-      "complexity": 11
-    },
-    {
-      "path": "src/jacobian/plugins/graph_paths.py",
-      "symbol": "validate_candidate",
-      "complexity": 16
-    },
-    {
       "path": "src/jacobian/plugins/matrices.py",
       "symbol": "_kernel_vector",
       "complexity": 11
-    },
-    {
-      "path": "src/jacobian/plugins/matrices.py",
-      "symbol": "find_witness",
-      "complexity": 15
-    },
-    {
-      "path": "src/jacobian/plugins/matrices.py",
-      "symbol": "reductions",
-      "complexity": 12
-    },
-    {
-      "path": "src/jacobian/plugins/matrices.py",
-      "symbol": "validate_candidate",
-      "complexity": 12
     },
     {
       "path": "src/jacobian/polynomials/inverse.py",


### PR DESCRIPTION
## Problem

Follow-up to #301: the graph-path, matrix, and Erdős–Straus reference plugins still had two internal seams. Legacy dict-oriented `validate_*`, `evaluate`, `find_witness`, and `reductions` helpers duplicated the installed `*_capability` entrypoints, claim projection, and cross-field validation. That let tests exercise an unsupported API and left the mathematical kernels coupled to compatibility envelopes.

The root cause was adding typed capability contracts beside the old plugin interfaces without making the typed boundary the sole owner of request validation.

## Solution

- Remove the obsolete plugin validators, evaluation façades, duplicate evaluation request models, and legacy domain-test coverage.
- Make the installed capability entrypoints parse Pydantic requests once and pass typed requests directly into the graph, matrix, and Erdős–Straus kernels.
- Move candidate/claim invariants into the contracts, including matrix shape/scope checks, candidate range matching, and the requirement that matrix integer strings use the canonical integer representation.
- Share generic `ClaimSpec` projection through one contract helper.
- Remove the now-resolved C901 baseline entries.

Installed capability IDs, result shapes, computed-only producer semantics, and independent-checker authority are unchanged. Invalid cross-field inputs now fail at the contract boundary before kernel execution.

Related: #228, #270, #271, #272, #273, #274, #275, #276, #277, #278, #279.

## Testing

- `make check` — passed; Ruff, formatting, complexity, MyPy, and 672 unit tests.
- `make test-plan BASE=origin/main` — produced the repository's fail-closed full plan because the branch is based on the already-merged #301 commit.
- `make test-affected BASE=origin/main` — all selected lanes passed: component 609, domain 188, composition 433, storage 109, process 160, MCP 23, provider 161, e2e 8, Lean 59, npm 15; build, security audit, duplicate scan, and documentation link check also passed.
- `git diff --check` — passed.

## Trust & Compatibility Impact

No verification authority, artifact format, state schema, supported capability ID, or native public API changes. The removed names are unsupported internal compatibility paths; callers should use the installed capability entrypoints. Producers remain `COMPUTED`, and no path can return `VERIFIED` without independent checker authority. Matrix inputs that were previously accepted only by the compatibility path, such as noncanonical integer strings, are now rejected by the authoritative contract.

## Suggested review order

1. Contract ownership and shared claim projection in `src/jacobian/contracts/`.
2. Typed kernel and capability entrypoint changes in the three reference plugins.
3. Domain/unit tests and the complexity-baseline cleanup.

## Checklist

- [x] Routine local validation passes (`make check`)
- [x] Relevant focused and full-plan tests are listed above
