### PR TITLE
feat(combinatorics): add verified difference-set decisions

### DIFF
--- a/docs/reference/additive-combinatorics-decisions.md
+++ b/docs/reference/additive-combinatorics-decisions.md
@@ -64,11 +64,17 @@ rejection remain non-conclusions.
 ## Public research diagnostic
 
 `jacobian/jcb-postdoc-015` is a public answer-visible reproduction for the
-five-element set `{1,2,4,8,13}`. Its clean-room Harbor verifier checks all 20
-integer differences and exhausts orders 5, 6, and 7. The task explicitly marks
-the public universal obstruction as not replayed: those three finite checks do
-not prove that the set is absent from every finite perfect difference set.
+five-element set `{1,2,4,8,13}`. Its clean-room Harbor verifier validates the
+benchmark contract: it binds the agent-visible input to the frozen verifier
+copy, checks the submission envelope, confirms the expected conclusion and
+answer-visible key facts, and binds the recorded evidence file by digest. The
+task explicitly marks the public universal obstruction as not replayed: the
+contract-only Oracle does not enumerate the 20 integer differences or exhaust
+orders 5, 6, and 7, so those finite checks do not prove that the set is absent
+from every finite perfect difference set.
 
-The public Oracle validates the benchmark contract and the bounded operations.
-It is not held-out evidence of model improvement. Protected transformed cases
-and matched Jacobian-on/off runs remain a separate evaluation stage.
+The public Oracle validates the benchmark contract and the bounded operations
+at the submission-protocol level. It is not held-out evidence of model
+improvement, and it does not independently replay the underlying mathematics.
+Protected transformed cases and matched Jacobian-on/off runs remain a separate
+evaluation stage.

--- a/docs/reference/additive-combinatorics-decisions.md
+++ b/docs/reference/additive-combinatorics-decisions.md
@@ -1,0 +1,74 @@
+# Additive-combinatorics decisions
+
+[Documentation home](../index.md)
+
+- Status: Current implementation reference; contracts are pre-stable
+- Related reference: [Domain operation library](domain-operation-library.md)
+
+Jacobian exposes three bounded, atomic outcomes for Sidon and cyclic
+perfect-difference-set work. They support exact finite reasoning without
+claiming a general design-theory solver or a universal obstruction theorem.
+
+## Integer Sidon decision
+
+`combinatorics.integer_set.sidon.decide` accepts at most 32 distinct canonical
+integer strings. Its result sorts the set and records one row for every ordered
+pair of different elements. The result is Sidon exactly when every recorded
+difference is distinct. The producer is deterministic standard-library code
+and returns `COMPUTED` assurance.
+
+When authorized,
+`combinatorics.integer_set.sidon.verify` independently reconstructs the whole
+ordered profile in a bounded checker process. The inline verification request
+contains the original typed request and the candidate result.
+
+## Cyclic perfect-difference-set decision
+
+`combinatorics.cyclic_difference_set.perfect.decide` accepts a canonical
+residue set and a modulus no larger than 4096. It returns the multiplicity of
+every residue from 1 through `modulus-1`, the missing and repeated residues,
+the set order `k`, and the expected perfect modulus `k(k-1)+1`.
+
+The decision is true only when the submitted modulus equals that expected
+modulus and every nonzero residue occurs exactly once. The independent
+`combinatorics.cyclic_difference_set.perfect.verify` capability rebuilds this
+complete profile rather than accepting the Boolean field alone.
+
+## Fixed-order extension decision
+
+`combinatorics.cyclic_difference_set.extension.decide` asks whether the
+reduced residues of one integer base set are directly contained in a perfect
+difference set of one specified order `k`. The modulus is not arbitrary: it is
+derived as `k(k-1)+1`. Translation, affine equivalence, alternative embeddings,
+and universal quantification over `k` are outside this contract.
+
+The request is accepted only when all of these bounds hold:
+
+- `2 <= k <= 64` and the derived modulus is at most 4096;
+- at most three residues must be added; and
+- the complete candidate space contains at most 50,000 combinations.
+
+A positive result carries the complete extension witness. A negative result
+carries `coverage = ALL_CANDIDATES`, an empty witness, and the exact binomial
+candidate count. The result is a typed artifact, so discovery can match its
+schema to the verifier's `TYPED_ARTIFACT` input contract.
+
+The producer uses difference-conflict pruning. The independent
+`combinatorics.cyclic_difference_set.extension.verify` checker does not import
+that code or reuse its search: it enumerates the declared combination space
+directly and checks each candidate's complete residue profile. Only an
+operator-authorized successful replay is eligible for product `VERIFIED`.
+Unavailable authority, timeout, malformed output, scope mismatch, and checker
+rejection remain non-conclusions.
+
+## Public research diagnostic
+
+`jacobian/jcb-postdoc-015` is a public answer-visible reproduction for the
+five-element set `{1,2,4,8,13}`. Its clean-room Harbor verifier checks all 20
+integer differences and exhausts orders 5, 6, and 7. The task explicitly marks
+the public universal obstruction as not replayed: those three finite checks do
+not prove that the set is absent from every finite perfect difference set.
+
+The public Oracle validates the benchmark contract and the bounded operations.
+It is not held-out evidence of model improvement. Protected transformed cases
+and matched Jacobian-on/off runs remain a separate evaluation stage.

--- a/docs/reference/domain-operation-library.md
+++ b/docs/reference/domain-operation-library.md
@@ -186,12 +186,23 @@ before invocation. Do not infer a verifier ID or payload from naming
 conventions: checker availability depends on operator authorization and the
 installed runtime.
 
-Two bounded portfolio examples show the intended boundary:
+Bounded portfolio examples show the intended boundary:
 
 - `graph.hamiltonian_path.decide` returns either a complete spanning path
   witness or a negative decision after exhausting its order-18 state space.
   `graph.hamiltonian_path.verify` checks a positive witness directly and
   independently exhausts negative instances.
+- `combinatorics.integer_set.sidon.decide` materializes the complete ordered
+  integer-difference profile. `combinatorics.cyclic_difference_set.perfect.decide`
+  similarly materializes every nonzero cyclic residue multiplicity.
+  `combinatorics.cyclic_difference_set.extension.decide` asks only a bounded,
+  fixed-order direct-containment question in the derived modulus `k(k-1)+1`;
+  its negative result is durable and records the exact candidate-space size.
+  The corresponding `.verify` capabilities use a standard-library checker
+  module that imports no producer code. Negative extension replay enumerates
+  every candidate with `itertools.combinations`, independently of the
+  producer's pruned depth-first search. See
+  [Additive-combinatorics decisions](additive-combinatorics-decisions.md).
 - `polynomial.jacobian_syzygy.minimum_degree.compute` constructs the graded
   maps from degree zero through the first kernel or a declared finite bound.
   The source can be a canonical sparse polynomial or a labelled product of

--- a/src/jacobian/contracts/combinatorics.py
+++ b/src/jacobian/contracts/combinatorics.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import math
 from fractions import Fraction
 from itertools import pairwise
-from typing import Literal, Self
+from typing import Annotated, Literal, Self
 
-from pydantic import Field, StrictInt, model_validator
+from pydantic import Field, StrictBool, StrictInt, StringConstraints, model_validator
 
 from jacobian.canonical import (
     CanonicalLimits,
@@ -29,7 +29,28 @@ MAX_RATIONAL_SERIES_TRUNCATION_ORDER = 512
 MAX_COMBINATORICS_INPUT_RATIONAL_DIGITS = 64
 MAX_COMBINATORICS_RESULT_RATIONAL_DIGITS = 32_768
 MAX_COMBINATORICS_RESULT_ARTIFACT_BYTES = 10 * 1024 * 1024
+MAX_SIDON_SET_SIZE = 32
+MAX_CYCLIC_DIFFERENCE_SET_MODULUS = 4_096
+MAX_DIFFERENCE_SET_EXTENSION_CANDIDATES = 50_000
+MAX_DIFFERENCE_SET_ADDITIONAL_ELEMENTS = 3
 _LOG10_2 = math.log10(2)
+
+AdditiveInteger = Annotated[
+    str,
+    StringConstraints(
+        pattern=r"^(?:0|-?[1-9][0-9]*)$",
+        max_length=128,
+        strict=True,
+    ),
+]
+AdditiveDifferenceInteger = Annotated[
+    str,
+    StringConstraints(
+        pattern=r"^(?:0|-?[1-9][0-9]*)$",
+        max_length=129,
+        strict=True,
+    ),
+]
 
 
 def _fraction_wire(value: Fraction) -> dict[str, str]:
@@ -257,6 +278,252 @@ class NonnegativeIntegerRequest(ContractModel):
 class NonnegativePairRequest(ContractModel):
     n: StrictInt = Field(ge=0, le=_MAX_N)
     k: StrictInt = Field(ge=0, le=_MAX_N)
+
+
+class IntegerSidonRequest(ContractModel):
+    """One bounded finite integer set for ordered-difference replay."""
+
+    elements: tuple[AdditiveInteger, ...] = Field(max_length=MAX_SIDON_SET_SIZE)
+
+    @model_validator(mode="after")
+    def require_unique_elements(self) -> Self:
+        if len(set(self.elements)) != len(self.elements):
+            raise ValueError("Sidon input elements must be unique")
+        return self
+
+
+class OrderedIntegerDifference(ContractModel):
+    minuend: AdditiveInteger
+    subtrahend: AdditiveInteger
+    difference: AdditiveDifferenceInteger
+
+
+class IntegerSidonResult(ContractModel):
+    """Complete ordered-difference profile and exact Sidon decision."""
+
+    semantics_version: Literal["integer-sidon.ordered-differences.v1"]
+    normalized_elements: tuple[AdditiveInteger, ...] = Field(
+        max_length=MAX_SIDON_SET_SIZE
+    )
+    ordered_differences: tuple[OrderedIntegerDifference, ...] = Field(
+        max_length=MAX_SIDON_SET_SIZE * (MAX_SIDON_SET_SIZE - 1)
+    )
+    is_sidon: StrictBool
+    exactness: Literal["EXACT_INTEGER"] = "EXACT_INTEGER"
+    determinism: Literal["DETERMINISTIC"] = "DETERMINISTIC"
+    backend: Literal["python-stdlib"] = "python-stdlib"
+    verification: Literal["UNVERIFIED"] = "UNVERIFIED"
+
+    @model_validator(mode="after")
+    def bind_complete_ordered_difference_profile(self) -> Self:
+        values = tuple(int(value) for value in self.normalized_elements)
+        if values != tuple(sorted(set(values))):
+            raise ValueError("normalized Sidon elements must be sorted and unique")
+        expected = tuple(
+            (left, right, left - right)
+            for left in values
+            for right in values
+            if left != right
+        )
+        actual = tuple(
+            (
+                int(record.minuend),
+                int(record.subtrahend),
+                int(record.difference),
+            )
+            for record in self.ordered_differences
+        )
+        if actual != expected:
+            raise ValueError(
+                "ordered differences must cover every distinct ordered pair canonically"
+            )
+        if self.is_sidon != (len({item[2] for item in expected}) == len(expected)):
+            raise ValueError("Sidon decision must match the ordered differences")
+        return self
+
+
+class CyclicPerfectDifferenceSetRequest(ContractModel):
+    """One canonical residue set and modulus for exact PDS decision."""
+
+    modulus: StrictInt = Field(ge=2, le=MAX_CYCLIC_DIFFERENCE_SET_MODULUS)
+    residues: tuple[StrictInt, ...] = Field(min_length=1, max_length=64)
+
+    @model_validator(mode="after")
+    def require_canonical_residue_set(self) -> Self:
+        if len(set(self.residues)) != len(self.residues):
+            raise ValueError("PDS residues must be unique")
+        if any(residue < 0 or residue >= self.modulus for residue in self.residues):
+            raise ValueError("PDS residues must be canonical modulo the modulus")
+        return self
+
+
+class CyclicDifferenceMultiplicity(ContractModel):
+    residue: StrictInt = Field(ge=1, lt=MAX_CYCLIC_DIFFERENCE_SET_MODULUS)
+    multiplicity: StrictInt = Field(ge=0, le=4_096)
+
+
+class CyclicPerfectDifferenceSetResult(ContractModel):
+    """Complete nonzero cyclic difference profile and exact PDS decision."""
+
+    semantics_version: Literal["cyclic-perfect-difference-set.v1"]
+    modulus: StrictInt = Field(ge=2, le=MAX_CYCLIC_DIFFERENCE_SET_MODULUS)
+    normalized_residues: tuple[StrictInt, ...] = Field(min_length=1, max_length=64)
+    order: StrictInt = Field(ge=1, le=64)
+    expected_modulus: StrictInt = Field(ge=1, le=MAX_CYCLIC_DIFFERENCE_SET_MODULUS)
+    difference_multiplicities: tuple[CyclicDifferenceMultiplicity, ...] = Field(
+        min_length=1,
+        max_length=MAX_CYCLIC_DIFFERENCE_SET_MODULUS - 1,
+    )
+    missing_residues: tuple[StrictInt, ...] = Field(
+        max_length=MAX_CYCLIC_DIFFERENCE_SET_MODULUS - 1
+    )
+    repeated_residues: tuple[StrictInt, ...] = Field(
+        max_length=MAX_CYCLIC_DIFFERENCE_SET_MODULUS - 1
+    )
+    is_perfect: StrictBool
+    exactness: Literal["EXACT_FINITE"] = "EXACT_FINITE"
+    determinism: Literal["DETERMINISTIC"] = "DETERMINISTIC"
+    backend: Literal["python-stdlib"] = "python-stdlib"
+    verification: Literal["UNVERIFIED"] = "UNVERIFIED"
+
+    @model_validator(mode="after")
+    def bind_complete_cyclic_profile(self) -> Self:
+        residues = self.normalized_residues
+        if residues != tuple(sorted(set(residues))):
+            raise ValueError("normalized PDS residues must be sorted and unique")
+        if any(residue < 0 or residue >= self.modulus for residue in residues):
+            raise ValueError("normalized PDS residues must lie in the modulus")
+        if self.order != len(residues):
+            raise ValueError("PDS order must equal the residue-set cardinality")
+        if self.expected_modulus != self.order * (self.order - 1) + 1:
+            raise ValueError("expected_modulus must equal k(k-1)+1")
+        profile = self.difference_multiplicities
+        if tuple(item.residue for item in profile) != tuple(range(1, self.modulus)):
+            raise ValueError(
+                "cyclic difference profile must cover every nonzero residue"
+            )
+        missing = tuple(item.residue for item in profile if item.multiplicity == 0)
+        repeated = tuple(item.residue for item in profile if item.multiplicity > 1)
+        if self.missing_residues != missing or self.repeated_residues != repeated:
+            raise ValueError("missing and repeated residues must match the profile")
+        expected_perfect = (
+            self.modulus == self.expected_modulus and not missing and not repeated
+        )
+        if self.is_perfect != expected_perfect:
+            raise ValueError("PDS decision must match the complete residue profile")
+        return self
+
+
+class CyclicDifferenceSetExtensionRequest(ContractModel):
+    """A fixed-order direct-containment question in the derived cyclic group."""
+
+    base_elements: tuple[AdditiveInteger, ...] = Field(min_length=1, max_length=64)
+    target_order: StrictInt = Field(ge=2, le=64)
+
+    @model_validator(mode="after")
+    def require_bounded_complete_candidate_space(self) -> Self:
+        if len(set(self.base_elements)) != len(self.base_elements):
+            raise ValueError("extension base elements must be unique")
+        modulus = self.target_order * (self.target_order - 1) + 1
+        if modulus > MAX_CYCLIC_DIFFERENCE_SET_MODULUS:
+            raise ValueError("derived extension modulus exceeds the supported bound")
+        base_residues = {int(value) % modulus for value in self.base_elements}
+        additional = self.target_order - len(base_residues)
+        if additional < 0:
+            raise ValueError("target_order is smaller than the reduced base set")
+        if additional > MAX_DIFFERENCE_SET_ADDITIONAL_ELEMENTS:
+            raise ValueError("extension request requires too many added elements")
+        candidates = math.comb(modulus - len(base_residues), additional)
+        if candidates > MAX_DIFFERENCE_SET_EXTENSION_CANDIDATES:
+            raise ValueError(
+                "extension candidate space exceeds the complete-search bound"
+            )
+        return self
+
+
+def _extension_result_candidate_count(
+    *,
+    target_order: int,
+    modulus: int,
+    base_residues: tuple[int, ...],
+) -> int:
+    expected_modulus = target_order * (target_order - 1) + 1
+    if modulus != expected_modulus:
+        raise ValueError("extension modulus must equal k(k-1)+1")
+    if base_residues != tuple(sorted(set(base_residues))):
+        raise ValueError("base residues must be sorted and unique")
+    if any(residue < 0 or residue >= modulus for residue in base_residues):
+        raise ValueError("base residues must lie in the derived modulus")
+    additional = target_order - len(base_residues)
+    if additional < 0 or additional > MAX_DIFFERENCE_SET_ADDITIONAL_ELEMENTS:
+        raise ValueError(
+            "extension result lies outside the supported added-element bound"
+        )
+    return math.comb(modulus - len(base_residues), additional)
+
+
+def _require_positive_extension_shape(
+    *,
+    target_order: int,
+    modulus: int,
+    base_residues: tuple[int, ...],
+    extension: tuple[int, ...],
+    coverage: str,
+) -> None:
+    if coverage != "WITNESS":
+        raise ValueError("positive extension decisions require witness coverage")
+    if extension != tuple(sorted(set(extension))):
+        raise ValueError("extension witness must be sorted and unique")
+    if len(extension) != target_order:
+        raise ValueError("extension witness must have target_order residues")
+    if any(residue < 0 or residue >= modulus for residue in extension):
+        raise ValueError("extension witness residues must lie in the derived modulus")
+    if not set(base_residues) <= set(extension):
+        raise ValueError("extension witness must contain the reduced base set")
+
+
+class CyclicDifferenceSetExtensionResult(ContractModel):
+    """A witness or complete negative decision for one fixed PDS order."""
+
+    semantics_version: Literal["cyclic-pds-extension.fixed-order.v1"]
+    target_order: StrictInt = Field(ge=2, le=64)
+    modulus: StrictInt = Field(ge=2, le=MAX_CYCLIC_DIFFERENCE_SET_MODULUS)
+    base_residues: tuple[StrictInt, ...] = Field(min_length=1, max_length=64)
+    candidate_space_size: StrictInt = Field(
+        ge=1, le=MAX_DIFFERENCE_SET_EXTENSION_CANDIDATES
+    )
+    decision: Literal["EXTENDS", "DOES_NOT_EXTEND"]
+    extension: tuple[StrictInt, ...] = Field(max_length=64)
+    coverage: Literal["WITNESS", "ALL_CANDIDATES"]
+    exactness: Literal["EXACT_FINITE"] = "EXACT_FINITE"
+    determinism: Literal["DETERMINISTIC"] = "DETERMINISTIC"
+    backend: Literal["python-stdlib"] = "python-stdlib"
+    verification: Literal["UNVERIFIED"] = "UNVERIFIED"
+
+    @model_validator(mode="after")
+    def bind_fixed_order_scope_and_decision_shape(self) -> Self:
+        expected_candidates = _extension_result_candidate_count(
+            target_order=self.target_order,
+            modulus=self.modulus,
+            base_residues=self.base_residues,
+        )
+        if self.candidate_space_size != expected_candidates:
+            raise ValueError(
+                "candidate_space_size must cover the exact combination space"
+            )
+        if self.decision == "EXTENDS":
+            _require_positive_extension_shape(
+                target_order=self.target_order,
+                modulus=self.modulus,
+                base_residues=self.base_residues,
+                extension=self.extension,
+                coverage=self.coverage,
+            )
+        elif self.extension or self.coverage != "ALL_CANDIDATES":
+            raise ValueError(
+                "negative extension decisions require empty witness and full coverage"
+            )
+        return self
 
 
 class IntegerListRequest(ContractModel):

--- a/src/jacobian/contracts/combinatorics.py
+++ b/src/jacobian/contracts/combinatorics.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import itertools
 import math
+from collections import Counter
+from collections.abc import Iterator
 from fractions import Fraction
 from itertools import pairwise
 from typing import Annotated, Literal, Self
@@ -367,6 +370,43 @@ class CyclicPerfectDifferenceSetRequest(ContractModel):
         return self
 
 
+def _cyclic_difference_multiplicities(
+    residues: tuple[int, ...],
+    modulus: int,
+) -> dict[int, int]:
+    """Recompute nonzero cyclic difference multiplicities from the residue set.
+
+    The authoritative result-model validators use this clean-room recompute to
+    reject forged but internally self-consistent profiles: a producer regression
+    that materializes an incorrect ``COMPUTED`` result cannot pass the boundary
+    even when the submitted multiplicity fields agree with the decision flag.
+    """
+
+    counts: Counter[int] = Counter(
+        (left - right) % modulus
+        for left in residues
+        for right in residues
+        if left != right
+    )
+    return {residue: counts.get(residue, 0) for residue in range(1, modulus)}
+
+
+def _is_perfect_difference_set(
+    residues: tuple[int, ...],
+    modulus: int,
+) -> bool:
+    """Decide the perfect-difference-set property from the residue set."""
+
+    if modulus != len(residues) * (len(residues) - 1) + 1:
+        return False
+    return all(
+        multiplicity == 1
+        for multiplicity in _cyclic_difference_multiplicities(
+            residues, modulus
+        ).values()
+    )
+
+
 class CyclicDifferenceMultiplicity(ContractModel):
     residue: StrictInt = Field(ge=1, lt=MAX_CYCLIC_DIFFERENCE_SET_MODULUS)
     multiplicity: StrictInt = Field(ge=0, le=4_096)
@@ -411,6 +451,11 @@ class CyclicPerfectDifferenceSetResult(ContractModel):
         if tuple(item.residue for item in profile) != tuple(range(1, self.modulus)):
             raise ValueError(
                 "cyclic difference profile must cover every nonzero residue"
+            )
+        recomputed = _cyclic_difference_multiplicities(residues, self.modulus)
+        if any(item.multiplicity != recomputed[item.residue] for item in profile):
+            raise ValueError(
+                "cyclic difference multiplicities must be derived from the residues"
             )
         missing = tuple(item.residue for item in profile if item.multiplicity == 0)
         repeated = tuple(item.residue for item in profile if item.multiplicity > 1)
@@ -490,6 +535,39 @@ def _require_positive_extension_shape(
         raise ValueError("extension witness residues must lie in the derived modulus")
     if not set(base_residues) <= set(extension):
         raise ValueError("extension witness must contain the reduced base set")
+    if not _is_perfect_difference_set(extension, modulus):
+        raise ValueError(
+            "extension witness must be a perfect difference set of the derived modulus"
+        )
+
+
+def _enumerate_extension_candidates(
+    base_residues: tuple[int, ...],
+    target_order: int,
+    modulus: int,
+) -> Iterator[tuple[int, ...]]:
+    """Yield every target_order residue superset of the reduced base set."""
+
+    base_set = set(base_residues)
+    available = tuple(residue for residue in range(modulus) if residue not in base_set)
+    additional = target_order - len(base_residues)
+    for combination in itertools.combinations(available, additional):
+        yield tuple(sorted((*base_residues, *combination)))
+
+
+def _find_extension_witness(
+    base_residues: tuple[int, ...],
+    target_order: int,
+    modulus: int,
+) -> tuple[int, ...] | None:
+    """Return one perfect extension witness, or ``None`` if none exists."""
+
+    for candidate in _enumerate_extension_candidates(
+        base_residues, target_order, modulus
+    ):
+        if _is_perfect_difference_set(candidate, modulus):
+            return candidate
+    return None
 
 
 class CyclicDifferenceSetExtensionResult(ContractModel):
@@ -533,6 +611,16 @@ class CyclicDifferenceSetExtensionResult(ContractModel):
             raise ValueError(
                 "negative extension decisions require empty witness and full coverage"
             )
+        else:
+            if (
+                _find_extension_witness(
+                    self.base_residues, self.target_order, self.modulus
+                )
+                is not None
+            ):
+                raise ValueError(
+                    "negative extension decision must match the exhaustive search"
+                )
         return self
 
 

--- a/src/jacobian/contracts/combinatorics.py
+++ b/src/jacobian/contracts/combinatorics.py
@@ -33,13 +33,23 @@ MAX_SIDON_SET_SIZE = 32
 MAX_CYCLIC_DIFFERENCE_SET_MODULUS = 4_096
 MAX_DIFFERENCE_SET_EXTENSION_CANDIDATES = 50_000
 MAX_DIFFERENCE_SET_ADDITIONAL_ELEMENTS = 3
+# An ``AdditiveInteger`` canonical string is at most
+# ``MAX_ADDITIVE_INTEGER_LENGTH`` characters: a positive value may use every
+# character for digits, while a negative value spends one character on the
+# leading ``-``. The widest ordered difference ``minuend - subtrahend`` pairs
+# the largest accepted positive value with the most-negative accepted value
+# (or vice versa), so its magnitude reaches ``(10**L - 1) + (10**(L - 1) - 1)``,
+# which carries one extra digit; the negative sign then adds one more
+# character. The result bound is therefore the input bound plus two.
+MAX_ADDITIVE_INTEGER_LENGTH = 128
+MAX_ADDITIVE_DIFFERENCE_INTEGER_LENGTH = MAX_ADDITIVE_INTEGER_LENGTH + 2
 _LOG10_2 = math.log10(2)
 
 AdditiveInteger = Annotated[
     str,
     StringConstraints(
         pattern=r"^(?:0|-?[1-9][0-9]*)$",
-        max_length=128,
+        max_length=MAX_ADDITIVE_INTEGER_LENGTH,
         strict=True,
     ),
 ]
@@ -47,7 +57,7 @@ AdditiveDifferenceInteger = Annotated[
     str,
     StringConstraints(
         pattern=r"^(?:0|-?[1-9][0-9]*)$",
-        max_length=129,
+        max_length=MAX_ADDITIVE_DIFFERENCE_INTEGER_LENGTH,
         strict=True,
     ),
 ]

--- a/src/jacobian/domains/combinatorics/_support.py
+++ b/src/jacobian/domains/combinatorics/_support.py
@@ -1,12 +1,17 @@
 """Combinatorics operation declarations."""
 
-from jacobian.operations import ComputedOperationFactory, OperationFailure
-
-combinatorics_operation = ComputedOperationFactory(
-    OperationFailure(
-        code="COMBINATORICS_OPERATION_NOT_APPLICABLE",
-        stage="combinatorics_computation",
-        hint="Check non-negativity and ordering preconditions.",
-        exceptions=(TypeError, ValueError, ArithmeticError),
-    )
+from jacobian.operations import (
+    ComputedOperationFactory,
+    MaterializedOperationFactory,
+    OperationFailure,
 )
+
+_FAILURE = OperationFailure(
+    code="COMBINATORICS_OPERATION_NOT_APPLICABLE",
+    stage="combinatorics_computation",
+    hint="Check the bounded combinatorics input and mathematical preconditions.",
+    exceptions=(TypeError, ValueError, ArithmeticError),
+)
+
+combinatorics_operation = ComputedOperationFactory(_FAILURE)
+materialized_combinatorics_operation = MaterializedOperationFactory(_FAILURE)

--- a/src/jacobian/domains/combinatorics/bundle.py
+++ b/src/jacobian/domains/combinatorics/bundle.py
@@ -7,6 +7,7 @@ import platform
 from jacobian.contracts.capabilities import CapabilityDiagnostic
 from jacobian.domains.combinatorics.checkers import COMBINATORICS_EXACT_REPLAY_CHECKERS
 from jacobian.domains.combinatorics.counting import COUNTING_CAPABILITIES
+from jacobian.domains.combinatorics.difference_sets import DIFFERENCE_SET_CAPABILITIES
 from jacobian.domains.combinatorics.partitions import PARTITION_CAPABILITIES
 from jacobian.domains.combinatorics.recurrence import RECURRENCE_CAPABILITIES
 from jacobian.operations import (
@@ -46,6 +47,7 @@ def build_combinatorics_bundle() -> DomainBundle:
             *COUNTING_CAPABILITIES,
             *PARTITION_CAPABILITIES,
             *RECURRENCE_CAPABILITIES,
+            *DIFFERENCE_SET_CAPABILITIES,
         ),
         diagnostics=DomainDiagnostics(
             invalid_request=CapabilityDiagnostic(

--- a/src/jacobian/domains/combinatorics/checkers.py
+++ b/src/jacobian/domains/combinatorics/checkers.py
@@ -2,6 +2,9 @@
 
 from jacobian.checker_operations import ExactReplayCheckerDeclaration
 from jacobian.contracts.combinatorics import (
+    CyclicDifferenceSetExtensionRequest,
+    CyclicPerfectDifferenceSetRequest,
+    IntegerSidonRequest,
     LinearRecurrenceEvaluationRequest,
     RationalGeneratingFunctionCoefficientsRequest,
 )
@@ -13,6 +16,42 @@ _REASON = (
 )
 
 COMBINATORICS_EXACT_REPLAY_CHECKERS = (
+    ExactReplayCheckerDeclaration(
+        "combinatorics.integer_set.sidon.decide",
+        IntegerSidonRequest,
+        "check_integer_sidon",
+        "combinatorics.integer-sidon.ordered-difference-replay",
+        entrypoint_module="jacobian_checkers.additive_combinatorics",
+        replay_method="standard-library ordered-difference replay",
+        reason=(
+            "operator-authorized standard-library checker independently enumerates "
+            "every ordered integer difference without importing producer code"
+        ),
+    ),
+    ExactReplayCheckerDeclaration(
+        "combinatorics.cyclic_difference_set.perfect.decide",
+        CyclicPerfectDifferenceSetRequest,
+        "check_cyclic_perfect_difference_set",
+        "combinatorics.cyclic-pds.residue-profile-replay",
+        entrypoint_module="jacobian_checkers.additive_combinatorics",
+        replay_method="standard-library cyclic residue-profile replay",
+        reason=(
+            "operator-authorized standard-library checker independently rebuilds "
+            "the complete nonzero cyclic difference multiplicities"
+        ),
+    ),
+    ExactReplayCheckerDeclaration(
+        "combinatorics.cyclic_difference_set.extension.decide",
+        CyclicDifferenceSetExtensionRequest,
+        "check_cyclic_difference_set_extension",
+        "combinatorics.cyclic-pds-extension.exhaustive-replay",
+        entrypoint_module="jacobian_checkers.additive_combinatorics",
+        replay_method="standard-library fixed-order exhaustive extension replay",
+        reason=(
+            "operator-authorized checker independently enumerates every bounded "
+            "completion using itertools rather than the producer's pruning search"
+        ),
+    ),
     ExactReplayCheckerDeclaration(
         "combinatorics.recurrence.linear.evaluate",
         LinearRecurrenceEvaluationRequest,

--- a/src/jacobian/domains/combinatorics/difference_sets.py
+++ b/src/jacobian/domains/combinatorics/difference_sets.py
@@ -1,0 +1,271 @@
+"""Exact additive-combinatorics decisions for finite difference sets."""
+
+from __future__ import annotations
+
+import math
+from collections import Counter
+
+from jacobian.contracts.combinatorics import (
+    CyclicDifferenceMultiplicity,
+    CyclicDifferenceSetExtensionRequest,
+    CyclicDifferenceSetExtensionResult,
+    CyclicPerfectDifferenceSetRequest,
+    CyclicPerfectDifferenceSetResult,
+    IntegerSidonRequest,
+    IntegerSidonResult,
+    OrderedIntegerDifference,
+)
+from jacobian.domains._examples import example
+from jacobian.domains.combinatorics._support import (
+    combinatorics_operation,
+    materialized_combinatorics_operation,
+)
+
+
+def decide_integer_sidon(request: IntegerSidonRequest) -> IntegerSidonResult:
+    elements = tuple(sorted(int(value) for value in request.elements))
+    differences = tuple(
+        OrderedIntegerDifference(
+            minuend=str(left),
+            subtrahend=str(right),
+            difference=str(left - right),
+        )
+        for left in elements
+        for right in elements
+        if left != right
+    )
+    values = tuple(int(record.difference) for record in differences)
+    return IntegerSidonResult(
+        semantics_version="integer-sidon.ordered-differences.v1",
+        normalized_elements=tuple(str(value) for value in elements),
+        ordered_differences=differences,
+        is_sidon=len(set(values)) == len(values),
+    )
+
+
+def _difference_counts(residues: tuple[int, ...], modulus: int) -> Counter[int]:
+    return Counter(
+        (left - right) % modulus
+        for left in residues
+        for right in residues
+        if left != right
+    )
+
+
+def decide_cyclic_perfect_difference_set(
+    request: CyclicPerfectDifferenceSetRequest,
+) -> CyclicPerfectDifferenceSetResult:
+    residues = tuple(sorted(request.residues))
+    counts = _difference_counts(residues, request.modulus)
+    profile = tuple(
+        CyclicDifferenceMultiplicity(
+            residue=residue,
+            multiplicity=counts.get(residue, 0),
+        )
+        for residue in range(1, request.modulus)
+    )
+    missing = tuple(item.residue for item in profile if item.multiplicity == 0)
+    repeated = tuple(item.residue for item in profile if item.multiplicity > 1)
+    order = len(residues)
+    expected_modulus = order * (order - 1) + 1
+    return CyclicPerfectDifferenceSetResult(
+        semantics_version="cyclic-perfect-difference-set.v1",
+        modulus=request.modulus,
+        normalized_residues=residues,
+        order=order,
+        expected_modulus=expected_modulus,
+        difference_multiplicities=profile,
+        missing_residues=missing,
+        repeated_residues=repeated,
+        is_perfect=(
+            request.modulus == expected_modulus and not missing and not repeated
+        ),
+    )
+
+
+def _initial_difference_mask(residues: tuple[int, ...], modulus: int) -> int | None:
+    mask = 0
+    for left in residues:
+        for right in residues:
+            if left == right:
+                continue
+            residue = (left - right) % modulus
+            bit = 1 << residue
+            if residue == 0 or mask & bit:
+                return None
+            mask |= bit
+    return mask
+
+
+def _extended_difference_mask(
+    selected: tuple[int, ...],
+    mask: int,
+    candidate: int,
+    modulus: int,
+) -> int | None:
+    result = mask
+    for existing in selected:
+        for difference in (
+            (candidate - existing) % modulus,
+            (existing - candidate) % modulus,
+        ):
+            bit = 1 << difference
+            if difference == 0 or result & bit:
+                return None
+            result |= bit
+    return result
+
+
+def _visit_extensions(
+    selected: tuple[int, ...],
+    mask: int,
+    start: int,
+    available: tuple[int, ...],
+    target_order: int,
+    modulus: int,
+) -> tuple[int, ...] | None:
+    remaining = target_order - len(selected)
+    if remaining == 0:
+        return selected
+    if len(available) - start < remaining:
+        return None
+    for position in range(start, len(available)):
+        candidate = available[position]
+        local_mask = _extended_difference_mask(selected, mask, candidate, modulus)
+        if local_mask is None:
+            continue
+        found = _visit_extensions(
+            tuple(sorted((*selected, candidate))),
+            local_mask,
+            position + 1,
+            available,
+            target_order,
+            modulus,
+        )
+        if found is not None:
+            return found
+    return None
+
+
+def _find_extension(
+    base: tuple[int, ...], target_order: int, modulus: int
+) -> tuple[int, ...] | None:
+    initial_mask = _initial_difference_mask(base, modulus)
+    if initial_mask is None:
+        return None
+    needed = target_order - len(base)
+    if needed == 0:
+        return base
+    available = tuple(value for value in range(modulus) if value not in set(base))
+    return _visit_extensions(
+        base,
+        initial_mask,
+        0,
+        available,
+        target_order,
+        modulus,
+    )
+
+
+def decide_cyclic_difference_set_extension(
+    request: CyclicDifferenceSetExtensionRequest,
+) -> CyclicDifferenceSetExtensionResult:
+    order = request.target_order
+    modulus = order * (order - 1) + 1
+    base = tuple(sorted({int(value) % modulus for value in request.base_elements}))
+    additional = order - len(base)
+    candidate_count = math.comb(modulus - len(base), additional)
+    extension = _find_extension(base, order, modulus)
+    return CyclicDifferenceSetExtensionResult(
+        semantics_version="cyclic-pds-extension.fixed-order.v1",
+        target_order=order,
+        modulus=modulus,
+        base_residues=base,
+        candidate_space_size=candidate_count,
+        decision="EXTENDS" if extension is not None else "DOES_NOT_EXTEND",
+        extension=extension or (),
+        coverage="WITNESS" if extension is not None else "ALL_CANDIDATES",
+    )
+
+
+DIFFERENCE_SET_CAPABILITIES = (
+    combinatorics_operation(
+        "combinatorics.integer_set.sidon.decide",
+        "Decide the integer Sidon property",
+        (
+            "Materialize every ordered nonzero integer difference of one bounded "
+            "finite set and decide whether all such differences are distinct."
+        ),
+        IntegerSidonRequest,
+        IntegerSidonResult,
+        decide_integer_sidon,
+        "combinatorics",
+        "additive-combinatorics",
+        "sidon-set",
+        "ordered-differences",
+        invocation_examples=(
+            example(
+                "mian_chowla_prefix",
+                "Decide whether 1, 2, 4, 8, 13 is Sidon over the integers.",
+                {"elements": ["1", "2", "4", "8", "13"]},
+            ),
+        ),
+    ),
+    combinatorics_operation(
+        "combinatorics.cyclic_difference_set.perfect.decide",
+        "Decide the cyclic perfect-difference-set property",
+        (
+            "Compute the complete nonzero residue-difference multiplicity profile "
+            "and decide whether one finite residue set is perfect."
+        ),
+        CyclicPerfectDifferenceSetRequest,
+        CyclicPerfectDifferenceSetResult,
+        decide_cyclic_perfect_difference_set,
+        "combinatorics",
+        "additive-combinatorics",
+        "difference-set",
+        "finite-design",
+        invocation_examples=(
+            example(
+                "fano_difference_set",
+                "Decide whether 0, 1, 3 is a perfect difference set modulo 7.",
+                {"modulus": 7, "residues": [0, 1, 3]},
+            ),
+        ),
+    ),
+    materialized_combinatorics_operation(
+        "combinatorics.cyclic_difference_set.extension.decide",
+        "Decide fixed-order perfect-difference-set extension",
+        (
+            "Completely decide whether the reduced residues of one bounded integer "
+            "set extend to a cyclic perfect difference set of one fixed order."
+        ),
+        CyclicDifferenceSetExtensionRequest,
+        CyclicDifferenceSetExtensionResult,
+        decide_cyclic_difference_set_extension,
+        "combinatorics",
+        "additive-combinatorics",
+        "difference-set",
+        "bounded-completion",
+        invocation_examples=(
+            example(
+                "mian_chowla_order_six",
+                "Decide fixed-order extension of 1, 2, 4, 8, 13 at order 6.",
+                {
+                    "base_elements": ["1", "2", "4", "8", "13"],
+                    "target_order": 6,
+                },
+            ),
+        ),
+        preview=lambda result: result,
+        preview_complete=True,
+    ),
+)
+
+
+__all__ = [
+    "DIFFERENCE_SET_CAPABILITIES",
+    "decide_cyclic_difference_set_extension",
+    "decide_cyclic_perfect_difference_set",
+    "decide_integer_sidon",
+]

--- a/src/jacobian/exact_domain_checkers.py
+++ b/src/jacobian/exact_domain_checkers.py
@@ -21,6 +21,7 @@ from jacobian.contracts.capabilities import (
     CapabilityCompletenessStatus,
     CapabilityDescriptor,
     CapabilityDiagnostic,
+    CapabilityInputKind,
     CapabilityInstallTier,
     CapabilityMode,
     CapabilityProviderAvailability,
@@ -76,6 +77,7 @@ _ENTRYPOINT_PROVIDER_RUNTIME_KEYS = {
     "jacobian_checkers.graph_exact_operations": "finite-graph",
     "jacobian_checkers.exact_probability_operations": "finite-probability",
     "jacobian_checkers.recurrence_series": "combinatorics",
+    "jacobian_checkers.additive_combinatorics": "combinatorics",
     "jacobian_checkers.jacobian_syzygy": "graded-syzygy",
     "jacobian_checkers.projective_arrangements": "projective-arrangement",
     "jacobian_checkers.simplicial_topology": "topology",
@@ -464,6 +466,14 @@ class ExactComputedVerificationAdapter:
             ),
             output_schema=model_schema(ExactComputedVerificationOutput),
             tags=declaration.declaration.verification_tags,
+            accepted_input_kinds=(
+                (CapabilityInputKind.TYPED_ARTIFACT,)
+                if stored_result_input
+                else (CapabilityInputKind.STRUCTURED_REQUEST,)
+            ),
+            accepted_artifact_types=(
+                (declaration.result_schema_uri,) if stored_result_input else ()
+            ),
         )
 
     @property

--- a/src/jacobian/graphs/neighborhood_independence.py
+++ b/src/jacobian/graphs/neighborhood_independence.py
@@ -19,6 +19,7 @@ from jacobian.contracts.capabilities import (
     CapabilityCompletenessStatus,
     CapabilityDescriptor,
     CapabilityDiagnostic,
+    CapabilityInputKind,
     CapabilityMode,
     CapabilityRelationship,
     CapabilityRequest,
@@ -86,6 +87,8 @@ class GraphNeighborhoodIndependenceAdapter:
                 "independence-number",
                 "exact-computation",
             ),
+            accepted_input_kinds=(CapabilityInputKind.TYPED_ARTIFACT,),
+            accepted_artifact_types=(resources.graph.graph_schema_uri,),
         )
 
     @property

--- a/src/jacobian/providers/flint_runtime.py
+++ b/src/jacobian/providers/flint_runtime.py
@@ -332,19 +332,25 @@ def combinatorics_exact_checker_provider_runtime(
     *,
     checker_ids: tuple[str, ...] = (),
 ) -> CapabilityProviderRuntime:
-    """Bind recurrence and rational-series checker source without SymPy."""
+    """Bind exact combinatorics checker source without producer dependencies."""
 
     try:
         version, _, license_files = _jacobian_identity()
     except ProviderRuntimeError:
-        source = _unavailable_runtime(
+        recurrence_source = _unavailable_runtime(
             provider="jacobian.combinatorics-exact-checker-source",
             install_tier=CapabilityInstallTier.T1,
             license_id="MIT",
-            diagnostic="The exact combinatorics checker source could not be identified.",
+            diagnostic="The recurrence checker source could not be identified.",
+        )
+        additive_source = _unavailable_runtime(
+            provider="jacobian.additive-combinatorics-checker-source",
+            install_tier=CapabilityInstallTier.T1,
+            license_id="MIT",
+            diagnostic="The additive-combinatorics checker source could not be identified.",
         )
     else:
-        source = source_provider_runtime(
+        recurrence_source = source_provider_runtime(
             "jacobian.combinatorics-exact-checker-source",
             version=version,
             entrypoint=(
@@ -355,11 +361,26 @@ def combinatorics_exact_checker_provider_runtime(
             license_files=license_files,
             features=("clean-process-replay", "standard-library-only"),
         )
+        additive_source = source_provider_runtime(
+            "jacobian.additive-combinatorics-checker-source",
+            version=version,
+            entrypoint=("jacobian_checkers.additive_combinatorics:check_integer_sidon"),
+            install_tier=CapabilityInstallTier.T1,
+            license_id="MIT",
+            license_files=license_files,
+            features=(
+                "clean-process-replay",
+                "fixed-order-extension-exhaustion",
+                "standard-library-only",
+            ),
+        )
     return composite_provider_runtime(
         "jacobian.combinatorics-exact-checkers",
-        components=(source,),
+        components=(recurrence_source, additive_source),
         features=(
             "clean-process-replay",
+            "additive-difference-set-replay",
+            "fixed-order-extension-exhaustion",
             "linear-recurrence-replay",
             "rational-series-residual-replay",
             "standard-library-only",

--- a/src/jacobian_checkers/additive_combinatorics.py
+++ b/src/jacobian_checkers/additive_combinatorics.py
@@ -1,0 +1,338 @@
+"""Independent finite difference-set replay using only the standard library.
+
+This module imports neither the combinatorics producer nor its helper functions.
+Only passive artifact-bound JSON crosses the checker boundary.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from itertools import combinations
+from typing import Any
+
+from jacobian_checkers.bound_artifacts import bound_request
+
+_INTEGER = re.compile(r"^(?:0|-?[1-9][0-9]*)$")
+_META_INTEGER = {
+    "exactness": "EXACT_INTEGER",
+    "determinism": "DETERMINISTIC",
+    "backend": "python-stdlib",
+    "verification": "UNVERIFIED",
+}
+_META_FINITE = {
+    "exactness": "EXACT_FINITE",
+    "determinism": "DETERMINISTIC",
+    "backend": "python-stdlib",
+    "verification": "UNVERIFIED",
+}
+
+
+def _reject(detail: str) -> dict[str, Any]:
+    return {
+        "accepted": False,
+        "conclusion": "UNKNOWN",
+        "arithmetic": "EXACT_INTEGER",
+        "method": "DIRECT_WITNESS",
+        "coverage": "NOT_APPLICABLE",
+        "detail": detail,
+    }
+
+
+def _accept(detail: str, *, exhaustive: bool = False) -> dict[str, Any]:
+    return {
+        "accepted": True,
+        "conclusion": "TRUE",
+        "arithmetic": "EXACT_INTEGER",
+        "method": "EXHAUSTIVE_FINITE" if exhaustive else "DIRECT_WITNESS",
+        "coverage": "EXHAUSTIVE" if exhaustive else "NOT_APPLICABLE",
+        "detail": detail,
+    }
+
+
+def _canonical_integer(value: object, *, max_digits: int) -> int:
+    if (
+        not isinstance(value, str)
+        or len(value.lstrip("-")) > max_digits
+        or _INTEGER.fullmatch(value) is None
+    ):
+        raise ValueError("integer is outside the checker scope")
+    parsed = int(value)
+    if str(parsed) != value:
+        raise ValueError("integer is not canonical")
+    return parsed
+
+
+def _integer_list(
+    value: object,
+    *,
+    minimum: int,
+    maximum: int,
+    max_digits: int,
+) -> list[int]:
+    if not isinstance(value, list) or not minimum <= len(value) <= maximum:
+        raise ValueError("integer list is outside the checker scope")
+    parsed = [_canonical_integer(item, max_digits=max_digits) for item in value]
+    if len(parsed) != len(set(parsed)):
+        raise ValueError("integer list is not a set")
+    return parsed
+
+
+def _metadata(
+    result: dict[str, Any], fields: set[str], expected: dict[str, str]
+) -> bool:
+    return set(result) == fields | set(expected) and all(
+        result.get(key) == value for key, value in expected.items()
+    )
+
+
+def _replay_sidon(source: dict[str, Any], result: dict[str, Any]) -> bool:
+    if set(source) != {"elements"} or not _metadata(
+        result,
+        {
+            "semantics_version",
+            "normalized_elements",
+            "ordered_differences",
+            "is_sidon",
+        },
+        _META_INTEGER,
+    ):
+        return False
+    source_values = _integer_list(
+        source["elements"], minimum=0, maximum=32, max_digits=128
+    )
+    normalized = sorted(source_values)
+    if result["semantics_version"] != "integer-sidon.ordered-differences.v1" or result[
+        "normalized_elements"
+    ] != [str(value) for value in normalized]:
+        return False
+    expected = [
+        {
+            "minuend": str(left),
+            "subtrahend": str(right),
+            "difference": str(left - right),
+        }
+        for left in normalized
+        for right in normalized
+        if left != right
+    ]
+    differences = [int(item["difference"]) for item in expected]
+    return (
+        result["ordered_differences"] == expected
+        and type(result["is_sidon"]) is bool
+        and result["is_sidon"] == (len(set(differences)) == len(differences))
+    )
+
+
+def _residue_counts(residues: list[int], modulus: int) -> list[int]:
+    counts = [0] * modulus
+    for left in residues:
+        for right in residues:
+            if left != right:
+                counts[(left - right) % modulus] += 1
+    return counts
+
+
+def _is_perfect(residues: list[int], modulus: int) -> bool:
+    if len(residues) != len(set(residues)):
+        return False
+    order = len(residues)
+    if modulus != order * (order - 1) + 1:
+        return False
+    counts = _residue_counts(residues, modulus)
+    return counts[0] == 0 and all(count == 1 for count in counts[1:])
+
+
+def _replay_perfect(source: dict[str, Any], result: dict[str, Any]) -> bool:
+    if set(source) != {"modulus", "residues"} or not _metadata(
+        result,
+        {
+            "semantics_version",
+            "modulus",
+            "normalized_residues",
+            "order",
+            "expected_modulus",
+            "difference_multiplicities",
+            "missing_residues",
+            "repeated_residues",
+            "is_perfect",
+        },
+        _META_FINITE,
+    ):
+        return False
+    modulus = source["modulus"]
+    raw_residues = source["residues"]
+    if (
+        type(modulus) is not int
+        or not 2 <= modulus <= 4_096
+        or not isinstance(raw_residues, list)
+        or not 1 <= len(raw_residues) <= 64
+        or any(
+            type(value) is not int or not 0 <= value < modulus for value in raw_residues
+        )
+        or len(raw_residues) != len(set(raw_residues))
+    ):
+        return False
+    residues = sorted(raw_residues)
+    counts = _residue_counts(residues, modulus)
+    profile = [
+        {"residue": residue, "multiplicity": counts[residue]}
+        for residue in range(1, modulus)
+    ]
+    missing = [residue for residue in range(1, modulus) if counts[residue] == 0]
+    repeated = [residue for residue in range(1, modulus) if counts[residue] > 1]
+    order = len(residues)
+    expected_modulus = order * (order - 1) + 1
+    return result == {
+        "semantics_version": "cyclic-perfect-difference-set.v1",
+        "modulus": modulus,
+        "normalized_residues": residues,
+        "order": order,
+        "expected_modulus": expected_modulus,
+        "difference_multiplicities": profile,
+        "missing_residues": missing,
+        "repeated_residues": repeated,
+        "is_perfect": modulus == expected_modulus and not missing and not repeated,
+        **_META_FINITE,
+    }
+
+
+def _extension_scope(source: dict[str, Any]) -> tuple[list[int], int, int, int]:
+    if set(source) != {"base_elements", "target_order"}:
+        raise ValueError("extension request fields are malformed")
+    base_elements = _integer_list(
+        source["base_elements"], minimum=1, maximum=64, max_digits=128
+    )
+    order = source["target_order"]
+    if type(order) is not int or not 2 <= order <= 64:
+        raise ValueError("extension order is outside the checker scope")
+    modulus = order * (order - 1) + 1
+    if modulus > 4_096:
+        raise ValueError("extension modulus is outside the checker scope")
+    base = sorted({value % modulus for value in base_elements})
+    additional = order - len(base)
+    if additional < 0 or additional > 3:
+        raise ValueError("extension cardinality is outside the checker scope")
+    candidate_count = math.comb(modulus - len(base), additional)
+    if candidate_count > 50_000:
+        raise ValueError("extension candidate space is outside the checker scope")
+    return base, order, modulus, candidate_count
+
+
+def _replay_extension(
+    source: dict[str, Any], result: dict[str, Any]
+) -> tuple[bool, bool]:
+    if not _metadata(
+        result,
+        {
+            "semantics_version",
+            "target_order",
+            "modulus",
+            "base_residues",
+            "candidate_space_size",
+            "decision",
+            "extension",
+            "coverage",
+        },
+        _META_FINITE,
+    ):
+        return False, False
+    base, order, modulus, candidate_count = _extension_scope(source)
+    if (
+        result["semantics_version"] != "cyclic-pds-extension.fixed-order.v1"
+        or result["target_order"] != order
+        or result["modulus"] != modulus
+        or result["base_residues"] != base
+        or result["candidate_space_size"] != candidate_count
+    ):
+        return False, False
+    if result["decision"] == "EXTENDS":
+        extension = result["extension"]
+        if (
+            result["coverage"] != "WITNESS"
+            or not isinstance(extension, list)
+            or extension != sorted(set(extension))
+            or len(extension) != order
+            or any(
+                type(value) is not int or not 0 <= value < modulus
+                for value in extension
+            )
+            or not set(base) <= set(extension)
+        ):
+            return False, False
+        return _is_perfect(extension, modulus), False
+    if (
+        result["decision"] != "DOES_NOT_EXTEND"
+        or result["coverage"] != "ALL_CANDIDATES"
+        or result["extension"] != []
+    ):
+        return False, False
+    pool = [value for value in range(modulus) if value not in set(base)]
+    additional = order - len(base)
+    for extra in combinations(pool, additional):
+        if _is_perfect(sorted((*base, *extra)), modulus):
+            return False, True
+    return True, True
+
+
+def _run_simple(
+    request: object,
+    *,
+    operation_id: str,
+    witness_format: str,
+    replay: Any,
+) -> dict[str, Any]:
+    try:
+        source, result = bound_request(
+            request,
+            operation_id=operation_id,
+            witness_format=witness_format,
+        )
+        if not replay(source, result):
+            return _reject("declared result does not match independent finite replay")
+        return _accept(f"independent finite replay accepted {operation_id}")
+    except (KeyError, TypeError, ValueError, OverflowError):
+        return _reject("malformed, unsupported, or mismatched checker request")
+
+
+def check_integer_sidon(request: object) -> dict[str, Any]:
+    return _run_simple(
+        request,
+        operation_id="combinatorics.integer_set.sidon.decide",
+        witness_format="combinatorics.integer-sidon.ordered-difference-replay",
+        replay=_replay_sidon,
+    )
+
+
+def check_cyclic_perfect_difference_set(request: object) -> dict[str, Any]:
+    return _run_simple(
+        request,
+        operation_id="combinatorics.cyclic_difference_set.perfect.decide",
+        witness_format="combinatorics.cyclic-pds.residue-profile-replay",
+        replay=_replay_perfect,
+    )
+
+
+def check_cyclic_difference_set_extension(request: object) -> dict[str, Any]:
+    try:
+        source, result = bound_request(
+            request,
+            operation_id="combinatorics.cyclic_difference_set.extension.decide",
+            witness_format="combinatorics.cyclic-pds-extension.exhaustive-replay",
+        )
+        accepted, exhaustive = _replay_extension(source, result)
+        if not accepted:
+            return _reject("declared extension decision failed independent replay")
+        return _accept(
+            "independent fixed-order PDS extension replay accepted the decision",
+            exhaustive=exhaustive,
+        )
+    except (KeyError, TypeError, ValueError, OverflowError):
+        return _reject("malformed, unsupported, or mismatched checker request")
+
+
+__all__ = [
+    "check_cyclic_difference_set_extension",
+    "check_cyclic_perfect_difference_set",
+    "check_integer_sidon",
+]

--- a/tests/component/checkers/test_additive_combinatorics_checker.py
+++ b/tests/component/checkers/test_additive_combinatorics_checker.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import copy
+import inspect
+from typing import Any
+
+import pytest
+from tests.support.artifacts import artifact_uri as _uri
+from tests.support.artifacts import canonical_digest as _digest
+
+import jacobian_checkers.additive_combinatorics as checker_module
+from jacobian_checkers.additive_combinatorics import (
+    check_cyclic_difference_set_extension,
+    check_cyclic_perfect_difference_set,
+    check_integer_sidon,
+)
+
+_BASE = [1, 2, 4, 8, 13]
+_META_INTEGER = {
+    "exactness": "EXACT_INTEGER",
+    "determinism": "DETERMINISTIC",
+    "backend": "python-stdlib",
+    "verification": "UNVERIFIED",
+}
+_META_FINITE = {
+    "exactness": "EXACT_FINITE",
+    "determinism": "DETERMINISTIC",
+    "backend": "python-stdlib",
+    "verification": "UNVERIFIED",
+}
+
+
+def _artifact(
+    character: str,
+    payload: dict[str, Any],
+    *,
+    semantics: str,
+    parents: list[str],
+) -> dict[str, Any]:
+    return {
+        "artifact_uri": _uri(character),
+        "object_digest": "sha256:" + character * 64,
+        "payload_digest": _digest(payload),
+        "schema_uri": _uri(chr(ord(character) + 1)),
+        "semantics_uri": semantics,
+        "parents": parents,
+        "payload": payload,
+    }
+
+
+def _request(
+    operation_id: str,
+    witness_format: str,
+    source: dict[str, Any],
+    result: dict[str, Any],
+) -> dict[str, Any]:
+    semantics = _uri("e")
+    semantics_artifact = _artifact(
+        "e", {"kind": "semantics"}, semantics=_uri("0"), parents=[]
+    )
+    semantics_artifact["object_digest"] = "sha256:" + "8" * 64
+    claim = _artifact("1", source, semantics=semantics, parents=[])
+    candidate = _artifact(
+        "3", result, semantics=semantics, parents=[claim["artifact_uri"]]
+    )
+    bindings = {
+        "claim_digest": claim["object_digest"],
+        "semantics_digest": semantics_artifact["object_digest"],
+        "candidate_digest": candidate["object_digest"],
+        "scope_digest": None,
+        "encoding_digest": None,
+    }
+    witness = _artifact(
+        "5",
+        {
+            "evidence_schema_version": "1",
+            "witness_format": witness_format,
+            "format_version": "1",
+            "role": "SUPPORTS_CLAIM",
+            "bindings": bindings,
+            "payload": {
+                "operation_id": operation_id,
+                "input_uri": claim["artifact_uri"],
+                "result_uri": candidate["artifact_uri"],
+            },
+        },
+        semantics=semantics,
+        parents=[claim["artifact_uri"], candidate["artifact_uri"]],
+    )
+    return {
+        "request_version": "1",
+        "claim": claim,
+        "candidate": candidate,
+        "semantics": semantics_artifact,
+        "scope": None,
+        "witness": witness,
+        "expected_bindings": bindings,
+    }
+
+
+def _sidon_case() -> dict[str, Any]:
+    differences = [
+        {
+            "minuend": str(left),
+            "subtrahend": str(right),
+            "difference": str(left - right),
+        }
+        for left in _BASE
+        for right in _BASE
+        if left != right
+    ]
+    return _request(
+        "combinatorics.integer_set.sidon.decide",
+        "combinatorics.integer-sidon.ordered-difference-replay",
+        {"elements": [str(value) for value in _BASE]},
+        {
+            "semantics_version": "integer-sidon.ordered-differences.v1",
+            "normalized_elements": [str(value) for value in _BASE],
+            "ordered_differences": differences,
+            "is_sidon": True,
+            **_META_INTEGER,
+        },
+    )
+
+
+def _perfect_case() -> dict[str, Any]:
+    return _request(
+        "combinatorics.cyclic_difference_set.perfect.decide",
+        "combinatorics.cyclic-pds.residue-profile-replay",
+        {"modulus": 7, "residues": [0, 1, 3]},
+        {
+            "semantics_version": "cyclic-perfect-difference-set.v1",
+            "modulus": 7,
+            "normalized_residues": [0, 1, 3],
+            "order": 3,
+            "expected_modulus": 7,
+            "difference_multiplicities": [
+                {"residue": residue, "multiplicity": 1} for residue in range(1, 7)
+            ],
+            "missing_residues": [],
+            "repeated_residues": [],
+            "is_perfect": True,
+            **_META_FINITE,
+        },
+    )
+
+
+def _negative_extension_case() -> dict[str, Any]:
+    return _request(
+        "combinatorics.cyclic_difference_set.extension.decide",
+        "combinatorics.cyclic-pds-extension.exhaustive-replay",
+        {"base_elements": [str(value) for value in _BASE], "target_order": 6},
+        {
+            "semantics_version": "cyclic-pds-extension.fixed-order.v1",
+            "target_order": 6,
+            "modulus": 31,
+            "base_residues": _BASE,
+            "candidate_space_size": 26,
+            "decision": "DOES_NOT_EXTEND",
+            "extension": [],
+            "coverage": "ALL_CANDIDATES",
+            **_META_FINITE,
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    ("checker", "case_request"),
+    (
+        (check_integer_sidon, _sidon_case()),
+        (check_cyclic_perfect_difference_set, _perfect_case()),
+        (check_cyclic_difference_set_extension, _negative_extension_case()),
+    ),
+)
+def test_additive_combinatorics_checkers_accept_complete_exact_replay(
+    checker: Any,
+    case_request: dict[str, Any],
+) -> None:
+    checked = checker(case_request)
+    assert checked["accepted"] is True
+    assert checked["conclusion"] == "TRUE"
+
+
+def test_sidon_checker_rejects_a_missing_difference_with_fresh_digest() -> None:
+    forged = copy.deepcopy(_sidon_case())
+    forged["candidate"]["payload"]["ordered_differences"].pop()
+    forged["candidate"]["payload_digest"] = _digest(forged["candidate"]["payload"])
+
+    checked = check_integer_sidon(forged)
+
+    assert checked["accepted"] is False
+    assert checked["conclusion"] == "UNKNOWN"
+
+
+def test_perfect_checker_rejects_a_false_multiplicity_with_fresh_digest() -> None:
+    forged = copy.deepcopy(_perfect_case())
+    forged["candidate"]["payload"]["difference_multiplicities"][0]["multiplicity"] = 2
+    forged["candidate"]["payload_digest"] = _digest(forged["candidate"]["payload"])
+
+    assert check_cyclic_perfect_difference_set(forged)["accepted"] is False
+
+
+def test_extension_checker_rejects_wrong_scope_with_fresh_digest() -> None:
+    forged = copy.deepcopy(_negative_extension_case())
+    forged["candidate"]["payload"]["target_order"] = 5
+    forged["candidate"]["payload_digest"] = _digest(forged["candidate"]["payload"])
+
+    assert check_cyclic_difference_set_extension(forged)["accepted"] is False
+
+
+def test_additive_checker_has_no_producer_dependency() -> None:
+    source = inspect.getsource(checker_module)
+    assert "domains.combinatorics" not in source

--- a/tests/composition/portfolio/test_domain_bundles.py
+++ b/tests/composition/portfolio/test_domain_bundles.py
@@ -19,8 +19,11 @@ from jacobian.contracts.capabilities import (
     CapabilityRequest,
 )
 from jacobian.contracts.combinatorics import (
+    CyclicDifferenceSetExtensionRequest,
+    CyclicPerfectDifferenceSetRequest,
     FibonacciPairRequest,
     IntegerPartitionEnumerationRequest,
+    IntegerSidonRequest,
     LinearRecurrenceEvaluationRequest,
     RationalGeneratingFunctionCoefficientsRequest,
 )
@@ -94,6 +97,12 @@ _REPR: list[tuple[type[ContractModel], dict[str, object]]] = [
     (FibonacciPairRequest, {"n": 5}),
     (CombNonnegPairRequest, {"n": 5, "k": 2}),
     (CombIntegerListRequest, {"values": ["2", "1", "1"]}),
+    (IntegerSidonRequest, {"elements": ["1", "2", "4"]}),
+    (CyclicPerfectDifferenceSetRequest, {"modulus": 7, "residues": [0, 1, 3]}),
+    (
+        CyclicDifferenceSetExtensionRequest,
+        {"base_elements": ["0", "1"], "target_order": 3},
+    ),
     (IntegerPartitionEnumerationRequest, {"n": 5, "max_parts": 3}),
     (
         LinearRecurrenceEvaluationRequest,

--- a/tests/composition/runtime/test_additive_combinatorics_verification.py
+++ b/tests/composition/runtime/test_additive_combinatorics_verification.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import pytest
+
+from jacobian.contracts.capabilities import (
+    CapabilityAssuranceLevel,
+    CapabilityDiscoveryRequest,
+    CapabilityInputKind,
+    CapabilityMode,
+    CapabilityRequest,
+)
+from jacobian.contracts.results import ExecutionStatus
+
+_BASE = ["1", "2", "4", "8", "13"]
+_INLINE_CASES = (
+    (
+        "combinatorics.integer_set.sidon.decide",
+        "combinatorics.integer_set.sidon.verify",
+        {"elements": _BASE},
+    ),
+    (
+        "combinatorics.cyclic_difference_set.perfect.decide",
+        "combinatorics.cyclic_difference_set.perfect.verify",
+        {"modulus": 7, "residues": [0, 1, 3]},
+    ),
+)
+
+
+@pytest.mark.parametrize(("producer_id", "verifier_id", "payload"), _INLINE_CASES)
+def test_additive_decisions_are_independently_verified(
+    authorized_complete_runtime,
+    producer_id: str,
+    verifier_id: str,
+    payload: dict[str, object],
+) -> None:
+    computed = authorized_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(capability_id=producer_id, input=payload)
+    )
+    verified = authorized_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id=verifier_id,
+            mode=CapabilityMode.VERIFY,
+            input={"input": payload, "candidate": computed.output["result"]},
+        )
+    )
+
+    assert computed.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert verified.execution.status is ExecutionStatus.COMPLETED
+    assert verified.output["status"] == "VERIFIED"
+    assert verified.output["operation_id"] == producer_id
+    assert verified.output["verification_record_uri"] in verified.artifact_uris
+    assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED
+
+
+def test_fixed_order_negative_result_is_verified_from_its_typed_artifact(
+    authorized_complete_runtime,
+) -> None:
+    producer_id = "combinatorics.cyclic_difference_set.extension.decide"
+    verifier_id = "combinatorics.cyclic_difference_set.extension.verify"
+    computed = authorized_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id=producer_id,
+            input={"base_elements": _BASE, "target_order": 7},
+        )
+    )
+    verified = authorized_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id=verifier_id,
+            mode=CapabilityMode.VERIFY,
+            input={"result_uri": computed.output["result_uri"]},
+        )
+    )
+
+    assert verified.execution.status is ExecutionStatus.COMPLETED
+    assert verified.output["status"] == "VERIFIED"
+    assert verified.output["operation_id"] == producer_id
+    assert verified.output["verification_record_uri"] in verified.artifact_uris
+    assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED
+
+    descriptor = next(
+        item
+        for item in authorized_complete_runtime.core.capabilities.catalog().capabilities
+        if item.capability_id == verifier_id
+    )
+    source = authorized_complete_runtime.core.store.get(computed.output["result_uri"])
+    assert descriptor.accepted_input_kinds == (CapabilityInputKind.TYPED_ARTIFACT,)
+    assert descriptor.accepted_artifact_types == (source.manifest.schema_uri,)
+
+    discovered = authorized_complete_runtime.core.capabilities.discover(
+        CapabilityDiscoveryRequest(
+            query="verify a fixed-order cyclic difference-set extension result",
+            mode=CapabilityMode.VERIFY,
+            input_kind=CapabilityInputKind.TYPED_ARTIFACT,
+            artifact_type=source.manifest.schema_uri,
+        )
+    )
+    assert [match.capability_id for match in discovered.matches] == [verifier_id]
+
+
+def test_fixed_order_positive_witness_is_independently_verified(
+    authorized_complete_runtime,
+) -> None:
+    computed = authorized_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="combinatorics.cyclic_difference_set.extension.decide",
+            input={"base_elements": ["0", "1"], "target_order": 3},
+        )
+    )
+    verified = authorized_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="combinatorics.cyclic_difference_set.extension.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"result_uri": computed.output["result_uri"]},
+        )
+    )
+
+    assert computed.output["preview"]["extension"] == [0, 1, 3]
+    assert verified.output["status"] == "VERIFIED"
+    assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED
+
+
+def test_inline_checker_rejects_a_contract_valid_false_sidon_result(
+    authorized_complete_runtime,
+) -> None:
+    payload = {"elements": _BASE}
+    different = authorized_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="combinatorics.integer_set.sidon.decide",
+            input={"elements": ["0", "1", "2"]},
+        )
+    )
+
+    rejected = authorized_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="combinatorics.integer_set.sidon.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"input": payload, "candidate": different.output["result"]},
+        )
+    )
+
+    assert rejected.execution.status is ExecutionStatus.COMPLETED
+    assert rejected.output["status"] == "REJECTED"
+    assert rejected.output["conclusion"] == "UNKNOWN"
+    assert rejected.output["verification_record_uri"] is None
+    assert rejected.assurance.level is CapabilityAssuranceLevel.COMPUTED
+
+
+def test_additive_checker_runtime_binds_both_independent_sources(
+    authorized_complete_runtime,
+) -> None:
+    descriptor = next(
+        item
+        for item in authorized_complete_runtime.core.capabilities.catalog().capabilities
+        if item.capability_id == "combinatorics.integer_set.sidon.verify"
+    )
+    assert descriptor.provider_runtime is not None
+    assert {
+        component["provider"]
+        for component in descriptor.provider_runtime.configuration["components"]
+    } == {
+        "jacobian.additive-combinatorics-checker-source",
+        "jacobian.combinatorics-exact-checker-source",
+    }

--- a/tests/composition/runtime/test_graph_neighborhood_independence.py
+++ b/tests/composition/runtime/test_graph_neighborhood_independence.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from jacobian.contracts.capabilities import (
     CapabilityAssuranceLevel,
+    CapabilityInputKind,
     CapabilityMode,
     CapabilityRequest,
 )
@@ -86,3 +87,13 @@ def test_neighborhood_independence_reproduces_wowii_200_invariant(
     assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED
     assert verified.output["conclusion"] == Conclusion.TRUE.value
     assert verified.output["verification_record_uri"]
+
+    descriptor = next(
+        item
+        for item in authorized_complete_runtime.core.capabilities.catalog().capabilities
+        if item.capability_id == "graph.compute.neighborhood_independence"
+    )
+    assert descriptor.accepted_input_kinds == (CapabilityInputKind.TYPED_ARTIFACT,)
+    assert descriptor.accepted_artifact_types == (
+        authorized_complete_runtime.portfolio.graph.graph_schema_uri,
+    )

--- a/tests/composition/runtime/test_recurrence_series_verification.py
+++ b/tests/composition/runtime/test_recurrence_series_verification.py
@@ -113,7 +113,10 @@ def test_checker_runtime_binds_only_independent_source(
     assert {
         component["provider"]
         for component in descriptor.provider_runtime.configuration["components"]
-    } == {"jacobian.combinatorics-exact-checker-source"}
+    } == {
+        "jacobian.additive-combinatorics-checker-source",
+        "jacobian.combinatorics-exact-checker-source",
+    }
 
 
 def test_checker_replays_a_result_above_python_default_integer_digit_limit(

--- a/tests/domain/combinatorics/test_additive_combinatorics.py
+++ b/tests/domain/combinatorics/test_additive_combinatorics.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from tests.support.services import DomainTestServices, open_domain_services
+
+from jacobian.contracts.capabilities import CapabilityAssuranceLevel, CapabilityRequest
+from jacobian.contracts.results import ExecutionStatus
+from jacobian.domains.combinatorics import build_combinatorics_bundle
+
+_BASE = ["1", "2", "4", "8", "13"]
+
+
+@pytest.fixture
+def domain_services(tmp_path: Path) -> Iterator[DomainTestServices]:
+    with open_domain_services(
+        tmp_path / "state", build_combinatorics_bundle()
+    ) as services:
+        yield services
+
+
+def test_integer_sidon_materializes_every_ordered_difference(
+    domain_services: DomainTestServices,
+) -> None:
+    computed = domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="combinatorics.integer_set.sidon.decide",
+            input={"elements": _BASE},
+        )
+    )
+
+    result = computed.output["result"]
+    assert computed.execution.status is ExecutionStatus.COMPLETED
+    assert computed.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert result["is_sidon"] is True
+    assert len(result["ordered_differences"]) == 20
+
+
+def test_perfect_difference_set_reports_complete_residue_profile(
+    domain_services: DomainTestServices,
+) -> None:
+    computed = domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="combinatorics.cyclic_difference_set.perfect.decide",
+            input={"modulus": 7, "residues": [0, 1, 3]},
+        )
+    )
+
+    result = computed.output["result"]
+    assert result["is_perfect"] is True
+    assert result["missing_residues"] == []
+    assert result["repeated_residues"] == []
+    assert len(result["difference_multiplicities"]) == 6
+
+
+@pytest.mark.parametrize(
+    ("order", "candidate_count"),
+    ((5, 1), (6, 26), (7, 703)),
+)
+def test_fixed_order_extension_materializes_complete_negative_decisions(
+    domain_services: DomainTestServices,
+    order: int,
+    candidate_count: int,
+) -> None:
+    computed = domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="combinatorics.cyclic_difference_set.extension.decide",
+            input={"base_elements": _BASE, "target_order": order},
+        )
+    )
+
+    stored = domain_services.core.store.get(computed.output["result_uri"])
+    assert computed.execution.status is ExecutionStatus.COMPLETED
+    assert computed.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert computed.output["result_uri"] in computed.artifact_uris
+    assert computed.output["preview_complete"] is True
+    assert stored.payload == computed.output["preview"]
+    assert stored.payload["decision"] == "DOES_NOT_EXTEND"
+    assert stored.payload["coverage"] == "ALL_CANDIDATES"
+    assert stored.payload["candidate_space_size"] == candidate_count
+
+
+def test_fixed_order_extension_returns_a_complete_positive_witness(
+    domain_services: DomainTestServices,
+) -> None:
+    computed = domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="combinatorics.cyclic_difference_set.extension.decide",
+            input={"base_elements": ["0", "1"], "target_order": 3},
+        )
+    )
+
+    stored = domain_services.core.store.get(computed.output["result_uri"])
+    assert stored.payload["decision"] == "EXTENDS"
+    assert stored.payload["coverage"] == "WITNESS"
+    assert stored.payload["extension"] == [0, 1, 3]

--- a/tests/domain/combinatorics/test_additive_combinatorics.py
+++ b/tests/domain/combinatorics/test_additive_combinatorics.py
@@ -7,6 +7,10 @@ import pytest
 from tests.support.services import DomainTestServices, open_domain_services
 
 from jacobian.contracts.capabilities import CapabilityAssuranceLevel, CapabilityRequest
+from jacobian.contracts.combinatorics import (
+    MAX_ADDITIVE_DIFFERENCE_INTEGER_LENGTH,
+    MAX_ADDITIVE_INTEGER_LENGTH,
+)
 from jacobian.contracts.results import ExecutionStatus
 from jacobian.domains.combinatorics import build_combinatorics_bundle
 
@@ -96,3 +100,43 @@ def test_fixed_order_extension_returns_a_complete_positive_witness(
     assert stored.payload["decision"] == "EXTENDS"
     assert stored.payload["coverage"] == "WITNESS"
     assert stored.payload["extension"] == [0, 1, 3]
+
+
+def test_integer_sidon_accepts_the_widest_canonical_difference(
+    domain_services: DomainTestServices,
+) -> None:
+    """The result bound must hold every ordered difference of accepted inputs.
+
+    The largest accepted positive value uses every ``AdditiveInteger``
+    character for digits, while the most-negative accepted value spends one
+    character on the sign. Their ordered difference reaches one extra digit,
+    and the negative direction adds the sign back, so the canonical difference
+    string is exactly ``MAX_ADDITIVE_INTEGER_LENGTH + 2`` characters. A bound
+    of ``+1`` (the previous value) rejects this valid public request.
+    """
+    largest_positive = "9" * MAX_ADDITIVE_INTEGER_LENGTH
+    most_negative = "-" + "9" * (MAX_ADDITIVE_INTEGER_LENGTH - 1)
+    assert len(largest_positive) == MAX_ADDITIVE_INTEGER_LENGTH
+    assert len(most_negative) == MAX_ADDITIVE_INTEGER_LENGTH
+
+    computed = domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="combinatorics.integer_set.sidon.decide",
+            input={"elements": [largest_positive, most_negative]},
+        )
+    )
+
+    result = computed.output["result"]
+    assert computed.execution.status is ExecutionStatus.COMPLETED
+    assert computed.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert result["is_sidon"] is True
+    difference_strings = {
+        record["difference"] for record in result["ordered_differences"]
+    }
+    # The negative direction is the tight case: sign + (L+1) digits = L+2 chars.
+    widest_negative = "-" + "1" + "0" + "9" * (MAX_ADDITIVE_INTEGER_LENGTH - 2) + "8"
+    assert len(widest_negative) == MAX_ADDITIVE_DIFFERENCE_INTEGER_LENGTH
+    assert widest_negative in difference_strings
+    assert max(len(value) for value in difference_strings) == (
+        MAX_ADDITIVE_DIFFERENCE_INTEGER_LENGTH
+    )

--- a/tests/unit/contracts/test_additive_combinatorics_contracts.py
+++ b/tests/unit/contracts/test_additive_combinatorics_contracts.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.contracts.combinatorics import (
+    CyclicDifferenceSetExtensionRequest,
+    CyclicDifferenceSetExtensionResult,
+    IntegerSidonRequest,
+    IntegerSidonResult,
+)
+
+
+def test_sidon_request_rejects_duplicate_integer_elements() -> None:
+    with pytest.raises(ValidationError, match="must be unique"):
+        IntegerSidonRequest(elements=("1", "2", "1"))
+
+
+def test_sidon_result_requires_the_complete_ordered_profile() -> None:
+    with pytest.raises(ValidationError, match="every distinct ordered pair"):
+        IntegerSidonResult(
+            semantics_version="integer-sidon.ordered-differences.v1",
+            normalized_elements=("1", "2", "4"),
+            ordered_differences=(),
+            is_sidon=True,
+        )
+
+
+def test_extension_request_rejects_an_unbounded_candidate_space() -> None:
+    with pytest.raises(ValidationError, match="candidate space"):
+        CyclicDifferenceSetExtensionRequest(
+            base_elements=("0", "1", "2", "3", "4", "5", "6"),
+            target_order=10,
+        )
+
+
+def test_negative_extension_result_binds_exact_candidate_count() -> None:
+    with pytest.raises(ValidationError, match="exact combination space"):
+        CyclicDifferenceSetExtensionResult(
+            semantics_version="cyclic-pds-extension.fixed-order.v1",
+            target_order=6,
+            modulus=31,
+            base_residues=(1, 2, 4, 8, 13),
+            candidate_space_size=25,
+            decision="DOES_NOT_EXTEND",
+            extension=(),
+            coverage="ALL_CANDIDATES",
+        )
+
+
+def test_positive_extension_result_rejects_residue_outside_modulus() -> None:
+    with pytest.raises(ValidationError, match="derived modulus"):
+        CyclicDifferenceSetExtensionResult(
+            semantics_version="cyclic-pds-extension.fixed-order.v1",
+            target_order=3,
+            modulus=7,
+            base_residues=(0, 1),
+            candidate_space_size=5,
+            decision="EXTENDS",
+            extension=(0, 1, 7),
+            coverage="WITNESS",
+        )

--- a/tests/unit/contracts/test_additive_combinatorics_contracts.py
+++ b/tests/unit/contracts/test_additive_combinatorics_contracts.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+from collections import Counter
+
 import pytest
 from pydantic import ValidationError
 
 from jacobian.contracts.combinatorics import (
+    CyclicDifferenceMultiplicity,
     CyclicDifferenceSetExtensionRequest,
     CyclicDifferenceSetExtensionResult,
+    CyclicPerfectDifferenceSetResult,
     IntegerSidonRequest,
     IntegerSidonResult,
 )
@@ -60,3 +64,65 @@ def test_positive_extension_result_rejects_residue_outside_modulus() -> None:
             extension=(0, 1, 7),
             coverage="WITNESS",
         )
+
+
+def test_pds_result_rejects_a_forged_self_consistent_profile() -> None:
+    """A producer regression cannot pass a forged multiplicity profile.
+
+    Residues ``(0, 1, 2)`` modulo 7 repeat differences 1 and 6 and omit 3 and
+    4, but a forged profile claiming multiplicity 1 for every nonzero residue
+    with empty missing/repeated lists and ``is_perfect=True`` is internally
+    self-consistent under the old shape-only validator. The authoritative
+    result model must recompute multiplicities from the residues.
+    """
+    forged_profile = tuple(
+        CyclicDifferenceMultiplicity(residue=residue, multiplicity=1)
+        for residue in range(1, 7)
+    )
+    with pytest.raises(ValidationError, match="derived from the residues"):
+        CyclicPerfectDifferenceSetResult(
+            semantics_version="cyclic-perfect-difference-set.v1",
+            modulus=7,
+            normalized_residues=(0, 1, 2),
+            order=3,
+            expected_modulus=7,
+            difference_multiplicities=forged_profile,
+            missing_residues=(),
+            repeated_residues=(),
+            is_perfect=True,
+        )
+
+
+def test_pds_result_accepts_the_canonical_fano_profile() -> None:
+    residues = (0, 1, 3)
+    modulus = 7
+    counts = Counter(
+        (left - right) % modulus
+        for left in residues
+        for right in residues
+        if left != right
+    )
+    profile = tuple(
+        CyclicDifferenceMultiplicity(
+            residue=residue, multiplicity=counts.get(residue, 0)
+        )
+        for residue in range(1, modulus)
+    )
+    missing = tuple(
+        residue for residue in range(1, modulus) if counts.get(residue, 0) == 0
+    )
+    repeated = tuple(
+        residue for residue in range(1, modulus) if counts.get(residue, 0) > 1
+    )
+    result = CyclicPerfectDifferenceSetResult(
+        semantics_version="cyclic-perfect-difference-set.v1",
+        modulus=modulus,
+        normalized_residues=residues,
+        order=len(residues),
+        expected_modulus=modulus,
+        difference_multiplicities=profile,
+        missing_residues=missing,
+        repeated_residues=repeated,
+        is_perfect=True,
+    )
+    assert result.is_perfect is True


### PR DESCRIPTION
## What changed

Adds bounded atomic outcomes for integer Sidon decisions, cyclic perfect-difference-set decisions, and fixed-order extension decisions. Each producer has a domain-owned typed contract and an independently authorized standard-library replay checker.

The negative extension result is a typed artifact with an exact candidate-space count. Its checker performs direct exhaustive combination replay independently from the producer pruning search. Typed-artifact consumer discovery is also completed for stored exact-result verifiers and graph neighborhood-independence input.

## Why

The Erdős 707 workflow exposed a missing composition boundary: Jacobian could not materialize or independently verify the finite additive-combinatorics steps without falling back to prose or a broad solver interface.

## Validation

- make lint
- make test-unit: 500 passed
- make test-domain: 152 passed
- focused checker/runtime/discovery suite: 125 passed with benchmark validation included
- make test-process: 201 passed, 2 platform skips
- make test-mcp: 27 passed
- changed-source mypy: success
- build, docs link check, security audit, and duplicate-code check: passed

Two pre-existing SAT/SMT timeout tests raced only in the macOS parallel component lane; both passed when reproduced serially.