### PR TITLE
ci(benchmarks): upload timing evidence via non-hidden filename

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -296,11 +296,13 @@ jobs:
         run: |
           uv run --locked python -m benchmarks.tooling.benchmark_timings \
             --root oracle-artifacts --output .benchmark-timings.json
+      - name: Stage timing evidence for upload
+        run: cp .benchmark-timings.json benchmark-timings.json
       - name: Upload timing evidence
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: benchmark-timings-${{ github.sha }}
-          path: .benchmark-timings.json
+          path: benchmark-timings.json
           if-no-files-found: error
           retention-days: 90
       - name: Save timing history for future main-branch plans


### PR DESCRIPTION
## Summary

Fix the shared benchmark timing-upload failure that affects multiple benchmark pull requests.

### Problem

The `Publish Benchmark Timings` job collects its output as `.benchmark-timings.json`. The pinned `actions/upload-artifact` action excludes hidden files, so the upload step fails with:

> No files were found with the provided path: .benchmark-timings.json

The same failure was reproduced on benchmark PRs including #331 and #321.

### Change

Keep `.benchmark-timings.json` unchanged for planner and cache behavior. Stage a non-hidden `benchmark-timings.json` immediately after collection and upload that file instead. No benchmark collector or verifier behavior changes.

### Validation

- `uv run pre-commit run --files .github/workflows/benchmarks.yml` — all hooks passed, including actionlint.
- YAML parsing passed.
- `git diff --check origin/main..origin/codex/fix-benchmark-timing-upload-20260802` — clean.

The PR is intentionally limited to the shared workflow fix.
