### PR TITLE
fix(benchmarks): bound exponential integer parsing

### DIFF
--- a/benchmarks/datasets/agent-workflow-v1/prime-power-divisibility-gap-audit/tests/Dockerfile
+++ b/benchmarks/datasets/agent-workflow-v1/prime-power-divisibility-gap-audit/tests/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
-LABEL jacobian.checksum="07ef4a8734c1e43fbf335247be6e4f7617397559549ac488c2b458eb95ae554c"
+LABEL jacobian.checksum="88a9fceb88222e1dd6511e31d0e3a0c5a53de223f649f5c1175b1bc00a150d77"
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/prime-power-divisibility-gap-audit"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/

--- a/benchmarks/datasets/agent-workflow-v1/prime-power-divisibility-gap-audit/tests/Dockerfile
+++ b/benchmarks/datasets/agent-workflow-v1/prime-power-divisibility-gap-audit/tests/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
-LABEL jacobian.checksum="88a9fceb88222e1dd6511e31d0e3a0c5a53de223f649f5c1175b1bc00a150d77"
+LABEL jacobian.checksum="89b6ef9627025e3d256e14b9a9b9f0673299267ace8ec750a0949cb052fb611d"
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/prime-power-divisibility-gap-audit"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/

--- a/benchmarks/datasets/agent-workflow-v1/prime-power-divisibility-gap-audit/tests/Dockerfile
+++ b/benchmarks/datasets/agent-workflow-v1/prime-power-divisibility-gap-audit/tests/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
-LABEL jacobian.checksum="0415ccf91c1fe24beeb2c09cb0d054fa58d98f6bf987cbec96b6df2b537f6a56"
+LABEL jacobian.checksum="07ef4a8734c1e43fbf335247be6e4f7617397559549ac488c2b458eb95ae554c"
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/prime-power-divisibility-gap-audit"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/

--- a/benchmarks/datasets/agent-workflow-v1/prime-power-divisibility-gap-audit/tests/verifier.py
+++ b/benchmarks/datasets/agent-workflow-v1/prime-power-divisibility-gap-audit/tests/verifier.py
@@ -32,17 +32,17 @@ class _JsonFloat(float):
         return instance
 
 
-def _bounded_json_float(value: str) -> _JsonFloat:
+def _bounded_json_float(value: str) -> int | _JsonFloat:
     try:
         exact = Decimal(value)
     except InvalidOperation as error:
         raise ValueError(f"invalid JSON number: {value}") from error
+    if not exact.is_finite() or (exact != 0 and exact.adjusted() >= MAX_INTEGER_DIGITS):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    if exact == exact.to_integral_value():
+        return int(exact)
     parsed = _JsonFloat(value)
-    if (
-        not exact.is_finite()
-        or not math.isfinite(parsed)
-        or (exact != 0 and exact.adjusted() >= MAX_INTEGER_DIGITS)
-    ):
+    if not math.isfinite(parsed):
         raise ValueError(f"out-of-range JSON number: {value}")
     return parsed
 

--- a/benchmarks/datasets/agent-workflow-v1/prime-power-divisibility-gap-audit/tests/verifier.py
+++ b/benchmarks/datasets/agent-workflow-v1/prime-power-divisibility-gap-audit/tests/verifier.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import math
+import sys
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any
@@ -18,6 +19,8 @@ from verifier_support import (
 WORKSPACE, TESTS = Path("/app"), Path("/tests")
 EVIDENCE_PATH = "evidence/divisibility-audit.json"
 LIMITATION = "The countermodel refutes the frozen divisibility inference; it does not adjudicate the source theorem."
+# Keep exponent-form integers within Python's default raw-integer parsing ceiling.
+MAX_INTEGER_DIGITS = sys.int_info.default_max_str_digits
 
 
 class _JsonFloat(float):
@@ -48,17 +51,32 @@ def _submission() -> dict[str, Any] | None:
     return value if isinstance(value, dict) else None
 
 
-def _integer(value: object) -> int | None:
+def _integer(
+    value: object, *, minimum: int | None = None, maximum: int | None = None
+) -> int | None:
     if type(value) is int:
-        return value
+        integer = value
     if isinstance(value, _JsonFloat):
         try:
             exact = Decimal(value.lexeme)
         except InvalidOperation:
             return None
-        if exact.is_finite() and exact == exact.to_integral_value():
-            return int(exact)
-    return None
+        if (
+            not exact.is_finite()
+            or exact != exact.to_integral_value()
+            or (exact != 0 and exact.adjusted() >= MAX_INTEGER_DIGITS)
+            or (minimum is not None and exact < minimum)
+            or (maximum is not None and exact > maximum)
+        ):
+            return None
+        integer = int(exact)
+    elif type(value) is not int:
+        return None
+    if minimum is not None and integer < minimum:
+        return None
+    if maximum is not None and integer > maximum:
+        return None
+    return integer
 
 
 def _prime(value: int) -> bool:
@@ -90,28 +108,28 @@ def _result(value: object, frozen: dict[str, Any]) -> bool:
         "global_statement",
         "missing_condition",
     }
+    maximum_modulus = frozen.get("maximum_modulus")
     if (
         not isinstance(value, dict)
         or set(value) != fields
         or frozen.get("human_score") != 0
+        or type(maximum_modulus) is not int
+        or maximum_modulus < 4
     ):
         return False
-    prime = _integer(value["prime"])
-    exponent = _integer(value["exponent"])
-    factor = _integer(value["coprime_factor"])
-    modulus = _integer(value["modulus"])
-    cycle_count = _integer(value["cycle_count"])
-    total = _integer(value["total_sum"])
+    prime = _integer(value["prime"], minimum=2, maximum=29)
+    exponent = _integer(value["exponent"], minimum=2, maximum=6)
+    factor = _integer(value["coprime_factor"], minimum=1, maximum=1)
+    modulus = _integer(value["modulus"], minimum=4, maximum=maximum_modulus)
+    cycle_count = _integer(
+        value["cycle_count"], minimum=4, maximum=maximum_modulus // 2
+    )
+    total = _integer(value["total_sum"], minimum=1)
     if None in {prime, exponent, factor, modulus, cycle_count, total}:
         return False
-    if not (2 <= prime <= 29 and _prime(prime) and 2 <= exponent <= 6 and factor == 1):
+    if not (_prime(prime) and factor == 1):
         return False
-    if (
-        modulus != prime**exponent * factor
-        or modulus > frozen.get("maximum_modulus")
-        or cycle_count != modulus // prime
-        or cycle_count < 4
-    ):
+    if modulus != prime**exponent * factor or cycle_count != modulus // prime:
         return False
     groups = value["cycle_groups"]
     if not isinstance(groups, list) or not 2 <= len(groups) <= 6:
@@ -122,13 +140,11 @@ def _result(value: object, frozen: dict[str, Any]) -> bool:
     for group in groups:
         if not isinstance(group, dict) or set(group) != {"multiplicity", "cycle_sum"}:
             return False
-        multiplicity = _integer(group["multiplicity"])
-        cycle_sum = _integer(group["cycle_sum"])
+        multiplicity = _integer(group["multiplicity"], minimum=1, maximum=cycle_count)
+        cycle_sum = _integer(group["cycle_sum"], minimum=1)
         if (
             multiplicity is None
             or cycle_sum is None
-            or multiplicity < 1
-            or cycle_sum < 1
             or cycle_sum in seen_sums
             or cycle_sum % prime
         ):
@@ -136,9 +152,13 @@ def _result(value: object, frozen: dict[str, Any]) -> bool:
         seen_sums.add(cycle_sum)
         multiplicity_sum += multiplicity
         recomputed_total += multiplicity * cycle_sum
-    reported_modulus_valuation = _integer(value["p_valuation_modulus"])
-    reported_total_valuation = _integer(value["p_valuation_total"])
-    if total <= 0 or None in {reported_modulus_valuation, reported_total_valuation}:
+    reported_modulus_valuation = _integer(
+        value["p_valuation_modulus"], minimum=2, maximum=exponent
+    )
+    reported_total_valuation = _integer(
+        value["p_valuation_total"], minimum=1, maximum=exponent - 1
+    )
+    if None in {reported_modulus_valuation, reported_total_valuation}:
         return False
     valuation_modulus = _valuation(modulus, prime)
     valuation_total = _valuation(total, prime)

--- a/benchmarks/datasets/agent-workflow-v1/prime-power-divisibility-gap-audit/tests/verifier.py
+++ b/benchmarks/datasets/agent-workflow-v1/prime-power-divisibility-gap-audit/tests/verifier.py
@@ -11,7 +11,7 @@ from verifier_support import (
     MAX_SUBMISSION_BYTES,
     false_verified_claim,
     is_regular_bounded_file,
-    read_evidence_json,
+    resolve_evidence,
     strict_submission_contract,
     workspace_input_is_bound,
 )
@@ -32,6 +32,36 @@ class _JsonFloat(float):
         return instance
 
 
+def _bounded_json_float(value: str) -> _JsonFloat:
+    try:
+        exact = Decimal(value)
+    except InvalidOperation as error:
+        raise ValueError(f"invalid JSON number: {value}") from error
+    parsed = _JsonFloat(value)
+    if (
+        not exact.is_finite()
+        or not math.isfinite(parsed)
+        or (exact != 0 and exact.adjusted() >= MAX_INTEGER_DIGITS)
+    ):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _read_untrusted_json(path: Path) -> object | None:
+    try:
+        return json.loads(
+            path.read_text(),
+            parse_float=_bounded_json_float,
+            parse_constant=_reject_nonfinite_json,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+
+
 def _frozen() -> dict[str, Any]:
     try:
         value = json.loads((TESTS / "input.json").read_text())
@@ -44,10 +74,7 @@ def _submission() -> dict[str, Any] | None:
     path = WORKSPACE / "submission.json"
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text(), parse_float=_JsonFloat)
-    except (OSError, ValueError, RecursionError, MemoryError):
-        return None
+    value = _read_untrusted_json(path)
     return value if isinstance(value, dict) else None
 
 
@@ -180,7 +207,10 @@ def _evidence(submission: dict[str, Any], *, expected_task_id: str) -> bool:
     evidence = submission.get("evidence")
     if not isinstance(evidence, list) or len(evidence) != 1:
         return False
-    payload = read_evidence_json(evidence[0], expected_path=EVIDENCE_PATH)
+    evidence_path = resolve_evidence(evidence[0], expected_path=EVIDENCE_PATH)
+    if evidence_path is None:
+        return False
+    payload = _read_untrusted_json(evidence_path)
     return bool(
         isinstance(payload, dict)
         and set(payload) == {"schema_version", "task_id", "result", "limitations"}

--- a/benchmarks/validation/agent_workflow_v1/test_prime_power_divisibility_gap_audit.py
+++ b/benchmarks/validation/agent_workflow_v1/test_prime_power_divisibility_gap_audit.py
@@ -173,6 +173,43 @@ def test_rejects_decimal_token_rounded_by_binary_float(tmp_path: Path) -> None:
     assert reward["reward"] == 0.0
 
 
+def test_rejects_exponential_integer_before_materializing_it(tmp_path: Path) -> None:
+    submission = copy.deepcopy(_oracle())
+    task, app, logs = _prepare(tmp_path, submission)
+    submission_text = json.dumps(submission).replace(
+        '"prime": 2', '"prime": 1e10000000', 1
+    )
+    (app / "submission.json").write_text(submission_text)
+
+    reward = _run_verifier(task, app, logs)
+
+    assert reward["correctness"] == 0.0
+    assert reward["evidence_validity"] == 0.0
+    assert reward["protocol_compliance"] == 0.0
+    assert reward["reward"] == 0.0
+
+
+def test_accepts_bounded_exponential_integer_tokens(tmp_path: Path) -> None:
+    submission = copy.deepcopy(_oracle())
+    task, app, logs = _prepare(tmp_path, submission)
+    evidence_path = app / "evidence/divisibility-audit.json"
+    evidence_path.write_text(
+        evidence_path.read_text().replace('"prime":2', '"prime":2e0', 1)
+    )
+    submission["evidence"][0]["sha256"] = (
+        "sha256:" + hashlib.sha256(evidence_path.read_bytes()).hexdigest()
+    )
+    submission_text = json.dumps(submission).replace('"prime": 2', '"prime": 2e0', 1)
+    (app / "submission.json").write_text(submission_text)
+
+    reward = _run_verifier(task, app, logs)
+
+    assert reward["correctness"] == 1.0
+    assert reward["evidence_validity"] == 1.0
+    assert reward["protocol_compliance"] == 1.0
+    assert reward["reward"] == 1.0
+
+
 def test_protocol_and_input_failures_preserve_diagnostics(tmp_path: Path) -> None:
     bad_conclusion = copy.deepcopy(_oracle())
     bad_conclusion["conclusion"] = "WRONG"

--- a/benchmarks/validation/agent_workflow_v1/test_prime_power_divisibility_gap_audit.py
+++ b/benchmarks/validation/agent_workflow_v1/test_prime_power_divisibility_gap_audit.py
@@ -176,6 +176,13 @@ def test_rejects_decimal_token_rounded_by_binary_float(tmp_path: Path) -> None:
 def test_rejects_exponential_integer_before_materializing_it(tmp_path: Path) -> None:
     submission = copy.deepcopy(_oracle())
     task, app, logs = _prepare(tmp_path, submission)
+    evidence_path = app / "evidence/divisibility-audit.json"
+    evidence_path.write_text(
+        evidence_path.read_text().replace('"prime":2', '"prime":1e10000000', 1)
+    )
+    submission["evidence"][0]["sha256"] = (
+        "sha256:" + hashlib.sha256(evidence_path.read_bytes()).hexdigest()
+    )
     submission_text = json.dumps(submission).replace(
         '"prime": 2', '"prime": 1e10000000', 1
     )

--- a/benchmarks/validation/agent_workflow_v1/test_prime_power_divisibility_gap_audit.py
+++ b/benchmarks/validation/agent_workflow_v1/test_prime_power_divisibility_gap_audit.py
@@ -198,15 +198,23 @@ def test_rejects_exponential_integer_before_materializing_it(tmp_path: Path) -> 
 
 def test_accepts_bounded_exponential_integer_tokens(tmp_path: Path) -> None:
     submission = copy.deepcopy(_oracle())
+    result = submission["result"]
+    result["cycle_groups"] = [
+        {"multiplicity": 1, "cycle_sum": 2},
+        {"multiplicity": 3, "cycle_sum": 2},
+    ]
+    result["total_sum"] = int("2" + "0" * 308 + "6")
     task, app, logs = _prepare(tmp_path, submission)
     evidence_path = app / "evidence/divisibility-audit.json"
     evidence_path.write_text(
-        evidence_path.read_text().replace('"prime":2', '"prime":2e0', 1)
+        evidence_path.read_text().replace('"cycle_sum":2', '"cycle_sum":2e309', 1)
     )
     submission["evidence"][0]["sha256"] = (
         "sha256:" + hashlib.sha256(evidence_path.read_bytes()).hexdigest()
     )
-    submission_text = json.dumps(submission).replace('"prime": 2', '"prime": 2e0', 1)
+    submission_text = json.dumps(submission).replace(
+        '"cycle_sum": 2', '"cycle_sum": 2e309', 1
+    )
     (app / "submission.json").write_text(submission_text)
 
     reward = _run_verifier(task, app, logs)


### PR DESCRIPTION
## Summary

The prime-power divisibility verifier converts submitted JSON numbers to integers. A raw JSON exponent such as `1e100000000` could make the decimal-to-integer conversion allocate an unexpectedly large value before the verifier applied its ordinary numeric bounds.

This follow-up bounds the exponent lexeme before conversion and adds an adversarial regression covering the oversized exponent path. It is intentionally limited to the verifier/parser boundary; the mathematical audit and evidence contract from #492 are unchanged.

## Validation

- `uv run pytest -q benchmarks/validation/agent_workflow_v1/test_prime_power_divisibility_gap_audit.py` (15 passed)
- `make complexity-check`
