### PR TITLE
fix(benchmarks): resolve deferred benchmark Oracle ownership on main pushes

### DIFF
--- a/.github/scripts/plan-benchmarks
+++ b/.github/scripts/plan-benchmarks
@@ -573,28 +573,14 @@ def plan(
     by_task, suites_by_id = _membership()
     topology_digest = _topology_digest(list(suites_by_id.values()))
 
-    # A main push repeats the deterministic contract lanes for the landed tree
-    # without rerunning the same Docker Oracle portfolio after merge-queue
-    # validation.  Inventory validation is the merge queue's responsibility.
-    if event == "push":
-        return _emit(
-            event=event,
-            base=base,
-            head=head,
-            planner_digest=planner_digest,
-            topology_digest=topology_digest,
-            mode="changed",
-            run_check=True,
-            record_schema=True,
-            prospective_digest=True,
-            inventory=False,
-            run_oracle=False,
-            scope="none",
-            matrix=[],
-            reasons=["main push repeats contracts; merge queue owns Oracle evidence"],
-        )
-
-    integration = event == "merge_group"
+    # Both merge-group validation and a landed main push are integration
+    # boundaries.  A repository may permit direct merges, so a push cannot
+    # assume that a merge-group run already owns Oracle evidence deferred by
+    # the pull-request task cap or by integration-only path classification.
+    # Replaying after a merge queue is intentionally conservative: avoiding
+    # that duplication requires a content-bound evidence handoff, not an
+    # assumption that a merge-group run occurred.
+    integration = event in {"merge_group", "push"}
     classification = _classify_benchmark_paths(
         benchmark_paths, suites_by_id, integration=integration
     )

--- a/benchmarks/validation/test_benchmark_planner.py
+++ b/benchmarks/validation/test_benchmark_planner.py
@@ -403,6 +403,27 @@ def test_large_task_set_is_deferred_from_pull_request_to_merge_queue() -> None:
     assert set(task_ids) <= _matrix_tasks(merge_group)
 
 
+def test_large_task_set_deferred_on_pull_request_runs_on_main_push() -> None:
+    by_task, _suites = planner._membership()
+    task_ids = sorted(by_task)[:9]
+    paths = [
+        f"benchmarks/datasets/{dataset}/{task_id}/tests/verifier.py"
+        for task_id in task_ids
+        for dataset, _path in by_task[task_id]
+    ]
+
+    pull_request = planner.plan(paths, event="pull_request")
+    push = planner.plan(paths, event="push")
+
+    assert pull_request["run-benchmark-oracle"] == "false"
+    assert push["run-benchmark-oracle"] == "true"
+    assert push["benchmark-oracle-scope"] == "changed-tasks"
+    assert push["benchmark-plan-mode"] == "integration"
+    assert push["run-benchmark-inventory"] == "true"
+    assert set(task_ids) <= _matrix_tasks(push)
+    _assert_plan_valid(push)
+
+
 def test_documentation_changes_do_not_consume_the_oracle_task_cap() -> None:
     by_task, _suites = planner._membership()
     task_ids = sorted(by_task)[:9]
@@ -423,17 +444,17 @@ def test_documentation_changes_do_not_consume_the_oracle_task_cap() -> None:
     assert _matrix_tasks(result) == {task_ids[0]}
 
 
-def test_main_push_runs_contracts_without_inventory_or_oracle() -> None:
+def test_main_push_owns_integration_oracle_and_inventory() -> None:
     result = planner.plan(["benchmarks/tooling/verifier_support.py"], event="push")
 
     assert result["run-benchmark-check"] == "true"
     assert result["run-benchmark-record-schema"] == "true"
     assert result["run-benchmark-prospective-digest"] == "true"
-    assert result["run-benchmark-inventory"] == "false"
-    assert result["run-benchmark-oracle"] == "false"
-    assert result["benchmark-oracle-scope"] == "none"
-    assert result["benchmark-plan-mode"] == "changed"
-    assert _matrix(result) == []
+    assert result["run-benchmark-inventory"] == "true"
+    assert result["run-benchmark-oracle"] == "true"
+    assert result["benchmark-oracle-scope"] == "all"
+    assert result["benchmark-plan-mode"] == "integration"
+    assert _matrix(result)
     _assert_plan_valid(result)
 
 

--- a/tests/boundary/process/tooling/test_benchmark_classification.py
+++ b/tests/boundary/process/tooling/test_benchmark_classification.py
@@ -119,3 +119,22 @@ def test_shared_environment_profile_escalates_only_on_integration_event(
     assert pull_request["run-benchmark-oracle"] == "false"
     assert merge_group["run-benchmark-oracle"] == "true"
     assert merge_group["benchmark-oracle-scope"] == "all"
+
+
+def test_main_push_is_an_integration_owner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load()
+    _patch_plan(module, monkeypatch)
+
+    push = module.plan(
+        ["benchmarks/environment-profiles.toml"],
+        event="push",
+        base="a" * 40,
+        head="b" * 40,
+    )
+
+    assert push["run-benchmark-oracle"] == "true"
+    assert push["benchmark-oracle-scope"] == "all"
+    assert push["run-benchmark-inventory"] == "true"
+    assert push["benchmark-plan-mode"] == "integration"


### PR DESCRIPTION
## Summary

Fixes #490 by making a benchmark-changing push to `main` an integration validation boundary, alongside `merge_group`.

A pull request may intentionally defer Docker Oracle work when more than eight executable tasks change, or when an integration-only benchmark path changes. The previous push plan assumed a merge-group run had already supplied that evidence. Direct merges violated that assumption, leaving the deferred Oracle without an owner while `Benchmark Validation` still passed.

## Changes

- classify both `merge_group` and `push` as benchmark integration events;
- run the appropriate content-derived Oracle scope and inventory validation on benchmark-changing main pushes;
- preserve the existing selective pull-request cap;
- add regression coverage for:
  - a nine-task PR deferral being recovered on push;
  - shared benchmark tooling changes selecting full integration validation;
  - environment-profile changes selecting full integration validation.

This deliberately prefers a conservative post-merge replay when a merge queue was used. Safely eliminating that duplication would require a content-bound evidence handoff proving that the merge-group evidence covers the landed tree.

## Validation

- focused planner and process-boundary tests: 42 passed;
- `make test-unit`: 510 passed;
- `make test-process`: 202 passed, 2 platform skips;
- `make check-static`: Ruff, formatting, complexity baseline, dependency audit, Vulture, mypy, and test architecture passed;
- `make build`: source distribution and wheel built successfully;
- `git diff --check`: passed.

No benchmark implementation, mathematical verifier, repository setting, dependency, or isolation policy is changed.