### PR TITLE
fix(ci): run checks after pull request base edits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
   merge_group:
     types: [checks_requested]
 

--- a/tests/unit/tooling/test_ci_execution_policy.py
+++ b/tests/unit/tooling/test_ci_execution_policy.py
@@ -6,6 +6,15 @@ from pathlib import Path
 ROOT = Path(__file__).parents[3]
 
 
+def test_pr_base_edits_trigger_ci() -> None:
+    workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    pull_request_trigger = workflow.split("  pull_request:", 1)[1].split(
+        "  merge_group:", 1
+    )[0]
+
+    assert "edited" in pull_request_trigger
+
+
 def test_python_313_uses_the_narrow_compatibility_smoke() -> None:
     workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
     compatibility = workflow.split("  compatibility-test:", 1)[1].split(


### PR DESCRIPTION
## Problem

The CI workflow does not subscribe to the `pull_request.edited` event. When GitHub retargets a stacked pull request after its parent merges, the base changes without changing the head SHA, so no `synchronize` event is emitted. After #288 merged, #289 retargeted to `main` with no status-check rollup and remained blocked on required checks.

## Solution

Subscribe CI to `edited` pull-request events so base-branch changes create a fresh required-check run. Add a policy regression test that asserts the event remains in the pull-request trigger. GitHub does not offer trigger-level filtering by the edited field, so other pull-request metadata edits will also rerun CI.

## Testing

- `make test-unit TESTS=tests/unit/tooling/test_ci_execution_policy.py` — 11 passed
- `uv run --locked pre-commit run actionlint --files .github/workflows/ci.yml` — passed
- `make check-static` — lint, formatting, complexity baseline, dependency checks, dead-code checks, mypy, test architecture, and package build passed
- `make check` — lint, formatting, complexity baseline, mypy, and 722 unit tests passed
- `make test-plan BASE=origin/main` — CI workflow changes route fail-closed to all functional lanes

## Trust & Compatibility Impact

No verification-kernel, checker-registry, artifact-format, or public-API changes.

## Checklist

- [x] Routine local validation passes (`make check`)
- [x] Relevant focused tests are listed above