### PR TITLE
fix(mcp): harden runtime lifecycle and release deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: Release
 
 on:
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       tag:
@@ -13,6 +15,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
+  actions: read
   contents: read
 
 jobs:
@@ -20,18 +23,20 @@ jobs:
     name: Build release artifacts
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    outputs:
+      release_sha: ${{ steps.release.outputs.sha }}
     steps:
       - name: Resolve release tag
         id: release
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ inputs.tag }}
+          RELEASE_TAG: ${{ inputs.tag || github.event.release.tag_name }}
         run: |
           test -n "$RELEASE_TAG"
           echo "sha=$(gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" --jq .sha)" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ inputs.tag }}
+          ref: ${{ steps.release.outputs.sha }}
           persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -51,6 +56,14 @@ jobs:
         env:
           RELEASE_SHA: ${{ steps.release.outputs.sha }}
         run: test "$(git rev-parse HEAD)" = "$RELEASE_SHA"
+      - name: Require successful CI for release commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ steps.release.outputs.sha }}
+        run: |
+          test "$(gh api \
+            "repos/$GITHUB_REPOSITORY/actions/workflows/ci.yml/runs?head_sha=$RELEASE_SHA&status=success&per_page=100" \
+            --jq '[.workflow_runs[] | select(.head_sha == env.RELEASE_SHA and .conclusion == "success")] | length')" -gt 0
       - name: Build Python distributions
         run: uv build --out-dir dist/python
       - name: Test and pack npm distribution
@@ -86,7 +99,7 @@ jobs:
 
   publish-npm:
     name: Publish to npm
-    needs: publish-pypi
+    needs: [build, publish-pypi]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: npm
@@ -96,7 +109,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ inputs.tag }}
+          ref: ${{ needs.build.outputs.release_sha }}
           persist-credentials: false
       - id: node
         name: Load npm Node version
@@ -178,7 +191,7 @@ jobs:
 
   publish-mcp:
     name: Publish to MCP Registry
-    needs: publish-npm
+    needs: [build, publish-npm]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -187,14 +200,35 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ inputs.tag }}
+          ref: ${{ needs.build.outputs.release_sha }}
           persist-credentials: false
+      - name: Verify immutable release commit
+        env:
+          RELEASE_SHA: ${{ needs.build.outputs.release_sha }}
+        run: test "$(git rev-parse HEAD)" = "$RELEASE_SHA"
       - name: Install MCP Registry publisher
         env:
           MCP_PUBLISHER_VERSION: v1.8.0
         run: |
-          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
-            | tar xz mcp-publisher
+          case "$(uname -m)" in
+            x86_64)
+              architecture=amd64
+              checksum=1370446bbe74d562608e8005a6ccce02d146a661fbd78674e11cc70b9618d6cf
+              ;;
+            aarch64|arm64)
+              architecture=arm64
+              checksum=c978982c60e1b4903a976de090f04dc4fac4a320daa50704fcad2dbc93433d62
+              ;;
+            *)
+              echo "unsupported MCP Publisher architecture: $(uname -m)" >&2
+              exit 1
+              ;;
+          esac
+          archive="mcp-publisher_linux_${architecture}.tar.gz"
+          curl -fsSLo "$archive" \
+            "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/${archive}"
+          echo "$checksum  $archive" | sha256sum --check --strict
+          tar xzf "$archive" mcp-publisher
           chmod +x mcp-publisher
       - name: Validate server metadata
         run: ./mcp-publisher validate

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ coverage.json
 coverage.xml
 .hypothesis/
 .jacobian/
+.diagnostics/
 .mypy_cache/
 .pytest_cache/
 .ruff_cache/

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -10,6 +10,7 @@ set -Eeuo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+source "${SCRIPT_DIR}/lib/service_state.sh"
 
 MODE="local"
 DOMAIN=""
@@ -34,6 +35,10 @@ TAILSCALE_STATUS=""
 RENDER_ROOT=""
 RELEASE_BUILD_DIR=""
 RELEASE_WAS_BUILT=0
+ROLLBACK_ROOT=""
+ROLLBACK_ARMED=0
+DEPLOYMENT_ACCEPTED=0
+PREVIOUS_RELEASE=""
 
 cleanup() {
     if [[ -n "${RELEASE_BUILD_DIR}" && -d "${RELEASE_BUILD_DIR}" ]]; then
@@ -44,6 +49,9 @@ cleanup() {
     fi
     if [[ -n "${TAILSCALE_STATUS}" && -f "${TAILSCALE_STATUS}" ]]; then
         rm -f "${TAILSCALE_STATUS}"
+    fi
+    if [[ -n "${ROLLBACK_ROOT}" && -d "${ROLLBACK_ROOT}" ]]; then
+        rm -rf -- "${ROLLBACK_ROOT}"
     fi
 }
 
@@ -80,19 +88,100 @@ Examples:
   sudo ./deploy/install.sh --mode tailscale
 
 The default is token authentication. On the first authenticated install, the
-script creates /etc/jacobian-mcp/tokens.json and prints the generated token once.
-Subsequent runs reuse that secret unless --auth-tokens-file is supplied.
+script creates /etc/jacobian-mcp/tokens.json with mode 0600. It prints only that
+path; retrieve it explicitly with privileged access or import it into a secret
+manager. Subsequent runs reuse it unless --auth-tokens-file is supplied.
 EOF
 }
 
 die() {
     printf 'error: %s\n' "$*" >&2
+    if ((ROLLBACK_ARMED)) && ((!DEPLOYMENT_ACCEPTED)); then
+        rollback_deployment 1 || true
+    fi
     exit 1
 }
 
 log() {
     printf '==> %s\n' "$*"
 }
+
+snapshot_file() {
+    local name="$1"
+    local path="$2"
+    if [[ -e "${path}" || -L "${path}" ]]; then
+        cp -a -- "${path}" "${ROLLBACK_ROOT}/${name}"
+        : >"${ROLLBACK_ROOT}/${name}.present"
+    else
+        : >"${ROLLBACK_ROOT}/${name}.absent"
+    fi
+}
+
+restore_file() {
+    local name="$1"
+    local path="$2"
+    if [[ -f "${ROLLBACK_ROOT}/${name}.present" ]]; then
+        install -d -m 0755 "$(dirname -- "${path}")"
+        rm -rf -- "${path}"
+        cp -a -- "${ROLLBACK_ROOT}/${name}" "${path}"
+    else
+        rm -rf -- "${path}"
+    fi
+}
+
+rollback_deployment() {
+    local original_status="$1"
+    local rollback_failed=0
+    trap - ERR
+    set +e
+    printf 'error: deployment failed; restoring the previous activation\n' >&2
+    restore_file token "${TOKEN_DESTINATION}" || rollback_failed=1
+    restore_file mcp-service "${SYSTEMD_ROOT}/jacobian-mcp.service" \
+        || rollback_failed=1
+    restore_file anonymous \
+        "${SYSTEMD_ROOT}/jacobian-mcp.service.d/anonymous.conf" \
+        || rollback_failed=1
+    restore_file caddy-config "${CADDY_CONFIG_ROOT}/Caddyfile" \
+        || rollback_failed=1
+    restore_file caddy-service "${SYSTEMD_ROOT}/jacobian-caddy.service" \
+        || rollback_failed=1
+    restore_file funnel-service "${SYSTEMD_ROOT}/jacobian-funnel.service" \
+        || rollback_failed=1
+    if [[ -n "${PREVIOUS_RELEASE}" ]]; then
+        ln -sfn "${PREVIOUS_RELEASE}" "${CURRENT_LINK}.rollback" \
+            && mv -Tf "${CURRENT_LINK}.rollback" "${CURRENT_LINK}" \
+            || rollback_failed=1
+    else
+        rm -f -- "${CURRENT_LINK}" || rollback_failed=1
+    fi
+    "${SYSTEMCTL_BIN}" daemon-reload || rollback_failed=1
+    restore_systemd_service_state "${SYSTEMCTL_BIN}" "${ROLLBACK_ROOT}" \
+        jacobian-mcp.service || rollback_failed=1
+    restore_systemd_service_state "${SYSTEMCTL_BIN}" "${ROLLBACK_ROOT}" \
+        jacobian-caddy.service || rollback_failed=1
+    restore_systemd_service_state "${SYSTEMCTL_BIN}" "${ROLLBACK_ROOT}" \
+        jacobian-funnel.service || rollback_failed=1
+    ROLLBACK_ARMED=0
+    if ((rollback_failed)); then
+        printf 'error: rollback encountered additional failures; inspect systemd and the preserved release %s\n' \
+            "${RELEASE_DIR}" >&2
+    else
+        printf 'error: previous deployment activation restored; failed release preserved at %s\n' \
+            "${RELEASE_DIR}" >&2
+    fi
+    set -e
+    return "${original_status}"
+}
+
+on_error() {
+    local status="$?"
+    if ((ROLLBACK_ARMED)) && ((!DEPLOYMENT_ACCEPTED)); then
+        rollback_deployment "${status}" || true
+    fi
+    exit "${status}"
+}
+
+trap on_error ERR
 
 find_executable() {
     local name="$1"
@@ -389,13 +478,29 @@ fi
 if [[ -e "${CURRENT_LINK}" && ! -L "${CURRENT_LINK}" ]]; then
     die "${CURRENT_LINK} exists and is not a symlink"
 fi
+ROLLBACK_ROOT="$(mktemp -d)"
+PREVIOUS_RELEASE="$(readlink "${CURRENT_LINK}" 2>/dev/null || true)"
+snapshot_file token "${TOKEN_DESTINATION}"
+snapshot_file mcp-service "${SYSTEMD_ROOT}/jacobian-mcp.service"
+snapshot_file anonymous "${SYSTEMD_ROOT}/jacobian-mcp.service.d/anonymous.conf"
+snapshot_file caddy-config "${CADDY_CONFIG_ROOT}/Caddyfile"
+snapshot_file caddy-service "${SYSTEMD_ROOT}/jacobian-caddy.service"
+snapshot_file funnel-service "${SYSTEMD_ROOT}/jacobian-funnel.service"
+snapshot_systemd_service_state "${SYSTEMCTL_BIN}" "${ROLLBACK_ROOT}" \
+    jacobian-mcp.service
+snapshot_systemd_service_state "${SYSTEMCTL_BIN}" "${ROLLBACK_ROOT}" \
+    jacobian-caddy.service
+snapshot_systemd_service_state "${SYSTEMCTL_BIN}" "${ROLLBACK_ROOT}" \
+    jacobian-funnel.service
+ROLLBACK_ARMED=1
+
 install -d -m 0755 "$(dirname -- "${CURRENT_LINK}")"
 ln -sfn "${RELEASE_DIR}" "${CURRENT_LINK}.new"
 mv -Tf "${CURRENT_LINK}.new" "${CURRENT_LINK}"
 
 log "installing authentication configuration"
 install -d -m 0700 "${CONFIG_ROOT}"
-GENERATED_TOKEN=""
+GENERATED_TOKEN_FILE=0
 if ((ALLOW_ANONYMOUS)); then
     install -d -m 0755 \
         "${SYSTEMD_ROOT}/jacobian-mcp.service.d"
@@ -418,15 +523,32 @@ if not any("jacobian:use" in grant.scopes for grant in grants):
 PY
         install -m 0600 "${AUTH_TOKENS_FILE}" "${TOKEN_DESTINATION}"
     elif [[ ! -f "${TOKEN_DESTINATION}" ]]; then
-        GENERATED_TOKEN="$("${RELEASE_DIR}/.venv/bin/python" - <<'PY'
+        "${RELEASE_DIR}/.venv/bin/python" - \
+            "${TOKEN_DESTINATION}" "${TENANT_ID}" <<'PY'
+import json
+import os
 import secrets
+import sys
 
-print(secrets.token_urlsafe(48))
+destination, tenant_id = sys.argv[1:]
+descriptor = os.open(destination, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+    json.dump(
+        {
+            "tokens": [
+                {
+                    "tenant_id": tenant_id,
+                    "token": secrets.token_urlsafe(48),
+                    "scopes": ["jacobian:use"],
+                }
+            ]
+        },
+        stream,
+        indent=2,
+    )
+    stream.write("\n")
 PY
-)"
-        umask 077
-        printf '{\n  "tokens": [\n    {\n      "tenant_id": "%s",\n      "token": "%s",\n      "scopes": ["jacobian:use"]\n    }\n  ]\n}\n' \
-            "${TENANT_ID}" "${GENERATED_TOKEN}" >"${TOKEN_DESTINATION}"
+        GENERATED_TOKEN_FILE=1
     fi
     "${RELEASE_DIR}/.venv/bin/python" - "${TOKEN_DESTINATION}" <<'PY'
 import sys
@@ -524,22 +646,13 @@ fi
 
 if ((!SKIP_SMOKE)); then
     log "running the read-only deployment smoke"
-    SMOKE_TOKEN=""
+    SMOKE_TOKEN_FILE=""
     if ((!ALLOW_ANONYMOUS)); then
-        SMOKE_TOKEN="$("${RELEASE_DIR}/.venv/bin/python" - \
-            "${TOKEN_DESTINATION}" <<'PY'
-import sys
-
-from jacobian.adapters.mcp.remote import load_static_token_file
-
-grants = load_static_token_file(sys.argv[1])
-print(next(grant.token for grant in grants if "jacobian:use" in grant.scopes))
-PY
-)"
+        SMOKE_TOKEN_FILE="${TOKEN_DESTINATION}"
     fi
     SMOKE_SUCCEEDED=0
     for attempt in {1..12}; do
-        if JACOBIAN_MCP_BEARER_TOKEN="${SMOKE_TOKEN}" \
+        if JACOBIAN_MCP_AUTH_TOKENS_FILE="${SMOKE_TOKEN_FILE}" \
             "${RELEASE_DIR}/.venv/bin/python" \
             "${RELEASE_DIR}/deploy/smoke_remote.py" \
             "${CONNECTOR_URL}" \
@@ -556,6 +669,9 @@ PY
         "deployment smoke failed; inspect jacobian-mcp and ingress journals"
 fi
 
+DEPLOYMENT_ACCEPTED=1
+ROLLBACK_ARMED=0
+
 cat <<EOF
 
 Jacobian MCP deployment is active.
@@ -564,10 +680,11 @@ Jacobian MCP deployment is active.
   connector: ${CONNECTOR_URL}
   auth file: $([[ "${ALLOW_ANONYMOUS}" == 1 ]] && printf 'anonymous mode' || printf '%s' "${TOKEN_DESTINATION}")
 EOF
-if [[ -n "${GENERATED_TOKEN}" ]]; then
+if ((GENERATED_TOKEN_FILE)); then
     cat <<EOF
 
-Generated bearer token (shown once; store it in your client secret manager):
-${GENERATED_TOKEN}
+A bearer token was generated in ${TOKEN_DESTINATION}.
+Retrieve it explicitly with privileged access or import that root-readable file
+into your secret manager; the installer never prints credential values.
 EOF
 fi

--- a/deploy/lib/service_state.sh
+++ b/deploy/lib/service_state.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+snapshot_systemd_service_state() {
+    local systemctl_bin="$1"
+    local snapshot_root="$2"
+    local unit="$3"
+    if "${systemctl_bin}" is-enabled --quiet "${unit}"; then
+        : >"${snapshot_root}/${unit}.enabled"
+    else
+        : >"${snapshot_root}/${unit}.disabled"
+    fi
+    if "${systemctl_bin}" is-active --quiet "${unit}"; then
+        : >"${snapshot_root}/${unit}.active"
+    else
+        : >"${snapshot_root}/${unit}.inactive"
+    fi
+}
+
+restore_systemd_service_state() {
+    local systemctl_bin="$1"
+    local snapshot_root="$2"
+    local unit="$3"
+    if [[ -f "${snapshot_root}/${unit}.enabled" ]]; then
+        "${systemctl_bin}" enable "${unit}" || return 1
+    else
+        "${systemctl_bin}" disable "${unit}" >/dev/null 2>&1 || true
+        if "${systemctl_bin}" is-enabled --quiet "${unit}"; then
+            return 1
+        fi
+    fi
+    if [[ -f "${snapshot_root}/${unit}.active" ]]; then
+        "${systemctl_bin}" restart "${unit}" || return 1
+    else
+        "${systemctl_bin}" stop "${unit}" >/dev/null 2>&1 || true
+        if "${systemctl_bin}" is-active --quiet "${unit}"; then
+            return 1
+        fi
+    fi
+}

--- a/deploy/smoke_remote.py
+++ b/deploy/smoke_remote.py
@@ -69,6 +69,17 @@ async def inspect(
     timeout_seconds: float,
 ) -> dict[str, Any]:
     token = os.environ.get("JACOBIAN_MCP_BEARER_TOKEN")
+    token_file = os.environ.get("JACOBIAN_MCP_AUTH_TOKENS_FILE")
+    if token is None and token_file:
+        from jacobian.adapters.mcp.remote import load_static_token_file
+
+        grants = load_static_token_file(token_file)
+        token = next(
+            (grant.token for grant in grants if "jacobian:use" in grant.scopes),
+            None,
+        )
+        if token is None:
+            raise RuntimeError("smoke token file has no jacobian:use grant")
     headers = {"Authorization": f"Bearer {token}"} if token else None
     failures: list[str] = []
     async with (

--- a/docs/how-to/deploy-remote-mcp.md
+++ b/docs/how-to/deploy-remote-mcp.md
@@ -49,12 +49,13 @@ procedure. For `domain`, point the domain's DNS at the host and allow inbound
 TCP 80 and 443 before deployment so Caddy can obtain and renew its certificate.
 
 Authentication is the default. The first authenticated run creates
-`/etc/jacobian-mcp/tokens.json`, prints its generated token once, and uses that
-token for the smoke. A subsequent run reuses the secret. Supply a reviewed
-multi-tenant file with `--auth-tokens-file PATH` instead. Anonymous operation
-requires `--allow-anonymous`; a public anonymous endpoint additionally requires
-`--confirm-public-anonymous`, because every reachable caller shares its
-operator-chosen tenant and state.
+`/etc/jacobian-mcp/tokens.json` with mode `0600` and uses that file for the
+smoke without printing the credential. Retrieve it explicitly with privileged
+access or import it into a secret manager. A subsequent run reuses the secret.
+Supply a reviewed multi-tenant file with `--auth-tokens-file PATH` instead.
+Anonymous operation requires `--allow-anonymous`; a public anonymous endpoint
+additionally requires `--confirm-public-anonymous`, because every reachable
+caller shares its operator-chosen tenant and state.
 
 Inspect a complete plan without root or host mutation:
 
@@ -105,6 +106,7 @@ uv run jacobian-mcp \
   --path /mcp \
   --state-dir /var/lib/jacobian \
   --max-tenant-runtimes 32 \
+  --tenant-idle-timeout-seconds 900 \
   --auth-tokens-file /run/secrets/jacobian-tokens.json \
   --public-base-url https://math-tools.example.org
 ```
@@ -113,9 +115,12 @@ Put a TLS-terminating reverse proxy in front of `127.0.0.1:8000`. The public
 URL must route `/mcp` without stripping the path. Each authenticated subject is
 mapped to a separate hashed directory below
 `/var/lib/jacobian/tenants/`. The server retains at most 32 tenant runtimes by
-default. Existing tenants remain available at the limit; new tenants receive a
-bounded admission error. Set `--max-tenant-runtimes` to match the instance's
-memory budget.
+default. At the limit, it evicts the least-recently-used inactive runtime; it
+never evicts a runtime with an active request, and returns a bounded admission
+error when every slot is active. Inactive runtimes expire after 900 seconds by
+default. Expiry is checked on the next tenant acquisition rather than by a
+background reaper. Set `--max-tenant-runtimes` and
+`--tenant-idle-timeout-seconds` to match the instance's memory budget.
 
 For a disposable local transport test only:
 
@@ -123,6 +128,7 @@ For a disposable local transport test only:
 uv run jacobian-mcp \
   --transport streamable-http \
   --max-tenant-runtimes 32 \
+  --tenant-idle-timeout-seconds 900 \
   --allow-anonymous \
   --anonymous-tenant-id local-smoke-2026-07
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,12 @@ dev = [
 [tool.hatch.build.targets.wheel]
 packages = ["src/jacobian", "src/jacobian_checkers"]
 
+[tool.hatch.build.targets.sdist]
+exclude = [
+    "/.diagnostics",
+    "/.diagnostics/**",
+]
+
 [tool.pytest.ini_options]
 addopts = "-ra --strict-config --strict-markers"
 testpaths = ["tests"]

--- a/src/jacobian/adapters/mcp/cli.py
+++ b/src/jacobian/adapters/mcp/cli.py
@@ -118,6 +118,15 @@ def _parser() -> argparse.ArgumentParser:
         default=32,
         help="maximum in-memory tenant runtimes for remote transports",
     )
+    parser.add_argument(
+        "--tenant-idle-timeout-seconds",
+        type=float,
+        default=900.0,
+        help=(
+            "inactive tenant runtime TTL in seconds; expiry is checked on the "
+            "next acquisition"
+        ),
+    )
     return parser
 
 
@@ -126,6 +135,10 @@ def main() -> None:
     args = parser.parse_args()
     if args.max_tenant_runtimes < 1:
         parser.error("--max-tenant-runtimes must be positive")
+    if args.tenant_idle_timeout_seconds <= 0:
+        parser.error("--tenant-idle-timeout-seconds must be positive")
+    if args.allow_anonymous and args.auth_tokens_file is not None:
+        parser.error("--allow-anonymous and --auth-tokens-file are mutually exclusive")
     if args.anonymous_tenant_id != "anonymous" and not args.allow_anonymous:
         parser.error("--anonymous-tenant-id requires --allow-anonymous")
     args.path = args.path if args.path.startswith("/") else f"/{args.path}"
@@ -195,6 +208,7 @@ def main() -> None:
         capability_adapter_entrypoints=tuple(args.capability_adapter),
         capability_policy=capability_policy,
         max_tenant_runtimes=args.max_tenant_runtimes,
+        tenant_idle_timeout_seconds=args.tenant_idle_timeout_seconds,
     )
     if args.transport == "streamable-http":
         server.run(

--- a/src/jacobian/adapters/mcp/context.py
+++ b/src/jacobian/adapters/mcp/context.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 import logging
 import os
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -80,10 +82,11 @@ def _start_lean_warmup(runtime: JacobianRuntime) -> None:
         runtime.portfolio.lean.start_mathlib_warmup()
 
 
+@contextmanager
 def _resource_runtime(
     runtime: JacobianRuntime | None,
     tenant_router: TenantRuntimeRouter | None,
-) -> JacobianRuntime:
+) -> Iterator[JacobianRuntime]:
     """Route resources through the same auth context as tools.
 
     MCP 2.0.0 does not inject ``Context`` into static resources, but its HTTP
@@ -95,13 +98,16 @@ def _resource_runtime(
 
         access_token = get_access_token()
         subject = access_token.subject if access_token is not None else None
-        return tenant_router.runtime_for(subject)
+        with tenant_router.lease_for(subject) as active_runtime:
+            _start_lean_warmup(active_runtime)
+            yield active_runtime
+        return
     if runtime is None:
         raise AgentRecoveryError(
             "Jacobian is unavailable for this resource request. Retry once; if it "
             "fails again, inspect the local Jacobian log."
         )
-    return runtime
+    yield runtime
 
 
 def _configured_root(state_dir: str | Path | None) -> Path:

--- a/src/jacobian/adapters/mcp/remote.py
+++ b/src/jacobian/adapters/mcp/remote.py
@@ -7,9 +7,11 @@ import hmac
 import json
 import re
 import threading
+import time
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from mcp.server.auth.provider import AccessToken
 
@@ -19,6 +21,7 @@ from jacobian.runtime.model import JacobianRuntime
 
 _TENANT_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 DEFAULT_MAX_TENANT_RUNTIMES = 32
+DEFAULT_TENANT_IDLE_TIMEOUT_SECONDS = 900.0
 
 
 class AuthenticationError(PermissionError):
@@ -27,6 +30,49 @@ class AuthenticationError(PermissionError):
 
 class TenantRuntimeLimitError(RuntimeError):
     """The server cannot admit another in-memory tenant runtime."""
+
+
+class TenantRuntimeRouterClosedError(RuntimeError):
+    """The tenant runtime owner is shutting down or closed."""
+
+
+@dataclass(slots=True)
+class _TenantRuntimeEntry:
+    runtime: JacobianRuntime
+    active_leases: int
+    last_used: float
+
+
+class TenantRuntimeLease:
+    """One caller-owned hold preventing eviction or shutdown of a runtime."""
+
+    def __init__(
+        self,
+        router: TenantRuntimeRouter,
+        tenant_key: str,
+        runtime: JacobianRuntime,
+    ) -> None:
+        self._router = router
+        self._tenant_key = tenant_key
+        self.runtime = runtime
+        self._released = False
+
+    def __enter__(self) -> JacobianRuntime:
+        return self.runtime
+
+    def __exit__(self, *_exc: object) -> None:
+        self.release()
+
+    def release(self) -> None:
+        if self._released:
+            return
+        self._released = True
+        self._router._release(self._tenant_key)
+
+
+type _AcquisitionPlan = (
+    TenantRuntimeLease | tuple[str, _TenantRuntimeEntry] | Literal["CREATE", "WAIT"]
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -88,9 +134,14 @@ class TenantRuntimeRouter:
         capability_adapter_entrypoints: tuple[str, ...] = (),
         capability_policy: CapabilityPolicy | None = None,
         max_tenant_runtimes: int = DEFAULT_MAX_TENANT_RUNTIMES,
+        idle_timeout_seconds: float = DEFAULT_TENANT_IDLE_TIMEOUT_SECONDS,
+        clock: Callable[[], float] = time.monotonic,
+        runtime_factory: Callable[..., JacobianRuntime] = create_runtime,
     ) -> None:
         if max_tenant_runtimes < 1:
             raise ValueError("max_tenant_runtimes must be positive")
+        if idle_timeout_seconds <= 0:
+            raise ValueError("idle_timeout_seconds must be positive")
         if not _TENANT_PATTERN.fullmatch(anonymous_tenant_id):
             raise ValueError(
                 "anonymous_tenant_id must start with a letter or digit, contain only "
@@ -103,10 +154,70 @@ class TenantRuntimeRouter:
         self.capability_adapter_entrypoints = capability_adapter_entrypoints
         self.capability_policy = capability_policy
         self.max_tenant_runtimes = max_tenant_runtimes
-        self._runtimes: dict[str, JacobianRuntime] = {}
-        self._lock = threading.Lock()
+        self.idle_timeout_seconds = idle_timeout_seconds
+        self._clock = clock
+        self._runtime_factory = runtime_factory
+        self._runtimes: dict[str, _TenantRuntimeEntry] = {}
+        self._creating: set[str] = set()
+        self._evictions_in_flight = 0
+        self._condition = threading.Condition()
+        self._closing = False
+        self._closed = False
+        self._shutdown_in_flight = False
 
     def runtime_for(self, subject: str | None) -> JacobianRuntime:
+        """Return a compatible unleased runtime for non-request local callers."""
+
+        lease = self.lease_for(subject)
+        try:
+            return lease.runtime
+        finally:
+            lease.release()
+
+    def lease_for(self, subject: str | None) -> TenantRuntimeLease:
+        """Acquire one tenant runtime, creating or evicting outside the lock."""
+
+        tenant_key = self._tenant_key(subject)
+        while True:
+            with self._condition:
+                if self._closing or self._closed:
+                    raise TenantRuntimeRouterClosedError(
+                        "tenant runtime router is closing"
+                    )
+                plan = self._plan_acquisition(tenant_key)
+                if isinstance(plan, TenantRuntimeLease):
+                    return plan
+                if plan == "WAIT":
+                    self._condition.wait()
+                    continue
+                if plan == "CREATE":
+                    break
+            self._close_evicted(plan)
+
+        try:
+            runtime = self._runtime_factory(
+                self.root / "tenants" / tenant_key,
+                checker_authority=self.checker_authority,
+                capability_adapter_entrypoints=self.capability_adapter_entrypoints,
+                capability_policy=self.capability_policy,
+            )
+        except BaseException:
+            with self._condition:
+                self._creating.discard(tenant_key)
+                self._condition.notify_all()
+            raise
+        with self._condition:
+            self._creating.discard(tenant_key)
+            entry = _TenantRuntimeEntry(
+                runtime=runtime,
+                active_leases=1,
+                last_used=self._clock(),
+            )
+            self._runtimes[tenant_key] = entry
+            self._condition.notify_all()
+        return TenantRuntimeLease(self, tenant_key, runtime)
+
+    def _tenant_key(self, subject: str | None) -> str:
         tenant = subject
         if tenant is None:
             if not self.allow_anonymous:
@@ -120,41 +231,107 @@ class TenantRuntimeRouter:
                 "The authenticated subject cannot be used for tenant isolation. "
                 "Check the server token configuration, then authenticate again."
             )
-        tenant_key = hashlib.sha256(tenant.encode("utf-8")).hexdigest()
-        with self._lock:
-            runtime = self._runtimes.get(tenant_key)
-            if runtime is None:
-                if len(self._runtimes) >= self.max_tenant_runtimes:
-                    raise TenantRuntimeLimitError(
-                        "This server has reached its in-memory tenant limit."
-                    )
-                runtime = create_runtime(
-                    self.root / "tenants" / tenant_key,
-                    checker_authority=self.checker_authority,
-                    capability_adapter_entrypoints=(
-                        self.capability_adapter_entrypoints
-                    ),
-                    capability_policy=self.capability_policy,
-                )
-                self._runtimes[tenant_key] = runtime
-            return runtime
+        return hashlib.sha256(tenant.encode("utf-8")).hexdigest()
+
+    def _plan_acquisition(self, tenant_key: str) -> _AcquisitionPlan:
+        now = self._clock()
+        entry = self._runtimes.get(tenant_key)
+        if entry is not None and not (
+            entry.active_leases == 0
+            and now - entry.last_used >= self.idle_timeout_seconds
+        ):
+            entry.active_leases += 1
+            entry.last_used = now
+            return TenantRuntimeLease(self, tenant_key, entry.runtime)
+        if entry is not None:
+            eviction = (tenant_key, self._runtimes.pop(tenant_key))
+            self._evictions_in_flight += 1
+            return eviction
+        if tenant_key in self._creating:
+            return "WAIT"
+        if (
+            len(self._runtimes) + len(self._creating) + self._evictions_in_flight
+            < self.max_tenant_runtimes
+        ):
+            self._creating.add(tenant_key)
+            return "CREATE"
+        inactive = tuple(
+            (key, candidate)
+            for key, candidate in self._runtimes.items()
+            if candidate.active_leases == 0
+        )
+        if not inactive:
+            raise TenantRuntimeLimitError(
+                "This server has reached its in-memory tenant limit."
+            )
+        eviction = min(inactive, key=lambda item: (item[1].last_used, item[0]))
+        del self._runtimes[eviction[0]]
+        self._evictions_in_flight += 1
+        return eviction
+
+    def _close_evicted(self, eviction: tuple[str, _TenantRuntimeEntry]) -> None:
+        tenant_key, entry = eviction
+        try:
+            entry.runtime.close()
+        except BaseException:
+            with self._condition:
+                self._evictions_in_flight -= 1
+                self._runtimes[tenant_key] = entry
+                self._condition.notify_all()
+            raise
+        with self._condition:
+            self._evictions_in_flight -= 1
+            self._condition.notify_all()
+
+    def _release(self, tenant_key: str) -> None:
+        with self._condition:
+            entry = self._runtimes.get(tenant_key)
+            if entry is None or entry.active_leases < 1:
+                raise RuntimeError("tenant runtime lease ownership was lost")
+            entry.active_leases -= 1
+            entry.last_used = self._clock()
+            self._condition.notify_all()
 
     def close(self) -> None:
         """Close every tenant runtime owned by this router."""
 
-        with self._lock:
-            runtimes = tuple(self._runtimes.values())
-            self._runtimes.clear()
+        with self._condition:
+            if self._closed:
+                return
+            while self._shutdown_in_flight:
+                self._condition.wait()
+                if self._closed:
+                    return
+            self._closing = True
+            while (
+                self._creating
+                or self._evictions_in_flight
+                or any(entry.active_leases for entry in self._runtimes.values())
+            ):
+                self._condition.wait()
+            self._shutdown_in_flight = True
+            runtimes = tuple(self._runtimes.items())
         failures: list[Exception] = []
-        for runtime in runtimes:
+        for tenant_key, entry in runtimes:
             try:
-                runtime.close()
+                entry.runtime.close()
             except Exception as exc:
                 failures.append(exc)
+            else:
+                with self._condition:
+                    self._runtimes.pop(tenant_key, None)
         if failures:
+            with self._condition:
+                self._shutdown_in_flight = False
+                self._condition.notify_all()
             raise ExceptionGroup(
                 "one or more tenant runtimes failed to close", failures
             )
+        with self._condition:
+            self._shutdown_in_flight = False
+            self._closed = True
+            self._closing = False
+            self._condition.notify_all()
 
 
 def load_static_token_file(path: str | Path) -> tuple[StaticTokenGrant, ...]:

--- a/src/jacobian/adapters/mcp/resources.py
+++ b/src/jacobian/adapters/mcp/resources.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 from typing import Annotated, Any
@@ -14,6 +13,7 @@ from jacobian.adapters.mcp.guidance import (
     discovery_prompt,
     evidence_check_prompt,
 )
+from jacobian.adapters.mcp.tooling import _run_blocking
 from jacobian.runtime.model import JacobianRuntime
 
 _LOGGER = logging.getLogger(__name__)
@@ -35,20 +35,20 @@ def _register_resources_and_prompts(
     async def artifact_resource(
         digest: str,
     ) -> str:
-        active_runtime = _resource_runtime(runtime, tenant_router)
-        artifact = await asyncio.to_thread(
-            active_runtime.core.store.get,
-            f"artifact://sha256/{digest}",
-        )
-        return json.dumps(
-            {
-                "artifact_uri": artifact.artifact_uri,
-                "manifest": artifact.manifest.model_dump(mode="json"),
-                "payload": artifact.payload,
-            },
-            ensure_ascii=False,
-            sort_keys=True,
-        )
+        with _resource_runtime(runtime, tenant_router) as active_runtime:
+            artifact = await _run_blocking(
+                active_runtime.core.store.get,
+                f"artifact://sha256/{digest}",
+            )
+            return json.dumps(
+                {
+                    "artifact_uri": artifact.artifact_uri,
+                    "manifest": artifact.manifest.model_dump(mode="json"),
+                    "payload": artifact.payload,
+                },
+                ensure_ascii=False,
+                sort_keys=True,
+            )
 
     @server.resource(  # type: ignore[untyped-decorator]
         "experiment://{experiment_id}",
@@ -59,16 +59,16 @@ def _register_resources_and_prompts(
     async def experiment_resource(
         experiment_id: str,
     ) -> str:
-        active_runtime = _resource_runtime(runtime, tenant_router)
-        snapshot = await asyncio.to_thread(
-            active_runtime.services.experiment_router.inspect,
-            f"experiment://{experiment_id}",
-        )
-        return json.dumps(
-            snapshot.model_dump(mode="json"),
-            ensure_ascii=False,
-            sort_keys=True,
-        )
+        with _resource_runtime(runtime, tenant_router) as active_runtime:
+            snapshot = await _run_blocking(
+                active_runtime.services.experiment_router.inspect,
+                f"experiment://{experiment_id}",
+            )
+            return json.dumps(
+                snapshot.model_dump(mode="json"),
+                ensure_ascii=False,
+                sort_keys=True,
+            )
 
     @server.resource(  # type: ignore[untyped-decorator]
         "experiment://{experiment_id}/accounting",
@@ -79,28 +79,28 @@ def _register_resources_and_prompts(
     async def experiment_accounting_resource(
         experiment_id: str,
     ) -> str:
-        active_runtime = _resource_runtime(runtime, tenant_router)
-        snapshot = await asyncio.to_thread(
-            active_runtime.services.experiment_router.inspect,
-            f"experiment://{experiment_id}",
-        )
-        coverage = getattr(snapshot, "coverage", None)
-        return json.dumps(
-            {
-                "experiment_uri": snapshot.experiment_uri,
-                "state": snapshot.state.value,
-                "stop_reason": (
-                    snapshot.stop_reason.value
-                    if snapshot.stop_reason is not None
-                    else None
-                ),
-                "coverage": coverage.value if coverage is not None else None,
-                "verification": snapshot.verification.value,
-                "accounting": snapshot.accounting.model_dump(mode="json"),
-            },
-            ensure_ascii=False,
-            sort_keys=True,
-        )
+        with _resource_runtime(runtime, tenant_router) as active_runtime:
+            snapshot = await _run_blocking(
+                active_runtime.services.experiment_router.inspect,
+                f"experiment://{experiment_id}",
+            )
+            coverage = getattr(snapshot, "coverage", None)
+            return json.dumps(
+                {
+                    "experiment_uri": snapshot.experiment_uri,
+                    "state": snapshot.state.value,
+                    "stop_reason": (
+                        snapshot.stop_reason.value
+                        if snapshot.stop_reason is not None
+                        else None
+                    ),
+                    "coverage": coverage.value if coverage is not None else None,
+                    "verification": snapshot.verification.value,
+                    "accounting": snapshot.accounting.model_dump(mode="json"),
+                },
+                ensure_ascii=False,
+                sort_keys=True,
+            )
 
     @server.resource(  # type: ignore[untyped-decorator]
         "experiment://{experiment_id}/scope",
@@ -111,16 +111,16 @@ def _register_resources_and_prompts(
     async def experiment_scope_resource(
         experiment_id: str,
     ) -> str:
-        active_runtime = _resource_runtime(runtime, tenant_router)
-        snapshot = await asyncio.to_thread(
-            active_runtime.services.experiment_router.inspect,
-            f"experiment://{experiment_id}",
-        )
-        return await asyncio.to_thread(
-            _experiment_scope_content,
-            active_runtime,
-            snapshot,
-        )
+        with _resource_runtime(runtime, tenant_router) as active_runtime:
+            snapshot = await _run_blocking(
+                active_runtime.services.experiment_router.inspect,
+                f"experiment://{experiment_id}",
+            )
+            return await _run_blocking(
+                _experiment_scope_content,
+                active_runtime,
+                snapshot,
+            )
 
     @server.resource(  # type: ignore[untyped-decorator]
         "experiment://{experiment_id}/archive",
@@ -131,34 +131,34 @@ def _register_resources_and_prompts(
     async def experiment_archive_resource(
         experiment_id: str,
     ) -> str:
-        active_runtime = _resource_runtime(runtime, tenant_router)
-        snapshot = await asyncio.to_thread(
-            active_runtime.services.experiment_router.inspect,
-            f"experiment://{experiment_id}",
-        )
-        if snapshot.archive_uri is None:
+        with _resource_runtime(runtime, tenant_router) as active_runtime:
+            snapshot = await _run_blocking(
+                active_runtime.services.experiment_router.inspect,
+                f"experiment://{experiment_id}",
+            )
+            if snapshot.archive_uri is None:
+                return json.dumps(
+                    {
+                        "experiment_uri": snapshot.experiment_uri,
+                        "archive_uri": None,
+                        "page_uris": list(snapshot.archive_page_uris),
+                    },
+                    sort_keys=True,
+                )
+            archive = await _run_blocking(
+                active_runtime.core.store.get,
+                snapshot.archive_uri,
+            )
             return json.dumps(
                 {
                     "experiment_uri": snapshot.experiment_uri,
-                    "archive_uri": None,
-                    "page_uris": list(snapshot.archive_page_uris),
+                    "archive_uri": archive.artifact_uri,
+                    "manifest": archive.manifest.model_dump(mode="json"),
+                    "payload": archive.payload,
                 },
+                ensure_ascii=False,
                 sort_keys=True,
             )
-        archive = await asyncio.to_thread(
-            active_runtime.core.store.get,
-            snapshot.archive_uri,
-        )
-        return json.dumps(
-            {
-                "experiment_uri": snapshot.experiment_uri,
-                "archive_uri": archive.artifact_uri,
-                "manifest": archive.manifest.model_dump(mode="json"),
-                "payload": archive.payload,
-            },
-            ensure_ascii=False,
-            sort_keys=True,
-        )
 
     @server.prompt(  # type: ignore[untyped-decorator]
         name="jacobian-discover",

--- a/src/jacobian/adapters/mcp/server.py
+++ b/src/jacobian/adapters/mcp/server.py
@@ -7,7 +7,7 @@ import json
 import logging
 import time
 from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
+from contextlib import ExitStack, asynccontextmanager
 from functools import wraps
 from pathlib import Path
 from typing import Any
@@ -55,7 +55,6 @@ from jacobian.adapters.mcp.tools import (
     workspace_write,
 )
 from jacobian.capabilities import CapabilityPolicy
-from jacobian.contracts.workspaces import WorkspaceWriteRequest
 from jacobian.references import reference_catalog
 from jacobian.runtime import CheckerAuthorityMode, create_runtime
 from jacobian.runtime.model import JacobianRuntime
@@ -202,28 +201,28 @@ class JacobianCoreExtension(Extension):
         )
 
     async def _capability_catalog(self) -> str:
-        active_runtime = _resource_runtime(self._runtime, self._tenant_router)
-        return json.dumps(
-            active_runtime.core.capabilities.catalog().model_dump(mode="json"),
-            ensure_ascii=False,
-            sort_keys=True,
-        )
+        with _resource_runtime(self._runtime, self._tenant_router) as active_runtime:
+            return json.dumps(
+                active_runtime.core.capabilities.catalog().model_dump(mode="json"),
+                ensure_ascii=False,
+                sort_keys=True,
+            )
 
     async def _reference_catalog(self) -> str:
-        active_runtime = _resource_runtime(self._runtime, self._tenant_router)
-        return json.dumps(
-            reference_catalog(
-                active_runtime.portfolio.references,
-                graph=active_runtime.portfolio.graph,
-                polytope=active_runtime.services.polytope,
-                polytope_checkers=active_runtime.portfolio.polytope_checkers,
-                polynomial=active_runtime.portfolio.polynomial,
-                universal_algebra=active_runtime.portfolio.universal_algebra,
-                lean=active_runtime.portfolio.lean_checkers,
-            ),
-            ensure_ascii=False,
-            sort_keys=True,
-        )
+        with _resource_runtime(self._runtime, self._tenant_router) as active_runtime:
+            return json.dumps(
+                reference_catalog(
+                    active_runtime.portfolio.references,
+                    graph=active_runtime.portfolio.graph,
+                    polytope=active_runtime.services.polytope,
+                    polytope_checkers=active_runtime.portfolio.polytope_checkers,
+                    polynomial=active_runtime.portfolio.polynomial,
+                    universal_algebra=active_runtime.portfolio.universal_algebra,
+                    lean=active_runtime.portfolio.lean_checkers,
+                ),
+                ensure_ascii=False,
+                sort_keys=True,
+            )
 
     async def intercept_tool_call(
         self,
@@ -235,29 +234,39 @@ class JacobianCoreExtension(Extension):
         arguments = params.arguments or {}
         argument_digest = _argument_digest(arguments)
         try:
-            # MCP 2.0.0 validates declared parameter values through the generated
-            # Pydantic model, but that model intentionally ignores unknown keys.
-            # Keep this narrow adapter check so the public tool boundary remains
-            # closed; domain-selected capability payloads are validated later by
-            # Jacobian's descriptor contract.
-            binding = next(
-                binding
-                for binding in self.tools()
-                if binding.kwargs["name"] == params.name
-            )
-            accepted_arguments = {
-                name
-                for name in inspect.signature(binding.fn).parameters
-                if name != "ctx"
-            }
-            unknown_arguments = sorted(set(arguments) - accepted_arguments)
-            if unknown_arguments:
-                raise ValueError(
-                    "unknown tool arguments: " + ", ".join(unknown_arguments)
+            with ExitStack() as request_resources:
+                if self._tenant_router is not None:
+                    from mcp.server.auth.middleware.auth_context import (
+                        get_access_token,
+                    )
+
+                    access_token = get_access_token()
+                    subject = access_token.subject if access_token is not None else None
+                    active_runtime = request_resources.enter_context(
+                        self._tenant_router.lease_for(subject)
+                    )
+                    _start_lean_warmup(active_runtime)
+                # MCP 2.0.0 validates declared parameter values through the generated
+                # Pydantic model, but that model intentionally ignores unknown keys.
+                # Keep this narrow adapter check so the public tool boundary remains
+                # closed; domain-selected capability payloads are validated later by
+                # Jacobian's descriptor contract.
+                binding = next(
+                    binding
+                    for binding in self.tools()
+                    if binding.kwargs["name"] == params.name
                 )
-            if params.name == "workspace.write":
-                WorkspaceWriteRequest.model_validate(arguments)
-            result = await call_next(ctx)
+                accepted_arguments = {
+                    name
+                    for name in inspect.signature(binding.fn).parameters
+                    if name != "ctx"
+                }
+                unknown_arguments = sorted(set(arguments) - accepted_arguments)
+                if unknown_arguments:
+                    raise ValueError(
+                        "unknown tool arguments: " + ", ".join(unknown_arguments)
+                    )
+                result = await call_next(ctx)
         except MCPError:
             _log_tool_call(params.name, started, argument_digest, status="error")
             raise
@@ -371,6 +380,7 @@ def create_server(
     capability_exclusions: frozenset[str] = frozenset(),
     capability_policy: CapabilityPolicy | None = None,
     max_tenant_runtimes: int | None = None,
+    tenant_idle_timeout_seconds: float | None = None,
     _projection_strategy: CapabilityProjectionStrategy = (
         "COMPACT_URI_TEXT_RESOURCE_LINK"
     ),
@@ -392,6 +402,7 @@ def create_server(
 
     from jacobian.adapters.mcp.remote import (
         DEFAULT_MAX_TENANT_RUNTIMES,
+        DEFAULT_TENANT_IDLE_TIMEOUT_SECONDS,
         TenantRuntimeRouter,
     )
     from jacobian.runtime.model import JacobianRuntime
@@ -428,6 +439,11 @@ def create_server(
                 DEFAULT_MAX_TENANT_RUNTIMES
                 if max_tenant_runtimes is None
                 else max_tenant_runtimes
+            ),
+            idle_timeout_seconds=(
+                DEFAULT_TENANT_IDLE_TIMEOUT_SECONDS
+                if tenant_idle_timeout_seconds is None
+                else tenant_idle_timeout_seconds
             ),
         )
         if tenant_isolation

--- a/src/jacobian/adapters/mcp/tooling.py
+++ b/src/jacobian/adapters/mcp/tooling.py
@@ -8,12 +8,12 @@ import json
 import logging
 import threading
 import time
+from collections.abc import Callable
 from typing import Any
 
 from mcp_types import ToolAnnotations
 
 from jacobian.adapters.mcp.projections import (
-    _consume_cancelled_worker_result,
     _invoke_capability_with_cancellation,
 )
 from jacobian.canonical import canonicalize_json
@@ -24,6 +24,30 @@ from jacobian.contracts.capabilities import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+async def _run_blocking[BlockingResultT](
+    function: Callable[..., BlockingResultT],
+    /,
+    *args: Any,
+    on_cancel: Callable[[], None] | None = None,
+) -> BlockingResultT:
+    """Run blocking MCP work without detaching it from request teardown."""
+
+    worker = asyncio.create_task(asyncio.to_thread(function, *args))
+    try:
+        return await asyncio.shield(worker)
+    except asyncio.CancelledError:
+        if on_cancel is not None:
+            on_cancel()
+        try:
+            await asyncio.shield(worker)
+        except Exception:
+            _LOGGER.debug(
+                "blocking MCP worker failed while its cancelled request drained",
+                exc_info=True,
+            )
+        raise
 
 
 class AgentRecoveryError(RuntimeError):
@@ -159,8 +183,8 @@ async def _invoke_capability_attempt(
     )
     trace_digest, trace_source = _request_trace_digest(ctx)
     cancellation_event = threading.Event()
-    worker = asyncio.create_task(
-        asyncio.to_thread(
+    try:
+        result = await _run_blocking(
             _invoke_capability_with_cancellation,
             runtime,
             CapabilityRequest(
@@ -169,13 +193,9 @@ async def _invoke_capability_attempt(
                 input=payload,
             ),
             cancellation_event,
+            on_cancel=cancellation_event.set,
         )
-    )
-    try:
-        result = await asyncio.shield(worker)
     except asyncio.CancelledError:
-        cancellation_event.set()
-        worker.add_done_callback(_consume_cancelled_worker_result)
         _log_capability_attempt(
             capability_id=capability_id,
             mode=mode,

--- a/src/jacobian/adapters/mcp/tools.py
+++ b/src/jacobian/adapters/mcp/tools.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from typing import Annotated, Any, Literal
 
@@ -18,7 +17,11 @@ from jacobian.adapters.mcp.projections import (
     _capability_discovery_response,
     _capability_inspection_extensions,
 )
-from jacobian.adapters.mcp.tooling import AgentRecoveryError, _invoke_capability_attempt
+from jacobian.adapters.mcp.tooling import (
+    AgentRecoveryError,
+    _invoke_capability_attempt,
+    _run_blocking,
+)
 from jacobian.contracts.capabilities import (
     CapabilityInputKind,
     CapabilityMode,
@@ -276,7 +279,7 @@ async def workspace_open(
     ctx: Context[AppState, Any] | None = None,
 ) -> WorkspaceOpenResult:
     active_runtime = _runtime(ctx)
-    return await asyncio.to_thread(
+    return await _run_blocking(
         active_runtime.core.workspaces.open,
         WorkspaceOpenRequest(
             idempotency_key=idempotency_key,
@@ -390,7 +393,7 @@ async def workspace_write(
     ctx: Context[AppState, Any] | None = None,
 ) -> WorkspaceWriteResult:
     active_runtime = _runtime(ctx)
-    return await asyncio.to_thread(
+    return await _run_blocking(
         active_runtime.core.workspaces.write,
         WorkspaceWriteRequest(
             idempotency_key=idempotency_key,
@@ -424,7 +427,7 @@ async def workspace_query(
     ctx: Context[AppState, Any] | None = None,
 ) -> WorkspaceQueryResult:
     active_runtime = _runtime(ctx)
-    return await asyncio.to_thread(
+    return await _run_blocking(
         active_runtime.core.workspaces.query,
         WorkspaceQueryRequest(
             workspace_id=workspace_id,

--- a/src/jacobian/contracts/graph_invariants.py
+++ b/src/jacobian/contracts/graph_invariants.py
@@ -39,7 +39,7 @@ class GraphInvariantBatchRequest(ContractModel):
 
 class GraphInvariantResult(ContractModel):
     invariant: GraphInvariantName
-    status: Literal["COMPUTED", "NOT_APPLICABLE", "UNSUPPORTED"]
+    status: Literal["COMPUTED", "NOT_COMPUTED", "NOT_APPLICABLE", "UNSUPPORTED"]
     value: Any = None
     exactness: Literal["EXACT", "NOT_APPLICABLE"]
     backend: str | None = Field(default=None, min_length=1, max_length=128)

--- a/src/jacobian/experiments/service.py
+++ b/src/jacobian/experiments/service.py
@@ -109,6 +109,9 @@ class ExperimentService:
         self.structures = structures
         self._threads: dict[str, threading.Thread] = {}
         self._thread_lock = threading.Lock()
+        self._starts_in_flight = 0
+        self._closing = False
+        self._closed = False
         self._recover_interrupted_experiments()
         self.semantics_uri = store.register_descriptor(
             kind="semantics",
@@ -140,6 +143,36 @@ class ExperimentService:
             version="1",
             schema=model_schema(EvaluationBatchResult),
         )
+
+    def close(self, *, timeout_seconds: float = 30) -> None:
+        """Quiesce enumeration starts and workers before storage teardown."""
+
+        if timeout_seconds < 0:
+            raise ValueError("timeout_seconds must be non-negative")
+        deadline = time.monotonic() + timeout_seconds
+        with self._thread_lock:
+            if self._closed:
+                return
+            self._closing = True
+        while True:
+            with self._thread_lock:
+                active = tuple(
+                    thread for thread in self._threads.values() if thread.is_alive()
+                )
+                if not active and self._starts_in_flight == 0:
+                    self._closed = True
+                    self._closing = False
+                    return
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise ExperimentError(
+                    "enumeration workers did not quiesce before runtime shutdown"
+                )
+            if not active:
+                time.sleep(min(remaining, 0.01))
+                continue
+            for thread in active:
+                thread.join(timeout=min(remaining, 0.05))
 
     def _put_internal_artifact(
         self,
@@ -277,6 +310,22 @@ class ExperimentService:
     ) -> ExperimentHandle:
         """Validate, persist, and launch one bounded enumeration job."""
 
+        with self._thread_lock:
+            if self._closing or self._closed:
+                raise ExperimentError("experiment service is closing")
+            self._starts_in_flight += 1
+        try:
+            return self._start_enumeration_reserved(request)
+        finally:
+            with self._thread_lock:
+                self._starts_in_flight -= 1
+
+    def _start_enumeration_reserved(
+        self,
+        request: SearchEnumerateRequest | dict[str, Any],
+    ) -> ExperimentHandle:
+        """Start after reserving the lifecycle through worker launch."""
+
         selected = SearchEnumerateRequest.model_validate(request)
         validation = self.claims.validate(
             claim_uri=selected.claim_uri,
@@ -319,19 +368,35 @@ class ExperimentService:
             updated_at=now,
         )
         self._write_new(snapshot)
-        thread = threading.Thread(
-            target=self._run_enumeration,
-            args=(experiment_uri,),
-            name=f"jacobian-enumeration-{experiment_uri.removeprefix('experiment://')}",
-            daemon=True,
-        )
-        with self._thread_lock:
-            self._threads[experiment_uri] = thread
-        thread.start()
+        self._launch_enumeration(experiment_uri, lifecycle_reserved=True)
         return ExperimentHandle(
             experiment_uri=experiment_uri,
             state=ExperimentState.PENDING,
         )
+
+    def _launch_enumeration(
+        self,
+        experiment_uri: str,
+        *,
+        lifecycle_reserved: bool = False,
+    ) -> None:
+        with self._thread_lock:
+            if self._closed or (self._closing and not lifecycle_reserved):
+                raise ExperimentError("experiment service is closing")
+            current = self._threads.get(experiment_uri)
+            if current is not None and current.is_alive():
+                return
+            thread = threading.Thread(
+                target=self._run_enumeration,
+                args=(experiment_uri,),
+                name=(
+                    "jacobian-enumeration-"
+                    f"{experiment_uri.removeprefix('experiment://')}"
+                ),
+                daemon=True,
+            )
+            self._threads[experiment_uri] = thread
+            thread.start()
 
     def inspect(self, experiment_uri: str) -> ExperimentSnapshot:
         """Read the latest durable experiment snapshot."""

--- a/src/jacobian/graphs/artifacts.py
+++ b/src/jacobian/graphs/artifacts.py
@@ -6,10 +6,14 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from pydantic import ValidationError
+
 from jacobian.artifacts import ArtifactService
 from jacobian.capabilities import CapabilityInvocationError
 from jacobian.contracts.capabilities import CapabilityDiagnostic
+from jacobian.contracts.graph_isomorphism import SimpleUndirectedGraph
 from jacobian.graphs.atlas import networkx_loader
+from jacobian.schema_registry import model_schema
 from jacobian.store import ArtifactStore, StoreError
 
 if TYPE_CHECKING:
@@ -18,29 +22,7 @@ if TYPE_CHECKING:
 
 ARTIFACT_URI_PATTERN = r"^artifact://sha256/[0-9a-f]{64}$"
 
-GRAPH_PAYLOAD_SCHEMA: dict[str, Any] = {
-    "type": "object",
-    "properties": {
-        "graph_schema_version": {"const": "1"},
-        "vertices": {
-            "type": "array",
-            "items": {"type": "string"},
-            "uniqueItems": True,
-        },
-        "edges": {
-            "type": "array",
-            "items": {
-                "type": "array",
-                "items": {"type": "string"},
-                "minItems": 2,
-                "maxItems": 2,
-            },
-            "uniqueItems": True,
-        },
-    },
-    "required": ["graph_schema_version", "vertices", "edges"],
-    "additionalProperties": False,
-}
+GRAPH_PAYLOAD_SCHEMA: dict[str, Any] = model_schema(SimpleUndirectedGraph)
 
 
 @dataclass(frozen=True, slots=True)
@@ -112,16 +94,9 @@ def load_graph(resources: GraphArtifactResources, graph_uri: str) -> nx_type.Gra
                 ),
             )
         )
-    payload = artifact.payload
-    vertices = payload.get("vertices")
-    edges = payload.get("edges")
-    if (
-        payload.get("graph_schema_version") != "1"
-        or not isinstance(vertices, list)
-        or not all(isinstance(vertex, str) for vertex in vertices)
-        or len(set(vertices)) != len(vertices)
-        or not isinstance(edges, list)
-    ):
+    try:
+        payload = SimpleUndirectedGraph.model_validate(artifact.payload)
+    except ValidationError as exc:
         raise CapabilityInvocationError(
             CapabilityDiagnostic(
                 code="INCOMPATIBLE_GRAPH_ARTIFACT",
@@ -131,43 +106,10 @@ def load_graph(resources: GraphArtifactResources, graph_uri: str) -> nx_type.Gra
                 schema_uri=resources.graph_schema_uri,
                 hint="Recreate the graph through its owning capability.",
             )
-        )
-    vertex_set = set(vertices)
-    normalized_edges: list[tuple[str, str]] = []
-    for edge in edges:
-        if (
-            not isinstance(edge, list)
-            or len(edge) != 2
-            or not all(isinstance(endpoint, str) for endpoint in edge)
-            or edge[0] not in vertex_set
-            or edge[1] not in vertex_set
-            or edge[0] >= edge[1]
-        ):
-            raise CapabilityInvocationError(
-                CapabilityDiagnostic(
-                    code="INCOMPATIBLE_GRAPH_ARTIFACT",
-                    stage="graph_validation",
-                    message="The graph artifact violates simple-graph semantics.",
-                    path="graph_uri",
-                    schema_uri=resources.graph_schema_uri,
-                    hint="Recreate the graph through its owning capability.",
-                )
-            )
-        normalized_edges.append((edge[0], edge[1]))
-    if len(set(normalized_edges)) != len(normalized_edges):
-        raise CapabilityInvocationError(
-            CapabilityDiagnostic(
-                code="INCOMPATIBLE_GRAPH_ARTIFACT",
-                stage="graph_validation",
-                message="The graph artifact contains duplicate edges.",
-                path="graph_uri",
-                schema_uri=resources.graph_schema_uri,
-                hint="Recreate the graph through its owning capability.",
-            )
-        )
+        ) from exc
     graph: nx_type.Graph[str] = nx().Graph()
-    graph.add_nodes_from(vertices)
-    graph.add_edges_from(normalized_edges)
+    graph.add_nodes_from(payload.vertices)
+    graph.add_edges_from(payload.edges)
     return graph
 
 

--- a/src/jacobian/graphs/installation.py
+++ b/src/jacobian/graphs/installation.py
@@ -19,10 +19,8 @@ from jacobian.contracts.graph_invariants import (
     GraphNeighborhoodIndependenceArtifact,
     GraphNeighborhoodIndependenceClaim,
 )
-from jacobian.graphs.artifacts import (
-    GRAPH_PAYLOAD_SCHEMA,
-    GraphArtifactResources,
-)
+from jacobian.contracts.graph_isomorphism import SimpleUndirectedGraph
+from jacobian.graphs.artifacts import GraphArtifactResources
 from jacobian.graphs.atlas_search import (
     GraphAtlasSearchAdapter,
     GraphAtlasSearchResources,
@@ -97,10 +95,10 @@ def install_graph_capabilities(
             ),
         },
     )
-    graph_schema_uri = schemas.register(
+    graph_schema_uri = schemas.register_model(
         name="jacobian.simple-undirected-graph",
         version="1",
-        schema=GRAPH_PAYLOAD_SCHEMA,
+        model=SimpleUndirectedGraph,
     )
     scope_schema_uri = schemas.register(
         name="jacobian.graph-atlas-scope",

--- a/src/jacobian/graphs/invariants.py
+++ b/src/jacobian/graphs/invariants.py
@@ -68,6 +68,8 @@ PROPERTY_NAMES = (
     "triangle_frequencies",
 )
 
+MAX_EXACT_INDEPENDENCE_ORDER = 24
+
 
 @dataclass(frozen=True, slots=True)
 class GraphInvariantResources:
@@ -197,7 +199,8 @@ class GraphPropertyAdapter:
                 status=CapabilityCompletenessStatus.COMPLETE,
                 basis=(
                     "every requested invariant received a terminal COMPUTED, "
-                    "NOT_APPLICABLE, or UNSUPPORTED result under registry version 1"
+                    "NOT_COMPUTED, NOT_APPLICABLE, or UNSUPPORTED result under "
+                    "registry version 1"
                 ),
                 assurance_level=CapabilityAssuranceLevel.COMPUTED,
             ),
@@ -338,6 +341,20 @@ def _compute_invariant_result(
             detail=(
                 "the invariant is not present in graph.compute.properties "
                 "registry version 1"
+            ),
+        )
+    if name == "independence_number" and graph.number_of_nodes() > (
+        MAX_EXACT_INDEPENDENCE_ORDER
+    ):
+        return GraphInvariantResult(
+            invariant=name,
+            status="NOT_COMPUTED",
+            exactness="NOT_APPLICABLE",
+            backend=_property_backend(name),
+            detail=(
+                "exact independence-number computation is limited to graphs of "
+                f"order {MAX_EXACT_INDEPENDENCE_ORDER}; received order "
+                f"{graph.number_of_nodes()}"
             ),
         )
     try:

--- a/src/jacobian/graphs/invariants.py
+++ b/src/jacobian/graphs/invariants.py
@@ -177,6 +177,9 @@ class GraphPropertyAdapter:
             **batch.model_dump(mode="python"),
             property_artifact_uri=property_artifact.artifact_uri,
         )
+        has_incomplete_results = any(
+            binding.result.status == "NOT_COMPUTED" for binding in bindings
+        )
         return CapabilityResult(
             capability_id=self.descriptor.capability_id,
             capability_version=self.descriptor.version,
@@ -196,11 +199,17 @@ class GraphPropertyAdapter:
                 artifact_uri=graph_uri,
             ),
             completeness=CapabilityCompleteness(
-                status=CapabilityCompletenessStatus.COMPLETE,
+                status=(
+                    CapabilityCompletenessStatus.PARTIAL
+                    if has_incomplete_results
+                    else CapabilityCompletenessStatus.COMPLETE
+                ),
                 basis=(
-                    "every requested invariant received a terminal COMPUTED, "
-                    "NOT_COMPUTED, NOT_APPLICABLE, or UNSUPPORTED result under "
-                    "registry version 1"
+                    "at least one requested invariant was not computed because "
+                    "the declared exact scope exceeded its safety boundary"
+                    if has_incomplete_results
+                    else "every requested invariant received a terminal COMPUTED, "
+                    "NOT_APPLICABLE, or UNSUPPORTED result under registry version 1"
                 ),
                 assurance_level=CapabilityAssuranceLevel.COMPUTED,
             ),

--- a/src/jacobian/lean_frontend/declarations.py
+++ b/src/jacobian/lean_frontend/declarations.py
@@ -525,6 +525,13 @@ class LeanDeclarationService:
     def __init__(self, backend: LeanDeclarationBackend) -> None:
         self.backend = backend
 
+    def close(self) -> None:
+        """Release backend-owned declaration sessions when supported."""
+
+        close = getattr(self.backend, "close", None)
+        if callable(close):
+            close()
+
     def search(
         self,
         query: LeanDeclarationSearchRequest,

--- a/src/jacobian/lean_frontend/exploration.py
+++ b/src/jacobian/lean_frontend/exploration.py
@@ -110,6 +110,7 @@ class PersistentLeanRepl:
         self._lock = threading.Lock()
         self._process: subprocess.Popen[str] | None = None
         self._responses: queue.Queue[dict[str, Any] | BaseException] = queue.Queue()
+        self._reader_thread: threading.Thread | None = None
         self._base_env: int | None = None
         self._started_at = 0.0
         self._requests = 0
@@ -212,12 +213,13 @@ class PersistentLeanRepl:
         self._started_at = time.monotonic()
         self._requests = 0
         self._base_env = None
-        threading.Thread(
+        self._reader_thread = threading.Thread(
             target=self._read_responses,
             args=(self._process, responses),
             name="jacobian-lean-repl-reader",
             daemon=True,
-        ).start()
+        )
+        self._reader_thread.start()
         if self._base_command is not None:
             response = self._exchange({"cmd": self._base_command})
             base_env = response.get("env")
@@ -302,26 +304,31 @@ class PersistentLeanRepl:
         process = self._process
         self._process = None
         self._base_env = None
-        if process is None:
-            return
-        if process.stdin is not None:
-            with suppress(OSError):
-                process.stdin.close()
-        if process.poll() is None:
-            if os.name == "posix":
-                os.killpg(process.pid, signal.SIGTERM)
-            else:
-                process.terminate()
-            try:
-                process.wait(timeout=2)
-            except subprocess.TimeoutExpired:
+        if process is not None:
+            if process.stdin is not None:
+                with suppress(OSError):
+                    process.stdin.close()
+            if process.poll() is None:
                 if os.name == "posix":
-                    os.killpg(process.pid, signal.SIGKILL)
+                    os.killpg(process.pid, signal.SIGTERM)
                 else:
-                    process.kill()
-                process.wait()
-        if process.stdout is not None:
-            process.stdout.close()
+                    process.terminate()
+                try:
+                    process.wait(timeout=2)
+                except subprocess.TimeoutExpired:
+                    if os.name == "posix":
+                        os.killpg(process.pid, signal.SIGKILL)
+                    else:
+                        process.kill()
+                    process.wait()
+            if process.stdout is not None:
+                process.stdout.close()
+        reader = self._reader_thread
+        if reader is not None and reader is not threading.current_thread():
+            reader.join(timeout=2)
+            if reader.is_alive():
+                raise RuntimeError("Lean REPL reader did not quiesce")
+        self._reader_thread = None
 
 
 def _single_proof_state(response: Mapping[str, Any]) -> int:
@@ -369,6 +376,8 @@ class LeanExplorationReplRuntime:
         self._policy = policy or LeanReplPolicy()
         self._sessions: dict[LeanEnvironment, PersistentLeanRepl] = {}
         self._lock = threading.Lock()
+        self._closing = False
+        self._closed = False
         self._finalizer = weakref.finalize(self, _close_repls, self._sessions)
 
     def execute(
@@ -382,6 +391,8 @@ class LeanExplorationReplRuntime:
         """Serialize exploration and reuse only an environment's base snapshot."""
 
         with self._lock:
+            if self._closing or self._closed:
+                raise RuntimeError("Lean exploration runtime is closing")
             session = self._sessions.get(environment)
             if session is None:
                 session = self._create_session(environment)
@@ -402,25 +413,47 @@ class LeanExplorationReplRuntime:
     ) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
         """Replay and apply in a new process that is always discarded."""
 
-        session = self._create_session(environment)
-        try:
-            if pickle_path is None:
+        with self._lock:
+            if self._closing or self._closed:
+                raise RuntimeError("Lean exploration runtime is closing")
+            session = self._create_session(environment)
+            try:
+                if pickle_path is None:
+                    return session.execute_validated(
+                        command=command,
+                        tactic=tactic,
+                    )
                 return session.execute_validated(
                     command=command,
                     tactic=tactic,
+                    pickle_path=pickle_path,
                 )
-            return session.execute_validated(
-                command=command,
-                tactic=tactic,
-                pickle_path=pickle_path,
-            )
-        finally:
-            session.close()
+            finally:
+                session.close()
 
     def close(self) -> None:
         """Stop every exploration process without affecting independent checkers."""
 
-        self._finalizer()
+        with self._lock:
+            if self._closed:
+                return
+            self._closing = True
+            sessions = tuple(self._sessions.items())
+        failures: list[Exception] = []
+        for environment, session in sessions:
+            try:
+                session.close()
+            except Exception as exc:
+                failures.append(exc)
+            else:
+                with self._lock:
+                    self._sessions.pop(environment, None)
+        if failures:
+            raise ExceptionGroup("Lean exploration sessions failed to close", failures)
+        with self._lock:
+            self._finalizer.detach()
+            self._closed = True
+            self._closing = False
 
     def _create_session(self, environment: LeanEnvironment) -> PersistentLeanRepl:
         elan = shutil.which("elan")
@@ -474,6 +507,7 @@ class LeanExplorationInstallation:
     state_schema_uri: str
     transition_schema_uri: str
     retrieval_schema_uri: str
+    repl: LeanExplorationReplRuntime
 
 
 @dataclass(frozen=True, slots=True)
@@ -559,6 +593,7 @@ def install_lean_exploration_capabilities(
             state_schema_uri=state_schema_uri,
             transition_schema_uri=transition_schema_uri,
             retrieval_schema_uri=retrieval_schema_uri,
+            repl=repl,
         ),
     )
 

--- a/src/jacobian/lean_frontend/service.py
+++ b/src/jacobian/lean_frontend/service.py
@@ -53,6 +53,8 @@ class LeanService:
             weakref.WeakValueDictionary()
         )
         self._warmup_started = False
+        self._warmup_thread: threading.Thread | None = None
+        self._closing = False
         self._mathlib_warmup_status = "NOT_STARTED"
         self._mathlib_warmup_detail: str | None = None
 
@@ -176,18 +178,36 @@ class LeanService:
     def start_mathlib_warmup(self) -> bool:
         """Warm the pinned Mathlib runtime once without delaying server startup."""
 
-        with self._cache_lock:
-            if self._warmup_started:
-                return False
-            self._warmup_started = True
-            self._mathlib_warmup_status = "RUNNING"
         thread = threading.Thread(
             target=self._warm_mathlib,
             name="jacobian-lean-mathlib-warmup",
             daemon=True,
         )
-        thread.start()
+        with self._cache_lock:
+            if self._warmup_started or self._closing:
+                return False
+            self._warmup_started = True
+            self._mathlib_warmup_status = "RUNNING"
+            self._warmup_thread = thread
+            thread.start()
         return True
+
+    def close(self, *, timeout_seconds: float = 120) -> None:
+        """Wait for the optional warm-up before releasing its shared store."""
+
+        if timeout_seconds < 0:
+            raise ValueError("timeout_seconds must be non-negative")
+        with self._cache_lock:
+            self._closing = True
+            thread = self._warmup_thread
+        if thread is not None:
+            thread.join(timeout=timeout_seconds)
+            if thread.is_alive():
+                raise RuntimeError("Lean Mathlib warm-up did not quiesce")
+        with self._cache_lock:
+            self._warmup_thread = None
+            self._cache.clear()
+            self._certificate_locks.clear()
 
     def _warm_mathlib(self) -> None:
         try:

--- a/src/jacobian/persistence/database.py
+++ b/src/jacobian/persistence/database.py
@@ -51,7 +51,7 @@ class StateDatabase:
         self.path = path
         self.synchronous = synchronous
         self._state = _ConnectionState()
-        self._connection_lock = threading.Lock()
+        self._connection_lock = threading.RLock()
         self._open_connections: set[sqlite3.Connection] = set()
         self._lifecycle_lock = PersistenceLock(
             path.with_name(path.name + ".lifecycle.lock")
@@ -81,8 +81,21 @@ class StateDatabase:
     def connect(self) -> sqlite3.Connection:
         """Open and configure one tracked SQLite handle."""
 
-        if self._closed:
-            raise StateDatabaseError("state database is closed")
+        with self._connection_lock:
+            if self._closed:
+                raise StateDatabaseError("state database is closed")
+            connection = self._open_configured_connection()
+            try:
+                self._open_connections.add(connection)
+            except BaseException:
+                connection.close()
+                self._open_connections.discard(connection)
+                raise
+            return connection
+
+    def _open_configured_connection(self) -> sqlite3.Connection:
+        """Open a configured handle without registering it as caller-owned."""
+
         connection = sqlite3.connect(
             self.path,
             timeout=30,
@@ -92,12 +105,8 @@ class StateDatabase:
             connection.row_factory = sqlite3.Row
             connection.execute("PRAGMA foreign_keys = ON")
             connection.execute(f"PRAGMA synchronous = {self.synchronous}")
-            with self._connection_lock:
-                self._open_connections.add(connection)
         except BaseException:
             connection.close()
-            with self._connection_lock:
-                self._open_connections.discard(connection)
             raise
         return connection
 
@@ -226,15 +235,19 @@ class StateDatabase:
     def connection(self) -> Iterator[sqlite3.Connection]:
         """Yield this thread's transaction or reusable owned connection."""
 
-        transaction = self._state.transaction
-        if transaction is not None:
-            yield transaction
+        with self._connection_lock:
+            if self._closed:
+                raise StateDatabaseError("state database is closed")
+            connection = self._state.transaction
+            in_transaction = connection is not None
+            if connection is None:
+                connection = self._state.connection
+            if connection is None:
+                connection = self.connect()
+                self._state.connection = connection
+        if in_transaction:
+            yield connection
             return
-
-        connection = self._state.connection
-        if connection is None:
-            connection = self.connect()
-            self._state.connection = connection
         with connection:
             yield connection
 
@@ -252,30 +265,47 @@ class StateDatabase:
     def close(self, *, checkpoint: bool) -> None:
         """Checkpoint when requested, close every handle, and end ownership."""
 
-        if self._closed:
-            return
-        checkpoint_error: BaseException | None = None
-        if checkpoint:
-            with self._lifecycle_lock.hold():
-                connection = self.connect()
-                try:
-                    result = connection.execute(
-                        "PRAGMA wal_checkpoint(TRUNCATE)"
-                    ).fetchone()
-                    if result is None or result[0] != 0:
-                        checkpoint_error = StateDatabaseError(
-                            f"could not checkpoint state database: {result!r}"
-                        )
-                except BaseException as exc:
-                    checkpoint_error = exc
-                finally:
-                    self.close_connection(connection)
-        self._close_all_connections()
+        with self._connection_lock:
+            if self._closed:
+                return
+            self._closed = True
+            checkpoint_error = self._checkpoint_for_close() if checkpoint else None
+            close_error: BaseException | None = None
+            try:
+                self._close_all_connections()
+            except BaseException as exc:
+                close_error = exc
+            self._state.connection = None
         if checkpoint_error is not None:
             raise StateDatabaseError(
                 "could not checkpoint state database"
             ) from checkpoint_error
-        self._closed = True
+        if close_error is not None:
+            raise close_error
+
+    def _checkpoint_for_close(self) -> BaseException | None:
+        with self._lifecycle_lock.hold():
+            connection: sqlite3.Connection | None = None
+            failure: BaseException | None = None
+            try:
+                connection = self._open_configured_connection()
+                result = connection.execute(
+                    "PRAGMA wal_checkpoint(TRUNCATE)"
+                ).fetchone()
+                if result is None or result[0] != 0:
+                    failure = StateDatabaseError(
+                        f"could not checkpoint state database: {result!r}"
+                    )
+            except BaseException as exc:
+                failure = exc
+            finally:
+                if connection is not None:
+                    try:
+                        connection.close()
+                    except BaseException as exc:
+                        if failure is None:
+                            failure = exc
+            return failure
 
     def _close_all_connections(self) -> None:
         failures: list[BaseException] = []
@@ -287,7 +317,6 @@ class StateDatabase:
                     failures.append(exc)
                 finally:
                     self._open_connections.discard(connection)
-        self._state.connection = None
         if failures:
             raise StateDatabaseError(
                 "could not close every state database handle"

--- a/src/jacobian/portfolio/assembler.py
+++ b/src/jacobian/portfolio/assembler.py
@@ -35,25 +35,32 @@ def install_portfolio(
 
     result = PortfolioInstallation()
     resolver = ProviderAvailabilityResolver()
-    with (
-        core.checkers.policy_transaction(),
-        core.store.transaction(),
-        cached_package_digests(),
-    ):
-        runtimes = resolver.resolve()
-        FoundationInstaller(context).install(
-            core,
-            result,
-            runtimes,
-        )
-        CoreApplicationInstaller(context).install(
-            application,
-            result,
-        )
-        ResourceCapabilityInstaller(context).install(result)
-        ReferenceLeanInstaller(context, resolver).install(
-            application,
-            result,
-            capability_adapter_entrypoints=capability_adapter_entrypoints,
-        )
+    try:
+        with (
+            core.checkers.policy_transaction(),
+            core.store.transaction(),
+            cached_package_digests(),
+        ):
+            runtimes = resolver.resolve()
+            FoundationInstaller(context).install(
+                core,
+                result,
+                runtimes,
+            )
+            CoreApplicationInstaller(context).install(
+                application,
+                result,
+            )
+            ResourceCapabilityInstaller(context).install(result)
+            ReferenceLeanInstaller(context, resolver).install(
+                application,
+                result,
+                capability_adapter_entrypoints=capability_adapter_entrypoints,
+            )
+    except BaseException as exc:
+        try:
+            result.close()
+        except BaseException as cleanup_exc:
+            exc.add_note(f"partial portfolio cleanup also failed: {cleanup_exc}")
+        raise
     return result

--- a/src/jacobian/portfolio/result.py
+++ b/src/jacobian/portfolio/result.py
@@ -284,6 +284,29 @@ class PortfolioInstallation:
     lean_checkers: dict[LeanEnvironment, LeanCheckerInstallation] = field(
         default_factory=dict
     )
+    _closed: bool = field(default=False, init=False, repr=False)
+
+    def close(self) -> None:
+        """Release portfolio-owned Lean sessions, processes, and warm-up work."""
+
+        if self._closed:
+            return
+        failures: list[Exception] = []
+        resources = (
+            self.lean_declarations,
+            self.lean_exploration.repl if self.lean_exploration is not None else None,
+            self.lean,
+        )
+        for resource in resources:
+            if resource is None:
+                continue
+            try:
+                resource.close()
+            except Exception as exc:
+                failures.append(exc)
+        if failures:
+            raise ExceptionGroup("portfolio resources failed to close", failures)
+        self._closed = True
 
     def installed_bundle(self, domain_id: str) -> InstalledDomainBundle | None:
         """Return one installed mathematical domain bundle, if available."""

--- a/src/jacobian/runtime/model.py
+++ b/src/jacobian/runtime/model.py
@@ -20,10 +20,11 @@ class JacobianRuntime:
     def __init__(self, root: str | Path, options: RuntimeOptions) -> None:
         self._closed = False
         self.core = bootstrap_services(root, options)
+        services = None
         try:
             from jacobian.portfolio import install_portfolio
 
-            self.services = build_application_services(self.core)
+            self.services = services = build_application_services(self.core)
             installation = create_installation_context(
                 self.core,
                 self.services,
@@ -34,9 +35,23 @@ class JacobianRuntime:
                 self.services,
                 capability_adapter_entrypoints=options.capability_adapter_entrypoints,
             )
-        except BaseException:
-            self.core.close()
+        except BaseException as exc:
+            cleanup_failures: list[BaseException] = []
+            if services is not None:
+                try:
+                    services.close()
+                except BaseException as cleanup_exc:
+                    cleanup_failures.append(cleanup_exc)
+            try:
+                self.core.close()
+            except BaseException as cleanup_exc:
+                cleanup_failures.append(cleanup_exc)
             self._closed = True
+            if cleanup_failures:
+                exc.add_note(
+                    "runtime construction cleanup also failed: "
+                    + "; ".join(str(failure) for failure in cleanup_failures)
+                )
             raise
 
     def close(self) -> None:
@@ -45,6 +60,7 @@ class JacobianRuntime:
         if self._closed:
             return
         self.services.close()
+        self.portfolio.close()
         self.core.close()
         self._closed = True
 

--- a/src/jacobian/runtime/services.py
+++ b/src/jacobian/runtime/services.py
@@ -86,7 +86,14 @@ class ApplicationServices:
     def close(self) -> None:
         """Quiesce application-owned workers before foundational teardown."""
 
-        self.search.close()
+        failures: list[Exception] = []
+        for close in (self.search.close, self.experiments.close):
+            try:
+                close()
+            except Exception as exc:
+                failures.append(exc)
+        if failures:
+            raise ExceptionGroup("application services did not quiesce", failures)
 
 
 def build_application_services(core: CoreServices) -> ApplicationServices:

--- a/src/jacobian/workspaces/service.py
+++ b/src/jacobian/workspaces/service.py
@@ -113,7 +113,7 @@ class WorkspaceService:
             WorkspaceRevisionOperation.OPEN,
             selected.model_dump(mode="json"),
         )
-        with self.store.connection() as connection:
+        with self.store.transaction(), self.store.connection() as connection:
             reused = self._reuse(
                 connection,
                 idempotency_key=selected.idempotency_key,
@@ -124,60 +124,48 @@ class WorkspaceService:
             if reused is not None:
                 return reused
 
-        workspace_id = _opaque_id("workspace")
-        branch_id = _opaque_id("branch")
-        revision_id = _opaque_id("revision")
-        problem_card_id = _opaque_id("card")
-        now = _now()
-        problem = WorkspaceFinding(
-            card_id=problem_card_id,
-            kind=WorkspaceFindingKind.PROBLEM,
-            title=selected.name,
-            body=selected.problem,
-            tags=selected.tags,
-            created_revision=revision_id,
-            created_at=now,
-        )
-        focus = WorkspaceFocus(
-            active_item_id=problem_card_id,
-            pinned_item_ids=(problem_card_id,),
-            updated_revision=revision_id,
-        )
-        revision = WorkspaceRevision(
-            revision_id=revision_id,
-            workspace_id=workspace_id,
-            branch_id=branch_id,
-            operation=WorkspaceRevisionOperation.OPEN,
-            request_digest=request_digest,
-            findings=(problem,),
-            focus=focus,
-            created_at=now,
-        )
-        stored = self.store.put(
-            schema_uri=self.revision_schema_uri,
-            semantics_uri=self.revision_semantics_uri,
-            payload=revision.model_dump(mode="json"),
-            summary=f"open epistemic workspace {selected.name}",
-        )
-        result = WorkspaceOpenResult(
-            workspace_id=workspace_id,
-            branch_id=branch_id,
-            revision_id=revision_id,
-            revision_artifact_uri=stored.artifact_uri,
-            problem_card_id=problem_card_id,
-        )
-
-        with self.store.connection() as connection:
-            connection.execute("BEGIN IMMEDIATE")
-            reused = self._reuse(
-                connection,
-                idempotency_key=selected.idempotency_key,
+            workspace_id = _opaque_id("workspace")
+            branch_id = _opaque_id("branch")
+            revision_id = _opaque_id("revision")
+            problem_card_id = _opaque_id("card")
+            now = _now()
+            problem = WorkspaceFinding(
+                card_id=problem_card_id,
+                kind=WorkspaceFindingKind.PROBLEM,
+                title=selected.name,
+                body=selected.problem,
+                tags=selected.tags,
+                created_revision=revision_id,
+                created_at=now,
+            )
+            focus = WorkspaceFocus(
+                active_item_id=problem_card_id,
+                pinned_item_ids=(problem_card_id,),
+                updated_revision=revision_id,
+            )
+            revision = WorkspaceRevision(
+                revision_id=revision_id,
+                workspace_id=workspace_id,
+                branch_id=branch_id,
                 operation=WorkspaceRevisionOperation.OPEN,
                 request_digest=request_digest,
-                result_type=WorkspaceOpenResult,
+                findings=(problem,),
+                focus=focus,
+                created_at=now,
             )
-            if reused is not None:
-                return reused
+            stored = self.store.put(
+                schema_uri=self.revision_schema_uri,
+                semantics_uri=self.revision_semantics_uri,
+                payload=revision.model_dump(mode="json"),
+                summary=f"open epistemic workspace {selected.name}",
+            )
+            result = WorkspaceOpenResult(
+                workspace_id=workspace_id,
+                branch_id=branch_id,
+                revision_id=revision_id,
+                revision_artifact_uri=stored.artifact_uri,
+                problem_card_id=problem_card_id,
+            )
             timestamp = now.isoformat()
             connection.execute(
                 """
@@ -195,11 +183,7 @@ class WorkspaceService:
                 """,
                 (branch_id, workspace_id, revision_id, timestamp),
             )
-            self._insert_revision(
-                connection,
-                revision,
-                stored.artifact_uri,
-            )
+            self._insert_revision(connection, revision, stored.artifact_uri)
             self._insert_finding(connection, workspace_id, branch_id, problem)
             self._upsert_focus(connection, workspace_id, branch_id, focus)
             self._bind_idempotency(
@@ -217,7 +201,7 @@ class WorkspaceService:
             WorkspaceRevisionOperation.WRITE,
             selected.model_dump(mode="json"),
         )
-        with self.store.connection() as connection:
+        with self.store.transaction(), self.store.connection() as connection:
             reused = self._reuse(
                 connection,
                 idempotency_key=selected.idempotency_key,
@@ -228,51 +212,32 @@ class WorkspaceService:
             if reused is not None:
                 return reused
             prepared = self._prepare_write(connection, selected, request_digest)
-
-        result = WorkspaceWriteResult(
-            workspace_id=selected.workspace_id,
-            branch_id=selected.branch_id,
-            revision_id=prepared.revision.revision_id,
-            revision_artifact_uri=prepared.revision_artifact_uri,
-            id_map=prepared.id_map,
-            scratch_written=len(prepared.revision.scratch),
-            findings_written=len(prepared.revision.findings),
-            attempts_written=len(prepared.revision.attempts),
-            marks_written=len(prepared.revision.marks),
-            focus_updated=prepared.revision.focus is not None,
-            unverified_finding_ids=tuple(
-                finding.card_id for finding in prepared.revision.findings
-            ),
-            unresolved_dependency_ids=tuple(
-                sorted(
-                    {
-                        dependency_id
-                        for finding in prepared.revision.findings
-                        for dependency_id in (
-                            *finding.dependency_ids,
-                            *finding.assumption_ids,
-                        )
-                    }
-                )
-            ),
-        )
-
-        with self.store.connection() as connection:
-            connection.execute("BEGIN IMMEDIATE")
-            reused = self._reuse(
-                connection,
-                idempotency_key=selected.idempotency_key,
-                operation=WorkspaceRevisionOperation.WRITE,
-                request_digest=request_digest,
-                result_type=WorkspaceWriteResult,
-            )
-            if reused is not None:
-                return reused
-            self._require_head(
-                connection,
-                selected.workspace_id,
-                selected.branch_id,
-                selected.base_revision,
+            result = WorkspaceWriteResult(
+                workspace_id=selected.workspace_id,
+                branch_id=selected.branch_id,
+                revision_id=prepared.revision.revision_id,
+                revision_artifact_uri=prepared.revision_artifact_uri,
+                id_map=prepared.id_map,
+                scratch_written=len(prepared.revision.scratch),
+                findings_written=len(prepared.revision.findings),
+                attempts_written=len(prepared.revision.attempts),
+                marks_written=len(prepared.revision.marks),
+                focus_updated=prepared.revision.focus is not None,
+                unverified_finding_ids=tuple(
+                    finding.card_id for finding in prepared.revision.findings
+                ),
+                unresolved_dependency_ids=tuple(
+                    sorted(
+                        {
+                            dependency_id
+                            for finding in prepared.revision.findings
+                            for dependency_id in (
+                                *finding.dependency_ids,
+                                *finding.assumption_ids,
+                            )
+                        }
+                    )
+                ),
             )
             self._insert_revision(
                 connection,

--- a/tests/boundary/mcp/test_mcp_adapter.py
+++ b/tests/boundary/mcp/test_mcp_adapter.py
@@ -524,6 +524,57 @@ def test_mcp_workspace_schema_and_fail_closed_round_trip(
     asyncio.run(scenario())
 
 
+def test_mcp_workspace_write_treats_explicit_null_collections_as_empty(
+    tmp_path: Path,
+) -> None:
+    server = create_server(tmp_path)
+
+    async def scenario() -> None:
+        from mcp import Client
+
+        async with Client(server, raise_exceptions=True) as client:
+            opened_result = await client.call_tool(
+                "workspace.open",
+                {
+                    "idempotency_key": "mcp-workspace-open-null-001",
+                    "name": "Nullable collections",
+                    "problem": "Explicit null and omission have the same meaning.",
+                },
+            )
+            opened = json.loads(opened_result.content[0].text)
+            written_result = await client.call_tool(
+                "workspace.write",
+                {
+                    "idempotency_key": "mcp-workspace-write-null-001",
+                    "workspace_id": opened["workspace_id"],
+                    "branch_id": opened["branch_id"],
+                    "base_revision": opened["revision_id"],
+                    "scratch": None,
+                    "findings": [
+                        {
+                            "client_ref": "G1",
+                            "kind": "GOAL",
+                            "title": "One real mutation",
+                            "body": "The other nullable collections are empty.",
+                        }
+                    ],
+                    "attempts": None,
+                    "marks": None,
+                    "focus": None,
+                },
+            )
+
+            assert written_result.is_error is False
+            written = json.loads(written_result.content[0].text)
+            assert written["scratch_written"] == 0
+            assert written["findings_written"] == 1
+            assert written["attempts_written"] == 0
+            assert written["marks_written"] == 0
+            assert written["focus_updated"] is False
+
+    asyncio.run(scenario())
+
+
 def test_mcp_describes_and_invokes_capabilities(tmp_path: Path) -> None:
     async def scenario() -> None:
         from mcp import Client

--- a/tests/boundary/mcp/test_mcp_operations.py
+++ b/tests/boundary/mcp/test_mcp_operations.py
@@ -7,6 +7,7 @@ import logging
 import os
 import subprocess
 import sys
+import threading
 from importlib.metadata import version
 from pathlib import Path
 
@@ -15,7 +16,7 @@ import pytest
 from jacobian.adapters.mcp.context import _public_tool_error
 from jacobian.adapters.mcp.projections import WORKSPACE_TOOL_NAMES
 from jacobian.adapters.mcp.server import create_server
-from jacobian.adapters.mcp.tooling import _request_trace_digest
+from jacobian.adapters.mcp.tooling import _request_trace_digest, _run_blocking
 
 MCP_TOOL_NAMES = {
     "capability.describe",
@@ -217,3 +218,37 @@ def test_mcp_entrypoint_reports_distribution_version() -> None:
 
     assert completed.returncode == 0
     assert completed.stdout.strip() == f"jacobian-mcp {version('jacobian')}"
+
+
+def test_cancelled_mcp_blocking_work_drains_before_request_task_finishes() -> None:
+    started = threading.Event()
+    release = threading.Event()
+    finished = threading.Event()
+    cancellation_signalled = threading.Event()
+
+    def blocking_operation() -> str:
+        started.set()
+        release.wait(timeout=2)
+        finished.set()
+        return "finished"
+
+    async def scenario() -> None:
+        task = asyncio.create_task(
+            _run_blocking(
+                blocking_operation,
+                on_cancel=cancellation_signalled.set,
+            )
+        )
+        while not started.is_set():
+            await asyncio.sleep(0)
+        task.cancel()
+        await asyncio.sleep(0.05)
+        assert cancellation_signalled.is_set()
+        assert not task.done()
+        assert not finished.is_set()
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert finished.is_set()
+
+    asyncio.run(scenario())

--- a/tests/boundary/mcp/test_remote_mcp.py
+++ b/tests/boundary/mcp/test_remote_mcp.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import socket
 import subprocess
@@ -21,6 +22,7 @@ from jacobian.adapters.mcp.remote import (
     StaticTokenVerifier,
     TenantRuntimeLimitError,
     TenantRuntimeRouter,
+    TenantRuntimeRouterClosedError,
     load_static_token_file,
 )
 from jacobian.adapters.mcp.server import create_server
@@ -169,10 +171,172 @@ def test_tenant_router_isolates_artifact_stores(tmp_path: Path) -> None:
 
     assert alpha.core.store.root != beta.core.store.root
     assert router.runtime_for("alpha") is alpha
-    with pytest.raises(TenantRuntimeLimitError, match="tenant limit"):
-        router.runtime_for("gamma")
     with pytest.raises(ArtifactNotFoundError):
         beta.core.store.get(stored)
+
+
+class _FakeRuntime:
+    def __init__(self, identity: Path, *, fail_close: bool = False) -> None:
+        self.identity = identity
+        self.fail_close = fail_close
+        self.close_calls = 0
+
+    def close(self) -> None:
+        self.close_calls += 1
+        if self.fail_close:
+            raise RuntimeError("injected close failure")
+
+
+def test_tenant_router_single_flights_one_tenant_and_parallelizes_distinct_tenants(
+    tmp_path: Path,
+) -> None:
+    creation_barrier = threading.Barrier(2)
+    created: list[_FakeRuntime] = []
+    created_lock = threading.Lock()
+
+    def factory(path: Path, **_kwargs: object) -> _FakeRuntime:
+        creation_barrier.wait(timeout=2)
+        runtime = _FakeRuntime(path)
+        with created_lock:
+            created.append(runtime)
+        return runtime
+
+    router = TenantRuntimeRouter(
+        tmp_path,
+        max_tenant_runtimes=3,
+        runtime_factory=factory,  # type: ignore[arg-type]
+    )
+    leases = []
+
+    def acquire(subject: str) -> None:
+        leases.append(router.lease_for(subject))
+
+    workers = [
+        threading.Thread(target=acquire, args=(subject,))
+        for subject in ("alpha", "alpha", "beta")
+    ]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join(timeout=2)
+        assert not worker.is_alive()
+
+    alpha_runtimes = [
+        lease.runtime
+        for lease in leases
+        if lease.runtime.identity.name == hashlib.sha256(b"alpha").hexdigest()
+    ]
+    assert len(created) == 2
+    assert len(alpha_runtimes) == 2
+    assert alpha_runtimes[0] is alpha_runtimes[1]
+    for lease in leases:
+        lease.release()
+
+
+def test_tenant_router_uses_idle_ttl_lru_and_never_evicts_an_active_lease(
+    tmp_path: Path,
+) -> None:
+    now = [0.0]
+    created: list[_FakeRuntime] = []
+
+    def factory(path: Path, **_kwargs: object) -> _FakeRuntime:
+        runtime = _FakeRuntime(path)
+        created.append(runtime)
+        return runtime
+
+    router = TenantRuntimeRouter(
+        tmp_path,
+        max_tenant_runtimes=2,
+        idle_timeout_seconds=10,
+        clock=lambda: now[0],
+        runtime_factory=factory,  # type: ignore[arg-type]
+    )
+    alpha = router.lease_for("alpha")
+    now[0] = 1
+    beta_runtime = router.runtime_for("beta")
+    now[0] = 2
+    alpha.release()
+    now[0] = 3
+    alpha_runtime = router.runtime_for("alpha")
+    now[0] = 4
+    gamma_runtime = router.runtime_for("gamma")
+
+    assert beta_runtime.close_calls == 1
+    assert alpha_runtime.close_calls == 0
+    assert gamma_runtime.close_calls == 0
+
+    active = router.lease_for("alpha")
+    now[0] = 20
+    refreshed_gamma = router.runtime_for("gamma")
+    assert refreshed_gamma is not gamma_runtime
+    assert gamma_runtime.close_calls == 1
+    active.release()
+
+
+def test_tenant_router_restores_failed_eviction_and_shutdown_waits_for_leases(
+    tmp_path: Path,
+) -> None:
+    first = _FakeRuntime(tmp_path / "first", fail_close=True)
+    created = [first]
+
+    def factory(path: Path, **_kwargs: object) -> _FakeRuntime:
+        if len(created) == 1:
+            return first
+        runtime = _FakeRuntime(path)
+        created.append(runtime)
+        return runtime
+
+    router = TenantRuntimeRouter(
+        tmp_path,
+        max_tenant_runtimes=1,
+        runtime_factory=factory,  # type: ignore[arg-type]
+    )
+    assert router.runtime_for("alpha") is first
+    with pytest.raises(RuntimeError, match="injected close failure"):
+        router.runtime_for("beta")
+    assert router.runtime_for("alpha") is first
+
+    lease = router.lease_for("alpha")
+    with pytest.raises(TenantRuntimeLimitError, match="tenant limit"):
+        router.lease_for("beta")
+    first.fail_close = False
+    closed = threading.Event()
+    closer = threading.Thread(target=lambda: (router.close(), closed.set()))
+    closer.start()
+    time.sleep(0.05)
+    assert not closed.is_set()
+    with pytest.raises(TenantRuntimeRouterClosedError, match="closing"):
+        router.lease_for("beta")
+    lease.release()
+    closer.join(timeout=2)
+    assert closed.is_set()
+
+
+def test_tenant_router_retries_only_failed_runtime_shutdowns(tmp_path: Path) -> None:
+    created: list[_FakeRuntime] = []
+
+    def factory(path: Path, **_kwargs: object) -> _FakeRuntime:
+        runtime = _FakeRuntime(path, fail_close=not created)
+        created.append(runtime)
+        return runtime
+
+    router = TenantRuntimeRouter(
+        tmp_path,
+        max_tenant_runtimes=2,
+        runtime_factory=factory,  # type: ignore[arg-type]
+    )
+    router.runtime_for("alpha")
+    router.runtime_for("beta")
+
+    with pytest.raises(ExceptionGroup, match="tenant runtimes failed to close"):
+        router.close()
+    assert [runtime.close_calls for runtime in created] == [1, 1]
+
+    created[0].fail_close = False
+    router.close()
+    router.close()
+
+    assert [runtime.close_calls for runtime in created] == [2, 1]
 
 
 def test_anonymous_tenant_namespace_is_fixed_by_the_operator(tmp_path: Path) -> None:
@@ -279,6 +443,46 @@ def test_token_file_is_strict_and_remote_cli_fails_closed(
     assert named_without_anonymous.returncode != 0
     assert "--anonymous-tenant-id requires --allow-anonymous" in (
         named_without_anonymous.stderr
+    )
+
+    conflicting_auth = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "jacobian.adapters.mcp.server",
+            "--transport",
+            "streamable-http",
+            "--allow-anonymous",
+            "--auth-tokens-file",
+            str(token_file),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert conflicting_auth.returncode != 0
+    assert "mutually exclusive" in conflicting_auth.stderr
+
+    invalid_idle_timeout = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "jacobian.adapters.mcp.server",
+            "--transport",
+            "streamable-http",
+            "--allow-anonymous",
+            "--tenant-idle-timeout-seconds",
+            "0",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert invalid_idle_timeout.returncode != 0
+    assert "--tenant-idle-timeout-seconds must be positive" in (
+        invalid_idle_timeout.stderr
     )
 
 

--- a/tests/boundary/process/tooling/test_deploy_installer.py
+++ b/tests/boundary/process/tooling/test_deploy_installer.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import os
 import subprocess
 from pathlib import Path
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
 INSTALLER = REPOSITORY_ROOT / "deploy" / "install.sh"
+SERVICE_STATE = REPOSITORY_ROOT / "deploy" / "lib" / "service_state.sh"
 
 
 def _run(*arguments: str) -> subprocess.CompletedProcess[str]:
@@ -53,6 +55,21 @@ def test_domain_dry_run_reports_connector_without_requiring_root() -> None:
     assert "python:      /opt/jacobian/python" in completed.stdout
     assert "caddy:       enabled" in completed.stdout
     assert "funnel:      disabled" in completed.stdout
+
+
+def test_dry_run_never_echoes_supplied_credentials(tmp_path: Path) -> None:
+    sentinel = "sentinel-secret-that-must-not-be-logged"
+    credentials = tmp_path / "tokens.json"
+    credentials.write_text(
+        '{"tokens":{"' + sentinel + '":{"tenant_id":"tenant-a"}}}',
+        encoding="utf-8",
+    )
+
+    completed = _run("--auth-tokens-file", str(credentials), "--dry-run")
+
+    assert completed.returncode == 0, completed.stderr
+    assert sentinel not in completed.stdout
+    assert sentinel not in completed.stderr
 
 
 def test_domain_mode_requires_a_valid_fqdn() -> None:
@@ -136,3 +153,105 @@ def test_release_runtime_is_checked_before_current_symlink_is_changed() -> None:
 
     assert validation < revision_marker < current_link
     assert '"${RUNUSER_BIN}" --user jacobian -- "${entrypoint}" --version' in source
+
+
+def test_activation_arms_rollback_before_switching_current() -> None:
+    source = INSTALLER.read_text(encoding="utf-8")
+
+    armed = source.index("ROLLBACK_ARMED=1")
+    current_link = source.index('ln -sfn "${RELEASE_DIR}" "${CURRENT_LINK}.new"')
+    smoke = source.index('log "running the read-only deployment smoke"')
+    accepted = source.index("DEPLOYMENT_ACCEPTED=1")
+
+    assert armed < current_link < smoke < accepted
+    assert 'return "${original_status}"' in source
+    assert 'exit "${status}"' in source
+    assert "rollback encountered additional failures" in source
+
+
+def test_generated_token_is_written_only_to_the_restricted_file() -> None:
+    source = INSTALLER.read_text(encoding="utf-8")
+
+    assert "os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600" in source
+    assert "print(token)" not in source
+    assert "print(next(grant.token" not in source
+    assert "JACOBIAN_MCP_AUTH_TOKENS_FILE" in source
+    assert "generated bearer token: ${" not in source
+    assert "retrieve it explicitly with privileged access" in source
+
+
+def test_rollback_restores_prior_service_activity_and_enablement(
+    tmp_path: Path,
+) -> None:
+    state = tmp_path / "systemd-state"
+    snapshots = tmp_path / "snapshots"
+    state.mkdir()
+    snapshots.mkdir()
+    fake_systemctl = tmp_path / "systemctl"
+    fake_systemctl.write_text(
+        """#!/usr/bin/env bash
+set -eu
+action="$1"
+case "$action" in
+  is-enabled) test -f "$FAKE_SYSTEMD_STATE/$3.enabled" ;;
+  is-active) test -f "$FAKE_SYSTEMD_STATE/$3.active" ;;
+  enable) : >"$FAKE_SYSTEMD_STATE/$2.enabled" ;;
+  disable) rm -f -- "$FAKE_SYSTEMD_STATE/$2.enabled" ;;
+  restart) : >"$FAKE_SYSTEMD_STATE/$2.active" ;;
+  stop) rm -f -- "$FAKE_SYSTEMD_STATE/$2.active" ;;
+  *) exit 2 ;;
+esac
+""",
+        encoding="utf-8",
+    )
+    fake_systemctl.chmod(0o755)
+    (state / "jacobian-mcp.service.enabled").touch()
+    (state / "jacobian-mcp.service.active").touch()
+    (state / "jacobian-caddy.service.enabled").touch()
+    environment = os.environ | {"FAKE_SYSTEMD_STATE": str(state)}
+    units = (
+        "jacobian-mcp.service",
+        "jacobian-caddy.service",
+        "jacobian-funnel.service",
+    )
+
+    for unit in units:
+        subprocess.run(
+            [
+                "bash",
+                "-c",
+                'source "$1"; snapshot_systemd_service_state "$2" "$3" "$4"',
+                "service-state-test",
+                str(SERVICE_STATE),
+                str(fake_systemctl),
+                str(snapshots),
+                unit,
+            ],
+            check=True,
+            env=environment,
+        )
+        (state / f"{unit}.enabled").touch()
+        (state / f"{unit}.active").touch()
+
+    for unit in units:
+        subprocess.run(
+            [
+                "bash",
+                "-c",
+                'source "$1"; restore_systemd_service_state "$2" "$3" "$4"',
+                "service-state-test",
+                str(SERVICE_STATE),
+                str(fake_systemctl),
+                str(snapshots),
+                unit,
+            ],
+            check=True,
+            env=environment,
+        )
+
+    assert (state / "jacobian-mcp.service.enabled").is_file()
+    assert (state / "jacobian-mcp.service.active").is_file()
+    assert (state / "jacobian-caddy.service.enabled").is_file()
+    assert not (state / "jacobian-caddy.service.active").exists()
+    assert not (state / "jacobian-funnel.service.enabled").exists()
+    assert not (state / "jacobian-funnel.service.active").exists()

--- a/tests/boundary/providers/lean/test_lean_repl_runtime.py
+++ b/tests/boundary/providers/lean/test_lean_repl_runtime.py
@@ -191,3 +191,99 @@ def test_clean_execution_discards_every_repl_instance(
 
     assert len(sessions) == 2
     assert all(session.closed for session in sessions)
+
+
+def test_runtime_close_releases_retained_sessions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = LeanExplorationReplRuntime(tmp_path, {})
+
+    class FakeSession:
+        closed = False
+
+        def execute(
+            self,
+            *,
+            command: str,
+            tactic: str,
+            pickle_path: Path | None = None,
+        ) -> tuple[dict[str, object], dict[str, object]]:
+            assert command and tactic
+            assert pickle_path is None
+            return {}, {}
+
+        def close(self) -> None:
+            self.closed = True
+
+    session = FakeSession()
+    monkeypatch.setattr(runtime, "_create_session", lambda _environment: session)
+
+    runtime.execute(
+        command="example : True := by sorry",
+        tactic="trivial",
+        environment=LeanEnvironment.CORE,
+    )
+    runtime.close()
+    runtime.close()
+
+    assert session.closed
+
+
+def test_runtime_close_retries_failed_sessions_and_rejects_new_execution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = LeanExplorationReplRuntime(tmp_path, {})
+
+    class FakeSession:
+        def __init__(self, *, fail_close: bool) -> None:
+            self.fail_close = fail_close
+            self.close_calls = 0
+
+        def execute(
+            self,
+            *,
+            command: str,
+            tactic: str,
+            pickle_path: Path | None = None,
+        ) -> tuple[dict[str, object], dict[str, object]]:
+            return {}, {}
+
+        def close(self) -> None:
+            self.close_calls += 1
+            if self.fail_close:
+                raise RuntimeError("injected session close failure")
+
+    sessions = [FakeSession(fail_close=True), FakeSession(fail_close=False)]
+    monkeypatch.setattr(
+        runtime, "_create_session", lambda _environment: sessions.pop(0)
+    )
+    runtime.execute(command="first", tactic="skip", environment=LeanEnvironment.CORE)
+    runtime.execute(
+        command="second", tactic="skip", environment=LeanEnvironment.MATHLIB
+    )
+    failed, succeeded = tuple(
+        runtime._sessions[environment]
+        for environment in (LeanEnvironment.CORE, LeanEnvironment.MATHLIB)
+    )
+
+    with pytest.raises(ExceptionGroup, match="sessions failed to close"):
+        runtime.close()
+    assert failed.close_calls == 1
+    assert succeeded.close_calls == 1
+    with pytest.raises(RuntimeError, match="runtime is closing"):
+        runtime.execute(
+            command="third", tactic="skip", environment=LeanEnvironment.CORE
+        )
+
+    failed.fail_close = False
+    runtime.close()
+    assert failed.close_calls == 2
+    assert succeeded.close_calls == 1
+    with pytest.raises(RuntimeError, match="runtime is closing"):
+        runtime.execute_clean(
+            command="third",
+            tactic="skip",
+            environment=LeanEnvironment.CORE,
+        )

--- a/tests/boundary/storage/transactions/test_state_database_migrations.py
+++ b/tests/boundary/storage/transactions/test_state_database_migrations.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import sqlite3
 import subprocess
 import sys
+import threading
 from pathlib import Path
 
 import pytest
@@ -249,6 +250,48 @@ def test_invalid_in_memory_migration_order_is_rejected(tmp_path: Path) -> None:
     with pytest.raises(StateDatabaseError, match="ordered, consecutive"):
         database.migrate((migration,))
     database.close(checkpoint=False)
+
+
+def test_close_cannot_race_connection_configuration_and_registration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database = StateDatabase(tmp_path / "state.sqlite3", synchronous="FULL")
+    raw_connection_opened = threading.Event()
+    release_connect = threading.Event()
+    original_connect = sqlite3.connect
+
+    def blocked_connect(*args: object, **kwargs: object) -> sqlite3.Connection:
+        connection = original_connect(*args, **kwargs)
+        raw_connection_opened.set()
+        assert release_connect.wait(timeout=2)
+        return connection
+
+    monkeypatch.setattr(sqlite3, "connect", blocked_connect)
+    connect_errors: list[BaseException] = []
+
+    def connect() -> None:
+        try:
+            database.connect()
+        except BaseException as exc:
+            connect_errors.append(exc)
+
+    connector = threading.Thread(target=connect)
+    connector.start()
+    assert raw_connection_opened.wait(timeout=1)
+
+    closer = threading.Thread(target=lambda: database.close(checkpoint=False))
+    closer.start()
+    release_connect.set()
+    connector.join(timeout=2)
+    closer.join(timeout=2)
+
+    assert not connector.is_alive()
+    assert not closer.is_alive()
+    assert database.open_connection_count == 0
+    with pytest.raises(StateDatabaseError, match="closed"):
+        database.connect()
+    assert connect_errors == []
 
 
 def test_two_processes_can_race_to_migrate_empty_state(tmp_path: Path) -> None:

--- a/tests/composition/runtime/test_graph_capabilities.py
+++ b/tests/composition/runtime/test_graph_capabilities.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from jacobian.artifacts import ArtifactValidationError
 from jacobian.contracts.capabilities import (
     CapabilityAssuranceLevel,
     CapabilityCompletenessStatus,
@@ -10,6 +11,103 @@ from jacobian.contracts.capabilities import (
     CapabilityRequest,
 )
 from jacobian.contracts.results import ExecutionStatus
+
+
+def test_generic_graph_artifacts_use_the_authoritative_bounded_model(
+    authorized_complete_runtime,
+) -> None:
+    runtime = authorized_complete_runtime
+    installation = runtime.portfolio.graph
+    vertices = [f"v{index:03d}" for index in range(256)]
+
+    accepted = runtime.core.artifacts.put(
+        schema_uri=installation.graph_schema_uri,
+        semantics_uri=installation.semantics_uri,
+        payload={
+            "graph_schema_version": "1",
+            "vertices": vertices,
+            "edges": [],
+        },
+    )
+
+    assert runtime.core.store.get(accepted.artifact_uri).payload["vertices"] == vertices
+    with pytest.raises(ArtifactValidationError, match="does not match its schema"):
+        runtime.core.artifacts.put(
+            schema_uri=installation.graph_schema_uri,
+            semantics_uri=installation.semantics_uri,
+            payload={
+                "graph_schema_version": "1",
+                "vertices": [*vertices, "v256"],
+                "edges": [],
+            },
+        )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "graph_schema_version": "1",
+            "vertices": ["a", "b"],
+            "edges": [["b", "a"]],
+        },
+        {
+            "graph_schema_version": "1",
+            "vertices": ["a", "b"],
+            "edges": [["a", "a"]],
+        },
+        {
+            "graph_schema_version": "1",
+            "vertices": ["a", "b"],
+            "edges": [["a", "c"]],
+        },
+        {
+            "graph_schema_version": "1",
+            "vertices": ["a", "b"],
+            "edges": [["a", "b"], ["a", "b"]],
+        },
+    ],
+)
+def test_generic_graph_artifacts_reject_noncanonical_simple_graphs(
+    authorized_complete_runtime,
+    payload: dict[str, object],
+) -> None:
+    runtime = authorized_complete_runtime
+    installation = runtime.portfolio.graph
+
+    with pytest.raises(ArtifactValidationError, match="does not match its schema"):
+        runtime.core.artifacts.put(
+            schema_uri=installation.graph_schema_uri,
+            semantics_uri=installation.semantics_uri,
+            payload=payload,
+        )
+
+
+def test_graph_consumers_reject_forged_malformed_payloads(
+    authorized_complete_runtime,
+) -> None:
+    runtime = authorized_complete_runtime
+    installation = runtime.portfolio.graph
+    forged = runtime.core.store.put(
+        schema_uri=installation.graph_schema_uri,
+        semantics_uri=installation.semantics_uri,
+        payload={
+            "graph_schema_version": "1",
+            "vertices": ["a", "b"],
+            "edges": [["a", "a"]],
+        },
+        summary="forged malformed graph",
+    )
+
+    result = runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.compute.properties",
+            input={"graph_uri": forged.artifact_uri, "properties": ["order"]},
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.diagnostics[0].code == "INCOMPATIBLE_GRAPH_ARTIFACT"
 
 
 def test_explicit_graph_construction_canonicalizes_and_feeds_graph_capabilities(
@@ -296,6 +394,46 @@ def test_graph_property_batch_materializes_exact_computed_artifact(
         )
         assert invariant_artifact.manifest.parents == (graph_uri,)
         assert invariant_artifact.payload["result"] == binding["result"]
+
+
+@pytest.mark.parametrize(
+    ("order", "expected_status"),
+    [(24, "COMPUTED"), (25, "NOT_COMPUTED")],
+)
+def test_exact_independence_number_stops_at_the_order_boundary(
+    authorized_complete_runtime,
+    order: int,
+    expected_status: str,
+) -> None:
+    runtime = authorized_complete_runtime
+    installation = runtime.portfolio.graph
+    graph = runtime.core.artifacts.put(
+        schema_uri=installation.graph_schema_uri,
+        semantics_uri=installation.semantics_uri,
+        payload={
+            "graph_schema_version": "1",
+            "vertices": [f"v{index:02d}" for index in range(order)],
+            "edges": [],
+        },
+    )
+
+    result = runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.compute.properties",
+            input={
+                "graph_uri": graph.artifact_uri,
+                "properties": ["independence_number"],
+            },
+        )
+    )
+
+    invariant = result.output["results"][0]["result"]
+    assert invariant["status"] == expected_status
+    if order == 24:
+        assert invariant["value"] == 24
+    else:
+        assert invariant["value"] is None
+        assert "limited to graphs of order 24" in invariant["detail"]
 
 
 def test_graph_counterexample_invariant_batch_reproduces_path_five(

--- a/tests/composition/runtime/test_graph_capabilities.py
+++ b/tests/composition/runtime/test_graph_capabilities.py
@@ -430,8 +430,10 @@ def test_exact_independence_number_stops_at_the_order_boundary(
     invariant = result.output["results"][0]["result"]
     assert invariant["status"] == expected_status
     if order == 24:
+        assert result.completeness.status is CapabilityCompletenessStatus.COMPLETE
         assert invariant["value"] == 24
     else:
+        assert result.completeness.status is CapabilityCompletenessStatus.PARTIAL
         assert invariant["value"] is None
         assert "limited to graphs of order 24" in invariant["detail"]
 

--- a/tests/composition/runtime/test_runtime_lifecycle.py
+++ b/tests/composition/runtime/test_runtime_lifecycle.py
@@ -20,6 +20,7 @@ import pytest
 
 from jacobian.contracts.discovery import ExperimentHandle
 from jacobian.contracts.search import ExperimentState
+from jacobian.experiments import ExperimentError, ExperimentService
 from jacobian.runtime import create_runtime
 from jacobian.runtime.model import RuntimeClosedError
 from jacobian.search import SearchError, SearchService
@@ -133,6 +134,79 @@ def test_close_quiesces_search_workers_before_closing_store(
         )
 
 
+def test_close_quiesces_enumeration_workers_before_closing_store(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = create_runtime(tmp_path)
+    worker_started = threading.Event()
+    release_worker = threading.Event()
+    worker_errors: list[BaseException] = []
+
+    def blocked_run(service: ExperimentService, _experiment_uri: str) -> None:
+        worker_started.set()
+        release_worker.wait(timeout=2)
+        try:
+            service.store.register_descriptor(
+                kind="schema",
+                name="enumeration-worker-during-close",
+                version="1",
+                definition={"type": "object"},
+            )
+        except BaseException as exc:
+            worker_errors.append(exc)
+
+    monkeypatch.setattr(ExperimentService, "_run_enumeration", blocked_run)
+    runtime.services.experiments._launch_enumeration(
+        "experiment://runtime-enumeration-close"
+    )
+    assert worker_started.wait(timeout=1)
+
+    releaser = threading.Thread(target=lambda: (time.sleep(0.05), release_worker.set()))
+    releaser.start()
+    runtime.close()
+    releaser.join(timeout=1)
+
+    assert worker_errors == []
+    with pytest.raises(StoreClosedError):
+        runtime.core.store.register_descriptor(
+            kind="schema",
+            name="after-enumeration-worker-close",
+            version="1",
+            definition={"type": "object"},
+        )
+
+
+def test_enumeration_close_timeout_keeps_store_open_for_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = create_runtime(tmp_path)
+    worker_started = threading.Event()
+    release_worker = threading.Event()
+
+    def blocked_run(_service: ExperimentService, _experiment_uri: str) -> None:
+        worker_started.set()
+        release_worker.wait(timeout=2)
+
+    monkeypatch.setattr(ExperimentService, "_run_enumeration", blocked_run)
+    runtime.services.experiments._launch_enumeration(
+        "experiment://runtime-enumeration-timeout"
+    )
+    assert worker_started.wait(timeout=1)
+
+    with pytest.raises(ExperimentError, match="did not quiesce"):
+        runtime.services.experiments.close(timeout_seconds=0)
+    runtime.core.store.register_descriptor(
+        kind="schema",
+        name="store-open-after-enumeration-timeout",
+        version="1",
+        definition={"type": "object"},
+    )
+    release_worker.set()
+    runtime.close()
+
+
 def test_close_waits_for_a_reserved_search_start_through_worker_launch(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -174,6 +248,60 @@ def test_close_waits_for_a_reserved_search_start_through_worker_launch(
         release_start.set()
 
     releaser = threading.Thread(target=release_after_close_begins)
+    releaser.start()
+    runtime.close()
+    starter.join(timeout=1)
+    releaser.join(timeout=1)
+
+    assert start_errors == []
+    assert start_results == [
+        ExperimentHandle(
+            experiment_uri=experiment_uri,
+            state=ExperimentState.PENDING,
+        )
+    ]
+
+
+def test_close_waits_for_a_reserved_enumeration_start_through_worker_launch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = create_runtime(tmp_path)
+    start_reserved = threading.Event()
+    release_start = threading.Event()
+    start_results: list[ExperimentHandle] = []
+    start_errors: list[BaseException] = []
+    experiment_uri = "experiment://" + "b" * 32
+
+    def blocked_start(
+        service: ExperimentService,
+        _request: object,
+    ) -> ExperimentHandle:
+        start_reserved.set()
+        release_start.wait(timeout=2)
+        service._launch_enumeration(experiment_uri, lifecycle_reserved=True)
+        return ExperimentHandle(
+            experiment_uri=experiment_uri,
+            state=ExperimentState.PENDING,
+        )
+
+    monkeypatch.setattr(
+        ExperimentService,
+        "_start_enumeration_reserved",
+        blocked_start,
+    )
+    monkeypatch.setattr(ExperimentService, "_run_enumeration", lambda *_args: None)
+
+    def start_enumeration() -> None:
+        try:
+            start_results.append(runtime.services.experiments.start_enumeration({}))
+        except BaseException as exc:
+            start_errors.append(exc)
+
+    starter = threading.Thread(target=start_enumeration)
+    starter.start()
+    assert start_reserved.wait(timeout=1)
+    releaser = threading.Thread(target=lambda: (time.sleep(0.05), release_start.set()))
     releaser.start()
     runtime.close()
     starter.join(timeout=1)

--- a/tests/composition/runtime/test_workspace_revisions.py
+++ b/tests/composition/runtime/test_workspace_revisions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sqlite3
+import threading
 from pathlib import Path
 
 import pytest
@@ -28,6 +29,16 @@ from jacobian.workspaces import (
 )
 
 pytestmark = pytest.mark.usefixtures("attached_complete_runtime")
+
+
+def _blob_paths(blob_root: Path) -> set[Path]:
+    return {
+        blob
+        for prefix in blob_root.iterdir()
+        if prefix.is_dir()
+        for blob in prefix.iterdir()
+        if blob.is_file()
+    }
 
 
 def test_workspace_open_is_idempotent_and_restart_replays_revision(
@@ -67,6 +78,54 @@ def test_workspace_open_is_idempotent_and_restart_replays_revision(
     assert resume.resume is not None
     assert resume.resume.problem.verification == "UNVERIFIED"
     assert "retrieval does not promote" in resume.warning
+
+
+def test_concurrent_idempotent_workspace_open_publishes_one_revision(
+    attached_complete_runtime,
+) -> None:
+    runtime = attached_complete_runtime
+    request = WorkspaceOpenRequest(
+        idempotency_key="workspace-open-concurrent-001",
+        name="concurrent replay fixture",
+        problem="Two retries must resolve to one accepted workspace.",
+    )
+    ready = threading.Barrier(3)
+    results = []
+    errors: list[BaseException] = []
+    with runtime.core.store.connection() as connection:
+        artifacts_before = connection.execute(
+            "SELECT COUNT(*) FROM artifacts"
+        ).fetchone()[0]
+    quota_before = runtime.core.store._blob_bytes_committed()
+    blobs_before = _blob_paths(runtime.core.store.blob_root)
+
+    def open_workspace() -> None:
+        ready.wait(timeout=2)
+        try:
+            results.append(runtime.core.workspaces.open(request))
+        except BaseException as exc:
+            errors.append(exc)
+
+    workers = [threading.Thread(target=open_workspace) for _ in range(2)]
+    for worker in workers:
+        worker.start()
+    ready.wait(timeout=2)
+    for worker in workers:
+        worker.join(timeout=5)
+
+    assert errors == []
+    assert len(results) == 2
+    assert results[0] == results[1]
+    with runtime.core.store.connection() as connection:
+        artifacts_after = connection.execute(
+            "SELECT COUNT(*) FROM artifacts"
+        ).fetchone()[0]
+    assert artifacts_after == artifacts_before + 1
+    quota_after = runtime.core.store._blob_bytes_committed()
+    blobs_after = _blob_paths(runtime.core.store.blob_root)
+    assert len(blobs_after - blobs_before) == 2
+    assert quota_after > quota_before
+    assert runtime.core.store._blob_bytes_committed() == quota_after
 
 
 def test_workspace_write_cannot_add_a_second_problem(attached_complete_runtime) -> None:
@@ -328,6 +387,69 @@ def test_workspace_rejects_stale_base_without_partial_index_writes(
                 revision_id=opened.revision_id,
             )
         )
+
+
+def test_concurrent_workspace_writes_publish_only_the_winning_revision(
+    attached_complete_runtime,
+) -> None:
+    runtime = attached_complete_runtime
+    opened = _open(runtime, key="workspace-open-concurrent-write-001")
+    ready = threading.Barrier(3)
+    results = []
+    errors: list[BaseException] = []
+    with runtime.core.store.connection() as connection:
+        artifacts_before = connection.execute(
+            "SELECT COUNT(*) FROM artifacts"
+        ).fetchone()[0]
+    quota_before = runtime.core.store._blob_bytes_committed()
+    blobs_before = _blob_paths(runtime.core.store.blob_root)
+
+    def write(client_ref: str) -> None:
+        request = WorkspaceWriteRequest(
+            idempotency_key=f"workspace-write-concurrent-{client_ref}",
+            workspace_id=opened.workspace_id,
+            branch_id=opened.branch_id,
+            base_revision=opened.revision_id,
+            findings=(
+                WorkspaceFindingDraft(
+                    client_ref=client_ref,
+                    kind=WorkspaceFindingKind.GOAL,
+                    title=f"Competing goal {client_ref}",
+                    body="Only one revision may advance this branch head.",
+                ),
+            ),
+        )
+        ready.wait(timeout=2)
+        try:
+            results.append(runtime.core.workspaces.write(request))
+        except BaseException as exc:
+            errors.append(exc)
+
+    workers = [threading.Thread(target=write, args=(ref,)) for ref in ("G1", "G2")]
+    for worker in workers:
+        worker.start()
+    ready.wait(timeout=2)
+    for worker in workers:
+        worker.join(timeout=5)
+
+    assert len(results) == 1
+    assert len(errors) == 1
+    assert isinstance(errors[0], WorkspaceConflictError)
+    with runtime.core.store.connection() as connection:
+        artifacts_after = connection.execute(
+            "SELECT COUNT(*) FROM artifacts"
+        ).fetchone()[0]
+        revisions = connection.execute(
+            "SELECT COUNT(*) FROM workspace_revisions WHERE workspace_id = ?",
+            (opened.workspace_id,),
+        ).fetchone()[0]
+    assert artifacts_after == artifacts_before + 1
+    assert revisions == 2
+    quota_after = runtime.core.store._blob_bytes_committed()
+    blobs_after = _blob_paths(runtime.core.store.blob_root)
+    assert len(blobs_after - blobs_before) == 2
+    assert quota_after > quota_before
+    assert runtime.core.store._blob_bytes_committed() == quota_after
 
 
 def test_workspace_rejects_idempotency_rebinding_and_invalid_references(

--- a/tests/unit/portfolio/test_portfolio_installation_phases.py
+++ b/tests/unit/portfolio/test_portfolio_installation_phases.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from types import SimpleNamespace
-from typing import cast
+from typing import Any, cast
 
 import pytest
 
@@ -121,3 +121,27 @@ def test_reference_phase_derives_authority_from_its_context() -> None:
     assert result.references == {}
     assert result.lean_checkers == {}
     assert context.registered == []
+
+
+def test_portfolio_close_releases_every_owned_lean_resource_once() -> None:
+    closed: list[str] = []
+
+    class Resource:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        def close(self) -> None:
+            closed.append(self.name)
+
+    result = PortfolioInstallation()
+    result.lean_declarations = cast(Any, Resource("declarations"))
+    result.lean_exploration = cast(
+        Any,
+        SimpleNamespace(repl=Resource("exploration")),
+    )
+    result.lean = cast(Any, Resource("verification"))
+
+    result.close()
+    result.close()
+
+    assert closed == ["declarations", "exploration", "verification"]

--- a/tests/unit/tooling/test_release_workflow.py
+++ b/tests/unit/tooling/test_release_workflow.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+from tomllib import loads
+
+ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
+
+
+def test_release_build_resolves_and_verifies_one_immutable_sha() -> None:
+    source = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "release:\n    types: [published]" in source
+    assert "workflow_dispatch:" in source
+    assert "release_sha: ${{ steps.release.outputs.sha }}" in source
+    assert "ref: ${{ steps.release.outputs.sha }}" in source
+    assert 'test "$(git rev-parse HEAD)" = "$RELEASE_SHA"' in source
+    assert (
+        "actions/workflows/ci.yml/runs?head_sha=$RELEASE_SHA&status=success" in source
+    )
+    assert source.index("Require successful CI for release commit") < source.index(
+        "Build Python distributions"
+    )
+
+
+def test_mcp_publisher_is_verified_before_oidc_or_publication() -> None:
+    source = WORKFLOW.read_text(encoding="utf-8")
+    publisher = source[source.index("publish-mcp:") :]
+
+    assert "MCP_PUBLISHER_VERSION: v1.8.0" in publisher
+    assert (
+        "1370446bbe74d562608e8005a6ccce02d146a661fbd78674e11cc70b9618d6cf" in publisher
+    )
+    assert (
+        "c978982c60e1b4903a976de090f04dc4fac4a320daa50704fcad2dbc93433d62" in publisher
+    )
+    checksum = publisher.index("sha256sum --check --strict")
+    extraction = publisher.index('tar xzf "$archive" mcp-publisher')
+    source_check = publisher.index("Verify immutable release commit")
+    oidc = publisher.index("login github-oidc")
+    publication = publisher.index("./mcp-publisher publish")
+
+    assert source_check < checksum < extraction < oidc < publication
+
+
+def test_local_diagnostics_are_excluded_from_source_distributions() -> None:
+    configuration = loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    exclusions = configuration["tool"]["hatch"]["build"]["targets"]["sdist"]["exclude"]
+
+    assert "/.diagnostics" in exclusions
+    assert "/.diagnostics/**" in exclusions
+    assert ".diagnostics/" in (ROOT / ".gitignore").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

This PR hardens the runtime and deployment boundaries identified in the critical remediation audit.

- Drains blocking MCP work before cancellation and tenant/runtime teardown.
- Makes SQLite registration, workspace acceptance, and artifact publication contention-safe.
- Adds retryable service, Lean, portfolio, and tenant lifecycle ownership with leases, TTL/LRU eviction, and shutdown recovery.
- Uses the authoritative bounded graph model and stops exact independence computation at order 24.
- Adds fail-closed tenant CLI validation, credential-safe deployment output, transactional activation rollback, immutable release SHA checks, and checksum-pinned MCP Publisher installation.
- Excludes local `.diagnostics/` state from source distributions.

## Validation

The final repository-selected gate passed on the reviewed tree:

- 1,999 Python tests across unit, component, domain, composition, storage, process, MCP, and end-to-end lanes.
- 61 dedicated Lean tests after installing/verifying `leanprover/lean4:v4.31.0`, including real Mathlib discovery and proof/replay flows.
- 32 npm tests and package dry-run.
- Ruff, mypy, complexity, dependency, dead-code, test-architecture, build, security audit, duplicate-code, and documentation-link checks.
- Independent exact-diff review, including a follow-up after fixing three P1 lifecycle/rollback findings.

## Proof gap

A controlled FlameOx before/after comparison was not run because no `flameox` executable or frozen baseline was available.