### PR TITLE
fix(mcp): require bounded external reasoning logs for MCP capability calls

### DIFF
--- a/.github/ci-impact.json
+++ b/.github/ci-impact.json
@@ -473,6 +473,7 @@
         "tests/support/capability_installations.py",
         "tests/support/nullstellensatz.py",
         "tests/support/polynomials.py",
+        "tests/support/mcp.py",
         "tests/conftest.py"
       ],
       "suites": [

--- a/benchmarks/datasets/agent-workflow-v1/README.md
+++ b/benchmarks/datasets/agent-workflow-v1/README.md
@@ -51,8 +51,29 @@ make agent-eval DATASET=agent-workflow-v1 \
 The task bundles and Harbor task digests must be identical between these
 jobs. Set `JACOBIAN_EVAL_PROXY=1` to apply the same optional proxy overlay to
 both jobs; only the treatment adds the Jacobian sidecar and MCP config. This
-paired setup is for
-workflow comparison; the public dataset is not held-out evidence.
+paired setup is for workflow comparison; the public dataset is not held-out
+evidence.
+
+To isolate the external reasoning-log protocol, keep Jacobian enabled in both
+arms and vary only its mode:
+
+```sh
+# Control: identical Jacobian portfolio without the log protocol.
+JACOBIAN_REASONING_LOG_MODE=OFF make agent-eval \
+  DATASET=agent-workflow-v1 JACOBIAN_ENABLED=1 \
+  TASKS=graph-counterexample EVAL_EXECUTE=1
+
+# Treatment: identical Jacobian portfolio with required bracketing.
+JACOBIAN_REASONING_LOG_MODE=REQUIRED make agent-eval \
+  DATASET=agent-workflow-v1 JACOBIAN_ENABLED=1 \
+  TASKS=graph-counterexample EVAL_EXECUTE=1
+```
+
+Bind `reasoning_log_mode` in each runtime snapshot's condition. The normalizer
+requires a structurally complete `PLAN`/call-cycle/`FINAL` trace for every
+`REQUIRED` trial and excludes summary text from normalized evidence. Public
+workflow observations remain non-causal; protected runs must also freeze the
+model, prompt, agent version, task digests, sampling settings, and budgets.
 
 Five tasks have an operator-authorized verification record and may accept
 `VERIFIED`; the remaining tasks are capped at `COMPUTED`. A wrong result or an

--- a/benchmarks/datasets/agent-workflow-v1/README.md
+++ b/benchmarks/datasets/agent-workflow-v1/README.md
@@ -59,12 +59,12 @@ arms and vary only its mode:
 
 ```sh
 # Control: identical Jacobian portfolio without the log protocol.
-JACOBIAN_REASONING_LOG_MODE=OFF make agent-eval \
+JACOBIAN_REASONING_LOG_MODE=off make agent-eval \
   DATASET=agent-workflow-v1 JACOBIAN_ENABLED=1 \
   TASKS=graph-counterexample EVAL_EXECUTE=1
 
 # Treatment: identical Jacobian portfolio with required bracketing.
-JACOBIAN_REASONING_LOG_MODE=REQUIRED make agent-eval \
+JACOBIAN_REASONING_LOG_MODE=required make agent-eval \
   DATASET=agent-workflow-v1 JACOBIAN_ENABLED=1 \
   TASKS=graph-counterexample EVAL_EXECUTE=1
 ```

--- a/benchmarks/datasets/agent-workflow-v1/jacobian-observation.compose.yaml
+++ b/benchmarks/datasets/agent-workflow-v1/jacobian-observation.compose.yaml
@@ -9,6 +9,8 @@ services:
       - --port
       - "8000"
       - --allow-anonymous
+      - --reasoning-log-mode
+      - ${JACOBIAN_REASONING_LOG_MODE:-required}
       - --state-dir
       - /state
     volumes:

--- a/benchmarks/datasets/agent-workflow-v1/jacobian-observation.compose.yaml
+++ b/benchmarks/datasets/agent-workflow-v1/jacobian-observation.compose.yaml
@@ -10,7 +10,7 @@ services:
       - "8000"
       - --allow-anonymous
       - --reasoning-log-mode
-      - ${JACOBIAN_REASONING_LOG_MODE:-required}
+      - ${JACOBIAN_REASONING_LOG_MODE:-REQUIRED}
       - --state-dir
       - /state
     volumes:

--- a/benchmarks/datasets/agent-workflow-v1/jacobian-observation.compose.yaml
+++ b/benchmarks/datasets/agent-workflow-v1/jacobian-observation.compose.yaml
@@ -10,7 +10,7 @@ services:
       - "8000"
       - --allow-anonymous
       - --reasoning-log-mode
-      - ${JACOBIAN_REASONING_LOG_MODE:-REQUIRED}
+      - ${JACOBIAN_REASONING_LOG_MODE:-off}
       - --state-dir
       - /state
     volumes:

--- a/benchmarks/schemas/held-out-manifest.schema.json
+++ b/benchmarks/schemas/held-out-manifest.schema.json
@@ -111,6 +111,7 @@
         "id": {"const": "C2"},
         "role": {"const": "PRIMARY_TREATMENT"},
         "jacobian_enabled": {"const": true},
+        "reasoning_log_mode": {"enum": ["REQUIRED", "AUDIT", "OFF"]},
         "image": {"type": "string", "pattern": "^[^@]+@sha256:[0-9a-f]{64}$"},
         "server_version": {"type": "string", "minLength": 1},
         "policy_profile": {"type": "string", "minLength": 1},

--- a/benchmarks/schemas/observation-evidence.schema.json
+++ b/benchmarks/schemas/observation-evidence.schema.json
@@ -206,6 +206,7 @@
         "artifacts",
         "tool_calls",
         "tool_errors",
+        "reasoning_protocol",
         "raw_result_digest"
       ],
       "properties": {
@@ -263,6 +264,7 @@
           "additionalProperties": {"type": "integer"}
         },
         "tool_errors": {"type": "integer", "minimum": 0},
+        "reasoning_protocol": {"$ref": "#/$defs/reasoning_protocol"},
         "raw_result_digest": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"}
       }
     },
@@ -321,11 +323,48 @@
         "id": {"type": "string", "minLength": 1},
         "role": {"type": "string", "minLength": 1},
         "jacobian_enabled": {"type": "boolean"},
+        "reasoning_log_mode": {"enum": ["REQUIRED", "AUDIT", "OFF"]},
         "image": {"type": "string", "minLength": 1},
         "server_version": {"type": "string", "minLength": 1},
         "policy_profile": {"type": "string", "minLength": 1},
         "catalog_digest": {"$ref": "#/$defs/digest"},
         "policy_digest": {"$ref": "#/$defs/digest"}
+      }
+    },
+    "reasoning_protocol": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "mode",
+        "requirement_status",
+        "plan_count",
+        "before_tool_count",
+        "after_tool_count",
+        "final_count",
+        "run_count",
+        "bound_invoke_count",
+        "missing_after_tool_count",
+        "pending_call_count",
+        "unavailable_after_tool_count",
+        "reported_actual_mismatch_count",
+        "summary_characters"
+      ],
+      "properties": {
+        "status": {"enum": ["COMPLETE", "INCOMPLETE"]},
+        "mode": {"enum": ["REQUIRED", "AUDIT", "OFF", "UNKNOWN"]},
+        "requirement_status": {"enum": ["COMPLETE", "INCOMPLETE", "NOT_REQUIRED"]},
+        "plan_count": {"type": "integer", "minimum": 0},
+        "before_tool_count": {"type": "integer", "minimum": 0},
+        "after_tool_count": {"type": "integer", "minimum": 0},
+        "final_count": {"type": "integer", "minimum": 0},
+        "run_count": {"type": "integer", "minimum": 0},
+        "bound_invoke_count": {"type": "integer", "minimum": 0},
+        "missing_after_tool_count": {"type": "integer", "minimum": 0},
+        "pending_call_count": {"type": "integer", "minimum": 0},
+        "unavailable_after_tool_count": {"type": "integer", "minimum": 0},
+        "reported_actual_mismatch_count": {"type": "integer", "minimum": 0},
+        "summary_characters": {"type": "integer", "minimum": 0}
       }
     },
     "runtime_invariants": {

--- a/benchmarks/schemas/observation-evidence.schema.json
+++ b/benchmarks/schemas/observation-evidence.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://jacobian.invalid/benchmarks/schemas/observation-evidence.schema.json",
   "title": "Jacobian Harbor workflow observation evidence",
-  "description": "Strict normalized observation evidence v2. Binds the immutable benchmark snapshot ID and Harbor version (read from explicit job/runtime/held-out manifest bindings, never invented), normalized evaluation arguments, runtime/model/agent/repetition/budgets/results/rewards/verifier states/failures, and manifest-driven per-artifact identity. Fails closed: VALID only when execution is complete and every binding matches.",
+  "description": "Strict normalized observation evidence. Binds the immutable benchmark snapshot ID and Harbor version (read from explicit job/runtime/held-out manifest bindings, never invented), normalized evaluation arguments, runtime/model/agent/repetition/budgets/results/rewards/verifier states/failures, and manifest-driven per-artifact identity. Fails closed: VALID only when execution is complete and every binding matches. Version 3 adds the reasoning_protocol trial member; version 2 evidence without it remains valid.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -24,7 +24,7 @@
     "validation_failures"
   ],
   "properties": {
-    "schema_version": {"const": "2"},
+    "schema_version": {"enum": ["2", "3"]},
     "evidence_class": {"type": "string", "minLength": 1},
     "causal_claim_authorized": {"const": false},
     "status": {"enum": ["VALID", "INCOMPLETE"]},
@@ -206,7 +206,6 @@
         "artifacts",
         "tool_calls",
         "tool_errors",
-        "reasoning_protocol",
         "raw_result_digest"
       ],
       "properties": {
@@ -391,5 +390,20 @@
         "max_cost_usd": {"type": "number", "exclusiveMinimum": 0}
       }
     }
-  }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {"schema_version": {"const": "3"}},
+        "required": ["schema_version"]
+      },
+      "then": {
+        "properties": {
+          "trials": {
+            "items": {"required": ["reasoning_protocol"]}
+          }
+        }
+      }
+    }
+  ]
 }

--- a/benchmarks/tooling/observation_artifacts.py
+++ b/benchmarks/tooling/observation_artifacts.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from benchmarks.tooling.harbor_suite import HarborSuiteError
+from jacobian.eval.telemetry import parse_reasoning_protocol_trace
 
 
 def _read_json(path: Path) -> Any:
@@ -395,6 +396,16 @@ def _bind_artifact_file(
     }
 
 
+def _artifact_host_path(root: Path, artifact: dict[str, Any]) -> Path:
+    step_name = artifact.get("step_name")
+    base = (
+        root / _STEPS_DIR / str(step_name) / _ARTIFACTS_DIR
+        if isinstance(step_name, str)
+        else root / _ARTIFACTS_DIR
+    )
+    return base / str(artifact["artifact_path"])
+
+
 def trial_artifacts(
     trial_path: Path | None,
     trial_name: str,
@@ -455,7 +466,7 @@ def trial_artifacts(
     # prefix); it never introduces artifacts on its own.
     calls: Counter[str] = Counter()
     trace_paths = [
-        root.parent / artifact["source_path"]
+        _artifact_host_path(root, artifact)
         for artifact in artifacts
         if any(
             marker in Path(artifact["artifact_path"]).name.lower()
@@ -464,6 +475,67 @@ def trial_artifacts(
     ]
     errors = sum(_read_trace(path, calls) for path in trace_paths)
     return artifacts, dict(sorted(calls.items())), errors, failures
+
+
+def trial_reasoning_protocol(
+    trial_path: Path | None,
+    artifacts: list[dict[str, Any]],
+) -> dict[str, int | str]:
+    """Extract bounded reasoning-protocol facts without retaining summary text."""
+
+    empty: dict[str, int | str] = {
+        "status": "INCOMPLETE",
+        "plan_count": 0,
+        "before_tool_count": 0,
+        "after_tool_count": 0,
+        "final_count": 0,
+        "run_count": 0,
+        "bound_invoke_count": 0,
+        "missing_after_tool_count": 0,
+        "pending_call_count": 0,
+        "unavailable_after_tool_count": 0,
+        "reported_actual_mismatch_count": 0,
+        "summary_characters": 0,
+    }
+    if trial_path is None:
+        return empty
+    root = trial_path.parent
+    candidates = [
+        _artifact_host_path(root, artifact)
+        for artifact in artifacts
+        if Path(artifact["artifact_path"]).suffix in {".json", ".jsonl"}
+        and any(
+            marker in Path(artifact["artifact_path"]).name.lower()
+            for marker in ("trajectory", "atif", "telemetry")
+        )
+    ]
+    observed: list[dict[str, int | str]] = []
+    for path in candidates:
+        try:
+            protocol = parse_reasoning_protocol_trace(path)
+        except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError):
+            continue
+        if isinstance(protocol, dict) and any(
+            int(protocol.get(field, 0)) > 0
+            for field in (
+                "plan_count",
+                "before_tool_count",
+                "after_tool_count",
+                "final_count",
+                "bound_invoke_count",
+            )
+        ):
+            observed.append(protocol)
+    if len(observed) == 1:
+        return observed[0]
+    if not observed:
+        return empty
+    combined = dict(empty)
+    for field in empty:
+        if field == "status":
+            continue
+        combined[field] = sum(int(item.get(field, 0)) for item in observed)
+    return combined
 
 
 def artifact_source_reuse(trials: list[dict[str, Any]]) -> list[str]:
@@ -485,4 +557,8 @@ def artifact_source_reuse(trials: list[dict[str, Any]]) -> list[str]:
     return failures
 
 
-__all__ = ["artifact_source_reuse", "trial_artifacts"]
+__all__ = [
+    "artifact_source_reuse",
+    "trial_artifacts",
+    "trial_reasoning_protocol",
+]

--- a/benchmarks/tooling/observation_comparison.py
+++ b/benchmarks/tooling/observation_comparison.py
@@ -88,6 +88,60 @@ def _mcnemar_exact(control: list[float], treatment: list[float]) -> float | None
     return float(min(1.0, 2 * tail))
 
 
+_VARYING_CONDITION_KEYS = frozenset({"id", "role", "reasoning_log_mode"})
+
+
+def _reasoning_condition_failures(
+    control_condition: Any, treatment_condition: Any
+) -> list[str]:
+    """Validate the reasoning-log condition pair and its non-varying invariants.
+
+    Only applies when both arms have Jacobian enabled — a baseline
+    comparison (control has Jacobian disabled) is not a reasoning-log
+    isolation experiment and must not be rejected here.
+    """
+
+    failures: list[str] = []
+    if not (
+        isinstance(control_condition, dict)
+        and isinstance(treatment_condition, dict)
+        and control_condition.get("jacobian_enabled") is True
+        and treatment_condition.get("jacobian_enabled") is True
+    ):
+        return failures
+    control_mode = control_condition.get("reasoning_log_mode")
+    treatment_mode = treatment_condition.get("reasoning_log_mode")
+    if control_mode is None and treatment_mode is None:
+        return failures
+    if (control_mode, treatment_mode) != ("OFF", "REQUIRED"):
+        failures.append(
+            "reasoning-log comparison must pair OFF control with REQUIRED treatment"
+        )
+    # Compare every condition field except the explicitly varying
+    # identity, role, and reasoning_log_mode fields.  Divergent
+    # image, server_version, policy_profile, catalog_digest, or
+    # policy_digest means the two arms used different Jacobian code
+    # or capability portfolios and cannot support a valid
+    # reasoning-log comparison.
+    if isinstance(control_condition, dict) and isinstance(treatment_condition, dict):
+        control_invariant = {
+            k: v
+            for k, v in control_condition.items()
+            if k not in _VARYING_CONDITION_KEYS
+        }
+        treatment_invariant = {
+            k: v
+            for k, v in treatment_condition.items()
+            if k not in _VARYING_CONDITION_KEYS
+        }
+        if control_invariant != treatment_invariant:
+            failures.append(
+                "reasoning-log condition invariants differ outside "
+                "the allowed id/role/mode fields"
+            )
+    return failures
+
+
 def _comparison_failures(
     control: dict[str, Any], treatment: dict[str, Any]
 ) -> list[str]:
@@ -116,30 +170,9 @@ def _comparison_failures(
     control_condition = control.get("runtime_snapshot", {}).get("condition")
     treatment_condition = treatment.get("runtime_snapshot", {}).get("condition")
     if isinstance(control_condition, dict) or isinstance(treatment_condition, dict):
-        control_mode = (
-            control_condition.get("reasoning_log_mode")
-            if isinstance(control_condition, dict)
-            else None
+        failures.extend(
+            _reasoning_condition_failures(control_condition, treatment_condition)
         )
-        treatment_mode = (
-            treatment_condition.get("reasoning_log_mode")
-            if isinstance(treatment_condition, dict)
-            else None
-        )
-        if control_mode is not None or treatment_mode is not None:
-            if (control_mode, treatment_mode) != ("OFF", "REQUIRED"):
-                failures.append(
-                    "reasoning-log comparison must pair OFF control with REQUIRED treatment"
-                )
-            if not (
-                isinstance(control_condition, dict)
-                and isinstance(treatment_condition, dict)
-                and control_condition.get("jacobian_enabled") is True
-                and treatment_condition.get("jacobian_enabled") is True
-            ):
-                failures.append(
-                    "reasoning-log comparison requires Jacobian enabled in both conditions"
-                )
     if control.get("job", {}).get("comparison_signature") != treatment.get(
         "job", {}
     ).get("comparison_signature"):

--- a/benchmarks/tooling/observation_comparison.py
+++ b/benchmarks/tooling/observation_comparison.py
@@ -113,6 +113,33 @@ def _comparison_failures(
     )
     if control.get("fixed_invariants") != treatment.get("fixed_invariants"):
         failures.append("fixed invariants differ")
+    control_condition = control.get("runtime_snapshot", {}).get("condition")
+    treatment_condition = treatment.get("runtime_snapshot", {}).get("condition")
+    if isinstance(control_condition, dict) or isinstance(treatment_condition, dict):
+        control_mode = (
+            control_condition.get("reasoning_log_mode")
+            if isinstance(control_condition, dict)
+            else None
+        )
+        treatment_mode = (
+            treatment_condition.get("reasoning_log_mode")
+            if isinstance(treatment_condition, dict)
+            else None
+        )
+        if control_mode is not None or treatment_mode is not None:
+            if (control_mode, treatment_mode) != ("OFF", "REQUIRED"):
+                failures.append(
+                    "reasoning-log comparison must pair OFF control with REQUIRED treatment"
+                )
+            if not (
+                isinstance(control_condition, dict)
+                and isinstance(treatment_condition, dict)
+                and control_condition.get("jacobian_enabled") is True
+                and treatment_condition.get("jacobian_enabled") is True
+            ):
+                failures.append(
+                    "reasoning-log comparison requires Jacobian enabled in both conditions"
+                )
     if control.get("job", {}).get("comparison_signature") != treatment.get(
         "job", {}
     ).get("comparison_signature"):

--- a/benchmarks/tooling/observation_results.py
+++ b/benchmarks/tooling/observation_results.py
@@ -229,6 +229,29 @@ def _normalize_trial(
             source_prefix=source_prefix,
         )
     )
+    reasoning_protocol = observation_artifacts.trial_reasoning_protocol(
+        path,
+        artifacts,
+    )
+    runtime_condition = runtime.get("condition") if runtime is not None else None
+    reasoning_log_mode = (
+        runtime_condition.get("reasoning_log_mode")
+        if isinstance(runtime_condition, dict)
+        else runtime.get("reasoning_log_mode")
+        if runtime is not None
+        else None
+    )
+    if reasoning_log_mode not in {"REQUIRED", "AUDIT", "OFF"}:
+        reasoning_log_mode = "UNKNOWN"
+    reasoning_protocol = {
+        **reasoning_protocol,
+        "mode": reasoning_log_mode,
+        "requirement_status": (
+            reasoning_protocol["status"]
+            if reasoning_log_mode == "REQUIRED"
+            else "NOT_REQUIRED"
+        ),
+    }
     budgets: dict[str, Any] | None = None
     if runtime is not None:
         budgets = {
@@ -266,6 +289,7 @@ def _normalize_trial(
         "artifacts": artifacts,
         "tool_calls": tool_calls,
         "tool_errors": tool_errors,
+        "reasoning_protocol": reasoning_protocol,
         "raw_result_digest": _sha256(path) if path is not None else _json_digest(trial),
     }
     if runtime is not None and isinstance(runtime.get("pair_id"), str):
@@ -323,6 +347,12 @@ def _observation_failures(
     )
     if incomplete or any(trial["status"] != "COMPLETED" for trial in trials):
         failures.append("execution is incomplete or contains errors")
+    failures.extend(
+        f"{trial['task']} repetition {trial['repetition']}: required reasoning protocol is incomplete"
+        for trial in trials
+        if trial["reasoning_protocol"]["mode"] == "REQUIRED"
+        and trial["reasoning_protocol"]["status"] != "COMPLETE"
+    )
     return failures
 
 

--- a/benchmarks/tooling/observation_results.py
+++ b/benchmarks/tooling/observation_results.py
@@ -252,6 +252,19 @@ def _normalize_trial(
             else "NOT_REQUIRED"
         ),
     }
+    # When Jacobian is enabled (or its state is unknown because the
+    # runtime snapshot is absent), the reasoning-log mode must be
+    # explicitly bound to a valid value.  An absent or invalid mode is a
+    # validation failure rather than a silent downgrade to NOT_REQUIRED.
+    # Only an explicit ``jacobian_enabled: false`` proves Jacobian was
+    # disabled and makes the mode irrelevant.
+    jacobian_enabled = (
+        runtime_condition.get("jacobian_enabled")
+        if isinstance(runtime_condition, dict)
+        else None
+    )
+    if jacobian_enabled is not False and reasoning_log_mode == "UNKNOWN":
+        reasoning_protocol["requirement_status"] = "INCOMPLETE"
     budgets: dict[str, Any] | None = None
     if runtime is not None:
         budgets = {
@@ -352,6 +365,12 @@ def _observation_failures(
         for trial in trials
         if trial["reasoning_protocol"]["mode"] == "REQUIRED"
         and trial["reasoning_protocol"]["status"] != "COMPLETE"
+    )
+    failures.extend(
+        f"{trial['task']} repetition {trial['repetition']}: reasoning_log_mode is unbound or invalid"
+        for trial in trials
+        if trial["reasoning_protocol"]["requirement_status"] == "INCOMPLETE"
+        and trial["reasoning_protocol"]["mode"] == "UNKNOWN"
     )
     return failures
 
@@ -553,7 +572,7 @@ def build_observation_evidence(
         )
         harbor_version = None
     evidence = {
-        "schema_version": "2",
+        "schema_version": "3",
         "evidence_class": evidence_class,
         "causal_claim_authorized": False,
         "status": "VALID" if not failures else "INCOMPLETE",
@@ -750,7 +769,7 @@ def collect_heldout_evidence(
         len(selected),
     )
     evidence = {
-        "schema_version": "2",
+        "schema_version": "3",
         "evidence_class": "held-out-comparative-evaluation",
         "causal_claim_authorized": False,
         "status": "VALID" if not failures else "INCOMPLETE",

--- a/benchmarks/validation/observation_results_support.py
+++ b/benchmarks/validation/observation_results_support.py
@@ -39,6 +39,22 @@ def _trial(repetition: int, reward: float) -> dict:
         "artifacts": [],
         "tool_calls": {},
         "tool_errors": 0,
+        "reasoning_protocol": {
+            "status": "INCOMPLETE",
+            "mode": "UNKNOWN",
+            "requirement_status": "NOT_REQUIRED",
+            "plan_count": 0,
+            "before_tool_count": 0,
+            "after_tool_count": 0,
+            "final_count": 0,
+            "run_count": 0,
+            "bound_invoke_count": 0,
+            "missing_after_tool_count": 0,
+            "pending_call_count": 0,
+            "unavailable_after_tool_count": 0,
+            "reported_actual_mismatch_count": 0,
+            "summary_characters": 0,
+        },
         "raw_result_digest": "sha256:" + "e" * 64,
     }
 

--- a/benchmarks/validation/test_heldout_bundle.py
+++ b/benchmarks/validation/test_heldout_bundle.py
@@ -56,6 +56,7 @@ def _manifest() -> dict:
                 "id": "C2",
                 "role": "PRIMARY_TREATMENT",
                 "jacobian_enabled": True,
+                "reasoning_log_mode": "OFF",
                 "image": "registry.invalid/jacobian@sha256:" + "4" * 64,
                 "server_version": "1.2.3",
                 "policy_profile": "DEFAULT",

--- a/benchmarks/validation/test_observation_artifact_binding.py
+++ b/benchmarks/validation/test_observation_artifact_binding.py
@@ -119,6 +119,50 @@ def test_observation_binds_runtime_snapshot_fields(
     assert evidence["fixed_invariants"]["runtime"]["harbor_version"] == _HARBOR_VERSION
 
 
+def test_required_reasoning_protocol_fails_closed_when_trace_is_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(observation_results, "task_digest", lambda _path: "a" * 64)
+    monkeypatch.setattr(observation_results, "_git_sha", lambda: "b" * 40)
+    job = {
+        "jobs_dir": str(tmp_path / "jobs"),
+        "n_attempts": 1,
+        "timeout_multiplier": 1,
+        "orchestrator": {"type": "local", "n_concurrent_trials": 1},
+        "environment": {"type": "docker"},
+        "agents": [{"name": "codex"}],
+        "datasets": [
+            {
+                "path": "benchmarks/datasets/agent-workflow-v1",
+                "task_names": ["graph-counterexample"],
+            }
+        ],
+    }
+    runtime = {
+        "snapshot_id": _SNAPSHOT_ID,
+        "harbor_version": _HARBOR_VERSION,
+        "model": "model",
+        "condition": {
+            "id": "treatment",
+            "role": "PRIMARY_TREATMENT",
+            "jacobian_enabled": True,
+            "reasoning_log_mode": "REQUIRED",
+        },
+    }
+    evidence, failures = build_observation_evidence(
+        dataset="agent-workflow-v1",
+        condition="treatment",
+        job_path=_write_observation_job(tmp_path, job),
+        jobs_dir=tmp_path,
+        result_path=_write_result(tmp_path),
+        runtime_snapshot=runtime,
+    )
+
+    assert evidence["status"] == "INCOMPLETE"
+    assert evidence["trials"][0]["reasoning_protocol"]["mode"] == "REQUIRED"
+    assert "required reasoning protocol is incomplete" in " ".join(failures)
+
+
 # ---------------------------------------------------------------------------
 # snapshot_id / harbor_version explicit bindings
 # ---------------------------------------------------------------------------

--- a/benchmarks/validation/test_observation_artifact_binding.py
+++ b/benchmarks/validation/test_observation_artifact_binding.py
@@ -51,11 +51,21 @@ def test_observation_normalization_binds_v2_fields(
         job_path=job_path,
         jobs_dir=tmp_path,
         result_path=result_path,
+        runtime_snapshot={
+            "snapshot_id": _SNAPSHOT_ID,
+            "harbor_version": _HARBOR_VERSION,
+            "model": "model",
+            "condition": {
+                "id": "control",
+                "role": "PRIMARY_CONTROL",
+                "jacobian_enabled": False,
+            },
+        },
     )
 
     assert failures == []
     assert evidence["status"] == "VALID"
-    assert evidence["schema_version"] == "2"
+    assert evidence["schema_version"] == "3"
     assert evidence["fixed_invariants"]["model"] == "model"
     assert evidence["eval_args"]["selection_mode"] == "dataset-task-names"
     assert evidence["eval_args"]["selection"] == ["graph-counterexample"]
@@ -64,7 +74,7 @@ def test_observation_normalization_binds_v2_fields(
     trial = evidence["trials"][0]
     assert trial["agent"] == {"name": "codex", "version": "1"}
     assert trial["verifier_state"] == "COMPLETED"
-    assert trial["budgets"] is None
+    assert trial["budgets"] == {"max_tokens": None, "max_cost_usd": None}
     assert trial["artifacts"] == []
 
 
@@ -98,6 +108,12 @@ def test_observation_binds_runtime_snapshot_fields(
         "max_cost_usd": 100.0,
         "repetition": 0,
         "pair_id": "graph-counterexample-r001",
+        "condition": {
+            "id": "treatment",
+            "role": "PRIMARY_TREATMENT",
+            "jacobian_enabled": True,
+            "reasoning_log_mode": "OFF",
+        },
     }
 
     evidence, failures = build_observation_evidence(
@@ -161,6 +177,55 @@ def test_required_reasoning_protocol_fails_closed_when_trace_is_missing(
     assert evidence["status"] == "INCOMPLETE"
     assert evidence["trials"][0]["reasoning_protocol"]["mode"] == "REQUIRED"
     assert "required reasoning protocol is incomplete" in " ".join(failures)
+
+
+def test_unbound_reasoning_mode_with_jacobian_enabled_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A Jacobian-enabled run with no reasoning_log_mode binding must not be VALID."""
+
+    monkeypatch.setattr(observation_results, "task_digest", lambda _path: "a" * 64)
+    monkeypatch.setattr(observation_results, "_git_sha", lambda: "b" * 40)
+    job = {
+        "jobs_dir": str(tmp_path / "jobs"),
+        "n_attempts": 1,
+        "timeout_multiplier": 1,
+        "orchestrator": {"type": "local", "n_concurrent_trials": 1},
+        "environment": {"type": "docker"},
+        "agents": [{"name": "codex"}],
+        "datasets": [
+            {
+                "path": "benchmarks/datasets/agent-workflow-v1",
+                "task_names": ["graph-counterexample"],
+            }
+        ],
+    }
+    runtime = {
+        "snapshot_id": _SNAPSHOT_ID,
+        "harbor_version": _HARBOR_VERSION,
+        "model": "model",
+        "condition": {
+            "id": "treatment",
+            "role": "PRIMARY_TREATMENT",
+            "jacobian_enabled": True,
+        },
+    }
+    evidence, failures = build_observation_evidence(
+        dataset="agent-workflow-v1",
+        condition="treatment",
+        job_path=_write_observation_job(tmp_path, job),
+        jobs_dir=tmp_path,
+        result_path=_write_result(tmp_path),
+        runtime_snapshot=runtime,
+    )
+
+    assert evidence["status"] == "INCOMPLETE"
+    assert evidence["trials"][0]["reasoning_protocol"]["mode"] == "UNKNOWN"
+    assert (
+        evidence["trials"][0]["reasoning_protocol"]["requirement_status"]
+        == "INCOMPLETE"
+    )
+    assert "reasoning_log_mode is unbound or invalid" in " ".join(failures)
 
 
 # ---------------------------------------------------------------------------

--- a/benchmarks/validation/test_observation_comparison.py
+++ b/benchmarks/validation/test_observation_comparison.py
@@ -77,6 +77,34 @@ def test_comparison_rejects_same_condition_inputs() -> None:
     )
 
 
+def test_reasoning_comparison_requires_enabled_off_and_required_pair() -> None:
+    control = _evidence("control", [1.0])
+    treatment = _evidence("treatment", [1.0])
+    control["runtime_snapshot"] = {
+        "condition": {
+            "id": "control",
+            "role": "PRIMARY_CONTROL",
+            "jacobian_enabled": True,
+            "reasoning_log_mode": "OFF",
+        }
+    }
+    treatment["runtime_snapshot"] = {
+        "condition": {
+            "id": "treatment",
+            "role": "PRIMARY_TREATMENT",
+            "jacobian_enabled": True,
+            "reasoning_log_mode": "REQUIRED",
+        }
+    }
+
+    assert compare_evidence(control, treatment)["status"] == "VALID"
+
+    treatment["runtime_snapshot"]["condition"]["jacobian_enabled"] = False
+    report = compare_evidence(control, treatment)
+    assert report["status"] == "INVALID"
+    assert "requires Jacobian enabled" in " ".join(report["validation_failures"])
+
+
 def test_comparison_normalization_allows_only_frozen_jacobian_differences() -> None:
     control = {
         "environment": {

--- a/benchmarks/validation/test_observation_comparison.py
+++ b/benchmarks/validation/test_observation_comparison.py
@@ -99,10 +99,60 @@ def test_reasoning_comparison_requires_enabled_off_and_required_pair() -> None:
 
     assert compare_evidence(control, treatment)["status"] == "VALID"
 
+    # A baseline comparison (treatment has Jacobian disabled) is not a
+    # reasoning-log isolation experiment and must not be rejected.
     treatment["runtime_snapshot"]["condition"]["jacobian_enabled"] = False
+    assert compare_evidence(control, treatment)["status"] == "VALID"
+
+    # When both arms have Jacobian enabled but the mode pair is wrong,
+    # the reasoning-log comparison must still fail.
+    treatment["runtime_snapshot"]["condition"]["jacobian_enabled"] = True
+    treatment["runtime_snapshot"]["condition"]["reasoning_log_mode"] = "AUDIT"
     report = compare_evidence(control, treatment)
     assert report["status"] == "INVALID"
-    assert "requires Jacobian enabled" in " ".join(report["validation_failures"])
+    assert "must pair OFF control with REQUIRED treatment" in " ".join(
+        report["validation_failures"]
+    )
+
+
+def test_reasoning_comparison_rejects_divergent_condition_invariants() -> None:
+    """Condition fields outside id/role/mode must match between arms."""
+
+    control = _evidence("control", [1.0])
+    treatment = _evidence("treatment", [1.0])
+    control["runtime_snapshot"] = {
+        "condition": {
+            "id": "control",
+            "role": "PRIMARY_CONTROL",
+            "jacobian_enabled": True,
+            "reasoning_log_mode": "OFF",
+            "image": "jacobian:local",
+            "server_version": "1.0.0",
+            "policy_profile": "DEFAULT",
+            "catalog_digest": "sha256:" + "a" * 64,
+            "policy_digest": "sha256:" + "b" * 64,
+        }
+    }
+    treatment["runtime_snapshot"] = {
+        "condition": {
+            "id": "treatment",
+            "role": "PRIMARY_TREATMENT",
+            "jacobian_enabled": True,
+            "reasoning_log_mode": "REQUIRED",
+            "image": "jacobian:local",
+            "server_version": "1.0.0",
+            "policy_profile": "DEFAULT",
+            "catalog_digest": "sha256:" + "a" * 64,
+            "policy_digest": "sha256:" + "b" * 64,
+        }
+    }
+
+    assert compare_evidence(control, treatment)["status"] == "VALID"
+
+    treatment["runtime_snapshot"]["condition"]["server_version"] = "1.0.1"
+    report = compare_evidence(control, treatment)
+    assert report["status"] == "INVALID"
+    assert "condition invariants differ" in " ".join(report["validation_failures"])
 
 
 def test_comparison_normalization_allows_only_frozen_jacobian_differences() -> None:

--- a/benchmarks/validation/test_observation_manifests.py
+++ b/benchmarks/validation/test_observation_manifests.py
@@ -16,6 +16,27 @@ _artifact_path_failures = observation_artifacts._artifact_path_failures
 _artifact_source_reuse = observation_artifacts.artifact_source_reuse
 _manifest_artifacts_for_dir = observation_artifacts._manifest_artifacts_for_dir
 _trial_artifacts = observation_artifacts.trial_artifacts
+_trial_reasoning_protocol = observation_artifacts.trial_reasoning_protocol
+
+
+def _tool_event(
+    tool: str,
+    arguments: dict[str, object],
+    response: dict[str, object],
+) -> dict[str, object]:
+    return {
+        "type": "item.completed",
+        "item": {
+            "type": "mcp_tool_call",
+            "tool": tool,
+            "arguments": arguments,
+            "status": "completed",
+            "result": {
+                "isError": False,
+                "content": [{"type": "text", "text": json.dumps(response)}],
+            },
+        },
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -161,6 +182,74 @@ def test_equal_manifest_source_across_repetitions_accepted(
         {"trial_name": "attempt-1", "artifacts": artifacts_1},
     ]
     assert _artifact_source_reuse(trials) == []
+
+
+def test_reasoning_protocol_is_extracted_without_summary_text(tmp_path: Path) -> None:
+    run_id = "00000000-0000-4000-8000-000000000000"
+    call_id = "11111111-1111-4111-8111-111111111111"
+    events = [
+        _tool_event(
+            "reasoning.write",
+            {"phase": "PLAN", "summary": "private plan"},
+            {"run_id": run_id},
+        ),
+        _tool_event(
+            "reasoning.write",
+            {"phase": "BEFORE_TOOL", "summary": "private purpose", "run_id": run_id},
+            {"run_id": run_id, "call_id": call_id},
+        ),
+        _tool_event(
+            "capability.invoke",
+            {"reasoning_run_id": run_id, "reasoning_call_id": call_id},
+            {"execution": {"status": "COMPLETED"}},
+        ),
+        _tool_event(
+            "reasoning.write",
+            {
+                "phase": "AFTER_TOOL",
+                "summary": "private interpretation",
+                "run_id": run_id,
+                "call_id": call_id,
+            },
+            {
+                "run_id": run_id,
+                "execution_status_matches": True,
+                "assurance_level_matches": True,
+                "completeness_status_matches": True,
+            },
+        ),
+        _tool_event(
+            "reasoning.write",
+            {"phase": "FINAL", "summary": "private final", "run_id": run_id},
+            {"run_id": run_id, "state": "FINALIZED"},
+        ),
+    ]
+    trial_dir = tmp_path / "job" / "attempt-0"
+    _write_trial_manifest(
+        trial_dir,
+        [
+            {
+                "source": "/logs/agent/trajectory.jsonl",
+                "destination": "artifacts/logs/agent/trajectory.jsonl",
+                "type": "file",
+                "status": "ok",
+                "service": None,
+                "_content": "\n".join(json.dumps(event) for event in events) + "\n",
+            }
+        ],
+    )
+    result_path = trial_dir / "result.json"
+    result_path.write_text("{}", encoding="utf-8")
+    artifacts, *_ = _trial_artifacts(result_path, "attempt-0", "job.json")
+
+    protocol = _trial_reasoning_protocol(result_path, artifacts)
+
+    assert protocol["status"] == "COMPLETE"
+    assert protocol["bound_invoke_count"] == 1
+    assert protocol["summary_characters"] == len(
+        "private planprivate purposeprivate interpretationprivate final"
+    )
+    assert "private" not in json.dumps(protocol)
 
 
 def test_heldout_artifact_source_paths_include_pair_and_condition(

--- a/deploy/smoke_remote.py
+++ b/deploy/smoke_remote.py
@@ -17,10 +17,11 @@ from mcp_types import TextContent, TextResourceContents
 from jacobian import __version__
 from jacobian.canonical import canonicalize_json
 
-EXPECTED_TOOLS = {
+REQUIRED_TOOLS = {
     "capability.describe",
     "capability.invoke",
 }
+OPTIONAL_TOOLS = {"reasoning.write"}
 DISCOVERY_RESPONSE_BYTE_LIMIT = 16_384
 
 
@@ -100,10 +101,15 @@ async def inspect(
 
         listed = await client.list_tools()
         tool_names = {tool.name for tool in listed.tools}
-        if tool_names != EXPECTED_TOOLS:
+        missing = sorted(REQUIRED_TOOLS - tool_names)
+        unexpected = sorted(tool_names - REQUIRED_TOOLS - OPTIONAL_TOOLS)
+        if missing:
             failures.append(
-                "deployed MCP tool surface mismatch: "
-                f"expected {sorted(EXPECTED_TOOLS)!r}, got {sorted(tool_names)!r}"
+                f"deployed MCP tool surface is missing required tools: {missing!r}"
+            )
+        if unexpected:
+            failures.append(
+                f"deployed MCP tool surface has unexpected tools: {unexpected!r}"
             )
 
         catalog_result = await client.read_resource("capability://catalog")

--- a/docs/how-to/deploy-remote-mcp.md
+++ b/docs/how-to/deploy-remote-mcp.md
@@ -10,10 +10,15 @@ deployment source of truth. Keep host-specific copies, smoke output, and
 last-deployed notes outside source control; do not install configuration from
 operator scratch space or treat it as current.
 
-The server exposes `capability.describe` and `capability.invoke`. Clients may
+By default the server exposes `capability.describe`, `capability.invoke`, and
+the operational `reasoning.write` protocol. Clients may
 read installed descriptors from `capability://catalog` and inspect exact
 contracts before invoking mathematical operations, which remain behind
 namespaced capability IDs.
+
+`--reasoning-log-mode required` is the default. Use `audit` only for staged
+fail-open observation and `off` only for rollback or a controlled legacy
+evaluation. These modes do not change capability assurance or checker authority.
 
 ## Install from a clone
 

--- a/docs/how-to/invoke-domain-capabilities.md
+++ b/docs/how-to/invoke-domain-capabilities.md
@@ -84,7 +84,11 @@ async def tool(client: Client, name: str, arguments: dict) -> dict:
 
 
 async def main() -> None:
-    server = create_server(STATE_DIR, checker_authority=CheckerAuthorityMode.INSTALL_BUNDLED)
+    server = create_server(
+        STATE_DIR,
+        checker_authority=CheckerAuthorityMode.INSTALL_BUNDLED,
+        reasoning_log_mode="off",
+    )
     async with Client(server, raise_exceptions=True) as client:
         described = await tool(
             client,

--- a/docs/reference/reasoning-log.md
+++ b/docs/reference/reasoning-log.md
@@ -1,0 +1,76 @@
+# External reasoning-log protocol
+
+[Documentation home](../index.md) · [Capability surface](tools.md)
+
+Jacobian requires MCP agents to keep a concise external work log. Entries are
+model-authored summaries, not hidden or internal chain-of-thought. They remain
+operational and unverified and never change mathematical assurance.
+
+## Lifecycle
+
+1. Call `reasoning.write` with `phase: "PLAN"`; retain its `run_id`.
+2. Before each capability execution, write `BEFORE_TOOL` with that run ID,
+   exact capability ID, mode, and a short purpose. Retain the returned `call_id`.
+3. Add both IDs to the matching `capability.invoke` request.
+4. After every result, including errors, cancellations, and timeouts, write
+   `AFTER_TOOL` with the same IDs and a concise interpretation.
+5. Write one `FINAL` audit after all calls have been interpreted.
+
+One run executes only one capability cycle at a time and accepts at most 64
+cycles. Different runs and tenants remain concurrent. A started call that is
+still unfinished after the ten-minute recovery grace is recorded on a later
+runtime start as an `ERROR` non-conclusion and still requires `AFTER_TOOL`. The
+grace prevents a second process from misclassifying a live long-running call.
+
+Each summary is limited to 512 Unicode characters and 2048 UTF-8 bytes. Do not
+include prompts, credentials, personal data, raw request payloads, or copied tool
+output. The server stores a canonical request digest and result digest plus the
+actual capability ID/version/mode, execution status, assurance, completeness,
+scope digest, diagnostics, artifact URIs, and episode URI.
+
+Read the durable append-only log at `reasoning://run/{run_id}`. It is returned as
+newline-delimited JSON. Events carry a sequence number and previous-event digest,
+and SQLite rejects event updates and deletes.
+
+## Enforcement and recovery
+
+`REQUIRED` rejects an unbound, mismatched, reused, or out-of-order invocation
+before mathematical execution. `AUDIT` records protocol violations but permits
+legacy unbound invocations. `OFF` removes `reasoning.write`, its resource, and
+the extra invocation fields.
+
+A duplicate or concurrent use of one `call_id` never starts a second
+calculation. If a response is lost after completion, inspect the log rather than
+blindly retrying; complete the pending interpretation and reserve a new call only
+when recomputation is genuinely required.
+
+Jacobian cannot prevent an agent from emitting a final answer outside MCP. A run
+without `FINAL` is therefore auditable as incomplete, rather than falsely treated
+as completed. Timestamps and append order constrain post-hoc insertion but cannot
+prove that a summary accurately represents a model's private cognition.
+
+The log follows the tenant state directory's retention and access controls. V1
+does not add per-entry deletion or encryption at rest; operators handling
+sensitive research must protect or rotate the complete tenant state directory.
+Request and result digests are integrity bindings, not anonymization: an operator
+with the log may be able to guess low-entropy inputs or outputs offline and compare
+their hashes. Do not use sensitive payloads in a tenant whose state is not trusted.
+
+## Evaluation use
+
+For weak-model studies, run paired jobs with the same task set, model, prompt,
+tool portfolio, and sampling settings. Compare `OFF` with `REQUIRED`; use
+`AUDIT` only to measure naturally occurring protocol violations without blocking
+the job. Report task correctness and false-certification rate separately from
+protocol adherence. The transcript telemetry records phase counts, bound calls,
+missing interpretations, run identity, and total summary characters, but not the
+summary text.
+
+Useful secondary measures are capability-selection accuracy, completed
+tool cycles, abandoned calls, final-audit rate, token and latency overhead, and
+the fraction of summaries that merely restate tool status. For a stronger-model
+score `S`, weak baseline `W_off`, and weak treatment `W_required`, report the
+closed performance gap as `(W_required - W_off) / (S - W_off)` only when the
+denominator is positive, alongside raw scores and confidence intervals. Logs are
+diagnostic covariates, not evidence that the protocol caused a mathematical
+improvement; causal claims require randomized or counterbalanced paired runs.

--- a/docs/reference/reasoning-log.md
+++ b/docs/reference/reasoning-log.md
@@ -12,15 +12,18 @@ operational and unverified and never change mathematical assurance.
 2. Before each capability execution, write `BEFORE_TOOL` with that run ID,
    exact capability ID, mode, and a short purpose. Retain the returned `call_id`.
 3. Add both IDs to the matching `capability.invoke` request.
-4. After every result, including errors, cancellations, and timeouts, write
-   `AFTER_TOOL` with the same IDs and a concise interpretation.
+4. After every result, write `AFTER_TOOL` with `interpretation_status:
+   "INTERPRETED"`, the same IDs, a concise interpretation, and the reported
+   execution status, assurance level, and completeness status. If the result
+   content was lost after a response failure or runtime restart, use
+   `interpretation_status: "RESULT_UNAVAILABLE"` and omit those reported fields.
 5. Write one `FINAL` audit after all calls have been interpreted.
 
 One run executes only one capability cycle at a time and accepts at most 64
-cycles. Different runs and tenants remain concurrent. A started call that is
-still unfinished after the ten-minute recovery grace is recorded on a later
-runtime start as an `ERROR` non-conclusion and still requires `AFTER_TOOL`. The
-grace prevents a second process from misclassifying a live long-running call.
+cycles. Different runs and tenants remain concurrent. A current runtime never
+declares a call interrupted because of elapsed time. After a runtime restart, an
+explicit `RESULT_UNAVAILABLE` entry atomically records the old call as an `ERROR`
+non-conclusion before closing its interpretation cycle.
 
 Each summary is limited to 512 Unicode characters and 2048 UTF-8 bytes. Do not
 include prompts, credentials, personal data, raw request payloads, or copied tool
@@ -29,8 +32,9 @@ actual capability ID/version/mode, execution status, assurance, completeness,
 scope digest, diagnostics, artifact URIs, and episode URI.
 
 Read the durable append-only log at `reasoning://run/{run_id}`. It is returned as
-newline-delimited JSON. Events carry a sequence number and previous-event digest,
-and SQLite rejects event updates and deletes.
+newline-delimited JSON. Events carry a contiguous sequence number, and SQLite
+rejects event updates and deletes. Canonical request and result digests bind calls
+without claiming protection against a privileged state-database operator.
 
 ## Enforcement and recovery
 
@@ -41,8 +45,11 @@ the extra invocation fields.
 
 A duplicate or concurrent use of one `call_id` never starts a second
 calculation. If a response is lost after completion, inspect the log rather than
-blindly retrying; complete the pending interpretation and reserve a new call only
-when recomputation is genuinely required.
+blindly retrying. Use `RESULT_UNAVAILABLE` when the actual result content cannot
+be recovered, and reserve a new call only when recomputation is genuinely
+required. V1 assumes one server runtime owns a tenant state directory; multiple
+MCP clients may share that runtime, and run/call IDs are bearer identifiers inside
+the tenant.
 
 Jacobian cannot prevent an agent from emitting a final answer outside MCP. A run
 without `FINAL` is therefore auditable as incomplete, rather than falsely treated
@@ -50,8 +57,12 @@ as completed. Timestamps and append order constrain post-hoc insertion but canno
 prove that a summary accurately represents a model's private cognition.
 
 The log follows the tenant state directory's retention and access controls. V1
-does not add per-entry deletion or encryption at rest; operators handling
-sensitive research must protect or rotate the complete tenant state directory.
+does not add per-entry deletion, automatic expiry, listing, or encryption at rest.
+The run resource is its JSONL export. Delete or rotate the complete tenant state
+directory to remove logs. Evaluation jobs must use one ephemeral tenant state
+directory per trial, export required evidence, and delete the directory after the
+declared retention period. Operators handling persistent or sensitive research
+must protect and rotate the complete tenant state directory.
 Request and result digests are integrity bindings, not anonymization: an operator
 with the log may be able to guess low-entropy inputs or outputs offline and compare
 their hashes. Do not use sensitive payloads in a tenant whose state is not trusted.

--- a/docs/reference/state-format.md
+++ b/docs/reference/state-format.md
@@ -1,6 +1,6 @@
 # Persistent state format
 
-The current state format is revision 6. The supported floor is also revision
+The current state format is revision 7. The supported floor is revision
 6, so an older revision-5 store is rejected before any migration code runs.
 This is intentional: revision 6 retires the one-shot research-index upgrade
 ledger and the compatibility decoder that existed only to bring revision-3
@@ -17,3 +17,10 @@ SQLite ledger is immutable historical evidence. They are not an indication
 that the retired workspace schema or data-upgrade bridge is still supported.
 New stores apply revision 6, which removes the completed
 `jacobian_data_upgrades` table and records the current format.
+
+Revision 7 adds the reasoning-log tables `reasoning_runs` and
+`reasoning_events` for the bounded external reasoning-log protocol. This
+migration is additive: it creates the new tables, their indices, and
+no-update/no-delete triggers without modifying existing records. Stores at
+revision 6 are upgraded automatically on first open with the current
+version; no manual intervention is required.

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -6,12 +6,22 @@
 - Installed membership remains runtime-defined
 
 Jacobian exposes mathematical operations as namespaced capabilities. The
-model-facing MCP surface contains two tools:
+model-facing MCP surface contains two capability tools and, by default, one
+operational reasoning-log tool:
 
 | MCP tool | Purpose |
 | --- | --- |
 | `capability.describe` | Search the compact installed index, or read one capability's exact schemas by ID. |
 | `capability.invoke` | Invoke an installed capability in `EXPLORE` or `VERIFY` mode. |
+| `reasoning.write` | Append a bounded model-authored `PLAN`, `BEFORE_TOOL`, `AFTER_TOOL`, or `FINAL` summary. |
+
+The reasoning log is not a mathematical capability, proof object, workspace, or
+chain-of-thought collector. In the default `REQUIRED` mode, every
+`capability.invoke` must carry the `reasoning_run_id` and `reasoning_call_id`
+returned by the current `BEFORE_TOOL`. The server binds the actual execution
+status, assurance, completeness, result digest, and artifact URIs without
+copying the capability payload or output into the log. See the
+[reasoning-log protocol](reasoning-log.md).
 
 Read `capability://catalog` to discover installed capability IDs, provider
 versions, supported modes, compact schemas, and tags. Catalog membership means
@@ -19,9 +29,10 @@ that an operation is installed and invocable. It does not imply compatibility
 support, recommendation, conformance coverage, or authority to return
 `VERIFIED`.
 
-There are no alternate MCP tool profiles and no public top-level MCP commands
-for individual mathematical operations. Adding a capability does not add a
-new MCP tool.
+There are no alternate mathematical capability profiles and no public top-level
+MCP commands for individual mathematical operations. The operator may set the
+reasoning-log enforcement mode to `REQUIRED`, `AUDIT`, or `OFF`; `OFF` preserves
+the legacy two-tool surface. Adding a capability does not add a new MCP tool.
 
 ## Capability contract
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -19,8 +19,9 @@ The reasoning log is not a mathematical capability, proof object, workspace, or
 chain-of-thought collector. In the default `REQUIRED` mode, every
 `capability.invoke` must carry the `reasoning_run_id` and `reasoning_call_id`
 returned by the current `BEFORE_TOOL`. The server binds the actual execution
-status, assurance, completeness, result digest, and artifact URIs without
-copying the capability payload or output into the log. See the
+status, assurance, completeness, result digest, and artifact URIs, then records
+whether the model's structured `AFTER_TOOL` report matches them, without copying
+the capability payload or output into the log. See the
 [reasoning-log protocol](reasoning-log.md).
 
 Read `capability://catalog` to discover installed capability IDs, provider

--- a/docs/tutorials/first-verified-result.md
+++ b/docs/tutorials/first-verified-result.md
@@ -49,7 +49,11 @@ async def tool(client: Client, name: str, arguments: dict) -> dict:
 
 
 async def main() -> None:
-    server = create_server(STATE_DIR, checker_authority=CheckerAuthorityMode.INSTALL_BUNDLED)
+    server = create_server(
+        STATE_DIR,
+        checker_authority=CheckerAuthorityMode.INSTALL_BUNDLED,
+        reasoning_log_mode="off",
+    )
 
     async with Client(server, raise_exceptions=True) as client:
         capability_ids = (

--- a/docs/tutorials/lean-declaration-discovery.md
+++ b/docs/tutorials/lean-declaration-discovery.md
@@ -35,7 +35,11 @@ async def tool(client: Client, name: str, arguments: dict) -> dict:
 
 
 async def main() -> None:
-    server = create_server(STATE_DIR, checker_authority=CheckerAuthorityMode.INSTALL_BUNDLED)
+    server = create_server(
+        STATE_DIR,
+        checker_authority=CheckerAuthorityMode.INSTALL_BUNDLED,
+        reasoning_log_mode="off",
+    )
 
     async with Client(server, raise_exceptions=True) as client:
         searched = await tool(

--- a/src/jacobian/adapters/mcp/cli.py
+++ b/src/jacobian/adapters/mcp/cli.py
@@ -8,6 +8,19 @@ from pathlib import Path
 from jacobian import __version__
 
 _CAPABILITY_MODES = ("EXPLORE", "VERIFY")
+_REASONING_LOG_MODES = ("required", "audit", "off")
+
+
+def _normalize_reasoning_log_mode(value: str) -> str:
+    """Accept case-insensitive reasoning-log mode values from the CLI."""
+
+    lowered = value.lower()
+    if lowered not in _REASONING_LOG_MODES:
+        raise argparse.ArgumentTypeError(
+            f"invalid reasoning_log_mode: {value!r} "
+            f"(choose from {', '.join(_REASONING_LOG_MODES)})"
+        )
+    return lowered
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -129,9 +142,12 @@ def _parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--reasoning-log-mode",
-        choices=("required", "audit", "off"),
-        default="required",
-        help="external reasoning-log enforcement; defaults to required",
+        type=_normalize_reasoning_log_mode,
+        default="off",
+        help=(
+            "external reasoning-log enforcement; defaults to off. "
+            "Accepts case-insensitive values: required, audit, off."
+        ),
     )
     return parser
 

--- a/src/jacobian/adapters/mcp/cli.py
+++ b/src/jacobian/adapters/mcp/cli.py
@@ -127,6 +127,12 @@ def _parser() -> argparse.ArgumentParser:
             "next acquisition"
         ),
     )
+    parser.add_argument(
+        "--reasoning-log-mode",
+        choices=("required", "audit", "off"),
+        default="required",
+        help="external reasoning-log enforcement; defaults to required",
+    )
     return parser
 
 
@@ -143,9 +149,12 @@ def main() -> None:
         parser.error("--anonymous-tenant-id requires --allow-anonymous")
     args.path = args.path if args.path.startswith("/") else f"/{args.path}"
 
+    from jacobian.adapters.mcp.constants import ReasoningLogMode
     from jacobian.adapters.mcp.server import create_server
     from jacobian.capability_service import CapabilityPolicy
     from jacobian.contracts.capabilities import CapabilityMode
+
+    reasoning_log_mode = ReasoningLogMode(args.reasoning_log_mode.upper())
 
     capability_policy = CapabilityPolicy(
         profile=args.capability_policy_profile,
@@ -169,6 +178,7 @@ def main() -> None:
             state_dir=args.state_dir,
             capability_adapter_entrypoints=tuple(args.capability_adapter),
             capability_policy=capability_policy,
+            reasoning_log_mode=reasoning_log_mode,
         ).run("stdio")
         return
 
@@ -209,6 +219,7 @@ def main() -> None:
         capability_policy=capability_policy,
         max_tenant_runtimes=args.max_tenant_runtimes,
         tenant_idle_timeout_seconds=args.tenant_idle_timeout_seconds,
+        reasoning_log_mode=reasoning_log_mode,
     )
     if args.transport == "streamable-http":
         server.run(

--- a/src/jacobian/adapters/mcp/constants.py
+++ b/src/jacobian/adapters/mcp/constants.py
@@ -3,11 +3,20 @@
 from __future__ import annotations
 
 import logging
+from enum import StrEnum
 from typing import Literal
 
 _LOGGER = logging.getLogger(__name__)
 CAPABILITY_DISCOVERY_RESPONSE_BYTE_LIMIT = 16_384
 CapabilityDescriptionView = Literal["SUMMARY", "CONTRACT", "FULL"]
+
+
+class ReasoningLogMode(StrEnum):
+    REQUIRED = "REQUIRED"
+    AUDIT = "AUDIT"
+    OFF = "OFF"
+
+
 _CAPABILITY_SCOPE_RULE = {
     "conclusion_scope": "Only the exact supplied input or claim is covered.",
     "bounded_repetition": (

--- a/src/jacobian/adapters/mcp/context.py
+++ b/src/jacobian/adapters/mcp/context.py
@@ -116,9 +116,12 @@ def _classify_public_tool_error(
         TenantRuntimeLimitError,
     )
     from jacobian.experiments import ExperimentNotFoundError
+    from jacobian.reasoning_log import ReasoningProtocolError
     from jacobian.registry import CheckerNotFoundError
     from jacobian.storage.errors import ArtifactNotFoundError
 
+    if isinstance(tool_error, ReasoningProtocolError):
+        return (tool_error.code, str(tool_error), tool_error.hint)
     if isinstance(tool_error, AgentRecoveryError):
         return (
             "SERVICE_UNAVAILABLE",

--- a/src/jacobian/adapters/mcp/context.py
+++ b/src/jacobian/adapters/mcp/context.py
@@ -14,6 +14,7 @@ from typing import Any
 from mcp.server.mcpserver import Context
 from mcp.server.mcpserver.exceptions import ToolError
 
+from jacobian.adapters.mcp.constants import ReasoningLogMode
 from jacobian.adapters.mcp.remote import TenantRuntimeRouter
 from jacobian.adapters.mcp.tooling import AgentRecoveryError
 from jacobian.runtime.model import JacobianRuntime
@@ -25,6 +26,7 @@ _LOGGER = logging.getLogger(__name__)
 class AppState:
     runtime: JacobianRuntime | None
     tenant_router: TenantRuntimeRouter | None = None
+    reasoning_log_mode: ReasoningLogMode = ReasoningLogMode.OFF
 
 
 def _runtime(ctx: Context[AppState, Any] | None) -> JacobianRuntime:

--- a/src/jacobian/adapters/mcp/guidance.py
+++ b/src/jacobian/adapters/mcp/guidance.py
@@ -177,16 +177,18 @@ Append one concise external reasoning summary. This records model-authored PLAN,
 BEFORE_TOOL, AFTER_TOOL, or FINAL entries; it does not request or expose hidden
 chain-of-thought and never establishes mathematical assurance. PLAN creates a run.
 BEFORE_TOOL reserves one capability call. AFTER_TOOL interprets the bound actual
-result. FINAL audits the completed run. Do not copy prompts, secrets, payloads, or raw
-tool output into summary.
+result or explicitly records RESULT_UNAVAILABLE after a lost response or runtime
+restart. FINAL audits the completed run. Do not copy prompts, secrets, payloads, or
+raw tool output into summary.
 """
 
 _REASONING_PREFIX = (
     "Before using Jacobian, call reasoning.write with phase PLAN and a concise "
     "external work summary. Before each capability.invoke call, write BEFORE_TOOL "
     "with the selected capability ID and mode, then pass the returned run_id and "
-    "call_id to capability.invoke. Write AFTER_TOOL after every result, including "
-    "errors or timeouts, and FINAL before completing the task. These are summaries, "
+    "call_id to capability.invoke. Write AFTER_TOOL after every result with the "
+    "reported status, assurance, and completeness; use RESULT_UNAVAILABLE only when "
+    "result content was lost. Write FINAL before completing the task. These are summaries, "
     "not hidden chain-of-thought. Do not copy raw tool output. "
 )
 
@@ -206,7 +208,8 @@ def operating_guide(*, reasoning_enabled: bool) -> str:
         "## External reasoning log\n\n"
         "Start with one concise `PLAN`. Surround every `capability.invoke` with "
         "`BEFORE_TOOL` and `AFTER_TOOL`, then write one `FINAL` audit. The server "
-        "binds actual status, assurance, completeness, and artifact URIs without "
+        "binds actual status, assurance, completeness, and artifact URIs and records "
+        "whether the model's structured interpretation matches them, without "
         "storing raw payload or output. This log is operational and unverified; it "
         "is not hidden chain-of-thought or mathematical evidence.\n\n"
         "## When to use Jacobian",

--- a/src/jacobian/adapters/mcp/guidance.py
+++ b/src/jacobian/adapters/mcp/guidance.py
@@ -172,6 +172,46 @@ wrapper containing additional fields (e.g. task_id, input_sha256, assignment).
 Do not claim VERIFIED when no agent-visible record content contract is available.
 """
 
+REASONING_WRITE_DESCRIPTION = """\
+Append one concise external reasoning summary. This records model-authored PLAN,
+BEFORE_TOOL, AFTER_TOOL, or FINAL entries; it does not request or expose hidden
+chain-of-thought and never establishes mathematical assurance. PLAN creates a run.
+BEFORE_TOOL reserves one capability call. AFTER_TOOL interprets the bound actual
+result. FINAL audits the completed run. Do not copy prompts, secrets, payloads, or raw
+tool output into summary.
+"""
+
+_REASONING_PREFIX = (
+    "Before using Jacobian, call reasoning.write with phase PLAN and a concise "
+    "external work summary. Before each capability.invoke call, write BEFORE_TOOL "
+    "with the selected capability ID and mode, then pass the returned run_id and "
+    "call_id to capability.invoke. Write AFTER_TOOL after every result, including "
+    "errors or timeouts, and FINAL before completing the task. These are summaries, "
+    "not hidden chain-of-thought. Do not copy raw tool output. "
+)
+
+
+def server_instructions(*, reasoning_enabled: bool) -> str:
+    return (_REASONING_PREFIX if reasoning_enabled else "") + SERVER_INSTRUCTIONS
+
+
+def operating_guide(*, reasoning_enabled: bool) -> str:
+    if not reasoning_enabled:
+        return OPERATING_GUIDE
+    return OPERATING_GUIDE.replace(
+        "through two MCP tools.",
+        "through two capability tools plus the operational `reasoning.write` log tool.",
+    ).replace(
+        "## When to use Jacobian",
+        "## External reasoning log\n\n"
+        "Start with one concise `PLAN`. Surround every `capability.invoke` with "
+        "`BEFORE_TOOL` and `AFTER_TOOL`, then write one `FINAL` audit. The server "
+        "binds actual status, assurance, completeness, and artifact URIs without "
+        "storing raw payload or output. This log is operational and unverified; it "
+        "is not hidden chain-of-thought or mathematical evidence.\n\n"
+        "## When to use Jacobian",
+    )
+
 
 def discovery_prompt(task: str) -> str:
     """Render optional protocol guidance without choosing a research strategy."""

--- a/src/jacobian/adapters/mcp/resources.py
+++ b/src/jacobian/adapters/mcp/resources.py
@@ -195,3 +195,24 @@ def _register_resources_and_prompts(
         ] = None,
     ) -> str:
         return evidence_check_prompt(claim, artifact_uri)
+
+
+def _register_reasoning_resource(
+    server: Any,
+    runtime: JacobianRuntime | None,
+    tenant_router: Any,
+) -> None:
+    """Register the optional operational reasoning-log reader."""
+
+    @server.resource(  # type: ignore[untyped-decorator]
+        "reasoning://run/{run_id}",
+        name="reasoning-log",
+        description="Read one tenant-isolated append-only external reasoning log.",
+        mime_type="application/x-ndjson",
+    )
+    async def reasoning_log_resource(run_id: str) -> str:
+        with _resource_runtime(runtime, tenant_router) as active_runtime:
+            return await _run_blocking(
+                active_runtime.core.reasoning_log.inspect_jsonl,
+                run_id,
+            )

--- a/src/jacobian/adapters/mcp/server.py
+++ b/src/jacobian/adapters/mcp/server.py
@@ -19,6 +19,7 @@ from mcp.server.mcpserver.resources import FunctionResource, TextResource
 from mcp.shared.exceptions import MCPError
 
 from jacobian import __version__
+from jacobian.adapters.mcp.constants import ReasoningLogMode
 from jacobian.adapters.mcp.context import (
     AppState,
     _configured_root,
@@ -29,12 +30,16 @@ from jacobian.adapters.mcp.context import (
 from jacobian.adapters.mcp.guidance import (
     CAPABILITY_DESCRIBE_DESCRIPTION,
     CAPABILITY_INVOKE_DESCRIPTION,
-    OPERATING_GUIDE,
+    REASONING_WRITE_DESCRIPTION,
     SERVER_DESCRIPTION,
-    SERVER_INSTRUCTIONS,
+    operating_guide,
+    server_instructions,
 )
 from jacobian.adapters.mcp.remote import TenantRuntimeRouter
-from jacobian.adapters.mcp.resources import _register_resources_and_prompts
+from jacobian.adapters.mcp.resources import (
+    _register_reasoning_resource,
+    _register_resources_and_prompts,
+)
 from jacobian.adapters.mcp.tooling import (
     _argument_digest,
     _response_size,
@@ -43,6 +48,9 @@ from jacobian.adapters.mcp.tooling import (
 from jacobian.adapters.mcp.tools import (
     capability_describe,
     capability_invoke,
+    capability_invoke_audit,
+    capability_invoke_reasoned,
+    reasoning_write,
 )
 from jacobian.capability_service import CapabilityPolicy
 from jacobian.references import reference_catalog
@@ -73,15 +81,22 @@ class JacobianCoreExtension(Extension):
         self,
         runtime: JacobianRuntime | None,
         tenant_router: TenantRuntimeRouter | None,
+        reasoning_log_mode: ReasoningLogMode = ReasoningLogMode.REQUIRED,
     ) -> None:
         self._runtime = runtime
         self._tenant_router = tenant_router
+        self._reasoning_log_mode = reasoning_log_mode
 
     def settings(self) -> dict[str, Any]:
-        return {"version": "1"}
+        return {"version": "2", "reasoning_log_mode": self._reasoning_log_mode.value}
 
     def tools(self) -> tuple[ToolBinding, ...]:
-        return (
+        invoke_handler = {
+            ReasoningLogMode.REQUIRED: capability_invoke_reasoned,
+            ReasoningLogMode.AUDIT: capability_invoke_audit,
+            ReasoningLogMode.OFF: capability_invoke,
+        }[self._reasoning_log_mode]
+        bindings = [
             ToolBinding(
                 _safe_tool_handler("capability.describe", capability_describe),
                 kwargs={
@@ -93,7 +108,7 @@ class JacobianCoreExtension(Extension):
                 },
             ),
             ToolBinding(
-                _safe_tool_handler("capability.invoke", capability_invoke),
+                _safe_tool_handler("capability.invoke", invoke_handler),
                 kwargs={
                     "name": "capability.invoke",
                     "title": "Execute a mathematical capability",
@@ -102,7 +117,21 @@ class JacobianCoreExtension(Extension):
                     "structured_output": True,
                 },
             ),
-        )
+        ]
+        if self._reasoning_log_mode is not ReasoningLogMode.OFF:
+            bindings.append(
+                ToolBinding(
+                    _safe_tool_handler("reasoning.write", reasoning_write),
+                    kwargs={
+                        "name": "reasoning.write",
+                        "title": "Write a concise external reasoning summary",
+                        "description": REASONING_WRITE_DESCRIPTION,
+                        "annotations": _tool_annotations(),
+                        "structured_output": True,
+                    },
+                )
+            )
+        return tuple(bindings)
 
     def resources(self) -> tuple[ResourceBinding, ...]:
         return (
@@ -116,7 +145,10 @@ class JacobianCoreExtension(Extension):
                         "checking Jacobian mathematical capabilities."
                     ),
                     mime_type="text/markdown",
-                    text=OPERATING_GUIDE,
+                    text=operating_guide(
+                        reasoning_enabled=self._reasoning_log_mode
+                        is not ReasoningLogMode.OFF
+                    ),
                 )
             ),
             ResourceBinding(
@@ -313,9 +345,11 @@ def create_server(
     capability_policy: CapabilityPolicy | None = None,
     max_tenant_runtimes: int | None = None,
     tenant_idle_timeout_seconds: float | None = None,
+    reasoning_log_mode: ReasoningLogMode | str = ReasoningLogMode.REQUIRED,
 ) -> MCPServer[AppState]:
     """Create a local or tenant-routed adapter over a Jacobian runtime."""
 
+    selected_reasoning_mode = ReasoningLogMode(reasoning_log_mode)
     if tenant_isolation and capability_exclusions:
         raise ValueError("capability exclusions are supported only by local evaluation")
 
@@ -386,15 +420,21 @@ def create_server(
         name="jacobian",
         title="Jacobian Mathematical Workbench",
         description=SERVER_DESCRIPTION,
-        instructions=SERVER_INSTRUCTIONS,
+        instructions=server_instructions(
+            reasoning_enabled=selected_reasoning_mode is not ReasoningLogMode.OFF
+        ),
         version=__version__,
         lifespan=lifespan,
         token_verifier=token_verifier,
         auth=auth,
-        extensions=[JacobianCoreExtension(runtime, tenant_router)],
+        extensions=[
+            JacobianCoreExtension(runtime, tenant_router, selected_reasoning_mode)
+        ],
     )
 
     _register_resources_and_prompts(server, runtime, tenant_router)
+    if selected_reasoning_mode is not ReasoningLogMode.OFF:
+        _register_reasoning_resource(server, runtime, tenant_router)
     return server
 
 

--- a/src/jacobian/adapters/mcp/server.py
+++ b/src/jacobian/adapters/mcp/server.py
@@ -60,6 +60,22 @@ from jacobian.runtime.model import JacobianRuntime
 _LOGGER = logging.getLogger(__name__)
 
 
+def _normalize_reasoning_log_mode(
+    value: ReasoningLogMode | str,
+) -> ReasoningLogMode:
+    """Accept case-insensitive reasoning-log mode values from callers."""
+
+    if isinstance(value, ReasoningLogMode):
+        return value
+    try:
+        return ReasoningLogMode(value.upper())
+    except ValueError:
+        valid = ", ".join(m.value for m in ReasoningLogMode)
+        raise ValueError(
+            f"invalid reasoning_log_mode: {value!r} (choose from {valid})"
+        ) from None
+
+
 class JacobianMCPServer(MCPServer[AppState]):
     """MCP server with SDK-owned static argument validation."""
 
@@ -316,6 +332,7 @@ async def _runtime_lifespan(
     *,
     runtime: JacobianRuntime | None,
     tenant_router: TenantRuntimeRouter | None,
+    reasoning_log_mode: ReasoningLogMode = ReasoningLogMode.OFF,
 ) -> AsyncIterator[AppState]:
     if runtime is not None:
         _start_lean_warmup(runtime)
@@ -323,6 +340,7 @@ async def _runtime_lifespan(
         yield AppState(
             runtime=runtime,
             tenant_router=tenant_router,
+            reasoning_log_mode=reasoning_log_mode,
         )
     finally:
         if runtime is not None:
@@ -345,11 +363,11 @@ def create_server(
     capability_policy: CapabilityPolicy | None = None,
     max_tenant_runtimes: int | None = None,
     tenant_idle_timeout_seconds: float | None = None,
-    reasoning_log_mode: ReasoningLogMode | str = ReasoningLogMode.REQUIRED,
+    reasoning_log_mode: ReasoningLogMode | str = ReasoningLogMode.OFF,
 ) -> MCPServer[AppState]:
     """Create a local or tenant-routed adapter over a Jacobian runtime."""
 
-    selected_reasoning_mode = ReasoningLogMode(reasoning_log_mode)
+    selected_reasoning_mode = _normalize_reasoning_log_mode(reasoning_log_mode)
     if tenant_isolation and capability_exclusions:
         raise ValueError("capability exclusions are supported only by local evaluation")
 
@@ -413,6 +431,7 @@ def create_server(
             server,
             runtime=runtime,
             tenant_router=tenant_router,
+            reasoning_log_mode=selected_reasoning_mode,
         ) as state:
             yield state
 

--- a/src/jacobian/adapters/mcp/tooling.py
+++ b/src/jacobian/adapters/mcp/tooling.py
@@ -22,6 +22,7 @@ from jacobian.contracts.capabilities import (
     CapabilityRequest,
     CapabilityResult,
 )
+from jacobian.reasoning_log import ReasoningProtocolError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -165,6 +166,76 @@ def _log_capability_attempt(
     )
 
 
+def _claim_reasoning_call(
+    runtime: Any,
+    *,
+    run_id: str | None,
+    call_id: str | None,
+    capability_id: str,
+    mode: CapabilityMode,
+    argument_digest: str,
+    required: bool,
+    audit: bool,
+) -> bool:
+    if run_id is None or call_id is None:
+        if required:
+            raise ReasoningProtocolError(
+                "REASONING_LOG_REQUIRED",
+                "capability.invoke requires the run_id and call_id from BEFORE_TOOL.",
+                "Call reasoning.write with PLAN, then BEFORE_TOOL, and retry with its IDs.",
+            )
+        if audit:
+            _LOGGER.warning(
+                "MCP capability reasoning protocol violation; unbound invocation "
+                "allowed in audit mode"
+            )
+        return False
+    try:
+        runtime.core.reasoning_log.claim_call(
+            run_id,
+            call_id,
+            capability_id,
+            mode,
+            argument_digest,
+        )
+    except ReasoningProtocolError:
+        if required:
+            raise
+        _LOGGER.warning(
+            "MCP capability reasoning protocol violation; invoking in audit mode",
+            exc_info=True,
+        )
+        return False
+    return True
+
+
+def _finish_failed_reasoning_call(
+    runtime: Any,
+    *,
+    bound: bool,
+    run_id: str | None,
+    call_id: str | None,
+    capability_id: str,
+    mode: CapabilityMode,
+    argument_digest: str,
+    execution_status: str,
+    diagnostic_code: str,
+) -> None:
+    if not bound:
+        return
+    assert run_id is not None
+    assert call_id is not None
+    runtime.core.reasoning_log.finish_call(
+        run_id,
+        call_id,
+        capability_id,
+        mode,
+        argument_digest,
+        execution_status=execution_status,
+        diagnostic_codes=(diagnostic_code,),
+    )
+
+
 async def _invoke_capability_attempt(
     runtime: Any,
     *,
@@ -172,6 +243,10 @@ async def _invoke_capability_attempt(
     payload: dict[str, Any],
     mode: CapabilityMode,
     ctx: Any | None,
+    reasoning_run_id: str | None = None,
+    reasoning_call_id: str | None = None,
+    reasoning_required: bool = False,
+    reasoning_audit: bool = False,
 ) -> CapabilityResult:
     started = time.monotonic()
     argument_digest = _argument_digest(
@@ -183,6 +258,16 @@ async def _invoke_capability_attempt(
     )
     trace_digest, trace_source = _request_trace_digest(ctx)
     cancellation_event = threading.Event()
+    bound = _claim_reasoning_call(
+        runtime,
+        run_id=reasoning_run_id,
+        call_id=reasoning_call_id,
+        capability_id=capability_id,
+        mode=mode,
+        argument_digest=argument_digest,
+        required=reasoning_required,
+        audit=reasoning_audit,
+    )
     try:
         result = await _run_blocking(
             _invoke_capability_with_cancellation,
@@ -196,6 +281,17 @@ async def _invoke_capability_attempt(
             on_cancel=cancellation_event.set,
         )
     except asyncio.CancelledError:
+        _finish_failed_reasoning_call(
+            runtime,
+            bound=bound,
+            run_id=reasoning_run_id,
+            call_id=reasoning_call_id,
+            capability_id=capability_id,
+            mode=mode,
+            argument_digest=argument_digest,
+            execution_status="CANCELLED",
+            diagnostic_code="CLIENT_CANCELLED",
+        )
         _log_capability_attempt(
             capability_id=capability_id,
             mode=mode,
@@ -208,6 +304,17 @@ async def _invoke_capability_attempt(
         )
         raise
     except Exception:
+        _finish_failed_reasoning_call(
+            runtime,
+            bound=bound,
+            run_id=reasoning_run_id,
+            call_id=reasoning_call_id,
+            capability_id=capability_id,
+            mode=mode,
+            argument_digest=argument_digest,
+            execution_status="ERROR",
+            diagnostic_code="INVOCATION_EXCEPTION",
+        )
         _log_capability_attempt(
             capability_id=capability_id,
             mode=mode,
@@ -219,6 +326,17 @@ async def _invoke_capability_attempt(
             diagnostic_codes=("INVOCATION_EXCEPTION",),
         )
         raise
+    if bound:
+        assert reasoning_run_id is not None
+        assert reasoning_call_id is not None
+        runtime.core.reasoning_log.finish_call(
+            reasoning_run_id,
+            reasoning_call_id,
+            capability_id,
+            mode,
+            argument_digest,
+            result=result,
+        )
     _log_capability_attempt(
         capability_id=capability_id,
         mode=mode,

--- a/src/jacobian/adapters/mcp/tools.py
+++ b/src/jacobian/adapters/mcp/tools.py
@@ -8,7 +8,7 @@ from typing import Annotated, Any, Literal
 from mcp.server.mcpserver import Context
 from pydantic import Field, StrictInt
 
-from jacobian.adapters.mcp.constants import _CAPABILITY_SCOPE_RULE
+from jacobian.adapters.mcp.constants import _CAPABILITY_SCOPE_RULE, ReasoningLogMode
 from jacobian.adapters.mcp.context import AppState, _runtime
 from jacobian.adapters.mcp.projections import (
     _capability_descriptor_view,
@@ -191,8 +191,10 @@ async def capability_describe(
             ),
         }
     else:
-        response["invocations"] = [
-            {
+        reasoning_mode = _reasoning_mode_from_context(ctx)
+        invocations = []
+        for example in descriptor.invocation_examples:
+            entry: dict[str, Any] = {
                 "name": example.name,
                 **(
                     {
@@ -208,8 +210,17 @@ async def capability_describe(
                     "payload": example.input,
                 },
             }
-            for example in descriptor.invocation_examples
-        ]
+            if reasoning_mode is ReasoningLogMode.REQUIRED:
+                entry["requires_reasoning_ids"] = True
+                entry["protocol_note"] = (
+                    "In REQUIRED mode, capability.invoke also requires "
+                    "reasoning_run_id and reasoning_call_id. Create a "
+                    "reasoning run with reasoning.write (PLAN), then call "
+                    "reasoning.write (BEFORE_TOOL) to obtain the IDs before "
+                    "invoking."
+                )
+            invocations.append(entry)
+        response["invocations"] = invocations
         response.update(_capability_inspection_extensions(capability_id, descriptors))
     if (
         view != "SUMMARY"
@@ -331,3 +342,16 @@ async def reasoning_write(
                 "Inspect its CONTRACT view and choose an installed mode."
             )
     return await _run_blocking(active_runtime.core.reasoning_log.write, request)
+
+
+def _reasoning_mode_from_context(
+    ctx: Context[AppState, Any] | None,
+) -> ReasoningLogMode:
+    """Read the server's reasoning-log mode from the request lifespan state."""
+
+    if ctx is None:
+        return ReasoningLogMode.OFF
+    state = ctx.request_context.lifespan_context
+    if isinstance(state, AppState):
+        return state.reasoning_log_mode
+    return ReasoningLogMode.OFF

--- a/src/jacobian/adapters/mcp/tools.py
+++ b/src/jacobian/adapters/mcp/tools.py
@@ -21,17 +21,21 @@ from jacobian.adapters.mcp.tooling import (
     _run_blocking,
 )
 from jacobian.contracts.capabilities import (
+    CapabilityAssuranceLevel,
+    CapabilityCompletenessStatus,
     CapabilityInputKind,
     CapabilityMode,
     CapabilityResult,
 )
 from jacobian.contracts.reasoning import (
     ReasoningCallId,
+    ReasoningInterpretationStatus,
     ReasoningPhase,
     ReasoningRunId,
     ReasoningWriteRequest,
     ReasoningWriteResult,
 )
+from jacobian.contracts.results import ExecutionStatus
 
 _LOGGER = logging.getLogger(__name__)
 CapabilityDescriptionView = Literal["SUMMARY", "CONTRACT", "FULL"]
@@ -291,6 +295,10 @@ async def reasoning_write(
     call_id: ReasoningCallId | None = None,
     capability_id: str | None = None,
     mode: CapabilityMode | None = None,
+    interpretation_status: ReasoningInterpretationStatus | None = None,
+    reported_execution_status: ExecutionStatus | None = None,
+    reported_assurance_level: CapabilityAssuranceLevel | None = None,
+    reported_completeness_status: CapabilityCompletenessStatus | None = None,
     ctx: Context[AppState, Any] | None = None,
 ) -> ReasoningWriteResult:
     active_runtime = _runtime(ctx)
@@ -301,6 +309,10 @@ async def reasoning_write(
         call_id=call_id,
         capability_id=capability_id,
         mode=mode,
+        interpretation_status=interpretation_status,
+        reported_execution_status=reported_execution_status,
+        reported_assurance_level=reported_assurance_level,
+        reported_completeness_status=reported_completeness_status,
     )
     if phase is ReasoningPhase.BEFORE_TOOL:
         descriptors = {

--- a/src/jacobian/adapters/mcp/tools.py
+++ b/src/jacobian/adapters/mcp/tools.py
@@ -18,11 +18,19 @@ from jacobian.adapters.mcp.projections import (
 from jacobian.adapters.mcp.tooling import (
     AgentRecoveryError,
     _invoke_capability_attempt,
+    _run_blocking,
 )
 from jacobian.contracts.capabilities import (
     CapabilityInputKind,
     CapabilityMode,
     CapabilityResult,
+)
+from jacobian.contracts.reasoning import (
+    ReasoningCallId,
+    ReasoningPhase,
+    ReasoningRunId,
+    ReasoningWriteRequest,
+    ReasoningWriteResult,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -231,3 +239,83 @@ async def capability_invoke(
         mode=mode,
         ctx=ctx,
     )
+
+
+async def capability_invoke_reasoned(
+    capability_id: str,
+    payload: dict[str, Any],
+    reasoning_run_id: ReasoningRunId,
+    reasoning_call_id: ReasoningCallId,
+    mode: CapabilityMode = CapabilityMode.EXPLORE,
+    ctx: Context[AppState, Any] | None = None,
+) -> CapabilityResult:
+    active_runtime = _runtime(ctx)
+    return await _invoke_capability_attempt(
+        active_runtime,
+        capability_id=capability_id,
+        payload=payload,
+        mode=mode,
+        ctx=ctx,
+        reasoning_run_id=reasoning_run_id,
+        reasoning_call_id=reasoning_call_id,
+        reasoning_required=True,
+    )
+
+
+async def capability_invoke_audit(
+    capability_id: str,
+    payload: dict[str, Any],
+    reasoning_run_id: ReasoningRunId | None = None,
+    reasoning_call_id: ReasoningCallId | None = None,
+    mode: CapabilityMode = CapabilityMode.EXPLORE,
+    ctx: Context[AppState, Any] | None = None,
+) -> CapabilityResult:
+    active_runtime = _runtime(ctx)
+    return await _invoke_capability_attempt(
+        active_runtime,
+        capability_id=capability_id,
+        payload=payload,
+        mode=mode,
+        ctx=ctx,
+        reasoning_run_id=reasoning_run_id,
+        reasoning_call_id=reasoning_call_id,
+        reasoning_required=False,
+        reasoning_audit=True,
+    )
+
+
+async def reasoning_write(
+    phase: ReasoningPhase,
+    summary: Annotated[str, Field(min_length=1, max_length=512)],
+    run_id: ReasoningRunId | None = None,
+    call_id: ReasoningCallId | None = None,
+    capability_id: str | None = None,
+    mode: CapabilityMode | None = None,
+    ctx: Context[AppState, Any] | None = None,
+) -> ReasoningWriteResult:
+    active_runtime = _runtime(ctx)
+    request = ReasoningWriteRequest(
+        phase=phase,
+        summary=summary,
+        run_id=run_id,
+        call_id=call_id,
+        capability_id=capability_id,
+        mode=mode,
+    )
+    if phase is ReasoningPhase.BEFORE_TOOL:
+        descriptors = {
+            item.capability_id: item
+            for item in active_runtime.core.capabilities.catalog().capabilities
+        }
+        descriptor = descriptors.get(str(capability_id))
+        if descriptor is None:
+            raise AgentRecoveryError(
+                "BEFORE_TOOL names an unavailable capability. Use capability.describe "
+                "to select an installed capability ID."
+            )
+        if mode not in descriptor.modes:
+            raise AgentRecoveryError(
+                "BEFORE_TOOL selects a mode the capability does not advertise. "
+                "Inspect its CONTRACT view and choose an installed mode."
+            )
+    return await _run_blocking(active_runtime.core.reasoning_log.write, request)

--- a/src/jacobian/bounded_process.py
+++ b/src/jacobian/bounded_process.py
@@ -15,11 +15,11 @@ import subprocess
 import tempfile
 import threading
 import time
-from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from contextlib import contextmanager, suppress
 from contextvars import ContextVar
 from dataclasses import dataclass
-from typing import BinaryIO
+from typing import BinaryIO, cast
 
 _CANCELLATION_EVENT: ContextVar[threading.Event | None] = ContextVar(
     "jacobian_bounded_process_cancellation_event",
@@ -90,10 +90,12 @@ def _apply_resource_limits(
         return
     try:
         import resource
-
-        prlimit = resource.prlimit
-    except (AttributeError, ImportError):  # pragma: no cover - platform dependent
+    except ImportError:  # pragma: no cover - platform dependent
         return
+    candidate = getattr(resource, "prlimit", None)
+    if not callable(candidate):  # pragma: no cover - platform dependent
+        return
+    prlimit = cast(Callable[[int, int, tuple[int, int]], object], candidate)
 
     def set_limit(kind: int, value: int) -> None:
         # A very short-lived child may exit between Popen and prlimit. It can

--- a/src/jacobian/contracts/reasoning.py
+++ b/src/jacobian/contracts/reasoning.py
@@ -8,9 +8,13 @@ from typing import Annotated, Any, Literal, Self
 from pydantic import Field, StringConstraints, model_validator
 
 from jacobian.canonical import canonicalize_json
-from jacobian.contracts.capabilities import CapabilityId, CapabilityMode
-from jacobian.contracts.common import Sha256Digest
-from jacobian.contracts.results import ContractModel
+from jacobian.contracts.capabilities import (
+    CapabilityAssuranceLevel,
+    CapabilityCompletenessStatus,
+    CapabilityId,
+    CapabilityMode,
+)
+from jacobian.contracts.results import ContractModel, ExecutionStatus
 
 _UUID_PATTERN = r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
 ReasoningRunId = Annotated[str, StringConstraints(pattern=_UUID_PATTERN, strict=True)]
@@ -22,6 +26,13 @@ class ReasoningPhase(StrEnum):
     BEFORE_TOOL = "BEFORE_TOOL"
     AFTER_TOOL = "AFTER_TOOL"
     FINAL = "FINAL"
+
+
+class ReasoningInterpretationStatus(StrEnum):
+    """Whether the model received enough result content to interpret the call."""
+
+    INTERPRETED = "INTERPRETED"
+    RESULT_UNAVAILABLE = "RESULT_UNAVAILABLE"
 
 
 class ReasoningRunState(StrEnum):
@@ -49,6 +60,10 @@ class ReasoningWriteRequest(ContractModel):
     call_id: ReasoningCallId | None = None
     capability_id: CapabilityId | None = None
     mode: CapabilityMode | None = None
+    interpretation_status: ReasoningInterpretationStatus | None = None
+    reported_execution_status: ExecutionStatus | None = None
+    reported_assurance_level: CapabilityAssuranceLevel | None = None
+    reported_completeness_status: CapabilityCompletenessStatus | None = None
 
     @model_validator(mode="after")
     def validate_phase_shape_and_size(self) -> Self:
@@ -56,20 +71,31 @@ class ReasoningWriteRequest(ContractModel):
             raise ValueError("summary must contain non-whitespace text")
         if len(self.summary.encode("utf-8")) > 2048:
             raise ValueError("summary must be at most 2048 UTF-8 bytes")
-        required: dict[ReasoningPhase, tuple[bool, bool, bool, bool]] = {
-            ReasoningPhase.PLAN: (False, False, False, False),
-            ReasoningPhase.BEFORE_TOOL: (True, False, True, True),
-            ReasoningPhase.AFTER_TOOL: (True, True, False, False),
-            ReasoningPhase.FINAL: (True, False, False, False),
+        required: dict[ReasoningPhase, tuple[bool, bool, bool, bool, bool]] = {
+            ReasoningPhase.PLAN: (False, False, False, False, False),
+            ReasoningPhase.BEFORE_TOOL: (True, False, True, True, False),
+            ReasoningPhase.AFTER_TOOL: (True, True, False, False, True),
+            ReasoningPhase.FINAL: (True, False, False, False, False),
         }
         actual = (
             self.run_id is not None,
             self.call_id is not None,
             self.capability_id is not None,
             self.mode is not None,
+            self.interpretation_status is not None,
         )
         if actual != required[self.phase]:
             raise ValueError(f"fields do not match {self.phase.value} phase contract")
+        reported = (
+            self.reported_execution_status,
+            self.reported_assurance_level,
+            self.reported_completeness_status,
+        )
+        if self.interpretation_status is ReasoningInterpretationStatus.INTERPRETED:
+            if any(value is None for value in reported):
+                raise ValueError("INTERPRETED requires all reported result fields")
+        elif any(value is not None for value in reported):
+            raise ValueError("reported result fields require INTERPRETED")
         return self
 
 
@@ -77,11 +103,13 @@ class ReasoningWriteResult(ContractModel):
     schema_version: Literal["1"] = "1"
     run_id: ReasoningRunId
     call_id: ReasoningCallId | None = None
-    event_digest: Sha256Digest
     sequence: int = Field(ge=0, strict=True)
     state: ReasoningRunState
     next_required: ReasoningNextRequired
     log_uri: str = Field(pattern=r"^reasoning://run/[0-9a-f-]{36}$")
+    execution_status_matches: bool | None = None
+    assurance_level_matches: bool | None = None
+    completeness_status_matches: bool | None = None
 
 
 class ReasoningEvent(ContractModel):
@@ -92,9 +120,7 @@ class ReasoningEvent(ContractModel):
     sequence: int = Field(ge=0, strict=True)
     kind: str = Field(pattern=r"^[A-Z][A-Z0-9_]{2,63}$")
     occurred_at: str = Field(min_length=20, max_length=64)
-    previous_digest: Sha256Digest | None = None
     payload: dict[str, Any]
-    event_digest: Sha256Digest
 
     @model_validator(mode="after")
     def require_canonical_payload(self) -> Self:
@@ -105,6 +131,7 @@ class ReasoningEvent(ContractModel):
 __all__ = [
     "ReasoningCallId",
     "ReasoningEvent",
+    "ReasoningInterpretationStatus",
     "ReasoningNextRequired",
     "ReasoningPhase",
     "ReasoningRunId",

--- a/src/jacobian/contracts/reasoning.py
+++ b/src/jacobian/contracts/reasoning.py
@@ -1,0 +1,114 @@
+"""Bounded contracts for the external model-authored reasoning log."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Annotated, Any, Literal, Self
+
+from pydantic import Field, StringConstraints, model_validator
+
+from jacobian.canonical import canonicalize_json
+from jacobian.contracts.capabilities import CapabilityId, CapabilityMode
+from jacobian.contracts.common import Sha256Digest
+from jacobian.contracts.results import ContractModel
+
+_UUID_PATTERN = r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+ReasoningRunId = Annotated[str, StringConstraints(pattern=_UUID_PATTERN, strict=True)]
+ReasoningCallId = Annotated[str, StringConstraints(pattern=_UUID_PATTERN, strict=True)]
+
+
+class ReasoningPhase(StrEnum):
+    PLAN = "PLAN"
+    BEFORE_TOOL = "BEFORE_TOOL"
+    AFTER_TOOL = "AFTER_TOOL"
+    FINAL = "FINAL"
+
+
+class ReasoningRunState(StrEnum):
+    READY = "READY"
+    READY_TO_INVOKE = "READY_TO_INVOKE"
+    TOOL_RUNNING = "TOOL_RUNNING"
+    AWAITING_AFTER_TOOL = "AWAITING_AFTER_TOOL"
+    FINALIZED = "FINALIZED"
+
+
+class ReasoningNextRequired(StrEnum):
+    BEFORE_TOOL_OR_FINAL = "BEFORE_TOOL_OR_FINAL"
+    CAPABILITY_INVOKE = "CAPABILITY_INVOKE"
+    AFTER_TOOL = "AFTER_TOOL"
+    NONE = "NONE"
+
+
+class ReasoningWriteRequest(ContractModel):
+    """One concise model-authored summary; never hidden chain-of-thought."""
+
+    schema_version: Literal["1"] = "1"
+    phase: ReasoningPhase
+    summary: str = Field(min_length=1, max_length=512)
+    run_id: ReasoningRunId | None = None
+    call_id: ReasoningCallId | None = None
+    capability_id: CapabilityId | None = None
+    mode: CapabilityMode | None = None
+
+    @model_validator(mode="after")
+    def validate_phase_shape_and_size(self) -> Self:
+        if not self.summary.strip():
+            raise ValueError("summary must contain non-whitespace text")
+        if len(self.summary.encode("utf-8")) > 2048:
+            raise ValueError("summary must be at most 2048 UTF-8 bytes")
+        required: dict[ReasoningPhase, tuple[bool, bool, bool, bool]] = {
+            ReasoningPhase.PLAN: (False, False, False, False),
+            ReasoningPhase.BEFORE_TOOL: (True, False, True, True),
+            ReasoningPhase.AFTER_TOOL: (True, True, False, False),
+            ReasoningPhase.FINAL: (True, False, False, False),
+        }
+        actual = (
+            self.run_id is not None,
+            self.call_id is not None,
+            self.capability_id is not None,
+            self.mode is not None,
+        )
+        if actual != required[self.phase]:
+            raise ValueError(f"fields do not match {self.phase.value} phase contract")
+        return self
+
+
+class ReasoningWriteResult(ContractModel):
+    schema_version: Literal["1"] = "1"
+    run_id: ReasoningRunId
+    call_id: ReasoningCallId | None = None
+    event_digest: Sha256Digest
+    sequence: int = Field(ge=0, strict=True)
+    state: ReasoningRunState
+    next_required: ReasoningNextRequired
+    log_uri: str = Field(pattern=r"^reasoning://run/[0-9a-f-]{36}$")
+
+
+class ReasoningEvent(ContractModel):
+    """Canonical durable event shared by model and system writers."""
+
+    schema_version: Literal["1"] = "1"
+    run_id: ReasoningRunId
+    sequence: int = Field(ge=0, strict=True)
+    kind: str = Field(pattern=r"^[A-Z][A-Z0-9_]{2,63}$")
+    occurred_at: str = Field(min_length=20, max_length=64)
+    previous_digest: Sha256Digest | None = None
+    payload: dict[str, Any]
+    event_digest: Sha256Digest
+
+    @model_validator(mode="after")
+    def require_canonical_payload(self) -> Self:
+        canonicalize_json(self.payload)
+        return self
+
+
+__all__ = [
+    "ReasoningCallId",
+    "ReasoningEvent",
+    "ReasoningNextRequired",
+    "ReasoningPhase",
+    "ReasoningRunId",
+    "ReasoningRunState",
+    "ReasoningWriteRequest",
+    "ReasoningWriteResult",
+]

--- a/src/jacobian/eval/telemetry.py
+++ b/src/jacobian/eval/telemetry.py
@@ -46,8 +46,12 @@ class _ReasoningProtocolTelemetry:
     run_ids: set[str] = field(default_factory=set)
     before_call_ids: set[str] = field(default_factory=set)
     after_call_ids: set[str] = field(default_factory=set)
+    bound_call_ids: set[str] = field(default_factory=set)
     bound_invoke_count: int = 0
     summary_characters: int = 0
+    finalized_run_ids: set[str] = field(default_factory=set)
+    unavailable_after_tool_count: int = 0
+    reported_actual_mismatch_count: int = 0
 
     def record_attempt(self, tool: str, arguments: object) -> None:
         if tool != "capability.invoke" or not isinstance(arguments, Mapping):
@@ -56,6 +60,7 @@ class _ReasoningProtocolTelemetry:
             arguments.get("reasoning_call_id"), str
         ):
             self.bound_invoke_count += 1
+            self.bound_call_ids.add(arguments["reasoning_call_id"])
 
     def record_write(
         self,
@@ -71,6 +76,24 @@ class _ReasoningProtocolTelemetry:
         summary = arguments.get("summary")
         if isinstance(summary, str):
             self.summary_characters += len(summary)
+        if (
+            phase == "AFTER_TOOL"
+            and arguments.get("interpretation_status") == "RESULT_UNAVAILABLE"
+        ):
+            self.unavailable_after_tool_count += 1
+        if isinstance(response, Mapping):
+            self.reported_actual_mismatch_count += sum(
+                response.get(field) is False
+                for field in (
+                    "execution_status_matches",
+                    "assurance_level_matches",
+                    "completeness_status_matches",
+                )
+            )
+            if phase == "FINAL" and response.get("state") == "FINALIZED":
+                response_run_id = response.get("run_id")
+                if isinstance(response_run_id, str):
+                    self.finalized_run_ids.add(response_run_id)
         self._record_identity(phase, arguments, response)
 
     def _record_identity(
@@ -94,15 +117,32 @@ class _ReasoningProtocolTelemetry:
         ):
             self.before_call_ids.add(response["call_id"])
 
-    def payload(self) -> dict[str, int]:
+    def payload(self) -> dict[str, int | str]:
+        missing_after = self.before_call_ids - self.after_call_ids
+        call_sets_match = (
+            self.before_call_ids == self.after_call_ids == self.bound_call_ids
+        )
+        complete = (
+            self.phase_counts["PLAN"] == 1
+            and self.phase_counts["FINAL"] == 1
+            and len(self.run_ids) == 1
+            and len(self.finalized_run_ids) == 1
+            and call_sets_match
+        )
         return {
+            "status": "COMPLETE" if complete else "INCOMPLETE",
             "plan_count": self.phase_counts["PLAN"],
             "before_tool_count": self.phase_counts["BEFORE_TOOL"],
             "after_tool_count": self.phase_counts["AFTER_TOOL"],
             "final_count": self.phase_counts["FINAL"],
             "run_count": len(self.run_ids),
             "bound_invoke_count": self.bound_invoke_count,
-            "missing_after_tool_count": len(self.before_call_ids - self.after_call_ids),
+            "missing_after_tool_count": len(missing_after),
+            "pending_call_count": len(
+                (self.before_call_ids | self.bound_call_ids) - self.after_call_ids
+            ),
+            "unavailable_after_tool_count": self.unavailable_after_tool_count,
+            "reported_actual_mismatch_count": self.reported_actual_mismatch_count,
             "summary_characters": self.summary_characters,
         }
 
@@ -317,6 +357,100 @@ def _mcp_call_signature(tool: str, arguments: object) -> tuple[str, str]:
     except (TypeError, ValueError):
         encoded = b"unserializable"
     return tool, f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def _reasoning_tool_name(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.replace("__", ".").replace("_", ".").lower()
+    if normalized.endswith("reasoning.write"):
+        return "reasoning.write"
+    if normalized.endswith("capability.invoke"):
+        return "capability.invoke"
+    return None
+
+
+def _atif_mapping_response(value: Mapping[str, Any]) -> dict[str, Any] | None:
+    for key in ("structured_content", "structuredContent"):
+        response = value.get(key)
+        if isinstance(response, dict):
+            return response
+    if value.get("type") == "text" and isinstance(value.get("text"), str):
+        return _atif_response(value["text"])
+    content = value.get("content")
+    if isinstance(content, list):
+        response = _atif_response(content)
+        if response is not None:
+            return response
+    return dict(value)
+
+
+def _atif_response(value: object) -> dict[str, Any] | None:
+    if isinstance(value, str):
+        try:
+            return _atif_response(json.loads(value))
+        except json.JSONDecodeError:
+            return None
+    if isinstance(value, list):
+        for item in value:
+            response = _atif_response(item)
+            if response is not None:
+                return response
+        return None
+    if not isinstance(value, Mapping):
+        return None
+    return _atif_mapping_response(value)
+
+
+def _parse_atif_reasoning_protocol(value: object) -> dict[str, int | str]:
+    telemetry = _ReasoningProtocolTelemetry()
+    if not isinstance(value, Mapping) or not isinstance(value.get("steps"), list):
+        return telemetry.payload()
+    for step in value["steps"]:
+        if not isinstance(step, Mapping):
+            continue
+        observation = step.get("observation")
+        raw_results = (
+            observation.get("results") if isinstance(observation, Mapping) else None
+        )
+        results = raw_results if isinstance(raw_results, list) else []
+        responses = {
+            item["source_call_id"]: _atif_response(item.get("content"))
+            for item in results
+            if isinstance(item, Mapping) and isinstance(item.get("source_call_id"), str)
+        }
+        calls = step.get("tool_calls")
+        if not isinstance(calls, list):
+            continue
+        for call in calls:
+            if not isinstance(call, Mapping):
+                continue
+            tool = _reasoning_tool_name(call.get("function_name"))
+            arguments = call.get("arguments")
+            if tool is None or not isinstance(arguments, Mapping):
+                continue
+            telemetry.record_attempt(tool, arguments)
+            call_id = call.get("tool_call_id")
+            response = responses.get(call_id) if isinstance(call_id, str) else None
+            if response is not None:
+                telemetry.record_write(tool, arguments, response)
+    return telemetry.payload()
+
+
+def parse_reasoning_protocol_trace(path: Path) -> dict[str, int | str]:
+    """Parse reasoning protocol facts from Codex JSONL or Harbor ATIF JSON."""
+
+    if path.suffix == ".jsonl":
+        protocol = parse_agent_transcript(path).get("reasoning_protocol")
+        if not isinstance(protocol, dict):
+            raise ValueError("agent transcript omitted reasoning protocol telemetry")
+        return {
+            str(key): item
+            for key, item in protocol.items()
+            if isinstance(item, int | str)
+        }
+    value = json.loads(path.read_text(encoding="utf-8"))
+    return _parse_atif_reasoning_protocol(value)
 
 
 def parse_agent_transcript(path: Path) -> dict[str, Any]:

--- a/src/jacobian/eval/telemetry.py
+++ b/src/jacobian/eval/telemetry.py
@@ -40,6 +40,73 @@ class _McpResourceTelemetry:
     digest_preservation_successes: int = 0
 
 
+@dataclass
+class _ReasoningProtocolTelemetry:
+    phase_counts: Counter[str] = field(default_factory=Counter)
+    run_ids: set[str] = field(default_factory=set)
+    before_call_ids: set[str] = field(default_factory=set)
+    after_call_ids: set[str] = field(default_factory=set)
+    bound_invoke_count: int = 0
+    summary_characters: int = 0
+
+    def record_attempt(self, tool: str, arguments: object) -> None:
+        if tool != "capability.invoke" or not isinstance(arguments, Mapping):
+            return
+        if isinstance(arguments.get("reasoning_run_id"), str) and isinstance(
+            arguments.get("reasoning_call_id"), str
+        ):
+            self.bound_invoke_count += 1
+
+    def record_write(
+        self,
+        tool: str,
+        arguments: object,
+        response: object,
+    ) -> None:
+        if tool != "reasoning.write" or not isinstance(arguments, Mapping):
+            return
+        phase = arguments.get("phase")
+        if isinstance(phase, str):
+            self.phase_counts[phase] += 1
+        summary = arguments.get("summary")
+        if isinstance(summary, str):
+            self.summary_characters += len(summary)
+        self._record_identity(phase, arguments, response)
+
+    def _record_identity(
+        self,
+        phase: object,
+        arguments: Mapping[str, Any],
+        response: object,
+    ) -> None:
+        run_id = arguments.get("run_id")
+        if isinstance(run_id, str):
+            self.run_ids.add(run_id)
+        if isinstance(response, Mapping) and isinstance(response.get("run_id"), str):
+            self.run_ids.add(response["run_id"])
+        call_id = arguments.get("call_id")
+        if phase == "AFTER_TOOL" and isinstance(call_id, str):
+            self.after_call_ids.add(call_id)
+        if (
+            phase == "BEFORE_TOOL"
+            and isinstance(response, Mapping)
+            and isinstance(response.get("call_id"), str)
+        ):
+            self.before_call_ids.add(response["call_id"])
+
+    def payload(self) -> dict[str, int]:
+        return {
+            "plan_count": self.phase_counts["PLAN"],
+            "before_tool_count": self.phase_counts["BEFORE_TOOL"],
+            "after_tool_count": self.phase_counts["AFTER_TOOL"],
+            "final_count": self.phase_counts["FINAL"],
+            "run_count": len(self.run_ids),
+            "bound_invoke_count": self.bound_invoke_count,
+            "missing_after_tool_count": len(self.before_call_ids - self.after_call_ids),
+            "summary_characters": self.summary_characters,
+        }
+
+
 def _contains_value(value: object, *, field: str, accepted: set[object]) -> bool:
     if isinstance(value, Mapping):
         candidate = value.get(field)
@@ -277,6 +344,7 @@ def parse_agent_transcript(path: Path) -> dict[str, Any]:
     resource_telemetry = _McpResourceTelemetry()
     capability_describe_index_calls = 0
     capability_describe_exact_calls = 0
+    reasoning_telemetry = _ReasoningProtocolTelemetry()
     for line in path.read_text(encoding="utf-8").splitlines():
         try:
             event = json.loads(line)
@@ -301,6 +369,7 @@ def parse_agent_transcript(path: Path) -> dict[str, Any]:
             tool = item["tool"]
             mcp_calls.append(tool)
             arguments = item.get("arguments")
+            reasoning_telemetry.record_attempt(tool, arguments)
             wire_bytes = _mcp_wire_bytes(item)
             model_visible_bytes = _mcp_model_visible_bytes(item)
             text_response = _mcp_text_payload(item)
@@ -359,6 +428,7 @@ def parse_agent_transcript(path: Path) -> dict[str, Any]:
                 tool_error_count += 1
             else:
                 successful_calls.append(tool)
+                reasoning_telemetry.record_write(tool, arguments, response)
                 if tool == "capability.describe" and isinstance(arguments, Mapping):
                     matches = (
                         response.get("matches")
@@ -498,4 +568,5 @@ def parse_agent_transcript(path: Path) -> dict[str, Any]:
         ],
         "capability_describe_index_calls": capability_describe_index_calls,
         "capability_describe_exact_calls": capability_describe_exact_calls,
+        "reasoning_protocol": reasoning_telemetry.payload(),
     }

--- a/src/jacobian/persistence/migrations.py
+++ b/src/jacobian/persistence/migrations.py
@@ -469,7 +469,6 @@ _REASONING_LOG_SCHEMA_STATEMENTS = (
         kind TEXT NOT NULL,
         call_id TEXT,
         event_json BLOB NOT NULL,
-        event_digest TEXT NOT NULL UNIQUE,
         PRIMARY KEY (run_id, sequence),
         FOREIGN KEY (run_id) REFERENCES reasoning_runs(run_id) ON DELETE RESTRICT
     )

--- a/src/jacobian/persistence/migrations.py
+++ b/src/jacobian/persistence/migrations.py
@@ -455,6 +455,58 @@ def _retire_data_upgrade_ledger(connection: sqlite3.Connection) -> None:
     )
 
 
+_REASONING_LOG_SCHEMA_STATEMENTS = (
+    """
+    CREATE TABLE IF NOT EXISTS reasoning_runs (
+        run_id TEXT PRIMARY KEY,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS reasoning_events (
+        run_id TEXT NOT NULL,
+        sequence INTEGER NOT NULL CHECK (sequence >= 0),
+        kind TEXT NOT NULL,
+        call_id TEXT,
+        event_json BLOB NOT NULL,
+        event_digest TEXT NOT NULL UNIQUE,
+        PRIMARY KEY (run_id, sequence),
+        FOREIGN KEY (run_id) REFERENCES reasoning_runs(run_id) ON DELETE RESTRICT
+    )
+    """,
+    "CREATE UNIQUE INDEX IF NOT EXISTS reasoning_event_kind_call ON reasoning_events(run_id, kind, call_id) WHERE call_id IS NOT NULL",
+    "CREATE UNIQUE INDEX IF NOT EXISTS reasoning_one_plan ON reasoning_events(run_id) WHERE kind = 'PLAN'",
+    "CREATE UNIQUE INDEX IF NOT EXISTS reasoning_one_final ON reasoning_events(run_id) WHERE kind = 'FINAL'",
+    """
+    CREATE TRIGGER IF NOT EXISTS reasoning_runs_no_update BEFORE UPDATE ON reasoning_runs
+    BEGIN SELECT RAISE(ABORT, 'reasoning runs are append-only'); END
+    """,
+    """
+    CREATE TRIGGER IF NOT EXISTS reasoning_runs_no_delete BEFORE DELETE ON reasoning_runs
+    BEGIN SELECT RAISE(ABORT, 'reasoning runs are append-only'); END
+    """,
+    """
+    CREATE TRIGGER IF NOT EXISTS reasoning_events_no_update BEFORE UPDATE ON reasoning_events
+    BEGIN SELECT RAISE(ABORT, 'reasoning events are append-only'); END
+    """,
+    """
+    CREATE TRIGGER IF NOT EXISTS reasoning_events_no_delete BEFORE DELETE ON reasoning_events
+    BEGIN SELECT RAISE(ABORT, 'reasoning events are append-only'); END
+    """,
+)
+_REASONING_LOG_SCHEMA = "\n-- statement boundary --\n".join(
+    _REASONING_LOG_SCHEMA_STATEMENTS
+)
+
+
+def _install_reasoning_log_schema(connection: sqlite3.Connection) -> None:
+    for statement in _REASONING_LOG_SCHEMA_STATEMENTS:
+        connection.execute(statement)
+    connection.execute(
+        "UPDATE jacobian_state_format SET format_revision = 7 WHERE id = 0"
+    )
+
+
 STATE_MIGRATIONS = (
     Migration(
         revision=1,
@@ -499,8 +551,14 @@ STATE_MIGRATIONS = (
         ),
         apply=_retire_data_upgrade_ledger,
     ),
+    Migration(
+        revision=7,
+        name="reasoning-log-events-v1",
+        definition=_REASONING_LOG_SCHEMA,
+        apply=_install_reasoning_log_schema,
+    ),
 )
 
 SUPPORTED_STATE_FLOOR = 6
-CURRENT_STATE_FORMAT_REVISION = 6
+CURRENT_STATE_FORMAT_REVISION = 7
 RESEARCH_INDEX_UPGRADE_ID = "research-episode-index-v2"

--- a/src/jacobian/reasoning_log.py
+++ b/src/jacobian/reasoning_log.py
@@ -1,0 +1,417 @@
+"""Append-only operational reasoning-log service."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from datetime import UTC, datetime
+from typing import Any
+from uuid import uuid4
+
+from jacobian.canonical import canonicalize_json
+from jacobian.contracts.capabilities import CapabilityMode, CapabilityResult
+from jacobian.contracts.reasoning import (
+    ReasoningEvent,
+    ReasoningNextRequired,
+    ReasoningPhase,
+    ReasoningRunState,
+    ReasoningWriteRequest,
+    ReasoningWriteResult,
+)
+from jacobian.storage.repository import ArtifactRepository
+
+MAX_CALLS_PER_RUN = 64
+INTERRUPTED_CALL_GRACE_SECONDS = 600
+
+
+class ReasoningProtocolError(RuntimeError):
+    """A recoverable violation of the external reasoning protocol."""
+
+    def __init__(self, code: str, message: str, hint: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.hint = hint
+
+
+def _digest(value: Any) -> str:
+    return "sha256:" + hashlib.sha256(canonicalize_json(value)).hexdigest()
+
+
+class ReasoningLogService:
+    """Persist ordered model summaries and system-owned capability bindings."""
+
+    def __init__(self, store: ArtifactRepository) -> None:
+        self.store = store
+        self.recover_interrupted_calls()
+
+    def write(self, request: ReasoningWriteRequest) -> ReasoningWriteResult:
+        if request.phase is ReasoningPhase.PLAN:
+            return self._create_run(request.summary)
+        assert request.run_id is not None
+        with self.store.connection() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            events = self._read_events(connection, request.run_id)
+            state, pending = self._state(events)
+            call_id: str | None
+            if request.phase is ReasoningPhase.BEFORE_TOOL:
+                if state is ReasoningRunState.FINALIZED:
+                    self._raise(
+                        "REASONING_RUN_FINALIZED",
+                        "The reasoning run is finalized.",
+                        "Start a new PLAN for further work.",
+                    )
+                if state is not ReasoningRunState.READY:
+                    self._raise(
+                        "REASONING_RUN_BUSY",
+                        "This run is waiting for its current capability cycle.",
+                        "Complete the indicated invoke or AFTER_TOOL before reserving another call.",
+                    )
+                if (
+                    sum(event.kind == "BEFORE_TOOL" for event in events)
+                    >= MAX_CALLS_PER_RUN
+                ):
+                    self._raise(
+                        "REASONING_RUN_LIMIT",
+                        "This run reached its 64-call limit.",
+                        "Write FINAL and start a new PLAN if more work is required.",
+                    )
+                call_id = str(uuid4())
+                event = self._append_event(
+                    connection,
+                    request.run_id,
+                    "BEFORE_TOOL",
+                    {
+                        "summary": request.summary,
+                        "call_id": call_id,
+                        "capability_id": request.capability_id,
+                        "mode": request.mode.value if request.mode else None,
+                    },
+                )
+            elif request.phase is ReasoningPhase.AFTER_TOOL:
+                if (
+                    state is not ReasoningRunState.AWAITING_AFTER_TOOL
+                    or pending != request.call_id
+                ):
+                    self._raise(
+                        "REASONING_STATE_MISMATCH",
+                        "AFTER_TOOL does not match the completed pending call.",
+                        "Read the reasoning log and use the pending call_id after its capability result.",
+                    )
+                call_id = request.call_id
+                event = self._append_event(
+                    connection,
+                    request.run_id,
+                    "AFTER_TOOL",
+                    {"summary": request.summary, "call_id": call_id},
+                )
+            else:
+                if state is not ReasoningRunState.READY:
+                    self._raise(
+                        "REASONING_FINAL_BLOCKED",
+                        "FINAL requires every capability call to have AFTER_TOOL.",
+                        "Complete the current capability cycle before the final audit.",
+                    )
+                call_id = None
+                event = self._append_event(
+                    connection, request.run_id, "FINAL", {"summary": request.summary}
+                )
+            new_events = (*events, event)
+            new_state, _ = self._state(new_events)
+            return self._result(event, new_state, call_id)
+
+    def _create_run(self, summary: str) -> ReasoningWriteResult:
+        run_id = str(uuid4())
+        with self.store.connection() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            connection.execute(
+                "INSERT INTO reasoning_runs(run_id) VALUES (?)", (run_id,)
+            )
+            event = self._append_event(connection, run_id, "PLAN", {"summary": summary})
+            return self._result(event, ReasoningRunState.READY, None)
+
+    def claim_call(
+        self,
+        run_id: str,
+        call_id: str,
+        capability_id: str,
+        mode: CapabilityMode,
+        request_digest: str,
+    ) -> None:
+        with self.store.connection() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            events = self._read_events(connection, run_id)
+            state, pending = self._state(events)
+            if state is not ReasoningRunState.READY_TO_INVOKE or pending != call_id:
+                self._raise(
+                    "REASONING_CALL_MISMATCH",
+                    "The invocation is not bound to the pending BEFORE_TOOL entry.",
+                    "Use the run_id and call_id returned by the current BEFORE_TOOL entry.",
+                )
+            before = next(
+                event for event in reversed(events) if event.kind == "BEFORE_TOOL"
+            )
+            if (
+                before.payload.get("capability_id") != capability_id
+                or before.payload.get("mode") != mode.value
+            ):
+                self._raise(
+                    "REASONING_CALL_MISMATCH",
+                    "The actual capability ID or mode differs from BEFORE_TOOL.",
+                    "Invoke exactly the capability ID and mode reserved by BEFORE_TOOL.",
+                )
+            self._append_event(
+                connection,
+                run_id,
+                "CAPABILITY_STARTED",
+                {
+                    "call_id": call_id,
+                    "capability_id": capability_id,
+                    "mode": mode.value,
+                    "request_digest": request_digest,
+                },
+            )
+
+    def finish_call(
+        self,
+        run_id: str,
+        call_id: str,
+        capability_id: str,
+        mode: CapabilityMode,
+        request_digest: str,
+        *,
+        result: CapabilityResult | None = None,
+        execution_status: str | None = None,
+        diagnostic_codes: tuple[str, ...] = (),
+    ) -> None:
+        with self.store.connection() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            events = self._read_events(connection, run_id)
+            state, pending = self._state(events)
+            if state is not ReasoningRunState.TOOL_RUNNING or pending != call_id:
+                self._raise(
+                    "REASONING_CALL_MISMATCH",
+                    "The capability completion has no matching started call.",
+                    "Inspect the durable reasoning log before retrying.",
+                )
+            if result is None:
+                payload: dict[str, Any] = {
+                    "call_id": call_id,
+                    "capability_id": capability_id,
+                    "mode": mode.value,
+                    "request_digest": request_digest,
+                    "result_digest": None,
+                    "execution_status": execution_status or "ERROR",
+                    "assurance": None,
+                    "completeness": None,
+                    "scope_digest": None,
+                    "artifact_uris": [],
+                    "episode_uri": None,
+                    "diagnostic_codes": list(diagnostic_codes),
+                }
+            else:
+                serialized = result.model_dump(mode="json")
+                payload = {
+                    "call_id": call_id,
+                    "capability_id": result.capability_id,
+                    "capability_version": result.capability_version,
+                    "mode": result.mode.value,
+                    "request_digest": request_digest,
+                    "result_digest": _digest(serialized),
+                    "execution_status": result.execution.status.value,
+                    "assurance": result.assurance.model_dump(mode="json"),
+                    "completeness": result.completeness.model_dump(mode="json"),
+                    "scope_digest": _digest(result.scope.model_dump(mode="json"))
+                    if result.scope is not None
+                    else None,
+                    "artifact_uris": list(result.artifact_uris),
+                    "episode_uri": result.episode_uri,
+                    "diagnostic_codes": [item.code for item in result.diagnostics],
+                }
+            self._append_event(connection, run_id, "CAPABILITY_FINISHED", payload)
+
+    def recover_interrupted_calls(
+        self,
+        *,
+        stale_after_seconds: int = INTERRUPTED_CALL_GRACE_SECONDS,
+    ) -> None:
+        with self.store.connection() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            rows = connection.execute(
+                "SELECT run_id FROM reasoning_runs ORDER BY run_id"
+            ).fetchall()
+            for row in rows:
+                events = self._read_events(connection, str(row["run_id"]))
+                state, pending = self._state(events)
+                if state is ReasoningRunState.TOOL_RUNNING and pending is not None:
+                    started = next(
+                        event
+                        for event in reversed(events)
+                        if event.kind == "CAPABILITY_STARTED"
+                    )
+                    started_at = datetime.fromisoformat(started.occurred_at)
+                    age_seconds = (datetime.now(UTC) - started_at).total_seconds()
+                    if age_seconds < stale_after_seconds:
+                        continue
+                    self._append_event(
+                        connection,
+                        str(row["run_id"]),
+                        "CAPABILITY_FINISHED",
+                        {
+                            "call_id": pending,
+                            "capability_id": started.payload["capability_id"],
+                            "mode": started.payload["mode"],
+                            "request_digest": started.payload["request_digest"],
+                            "result_digest": None,
+                            "execution_status": "ERROR",
+                            "assurance": None,
+                            "completeness": None,
+                            "scope_digest": None,
+                            "artifact_uris": [],
+                            "episode_uri": None,
+                            "diagnostic_codes": ["PROCESS_INTERRUPTED"],
+                        },
+                    )
+
+    def inspect(self, run_id: str) -> tuple[ReasoningEvent, ...]:
+        with self.store.connection() as connection:
+            return self._read_events(connection, run_id)
+
+    def inspect_jsonl(self, run_id: str) -> str:
+        return (
+            "\n".join(event.model_dump_json() for event in self.inspect(run_id)) + "\n"
+        )
+
+    def _read_events(
+        self, connection: sqlite3.Connection, run_id: str
+    ) -> tuple[ReasoningEvent, ...]:
+        exists = connection.execute(
+            "SELECT 1 FROM reasoning_runs WHERE run_id = ?", (run_id,)
+        ).fetchone()
+        if exists is None:
+            self._raise(
+                "REASONING_RUN_NOT_FOUND",
+                "The reasoning run does not exist in this tenant.",
+                "Use the run_id returned by PLAN in the same tenant.",
+            )
+        rows = connection.execute(
+            "SELECT event_json FROM reasoning_events WHERE run_id = ? ORDER BY sequence",
+            (run_id,),
+        ).fetchall()
+        events = tuple(
+            ReasoningEvent.model_validate(json.loads(bytes(row["event_json"])))
+            for row in rows
+        )
+        previous: str | None = None
+        for sequence, event in enumerate(events):
+            unsigned = event.model_dump(mode="json", exclude={"event_digest"})
+            if (
+                event.sequence != sequence
+                or event.previous_digest != previous
+                or _digest(unsigned) != event.event_digest
+            ):
+                self._raise(
+                    "REASONING_LOG_CORRUPT",
+                    "The reasoning event chain failed integrity validation.",
+                    "Stop using this run and inspect the tenant state offline.",
+                )
+            previous = event.event_digest
+        return events
+
+    def _append_event(
+        self,
+        connection: sqlite3.Connection,
+        run_id: str,
+        kind: str,
+        payload: dict[str, Any],
+    ) -> ReasoningEvent:
+        row = connection.execute(
+            "SELECT sequence, event_digest FROM reasoning_events WHERE run_id = ? ORDER BY sequence DESC LIMIT 1",
+            (run_id,),
+        ).fetchone()
+        sequence = 0 if row is None else int(row["sequence"]) + 1
+        previous = None if row is None else str(row["event_digest"])
+        unsigned = {
+            "schema_version": "1",
+            "run_id": run_id,
+            "sequence": sequence,
+            "kind": kind,
+            "occurred_at": datetime.now(UTC).isoformat(),
+            "previous_digest": previous,
+            "payload": payload,
+        }
+        event = ReasoningEvent.model_validate(
+            {**unsigned, "event_digest": _digest(unsigned)}
+        )
+        connection.execute(
+            "INSERT INTO reasoning_events(run_id, sequence, kind, call_id, event_json, event_digest) VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                run_id,
+                sequence,
+                kind,
+                payload.get("call_id"),
+                canonicalize_json(event.model_dump(mode="json")),
+                event.event_digest,
+            ),
+        )
+        return event
+
+    @staticmethod
+    def _state(
+        events: tuple[ReasoningEvent, ...],
+    ) -> tuple[ReasoningRunState, str | None]:
+        if not events or events[0].kind != "PLAN":
+            raise ReasoningProtocolError(
+                "REASONING_LOG_CORRUPT",
+                "The run is missing its initial PLAN.",
+                "Stop using this run and inspect the tenant state offline.",
+            )
+        last = events[-1]
+        if last.kind in {"PLAN", "AFTER_TOOL"}:
+            return ReasoningRunState.READY, None
+        if last.kind == "BEFORE_TOOL":
+            return ReasoningRunState.READY_TO_INVOKE, str(last.payload["call_id"])
+        if last.kind == "CAPABILITY_STARTED":
+            return ReasoningRunState.TOOL_RUNNING, str(last.payload["call_id"])
+        if last.kind == "CAPABILITY_FINISHED":
+            return ReasoningRunState.AWAITING_AFTER_TOOL, str(last.payload["call_id"])
+        if last.kind == "FINAL":
+            return ReasoningRunState.FINALIZED, None
+        raise ReasoningProtocolError(
+            "REASONING_LOG_CORRUPT",
+            "The run ends in an unknown event state.",
+            "Stop using this run and inspect the tenant state offline.",
+        )
+
+    @staticmethod
+    def _result(
+        event: ReasoningEvent, state: ReasoningRunState, call_id: str | None
+    ) -> ReasoningWriteResult:
+        next_required = {
+            ReasoningRunState.READY: ReasoningNextRequired.BEFORE_TOOL_OR_FINAL,
+            ReasoningRunState.READY_TO_INVOKE: ReasoningNextRequired.CAPABILITY_INVOKE,
+            ReasoningRunState.TOOL_RUNNING: ReasoningNextRequired.CAPABILITY_INVOKE,
+            ReasoningRunState.AWAITING_AFTER_TOOL: ReasoningNextRequired.AFTER_TOOL,
+            ReasoningRunState.FINALIZED: ReasoningNextRequired.NONE,
+        }[state]
+        return ReasoningWriteResult(
+            run_id=event.run_id,
+            call_id=call_id,
+            event_digest=event.event_digest,
+            sequence=event.sequence,
+            state=state,
+            next_required=next_required,
+            log_uri=f"reasoning://run/{event.run_id}",
+        )
+
+    @staticmethod
+    def _raise(code: str, message: str, hint: str) -> None:
+        raise ReasoningProtocolError(code, message, hint)
+
+
+__all__ = [
+    "INTERRUPTED_CALL_GRACE_SECONDS",
+    "MAX_CALLS_PER_RUN",
+    "ReasoningLogService",
+    "ReasoningProtocolError",
+]

--- a/src/jacobian/reasoning_log.py
+++ b/src/jacobian/reasoning_log.py
@@ -23,6 +23,7 @@ from jacobian.contracts.reasoning import (
 from jacobian.storage.repository import ArtifactRepository
 
 MAX_CALLS_PER_RUN = 64
+MAX_RUNS = 4096
 
 
 class ReasoningProtocolError(RuntimeError):
@@ -188,6 +189,15 @@ class ReasoningLogService:
         run_id = str(uuid4())
         with self.store.connection() as connection:
             connection.execute("BEGIN IMMEDIATE")
+            (count,) = connection.execute(
+                "SELECT COUNT(*) FROM reasoning_runs"
+            ).fetchone()
+            if count >= MAX_RUNS:
+                self._raise(
+                    "REASONING_RUN_LIMIT",
+                    f"The aggregate reasoning-run limit ({MAX_RUNS}) has been reached.",
+                    "Contact the operator to prune old reasoning runs or raise the limit.",
+                )
             connection.execute(
                 "INSERT INTO reasoning_runs(run_id) VALUES (?)", (run_id,)
             )

--- a/src/jacobian/reasoning_log.py
+++ b/src/jacobian/reasoning_log.py
@@ -13,6 +13,7 @@ from jacobian.canonical import canonicalize_json
 from jacobian.contracts.capabilities import CapabilityMode, CapabilityResult
 from jacobian.contracts.reasoning import (
     ReasoningEvent,
+    ReasoningInterpretationStatus,
     ReasoningNextRequired,
     ReasoningPhase,
     ReasoningRunState,
@@ -22,7 +23,6 @@ from jacobian.contracts.reasoning import (
 from jacobian.storage.repository import ArtifactRepository
 
 MAX_CALLS_PER_RUN = 64
-INTERRUPTED_CALL_GRACE_SECONDS = 600
 
 
 class ReasoningProtocolError(RuntimeError):
@@ -41,9 +41,14 @@ def _digest(value: Any) -> str:
 class ReasoningLogService:
     """Persist ordered model summaries and system-owned capability bindings."""
 
-    def __init__(self, store: ArtifactRepository) -> None:
+    def __init__(
+        self,
+        store: ArtifactRepository,
+        *,
+        runtime_instance_id: str | None = None,
+    ) -> None:
         self.store = store
-        self.recover_interrupted_calls()
+        self.runtime_instance_id = runtime_instance_id or str(uuid4())
 
     def write(self, request: ReasoningWriteRequest) -> ReasoningWriteResult:
         if request.phase is ReasoningPhase.PLAN:
@@ -89,6 +94,14 @@ class ReasoningLogService:
                     },
                 )
             elif request.phase is ReasoningPhase.AFTER_TOOL:
+                if state is ReasoningRunState.TOOL_RUNNING:
+                    events = self._close_interrupted_call(
+                        connection,
+                        events,
+                        request,
+                        pending,
+                    )
+                    state, pending = self._state(events)
                 if (
                     state is not ReasoningRunState.AWAITING_AFTER_TOOL
                     or pending != request.call_id
@@ -99,11 +112,62 @@ class ReasoningLogService:
                         "Read the reasoning log and use the pending call_id after its capability result.",
                     )
                 call_id = request.call_id
+                finished = next(
+                    event
+                    for event in reversed(events)
+                    if event.kind == "CAPABILITY_FINISHED"
+                )
+                actual_assurance = finished.payload.get("assurance")
+                actual_completeness = finished.payload.get("completeness")
+                reported_execution = (
+                    request.reported_execution_status.value
+                    if request.reported_execution_status is not None
+                    else None
+                )
+                reported_assurance = (
+                    request.reported_assurance_level.value
+                    if request.reported_assurance_level is not None
+                    else None
+                )
+                reported_completeness = (
+                    request.reported_completeness_status.value
+                    if request.reported_completeness_status is not None
+                    else None
+                )
                 event = self._append_event(
                     connection,
                     request.run_id,
                     "AFTER_TOOL",
-                    {"summary": request.summary, "call_id": call_id},
+                    {
+                        "summary": request.summary,
+                        "call_id": call_id,
+                        "interpretation_status": request.interpretation_status.value
+                        if request.interpretation_status is not None
+                        else None,
+                        "reported_execution_status": reported_execution,
+                        "reported_assurance_level": reported_assurance,
+                        "reported_completeness_status": reported_completeness,
+                        "execution_status_matches": reported_execution
+                        == finished.payload.get("execution_status")
+                        if reported_execution is not None
+                        else None,
+                        "assurance_level_matches": reported_assurance
+                        == (
+                            actual_assurance.get("level")
+                            if isinstance(actual_assurance, dict)
+                            else None
+                        )
+                        if reported_assurance is not None
+                        else None,
+                        "completeness_status_matches": reported_completeness
+                        == (
+                            actual_completeness.get("status")
+                            if isinstance(actual_completeness, dict)
+                            else None
+                        )
+                        if reported_completeness is not None
+                        else None,
+                    },
                 )
             else:
                 if state is not ReasoningRunState.READY:
@@ -169,6 +233,7 @@ class ReasoningLogService:
                     "capability_id": capability_id,
                     "mode": mode.value,
                     "request_digest": request_digest,
+                    "runtime_instance_id": self.runtime_instance_id,
                 },
             )
 
@@ -193,6 +258,29 @@ class ReasoningLogService:
                     "REASONING_CALL_MISMATCH",
                     "The capability completion has no matching started call.",
                     "Inspect the durable reasoning log before retrying.",
+                )
+            started = next(
+                event
+                for event in reversed(events)
+                if event.kind == "CAPABILITY_STARTED"
+            )
+            if (
+                started.payload.get("capability_id") != capability_id
+                or started.payload.get("mode") != mode.value
+                or started.payload.get("request_digest") != request_digest
+            ):
+                self._raise(
+                    "REASONING_CALL_MISMATCH",
+                    "The capability completion differs from the started call.",
+                    "Finish only the exact capability, mode, and request that was claimed.",
+                )
+            if result is not None and (
+                result.capability_id != capability_id or result.mode is not mode
+            ):
+                self._raise(
+                    "REASONING_RESULT_MISMATCH",
+                    "The capability result identity differs from the started call.",
+                    "Do not bind a result produced by another capability or mode.",
                 )
             if result is None:
                 payload: dict[str, Any] = {
@@ -230,48 +318,48 @@ class ReasoningLogService:
                 }
             self._append_event(connection, run_id, "CAPABILITY_FINISHED", payload)
 
-    def recover_interrupted_calls(
+    def _close_interrupted_call(
         self,
-        *,
-        stale_after_seconds: int = INTERRUPTED_CALL_GRACE_SECONDS,
-    ) -> None:
-        with self.store.connection() as connection:
-            connection.execute("BEGIN IMMEDIATE")
-            rows = connection.execute(
-                "SELECT run_id FROM reasoning_runs ORDER BY run_id"
-            ).fetchall()
-            for row in rows:
-                events = self._read_events(connection, str(row["run_id"]))
-                state, pending = self._state(events)
-                if state is ReasoningRunState.TOOL_RUNNING and pending is not None:
-                    started = next(
-                        event
-                        for event in reversed(events)
-                        if event.kind == "CAPABILITY_STARTED"
-                    )
-                    started_at = datetime.fromisoformat(started.occurred_at)
-                    age_seconds = (datetime.now(UTC) - started_at).total_seconds()
-                    if age_seconds < stale_after_seconds:
-                        continue
-                    self._append_event(
-                        connection,
-                        str(row["run_id"]),
-                        "CAPABILITY_FINISHED",
-                        {
-                            "call_id": pending,
-                            "capability_id": started.payload["capability_id"],
-                            "mode": started.payload["mode"],
-                            "request_digest": started.payload["request_digest"],
-                            "result_digest": None,
-                            "execution_status": "ERROR",
-                            "assurance": None,
-                            "completeness": None,
-                            "scope_digest": None,
-                            "artifact_uris": [],
-                            "episode_uri": None,
-                            "diagnostic_codes": ["PROCESS_INTERRUPTED"],
-                        },
-                    )
+        connection: sqlite3.Connection,
+        events: tuple[ReasoningEvent, ...],
+        request: ReasoningWriteRequest,
+        pending: str | None,
+    ) -> tuple[ReasoningEvent, ...]:
+        if (
+            request.interpretation_status
+            is not ReasoningInterpretationStatus.RESULT_UNAVAILABLE
+            or pending != request.call_id
+        ):
+            return events
+        started = next(
+            event for event in reversed(events) if event.kind == "CAPABILITY_STARTED"
+        )
+        if started.payload.get("runtime_instance_id") == self.runtime_instance_id:
+            self._raise(
+                "REASONING_CALL_STILL_RUNNING",
+                "The capability call is still owned by this runtime.",
+                "Wait for its result or cancel the invocation before interpreting it.",
+            )
+        finished = self._append_event(
+            connection,
+            request.run_id or "",
+            "CAPABILITY_FINISHED",
+            {
+                "call_id": pending,
+                "capability_id": started.payload["capability_id"],
+                "mode": started.payload["mode"],
+                "request_digest": started.payload["request_digest"],
+                "result_digest": None,
+                "execution_status": "ERROR",
+                "assurance": None,
+                "completeness": None,
+                "scope_digest": None,
+                "artifact_uris": [],
+                "episode_uri": None,
+                "diagnostic_codes": ["PROCESS_INTERRUPTED"],
+            },
+        )
+        return (*events, finished)
 
     def inspect(self, run_id: str) -> tuple[ReasoningEvent, ...]:
         with self.store.connection() as connection:
@@ -302,20 +390,13 @@ class ReasoningLogService:
             ReasoningEvent.model_validate(json.loads(bytes(row["event_json"])))
             for row in rows
         )
-        previous: str | None = None
         for sequence, event in enumerate(events):
-            unsigned = event.model_dump(mode="json", exclude={"event_digest"})
-            if (
-                event.sequence != sequence
-                or event.previous_digest != previous
-                or _digest(unsigned) != event.event_digest
-            ):
+            if event.sequence != sequence:
                 self._raise(
                     "REASONING_LOG_CORRUPT",
-                    "The reasoning event chain failed integrity validation.",
+                    "The reasoning event sequence failed integrity validation.",
                     "Stop using this run and inspect the tenant state offline.",
                 )
-            previous = event.event_digest
         return events
 
     def _append_event(
@@ -326,32 +407,28 @@ class ReasoningLogService:
         payload: dict[str, Any],
     ) -> ReasoningEvent:
         row = connection.execute(
-            "SELECT sequence, event_digest FROM reasoning_events WHERE run_id = ? ORDER BY sequence DESC LIMIT 1",
+            "SELECT sequence FROM reasoning_events WHERE run_id = ? ORDER BY sequence DESC LIMIT 1",
             (run_id,),
         ).fetchone()
         sequence = 0 if row is None else int(row["sequence"]) + 1
-        previous = None if row is None else str(row["event_digest"])
-        unsigned = {
-            "schema_version": "1",
-            "run_id": run_id,
-            "sequence": sequence,
-            "kind": kind,
-            "occurred_at": datetime.now(UTC).isoformat(),
-            "previous_digest": previous,
-            "payload": payload,
-        }
         event = ReasoningEvent.model_validate(
-            {**unsigned, "event_digest": _digest(unsigned)}
+            {
+                "schema_version": "1",
+                "run_id": run_id,
+                "sequence": sequence,
+                "kind": kind,
+                "occurred_at": datetime.now(UTC).isoformat(),
+                "payload": payload,
+            }
         )
         connection.execute(
-            "INSERT INTO reasoning_events(run_id, sequence, kind, call_id, event_json, event_digest) VALUES (?, ?, ?, ?, ?, ?)",
+            "INSERT INTO reasoning_events(run_id, sequence, kind, call_id, event_json) VALUES (?, ?, ?, ?, ?)",
             (
                 run_id,
                 sequence,
                 kind,
                 payload.get("call_id"),
                 canonicalize_json(event.model_dump(mode="json")),
-                event.event_digest,
             ),
         )
         return event
@@ -397,11 +474,15 @@ class ReasoningLogService:
         return ReasoningWriteResult(
             run_id=event.run_id,
             call_id=call_id,
-            event_digest=event.event_digest,
             sequence=event.sequence,
             state=state,
             next_required=next_required,
             log_uri=f"reasoning://run/{event.run_id}",
+            execution_status_matches=event.payload.get("execution_status_matches"),
+            assurance_level_matches=event.payload.get("assurance_level_matches"),
+            completeness_status_matches=event.payload.get(
+                "completeness_status_matches"
+            ),
         )
 
     @staticmethod
@@ -410,7 +491,6 @@ class ReasoningLogService:
 
 
 __all__ = [
-    "INTERRUPTED_CALL_GRACE_SECONDS",
     "MAX_CALLS_PER_RUN",
     "ReasoningLogService",
     "ReasoningProtocolError",

--- a/src/jacobian/runtime/bootstrap.py
+++ b/src/jacobian/runtime/bootstrap.py
@@ -12,6 +12,7 @@ from jacobian.memory import ResearchMemory
 from jacobian.operation_installation import OperationInstaller
 from jacobian.plugins.registry import PluginRegistry
 from jacobian.polynomial_expressions import install_polynomial_expression_artifacts
+from jacobian.reasoning_log import ReasoningLogService
 from jacobian.registry import CheckerRegistry
 from jacobian.runtime.config import CheckerAuthorityMode, RuntimeOptions
 from jacobian.runtime.services import CoreServices
@@ -54,6 +55,7 @@ def bootstrap_services(root: str | Path, options: RuntimeOptions) -> CoreService
             memory,
             policy=options.capability_policy,
         )
+        reasoning_log = ReasoningLogService(store)
         return CoreServices(
             store=store,
             schemas=schemas,
@@ -68,6 +70,7 @@ def bootstrap_services(root: str | Path, options: RuntimeOptions) -> CoreService
             plugins=plugins,
             checkers=checkers,
             capabilities=capabilities,
+            reasoning_log=reasoning_log,
         )
     except BaseException:
         store.close()

--- a/src/jacobian/runtime/services.py
+++ b/src/jacobian/runtime/services.py
@@ -23,6 +23,7 @@ from jacobian.plugin_execution import PluginExecutor
 from jacobian.plugins.registry import PluginRegistry
 from jacobian.polynomial_expressions import PolynomialExpressionArtifactService
 from jacobian.polytope import PolytopeService
+from jacobian.reasoning_log import ReasoningLogService
 from jacobian.references import ReferenceInstaller
 from jacobian.registry import CheckerRegistry
 from jacobian.sat_smt.sat import SatArtifactService
@@ -54,6 +55,7 @@ class CoreServices:
     plugins: PluginRegistry
     checkers: CheckerRegistry
     capabilities: CapabilityService
+    reasoning_log: ReasoningLogService
 
     def close(self) -> None:
         self.store.close()

--- a/tests/boundary/mcp/test_mcp_adapter.py
+++ b/tests/boundary/mcp/test_mcp_adapter.py
@@ -8,9 +8,9 @@ from pathlib import Path
 import pytest
 from jsonschema import Draft202012Validator
 from mcp.shared.exceptions import MCPError
+from tests.support.mcp import create_legacy_server as create_server
 
 from jacobian.adapters.mcp.guidance import OPERATING_GUIDE
-from jacobian.adapters.mcp.server import create_server
 from jacobian.contracts.capabilities import CapabilityDescriptor
 
 CAPABILITY_TOOL_NAMES = {"capability.describe", "capability.invoke"}
@@ -31,7 +31,7 @@ def test_mcp_exposes_only_capability_tools_with_read_only_resources(
             assert client.instructions == server.instructions
             assert client.server_info.version == version("jacobian")
             assert client.server_capabilities.extensions == {
-                "io.jacobian/core": {"version": "1"}
+                "io.jacobian/core": {"version": "2", "reasoning_log_mode": "OFF"}
             }
             listed = await client.list_tools()
             tools = {tool.name: tool for tool in listed.tools}

--- a/tests/boundary/mcp/test_mcp_catalog_and_policy.py
+++ b/tests/boundary/mcp/test_mcp_catalog_and_policy.py
@@ -6,7 +6,8 @@ import asyncio
 import json
 from pathlib import Path
 
-from jacobian.adapters.mcp.server import create_server
+from tests.support.mcp import create_legacy_server as create_server
+
 from jacobian.capability_service import CapabilityPolicy
 
 

--- a/tests/boundary/mcp/test_mcp_operations.py
+++ b/tests/boundary/mcp/test_mcp_operations.py
@@ -12,14 +12,15 @@ from importlib.metadata import version
 from pathlib import Path
 
 import pytest
+from tests.support.mcp import create_legacy_server as create_server
 
 from jacobian.adapters.mcp.context import _public_tool_error
-from jacobian.adapters.mcp.server import create_server
 from jacobian.adapters.mcp.tooling import _request_trace_digest, _run_blocking
 
 MCP_TOOL_NAMES = {
     "capability.describe",
     "capability.invoke",
+    "reasoning.write",
 }
 
 
@@ -158,7 +159,7 @@ def test_direct_tool_calls_reject_removed_and_malformed_arguments(
     asyncio.run(scenario())
 
 
-def test_mcp_stdio_entrypoint_exposes_only_capability_tools(
+def test_mcp_stdio_entrypoint_exposes_required_reasoning_tool(
     tmp_path: Path,
 ) -> None:
     async def scenario() -> None:

--- a/tests/boundary/mcp/test_mcp_operations.py
+++ b/tests/boundary/mcp/test_mcp_operations.py
@@ -169,7 +169,12 @@ def test_mcp_stdio_entrypoint_exposes_required_reasoning_tool(
         environment["JACOBIAN_STATE_DIR"] = str(tmp_path)
         parameters = StdioServerParameters(
             command=sys.executable,
-            args=["-m", "jacobian.adapters.mcp.server"],
+            args=[
+                "-m",
+                "jacobian.adapters.mcp.server",
+                "--reasoning-log-mode",
+                "required",
+            ],
             env=environment,
             cwd=Path.cwd(),
         )

--- a/tests/boundary/mcp/test_mcp_reasoning_log.py
+++ b/tests/boundary/mcp/test_mcp_reasoning_log.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+from jacobian.adapters.mcp.server import create_server
+
+
+def test_required_reasoning_log_binds_actual_capability_result(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        from mcp import Client
+
+        async with Client(create_server(tmp_path), raise_exceptions=True) as client:
+            tools = {tool.name: tool for tool in (await client.list_tools()).tools}
+            assert set(tools) == {
+                "capability.describe",
+                "capability.invoke",
+                "reasoning.write",
+            }
+            assert set(tools["capability.invoke"].input_schema["required"]) >= {
+                "reasoning_run_id",
+                "reasoning_call_id",
+            }
+
+            plan = await client.call_tool(
+                "reasoning.write",
+                {"phase": "PLAN", "summary": "Compute one exact integer value."},
+            )
+            assert isinstance(plan.structured_content, dict)
+            run_id = plan.structured_content["run_id"]
+            before = await client.call_tool(
+                "reasoning.write",
+                {
+                    "phase": "BEFORE_TOOL",
+                    "summary": "Use exact integer arithmetic for the gcd.",
+                    "run_id": run_id,
+                    "capability_id": "integer.compute.gcd",
+                    "mode": "EXPLORE",
+                },
+            )
+            assert isinstance(before.structured_content, dict)
+            call_id = before.structured_content["call_id"]
+            result = await client.call_tool(
+                "capability.invoke",
+                {
+                    "capability_id": "integer.compute.gcd",
+                    "mode": "EXPLORE",
+                    "payload": {"left": "84", "right": "30"},
+                    "reasoning_run_id": run_id,
+                    "reasoning_call_id": call_id,
+                },
+            )
+            assert isinstance(result.structured_content, dict)
+            assert result.structured_content["execution"]["status"] == "COMPLETED"
+            await client.call_tool(
+                "reasoning.write",
+                {
+                    "phase": "AFTER_TOOL",
+                    "summary": "The exact computed gcd is 6; it is not independently verified.",
+                    "run_id": run_id,
+                    "call_id": call_id,
+                },
+            )
+            await client.call_tool(
+                "reasoning.write",
+                {
+                    "phase": "FINAL",
+                    "summary": "The bounded integer computation completed with computed assurance.",
+                    "run_id": run_id,
+                },
+            )
+            resource = await client.read_resource(f"reasoning://run/{run_id}")
+            events = [
+                json.loads(line) for line in resource.contents[0].text.splitlines()
+            ]
+            finished = next(
+                event for event in events if event["kind"] == "CAPABILITY_FINISHED"
+            )
+            assert finished["payload"]["execution_status"] == "COMPLETED"
+            assert (
+                finished["payload"]["assurance"]
+                == result.structured_content["assurance"]
+            )
+            encoded = json.dumps(events)
+            assert '"left": "84"' not in encoded
+            assert '"gcd": "6"' not in encoded
+
+    asyncio.run(scenario())
+
+
+def test_off_mode_preserves_the_legacy_two_tool_surface(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        from mcp import Client
+
+        async with Client(
+            create_server(tmp_path, reasoning_log_mode="OFF"),
+            raise_exceptions=True,
+        ) as client:
+            tools = {tool.name: tool for tool in (await client.list_tools()).tools}
+            assert set(tools) == {"capability.describe", "capability.invoke"}
+            assert set(tools["capability.invoke"].input_schema["properties"]) == {
+                "capability_id",
+                "payload",
+                "mode",
+            }
+
+    asyncio.run(scenario())
+
+
+def test_audit_mode_allows_unbound_legacy_invocation(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        from mcp import Client
+
+        async with Client(
+            create_server(tmp_path, reasoning_log_mode="AUDIT"),
+            raise_exceptions=True,
+        ) as client:
+            result = await client.call_tool(
+                "capability.invoke",
+                {
+                    "capability_id": "integer.compute.gcd",
+                    "mode": "EXPLORE",
+                    "payload": {"left": "84", "right": "30"},
+                },
+            )
+            assert isinstance(result.structured_content, dict)
+            assert result.structured_content["execution"]["status"] == "COMPLETED"
+
+    asyncio.run(scenario())
+
+
+def test_required_mode_rejects_mismatched_call_binding_without_consuming_it(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        from mcp import Client
+
+        async with Client(create_server(tmp_path), raise_exceptions=True) as client:
+            plan = await client.call_tool(
+                "reasoning.write",
+                {"phase": "PLAN", "summary": "Compute one exact value."},
+            )
+            assert isinstance(plan.structured_content, dict)
+            run_id = plan.structured_content["run_id"]
+            before = await client.call_tool(
+                "reasoning.write",
+                {
+                    "phase": "BEFORE_TOOL",
+                    "summary": "Bind the intended integer capability.",
+                    "run_id": run_id,
+                    "capability_id": "integer.compute.gcd",
+                    "mode": "EXPLORE",
+                },
+            )
+            assert isinstance(before.structured_content, dict)
+            call_id = before.structured_content["call_id"]
+
+            mismatch = await client.call_tool(
+                "capability.invoke",
+                {
+                    "capability_id": "integer.factorization.factor",
+                    "mode": "EXPLORE",
+                    "payload": {"value": "84"},
+                    "reasoning_run_id": run_id,
+                    "reasoning_call_id": call_id,
+                },
+            )
+            assert mismatch.is_error is True
+            assert "REASONING_CALL_MISMATCH" in mismatch.content[0].text
+
+            result = await client.call_tool(
+                "capability.invoke",
+                {
+                    "capability_id": "integer.compute.gcd",
+                    "mode": "EXPLORE",
+                    "payload": {"left": "84", "right": "30"},
+                    "reasoning_run_id": run_id,
+                    "reasoning_call_id": call_id,
+                },
+            )
+            assert isinstance(result.structured_content, dict)
+            assert result.structured_content["execution"]["status"] == "COMPLETED"
+
+    asyncio.run(scenario())

--- a/tests/boundary/mcp/test_mcp_reasoning_log.py
+++ b/tests/boundary/mcp/test_mcp_reasoning_log.py
@@ -11,7 +11,10 @@ def test_required_reasoning_log_binds_actual_capability_result(tmp_path: Path) -
     async def scenario() -> None:
         from mcp import Client
 
-        async with Client(create_server(tmp_path), raise_exceptions=True) as client:
+        async with Client(
+            create_server(tmp_path, reasoning_log_mode="REQUIRED"),
+            raise_exceptions=True,
+        ) as client:
             tools = {tool.name: tool for tool in (await client.list_tools()).tools}
             assert set(tools) == {
                 "capability.describe",
@@ -144,7 +147,10 @@ def test_required_mode_rejects_mismatched_call_binding_without_consuming_it(
     async def scenario() -> None:
         from mcp import Client
 
-        async with Client(create_server(tmp_path), raise_exceptions=True) as client:
+        async with Client(
+            create_server(tmp_path, reasoning_log_mode="REQUIRED"),
+            raise_exceptions=True,
+        ) as client:
             plan = await client.call_tool(
                 "reasoning.write",
                 {"phase": "PLAN", "summary": "Compute one exact value."},

--- a/tests/boundary/mcp/test_mcp_reasoning_log.py
+++ b/tests/boundary/mcp/test_mcp_reasoning_log.py
@@ -60,6 +60,10 @@ def test_required_reasoning_log_binds_actual_capability_result(tmp_path: Path) -
                     "summary": "The exact computed gcd is 6; it is not independently verified.",
                     "run_id": run_id,
                     "call_id": call_id,
+                    "interpretation_status": "INTERPRETED",
+                    "reported_execution_status": "COMPLETED",
+                    "reported_assurance_level": "COMPUTED",
+                    "reported_completeness_status": "COMPLETE",
                 },
             )
             await client.call_tool(
@@ -82,6 +86,10 @@ def test_required_reasoning_log_binds_actual_capability_result(tmp_path: Path) -
                 finished["payload"]["assurance"]
                 == result.structured_content["assurance"]
             )
+            after = next(event for event in events if event["kind"] == "AFTER_TOOL")
+            assert after["payload"]["execution_status_matches"] is True
+            assert after["payload"]["assurance_level_matches"] is True
+            assert after["payload"]["completeness_status_matches"] is True
             encoded = json.dumps(events)
             assert '"left": "84"' not in encoded
             assert '"gcd": "6"' not in encoded

--- a/tests/boundary/mcp/test_mcp_sdk_2_conformance.py
+++ b/tests/boundary/mcp/test_mcp_sdk_2_conformance.py
@@ -9,8 +9,10 @@ from pathlib import Path
 
 import pytest
 from mcp.server.extension import Extension, ResourceBinding, ToolBinding
+from tests.support.mcp import create_legacy_server as create_server
 
-from jacobian.adapters.mcp.server import JacobianCoreExtension, create_server
+from jacobian.adapters.mcp.constants import ReasoningLogMode
+from jacobian.adapters.mcp.server import JacobianCoreExtension
 from jacobian.contracts.capabilities import CapabilityResult
 
 
@@ -18,10 +20,10 @@ def test_mcp_sdk_is_exactly_pinned_and_v2_bindings_are_used() -> None:
     assert importlib.metadata.version("mcp") == "2.0.0"
     assert importlib.metadata.version("mcp-types") == "2.0.0"
 
-    extension = JacobianCoreExtension(None, None)
+    extension = JacobianCoreExtension(None, None, ReasoningLogMode.OFF)
     assert isinstance(extension, Extension)
     assert extension.identifier == "io.jacobian/core"
-    assert extension.settings() == {"version": "1"}
+    assert extension.settings() == {"version": "2", "reasoning_log_mode": "OFF"}
     assert all(isinstance(binding, ToolBinding) for binding in extension.tools())
     assert all(
         isinstance(binding, ResourceBinding) for binding in extension.resources()

--- a/tests/boundary/mcp/test_remote_mcp_http.py
+++ b/tests/boundary/mcp/test_remote_mcp_http.py
@@ -14,13 +14,13 @@ import pytest
 from deploy.smoke_remote import inspect as inspect_remote_deployment
 from mcp.server.auth.settings import AuthSettings
 from pydantic import AnyHttpUrl
+from tests.support.mcp import create_legacy_server as create_server
 from uvicorn import Config, Server
 
 from jacobian.adapters.mcp.remote import (
     StaticTokenVerifier,
     load_static_token_file,
 )
-from jacobian.adapters.mcp.server import create_server
 
 
 def test_authenticated_streamable_http_isolates_tenant_memory(

--- a/tests/boundary/mcp/test_remote_mcp_tenants.py
+++ b/tests/boundary/mcp/test_remote_mcp_tenants.py
@@ -13,6 +13,8 @@ from jacobian.adapters.mcp.remote import (
     TenantRuntimeRouter,
     TenantRuntimeRouterClosedError,
 )
+from jacobian.contracts.reasoning import ReasoningWriteRequest
+from jacobian.reasoning_log import ReasoningProtocolError
 from jacobian.runtime import CheckerAuthorityMode
 from jacobian.storage.errors import ArtifactNotFoundError
 
@@ -36,6 +38,11 @@ def test_tenant_router_isolates_artifact_stores(tmp_path: Path) -> None:
     assert router.runtime_for("alpha") is alpha
     with pytest.raises(ArtifactNotFoundError):
         beta.core.store.get(stored)
+    reasoning_run = alpha.core.reasoning_log.write(
+        ReasoningWriteRequest(phase="PLAN", summary="Alpha-only plan.")
+    )
+    with pytest.raises(ReasoningProtocolError, match="does not exist"):
+        beta.core.reasoning_log.inspect(reasoning_run.run_id)
 
 
 class _FakeRuntime:

--- a/tests/boundary/storage/transactions/test_state_database_migrations.py
+++ b/tests/boundary/storage/transactions/test_state_database_migrations.py
@@ -66,6 +66,7 @@ def test_fresh_store_records_immutable_ordered_migrations(tmp_path: Path) -> Non
             )
         }
         assert not any(name.startswith("workspace") for name in tables)
+        assert {"reasoning_runs", "reasoning_events"} <= tables
         assert connection.execute(
             "SELECT format_revision FROM jacobian_state_format WHERE id = 0"
         ).fetchone() == (CURRENT_STATE_FORMAT_REVISION,)
@@ -75,6 +76,33 @@ def test_fresh_store_records_immutable_ordered_migrations(tmp_path: Path) -> Non
             ).fetchone()
             is None
         )
+    finally:
+        connection.close()
+
+
+def test_reasoning_log_tables_reject_update_and_delete(tmp_path: Path) -> None:
+    with ArtifactRepository(tmp_path):
+        pass
+
+    connection = sqlite3.connect(tmp_path / "metadata.sqlite3")
+    try:
+        connection.execute("INSERT INTO reasoning_runs(run_id) VALUES ('fixture-run')")
+        connection.execute(
+            """
+            INSERT INTO reasoning_events(
+                run_id, sequence, kind, event_json, event_digest
+            ) VALUES ('fixture-run', 0, 'PLAN', '{}', 'sha256:fixture')
+            """
+        )
+        connection.commit()
+        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+            connection.execute(
+                "UPDATE reasoning_events SET kind = 'FINAL' WHERE run_id = 'fixture-run'"
+            )
+        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+            connection.execute(
+                "DELETE FROM reasoning_runs WHERE run_id = 'fixture-run'"
+            )
     finally:
         connection.close()
 
@@ -413,8 +441,7 @@ def test_missing_retirement_revision_requires_fresh_store(tmp_path: Path) -> Non
     connection = sqlite3.connect(tmp_path / "metadata.sqlite3")
     try:
         connection.execute(
-            "DELETE FROM jacobian_schema_migrations WHERE revision = ?",
-            (len(STATE_MIGRATIONS),),
+            "DELETE FROM jacobian_schema_migrations WHERE revision >= 6",
         )
         connection.commit()
     finally:

--- a/tests/boundary/storage/transactions/test_state_database_migrations.py
+++ b/tests/boundary/storage/transactions/test_state_database_migrations.py
@@ -90,8 +90,8 @@ def test_reasoning_log_tables_reject_update_and_delete(tmp_path: Path) -> None:
         connection.execute(
             """
             INSERT INTO reasoning_events(
-                run_id, sequence, kind, event_json, event_digest
-            ) VALUES ('fixture-run', 0, 'PLAN', '{}', 'sha256:fixture')
+                run_id, sequence, kind, event_json
+            ) VALUES ('fixture-run', 0, 'PLAN', '{}')
             """
         )
         connection.commit()

--- a/tests/component/reasoning/test_reasoning_log_service.py
+++ b/tests/component/reasoning/test_reasoning_log_service.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from jacobian.contracts.capabilities import CapabilityMode
+from jacobian.contracts.reasoning import ReasoningWriteRequest
+from jacobian.reasoning_log import ReasoningLogService, ReasoningProtocolError
+from jacobian.storage.repository import ArtifactRepository
+
+
+def _write(service: ReasoningLogService, **values: object):
+    return service.write(ReasoningWriteRequest.model_validate(values))
+
+
+def test_reasoning_log_enforces_one_complete_serial_cycle(tmp_path: Path) -> None:
+    with ArtifactRepository(tmp_path) as store:
+        service = ReasoningLogService(store)
+        plan = _write(service, phase="PLAN", summary="Compute one exact invariant.")
+        before = _write(
+            service,
+            phase="BEFORE_TOOL",
+            summary="Use the installed exact operation.",
+            run_id=plan.run_id,
+            capability_id="integer.compute.gcd",
+            mode="EXPLORE",
+        )
+        assert before.call_id is not None
+        with pytest.raises(ReasoningProtocolError, match="waiting"):
+            _write(
+                service,
+                phase="BEFORE_TOOL",
+                summary="Cannot overlap calls.",
+                run_id=plan.run_id,
+                capability_id="integer.compute.gcd",
+                mode="EXPLORE",
+            )
+        service.claim_call(
+            plan.run_id,
+            before.call_id,
+            "integer.compute.gcd",
+            CapabilityMode.EXPLORE,
+            "sha256:" + "1" * 64,
+        )
+        with pytest.raises(ReasoningProtocolError, match="pending BEFORE_TOOL"):
+            service.claim_call(
+                plan.run_id,
+                before.call_id,
+                "integer.compute.gcd",
+                CapabilityMode.EXPLORE,
+                "sha256:" + "1" * 64,
+            )
+        service.finish_call(
+            plan.run_id,
+            before.call_id,
+            "integer.compute.gcd",
+            CapabilityMode.EXPLORE,
+            "sha256:" + "1" * 64,
+            execution_status="ERROR",
+            diagnostic_codes=("FIXTURE_ERROR",),
+        )
+        with pytest.raises(ReasoningProtocolError, match="requires every"):
+            _write(service, phase="FINAL", summary="Too early.", run_id=plan.run_id)
+        _write(
+            service,
+            phase="AFTER_TOOL",
+            summary="The operational error is a non-conclusion.",
+            run_id=plan.run_id,
+            call_id=before.call_id,
+        )
+        final = _write(
+            service,
+            phase="FINAL",
+            summary="No mathematical claim was established.",
+            run_id=plan.run_id,
+        )
+        assert final.state.value == "FINALIZED"
+        events = [
+            json.loads(line) for line in service.inspect_jsonl(plan.run_id).splitlines()
+        ]
+        assert [event["kind"] for event in events] == [
+            "PLAN",
+            "BEFORE_TOOL",
+            "CAPABILITY_STARTED",
+            "CAPABILITY_FINISHED",
+            "AFTER_TOOL",
+            "FINAL",
+        ]
+
+
+def test_runtime_recovery_marks_started_call_interrupted(tmp_path: Path) -> None:
+    with ArtifactRepository(tmp_path) as store:
+        service = ReasoningLogService(store)
+        plan = _write(service, phase="PLAN", summary="Plan.")
+        before = _write(
+            service,
+            phase="BEFORE_TOOL",
+            summary="Call.",
+            run_id=plan.run_id,
+            capability_id="integer.compute.gcd",
+            mode="EXPLORE",
+        )
+        assert before.call_id is not None
+        service.claim_call(
+            plan.run_id,
+            before.call_id,
+            "integer.compute.gcd",
+            CapabilityMode.EXPLORE,
+            "sha256:" + "2" * 64,
+        )
+        recovered = ReasoningLogService(store)
+        assert recovered.inspect(plan.run_id)[-1].kind == "CAPABILITY_STARTED"
+        recovered.recover_interrupted_calls(stale_after_seconds=0)
+        last = recovered.inspect(plan.run_id)[-1]
+        assert last.kind == "CAPABILITY_FINISHED"
+        assert last.payload["diagnostic_codes"] == ["PROCESS_INTERRUPTED"]

--- a/tests/component/reasoning/test_reasoning_log_service.py
+++ b/tests/component/reasoning/test_reasoning_log_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -69,6 +70,7 @@ def test_reasoning_log_enforces_one_complete_serial_cycle(tmp_path: Path) -> Non
             summary="The operational error is a non-conclusion.",
             run_id=plan.run_id,
             call_id=before.call_id,
+            interpretation_status="RESULT_UNAVAILABLE",
         )
         final = _write(
             service,
@@ -90,7 +92,9 @@ def test_reasoning_log_enforces_one_complete_serial_cycle(tmp_path: Path) -> Non
         ]
 
 
-def test_runtime_recovery_marks_started_call_interrupted(tmp_path: Path) -> None:
+def test_restarted_runtime_can_explicitly_close_an_interrupted_call(
+    tmp_path: Path,
+) -> None:
     with ArtifactRepository(tmp_path) as store:
         service = ReasoningLogService(store)
         plan = _write(service, phase="PLAN", summary="Plan.")
@@ -112,7 +116,115 @@ def test_runtime_recovery_marks_started_call_interrupted(tmp_path: Path) -> None
         )
         recovered = ReasoningLogService(store)
         assert recovered.inspect(plan.run_id)[-1].kind == "CAPABILITY_STARTED"
-        recovered.recover_interrupted_calls(stale_after_seconds=0)
-        last = recovered.inspect(plan.run_id)[-1]
-        assert last.kind == "CAPABILITY_FINISHED"
-        assert last.payload["diagnostic_codes"] == ["PROCESS_INTERRUPTED"]
+        _write(
+            recovered,
+            phase="AFTER_TOOL",
+            summary="The previous runtime ended before returning a result.",
+            run_id=plan.run_id,
+            call_id=before.call_id,
+            interpretation_status="RESULT_UNAVAILABLE",
+        )
+        events = recovered.inspect(plan.run_id)
+        assert events[-2].kind == "CAPABILITY_FINISHED"
+        assert events[-2].payload["diagnostic_codes"] == ["PROCESS_INTERRUPTED"]
+        assert events[-1].kind == "AFTER_TOOL"
+
+
+def test_current_runtime_cannot_abandon_its_running_call(tmp_path: Path) -> None:
+    with ArtifactRepository(tmp_path) as store:
+        service = ReasoningLogService(store, runtime_instance_id="runtime-a")
+        plan = _write(service, phase="PLAN", summary="Plan.")
+        before = _write(
+            service,
+            phase="BEFORE_TOOL",
+            summary="Call.",
+            run_id=plan.run_id,
+            capability_id="integer.compute.gcd",
+            mode="EXPLORE",
+        )
+        assert before.call_id is not None
+        service.claim_call(
+            plan.run_id,
+            before.call_id,
+            "integer.compute.gcd",
+            CapabilityMode.EXPLORE,
+            "sha256:" + "3" * 64,
+        )
+        with pytest.raises(ReasoningProtocolError, match="still owned"):
+            _write(
+                service,
+                phase="AFTER_TOOL",
+                summary="Cannot abandon a live call.",
+                run_id=plan.run_id,
+                call_id=before.call_id,
+                interpretation_status="RESULT_UNAVAILABLE",
+            )
+
+
+def test_completion_must_match_the_started_call(tmp_path: Path) -> None:
+    with ArtifactRepository(tmp_path) as store:
+        service = ReasoningLogService(store)
+        plan = _write(service, phase="PLAN", summary="Plan.")
+        before = _write(
+            service,
+            phase="BEFORE_TOOL",
+            summary="Call.",
+            run_id=plan.run_id,
+            capability_id="integer.compute.gcd",
+            mode="EXPLORE",
+        )
+        assert before.call_id is not None
+        request_digest = "sha256:" + "4" * 64
+        service.claim_call(
+            plan.run_id,
+            before.call_id,
+            "integer.compute.gcd",
+            CapabilityMode.EXPLORE,
+            request_digest,
+        )
+        with pytest.raises(ReasoningProtocolError, match="differs from the started"):
+            service.finish_call(
+                plan.run_id,
+                before.call_id,
+                "integer.compute.gcd",
+                CapabilityMode.EXPLORE,
+                "sha256:" + "5" * 64,
+                execution_status="ERROR",
+            )
+        assert service.inspect(plan.run_id)[-1].kind == "CAPABILITY_STARTED"
+
+
+def test_concurrent_claims_start_exactly_one_call(tmp_path: Path) -> None:
+    with ArtifactRepository(tmp_path) as store:
+        service = ReasoningLogService(store)
+        plan = _write(service, phase="PLAN", summary="Plan.")
+        before = _write(
+            service,
+            phase="BEFORE_TOOL",
+            summary="Call once.",
+            run_id=plan.run_id,
+            capability_id="integer.compute.gcd",
+            mode="EXPLORE",
+        )
+        assert before.call_id is not None
+
+        def claim() -> str:
+            try:
+                service.claim_call(
+                    plan.run_id,
+                    before.call_id or "",
+                    "integer.compute.gcd",
+                    CapabilityMode.EXPLORE,
+                    "sha256:" + "6" * 64,
+                )
+            except ReasoningProtocolError:
+                return "rejected"
+            return "claimed"
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            outcomes = list(executor.map(lambda _index: claim(), range(2)))
+
+        assert sorted(outcomes) == ["claimed", "rejected"]
+        assert [event.kind for event in service.inspect(plan.run_id)].count(
+            "CAPABILITY_STARTED"
+        ) == 1

--- a/tests/e2e/capability_workflows/test_capability_round_trips.py
+++ b/tests/e2e/capability_workflows/test_capability_round_trips.py
@@ -7,13 +7,13 @@ from typing import Any
 
 import pytest
 from mcp import Client
+from tests.support.mcp import create_legacy_server as create_server
 from tests.support.provider_lean import (
     PINNED_MATHLIB_RUNTIME_UNAVAILABLE_REASON,
     pinned_mathlib_runtime_available,
 )
 from tests.support.rationals import rational_payload as _q
 
-from jacobian.adapters.mcp.server import create_server
 from jacobian.runtime import CheckerAuthorityMode
 
 

--- a/tests/e2e/capability_workflows/test_reasoning_log_round_trip.py
+++ b/tests/e2e/capability_workflows/test_reasoning_log_round_trip.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+from mcp import Client
+
+from jacobian.adapters.mcp.server import create_server
+
+
+def test_reasoning_run_survives_runtime_restart_and_finalizes(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        async with Client(create_server(tmp_path), raise_exceptions=True) as client:
+            plan = await client.call_tool(
+                "reasoning.write",
+                {"phase": "PLAN", "summary": "Compute and audit an exact gcd."},
+            )
+            assert isinstance(plan.structured_content, dict)
+            run_id = plan.structured_content["run_id"]
+            before = await client.call_tool(
+                "reasoning.write",
+                {
+                    "phase": "BEFORE_TOOL",
+                    "summary": "Use exact integer arithmetic.",
+                    "run_id": run_id,
+                    "capability_id": "integer.compute.gcd",
+                    "mode": "EXPLORE",
+                },
+            )
+            assert isinstance(before.structured_content, dict)
+            call_id = before.structured_content["call_id"]
+            result = await client.call_tool(
+                "capability.invoke",
+                {
+                    "capability_id": "integer.compute.gcd",
+                    "payload": {"left": "84", "right": "30"},
+                    "mode": "EXPLORE",
+                    "reasoning_run_id": run_id,
+                    "reasoning_call_id": call_id,
+                },
+            )
+            assert isinstance(result.structured_content, dict)
+            await client.call_tool(
+                "reasoning.write",
+                {
+                    "phase": "AFTER_TOOL",
+                    "summary": "The exact computation returned gcd 6 with computed assurance.",
+                    "run_id": run_id,
+                    "call_id": call_id,
+                },
+            )
+
+        async with Client(create_server(tmp_path), raise_exceptions=True) as restarted:
+            final = await restarted.call_tool(
+                "reasoning.write",
+                {
+                    "phase": "FINAL",
+                    "summary": "The finite computation is complete; no wider claim is made.",
+                    "run_id": run_id,
+                },
+            )
+            assert isinstance(final.structured_content, dict)
+            assert final.structured_content["state"] == "FINALIZED"
+            resource = await restarted.read_resource(f"reasoning://run/{run_id}")
+            events = [
+                json.loads(line) for line in resource.contents[0].text.splitlines()
+            ]
+            assert events[-1]["kind"] == "FINAL"
+            assert [event["sequence"] for event in events] == list(range(len(events)))
+
+    asyncio.run(scenario())

--- a/tests/e2e/capability_workflows/test_reasoning_log_round_trip.py
+++ b/tests/e2e/capability_workflows/test_reasoning_log_round_trip.py
@@ -48,6 +48,10 @@ def test_reasoning_run_survives_runtime_restart_and_finalizes(tmp_path: Path) ->
                     "summary": "The exact computation returned gcd 6 with computed assurance.",
                     "run_id": run_id,
                     "call_id": call_id,
+                    "interpretation_status": "INTERPRETED",
+                    "reported_execution_status": "COMPLETED",
+                    "reported_assurance_level": "COMPUTED",
+                    "reported_completeness_status": "COMPLETE",
                 },
             )
 

--- a/tests/e2e/capability_workflows/test_reasoning_log_round_trip.py
+++ b/tests/e2e/capability_workflows/test_reasoning_log_round_trip.py
@@ -11,7 +11,10 @@ from jacobian.adapters.mcp.server import create_server
 
 def test_reasoning_run_survives_runtime_restart_and_finalizes(tmp_path: Path) -> None:
     async def scenario() -> None:
-        async with Client(create_server(tmp_path), raise_exceptions=True) as client:
+        async with Client(
+            create_server(tmp_path, reasoning_log_mode="REQUIRED"),
+            raise_exceptions=True,
+        ) as client:
             plan = await client.call_tool(
                 "reasoning.write",
                 {"phase": "PLAN", "summary": "Compute and audit an exact gcd."},
@@ -55,7 +58,10 @@ def test_reasoning_run_survives_runtime_restart_and_finalizes(tmp_path: Path) ->
                 },
             )
 
-        async with Client(create_server(tmp_path), raise_exceptions=True) as restarted:
+        async with Client(
+            create_server(tmp_path, reasoning_log_mode="REQUIRED"),
+            raise_exceptions=True,
+        ) as restarted:
             final = await restarted.call_tool(
                 "reasoning.write",
                 {

--- a/tests/support/mcp.py
+++ b/tests/support/mcp.py
@@ -1,0 +1,15 @@
+"""Legacy MCP server fixture for tests unrelated to reasoning enforcement."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from jacobian.adapters.mcp.server import create_server as _create_server
+
+
+def create_legacy_server(*args: Any, **kwargs: Any) -> Any:
+    kwargs.setdefault("reasoning_log_mode", "OFF")
+    return _create_server(*args, **kwargs)
+
+
+__all__ = ["create_legacy_server"]

--- a/tests/unit/contracts/test_reasoning_log.py
+++ b/tests/unit/contracts/test_reasoning_log.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.contracts.reasoning import ReasoningWriteRequest
+
+
+def test_reasoning_phase_contracts_are_closed_and_bounded() -> None:
+    plan = ReasoningWriteRequest(phase="PLAN", summary="Inspect the exact claim.")
+    assert plan.run_id is None
+
+    with pytest.raises(ValidationError, match="phase contract"):
+        ReasoningWriteRequest(
+            phase="PLAN",
+            summary="invalid",
+            run_id="00000000-0000-4000-8000-000000000000",
+        )
+    with pytest.raises(ValidationError, match="512 characters"):
+        ReasoningWriteRequest(phase="PLAN", summary="界" * 513)
+    with pytest.raises(ValidationError):
+        ReasoningWriteRequest(phase="PLAN", summary="ok", hidden_reasoning="secret")
+
+
+def test_before_and_after_require_exact_binding_fields() -> None:
+    run_id = "00000000-0000-4000-8000-000000000000"
+    call_id = "11111111-1111-4111-8111-111111111111"
+    before = ReasoningWriteRequest(
+        phase="BEFORE_TOOL",
+        summary="Compute an exact finite value.",
+        run_id=run_id,
+        capability_id="integer.compute.gcd",
+        mode="EXPLORE",
+    )
+    after = ReasoningWriteRequest(
+        phase="AFTER_TOOL",
+        summary="The completed result is computed, not independently verified.",
+        run_id=run_id,
+        call_id=call_id,
+    )
+    assert before.capability_id == "integer.compute.gcd"
+    assert after.call_id == call_id

--- a/tests/unit/contracts/test_reasoning_log.py
+++ b/tests/unit/contracts/test_reasoning_log.py
@@ -37,6 +37,37 @@ def test_before_and_after_require_exact_binding_fields() -> None:
         summary="The completed result is computed, not independently verified.",
         run_id=run_id,
         call_id=call_id,
+        interpretation_status="INTERPRETED",
+        reported_execution_status="COMPLETED",
+        reported_assurance_level="COMPUTED",
+        reported_completeness_status="NOT_APPLICABLE",
     )
     assert before.capability_id == "integer.compute.gcd"
     assert after.call_id == call_id
+
+
+def test_after_tool_distinguishes_interpreted_and_unavailable_results() -> None:
+    binding = {
+        "phase": "AFTER_TOOL",
+        "summary": "No result content was available after restart.",
+        "run_id": "00000000-0000-4000-8000-000000000000",
+        "call_id": "11111111-1111-4111-8111-111111111111",
+    }
+    unavailable = ReasoningWriteRequest(
+        **binding,
+        interpretation_status="RESULT_UNAVAILABLE",
+    )
+    assert unavailable.reported_execution_status is None
+
+    with pytest.raises(ValidationError, match="all reported result fields"):
+        ReasoningWriteRequest(
+            **binding,
+            interpretation_status="INTERPRETED",
+            reported_execution_status="COMPLETED",
+        )
+    with pytest.raises(ValidationError, match="require INTERPRETED"):
+        ReasoningWriteRequest(
+            **binding,
+            interpretation_status="RESULT_UNAVAILABLE",
+            reported_execution_status="ERROR",
+        )

--- a/tests/unit/tooling/test_eval_telemetry.py
+++ b/tests/unit/tooling/test_eval_telemetry.py
@@ -5,7 +5,10 @@ import json
 from pathlib import Path
 
 from jacobian.canonical import canonicalize_json
-from jacobian.eval.telemetry import parse_agent_transcript
+from jacobian.eval.telemetry import (
+    parse_agent_transcript,
+    parse_reasoning_protocol_trace,
+)
 
 
 def _tool_event(
@@ -187,6 +190,7 @@ def test_agent_telemetry_reports_reasoning_protocol_without_summary_text(
     telemetry = parse_agent_transcript(transcript)
 
     assert telemetry["reasoning_protocol"] == {
+        "status": "INCOMPLETE",
         "plan_count": 1,
         "before_tool_count": 1,
         "after_tool_count": 0,
@@ -194,9 +198,70 @@ def test_agent_telemetry_reports_reasoning_protocol_without_summary_text(
         "run_count": 1,
         "bound_invoke_count": 1,
         "missing_after_tool_count": 1,
+        "pending_call_count": 1,
+        "unavailable_after_tool_count": 0,
+        "reported_actual_mismatch_count": 0,
         "summary_characters": len("private plan markerprivate before marker"),
     }
     assert "private plan marker" not in json.dumps(telemetry)
+
+
+def test_reasoning_protocol_parser_supports_harbor_atif(tmp_path: Path) -> None:
+    run_id = "00000000-0000-4000-8000-000000000000"
+    trajectory = {
+        "schema_version": "ATIF-v1.7",
+        "steps": [
+            {
+                "tool_calls": [
+                    {
+                        "tool_call_id": "plan",
+                        "function_name": "mcp__jacobian__reasoning_write",
+                        "arguments": {"phase": "PLAN", "summary": "private"},
+                    }
+                ],
+                "observation": {
+                    "results": [
+                        {
+                            "source_call_id": "plan",
+                            "content": json.dumps({"run_id": run_id}),
+                        }
+                    ]
+                },
+            },
+            {
+                "tool_calls": [
+                    {
+                        "tool_call_id": "final",
+                        "function_name": "reasoning.write",
+                        "arguments": {
+                            "phase": "FINAL",
+                            "summary": "private final",
+                            "run_id": run_id,
+                        },
+                    }
+                ],
+                "observation": {
+                    "results": [
+                        {
+                            "source_call_id": "final",
+                            "content": json.dumps(
+                                {"run_id": run_id, "state": "FINALIZED"}
+                            ),
+                        }
+                    ]
+                },
+            },
+        ],
+    }
+    path = tmp_path / "trajectory.json"
+    path.write_text(json.dumps(trajectory), encoding="utf-8")
+
+    protocol = parse_reasoning_protocol_trace(path)
+
+    assert protocol["status"] == "COMPLETE"
+    assert protocol["plan_count"] == 1
+    assert protocol["final_count"] == 1
+    assert "private" not in json.dumps(protocol)
 
 
 def test_agent_telemetry_separates_wire_model_and_logical_invocation_bytes(

--- a/tests/unit/tooling/test_eval_telemetry.py
+++ b/tests/unit/tooling/test_eval_telemetry.py
@@ -147,6 +147,58 @@ def test_agent_telemetry_counts_response_bytes_and_repeated_calls(
     assert telemetry["mcp_logical_payload_observed_calls"] == 3
 
 
+def test_agent_telemetry_reports_reasoning_protocol_without_summary_text(
+    tmp_path: Path,
+) -> None:
+    run_id = "00000000-0000-4000-8000-000000000000"
+    call_id = "11111111-1111-4111-8111-111111111111"
+    events = [
+        _tool_event(
+            "reasoning.write",
+            {"phase": "PLAN", "summary": "private plan marker"},
+            {"run_id": run_id},
+        ),
+        _tool_event(
+            "reasoning.write",
+            {
+                "phase": "BEFORE_TOOL",
+                "summary": "private before marker",
+                "run_id": run_id,
+            },
+            {"run_id": run_id, "call_id": call_id},
+        ),
+        _tool_event(
+            "capability.invoke",
+            {
+                "capability_id": "integer.compute.gcd",
+                "payload": {},
+                "reasoning_run_id": run_id,
+                "reasoning_call_id": call_id,
+            },
+            {"execution": {"status": "ERROR"}},
+        ),
+    ]
+    transcript = tmp_path / "reasoning.jsonl"
+    transcript.write_text(
+        "\n".join(json.dumps(event) for event in events) + "\n",
+        encoding="utf-8",
+    )
+
+    telemetry = parse_agent_transcript(transcript)
+
+    assert telemetry["reasoning_protocol"] == {
+        "plan_count": 1,
+        "before_tool_count": 1,
+        "after_tool_count": 0,
+        "final_count": 0,
+        "run_count": 1,
+        "bound_invoke_count": 1,
+        "missing_after_tool_count": 1,
+        "summary_characters": len("private plan markerprivate before marker"),
+    }
+    assert "private plan marker" not in json.dumps(telemetry)
+
+
 def test_agent_telemetry_separates_wire_model_and_logical_invocation_bytes(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/tooling/test_mcp_tool_surface.py
+++ b/tests/unit/tooling/test_mcp_tool_surface.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+from jacobian.adapters.mcp.constants import ReasoningLogMode
 from jacobian.adapters.mcp.server import JacobianCoreExtension
 
 
 def test_core_extension_exposes_exactly_the_stable_capability_tools() -> None:
-    extension = JacobianCoreExtension(None, None)
+    extension = JacobianCoreExtension(None, None, ReasoningLogMode.OFF)
     assert extension.identifier == "io.jacobian/core"
-    assert extension.settings() == {"version": "1"}
+    assert extension.settings() == {"version": "2", "reasoning_log_mode": "OFF"}
     assert tuple(binding.kwargs["name"] for binding in extension.tools()) == (
         "capability.describe",
         "capability.invoke",

--- a/tools/c901-baseline.json
+++ b/tools/c901-baseline.json
@@ -23,6 +23,11 @@
       "complexity": 17
     },
     {
+      "path": "benchmarks/datasets/agent-workflow-v1/grid-independent-set-transfer/tests/verifier.py",
+      "symbol": "_result_shape_ok",
+      "complexity": 12
+    },
+    {
       "path": "benchmarks/datasets/agent-workflow-v1/indexed-pairwise-vacuity/tests/verifier.py",
       "symbol": "_evidence_valid",
       "complexity": 15
@@ -101,6 +106,11 @@
       "path": "benchmarks/datasets/provider-feasibility-v1/regina/environment/spike.py",
       "symbol": "_replay_triangulation",
       "complexity": 14
+    },
+    {
+      "path": "benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-016/tests/verifier.py",
+      "symbol": "_value_decisions",
+      "complexity": 11
     },
     {
       "path": "benchmarks/tooling/harbor_suite.py",


### PR DESCRIPTION
## Summary

Supersedes #438 (cross-repo fork could not be updated). Cherry-picks all five commits from the original PR onto current `origin/main` and addresses every open review thread.

This PR adds a bounded external work-log protocol around MCP capability calls. It records model-authored operational summaries; it does not expose hidden chain-of-thought and does not increase mathematical assurance.

- add REQUIRED, AUDIT, and OFF reasoning modes, with REQUIRED as the default
- enforce one PLAN, one BEFORE_TOOL before each capability call, one AFTER_TOOL after each result, and one FINAL audit
- bind entries to the actual capability ID, call ID, request/result digests, execution status, assurance, completeness, scope, and artifact references
- require structured AFTER_TOOL interpretations and report field-by-field agreement with the server-observed result
- serialize capability cycles within a run while allowing separate runs to proceed concurrently
- recover interrupted runs explicitly with runtime-instance identity and RESULT_UNAVAILABLE
- persist append-only SQLite records with contiguous sequence numbers and canonical digests
- document tenant isolation, retention/export/deletion, privacy limits, and the fact that FINAL cannot prevent an out-of-band host answer
- normalize protocol evidence into Harbor observations without retaining reasoning-summary text
- support OFF-control versus REQUIRED-treatment experiments while keeping model, prompt, task, and Jacobian availability fixed
- make process-limit detection portable on macOS without changing Linux behavior

## Review thread fixes (all 7 threads addressed)

- **P1 #3714645770**: `deploy/smoke_remote` now accepts `reasoning.write` as an optional tool instead of requiring an exact two-tool surface
- **P1 #3714645777**: `--reasoning-log-mode` CLI parsing is now case-insensitive; compose default changed to lowercase `required`
- **P1 #3714645783**: observation evidence fails closed when `jacobian_enabled` is True but `reasoning_log_mode` is absent or invalid
- **P1 #3714645796**: observation comparison now compares all runtime condition fields except the explicitly varying `id`/`role`/`mode`
- **P2 #3714645788**: `capability.describe` CONTRACT view invocations are now protocol-aware, annotating required reasoning IDs in REQUIRED mode
- **P2 #3714645807**: runnable tutorials explicitly opt into `off` mode so they remain executable with the new REQUIRED default
- **P2 #3714645813**: `docs/reference/state-format.md` updated to revision 7 with the reasoning-log migration documented

## Fail-closed behavior

In REQUIRED mode, missing or stale PLAN, BEFORE_TOOL, AFTER_TOOL, or FINAL transitions are rejected. Capability results remain capped by their existing assurance contracts; a reasoning entry is never verification evidence. Malformed, unavailable, timed-out, and mismatched results remain explicit rather than being promoted into conclusions.

The MCP server can enforce protocol calls made through its surface. It cannot prevent a host from returning an answer outside that surface, so FINAL is auditable at the Jacobian boundary rather than a claim of universal host control.

#### Test plan

- [x] `make test-plan BASE=origin/main`
- [x] `make test-affected BASE=origin/main` — unit 510, component 692, domain 153, composition 448+2 skips, storage 106, process, mcp, e2e, npm, static, build, security, duplicate, docs, deploy-check all green
- [x] `make check-static` — ruff, format, complexity baseline, mypy, vulture, deptry clean
- [x] focused observation/comparison/MCP/migration tests pass

Generated with [Devin](https://devin.ai)