### PR TITLE
fix(mcp): address post-merge reasoning-log review threads

### DIFF
--- a/docs/how-to/deploy-remote-mcp.md
+++ b/docs/how-to/deploy-remote-mcp.md
@@ -10,15 +10,16 @@ deployment source of truth. Keep host-specific copies, smoke output, and
 last-deployed notes outside source control; do not install configuration from
 operator scratch space or treat it as current.
 
-By default the server exposes `capability.describe`, `capability.invoke`, and
-the operational `reasoning.write` protocol. Clients may
-read installed descriptors from `capability://catalog` and inspect exact
-contracts before invoking mathematical operations, which remain behind
+By default the server exposes `capability.describe` and `capability.invoke`.
+Clients may read installed descriptors from `capability://catalog` and inspect
+exact contracts before invoking mathematical operations, which remain behind
 namespaced capability IDs.
 
-`--reasoning-log-mode required` is the default. Use `audit` only for staged
-fail-open observation and `off` only for rollback or a controlled legacy
-evaluation. These modes do not change capability assurance or checker authority.
+`--reasoning-log-mode off` is the default. Use `required` to enforce the
+operational `reasoning.write` protocol (PLAN → BEFORE_TOOL → invoke →
+AFTER_TOOL → FINAL) and expose the `reasoning.write` tool, or `audit` for
+staged fail-open observation. These modes do not change capability assurance
+or checker authority.
 
 ## Install from a clone
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -6,22 +6,22 @@
 - Installed membership remains runtime-defined
 
 Jacobian exposes mathematical operations as namespaced capabilities. The
-model-facing MCP surface contains two capability tools and, by default, one
-operational reasoning-log tool:
+model-facing MCP surface contains two capability tools and, in `REQUIRED` or
+`AUDIT` mode, one operational reasoning-log tool:
 
 | MCP tool | Purpose |
 | --- | --- |
 | `capability.describe` | Search the compact installed index, or read one capability's exact schemas by ID. |
 | `capability.invoke` | Invoke an installed capability in `EXPLORE` or `VERIFY` mode. |
-| `reasoning.write` | Append a bounded model-authored `PLAN`, `BEFORE_TOOL`, `AFTER_TOOL`, or `FINAL` summary. |
+| `reasoning.write` | Append a bounded model-authored `PLAN`, `BEFORE_TOOL`, `AFTER_TOOL`, or `FINAL` summary. Available only in `REQUIRED` or `AUDIT` mode. |
 
 The reasoning log is not a mathematical capability, proof object, workspace, or
-chain-of-thought collector. In the default `REQUIRED` mode, every
-`capability.invoke` must carry the `reasoning_run_id` and `reasoning_call_id`
-returned by the current `BEFORE_TOOL`. The server binds the actual execution
-status, assurance, completeness, result digest, and artifact URIs, then records
-whether the model's structured `AFTER_TOOL` report matches them, without copying
-the capability payload or output into the log. See the
+chain-of-thought collector. In `REQUIRED` mode, every `capability.invoke` must
+carry the `reasoning_run_id` and `reasoning_call_id` returned by the current
+`BEFORE_TOOL`. The server binds the actual execution status, assurance,
+completeness, result digest, and artifact URIs, then records whether the model's
+structured `AFTER_TOOL` report matches them, without copying the capability
+payload or output into the log. See the
 [reasoning-log protocol](reasoning-log.md).
 
 Read `capability://catalog` to discover installed capability IDs, provider
@@ -32,8 +32,9 @@ support, recommendation, conformance coverage, or authority to return
 
 There are no alternate mathematical capability profiles and no public top-level
 MCP commands for individual mathematical operations. The operator may set the
-reasoning-log enforcement mode to `REQUIRED`, `AUDIT`, or `OFF`; `OFF` preserves
-the legacy two-tool surface. Adding a capability does not add a new MCP tool.
+reasoning-log enforcement mode to `REQUIRED`, `AUDIT`, or `OFF`; `OFF` is the
+default and preserves the legacy two-tool surface. Adding a capability does not
+add a new MCP tool.
 
 ## Capability contract
 

--- a/src/jacobian/adapters/mcp/tooling.py
+++ b/src/jacobian/adapters/mcp/tooling.py
@@ -33,21 +33,28 @@ async def _run_blocking[BlockingResultT](
     *args: Any,
     on_cancel: Callable[[], None] | None = None,
 ) -> BlockingResultT:
-    """Run blocking MCP work without detaching it from request teardown."""
+    """Run blocking MCP work without detaching it from request teardown.
+
+    On cancellation, waits for the worker to drain and stores the result
+    in the ``drained_result`` attribute so the caller can persist a
+    completed outcome instead of unconditionally recording cancellation.
+    """
 
     worker = asyncio.create_task(asyncio.to_thread(function, *args))
     try:
         return await asyncio.shield(worker)
-    except asyncio.CancelledError:
+    except asyncio.CancelledError as exc:
         if on_cancel is not None:
             on_cancel()
+        drained: BlockingResultT | None = None
         try:
-            await asyncio.shield(worker)
+            drained = await asyncio.shield(worker)
         except Exception:
             _LOGGER.debug(
                 "blocking MCP worker failed while its cancelled request drained",
                 exc_info=True,
             )
+        exc.drained_result = drained  # type: ignore[attr-defined]
         raise
 
 
@@ -280,28 +287,51 @@ async def _invoke_capability_attempt(
             cancellation_event,
             on_cancel=cancellation_event.set,
         )
-    except asyncio.CancelledError:
-        _finish_failed_reasoning_call(
-            runtime,
-            bound=bound,
-            run_id=reasoning_run_id,
-            call_id=reasoning_call_id,
-            capability_id=capability_id,
-            mode=mode,
-            argument_digest=argument_digest,
-            execution_status="CANCELLED",
-            diagnostic_code="CLIENT_CANCELLED",
-        )
-        _log_capability_attempt(
-            capability_id=capability_id,
-            mode=mode,
-            started=started,
-            argument_digest=argument_digest,
-            trace_digest=trace_digest,
-            trace_source=trace_source,
-            execution_status="CANCELLED",
-            diagnostic_codes=("CLIENT_CANCELLED",),
-        )
+    except asyncio.CancelledError as exc:
+        drained = getattr(exc, "drained_result", None)
+        if isinstance(drained, CapabilityResult):
+            if bound:
+                assert reasoning_run_id is not None
+                assert reasoning_call_id is not None
+                runtime.core.reasoning_log.finish_call(
+                    reasoning_run_id,
+                    reasoning_call_id,
+                    capability_id,
+                    mode,
+                    argument_digest,
+                    result=drained,
+                )
+            _log_capability_attempt(
+                capability_id=capability_id,
+                mode=mode,
+                started=started,
+                argument_digest=argument_digest,
+                trace_digest=trace_digest,
+                trace_source=trace_source,
+                result=drained,
+            )
+        else:
+            _finish_failed_reasoning_call(
+                runtime,
+                bound=bound,
+                run_id=reasoning_run_id,
+                call_id=reasoning_call_id,
+                capability_id=capability_id,
+                mode=mode,
+                argument_digest=argument_digest,
+                execution_status="CANCELLED",
+                diagnostic_code="CLIENT_CANCELLED",
+            )
+            _log_capability_attempt(
+                capability_id=capability_id,
+                mode=mode,
+                started=started,
+                argument_digest=argument_digest,
+                trace_digest=trace_digest,
+                trace_source=trace_source,
+                execution_status="CANCELLED",
+                diagnostic_codes=("CLIENT_CANCELLED",),
+            )
         raise
     except Exception:
         _finish_failed_reasoning_call(

--- a/src/jacobian/reasoning_log.py
+++ b/src/jacobian/reasoning_log.py
@@ -189,14 +189,19 @@ class ReasoningLogService:
         run_id = str(uuid4())
         with self.store.connection() as connection:
             connection.execute("BEGIN IMMEDIATE")
+            # Count only active (non-finalized) runs.  Finalized runs are
+            # retained as immutable evidence but do not count against the
+            # concurrent-run ceiling, so a long-lived tenant is not
+            # exhausted by completed protocols.
             (count,) = connection.execute(
-                "SELECT COUNT(*) FROM reasoning_runs"
+                "SELECT COUNT(*) FROM reasoning_runs WHERE run_id NOT IN "
+                "(SELECT run_id FROM reasoning_events WHERE kind = 'FINAL')"
             ).fetchone()
             if count >= MAX_RUNS:
                 self._raise(
                     "REASONING_RUN_LIMIT",
-                    f"The aggregate reasoning-run limit ({MAX_RUNS}) has been reached.",
-                    "Contact the operator to prune old reasoning runs or raise the limit.",
+                    f"The active reasoning-run limit ({MAX_RUNS}) has been reached.",
+                    "Finalize or abandon existing runs before starting new ones.",
                 )
             connection.execute(
                 "INSERT INTO reasoning_runs(run_id) VALUES (?)", (run_id,)


### PR DESCRIPTION
## Summary

Addresses 3 review threads that appeared on PR #475 after merge.

- **P1**: \`reasoning_log._create_run\` now counts only active (non-finalized) runs against the \`MAX_RUNS\` ceiling. Finalized runs are retained as immutable evidence but don't exhaust the quota, so a long-lived tenant isn't locked out by completed protocols.
- **P2**: \`_run_blocking\` now stores the drained worker result on the \`CancelledError\` exception. The cancellation handler checks for it and records the actual execution status + artifact references instead of unconditionally recording \`CANCELLED\`.
- **P2**: Updated \`docs/how-to/deploy-remote-mcp.md\` and \`docs/reference/tools.md\` to reflect the OFF default and the REQUIRED/AUDIT opt-in for \`reasoning.write\`.

#### Test plan

- [x] \`ruff check\` + \`ruff format --check\` + \`check_complexity.py\` clean
- [x] \`test_mcp_reasoning_log.py\`, \`test_mcp_operations.py\`, \`test_reasoning_log_service.py\`, \`test_reasoning_log.py\` — 21 passed

Generated with [Devin](https://devin.ai)