### PR TITLE
test: forward pytest arguments through semantic test lanes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,8 +160,9 @@ check-changed: ## Run format, types, and exact changed-path tests.
 	$(MAKE) test-changed BASE="$(or $(BASE),origin/main)"
 
 define run_topology_lane
-	PYTEST_ADDOPTS="$(PYTEST_DIAGNOSTIC_ARGS) $(PYTEST_ARGS)" \
-		$(TOPOLOGY_RUNNER) $(1) $(if $(TESTS),$(TESTS))
+	$(TOPOLOGY_RUNNER) $(1) \
+		--pytest-args "$(PYTEST_DIAGNOSTIC_ARGS) $(PYTEST_ARGS)" \
+		$(if $(TESTS),$(TESTS))
 endef
 
 test-unit: ## Run pure contracts and models (10s lane, sequential).

--- a/tests/boundary/process/tooling/test_local_validation_tools.py
+++ b/tests/boundary/process/tooling/test_local_validation_tools.py
@@ -155,6 +155,26 @@ def test_domain_lane_dry_run_is_explicit_and_topology_owned() -> None:
     assert "--timeout 120" in result.stdout
 
 
+def test_make_semantic_lane_forwards_pytest_arguments() -> None:
+    result = subprocess.run(
+        [
+            "make",
+            "--dry-run",
+            "test-process",
+            "TESTS=tests/boundary/process/tooling/test_local_validation_tools.py",
+            "PYTEST_ARGS=-k target_test --junitxml=pytest.xml",
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert '--pytest-args "--durations=10 -k target_test --junitxml=pytest.xml"' in (
+        result.stdout
+    )
+
+
 def test_topology_runner_executes_pytest_via_command_runner(monkeypatch) -> None:
     from benchmarks.tooling.command_runner import ToolCommandStatus
     from tools import test_topology

--- a/tests/unit/tooling/test_topology_runner.py
+++ b/tests/unit/tooling/test_topology_runner.py
@@ -84,6 +84,23 @@ def test_dry_run_focused_selector_reports_zero_workers(capsys) -> None:
     assert "-n" not in out.splitlines()[-1]
 
 
+def test_dry_run_forwards_explicit_pytest_arguments(capsys) -> None:
+    rc = main(
+        [
+            "process",
+            "--pytest-args=-k target_test --junitxml=pytest.xml",
+            "tests/boundary/process/tooling/test_local_validation_tools.py",
+            "--dry-run",
+        ]
+    )
+    command = capsys.readouterr().out.splitlines()[-1]
+
+    assert rc == 0
+    assert "--pytest-args=" not in command
+    assert "-k target_test" in command
+    assert "--junitxml=pytest.xml" in command
+
+
 def test_dry_run_serial_lane_reports_no_workers(capsys) -> None:
     rc = main(["storage", "--dry-run"])
     out = capsys.readouterr().out

--- a/tests/unit/tooling/test_topology_runner.py
+++ b/tests/unit/tooling/test_topology_runner.py
@@ -35,6 +35,47 @@ def test_full_parallel_lane_retains_configured_workers() -> None:
     assert command[command.index("--dist") + 1] == "worksteal"
 
 
+def test_explicit_xdist_zero_suppresses_lane_worker_pool() -> None:
+    topology = load_topology(ROOT / "tests" / "topology.toml")
+
+    command = pytest_command(topology, "process", extra_args=["-n", "0"])
+
+    # The user's serial request is honored; lane defaults do not override it.
+    assert command[command.index("-n") + 1] == "0"
+    assert "--dist" not in command
+
+
+def test_explicit_xdist_zero_equals_form_suppresses_lane_worker_pool() -> None:
+    topology = load_topology(ROOT / "tests" / "topology.toml")
+
+    command = pytest_command(topology, "process", extra_args=["-n=0"])
+
+    assert "-n=0" in command
+    assert "--dist" not in command
+
+
+def test_explicit_numprocesses_suppresses_lane_worker_pool() -> None:
+    topology = load_topology(ROOT / "tests" / "topology.toml")
+
+    command = pytest_command(topology, "process", extra_args=["--numprocesses", "0"])
+
+    assert command[command.index("--numprocesses") + 1] == "0"
+    assert "--dist" not in command
+    assert "-n" not in command
+
+
+def test_dry_run_explicit_xdist_zero_suppresses_lane_workers(capsys) -> None:
+    rc = main(["process", "--pytest-args=-n 0", "--dry-run"])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    command = out.splitlines()[-1]
+    # The lane's configured ``-n 2 --dist worksteal`` is not appended.
+    assert "-n 0" in command
+    assert "-n 2" not in command
+    assert "--dist" not in command
+
+
 def test_focused_serial_lane_remains_serial_and_preserves_extra_args() -> None:
     topology = load_topology(ROOT / "tests" / "topology.toml")
 

--- a/tools/test_topology.py
+++ b/tools/test_topology.py
@@ -413,11 +413,21 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("selectors", nargs="*", help="exact pytest paths or node IDs")
     parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
     parser.add_argument(
+        "--pytest-args",
+        default="",
+        help="shell-style pytest arguments supplied by the repository wrapper",
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="print lane metadata and the pytest command without executing",
     )
     args, extra_args = parser.parse_known_args(argv)
+    try:
+        configured_pytest_args = shlex.split(args.pytest_args)
+    except ValueError as exc:
+        parser.error(f"invalid --pytest-args value: {exc}")
+    extra_args = [*configured_pytest_args, *extra_args]
     try:
         topology = load_topology(args.manifest)
         lane = topology.lane(args.lane)

--- a/tools/test_topology.py
+++ b/tools/test_topology.py
@@ -286,6 +286,24 @@ def load_topology(path: Path = DEFAULT_MANIFEST) -> Topology:
     return validate_topology(data, root=manifest.parent.parent, manifest=manifest)
 
 
+def _has_explicit_xdist_args(extra_args: list[str] | None) -> bool:
+    """Return whether ``extra_args`` supply their own xdist configuration.
+
+    pytest takes the last ``-n``/``--numprocesses`` value, so lane defaults
+    appended after an explicit ``-n 0`` would override the user's request for
+    serial execution.  Detect any explicit xdist worker count so the lane
+    defaults can be suppressed in that case.
+    """
+    if not extra_args:
+        return False
+    for arg in extra_args:
+        if arg in ("-n", "--numprocesses"):
+            return True
+        if arg.startswith(("-n=", "--numprocesses=")):
+            return True
+    return False
+
+
 def pytest_command(
     topology: Topology,
     lane_name: str,
@@ -299,12 +317,17 @@ def pytest_command(
     cost more than the selected test itself.  An omitted selector still means
     "the whole lane" and retains the configured CI parallelism.  Lanes with
     ``workers=0`` are unaffected by this distinction.
+
+    Explicit xdist arguments in ``extra_args`` (e.g. ``-n 0`` for
+    debugger-friendly serial execution) suppress the lane's configured worker
+    pool and distribution so the user's choice is honored rather than
+    overridden by the lane defaults that follow it.
     """
     lane = topology.lane(lane_name)
     command = [sys.executable, "-m", "pytest"]
     command.extend(selectors if selectors else list(lane.paths))
     command.extend(extra_args or ())
-    if lane.workers and not selectors:
+    if lane.workers and not selectors and not _has_explicit_xdist_args(extra_args):
         command.extend(["-n", str(lane.workers), "--dist", lane.distribution])
     command.extend(["--timeout", str(lane.timeout_seconds)])
     return command


### PR DESCRIPTION
Fixes #508.

## Problem

Semantic Make targets accepted `PYTEST_ARGS` and `PYTEST_DIAGNOSTIC_ARGS`, but attached them to the topology-runner process as `PYTEST_ADDOPTS`. The runner then launched pytest with its intentionally restricted environment, which removed that variable.

A local `-k` reproduction therefore ran all 30 tests in the selected file. The same break affected CI JUnit and coverage options, domain/composition shard selection, scheduled ordering seeds, and the documented diagnostic controls.

## Solution

Pass the combined pytest options through an explicit `--pytest-args` topology-runner argument. The runner parses that shell-style value and appends it to the existing explicit pytest argument vector.

The bounded child environment remains unchanged; this does not authorize arbitrary ambient variables.

## Regression coverage

- The Make boundary test verifies that filters and JUnit arguments reach `--pytest-args`.
- The topology-runner test verifies that the wrapper value is parsed into ordinary pytest arguments rather than forwarded as an opaque option.
- The original reproduction now runs one matching test and reports 29 deselections.
- A representative CI shard dry-run preserves `--splits`, `--group`, `--randomly-seed`, and `--junitxml`.

## Testing

- `make test-unit` — 606 passed.
- `make test-process` — 250 passed.
- `make check-static` — lint, formatting, complexity, dependency analysis, Vulture, mypy, architecture checks, sdist, and wheel passed.
- Focused `-k` reproduction — 1 passed, 29 deselected.
- `git diff --check` — passed.

## Trust & Compatibility Impact

This restores the documented and CI-configured pytest execution contract. Test selection and evidence artifacts now match the supplied arguments. The topology ownership, timeout, worker, environment allowlist, and optional-provider policies are unchanged.