### PR TITLE
feat(benchmarks): add a focused Harbor execution-configuration gate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ capability membership.
 | --- | --- | --- |
 | Documentation, benchmark README, or `benchmarks/validation/` | `make docs-command-check` (and `make docs-linkcheck` for Markdown links) | None |
 | Focused Python behavior | `make test-plan BASE=<revision>`, the selected lane, then `make check` | None |
-| Harbor job, MCP, Compose, or execution configuration | `make harbor-execution-check` | None |
+| Harbor job JSON, MCP config, job-level Compose overlay, or execution helper | `make harbor-execution-check` | None |
 | Benchmark task input or verifier | `make harbor-check-task DATASET=... TASKS=...`, then `make harbor-oracle-task DATASET=... TASKS=...` | Exact selected-task Oracle |
 | Deployment entrypoint | `make deploy-check` | None |
 | CI, dependencies, or unknown paths | `make check-static` plus affected tests | As required by the selected plan |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,7 @@ capability membership.
 | --- | --- | --- |
 | Documentation, benchmark README, or `benchmarks/validation/` | `make docs-command-check` (and `make docs-linkcheck` for Markdown links) | None |
 | Focused Python behavior | `make test-plan BASE=<revision>`, the selected lane, then `make check` | None |
+| Harbor job, MCP, Compose, or execution configuration | `make harbor-execution-check` | None |
 | Benchmark task input or verifier | `make harbor-check-task DATASET=... TASKS=...`, then `make harbor-oracle-task DATASET=... TASKS=...` | Exact selected-task Oracle |
 | Deployment entrypoint | `make deploy-check` | None |
 | CI, dependencies, or unknown paths | `make check-static` plus affected tests | As required by the selected plan |

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ ORDERING_DEFAULT_SEED := --randomly-seed=17
 PYTEST_DIAGNOSTIC_ARGS ?= --durations=10
 RUFF_PATHS := src tests benchmarks
 TOPOLOGY_RUNNER := $(UV_RUN) python tools/test_topology.py
-PUBLIC_COMMANDS := help setup check check-changed ci-plan test-plan test-changed test-unit test-component test-domain test-composition test-storage test-process test-mcp test-provider test-lean test-e2e docs-command-check docs-linkcheck harbor-plan harbor-check-task harbor-oracle-task npm-test test-all-ci check-static deploy-check
+PUBLIC_COMMANDS := help setup check check-changed ci-plan test-plan test-changed test-unit test-component test-domain test-composition test-storage test-process test-mcp test-provider test-lean test-e2e docs-command-check docs-linkcheck harbor-plan harbor-execution-check harbor-check-task harbor-oracle-task npm-test test-all-ci check-static deploy-check
 
 ifneq ($(strip $(PATHS)),)
 PATHS_FILE := $(shell mktemp)
@@ -26,7 +26,7 @@ endif
 # in pyproject.toml: direct pytest invocations must not silently inherit a
 # signal-based deadline that cannot interrupt a native solver.  Process and
 # provider lanes run risky work in killable children and set their own deadline.
-.PHONY: help help-all uv-version-check setup setup-agent container-image eval-image eval-image-pull eval-image-bind hooks fix lint complexity-check lint-full security-audit typecheck test-architecture architecture ci-plan test-plan test-changed check-changed test-unit test-component test-domain test-composition test-storage test-process test-mcp test-provider test-lean test-e2e test-affected test-all-ci test-compatibility test-stress test-ordering duplicate-code npm-test todo-check coverage build check precommit check-static harbor-plan harbor-sync harbor-contracts harbor-adapter-checks harbor-validation-tests harbor-validate harbor-check harbor-check-task benchmark-inventory benchmark-snapshot benchmark-snapshot-validate benchmark-publish harbor-oracle harbor-oracle-task harbor-oracle-run harbor-oracle-all harbor-adapter-check heldout-validate heldout-render heldout-smoke agent-eval agent-eval-validate agent-eval-compare provider-eval clean docs-command-check docs-linkcheck deploy-check
+.PHONY: help help-all uv-version-check setup setup-agent container-image eval-image eval-image-pull eval-image-bind hooks fix lint complexity-check lint-full security-audit typecheck test-architecture architecture ci-plan test-plan test-changed check-changed test-unit test-component test-domain test-composition test-storage test-process test-mcp test-provider test-lean test-e2e test-affected test-all-ci test-compatibility test-stress test-ordering duplicate-code npm-test todo-check coverage build check precommit check-static harbor-plan harbor-sync harbor-contracts harbor-execution-check harbor-adapter-checks harbor-validation-tests harbor-validate harbor-check harbor-check-task benchmark-inventory benchmark-snapshot benchmark-snapshot-validate benchmark-publish harbor-oracle harbor-oracle-task harbor-oracle-run harbor-oracle-all harbor-adapter-check heldout-validate heldout-render heldout-smoke agent-eval agent-eval-validate agent-eval-compare provider-eval clean docs-command-check docs-linkcheck deploy-check
 
 help: ## Show available developer commands.
 	@awk -v public="$(PUBLIC_COMMANDS)" 'BEGIN {FS = ":.*## "; n = split(public, names, " "); for (i = 1; i <= n; i++) wanted[names[i]] = 1; printf "Jacobian common developer commands:\n\n"} /^[a-zA-Z_-]+:.*## / && ($$1 in wanted) {printf "  %-18s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -313,6 +313,10 @@ harbor-sync: ## Update verifier checksum labels for selected tasks (DATASET=... 
 harbor-contracts: ## Check Harbor sync, task topology, schemas, and generated records.
 	$(HARBOR_PYTHON) tools/check_harbor_dataset.py --check
 	$(HARBOR_PYTHON) tools/check_benchmark_contracts.py
+
+harbor-execution-check: harbor-contracts ## Check Harbor jobs, MCP config, Compose, and execution helpers.
+	$(UV_RUN) pytest -n 0 tests/unit/tooling/test_harbor*.py \
+		$(PYTEST_DIAGNOSTIC_ARGS) $(PYTEST_ARGS)
 
 harbor-adapter-checks: ## Check every repository-owned Harbor adapter.
 	@set -eu; for adapter_dir in benchmarks/adapters/*; do \

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -63,6 +63,7 @@ validation does not depend on files from the agent context.
 
 ```sh
 make harbor-plan BASE=origin/main
+make harbor-execution-check
 make harbor-check-task DATASET=agent-workflow-v1 TASKS="task-id"
 make benchmark-inventory OUTPUT=/tmp/benchmark-inventory.json
 make benchmark-snapshot DATASET=agent-workflow-v1
@@ -79,12 +80,15 @@ make provider-eval PROVIDER=cgal
 from the fixed `agent-workflow-v1` snapshots. Its task bundles are solvable
 without Jacobian and do not yet include the later comparison harness.
 
-`harbor-check-task` and `harbor-oracle-task` require an explicit dataset and
-task selection and are the normal gates for a leaf task. The full
-`harbor-check`/`harbor-oracle` paths remain for shared tooling, schemas,
-registry, suite policy, and control-plane changes. `harbor-oracle` requires
-`TASKS` unless `FULL=1` is explicitly supplied; `harbor-oracle-all` is the
-intentional full-portfolio sweep.
+`harbor-execution-check` is the focused local gate for job JSON, MCP
+configuration, Compose overlays, and their execution helpers. It checks Harbor
+contracts and the owning tooling tests without running the task-specific
+verifier regression corpus. `harbor-check-task` and `harbor-oracle-task`
+require an explicit dataset and task selection and are the normal gates for a
+leaf task. The full `harbor-check`/`harbor-oracle` paths remain for shared
+tooling, schemas, registry, suite policy, and control-plane changes.
+`harbor-oracle` requires `TASKS` unless `FULL=1` is explicitly supplied;
+`harbor-oracle-all` is the intentional full-portfolio sweep.
 
 Pull requests run contract checks and exact Oracles for changed executable
 tasks; large multi-task edits defer that matrix to the merge queue. Merge-queue

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -81,9 +81,12 @@ from the fixed `agent-workflow-v1` snapshots. Its task bundles are solvable
 without Jacobian and do not yet include the later comparison harness.
 
 `harbor-execution-check` is the focused local gate for job JSON, MCP
-configuration, Compose overlays, and their execution helpers. It checks Harbor
-contracts and the owning tooling tests without running the task-specific
-verifier regression corpus. `harbor-check-task` and `harbor-oracle-task`
+configuration, job-level Compose overlays, and their execution helpers. It
+checks Harbor contracts and the owning tooling tests without running the
+task-specific verifier regression corpus. Task
+`environment/docker-compose.yaml` files are executable benchmark input, not
+job overlays, and remain gated by `harbor-check-task` and
+`harbor-oracle-task`. `harbor-check-task` and `harbor-oracle-task`
 require an explicit dataset and task selection and are the normal gates for a
 leaf task. The full `harbor-check`/`harbor-oracle` paths remain for shared
 tooling, schemas, registry, suite policy, and control-plane changes.

--- a/benchmarks/tooling/benchmark_contracts.py
+++ b/benchmarks/tooling/benchmark_contracts.py
@@ -318,6 +318,22 @@ def validate_all() -> list[str]:
             BENCHMARKS / "config" / "agent-workflow-v1-control.json", suites[0]
         )
     )
+    failures.extend(
+        _validate_job(
+            BENCHMARKS / "config" / "agent-workflow-v1-control-proxy.json",
+            suites[0],
+        )
+    )
+    failures.extend(
+        _validate_job(
+            BENCHMARKS
+            / "datasets"
+            / "agent-workflow-v1"
+            / "jobs"
+            / "jacobian-observation-proxy.json",
+            suites[0],
+        )
+    )
     failures.extend(_observation_pair_failures())
     failures.extend(_snapshot_contract_failures())
     return failures

--- a/docs/how-to/run-agent-evaluations.md
+++ b/docs/how-to/run-agent-evaluations.md
@@ -30,6 +30,17 @@ paths only for shared Harbor tooling, schemas, registry, suite policy, or
 other control-plane changes. Pass `TASKS="..."` for a bounded dataset Oracle;
 pass `FULL=1` only when a complete dataset sweep is intentional.
 
+For changes limited to Harbor job JSON, MCP configuration, Compose overlays,
+or their execution helpers, use the focused local handoff instead:
+
+```sh
+make harbor-execution-check
+```
+
+This checks repository Harbor contracts and the execution-configuration unit
+tests without running the task-specific verifier regression corpus, an Oracle,
+Docker, or a model.
+
 Task README and `benchmarks/validation/` changes do not require an Oracle;
 they affect documentation or deterministic host-side validation. Changes to a
 task's executable input or clean-room verifier do require the exact selected

--- a/docs/how-to/run-agent-evaluations.md
+++ b/docs/how-to/run-agent-evaluations.md
@@ -30,8 +30,8 @@ paths only for shared Harbor tooling, schemas, registry, suite policy, or
 other control-plane changes. Pass `TASKS="..."` for a bounded dataset Oracle;
 pass `FULL=1` only when a complete dataset sweep is intentional.
 
-For changes limited to Harbor job JSON, MCP configuration, Compose overlays,
-or their execution helpers, use the focused local handoff instead:
+For changes limited to Harbor job JSON, MCP configuration, job-level Compose
+overlays, or their execution helpers, use the focused local handoff instead:
 
 ```sh
 make harbor-execution-check
@@ -39,7 +39,9 @@ make harbor-execution-check
 
 This checks repository Harbor contracts and the execution-configuration unit
 tests without running the task-specific verifier regression corpus, an Oracle,
-Docker, or a model.
+Docker, or a model. Task `environment/docker-compose.yaml` files are
+executable benchmark input, not job overlays; they remain gated by
+`make harbor-check-task` and `make harbor-oracle-task`.
 
 Task README and `benchmarks/validation/` changes do not require an Oracle;
 they affect documentation or deterministic host-side validation. Changes to a

--- a/docs/reference/testing-strategy.md
+++ b/docs/reference/testing-strategy.md
@@ -8,6 +8,7 @@
 | --- | --- | --- |
 | Documentation or benchmark README/validation | `make docs-command-check` and `make docs-linkcheck` | No Oracle is needed |
 | Python behavior | `make test-plan BASE=<revision>` and the selected semantic lane | Finish with `make check` |
+| Harbor job, MCP, Compose, or execution configuration | `make harbor-execution-check` | Escalate to `make harbor-check` only when shared benchmark validation also changes |
 | Benchmark task input or verifier | `make harbor-check-task DATASET=... TASKS=...` | Run `make harbor-oracle-task ...` for the selected task |
 | Deployment entrypoint | `make deploy-check` | Include affected process checks for code changes |
 
@@ -115,6 +116,7 @@ make docs-linkcheck
 make ci-plan BASE=origin/main
 make test-plan BASE=origin/main
 make harbor-plan BASE=origin/main
+make harbor-execution-check
 make clean
 ```
 
@@ -201,6 +203,13 @@ input. Shared environment profiles and execution-control changes may escalate
 to merge-queue portfolio evidence. Ignored Python bytecode is excluded from
 source validation, while committed or explicitly unignored cache files remain
 invalid.
+
+Local execution-configuration work has its own focused handoff. `make
+harbor-execution-check` validates repository-wide Harbor contracts and the
+unit tests that own job JSON, MCP configuration, Compose overlays, and their
+execution helpers. It deliberately excludes the task-specific mathematical
+verifier regressions under `benchmarks/validation/`; `make harbor-check`
+retains that full integration role. Neither command starts an Oracle or model.
 
 The build lane produces the source distribution and wheel once. Its dependent
 package-validation job downloads that artifact and exercises both installed

--- a/docs/reference/testing-strategy.md
+++ b/docs/reference/testing-strategy.md
@@ -8,8 +8,8 @@
 | --- | --- | --- |
 | Documentation or benchmark README/validation | `make docs-command-check` and `make docs-linkcheck` | No Oracle is needed |
 | Python behavior | `make test-plan BASE=<revision>` and the selected semantic lane | Finish with `make check` |
-| Harbor job, MCP, Compose, or execution configuration | `make harbor-execution-check` | Escalate to `make harbor-check` only when shared benchmark validation also changes |
-| Benchmark task input or verifier | `make harbor-check-task DATASET=... TASKS=...` | Run `make harbor-oracle-task ...` for the selected task |
+| Harbor job JSON, MCP config, job-level Compose overlay, or execution helper | `make harbor-execution-check` | Escalate to `make harbor-check` only when shared benchmark validation also changes; task `environment/docker-compose.yaml` changes are benchmark task input, not job overlays |
+| Benchmark task input or verifier (including task `environment/docker-compose.yaml`) | `make harbor-check-task DATASET=... TASKS=...` | Run `make harbor-oracle-task ...` for the selected task |
 | Deployment entrypoint | `make deploy-check` | Include affected process checks for code changes |
 
 The four primary profiles cover most product changes. `unit` owns pure
@@ -206,10 +206,13 @@ invalid.
 
 Local execution-configuration work has its own focused handoff. `make
 harbor-execution-check` validates repository-wide Harbor contracts and the
-unit tests that own job JSON, MCP configuration, Compose overlays, and their
-execution helpers. It deliberately excludes the task-specific mathematical
-verifier regressions under `benchmarks/validation/`; `make harbor-check`
-retains that full integration role. Neither command starts an Oracle or model.
+unit tests that own job JSON, MCP configuration, job-level Compose overlays,
+and their execution helpers. It deliberately excludes the task-specific
+mathematical verifier regressions under `benchmarks/validation/`; `make
+harbor-check` retains that full integration role. Task
+`environment/docker-compose.yaml` files are executable benchmark input, not
+job overlays, and remain gated by `make harbor-check-task` and
+`make harbor-oracle-task`. Neither command starts an Oracle or model.
 
 The build lane produces the source distribution and wheel once. Its dependent
 package-validation job downloads that artifact and exercises both installed

--- a/tests/boundary/process/tooling/test_local_validation_tools.py
+++ b/tests/boundary/process/tooling/test_local_validation_tools.py
@@ -155,6 +155,23 @@ def test_domain_lane_dry_run_is_explicit_and_topology_owned() -> None:
     assert "--timeout 120" in result.stdout
 
 
+def test_harbor_execution_check_stays_out_of_the_full_verifier_corpus() -> None:
+    result = subprocess.run(
+        ["make", "--dry-run", "harbor-execution-check"],
+        cwd=ROOT,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "tools/check_harbor_dataset.py --check" in result.stdout
+    assert "tools/check_benchmark_contracts.py" in result.stdout
+    assert "tests/unit/tooling/test_harbor*.py" in result.stdout
+    assert "benchmarks/validation" not in result.stdout
+    assert "harbor-oracle" not in result.stdout
+
+
 def test_topology_runner_executes_pytest_via_command_runner(monkeypatch) -> None:
     from benchmarks.tooling.command_runner import ToolCommandStatus
     from tools import test_topology

--- a/tests/unit/tooling/test_harbor_job_config.py
+++ b/tests/unit/tooling/test_harbor_job_config.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+import yaml
+from benchmarks.tooling.benchmark_contracts import validate_all
 from benchmarks.tooling.harbor_suite import get_suite
 
 ROOT = Path(__file__).parents[3]
@@ -15,7 +18,26 @@ JOB = (
     / "jacobian-observation.json"
 )
 CONTROL_JOB = ROOT / "benchmarks" / "config" / "agent-workflow-v1-control.json"
+CONTROL_PROXY_JOB = (
+    ROOT / "benchmarks" / "config" / "agent-workflow-v1-control-proxy.json"
+)
+OBSERVATION_PROXY_JOB = (
+    ROOT
+    / "benchmarks"
+    / "datasets"
+    / "agent-workflow-v1"
+    / "jobs"
+    / "jacobian-observation-proxy.json"
+)
 MCP_CONFIG = ROOT / "benchmarks" / "config" / "jacobian.mcp.json"
+PROXY_COMPOSE = ROOT / "benchmarks" / "config" / "agent-eval-proxy.compose.yaml"
+OBSERVATION_COMPOSE = (
+    ROOT
+    / "benchmarks"
+    / "datasets"
+    / "agent-workflow-v1"
+    / "jacobian-observation.compose.yaml"
+)
 
 
 def test_observation_job_uses_harbor_dataset_selection() -> None:
@@ -73,19 +95,8 @@ def test_agent_eval_forwards_web_search_setting_to_harbor() -> None:
 
 
 def test_proxy_observation_job_is_opt_in_and_preserves_local_mcp_access() -> None:
-    proxy_job = json.loads(
-        (
-            ROOT
-            / "benchmarks"
-            / "datasets"
-            / "agent-workflow-v1"
-            / "jobs"
-            / "jacobian-observation-proxy.json"
-        ).read_text()
-    )
-    proxy_overlay = (
-        ROOT / "benchmarks" / "config" / "agent-eval-proxy.compose.yaml"
-    ).read_text()
+    proxy_job = json.loads(OBSERVATION_PROXY_JOB.read_text())
+    proxy_overlay = PROXY_COMPOSE.read_text()
 
     assert proxy_job["environment"]["extra_docker_compose"] == [
         "benchmarks/config/agent-eval-proxy.compose.yaml",
@@ -93,6 +104,53 @@ def test_proxy_observation_job_is_opt_in_and_preserves_local_mcp_access() -> Non
     ]
     assert "NO_PROXY" in proxy_overlay
     assert "jacobian" in proxy_overlay
+
+
+def test_proxy_control_job_is_valid_harbor_job_json() -> None:
+    job = json.loads(CONTROL_PROXY_JOB.read_text())
+
+    assert job["n_attempts"] == 3
+    assert job["datasets"] == [
+        {
+            "path": "benchmarks/datasets/agent-workflow-v1",
+            "task_names": ["graph-counterexample"],
+        }
+    ]
+    assert job["environment"]["extra_docker_compose"] == [
+        "benchmarks/config/agent-eval-proxy.compose.yaml"
+    ]
+
+
+def test_compose_overlays_parse_as_valid_yaml() -> None:
+    """Syntactically broken overlays must not pass the execution-config gate.
+
+    The gate claims to cover Compose overlays, so the owning tests must parse
+    them as YAML rather than only asserting on substring presence.
+    """
+    for compose_path in (PROXY_COMPOSE, OBSERVATION_COMPOSE):
+        parsed = yaml.safe_load(compose_path.read_text())
+        assert isinstance(parsed, dict), f"{compose_path.name}: root must be a mapping"
+        assert "services" in parsed, f"{compose_path.name}: missing services table"
+        assert isinstance(parsed["services"], dict), (
+            f"{compose_path.name}: services must be a mapping"
+        )
+
+
+def test_proxy_compose_overlay_declares_proxy_environment() -> None:
+    parsed = yaml.safe_load(PROXY_COMPOSE.read_text())
+    main = parsed["services"]["main"]
+
+    assert "extra_hosts" in main
+    assert "environment" in main
+    env = main["environment"]
+    for key in ("HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"):
+        assert key in env, f"proxy compose missing {key}"
+
+
+def test_observation_compose_overlay_declares_jacobian_service() -> None:
+    parsed = yaml.safe_load(OBSERVATION_COMPOSE.read_text())
+
+    assert "jacobian" in parsed["services"]
 
 
 def test_observation_mcp_config_is_external_to_the_task_job() -> None:
@@ -123,3 +181,40 @@ def test_paired_jobs_use_three_attempts_per_condition() -> None:
 
     assert treatment["n_attempts"] == 3
     assert control["n_attempts"] == 3
+
+
+def test_validate_all_covers_proxy_control_and_observation_jobs() -> None:
+    """The execution-config gate must validate proxied job configs, not skip them.
+
+    ``validate_all`` is the contract layer beneath ``make harbor-contracts``,
+    which is the first step of ``make harbor-execution-check``.  A malformed
+    proxied control or observation job must be caught here rather than only
+    failing when an operator runs the proxied evaluation.
+    """
+    failures = validate_all()
+
+    # The committed proxy jobs are valid, so there must be no failures.
+    assert failures == [], "benchmark contract failures:\n" + "\n".join(failures)
+
+
+def test_validate_all_catches_a_malformed_proxy_control_job(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A malformed proxied control job must not pass the execution-config gate."""
+    from benchmarks.tooling import benchmark_contracts
+
+    original_read_json = benchmark_contracts._read_json
+
+    def patched_read_json(path: Path) -> object:
+        if path.name == "agent-workflow-v1-control-proxy.json":
+            return {"n_attempts": "not-an-integer"}
+        return original_read_json(path)
+
+    monkeypatch.setattr(benchmark_contracts, "_read_json", patched_read_json)
+
+    failures = validate_all()
+
+    assert any("control-proxy" in f for f in failures), (
+        f"expected a contract failure for the malformed proxy control job, "
+        f"got: {failures}"
+    )


### PR DESCRIPTION
Closes #506.

## Problem

Harbor job JSON, MCP configuration, Compose overlays, and local execution helpers had no focused validation command. The benchmark planner correctly classified those edits as execution-configuration changes, but the documented local handoff was `make harbor-check`, which expands to all 2,898 task-specific verifier regression tests. A later configuration correction therefore encouraged another full exact-tree run even though those mathematical verifiers were unrelated.

On the base revision, `make --dry-run harbor-execution-check` fails because no such target exists.

## Solution

Add `make harbor-execution-check` as the local execution-configuration boundary. It runs repository Harbor contract checks and the Harbor tooling unit suite, including future `test_harbor*.py` owners, while deliberately excluding `benchmarks/validation`, Oracle, Docker, and model execution.

The full `make harbor-check` remains unchanged for shared benchmark validation and CI integration evidence. Contributor, testing-strategy, benchmark, and agent-evaluation docs now direct job/MCP/Compose changes to the focused gate.

## Testing

- `make harbor-execution-check PYTEST_DIAGNOSTIC_ARGS=--durations=0` — contracts matched for six datasets; 48 tests passed in 8.82 seconds total.
- `make test-process` — 250 tests passed.
- `make check-static` — Ruff, formatting, complexity, dependency analysis, Vulture, mypy, architecture checks, source distribution, and wheel passed.
- `make docs-command-check` — passed.
- `make docs-linkcheck` — passed.
- `git diff --check` — passed.

## Trust & Compatibility Impact

No mathematical verifier, evidence semantics, checker authorization, task contract, Oracle policy, model execution, or public API changes. The new command is additive; existing full validation remains available and unchanged.

## Checklist

- [x] Routine local validation passes
- [x] Relevant focused tests are listed above