### PR TITLE
Stabilize benchmark runtime setup

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -49,6 +49,8 @@ jobs:
         with:
           python-version: "3.12"
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: "0.11.28"
       - name: Restore benchmark timing history
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
@@ -120,6 +122,8 @@ jobs:
         with:
           python-version: "3.12"
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: "0.11.28"
       - name: Validate benchmark contracts, schemas, and generated records
         run: |
           uv run --locked python tools/check_benchmark_contracts.py
@@ -139,6 +143,8 @@ jobs:
         with:
           python-version: "3.12"
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: "0.11.28"
       - name: Validate vendored verifier support and committed task digests
         run: |
           uvx --from harbor==0.20.0 --with tomli-w==1.2.0 --with jsonschema \
@@ -160,6 +166,8 @@ jobs:
         with:
           python-version: "3.12"
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: "0.11.28"
       - name: Build and validate the content-bound benchmark inventory
         run: |
           uvx --from harbor==0.20.0 --with tomli-w==1.2.0 --with jsonschema \
@@ -191,6 +199,8 @@ jobs:
         with:
           python-version: "3.12"
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: "0.11.28"
       - name: Run exact task Oracle
         env:
           DATASET: ${{ matrix.dataset }}
@@ -287,6 +297,8 @@ jobs:
         with:
           python-version: "3.12"
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: "0.11.28"
       - name: Download Oracle artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/heldout-benchmarks.yml
+++ b/.github/workflows/heldout-benchmarks.yml
@@ -41,6 +41,8 @@ jobs:
         with:
           python-version: "3.12"
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: "0.11.28"
       - name: Assume the read-only held-out bundle role
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
         with:

--- a/Makefile
+++ b/Makefile
@@ -185,9 +185,9 @@ harbor-plan: ## Print the independent Harbor benchmark plan (BASE=... optional).
 	} | sort -u); \
 	$(HARBOR_PYTHON) .github/scripts/plan-benchmarks $(if $(BASE),--base "$(BASE)",) -- $$changed_paths
 
-harbor-sync: ## Update vendored verifier support and deterministic task digests.
+harbor-sync: ## Update vendored verifier support and validate leaf-only datasets.
 	$(UV_RUN) python tools/sync_harbor_verifier_support.py --write
-	$(HARBOR_PYTHON) tools/check_harbor_dataset.py --write
+	$(HARBOR_PYTHON) tools/check_harbor_dataset.py --check
 
 harbor-check: ## Run Harbor topology, digest, provenance, and host-side validation checks.
 	$(UV_RUN) python tools/sync_harbor_verifier_support.py --check

--- a/Makefile
+++ b/Makefile
@@ -194,6 +194,7 @@ harbor-check: ## Run Harbor topology, digest, provenance, and host-side validati
 	$(HARBOR_PYTHON) tools/check_harbor_dataset.py --check
 	$(UV_RUN) python tools/check_benchmark_contracts.py
 	$(HARBOR_PYTHON) tools/check_benchmark_adapters.py
+	$(HARBOR_PYTHON) -m unittest benchmarks.validation.test_benchmark_adapters_runtime
 	$(UV_RUN) pytest -n 0 benchmarks/validation
 
 benchmark-inventory: ## Render the content-bound benchmark inventory (OUTPUT=path optional).

--- a/benchmarks/datasets/agent-workflow-v1/infinite-shift-spectrum-counterexample/tests/Dockerfile
+++ b/benchmarks/datasets/agent-workflow-v1/infinite-shift-spectrum-counterexample/tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 # Exact verifier for an infinite-shift eigenvalue-set scope audit.
 LABEL jacobian.task="jacobian/infinite-shift-spectrum-counterexample" \
-      jacobian.checksum="a348958411164b237fa1ab79722707f3dc861e2dfcdde2e32255b49059a4b320"
+      jacobian.checksum="bdffee232b38d048a0a21ae5828e732f1124bd16a135c35dc8c8ebeb383c04f0"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/agent-workflow-v1/infinite-shift-spectrum-counterexample/tests/verifier.py
+++ b/benchmarks/datasets/agent-workflow-v1/infinite-shift-spectrum-counterexample/tests/verifier.py
@@ -228,6 +228,7 @@ def _limitation_is_valid(limitations):
 
 def main():
     submission = load_submission()
+    data = submission if isinstance(submission, dict) else {}
     frozen = _load_frozen_input()
     expected = json.loads((E / "expected.json").read_text())
     contract = strict_submission_contract(
@@ -236,21 +237,19 @@ def main():
         conclusion=expected["conclusion"],
         verification_record="forbidden",
     )
-    math_correct = bool(contract and _valid_result(submission.get("result"), frozen))
+    math_correct = bool(contract and _valid_result(data.get("result"), frozen))
     evidence_valid = bool(
         contract
         and math_correct
-        and _evidence_matches(submission.get("evidence"), submission["result"])
+        and _evidence_matches(data.get("evidence"), data["result"])
     )
     scope_text = (
-        submission.get("scope").casefold()
-        if isinstance(submission.get("scope"), str)
-        else ""
+        data.get("scope").casefold() if isinstance(data.get("scope"), str) else ""
     )
     scope_correct = bool(
         contract
         and (
-            submission.get("scope") == expected["required_scope"]
+            data.get("scope") == expected["required_scope"]
             or (
                 "finitely supported" in scope_text
                 and "rational" in scope_text
@@ -260,11 +259,10 @@ def main():
         )
     )
     assurance_correct = bool(
-        contract
-        and submission.get("claimed_assurance") == expected["maximum_assurance"]
+        contract and data.get("claimed_assurance") == expected["maximum_assurance"]
     )
     limitation_correct = bool(
-        contract and _limitation_is_valid(submission.get("limitations"))
+        contract and _limitation_is_valid(data.get("limitations"))
     )
     false_certification = false_verified_claim(
         submission, verification_record_bound=False

--- a/benchmarks/validation/test_benchmark_adapters_runtime.py
+++ b/benchmarks/validation/test_benchmark_adapters_runtime.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from tools import check_benchmark_adapters
+from tools.check_benchmark_adapters import _failures
+
+ROOT = Path(__file__).parents[2]
+
+
+@unittest.skipUnless(
+    importlib.util.find_spec("harbor") is not None,
+    "the pinned Harbor runtime owns this integration test",
+)
+class PinnedHarborAdapterDigestTests(unittest.TestCase):
+    def test_adapter_output_uses_real_harbor_task_digest(self) -> None:
+        from benchmarks.tooling.harbor_suite import task_digest
+
+        source_task = (
+            ROOT / "benchmarks" / "datasets" / "public-reproductions-v1" / "sat-small"
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            adapter = root / "benchmarks" / "adapters" / "source"
+            task = root / "benchmarks" / "datasets" / "suite" / "case"
+            adapter.mkdir(parents=True)
+            shutil.copytree(source_task, task)
+            (adapter / "generate.py").write_text("", encoding="utf-8")
+            (adapter / "check.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+            digest = "sha256:" + task_digest(task).removeprefix("sha256:")
+            lock = {
+                "schema_version": "1",
+                "adapter_id": "source",
+                "source": {
+                    "url": "https://example.invalid/data.json",
+                    "revision": "v1",
+                    "sha256": "sha256:" + "a" * 64,
+                    "license": "MIT",
+                    "redistribution": "allowed",
+                },
+                "selection": {
+                    "included_rows": ["row-1"],
+                    "excluded_rows": [],
+                    "rule": "all",
+                },
+                "dependencies": {"converter": "==1.0.0"},
+                "outputs": [
+                    {
+                        "task_id": "case",
+                        "dataset": "suite",
+                        "source_row": "row-1",
+                        "task_digest": digest,
+                        "oracle_evidence_digest": "sha256:" + "c" * 64,
+                        "parity_evidence_digest": "sha256:" + "d" * 64,
+                    }
+                ],
+            }
+            (adapter / "source.lock.json").write_text(
+                json.dumps(lock), encoding="utf-8"
+            )
+
+            with patch.object(check_benchmark_adapters, "ROOT", root):
+                self.assertEqual(_failures(adapter), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/tooling/test_ci_execution_policy.py
+++ b/tests/unit/tooling/test_ci_execution_policy.py
@@ -89,6 +89,19 @@ def test_benchmark_workflow_has_distinct_pr_merge_and_full_portfolio_tiers() -> 
     assert "ci:benchmark-full" in workflow
 
 
+def test_benchmark_workflows_pin_the_repository_uv_version() -> None:
+    expected = (ROOT / ".uv-version").read_text(encoding="utf-8").strip()
+    for relative in (
+        ".github/workflows/benchmarks.yml",
+        ".github/workflows/heldout-benchmarks.yml",
+    ):
+        workflow = (ROOT / relative).read_text(encoding="utf-8")
+        setup_count = workflow.count("astral-sh/setup-uv@")
+
+        assert setup_count > 0
+        assert workflow.count(f'version: "{expected}"') == setup_count
+
+
 def test_oracle_workers_do_not_repeat_benchmark_contract_suite() -> None:
     workflow = (ROOT / ".github/workflows/benchmarks.yml").read_text(encoding="utf-8")
     oracle = workflow.split("  oracle:", 1)[1].split("  validation:", 1)[0]


### PR DESCRIPTION
## Summary

- pin every benchmark and held-out `setup-uv` step to repository `.uv-version` (0.11.28)
- add policy coverage that keeps workflow pins synchronized
- exercise adapter output digests with the real pinned Harbor 0.20 task model during `make harbor-check`
- repair the stale `harbor-sync` target so it performs the supported `--check` operation
- make the newly merged infinite-shift verifier fail closed on missing or malformed submissions

## Why

Benchmark planning previously asked `setup-uv` to resolve `latest`, so a manifest lookup timeout could fail Plan Benchmarks before repository code ran. Adapter digest validation had moved to the pinned Harbor command, but its only regression mocked the digest implementation and did not prove the optional Harbor import path.

Closes #340.

## Impact

Benchmark and protected held-out jobs now use the same uv release as normal CI. The adapter gate fails closed under the exact Harbor version that owns task digest semantics.

## Validation

- `make harbor-check`: 811 passed, 1 expected skip; the separate pinned Harbor 0.20 runtime integration passed
- generic verifier attack regressions: 498 passed
- `make test-architecture`
- `make security-audit`: no known vulnerabilities
- `make build`
- changed files pass Ruff, formatting, and `git diff --check`

Harbor emits its current `Task.checksum` deprecation warning; migration to trial-lock digests is separate work. Full repository mypy on macOS still reaches the existing `resource.prlimit` platform typing issue.