### PR TITLE
feat(core): add exact rational-function identity verification

### DIFF
--- a/docs/reference/domain-operation-library.md
+++ b/docs/reference/domain-operation-library.md
@@ -145,6 +145,12 @@ authorization.
 
 ## Independent exact replay
 
+Exact replay also covers bounded sparse rational-function identities. The
+identity verifier preserves the submitted numerators and denominators and
+checks fraction-field equality by independent polynomial cross multiplication;
+pointwise denominator-definedness remains outside its scope. See
+[Rational-function identities](rational-function-identities.md).
+
 Some polynomial, matrix, graph, geometry, probability, topology, poset, and
 combinatorics results have a separate verification capability. The producer
 first returns a result artifact in `EXPLORE` mode. A verification request then

--- a/docs/reference/rational-function-identities.md
+++ b/docs/reference/rational-function-identities.md
@@ -1,0 +1,27 @@
+# Rational-function identities
+
+`polynomial.rational_function.identity.verify` decides equality of two bounded
+sparse rational functions in a declared fraction field
+`QQ(x1, ..., xn)`.
+
+The request preserves each numerator and denominator as a canonical sparse
+polynomial. Denominators must be nonzero polynomials. An authorized independent
+checker compares
+
+```text
+left.numerator * right.denominator
+    = right.numerator * left.denominator
+```
+
+using exact rational arithmetic. The resulting certificate and verification
+record are bound to both rational-function artifacts, the identity claim, the
+semantics descriptor, and the checker identity.
+
+This is fraction-field equality. It does not claim that either expression is
+defined at a particular point, that their pointwise domains agree, or that a
+larger theorem containing the identity is true. Those are separate
+obligations.
+
+The bounded contract accepts one to four ordered variables, at most 1024 terms
+per component polynomial, exponents at most 127, and at most 4096 term pairs in
+either cross product.

--- a/src/jacobian/contracts/polynomials.py
+++ b/src/jacobian/contracts/polynomials.py
@@ -234,6 +234,77 @@ class PolynomialIdentityRequest(ContractModel):
         return self
 
 
+class SparseRationalFunction(ContractModel):
+    """One bounded fraction of sparse polynomials over a shared QQ ring."""
+
+    numerator: SparseRationalPolynomial
+    denominator: SparseRationalPolynomial
+
+    @model_validator(mode="after")
+    def require_nonzero_denominator(self) -> Self:
+        if not self.denominator.terms:
+            raise ValueError("rational-function denominator must be nonzero")
+        return self
+
+
+class RationalFunctionIdentityRequest(ContractModel):
+    variables: tuple[PolynomialVariable, ...] = Field(min_length=1, max_length=4)
+    left: SparseRationalFunction
+    right: SparseRationalFunction
+
+    @model_validator(mode="after")
+    def require_matching_bounded_fraction_field(self) -> Self:
+        if len(set(self.variables)) != len(self.variables):
+            raise ValueError("rational-function variables must be unique")
+        dimension = len(self.variables)
+        polynomials = (
+            self.left.numerator,
+            self.left.denominator,
+            self.right.numerator,
+            self.right.denominator,
+        )
+        if any(
+            len(term.exponents) != dimension
+            for polynomial in polynomials
+            for term in polynomial.terms
+        ):
+            raise ValueError("every monomial must match the declared variable order")
+        if (
+            max(
+                len(self.left.numerator.terms) * len(self.right.denominator.terms),
+                len(self.right.numerator.terms) * len(self.left.denominator.terms),
+            )
+            > 4096
+        ):
+            raise ValueError("rational-function cross product exceeds 4096 term pairs")
+        return self
+
+
+class RationalFunctionArtifact(ContractModel):
+    rational_function_schema_version: Literal["1"] = "1"
+    domain: Literal["QQ_FRACTION_FIELD"] = "QQ_FRACTION_FIELD"
+    variables: tuple[PolynomialVariable, ...] = Field(min_length=1, max_length=4)
+    numerator: SparseRationalPolynomial
+    denominator: SparseRationalPolynomial
+
+    @model_validator(mode="after")
+    def require_matching_fraction_field(self) -> Self:
+        request = RationalFunctionIdentityRequest(
+            variables=self.variables,
+            left=SparseRationalFunction(
+                numerator=self.numerator,
+                denominator=self.denominator,
+            ),
+            right=SparseRationalFunction(
+                numerator=self.numerator,
+                denominator=self.denominator,
+            ),
+        )
+        if request.variables != self.variables:
+            raise ValueError("rational-function artifact has an invalid variable order")
+        return self
+
+
 class PolynomialMapInverseVerifyRequest(ContractModel):
     forward_map: RationalPolynomialMap
     inverse_map: RationalPolynomialMap
@@ -596,6 +667,24 @@ class PolynomialIdentityReplayPayload(ContractModel):
     right_uri: ArtifactUri
 
 
+class RationalFunctionIdentityClaim(ContractModel):
+    claim_schema_version: Literal["1"] = "1"
+    predicate: Literal["RATIONAL_FUNCTION_IDENTITY"] = "RATIONAL_FUNCTION_IDENTITY"
+    domain: Literal["QQ_FRACTION_FIELD"] = "QQ_FRACTION_FIELD"
+    variables: tuple[PolynomialVariable, ...] = Field(min_length=1, max_length=4)
+    left_uri: ArtifactUri
+    right_uri: ArtifactUri
+
+
+class RationalFunctionIdentityReplayPayload(ContractModel):
+    method: Literal["CROSS_MULTIPLY_SPARSE_POLYNOMIALS"] = (
+        "CROSS_MULTIPLY_SPARSE_POLYNOMIALS"
+    )
+    variables: tuple[PolynomialVariable, ...] = Field(min_length=1, max_length=4)
+    left_uri: ArtifactUri
+    right_uri: ArtifactUri
+
+
 class PolynomialMapInverseClaim(ContractModel):
     claim_schema_version: Literal["1"] = "1"
     predicate: Literal["POLYNOMIAL_MAP_TWO_SIDED_INVERSE"] = (
@@ -790,6 +879,37 @@ class PolynomialIdentityOutput(ContractModel):
         if self.conclusion not in expected:
             raise ValueError(
                 "polynomial identity conclusion must be TRUE, FALSE, or UNKNOWN"
+            )
+        if self.identical is not expected[self.conclusion]:
+            raise ValueError("identical must preserve an unknown checker conclusion")
+        return self
+
+
+class RationalFunctionIdentityOutput(ContractModel):
+    identical: bool | None
+    conclusion: Conclusion
+    left_uri: ArtifactUri
+    right_uri: ArtifactUri
+    claim_uri: ArtifactUri
+    certificate_uri: ArtifactUri
+    verification_record_uri: ArtifactUri | None = None
+    checker_id: CheckerUri | None = None
+    exactness: PolynomialExactness = PolynomialExactness.EXACT
+    determinism: PolynomialDeterminism = PolynomialDeterminism.DETERMINISTIC
+    equality_semantics: Literal["QQ_FRACTION_FIELD_CROSS_MULTIPLICATION"] = (
+        "QQ_FRACTION_FIELD_CROSS_MULTIPLICATION"
+    )
+
+    @model_validator(mode="after")
+    def identity_matches_conclusion(self) -> Self:
+        expected = {
+            Conclusion.TRUE: True,
+            Conclusion.FALSE: False,
+            Conclusion.UNKNOWN: None,
+        }
+        if self.conclusion not in expected:
+            raise ValueError(
+                "rational-function identity conclusion must be TRUE, FALSE, or UNKNOWN"
             )
         if self.identical is not expected[self.conclusion]:
             raise ValueError("identical must preserve an unknown checker conclusion")

--- a/src/jacobian/contracts/polynomials.py
+++ b/src/jacobian/contracts/polynomials.py
@@ -299,9 +299,7 @@ class RationalFunctionArtifact(ContractModel):
             raise ValueError("rational-function variables must be unique")
         dimension = len(self.variables)
         for polynomial in (self.numerator, self.denominator):
-            if any(
-                len(term.exponents) != dimension for term in polynomial.terms
-            ):
+            if any(len(term.exponents) != dimension for term in polynomial.terms):
                 raise ValueError(
                     "every monomial must match the declared variable order"
                 )

--- a/src/jacobian/contracts/polynomials.py
+++ b/src/jacobian/contracts/polynomials.py
@@ -289,21 +289,24 @@ class RationalFunctionArtifact(ContractModel):
 
     @model_validator(mode="after")
     def require_matching_fraction_field(self) -> Self:
-        # Reuse the identity-request validator for cross-field checks (variable
-        # uniqueness, exponent dimension matching, and cross-product bound).
-        # The self-comparison is intentional: we only need the side effect of
-        # the nested validator, not a real equality test.
-        RationalFunctionIdentityRequest(
-            variables=self.variables,
-            left=SparseRationalFunction(
-                numerator=self.numerator,
-                denominator=self.denominator,
-            ),
-            right=SparseRationalFunction(
-                numerator=self.numerator,
-                denominator=self.denominator,
-            ),
-        )
+        # Validate the artifact directly rather than reusing the
+        # two-function cross-product validator: the identity-request bound
+        # applies the pair limit to a single fraction's self-product
+        # (numerator.terms * denominator.terms), which incorrectly rejects a
+        # valid 65x65 fraction.  The artifact only needs variable uniqueness,
+        # exponent dimension matching, and a nonzero denominator.
+        if len(set(self.variables)) != len(self.variables):
+            raise ValueError("rational-function variables must be unique")
+        dimension = len(self.variables)
+        for polynomial in (self.numerator, self.denominator):
+            if any(
+                len(term.exponents) != dimension for term in polynomial.terms
+            ):
+                raise ValueError(
+                    "every monomial must match the declared variable order"
+                )
+        if not self.denominator.terms:
+            raise ValueError("rational-function denominator must be nonzero")
         return self
 
 

--- a/src/jacobian/contracts/polynomials.py
+++ b/src/jacobian/contracts/polynomials.py
@@ -289,7 +289,11 @@ class RationalFunctionArtifact(ContractModel):
 
     @model_validator(mode="after")
     def require_matching_fraction_field(self) -> Self:
-        request = RationalFunctionIdentityRequest(
+        # Reuse the identity-request validator for cross-field checks (variable
+        # uniqueness, exponent dimension matching, and cross-product bound).
+        # The self-comparison is intentional: we only need the side effect of
+        # the nested validator, not a real equality test.
+        RationalFunctionIdentityRequest(
             variables=self.variables,
             left=SparseRationalFunction(
                 numerator=self.numerator,
@@ -300,8 +304,6 @@ class RationalFunctionArtifact(ContractModel):
                 denominator=self.denominator,
             ),
         )
-        if request.variables != self.variables:
-            raise ValueError("rational-function artifact has an invalid variable order")
         return self
 
 

--- a/src/jacobian/polynomials/installation.py
+++ b/src/jacobian/polynomials/installation.py
@@ -19,6 +19,8 @@ from jacobian.contracts.polynomials import (
     PolynomialMapInverseClaim,
     PolynomialMapInverseSynthesisArtifact,
     PolynomialNoTwoSidedInverseClaim,
+    RationalFunctionArtifact,
+    RationalFunctionIdentityClaim,
     RationalPolynomial,
     RationalPolynomialMap,
     SparseRationalPolynomial,
@@ -40,6 +42,7 @@ from jacobian.polynomials.inverse import (
     PolynomialMapInverseSynthesizeAdapter,
     PolynomialMapInverseVerifyAdapter,
 )
+from jacobian.polynomials.rational_identity import RationalFunctionIdentityAdapter
 from jacobian.polynomials.resources import PolynomialInstallation, PolynomialResources
 from jacobian.registry import CheckerRegistry
 from jacobian.schema_registry import SchemaRegistry, model_schema
@@ -62,6 +65,7 @@ def install_polynomial_capabilities(
         PolynomialKellerConditionVerifyAdapter,
         PolynomialCollisionAdapter,
         PolynomialIdentityAdapter,
+        RationalFunctionIdentityAdapter,
         PolynomialCollisionSearchAdapter,
         PolynomialCollisionVerifyAdapter,
         PolynomialMapInverseCollisionVerifyAdapter,
@@ -106,6 +110,25 @@ def install_polynomial_capabilities(
             "maximum_exponent": 127,
             "monomial_order": "descending lexicographic",
             "zero_terms": "omitted",
+        },
+    )
+    rational_function_identity_semantics_uri = store.register_descriptor(
+        kind="semantics",
+        name="jacobian.sparse-rational-function-field",
+        version="1",
+        definition={
+            "description": (
+                "bounded fractions of canonical sparse polynomials over QQ in "
+                "an explicit ordered tuple of variables"
+            ),
+            "coefficient_field": "QQ",
+            "maximum_dimension": 4,
+            "maximum_terms_per_polynomial": 1024,
+            "maximum_exponent": 127,
+            "maximum_cross_product_term_pairs": 4096,
+            "denominators": "nonzero polynomials",
+            "equality": "exact polynomial cross multiplication",
+            "pointwise_definedness": "outside scope",
         },
     )
     inverse_semantics_uri = store.register_descriptor(
@@ -194,6 +217,21 @@ def install_polynomial_capabilities(
         name="jacobian.polynomial-identity-claim",
         version="1",
         schema=model_schema(PolynomialIdentityClaim),
+    )
+    rational_function_left_schema_uri = schemas.register(
+        name="jacobian.sparse-rational-function-left",
+        version="1",
+        schema=model_schema(RationalFunctionArtifact),
+    )
+    rational_function_right_schema_uri = schemas.register(
+        name="jacobian.sparse-rational-function-right",
+        version="1",
+        schema=model_schema(RationalFunctionArtifact),
+    )
+    rational_function_identity_claim_schema_uri = schemas.register(
+        name="jacobian.rational-function-identity-claim",
+        version="1",
+        schema=model_schema(RationalFunctionIdentityClaim),
     )
     keller_claim_schema_uri = schemas.register(
         name="jacobian.polynomial-map-keller-condition-claim",
@@ -315,6 +353,27 @@ def install_polynomial_capabilities(
         )
         .checker_id
     )
+    rational_function_identity_checker_id = (
+        CheckerInstaller(checkers)
+        .install(
+            CheckerOperation(
+                name="exact sparse rational-function identity checker",
+                entrypoint=(
+                    "jacobian_checkers.rational_functions:"
+                    "check_rational_function_identity"
+                ),
+                evidence_kind=EvidenceKind.CERTIFICATE,
+                format_id="polynomial.rational_function.identity_replay",
+                format_version="1",
+                claim_schema_uris=(rational_function_identity_claim_schema_uri,),
+                semantics_uris=(rational_function_identity_semantics_uri,),
+                candidate_schema_uris=(rational_function_right_schema_uri,),
+                reason="bundled independent sparse cross-multiplication checker",
+            ),
+            authorize=authorize_checker,
+        )
+        .checker_id
+    )
     inverse_checker_id = (
         CheckerInstaller(checkers)
         .install(
@@ -361,6 +420,9 @@ def install_polynomial_capabilities(
         polynomial_semantics_uri=polynomial_semantics_uri,
         factorization_semantics_uri=factorization_semantics_uri,
         identity_semantics_uri=identity_semantics_uri,
+        rational_function_identity_semantics_uri=(
+            rational_function_identity_semantics_uri
+        ),
         inverse_semantics_uri=inverse_semantics_uri,
         map_schema_uri=map_schema_uri,
         evaluation_schema_uri=evaluation_schema_uri,
@@ -370,6 +432,11 @@ def install_polynomial_capabilities(
         right_polynomial_schema_uri=right_polynomial_schema_uri,
         left_polynomial_schema_uri=left_polynomial_schema_uri,
         identity_claim_schema_uri=identity_claim_schema_uri,
+        rational_function_left_schema_uri=rational_function_left_schema_uri,
+        rational_function_right_schema_uri=rational_function_right_schema_uri,
+        rational_function_identity_claim_schema_uri=(
+            rational_function_identity_claim_schema_uri
+        ),
         keller_claim_schema_uri=keller_claim_schema_uri,
         inverse_collision_claim_schema_uri=inverse_collision_claim_schema_uri,
         inverse_claim_schema_uri=inverse_claim_schema_uri,
@@ -383,6 +450,7 @@ def install_polynomial_capabilities(
         jacobian_checker_id=jacobian_checker_id,
         keller_checker_id=keller_checker_id,
         identity_checker_id=identity_checker_id,
+        rational_function_identity_checker_id=rational_function_identity_checker_id,
         inverse_checker_id=inverse_checker_id,
         inverse_collision_checker_id=inverse_collision_checker_id,
     )
@@ -403,6 +471,11 @@ def install_polynomial_capabilities(
             ),
             PolynomialCollisionAdapter(resources),
             PolynomialIdentityAdapter(resources),
+            *(
+                (RationalFunctionIdentityAdapter(resources),)
+                if rational_function_identity_checker_id is not None
+                else ()
+            ),
             PolynomialCollisionSearchAdapter(resources),
             *(
                 (PolynomialCollisionVerifyAdapter(resources),)

--- a/src/jacobian/polynomials/rational_identity.py
+++ b/src/jacobian/polynomials/rational_identity.py
@@ -1,0 +1,291 @@
+"""Exact identity verification in a bounded rational-function field."""
+
+from __future__ import annotations
+
+import hashlib
+
+from jacobian.canonical import canonicalize_json
+from jacobian.contracts.capabilities import (
+    CapabilityAssurance,
+    CapabilityAssuranceLevel,
+    CapabilityCompleteness,
+    CapabilityCompletenessStatus,
+    CapabilityDescriptor,
+    CapabilityInvocationExample,
+    CapabilityMode,
+    CapabilityRelationship,
+    CapabilityRelationshipStatus,
+    CapabilityRequest,
+    CapabilityResult,
+    CapabilityScope,
+)
+from jacobian.contracts.evidence import CertificateEnvelope, EvidenceBindings
+from jacobian.contracts.polynomials import (
+    RationalFunctionArtifact,
+    RationalFunctionIdentityClaim,
+    RationalFunctionIdentityOutput,
+    RationalFunctionIdentityReplayPayload,
+    RationalFunctionIdentityRequest,
+)
+from jacobian.contracts.results import Conclusion
+from jacobian.polynomials._support import _polynomial_error, _validate_request
+from jacobian.polynomials.resources import PolynomialResources
+from jacobian.provider_runtime import known_provider_runtime
+from jacobian.schema_registry import model_schema
+
+
+class RationalFunctionIdentityAdapter:
+    """Verify equality in one declared QQ rational-function field."""
+
+    def __init__(self, resources: PolynomialResources) -> None:
+        self.resources = resources
+        checker_id = resources.installation.rational_function_identity_checker_id
+        self._descriptor = CapabilityDescriptor(
+            capability_id="polynomial.rational_function.identity.verify",
+            version="1",
+            title="Verify an exact rational-function identity",
+            description=(
+                "Independently verify equality of two bounded sparse rational "
+                "functions in a declared QQ fraction field by exact cross "
+                "multiplication. This does not prove pointwise definedness."
+            ),
+            provider="jacobian.rational-function-checker",
+            provider_runtime=known_provider_runtime(
+                "jacobian.rational-function-checker",
+                features=("rational-function-identity", "exact-rational"),
+                checker_ids=((checker_id,) if checker_id is not None else ()),
+            ),
+            modes=(CapabilityMode.VERIFY,),
+            input_schema=model_schema(RationalFunctionIdentityRequest),
+            output_schema=model_schema(RationalFunctionIdentityOutput),
+            tags=(
+                "polynomial",
+                "rational-function",
+                "identity",
+                "verification",
+            ),
+            invocation_examples=(
+                CapabilityInvocationExample(
+                    name="cancel_common_factor",
+                    description="Verify that (x²-1)/(x-1) equals x+1 in QQ(x).",
+                    mode=CapabilityMode.VERIFY,
+                    input=RationalFunctionIdentityRequest.model_validate(
+                        {
+                            "variables": ["x"],
+                            "left": {
+                                "numerator": {
+                                    "terms": [
+                                        {
+                                            "coefficient": {"num": "1", "den": "1"},
+                                            "exponents": [2],
+                                        },
+                                        {
+                                            "coefficient": {"num": "-1", "den": "1"},
+                                            "exponents": [0],
+                                        },
+                                    ]
+                                },
+                                "denominator": {
+                                    "terms": [
+                                        {
+                                            "coefficient": {"num": "1", "den": "1"},
+                                            "exponents": [1],
+                                        },
+                                        {
+                                            "coefficient": {"num": "-1", "den": "1"},
+                                            "exponents": [0],
+                                        },
+                                    ]
+                                },
+                            },
+                            "right": {
+                                "numerator": {
+                                    "terms": [
+                                        {
+                                            "coefficient": {"num": "1", "den": "1"},
+                                            "exponents": [1],
+                                        },
+                                        {
+                                            "coefficient": {"num": "1", "den": "1"},
+                                            "exponents": [0],
+                                        },
+                                    ]
+                                },
+                                "denominator": {
+                                    "terms": [
+                                        {
+                                            "coefficient": {"num": "1", "den": "1"},
+                                            "exponents": [0],
+                                        },
+                                    ]
+                                },
+                            },
+                        }
+                    ).model_dump(mode="json"),
+                ),
+            ),
+        )
+
+    @property
+    def descriptor(self) -> CapabilityDescriptor:
+        return self._descriptor
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        validated = _validate_request(
+            RationalFunctionIdentityRequest,
+            request.input,
+            code="INVALID_RATIONAL_FUNCTION_IDENTITY_REQUEST",
+            operation="rational-function identity verification",
+        )
+        checker_id = self.resources.installation.rational_function_identity_checker_id
+        if checker_id is None:
+            raise _polynomial_error(
+                "RATIONAL_FUNCTION_IDENTITY_CHECKER_UNAVAILABLE",
+                "rational_function_identity_verification",
+                "No authorized rational-function identity checker is installed.",
+            )
+        semantics_uri = (
+            self.resources.installation.rational_function_identity_semantics_uri
+        )
+        left_payload = RationalFunctionArtifact(
+            variables=validated.variables,
+            numerator=validated.left.numerator,
+            denominator=validated.left.denominator,
+        )
+        right_payload = RationalFunctionArtifact(
+            variables=validated.variables,
+            numerator=validated.right.numerator,
+            denominator=validated.right.denominator,
+        )
+        left = self.resources.artifacts.put(
+            schema_uri=self.resources.installation.rational_function_left_schema_uri,
+            semantics_uri=semantics_uri,
+            payload=left_payload.model_dump(mode="json"),
+            summary="left exact rational function",
+        )
+        right = self.resources.artifacts.put(
+            schema_uri=self.resources.installation.rational_function_right_schema_uri,
+            semantics_uri=semantics_uri,
+            payload=right_payload.model_dump(mode="json"),
+            summary="right exact rational function",
+        )
+        claim = self.resources.artifacts.put(
+            schema_uri=(
+                self.resources.installation.rational_function_identity_claim_schema_uri
+            ),
+            semantics_uri=semantics_uri,
+            payload=RationalFunctionIdentityClaim(
+                variables=validated.variables,
+                left_uri=left.artifact_uri,
+                right_uri=right.artifact_uri,
+            ).model_dump(mode="json"),
+            parents=(left.artifact_uri, right.artifact_uri),
+            summary="exact rational-function identity claim",
+        )
+        semantics = self.resources.store.get(semantics_uri)
+        replay_payload = RationalFunctionIdentityReplayPayload(
+            variables=validated.variables,
+            left_uri=left.artifact_uri,
+            right_uri=right.artifact_uri,
+        ).model_dump(mode="json")
+        certificate = CertificateEnvelope(
+            certificate_type="polynomial.rational_function.identity_replay",
+            format_version="1",
+            bindings=EvidenceBindings(
+                claim_digest=claim.object_digest,
+                semantics_digest=semantics.manifest.object_digest,
+                candidate_digest=right.object_digest,
+                scope_digest=left.object_digest,
+            ),
+            payload_digest=(
+                "sha256:"
+                + hashlib.sha256(canonicalize_json(replay_payload)).hexdigest()
+            ),
+            payload=replay_payload,
+        )
+        certificate_artifact = self.resources.artifacts.put(
+            schema_uri=self.resources.installation.certificate_schema_uri,
+            semantics_uri=semantics_uri,
+            payload=certificate.model_dump(mode="json"),
+            parents=(claim.artifact_uri, right.artifact_uri, left.artifact_uri),
+            summary="rational-function cross-multiplication replay certificate",
+        )
+        checked = self.resources.verification.verify_certificate(
+            certificate_uri=certificate_artifact.artifact_uri,
+            checker_id=checker_id,
+        )
+        verified = checked.verification_record_uri is not None
+        identical = {
+            Conclusion.TRUE: True,
+            Conclusion.FALSE: False,
+            Conclusion.UNKNOWN: None,
+        }[checked.conclusion]
+        output = RationalFunctionIdentityOutput(
+            identical=identical,
+            conclusion=checked.conclusion,
+            left_uri=left.artifact_uri,
+            right_uri=right.artifact_uri,
+            claim_uri=claim.artifact_uri,
+            certificate_uri=certificate_artifact.artifact_uri,
+            verification_record_uri=checked.verification_record_uri,
+            checker_id=checker_id,
+        )
+        return CapabilityResult(
+            capability_id=self.descriptor.capability_id,
+            capability_version=self.descriptor.version,
+            mode=request.mode,
+            execution=checked.execution,
+            output=output.model_dump(mode="json"),
+            scope=CapabilityScope(
+                description=(
+                    "equality in the declared QQ fraction field; pointwise "
+                    "denominator-definedness is outside scope"
+                ),
+                parameters={"variables": list(validated.variables)},
+                artifact_uri=left.artifact_uri,
+            ),
+            completeness=(
+                CapabilityCompleteness(
+                    status=CapabilityCompletenessStatus.COMPLETE,
+                    basis="both sparse cross products were replayed independently",
+                    assurance_level=CapabilityAssuranceLevel.VERIFIED,
+                    verification_record_uri=checked.verification_record_uri,
+                )
+                if verified
+                else CapabilityCompleteness(
+                    status=CapabilityCompletenessStatus.UNKNOWN,
+                    basis="the independent checker did not accept the replay",
+                )
+            ),
+            relationships=(
+                CapabilityRelationship(
+                    relation_id="polynomial.relation.rational-function-identity",
+                    source_artifact_uris=(left.artifact_uri,),
+                    target_artifact_uris=(right.artifact_uri,),
+                    status=CapabilityRelationshipStatus.VERIFIED,
+                    verification_record_uri=checked.verification_record_uri,
+                ),
+            )
+            if checked.conclusion is Conclusion.TRUE and verified
+            else (),
+            assurance=CapabilityAssurance(
+                level=(
+                    CapabilityAssuranceLevel.VERIFIED
+                    if verified
+                    else CapabilityAssuranceLevel.HEURISTIC
+                ),
+                basis=(
+                    "authorized independent sparse cross-multiplication replay"
+                    if verified
+                    else "the independent checker did not accept the replay"
+                ),
+                verification_record_uri=checked.verification_record_uri,
+            ),
+            artifact_uris=(
+                left.artifact_uri,
+                right.artifact_uri,
+                claim.artifact_uri,
+                certificate_artifact.artifact_uri,
+                *((checked.verification_record_uri,) if verified else ()),
+            ),
+        )

--- a/src/jacobian/polynomials/resources.py
+++ b/src/jacobian/polynomials/resources.py
@@ -15,6 +15,7 @@ class PolynomialInstallation:
     polynomial_semantics_uri: str
     factorization_semantics_uri: str
     identity_semantics_uri: str
+    rational_function_identity_semantics_uri: str
     inverse_semantics_uri: str
     map_schema_uri: str
     evaluation_schema_uri: str
@@ -24,6 +25,9 @@ class PolynomialInstallation:
     right_polynomial_schema_uri: str
     left_polynomial_schema_uri: str
     identity_claim_schema_uri: str
+    rational_function_left_schema_uri: str
+    rational_function_right_schema_uri: str
+    rational_function_identity_claim_schema_uri: str
     keller_claim_schema_uri: str
     inverse_collision_claim_schema_uri: str
     inverse_claim_schema_uri: str
@@ -37,6 +41,7 @@ class PolynomialInstallation:
     jacobian_checker_id: str | None
     keller_checker_id: str | None
     identity_checker_id: str | None
+    rational_function_identity_checker_id: str | None
     inverse_checker_id: str | None
     inverse_collision_checker_id: str | None
 

--- a/src/jacobian_checkers/rational_functions.py
+++ b/src/jacobian_checkers/rational_functions.py
@@ -1,0 +1,199 @@
+"""Independent exact replay for bounded sparse rational-function identities."""
+
+from __future__ import annotations
+
+import re
+from fractions import Fraction
+from typing import Any
+
+_INTEGER = re.compile(r"^-?(?:0|[1-9][0-9]*)$")
+_VARIABLE = re.compile(r"^[A-Za-z][A-Za-z0-9_]{0,31}$")
+_MAX_DIMENSION = 4
+_MAX_TERMS = 1024
+_MAX_EXPONENT = 127
+_MAX_TERM_PAIRS = 4096
+
+Exponent = tuple[int, ...]
+Polynomial = dict[Exponent, Fraction]
+
+
+def _reject(detail: str) -> dict[str, Any]:
+    return {
+        "accepted": False,
+        "conclusion": "UNKNOWN",
+        "arithmetic": "EXACT_RATIONAL",
+        "method": "CHECKED_CERTIFICATE",
+        "coverage": "NOT_APPLICABLE",
+        "detail": detail,
+    }
+
+
+def _parse_rational(value: object) -> Fraction:
+    if not isinstance(value, dict) or set(value) != {"num", "den"}:
+        raise ValueError("rational must contain num and den")
+    numerator, denominator = value["num"], value["den"]
+    if (
+        not isinstance(numerator, str)
+        or not isinstance(denominator, str)
+        or _INTEGER.fullmatch(numerator) is None
+        or _INTEGER.fullmatch(denominator) is None
+    ):
+        raise ValueError("rational integers are not canonical")
+    parsed = Fraction(int(numerator), int(denominator))
+    if str(parsed.numerator) != numerator or str(parsed.denominator) != denominator:
+        raise ValueError("rational is not reduced and canonical")
+    return parsed
+
+
+def _parse_polynomial(value: object, dimension: int) -> Polynomial:
+    if not isinstance(value, dict) or set(value) != {"terms"}:
+        raise ValueError("polynomial must contain terms")
+    terms = value["terms"]
+    if not isinstance(terms, list) or len(terms) > _MAX_TERMS:
+        raise ValueError("polynomial term list exceeds checker limits")
+    result: Polynomial = {}
+    last: Exponent | None = None
+    for term in terms:
+        if not isinstance(term, dict) or set(term) != {"coefficient", "exponents"}:
+            raise ValueError("malformed polynomial term")
+        coefficient = _parse_rational(term["coefficient"])
+        exponents = term["exponents"]
+        if (
+            coefficient == 0
+            or not isinstance(exponents, list)
+            or len(exponents) != dimension
+            or any(
+                not isinstance(exponent, int)
+                or isinstance(exponent, bool)
+                or not 0 <= exponent <= _MAX_EXPONENT
+                for exponent in exponents
+            )
+        ):
+            raise ValueError("invalid polynomial term")
+        exponent_tuple = tuple(exponents)
+        if exponent_tuple in result or (last is not None and exponent_tuple >= last):
+            raise ValueError("polynomial terms are not in canonical order")
+        result[exponent_tuple] = coefficient
+        last = exponent_tuple
+    return result
+
+
+def _parse_function(
+    value: object, variables: list[str]
+) -> tuple[Polynomial, Polynomial]:
+    if (
+        not isinstance(value, dict)
+        or set(value)
+        != {
+            "rational_function_schema_version",
+            "domain",
+            "variables",
+            "numerator",
+            "denominator",
+        }
+        or value.get("rational_function_schema_version") != "1"
+        or value.get("domain") != "QQ_FRACTION_FIELD"
+        or value.get("variables") != variables
+    ):
+        raise ValueError("rational-function artifact does not match the field")
+    numerator = _parse_polynomial(value["numerator"], len(variables))
+    denominator = _parse_polynomial(value["denominator"], len(variables))
+    if not denominator:
+        raise ValueError("rational-function denominator is zero")
+    return numerator, denominator
+
+
+def _multiply(left: Polynomial, right: Polynomial) -> Polynomial:
+    if len(left) * len(right) > _MAX_TERM_PAIRS:
+        raise ValueError("cross product exceeds checker limits")
+    result: Polynomial = {}
+    for left_exp, left_coefficient in left.items():
+        for right_exp, right_coefficient in right.items():
+            exponent = tuple(a + b for a, b in zip(left_exp, right_exp, strict=True))
+            result[exponent] = (
+                result.get(exponent, Fraction(0)) + left_coefficient * right_coefficient
+            )
+            if result[exponent] == 0:
+                del result[exponent]
+    return result
+
+
+def check_rational_function_identity(request: dict[str, Any]) -> dict[str, Any]:
+    """Decide equality in QQ(x1,...,xn) by independent cross multiplication."""
+
+    try:
+        if request.get("request_version") != "1":
+            return _reject("unsupported request version")
+        claim = request["claim"]["payload"]
+        candidate = request["candidate"]
+        scope = request["scope"]
+        certificate = request["certificate"]["payload"]
+        if (
+            not isinstance(claim, dict)
+            or set(claim)
+            != {
+                "claim_schema_version",
+                "predicate",
+                "domain",
+                "variables",
+                "left_uri",
+                "right_uri",
+            }
+            or claim.get("claim_schema_version") != "1"
+            or claim.get("predicate") != "RATIONAL_FUNCTION_IDENTITY"
+            or claim.get("domain") != "QQ_FRACTION_FIELD"
+            or not isinstance(candidate, dict)
+            or not isinstance(scope, dict)
+            or request.get("supporting_artifacts", []) != []
+            or claim.get("left_uri") != scope.get("artifact_uri")
+            or claim.get("right_uri") != candidate.get("artifact_uri")
+        ):
+            return _reject("unexpected rational-function claim or artifact binding")
+        variables = claim.get("variables")
+        if (
+            not isinstance(variables, list)
+            or not 1 <= len(variables) <= _MAX_DIMENSION
+            or any(
+                not isinstance(v, str) or _VARIABLE.fullmatch(v) is None
+                for v in variables
+            )
+            or len(set(variables)) != len(variables)
+        ):
+            return _reject("invalid rational-function field variables")
+        expected_payload = {
+            "method": "CROSS_MULTIPLY_SPARSE_POLYNOMIALS",
+            "variables": variables,
+            "left_uri": scope["artifact_uri"],
+            "right_uri": candidate["artifact_uri"],
+        }
+        if (
+            not isinstance(certificate, dict)
+            or certificate.get("certificate_type")
+            != "polynomial.rational_function.identity_replay"
+            or certificate.get("format_version") != "1"
+            or certificate.get("bindings") != request.get("expected_bindings")
+            or certificate.get("payload") != expected_payload
+        ):
+            return _reject("unexpected identity certificate or bindings")
+        left_num, left_den = _parse_function(scope["payload"], variables)
+        right_num, right_den = _parse_function(candidate["payload"], variables)
+        equal = _multiply(left_num, right_den) == _multiply(right_num, left_den)
+        return {
+            "accepted": True,
+            "conclusion": "TRUE" if equal else "FALSE",
+            "arithmetic": "EXACT_RATIONAL",
+            "method": "CHECKED_CERTIFICATE",
+            "coverage": "EXHAUSTIVE",
+            "detail": "both sparse cross products were compared exactly over QQ",
+            **(
+                {
+                    "relation_id": "polynomial.relation.rational-function-identity",
+                    "relationship_source_artifact_uris": [scope["artifact_uri"]],
+                    "relationship_target_artifact_uris": [candidate["artifact_uri"]],
+                }
+                if equal
+                else {}
+            ),
+        }
+    except (KeyError, TypeError, ValueError, ZeroDivisionError):
+        return _reject("malformed rational-function identity replay request")

--- a/src/jacobian_checkers/rational_functions.py
+++ b/src/jacobian_checkers/rational_functions.py
@@ -6,6 +6,8 @@ import re
 from fractions import Fraction
 from typing import Any
 
+from jacobian.canonical import format_canonical_integer, parse_canonical_integer
+
 _INTEGER = re.compile(r"^-?(?:0|[1-9][0-9]*)$")
 _VARIABLE = re.compile(r"^[A-Za-z][A-Za-z0-9_]{0,31}$")
 _MAX_DIMENSION = 4
@@ -39,8 +41,16 @@ def _parse_rational(value: object) -> Fraction:
         or _INTEGER.fullmatch(denominator) is None
     ):
         raise ValueError("rational integers are not canonical")
-    parsed = Fraction(int(numerator), int(denominator))
-    if str(parsed.numerator) != numerator or str(parsed.denominator) != denominator:
+    # Use the limit-independent canonical integer parser so coefficients up to
+    # the contract's 32,768-digit bound can be verified; Python's default
+    # 4,300-digit int() conversion limit would otherwise raise ValueError.
+    parsed = Fraction(
+        parse_canonical_integer(numerator), parse_canonical_integer(denominator)
+    )
+    if (
+        format_canonical_integer(parsed.numerator) != numerator
+        or format_canonical_integer(parsed.denominator) != denominator
+    ):
         raise ValueError("rational is not reduced and canonical")
     return parsed
 

--- a/tests/boundary/providers/sympy/runtime/test_polynomial_capabilities.py
+++ b/tests/boundary/providers/sympy/runtime/test_polynomial_capabilities.py
@@ -90,6 +90,108 @@ def _identity_input(
     }
 
 
+def _rational_function_identity_input(*, equal: bool = True) -> dict[str, Any]:
+    x = symbols("x")
+    return {
+        "variables": ["x"],
+        "left": {
+            "numerator": _poly_payload(Poly(x**2 - 1, x, domain="QQ")),
+            "denominator": _poly_payload(Poly(x - 1, x, domain="QQ")),
+        },
+        "right": {
+            "numerator": _poly_payload(Poly(x + (1 if equal else 2), x, domain="QQ")),
+            "denominator": _poly_payload(Poly(1, x, domain="QQ")),
+        },
+    }
+
+
+def test_rational_function_identity_cross_multiplies_exactly(
+    authorized_complete_runtime,
+) -> None:
+    runtime = authorized_complete_runtime
+    result = runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="polynomial.rational_function.identity.verify",
+            mode=CapabilityMode.VERIFY,
+            input=_rational_function_identity_input(),
+        )
+    )
+
+    assert result.output["identical"] is True
+    assert result.output["conclusion"] == Conclusion.TRUE.value
+    assert result.output["equality_semantics"] == (
+        "QQ_FRACTION_FIELD_CROSS_MULTIPLICATION"
+    )
+    assert result.assurance.level is CapabilityAssuranceLevel.VERIFIED
+    assert result.completeness.status is CapabilityCompletenessStatus.COMPLETE
+    assert len(result.relationships) == 1
+
+    semantics_uri = (
+        runtime.portfolio.polynomial.rational_function_identity_semantics_uri
+    )
+    semantics = runtime.core.store.get(semantics_uri)
+    assert semantics.payload["definition"]["pointwise_definedness"] == "outside scope"
+    for output_key in ("left_uri", "right_uri", "claim_uri", "certificate_uri"):
+        artifact = runtime.core.store.get(result.output[output_key])
+        assert artifact.manifest.semantics_uri == semantics_uri
+
+
+def test_rational_function_identity_reports_exact_difference(
+    authorized_complete_runtime,
+) -> None:
+    result = authorized_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="polynomial.rational_function.identity.verify",
+            mode=CapabilityMode.VERIFY,
+            input=_rational_function_identity_input(equal=False),
+        )
+    )
+
+    assert result.output["identical"] is False
+    assert result.output["conclusion"] == Conclusion.FALSE.value
+    assert result.assurance.level is CapabilityAssuranceLevel.VERIFIED
+    assert result.relationships == ()
+
+
+def test_rational_function_identity_rejects_zero_denominator(
+    authorized_complete_runtime,
+) -> None:
+    request = _rational_function_identity_input()
+    request["left"]["denominator"] = {"terms": []}
+    result = authorized_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="polynomial.rational_function.identity.verify",
+            mode=CapabilityMode.VERIFY,
+            input=request,
+        )
+    )
+
+    assert result.execution.status.value == "ERROR"
+    assert result.diagnostics[0].code == "INVALID_RATIONAL_FUNCTION_IDENTITY_REQUEST"
+
+
+def test_rational_function_identity_preserves_checker_rejection_as_unknown(
+    authorized_complete_runtime,
+) -> None:
+    runtime = authorized_complete_runtime
+    checker_id = runtime.portfolio.polynomial.rational_function_identity_checker_id
+    assert checker_id is not None
+    runtime.core.checkers.revoke(checker_id, reason="exercise fail-closed projection")
+    result = runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="polynomial.rational_function.identity.verify",
+            mode=CapabilityMode.VERIFY,
+            input=_rational_function_identity_input(),
+        )
+    )
+
+    assert result.output["identical"] is None
+    assert result.output["conclusion"] == Conclusion.UNKNOWN.value
+    assert result.output["verification_record_uri"] is None
+    assert result.assurance.level is CapabilityAssuranceLevel.HEURISTIC
+    assert result.completeness.status is CapabilityCompletenessStatus.UNKNOWN
+
+
 def test_polynomial_identity_descriptor_example_is_directly_invocable(
     authorized_complete_runtime,
 ) -> None:

--- a/tests/component/checkers/test_rational_function_checker.py
+++ b/tests/component/checkers/test_rational_function_checker.py
@@ -68,9 +68,7 @@ def _request(*, equal: bool = True) -> dict[str, Any]:
         numerator=_polynomial([(1, 1, 2), (-1, 1, 0)]),
         denominator=_polynomial([(1, 1, 1), (-1, 1, 0)]),
     )
-    right_numerator = _polynomial(
-        [(1, 1, 1), (1 if equal else 2, 1, 0)]
-    )
+    right_numerator = _polynomial([(1, 1, 1), (1 if equal else 2, 1, 0)])
     right_payload = _function(
         variables,
         numerator=right_numerator,

--- a/tests/component/checkers/test_rational_function_checker.py
+++ b/tests/component/checkers/test_rational_function_checker.py
@@ -397,6 +397,77 @@ def test_checker_rejects_cross_product_overflow() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Thread PRRT_kwDOThEfjc6VuwhT: coefficients beyond Python's 4,300-digit
+# int() conversion limit must still be verifiable up to the contract's
+# 32,768-digit bound.
+# ---------------------------------------------------------------------------
+
+
+def test_checker_accepts_identity_with_large_canonical_coefficients() -> None:
+    """A coefficient with more than 4,300 digits must not trigger
+    ValueError from int(); the limit-independent canonical parser must
+    handle it and the identity must be verified as TRUE.
+    """
+    large_digit_count = 5_000
+    large_numerator = "1" + "0" * (large_digit_count - 1)
+    request = _request(equal=True)
+    # Make both sides identical: same numerator and denominator with the
+    # large coefficient so the cross-multiplication identity holds.
+    identical_function = _function(
+        ["x"],
+        numerator=_polynomial([(1, 1, 2), (-1, 1, 0)]),
+        denominator=_polynomial([(1, 1, 1), (-1, 1, 0)]),
+    )
+    identical_function["numerator"]["terms"][0]["coefficient"] = {
+        "num": large_numerator,
+        "den": "1",
+    }
+    request["scope"]["payload"] = copy.deepcopy(identical_function)
+    request["candidate"]["payload"] = copy.deepcopy(identical_function)
+    _refresh_payload_digest(request["scope"])
+    _refresh_payload_digest(request["candidate"])
+
+    decision = check_rational_function_identity(request)
+
+    assert decision["accepted"] is True
+    assert decision["conclusion"] == "TRUE"
+
+
+def test_checker_detects_difference_with_large_canonical_coefficients() -> None:
+    """Large coefficients that differ must be detected as FALSE, not
+    rejected as UNKNOWN due to int() conversion failure.
+    """
+    large_digit_count = 5_000
+    left_numerator = "1" + "0" * (large_digit_count - 1)
+    right_numerator = "2" + "0" * (large_digit_count - 1)
+    request = _request(equal=True)
+    base_function = _function(
+        ["x"],
+        numerator=_polynomial([(1, 1, 2), (-1, 1, 0)]),
+        denominator=_polynomial([(1, 1, 1), (-1, 1, 0)]),
+    )
+    left_function = copy.deepcopy(base_function)
+    right_function = copy.deepcopy(base_function)
+    left_function["numerator"]["terms"][0]["coefficient"] = {
+        "num": left_numerator,
+        "den": "1",
+    }
+    right_function["numerator"]["terms"][0]["coefficient"] = {
+        "num": right_numerator,
+        "den": "1",
+    }
+    request["scope"]["payload"] = left_function
+    request["candidate"]["payload"] = right_function
+    _refresh_payload_digest(request["scope"])
+    _refresh_payload_digest(request["candidate"])
+
+    decision = check_rational_function_identity(request)
+
+    assert decision["accepted"] is True
+    assert decision["conclusion"] == "FALSE"
+
+
+# ---------------------------------------------------------------------------
 # Fail-closed: supporting-artifact and structural mutations
 # ---------------------------------------------------------------------------
 

--- a/tests/component/checkers/test_rational_function_checker.py
+++ b/tests/component/checkers/test_rational_function_checker.py
@@ -1,0 +1,437 @@
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+import pytest
+from tests.support.rationals import rational_payload as _rational
+from tests.unit.contracts.artifacts import artifact_uri as _uri
+from tests.unit.contracts.artifacts import json_digest as _digest
+
+from jacobian_checkers.rational_functions import check_rational_function_identity
+
+
+def _artifact(
+    *,
+    uri_character: str,
+    object_character: str,
+    schema_character: str,
+    semantics_uri: str,
+    payload: dict[str, Any],
+    parents: list[str],
+) -> dict[str, Any]:
+    return {
+        "artifact_uri": _uri(uri_character),
+        "object_digest": "sha256:" + object_character * 64,
+        "payload_digest": _digest(payload),
+        "schema_uri": _uri(schema_character),
+        "semantics_uri": semantics_uri,
+        "parents": parents,
+        "payload": payload,
+    }
+
+
+def _polynomial(terms: list[tuple[int, int, int]]) -> dict[str, Any]:
+    """Build a sparse polynomial from (num, den, exponent) tuples."""
+    return {
+        "terms": [
+            {
+                "coefficient": _rational(num, den),
+                "exponents": [exponent],
+            }
+            for num, den, exponent in terms
+        ]
+    }
+
+
+def _function(
+    variables: list[str],
+    numerator: dict[str, Any],
+    denominator: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "rational_function_schema_version": "1",
+        "domain": "QQ_FRACTION_FIELD",
+        "variables": variables,
+        "numerator": numerator,
+        "denominator": denominator,
+    }
+
+
+def _request(*, equal: bool = True) -> dict[str, Any]:
+    semantics_uri = _uri("e")
+    left_uri = _uri("a")
+    right_uri = _uri("c")
+    variables = ["x"]
+    left_payload = _function(
+        variables,
+        numerator=_polynomial([(1, 1, 2), (-1, 1, 0)]),
+        denominator=_polynomial([(1, 1, 1), (-1, 1, 0)]),
+    )
+    right_numerator = _polynomial(
+        [(1, 1, 1), (1 if equal else 2, 1, 0)]
+    )
+    right_payload = _function(
+        variables,
+        numerator=right_numerator,
+        denominator=_polynomial([(1, 1, 0)]),
+    )
+    claim = _artifact(
+        uri_character="a",
+        object_character="1",
+        schema_character="b",
+        semantics_uri=semantics_uri,
+        payload={
+            "claim_schema_version": "1",
+            "predicate": "RATIONAL_FUNCTION_IDENTITY",
+            "domain": "QQ_FRACTION_FIELD",
+            "variables": variables,
+            "left_uri": left_uri,
+            "right_uri": right_uri,
+        },
+        parents=[],
+    )
+    scope = _artifact(
+        uri_character="a",
+        object_character="2",
+        schema_character="b",
+        semantics_uri=semantics_uri,
+        payload=left_payload,
+        parents=[],
+    )
+    candidate = _artifact(
+        uri_character="c",
+        object_character="3",
+        schema_character="d",
+        semantics_uri=semantics_uri,
+        payload=right_payload,
+        parents=[left_uri],
+    )
+    bindings = {
+        "claim_digest": claim["object_digest"],
+        "semantics_digest": "sha256:" + "5" * 64,
+        "candidate_digest": candidate["object_digest"],
+        "scope_digest": scope["object_digest"],
+        "encoding_digest": None,
+    }
+    certificate = _artifact(
+        uri_character="f",
+        object_character="4",
+        schema_character="5",
+        semantics_uri=semantics_uri,
+        payload={
+            "certificate_type": "polynomial.rational_function.identity_replay",
+            "format_version": "1",
+            "bindings": bindings,
+            "payload": {
+                "method": "CROSS_MULTIPLY_SPARSE_POLYNOMIALS",
+                "variables": variables,
+                "left_uri": left_uri,
+                "right_uri": right_uri,
+            },
+        },
+        parents=[left_uri, right_uri],
+    )
+    return {
+        "request_version": "1",
+        "claim": claim,
+        "candidate": candidate,
+        "scope": scope,
+        "certificate": certificate,
+        "expected_bindings": bindings,
+        "supporting_artifacts": [],
+    }
+
+
+def _refresh_payload_digest(artifact: dict[str, Any]) -> None:
+    artifact["payload_digest"] = _digest(artifact["payload"])
+
+
+# ---------------------------------------------------------------------------
+# Accepted equality and inequality
+# ---------------------------------------------------------------------------
+
+
+def test_checker_accepts_exact_rational_function_identity() -> None:
+    decision = check_rational_function_identity(_request(equal=True))
+
+    assert decision["accepted"] is True
+    assert decision["conclusion"] == "TRUE"
+    assert decision["arithmetic"] == "EXACT_RATIONAL"
+    assert decision["method"] == "CHECKED_CERTIFICATE"
+    assert decision["coverage"] == "EXHAUSTIVE"
+    assert decision["relation_id"] == "polynomial.relation.rational-function-identity"
+
+
+def test_checker_reports_exact_difference_as_false() -> None:
+    decision = check_rational_function_identity(_request(equal=False))
+
+    assert decision["accepted"] is True
+    assert decision["conclusion"] == "FALSE"
+    assert "relation_id" not in decision
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed: malformed or mismatched bindings
+# ---------------------------------------------------------------------------
+
+
+def test_checker_rejects_mismatched_left_uri_binding() -> None:
+    request = _request()
+    request["claim"]["payload"]["left_uri"] = _uri("9")
+    _refresh_payload_digest(request["claim"])
+
+    decision = check_rational_function_identity(request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+def test_checker_rejects_mismatched_right_uri_binding() -> None:
+    request = _request()
+    request["claim"]["payload"]["right_uri"] = _uri("9")
+    _refresh_payload_digest(request["claim"])
+
+    decision = check_rational_function_identity(request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+def test_checker_rejects_certificate_bindings_mismatch() -> None:
+    request = _request()
+    request["certificate"]["payload"]["bindings"] = {
+        **request["expected_bindings"],
+        "claim_digest": "sha256:" + "9" * 64,
+    }
+    _refresh_payload_digest(request["certificate"])
+
+    decision = check_rational_function_identity(request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+def test_checker_rejects_wrong_certificate_type() -> None:
+    request = _request()
+    request["certificate"]["payload"]["certificate_type"] = "forged"
+    _refresh_payload_digest(request["certificate"])
+
+    decision = check_rational_function_identity(request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+def test_checker_rejects_wrong_request_version() -> None:
+    request = _request()
+    request["request_version"] = "2"
+
+    decision = check_rational_function_identity(request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+def test_checker_rejects_supporting_artifacts() -> None:
+    request = _request()
+    request["supporting_artifacts"] = [{"artifact_uri": _uri("z")}]
+
+    decision = check_rational_function_identity(request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+def test_checker_rejects_duplicate_variables() -> None:
+    request = _request()
+    request["claim"]["payload"]["variables"] = ["x", "x"]
+    _refresh_payload_digest(request["claim"])
+
+    decision = check_rational_function_identity(request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed: malformed payload
+# ---------------------------------------------------------------------------
+
+
+def test_checker_rejects_rational_function_missing_schema_version() -> None:
+    request = _request()
+    del request["scope"]["payload"]["rational_function_schema_version"]
+    _refresh_payload_digest(request["scope"])
+
+    decision = check_rational_function_identity(request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+def test_checker_rejects_rational_function_wrong_domain() -> None:
+    request = _request()
+    request["scope"]["payload"]["domain"] = "QQ"
+    _refresh_payload_digest(request["scope"])
+
+    decision = check_rational_function_identity(request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+def test_checker_rejects_rational_function_mismatched_variables() -> None:
+    request = _request()
+    request["scope"]["payload"]["variables"] = ["y"]
+    _refresh_payload_digest(request["scope"])
+
+    decision = check_rational_function_identity(request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed: malformed rational
+# ---------------------------------------------------------------------------
+
+
+def test_checker_rejects_noncanonical_rational_numerator() -> None:
+    request = _request()
+    request["scope"]["payload"]["numerator"]["terms"][0]["coefficient"]["num"] = "01"
+    _refresh_payload_digest(request["scope"])
+
+    decision = check_rational_function_identity(request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+def test_checker_rejects_unreduced_rational() -> None:
+    request = _request()
+    request["scope"]["payload"]["numerator"]["terms"][0]["coefficient"] = {
+        "num": "2",
+        "den": "2",
+    }
+    _refresh_payload_digest(request["scope"])
+
+    decision = check_rational_function_identity(request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed: denominator
+# ---------------------------------------------------------------------------
+
+
+def test_checker_rejects_zero_denominator() -> None:
+    request = _request()
+    request["scope"]["payload"]["denominator"] = {"terms": []}
+    _refresh_payload_digest(request["scope"])
+
+    decision = check_rational_function_identity(request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+def test_checker_rejects_denominator_with_zero_coefficient_term() -> None:
+    request = _request()
+    request["scope"]["payload"]["denominator"]["terms"][0]["coefficient"] = {
+        "num": "0",
+        "den": "1",
+    }
+    _refresh_payload_digest(request["scope"])
+
+    decision = check_rational_function_identity(request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+def test_checker_rejects_non_canonical_term_order() -> None:
+    request = _request()
+    terms = request["scope"]["payload"]["numerator"]["terms"]
+    terms[0], terms[1] = terms[1], terms[0]
+    _refresh_payload_digest(request["scope"])
+
+    decision = check_rational_function_identity(request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed: overflow
+# ---------------------------------------------------------------------------
+
+
+def _dense_polynomial(term_count: int) -> dict[str, Any]:
+    """Build a univariate polynomial with term_count terms in descending order."""
+    return {
+        "terms": [
+            {
+                "coefficient": _rational(1, 1),
+                "exponents": [term_count - 1 - index],
+            }
+            for index in range(term_count)
+        ]
+    }
+
+
+def test_checker_rejects_cross_product_overflow() -> None:
+    request = _request()
+    dense = _dense_polynomial(65)
+    request["scope"]["payload"]["numerator"] = dense
+    request["candidate"]["payload"]["denominator"] = dense
+    _refresh_payload_digest(request["scope"])
+    _refresh_payload_digest(request["candidate"])
+
+    decision = check_rational_function_identity(request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed: supporting-artifact and structural mutations
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda request: request.update(request_version="0"),
+        lambda request: request["claim"].pop("payload"),
+        lambda request: request["certificate"].pop("payload"),
+        lambda request: request["scope"].pop("payload"),
+        lambda request: request["candidate"].pop("payload"),
+        lambda request: request["claim"]["payload"].update(extra=True),
+        lambda request: request["certificate"]["payload"]["payload"].update(
+            method="DIRECT_SPARSE_REPLAY"
+        ),
+    ],
+    ids=(
+        "wrong_version",
+        "missing_claim_payload",
+        "missing_certificate_payload",
+        "missing_scope_payload",
+        "missing_candidate_payload",
+        "extra_claim_field",
+        "wrong_replay_method",
+    ),
+)
+def test_checker_rejects_malformed_or_rebound_payloads(mutation: Any) -> None:
+    request = copy.deepcopy(_request())
+    mutation(request)
+    for key in ("claim", "candidate", "scope", "certificate"):
+        if isinstance(request.get(key), dict) and "payload" in request[key]:
+            _refresh_payload_digest(request[key])
+
+    decision = check_rational_function_identity(request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"

--- a/tests/unit/contracts/test_polynomial_contracts.py
+++ b/tests/unit/contracts/test_polynomial_contracts.py
@@ -16,7 +16,11 @@ from jacobian.contracts.polynomials import (
     PolynomialEvaluationRequest,
     PolynomialJacobianRequest,
     PolynomialMapEvaluation,
+    RationalFunctionArtifact,
+    RationalFunctionIdentityRequest,
     RationalPolynomialMap,
+    SparseRationalFunction,
+    SparseRationalPolynomial,
 )
 
 
@@ -206,4 +210,82 @@ def test_system_search_rejects_exact_grid_over_limit() -> None:
                 "max_abs_numerator": 8,
                 "max_denominator": 8,
             }
+        )
+
+
+def _dense_sparse_polynomial(term_count: int) -> SparseRationalPolynomial:
+    """Build a univariate polynomial with term_count terms in descending order."""
+    return SparseRationalPolynomial(
+        terms=tuple(
+            {
+                "coefficient": _rational(1),
+                "exponents": [term_count - 1 - index],
+            }
+            for index in range(term_count)
+        )
+    )
+
+
+def test_rational_function_artifact_accepts_dense_self_product_fraction() -> None:
+    """Thread PRRT_kwDOThEfjc6VuwhR: a single fraction with 65 numerator terms
+    and 65 denominator terms has a 4,225-pair self-product, but the artifact
+    must not apply the two-function cross-product bound to itself.
+    """
+    dense = _dense_sparse_polynomial(65)
+    artifact = RationalFunctionArtifact(
+        variables=("x",),
+        numerator=dense,
+        denominator=dense,
+    )
+    assert artifact.numerator is dense
+    assert artifact.denominator is dense
+
+
+def test_rational_function_identity_request_still_enforces_cross_product_bound() -> None:
+    """The identity-request cross-product bound must still reject a pair of
+    fractions whose cross product exceeds 4096 term pairs.
+    """
+    dense = _dense_sparse_polynomial(65)
+    with pytest.raises(ValidationError, match="cross product exceeds 4096"):
+        RationalFunctionIdentityRequest(
+            variables=("x",),
+            left=SparseRationalFunction(numerator=dense, denominator=dense),
+            right=SparseRationalFunction(numerator=dense, denominator=dense),
+        )
+
+
+def test_rational_function_artifact_rejects_duplicate_variables() -> None:
+    with pytest.raises(ValidationError, match="variables must be unique"):
+        RationalFunctionArtifact(
+            variables=("x", "x"),
+            numerator=SparseRationalPolynomial(
+                terms=({"coefficient": _rational(1), "exponents": [1, 0]},)
+            ),
+            denominator=SparseRationalPolynomial(
+                terms=({"coefficient": _rational(1), "exponents": [0, 0]},)
+            ),
+        )
+
+
+def test_rational_function_artifact_rejects_zero_denominator() -> None:
+    with pytest.raises(ValidationError, match="denominator must be nonzero"):
+        RationalFunctionArtifact(
+            variables=("x",),
+            numerator=SparseRationalPolynomial(
+                terms=({"coefficient": _rational(1), "exponents": [0]},)
+            ),
+            denominator=SparseRationalPolynomial(terms=()),
+        )
+
+
+def test_rational_function_artifact_rejects_exponent_dimension_mismatch() -> None:
+    with pytest.raises(ValidationError, match="variable order"):
+        RationalFunctionArtifact(
+            variables=("x", "y"),
+            numerator=SparseRationalPolynomial(
+                terms=({"coefficient": _rational(1), "exponents": [1, 0]},)
+            ),
+            denominator=SparseRationalPolynomial(
+                terms=({"coefficient": _rational(1), "exponents": [0]},)
+            ),
         )

--- a/tests/unit/contracts/test_polynomial_contracts.py
+++ b/tests/unit/contracts/test_polynomial_contracts.py
@@ -241,7 +241,9 @@ def test_rational_function_artifact_accepts_dense_self_product_fraction() -> Non
     assert artifact.denominator is dense
 
 
-def test_rational_function_identity_request_still_enforces_cross_product_bound() -> None:
+def test_rational_function_identity_request_still_enforces_cross_product_bound() -> (
+    None
+):
     """The identity-request cross-product bound must still reject a pair of
     fractions whose cross product exceeds 4096 term pairs.
     """


### PR DESCRIPTION
## What changed

Adds `polynomial.rational_function.identity.verify`, a bounded exact verifier for equality in a declared sparse rational-function field over `QQ`.

The capability:
- preserves the submitted numerators and denominators as typed artifacts;
- binds the left and right expressions, claim, semantics, and certificate through the existing artifact system;
- uses an independent standard-library checker to compare the two polynomial cross products exactly;
- reports `TRUE`, `FALSE`, or fail-closed `UNKNOWN`; and
- explicitly excludes pointwise denominator-definedness and surrounding theorem semantics.

## Benchmark evidence

Two independent benchmark implementations exposed the same missing primitive:

- PR #232, `euler-line-symbolic-certificate` (symbolic geometry), implements multivariate rational-function parsing and arithmetic inside its verifier to validate a denominator-cleared identity.
- PR #312, `gaussian-moment-generality-audit` (probability), independently implements a univariate rational-function field and equality check inside its verifier.

These are separate benchmark families and implementations, satisfying the recurrence gate.

## Why existing infrastructure was insufficient

Jacobian already has exact sparse polynomial identity replay and exact rational scalar arithmetic. It did not have a reusable artifact/checker contract for equality between fractions of sparse polynomials. Benchmarks therefore had to recreate rational-function parsing, denominator validation, cross multiplication, and equality logic locally.

No equivalent capability was found in the merged repository, reusable benchmark support, historical capability PRs, or open PRs #309, #311, #312, and #313.

## Why this belongs in Jacobian

Exact fraction-field identity is an architectural mathematical primitive, not a benchmark workflow wrapper. It composes with existing polynomial artifacts and checker authorization while keeping a narrow, honest semantic boundary. Future symbolic-geometry, probability-moment, generating-function, algebraic-transformation, and theorem-certificate benchmark families can reuse the same contract.

Gap score: **93/100**
- Reusability: 24/25
- Missingness: 24/25
- Expected adoption: 18/20
- Architectural value: 19/20
- Maintenance efficiency: 8/10

## Validation

- 22 focused polynomial runtime tests passed.
- Repository-wide Ruff formatting/lint passed.
- Targeted mypy checks for changed source files passed.
- Source distribution and wheel build passed.
- Component suite reached 548 passing / 3 skipped before one unrelated existing SMT checker test failed on macOS.
- Global mypy remains blocked by the existing macOS `resource.prlimit` error.
- Documentation link checking could not run because `npx` is unavailable in this environment.
