### PR TITLE
feat(benchmarks): add a control/treatment toggle for Harbor Jacobian evaluations

### DIFF
--- a/.agents/skills/evaluate-math-capabilities/SKILL.md
+++ b/.agents/skills/evaluate-math-capabilities/SKILL.md
@@ -12,6 +12,25 @@ outcomes and evidence, not a preferred sequence of calls.
 Use the [shared handoff format](../../../docs/reference/capability-development-handoffs.md)
 for inputs, returns, and portfolio decisions.
 
+## Classify the evidence before running
+
+Label each case and result as exactly one of:
+
+- **regression/public reproduction:** known or public case; useful for contract
+  and breakage detection, never held-out causal evidence;
+- **assurance/conformance:** tests calibration, scope, schemas, artifacts,
+  discovery, or parameterization, and may not measure mathematical capability
+  value; or
+- **held-out causal comparison:** an unseen or transformed case with a frozen
+  control/treatment intervention and an independently judgeable outcome.
+
+Do not promote a public regression, a single observation, or a reward change
+caused only by assurance calibration into a claim that Jacobian improved
+mathematical problem solving. A causal comparison is not ready until a control
+pilot is below the success ceiling, treatment has a plausible capability-to-
+outcome hypothesis, and the plan specifies multiple repetitions and uncertainty
+reporting.
+
 ## Confirm evaluation readiness
 
 Start from a concrete intervention:
@@ -155,6 +174,12 @@ Make these primary:
 - scope and completeness accuracy;
 - evidence and verification-record bindings; and
 - acceptance of mathematically valid alternative strategies.
+
+Keep mathematical correctness, evidence validity, scope/completeness, false
+certification, and assurance calibration as separate reported metrics. An
+aggregate reward may summarize a workflow contract, but it must not be the
+primary evidence for a capability-benefit claim when it combines these
+dimensions.
 
 Among semantically correct runs, measure:
 

--- a/.agents/skills/evaluate-math-capabilities/SKILL.md
+++ b/.agents/skills/evaluate-math-capabilities/SKILL.md
@@ -14,13 +14,19 @@ for inputs, returns, and portfolio decisions.
 
 ## Classify the evidence before running
 
-Label each case and result as exactly one of:
+Give each case and result one primary evidence role:
 
+- **task/verifier validation:** checks the benchmark harness, task contract,
+  independent Oracle, or deliberate failure cases; it is harness evidence,
+  not model capability evidence;
 - **regression/public reproduction:** known or public case; useful for contract
   and breakage detection, never held-out causal evidence;
 - **assurance/conformance:** tests calibration, scope, schemas, artifacts,
   discovery, or parameterization, and may not measure mathematical capability
-  value; or
+  value;
+- **Jacobian workflow observation:** records agent discovery, tool use,
+  artifacts, and assurance behavior on a configured Harbor workflow; it is
+  workflow evidence, not comparative performance evidence;
 - **held-out causal comparison:** an unseen or transformed case with a frozen
   control/treatment intervention and an independently judgeable outcome.
 

--- a/.agents/skills/harbor-benchmarks/SKILL.md
+++ b/.agents/skills/harbor-benchmarks/SKILL.md
@@ -17,13 +17,21 @@ Classify the work before editing a task:
 
 - **Task/verifier validation:** parse the bundles, run the Oracle, and attack
   deliberate failure cases. This is harness evidence.
+- **Regression or public reproduction:** replay a known or public case to
+  detect breakage. This is not held-out evidence and must not support a causal
+  capability claim.
+- **Assurance or contract conformance:** test assurance calibration, scope,
+  schemas, artifacts, discovery, or parameterization. These cases may measure
+  workflow quality without measuring mathematical capability value.
 - **Jacobian workflow observation:** use the committed Harbor observation job,
   its direct local MCP service, and Harbor ATIF plus Jacobian telemetry. This is
   workflow evidence, not comparative performance.
 - **Future causal comparison:** put control/treatment conditions in Harbor job
   configuration, outside task bundles, with identical task digests, prompts,
-  models, budgets, environments, and seeds. Do not add an A/B condition merely
-  to validate v1.
+  models, budgets, environments, and seeds. Require held-out or transformed
+  cases, a non-ceiling control pilot, multiple repetitions, and separately
+  reported correctness and assurance metrics. Do not treat an A/B run on the
+  public suite as a causal result.
 
 ## Author or change a task
 
@@ -116,13 +124,19 @@ verifier logs, source SHA, task digest, and Harbor version.
 Review the committed observation job and run the local Harbor composition. The
 Jacobian service is intentionally anonymous for this local evaluation path;
 Harbor connects directly to `http://jacobian:8000/mcp`. Set `JACOBIAN_IMAGE`
-only when overriding the default local image:
+only when overriding the default local image. Use the toggle explicitly:
 
 ```sh
 export JACOBIAN_MODEL='your-model'
 export JACOBIAN_IMAGE='jacobian:local'
-make agent-eval DATASET=agent-workflow-v1 EVAL_EXECUTE=1
+make agent-eval DATASET=agent-workflow-v1 \
+  JACOBIAN_ENABLED=1 EVAL_EXECUTE=1
 ```
+
+For a control run, use `JACOBIAN_ENABLED=0`; it selects the matching Harbor
+job without the sidecar or MCP configuration. Keep the task filter, model,
+prompt, budget, and environment fixed when comparing the two modes. The
+external MCP configuration belongs to the treatment job, not task TOMLs.
 
 Inspect Harbor ATIF together with Jacobian telemetry for capability discovery
 and descriptions, invocation and parameter errors, artifact and verification

--- a/.github/scripts/plan-benchmarks
+++ b/.github/scripts/plan-benchmarks
@@ -37,6 +37,7 @@ BENCHMARK_EXECUTION_CONTROL_PATHS = frozenset(
         "tools/sync_harbor_verifier_support.py",
     }
 )
+BENCHMARK_CONFIG_PREFIX = "benchmarks/config/"
 
 
 def _json(value: object) -> str:
@@ -130,6 +131,16 @@ def plan(
     integration = event == "merge_group"
 
     for path in benchmark_paths:
+        if path.startswith(BENCHMARK_CONFIG_PREFIX):
+            if integration:
+                scope = "all"
+                run_oracle = True
+                reasons.append("benchmark execution configuration change")
+            else:
+                reasons.append(
+                    "benchmark execution configuration Oracle deferred to merge queue"
+                )
+            continue
         if path in BENCHMARK_CONTROL_PATHS:
             if path in BENCHMARK_EXECUTION_CONTROL_PATHS and integration:
                 scope = "all"

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ build/
 dist/
 htmlcov/
 benchmarks/results/
+jobs/
 lean/.lake/
 
 # Test infrastructure state

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@ build/
 dist/
 htmlcov/
 benchmarks/results/
-jobs/
+/jobs/
 lean/.lake/
 
 # Test infrastructure state

--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,15 @@ harbor-adapter-check: ## Check deterministic regeneration for ADAPTER=<id>.
 	@test -x "benchmarks/adapters/$(ADAPTER)/check.sh" || { echo "adapter check.sh is missing: $(ADAPTER)" >&2; exit 2; }
 	"benchmarks/adapters/$(ADAPTER)/check.sh"
 
-agent-eval: ## Run a Harbor Jacobian observation job (DATASET=agent-workflow-v1 EVAL_EXECUTE=1).
+ifeq ($(JACOBIAN_ENABLED),0)
+EVAL_CONFIG ?= benchmarks/config/agent-workflow-v1-control.json
+MCP_CONFIG ?=
+else
+EVAL_CONFIG ?= benchmarks/datasets/$(or $(DATASET),agent-workflow-v1)/jobs/jacobian-observation.json
+MCP_CONFIG ?= benchmarks/config/jacobian.mcp.json
+endif
+
+agent-eval: ## Run a Harbor evaluation (JACOBIAN_ENABLED=0|1, DATASET=agent-workflow-v1, EVAL_EXECUTE=1).
 	@if [ "$(EVAL_EXECUTE)" != "1" ]; then \
 		echo "Model execution is opt-in. Review the job, then run: make agent-eval DATASET=agent-workflow-v1 EVAL_EXECUTE=1"; \
 		exit 0; \
@@ -225,8 +233,10 @@ agent-eval: ## Run a Harbor Jacobian observation job (DATASET=agent-workflow-v1 
 		exit 2; \
 	fi; \
 	$(HARBOR_RUNNER) run \
-		-c "benchmarks/datasets/$(or $(DATASET),agent-workflow-v1)/jobs/jacobian-observation.json" \
+		-c "$(EVAL_CONFIG)" \
+		-a codex \
 		-m "$${JACOBIAN_MODEL}" \
+		$(if $(MCP_CONFIG),--mcp-config "$(MCP_CONFIG)",) \
 		$(if $(TASKS),-p "benchmarks/datasets/$(or $(DATASET),agent-workflow-v1)" $(foreach task,$(TASKS),--include-task-name "$(task)"),) \
 		$(EVAL_ARGS)
 

--- a/Makefile
+++ b/Makefile
@@ -215,9 +215,14 @@ harbor-adapter-check: ## Check deterministic regeneration for ADAPTER=<id>.
 	@test -x "benchmarks/adapters/$(ADAPTER)/check.sh" || { echo "adapter check.sh is missing: $(ADAPTER)" >&2; exit 2; }
 	"benchmarks/adapters/$(ADAPTER)/check.sh"
 
+JACOBIAN_ENABLED ?= 1
+ifneq ($(filter 0 1,$(JACOBIAN_ENABLED)),$(JACOBIAN_ENABLED))
+$(error JACOBIAN_ENABLED must be exactly 0 or 1 (got '$(JACOBIAN_ENABLED)'))
+endif
+
 ifeq ($(JACOBIAN_ENABLED),0)
 EVAL_CONFIG ?= benchmarks/config/agent-workflow-v1-control.json
-MCP_CONFIG ?=
+override MCP_CONFIG :=
 else
 EVAL_CONFIG ?= benchmarks/datasets/$(or $(DATASET),agent-workflow-v1)/jobs/jacobian-observation.json
 MCP_CONFIG ?= benchmarks/config/jacobian.mcp.json

--- a/benchmarks/config/agent-eval-proxy.compose.yaml
+++ b/benchmarks/config/agent-eval-proxy.compose.yaml
@@ -1,0 +1,13 @@
+services:
+  main:
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      HTTP_PROXY: ${JACOBIAN_EVAL_HTTP_PROXY:-}
+      HTTPS_PROXY: ${JACOBIAN_EVAL_HTTPS_PROXY:-}
+      ALL_PROXY: ${JACOBIAN_EVAL_ALL_PROXY:-}
+      NO_PROXY: ${JACOBIAN_EVAL_NO_PROXY:-localhost,127.0.0.1,jacobian}
+      http_proxy: ${JACOBIAN_EVAL_HTTP_PROXY:-}
+      https_proxy: ${JACOBIAN_EVAL_HTTPS_PROXY:-}
+      all_proxy: ${JACOBIAN_EVAL_ALL_PROXY:-}
+      no_proxy: ${JACOBIAN_EVAL_NO_PROXY:-localhost,127.0.0.1,jacobian}

--- a/benchmarks/config/agent-workflow-v1-control.json
+++ b/benchmarks/config/agent-workflow-v1-control.json
@@ -1,6 +1,6 @@
 {
   "jobs_dir": "benchmarks/results/agent-workflow-v1-control",
-  "n_attempts": 1,
+  "n_attempts": 3,
   "timeout_multiplier": 1,
   "orchestrator": {
     "type": "local",

--- a/benchmarks/config/agent-workflow-v1-control.json
+++ b/benchmarks/config/agent-workflow-v1-control.json
@@ -1,5 +1,5 @@
 {
-  "jobs_dir": "benchmarks/results/agent-workflow-v1",
+  "jobs_dir": "benchmarks/results/agent-workflow-v1-control",
   "n_attempts": 1,
   "timeout_multiplier": 1,
   "orchestrator": {
@@ -12,8 +12,7 @@
     "force_build": true,
     "delete": true,
     "extra_docker_compose": [
-      "benchmarks/config/agent-eval-proxy.compose.yaml",
-      "benchmarks/datasets/agent-workflow-v1/jacobian-observation.compose.yaml"
+      "benchmarks/config/agent-eval-proxy.compose.yaml"
     ]
   },
   "agents": [

--- a/benchmarks/config/jacobian.mcp.json
+++ b/benchmarks/config/jacobian.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcp_servers": [
+    {
+      "name": "jacobian",
+      "transport": "streamable-http",
+      "url": "http://jacobian:8000/mcp"
+    }
+  ]
+}

--- a/benchmarks/datasets/agent-workflow-v1/README.md
+++ b/benchmarks/datasets/agent-workflow-v1/README.md
@@ -1,7 +1,7 @@
 # Jacobian agent-workflow-v1
 
-This Harbor dataset contains fixed Jacobian-enabled mathematical workflows for
-Oracle validation and agent observation. Each task bundle is a direct child of
+This Harbor dataset contains fixed mathematical workflows for Oracle validation
+and agent observation. Each task bundle is a direct child of
 this directory and retains separate agent, Oracle, and verifier containers.
 
 `suite.toml` owns membership and contract metadata. `dataset.toml` is generated
@@ -11,21 +11,44 @@ from Harbor-computed task digests. The Oracle contract gate is:
 make harbor-oracle DATASET=agent-workflow-v1
 ```
 
-The observation job uses the Jacobian MCP sidecar and is selected with:
+The standalone observation job uses the Jacobian MCP sidecar and is selected
+with:
 
 ```sh
-make agent-eval DATASET=agent-workflow-v1 EVAL_EXECUTE=1
+make agent-eval DATASET=agent-workflow-v1 \
+  JACOBIAN_ENABLED=1 EVAL_EXECUTE=1
 ```
 
 Use `TASKS=graph-counterexample` for a small run. Harbor loads the task bundles
 from this dataset directory and applies the task-name filter; Jacobian does not
-render or rewrite a Harbor task selection.
+render or rewrite a Harbor task selection. The MCP endpoint is supplied through
+Harbor's external MCP configuration, not through task TOMLs.
+
+For a paired control/treatment run, use the same task filter and model in both
+jobs:
+
+```sh
+# Control: no Jacobian sidecar or MCP config.
+make agent-eval DATASET=agent-workflow-v1 \
+  JACOBIAN_ENABLED=0 TASKS=graph-counterexample EVAL_EXECUTE=1
+
+# Treatment: Jacobian sidecar and MCP config.
+make agent-eval DATASET=agent-workflow-v1 \
+  JACOBIAN_ENABLED=1 \
+  TASKS=graph-counterexample EVAL_EXECUTE=1
+```
+
+The task bundles and generated task digests must be identical between these
+jobs. Both jobs use the same optional proxy overlay; only the treatment adds
+the Jacobian sidecar and MCP config. This paired setup is for
+workflow comparison; the public dataset is not held-out evidence.
 
 Five tasks have an operator-authorized verification record and may accept
 `VERIFIED`; the remaining tasks are capped at `COMPUTED`. A wrong result or an
 unsupported certification claim forces reward to zero. These are workflow
-observations, not a causal performance benchmark: the dataset has no control
-condition or randomized pairing.
+observations, not a causal performance benchmark. The committed control and
+treatment jobs document a paired workflow setup, but the public suite is not
+held out and cannot support a causal performance claim.
 
 Version 1.1.0 adds the independently reviewed finite-magma and
 well-total-domination countermodel cases. Both remain public workflow evidence;

--- a/benchmarks/datasets/agent-workflow-v1/jacobian-observation.compose.yaml
+++ b/benchmarks/datasets/agent-workflow-v1/jacobian-observation.compose.yaml
@@ -1,4 +1,20 @@
 services:
+  # Harbor installs the selected agent inside `main` after the container
+  # starts. Keep proxying optional and explicit: an unset value preserves
+  # direct networking, while a configured value reaches apt/npm/Codex.
+  main:
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      HTTP_PROXY: ${JACOBIAN_EVAL_HTTP_PROXY:-}
+      HTTPS_PROXY: ${JACOBIAN_EVAL_HTTPS_PROXY:-}
+      ALL_PROXY: ${JACOBIAN_EVAL_ALL_PROXY:-}
+      NO_PROXY: ${JACOBIAN_EVAL_NO_PROXY:-localhost,127.0.0.1,jacobian}
+      http_proxy: ${JACOBIAN_EVAL_HTTP_PROXY:-}
+      https_proxy: ${JACOBIAN_EVAL_HTTPS_PROXY:-}
+      all_proxy: ${JACOBIAN_EVAL_ALL_PROXY:-}
+      no_proxy: ${JACOBIAN_EVAL_NO_PROXY:-localhost,127.0.0.1,jacobian}
+
   jacobian:
     image: ${JACOBIAN_IMAGE:-jacobian:local}
     command:

--- a/benchmarks/datasets/agent-workflow-v1/jacobian-observation.compose.yaml
+++ b/benchmarks/datasets/agent-workflow-v1/jacobian-observation.compose.yaml
@@ -1,20 +1,4 @@
 services:
-  # Harbor installs the selected agent inside `main` after the container
-  # starts. Keep proxying optional and explicit: an unset value preserves
-  # direct networking, while a configured value reaches apt/npm/Codex.
-  main:
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    environment:
-      HTTP_PROXY: ${JACOBIAN_EVAL_HTTP_PROXY:-}
-      HTTPS_PROXY: ${JACOBIAN_EVAL_HTTPS_PROXY:-}
-      ALL_PROXY: ${JACOBIAN_EVAL_ALL_PROXY:-}
-      NO_PROXY: ${JACOBIAN_EVAL_NO_PROXY:-localhost,127.0.0.1,jacobian}
-      http_proxy: ${JACOBIAN_EVAL_HTTP_PROXY:-}
-      https_proxy: ${JACOBIAN_EVAL_HTTPS_PROXY:-}
-      all_proxy: ${JACOBIAN_EVAL_ALL_PROXY:-}
-      no_proxy: ${JACOBIAN_EVAL_NO_PROXY:-localhost,127.0.0.1,jacobian}
-
   jacobian:
     image: ${JACOBIAN_IMAGE:-jacobian:local}
     command:

--- a/benchmarks/datasets/agent-workflow-v1/jobs/jacobian-observation.json
+++ b/benchmarks/datasets/agent-workflow-v1/jobs/jacobian-observation.json
@@ -1,6 +1,6 @@
 {
   "jobs_dir": "benchmarks/results/agent-workflow-v1",
-  "n_attempts": 1,
+  "n_attempts": 3,
   "timeout_multiplier": 1,
   "orchestrator": {
     "type": "local",

--- a/benchmarks/validation/test_benchmark_planner.py
+++ b/benchmarks/validation/test_benchmark_planner.py
@@ -62,6 +62,21 @@ def test_benchmark_control_plane_changes_run_contract_checks(path: str) -> None:
     assert _matrix(result) == []
 
 
+def test_execution_configuration_change_defers_oracle_to_merge_queue() -> None:
+    path = "benchmarks/config/jacobian.mcp.json"
+
+    pull_request = planner.plan([path], event="pull_request")
+    merge_group = planner.plan([path], event="merge_group")
+
+    assert pull_request["run-benchmark-check"] == "true"
+    assert pull_request["run-benchmark-oracle"] == "false"
+    assert pull_request["benchmark-oracle-scope"] == "none"
+    assert _matrix(pull_request) == []
+    assert merge_group["run-benchmark-oracle"] == "true"
+    assert merge_group["benchmark-oracle-scope"] == "all"
+    assert _matrix(merge_group)
+
+
 def test_executable_control_plane_change_defers_oracle_to_merge_queue() -> None:
     path = "benchmarks/tooling/harbor_suite.py"
 

--- a/docs/how-to/run-agent-evaluations.md
+++ b/docs/how-to/run-agent-evaluations.md
@@ -15,6 +15,26 @@ make harbor-check
 make harbor-oracle DATASET=agent-workflow-v1
 ```
 
+## Set shared run conditions
+
+For a paired comparison, set the same model, authentication, proxy, task
+filter, prompt, budget, and environment before running either condition. A
+proxy is optional, but if the host requires one for package installation or
+model access, export it before both runs:
+
+```sh
+export JACOBIAN_MODEL='your-model'
+export CODEX_FORCE_AUTH_JSON=1
+
+export JACOBIAN_EVAL_HTTP_PROXY='http://host.docker.internal:7890'
+export JACOBIAN_EVAL_HTTPS_PROXY='http://host.docker.internal:7890'
+export JACOBIAN_EVAL_NO_PROXY='localhost,127.0.0.1,jacobian'
+```
+
+Unset the proxy variables for direct networking. On Linux, the host proxy must
+accept connections from Docker's bridge interface; a proxy listening only on
+`127.0.0.1` is not reachable from the container.
+
 ## Run with Jacobian
 
 The local path uses Harbor's Docker environment, a Jacobian Compose sidecar,
@@ -23,8 +43,6 @@ and Harbor's external MCP configuration. The default sidecar image is
 
 ```sh
 export JACOBIAN_IMAGE='jacobian:local'
-export JACOBIAN_MODEL='your-model'
-export CODEX_FORCE_AUTH_JSON=1
 
 make agent-eval DATASET=agent-workflow-v1 \
   JACOBIAN_ENABLED=1 EVAL_EXECUTE=1
@@ -35,12 +53,9 @@ Use `TASKS=graph-counterexample` for a small smoke run. The treatment run uses
 
 ## Run without Jacobian
 
-Use the same model, task filter, prompt, budget, and environment:
+Use the same shared run conditions:
 
 ```sh
-export JACOBIAN_MODEL='your-model'
-export CODEX_FORCE_AUTH_JSON=1
-
 make agent-eval DATASET=agent-workflow-v1 \
   JACOBIAN_ENABLED=0 \
   TASKS=graph-counterexample EVAL_EXECUTE=1
@@ -50,25 +65,10 @@ make agent-eval DATASET=agent-workflow-v1 \
 MCP configuration. `JACOBIAN_ENABLED=1` selects the treatment job and passes
 Harbor's `--mcp-config` option.
 
-## Optional Docker proxy
-
-Networking is direct by default. If the host requires a proxy for package
-installation or model access, configure it explicitly:
-
-```sh
-export JACOBIAN_EVAL_HTTP_PROXY='http://host.docker.internal:7890'
-export JACOBIAN_EVAL_HTTPS_PROXY='http://host.docker.internal:7890'
-export JACOBIAN_EVAL_NO_PROXY='localhost,127.0.0.1,jacobian'
-```
-
 The shared Compose overlay maps `host.docker.internal` to the Docker host and
 passes upper- and lower-case proxy variables to Harbor's `main` container,
-including the agent installation phase. On Linux, the host proxy must accept
-connections from Docker's bridge interface; a proxy listening only on
-`127.0.0.1` is not reachable from the container.
-
-Unset proxy variables to use direct networking. Keep `jacobian` in `NO_PROXY`
-so the agent reaches the sidecar over Harbor's internal network.
+including the agent installation phase. Keep `jacobian` in `NO_PROXY` so the
+agent reaches the sidecar over Harbor's internal network.
 
 ## Docker and Daytona
 

--- a/docs/how-to/run-agent-evaluations.md
+++ b/docs/how-to/run-agent-evaluations.md
@@ -1,0 +1,121 @@
+# Run agent evaluations
+
+[Documentation home](../index.md) · [Evaluation reference](../reference/agent-evaluations.md)
+
+This guide covers the operational commands for Harbor workflow observations and
+paired Jacobian control/treatment runs. The evaluation roles, assurance rules,
+and interpretation boundaries are in the [reference page](../reference/agent-evaluations.md).
+
+## Validate the dataset
+
+Run the contract checks before spending model or Docker time:
+
+```sh
+make harbor-check
+make harbor-oracle DATASET=agent-workflow-v1
+```
+
+## Run with Jacobian
+
+The local path uses Harbor's Docker environment, a Jacobian Compose sidecar,
+and Harbor's external MCP configuration. The default sidecar image is
+`jacobian:local`.
+
+```sh
+export JACOBIAN_IMAGE='jacobian:local'
+export JACOBIAN_MODEL='your-model'
+export CODEX_FORCE_AUTH_JSON=1
+
+make agent-eval DATASET=agent-workflow-v1 \
+  JACOBIAN_ENABLED=1 EVAL_EXECUTE=1
+```
+
+Use `TASKS=graph-counterexample` for a small smoke run. The treatment run uses
+`benchmarks/config/jacobian.mcp.json`; task TOMLs remain agent-agnostic.
+
+## Run without Jacobian
+
+Use the same model, task filter, prompt, budget, and environment:
+
+```sh
+export JACOBIAN_MODEL='your-model'
+export CODEX_FORCE_AUTH_JSON=1
+
+make agent-eval DATASET=agent-workflow-v1 \
+  JACOBIAN_ENABLED=0 \
+  TASKS=graph-counterexample EVAL_EXECUTE=1
+```
+
+`JACOBIAN_ENABLED=0` selects the control job without the Jacobian sidecar or
+MCP configuration. `JACOBIAN_ENABLED=1` selects the treatment job and passes
+Harbor's `--mcp-config` option.
+
+## Optional Docker proxy
+
+Networking is direct by default. If the host requires a proxy for package
+installation or model access, configure it explicitly:
+
+```sh
+export JACOBIAN_EVAL_HTTP_PROXY='http://host.docker.internal:7890'
+export JACOBIAN_EVAL_HTTPS_PROXY='http://host.docker.internal:7890'
+export JACOBIAN_EVAL_NO_PROXY='localhost,127.0.0.1,jacobian'
+```
+
+The shared Compose overlay maps `host.docker.internal` to the Docker host and
+passes upper- and lower-case proxy variables to Harbor's `main` container,
+including the agent installation phase. On Linux, the host proxy must accept
+connections from Docker's bridge interface; a proxy listening only on
+`127.0.0.1` is not reachable from the container.
+
+Unset proxy variables to use direct networking. Keep `jacobian` in `NO_PROXY`
+so the agent reaches the sidecar over Harbor's internal network.
+
+## Docker and Daytona
+
+The checked-in Jacobian evaluation jobs use Docker Compose because Harbor's
+local multi-container path needs the `main` container and Jacobian sidecar on
+the same network. Daytona is a separate remote execution option and is not
+selected by these Makefile commands.
+
+The local image name `jacobian:local` is not pullable by a remote Daytona
+worker. A Daytona run therefore needs a published, immutable Jacobian image in
+a registry that the worker can access, plus a reachable MCP endpoint or a
+Daytona-compatible sidecar configuration. Do not compare a Docker control run
+with a Daytona treatment run unless the runtime, image, network, and resource
+limits are otherwise held constant.
+
+## Inspect results
+
+Harbor writes results under `benchmarks/results/`. Inspect the summary with:
+
+```sh
+uvx --from harbor==0.20.0 harbor view \
+  benchmarks/results/agent-workflow-v1
+```
+
+For Jacobian treatment runs, inspect Harbor ATIF together with Jacobian
+telemetry. Check capability discovery and descriptions, invocation and
+parameter errors, artifact and verification-record flow, repeated or
+irrelevant calls, shell/file activity, tokens, time, and completion.
+
+Record the git tree, task digests, provider/runtime, model and prompt settings,
+raw trace location, and validation actually run. A public workflow result is
+regression or observation evidence; it is not held-out causal evidence.
+
+## Troubleshooting
+
+If the command exits with `JACOBIAN_MODEL must be exported`, export the model
+before invoking Make:
+
+```sh
+export JACOBIAN_MODEL='your-model'
+```
+
+If the run stalls at `starting environment`, Docker may be building the task
+image or waiting on package installation. Check the Docker build output and
+verify proxy reachability from the container before cancelling the trial.
+
+If the treatment agent reports no Jacobian tools, confirm that
+`JACOBIAN_ENABLED=1` is set and that the treatment job includes the external
+MCP configuration. If the agent cannot reach the sidecar, inspect the Compose
+network and ensure the sidecar is listening on `0.0.0.0:8000`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,6 +52,7 @@ complete a specific task.
 - [Configure an agent from a source checkout](how-to/setup-agent-from-source.md)
 - [Deploy the remote MCP server](how-to/deploy-remote-mcp.md)
 - [Author a Harbor benchmark task](how-to/author-harbor-benchmark-task.md)
+- [Run agent evaluations](how-to/run-agent-evaluations.md)
 
 ## Reference
 

--- a/docs/reference/agent-evaluations.md
+++ b/docs/reference/agent-evaluations.md
@@ -50,6 +50,26 @@ The observation service is anonymous and intended for local evaluation. It
 does not add an image identity, token, proxy, or eligibility preflight in front
 of Harbor.
 
+### Optional Docker proxy
+
+The observation Compose overlay leaves the task container's network direct by
+default. If the host requires a proxy for package installation or Codex model
+access, configure it explicitly for the container:
+
+```sh
+export JACOBIAN_EVAL_HTTP_PROXY='http://host.docker.internal:7890'
+export JACOBIAN_EVAL_HTTPS_PROXY='http://host.docker.internal:7890'
+export JACOBIAN_EVAL_NO_PROXY='localhost,127.0.0.1,jacobian'
+make agent-eval DATASET=agent-workflow-v1 TASKS=graph-counterexample EVAL_EXECUTE=1
+```
+
+The overlay maps `host.docker.internal` to the Docker host and passes both
+upper- and lower-case proxy variables to Harbor's `main` container, including
+the agent installation phase. Proxying remains disabled when these variables
+are unset. On Linux, the host proxy must accept connections from Docker's
+bridge interface; a proxy bound only to the host's loopback address is not
+reachable from a container.
+
 Inspect Harbor ATIF together with Jacobian telemetry for discovery,
 descriptions, invocation and parameter errors, artifact and verification-record
 flow, repeated calls, shell activity, tokens, time, and completion. This is

--- a/docs/reference/agent-evaluations.md
+++ b/docs/reference/agent-evaluations.md
@@ -30,17 +30,57 @@ certification receive zero reward.
 
 ## Jacobian observation
 
+There are two Harbor workflows. Use standalone observation to check whether an
+agent can discover and use Jacobian. Use paired control/treatment jobs to ask
+whether Jacobian changes outcomes.
+
+### Standalone observation
+
 Harbor runs the same canonical tasks with the local Jacobian MCP service as an
 ordinary Compose sidecar:
 
 ```sh
 export JACOBIAN_IMAGE='jacobian:local'
 export JACOBIAN_MODEL='your-model'
-make agent-eval DATASET=agent-workflow-v1 EVAL_EXECUTE=1
+make agent-eval DATASET=agent-workflow-v1 \
+  JACOBIAN_ENABLED=1 EVAL_EXECUTE=1
 ```
 
-The Compose file defaults to `jacobian:local`; set `JACOBIAN_IMAGE` when using
-another local or registry image. Harbor selects tasks from the dataset
+The standalone observation job adds the Jacobian Compose sidecar and Harbor's
+external MCP configuration. Task TOMLs remain agent-agnostic.
+
+### Paired control/treatment evaluation
+
+The control and treatment jobs use identical task bundles and task digests. The
+only intended difference is Jacobian availability:
+
+```sh
+export JACOBIAN_MODEL='your-model'
+export CODEX_FORCE_AUTH_JSON=1
+
+# Control: no Jacobian sidecar and no MCP configuration.
+make agent-eval DATASET=agent-workflow-v1 \
+  JACOBIAN_ENABLED=0 TASKS=graph-counterexample EVAL_EXECUTE=1
+
+# Treatment: Jacobian sidecar plus external MCP configuration.
+export JACOBIAN_EVAL_HTTP_PROXY='http://host.docker.internal:7890'
+export JACOBIAN_EVAL_HTTPS_PROXY='http://host.docker.internal:7890'
+export JACOBIAN_EVAL_NO_PROXY='localhost,127.0.0.1,jacobian'
+make agent-eval DATASET=agent-workflow-v1 \
+  JACOBIAN_ENABLED=1 \
+  TASKS=graph-counterexample EVAL_EXECUTE=1
+```
+
+`JACOBIAN_ENABLED=0` selects the control job; `JACOBIAN_ENABLED=1` selects the
+treatment job and passes Harbor's supported `--mcp-config` option. Do not add
+Jacobian to every task TOML for this comparison: that changes the task contract
+and invalidates the matched boundary. Start with three representative cases and
+three repetitions per condition; public-suite results remain workflow
+observations, not held-out causal evidence.
+
+The treatment Compose file defaults to `jacobian:local`; set `JACOBIAN_IMAGE`
+when using another local or registry image. Both conditions use the shared
+optional proxy overlay; only treatment adds the Jacobian service. Harbor selects tasks from the dataset
 represented by the generated
 `benchmarks/datasets/agent-workflow-v1/dataset.toml` manifest. Pass
 `TASKS=graph-counterexample` selects the same small default explicitly; the
@@ -52,7 +92,7 @@ of Harbor.
 
 ### Optional Docker proxy
 
-The observation Compose overlay leaves the task container's network direct by
+The shared proxy Compose overlay leaves the task container's network direct by
 default. If the host requires a proxy for package installation or Codex model
 access, configure it explicitly for the container:
 
@@ -73,8 +113,8 @@ reachable from a container.
 Inspect Harbor ATIF together with Jacobian telemetry for discovery,
 descriptions, invocation and parameter errors, artifact and verification-record
 flow, repeated calls, shell activity, tokens, time, and completion. This is
-workflow evidence, not a causal comparison: version 1 has no control condition,
-randomized pairing, or held-out performance claim.
+workflow evidence, not a causal comparison: the public suite has no held-out
+performance claim.
 
 The separate
 [`research-diagnostics-v1`](../../benchmarks/datasets/research-diagnostics-v1/README.md)

--- a/docs/reference/agent-evaluations.md
+++ b/docs/reference/agent-evaluations.md
@@ -28,87 +28,32 @@ and validates the generated task digests. Wrong
 answers, malformed or escaped evidence, incomplete scope, and false
 certification receive zero reward.
 
-## Jacobian observation
+## Evaluation roles
 
-There are two Harbor workflows. Use standalone observation to check whether an
-agent can discover and use Jacobian. Use paired control/treatment jobs to ask
+There are two supported Jacobian observation modes. Standalone observation asks
+whether an agent can discover and use Jacobian. Paired control/treatment asks
 whether Jacobian changes outcomes.
 
-### Standalone observation
+For a paired run, control and treatment must use identical task bundles and
+task digests. The only intended difference is Jacobian availability. Do not add
+Jacobian to task TOMLs: that changes the task contract and invalidates the
+matched boundary.
 
-Harbor runs the same canonical tasks with the local Jacobian MCP service as an
-ordinary Compose sidecar:
+Use the [run agent evaluations how-to](../how-to/run-agent-evaluations.md) for
+commands, Docker and proxy setup, external MCP configuration, and
+troubleshooting.
 
-```sh
-export JACOBIAN_IMAGE='jacobian:local'
-export JACOBIAN_MODEL='your-model'
-make agent-eval DATASET=agent-workflow-v1 \
-  JACOBIAN_ENABLED=1 EVAL_EXECUTE=1
-```
+## Metrics and interpretation
 
-The standalone observation job adds the Jacobian Compose sidecar and Harbor's
-external MCP configuration. Task TOMLs remain agent-agnostic.
+Report mathematical correctness, evidence validity, scope/completeness, false
+certification, and assurance calibration separately. Aggregate reward may
+summarize a workflow contract, but is not primary evidence of Jacobian's
+mathematical capability value when it combines those dimensions.
 
-### Paired control/treatment evaluation
-
-The control and treatment jobs use identical task bundles and task digests. The
-only intended difference is Jacobian availability:
-
-```sh
-export JACOBIAN_MODEL='your-model'
-export CODEX_FORCE_AUTH_JSON=1
-
-# Control: no Jacobian sidecar and no MCP configuration.
-make agent-eval DATASET=agent-workflow-v1 \
-  JACOBIAN_ENABLED=0 TASKS=graph-counterexample EVAL_EXECUTE=1
-
-# Treatment: Jacobian sidecar plus external MCP configuration.
-export JACOBIAN_EVAL_HTTP_PROXY='http://host.docker.internal:7890'
-export JACOBIAN_EVAL_HTTPS_PROXY='http://host.docker.internal:7890'
-export JACOBIAN_EVAL_NO_PROXY='localhost,127.0.0.1,jacobian'
-make agent-eval DATASET=agent-workflow-v1 \
-  JACOBIAN_ENABLED=1 \
-  TASKS=graph-counterexample EVAL_EXECUTE=1
-```
-
-`JACOBIAN_ENABLED=0` selects the control job; `JACOBIAN_ENABLED=1` selects the
-treatment job and passes Harbor's supported `--mcp-config` option. Do not add
-Jacobian to every task TOML for this comparison: that changes the task contract
-and invalidates the matched boundary. Start with three representative cases and
-three repetitions per condition; public-suite results remain workflow
-observations, not held-out causal evidence.
-
-The treatment Compose file defaults to `jacobian:local`; set `JACOBIAN_IMAGE`
-when using another local or registry image. Both conditions use the shared
-optional proxy overlay; only treatment adds the Jacobian service. Harbor selects tasks from the dataset
-represented by the generated
-`benchmarks/datasets/agent-workflow-v1/dataset.toml` manifest. Pass
-`TASKS=graph-counterexample` selects the same small default explicitly; the
-committed observation job defaults to that task.
-
-The observation service is anonymous and intended for local evaluation. It
-does not add an image identity, token, proxy, or eligibility preflight in front
-of Harbor.
-
-### Optional Docker proxy
-
-The shared proxy Compose overlay leaves the task container's network direct by
-default. If the host requires a proxy for package installation or Codex model
-access, configure it explicitly for the container:
-
-```sh
-export JACOBIAN_EVAL_HTTP_PROXY='http://host.docker.internal:7890'
-export JACOBIAN_EVAL_HTTPS_PROXY='http://host.docker.internal:7890'
-export JACOBIAN_EVAL_NO_PROXY='localhost,127.0.0.1,jacobian'
-make agent-eval DATASET=agent-workflow-v1 TASKS=graph-counterexample EVAL_EXECUTE=1
-```
-
-The overlay maps `host.docker.internal` to the Docker host and passes both
-upper- and lower-case proxy variables to Harbor's `main` container, including
-the agent installation phase. Proxying remains disabled when these variables
-are unset. On Linux, the host proxy must accept connections from Docker's
-bridge interface; a proxy bound only to the host's loopback address is not
-reachable from a container.
+Start comparative work with three representative cases and three repetitions
+per condition. Stronger claims require held-out or transformed cases, a
+non-ceiling control pilot, more repetitions, and uncertainty reporting. Public
+suite results remain workflow observations, not held-out causal evidence.
 
 Inspect Harbor ATIF together with Jacobian telemetry for discovery,
 descriptions, invocation and parameter errors, artifact and verification-record

--- a/tests/unit/tooling/test_harbor_job_config.py
+++ b/tests/unit/tooling/test_harbor_job_config.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import subprocess
 from pathlib import Path
 
 from benchmarks.tooling.harbor_suite import get_suite
@@ -60,32 +59,3 @@ def test_paired_jobs_use_three_attempts_per_condition() -> None:
 
     assert treatment["n_attempts"] == 3
     assert control["n_attempts"] == 3
-
-
-def test_agent_eval_rejects_invalid_toggle_and_clears_control_mcp() -> None:
-    invalid = subprocess.run(
-        ["make", "-n", "agent-eval", "JACOBIAN_ENABLED=false"],
-        cwd=ROOT,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    assert invalid.returncode != 0
-    assert "JACOBIAN_ENABLED must be exactly 0 or 1" in invalid.stderr
-
-    control = subprocess.run(
-        [
-            "make",
-            "-n",
-            "agent-eval",
-            "JACOBIAN_ENABLED=0",
-            "MCP_CONFIG=unexpected.json",
-            "EVAL_EXECUTE=1",
-            "JACOBIAN_MODEL=test",
-        ],
-        cwd=ROOT,
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    assert "--mcp-config" not in control.stdout

--- a/tests/unit/tooling/test_harbor_job_config.py
+++ b/tests/unit/tooling/test_harbor_job_config.py
@@ -14,6 +14,8 @@ JOB = (
     / "jobs"
     / "jacobian-observation.json"
 )
+CONTROL_JOB = ROOT / "benchmarks" / "config" / "agent-workflow-v1-control.json"
+MCP_CONFIG = ROOT / "benchmarks" / "config" / "jacobian.mcp.json"
 
 
 def test_observation_job_uses_harbor_dataset_selection() -> None:
@@ -26,7 +28,23 @@ def test_observation_job_uses_harbor_dataset_selection() -> None:
             "task_names": ["graph-counterexample"],
         }
     ]
-    assert job["agents"][0]["mcp_servers"][0]["url"] == ("http://jacobian:8000/mcp")
+    assert job["agents"] == [{"name": "codex"}]
+
+
+def test_observation_mcp_config_is_external_to_the_task_job() -> None:
+    job = json.loads(JOB.read_text())
+    control = json.loads(CONTROL_JOB.read_text())
+    mcp = json.loads(MCP_CONFIG.read_text())
+
+    assert "mcp_servers" not in job["agents"][0]
+    assert "mcp_servers" not in control["agents"][0]
+    assert mcp["mcp_servers"] == [
+        {
+            "name": "jacobian",
+            "transport": "streamable-http",
+            "url": "http://jacobian:8000/mcp",
+        }
+    ]
 
 
 def test_observation_dataset_contains_the_canonical_task() -> None:

--- a/tests/unit/tooling/test_harbor_job_config.py
+++ b/tests/unit/tooling/test_harbor_job_config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 
 from benchmarks.tooling.harbor_suite import get_suite
@@ -51,3 +52,40 @@ def test_observation_dataset_contains_the_canonical_task() -> None:
     suite = get_suite("agent-workflow-v1")
 
     assert any(ref.path.name == "graph-counterexample" for ref in suite.tasks)
+
+
+def test_paired_jobs_use_three_attempts_per_condition() -> None:
+    treatment = json.loads(JOB.read_text())
+    control = json.loads(CONTROL_JOB.read_text())
+
+    assert treatment["n_attempts"] == 3
+    assert control["n_attempts"] == 3
+
+
+def test_agent_eval_rejects_invalid_toggle_and_clears_control_mcp() -> None:
+    invalid = subprocess.run(
+        ["make", "-n", "agent-eval", "JACOBIAN_ENABLED=false"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert invalid.returncode != 0
+    assert "JACOBIAN_ENABLED must be exactly 0 or 1" in invalid.stderr
+
+    control = subprocess.run(
+        [
+            "make",
+            "-n",
+            "agent-eval",
+            "JACOBIAN_ENABLED=0",
+            "MCP_CONFIG=unexpected.json",
+            "EVAL_EXECUTE=1",
+            "JACOBIAN_MODEL=test",
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "--mcp-config" not in control.stdout


### PR DESCRIPTION
## Summary

Closes #308.

This PR makes Jacobian-enabled Harbor runs a simple, explicit toggle and documents the distinction between workflow observation and paired control/treatment evaluation.

### What changed

- Added `JACOBIAN_ENABLED=0|1` selection to `make agent-eval`.
- Added a control Harbor job with no Jacobian sidecar or MCP configuration.
- Moved the treatment MCP declaration to Harbor's external `--mcp-config` file.
- Split the shared optional proxy overlay from the Jacobian sidecar Compose file.
- Added explicit `-a codex` so the model override works with Harbor's external MCP configuration.
- Documented identical task/digest requirements and the limitation that the public suite is not held out evidence.
- Preserved the existing optional Docker proxy behavior.

### Why

The previous `graph-counterexample` comparison showed a difference in assurance calibration, not mathematical necessity: the control agent solved the problem but claimed unsupported `VERIFIED` assurance. The new layout makes control and treatment runs reproducible while keeping Jacobian out of task TOMLs.

### Validation

- `make harbor-check` — 447 tests passed.
- `make docs-linkcheck` — completed successfully.
- `git diff --check` — passed.
- JSON configuration parsing — passed.
- `make -n agent-eval` verified both control and treatment command paths.

The public workflow remains a regression/observation suite, not a held-out causal performance benchmark.

