### PR TITLE
feat(mcp): make math.find and math.run the canonical MCP surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,8 +55,8 @@ consequential, use the
 [evaluation plan](docs/reference/evaluations/benchmark-contracts.md). Routine
 additions need no exhaustive pairwise or leave-one-out evaluation.
 
-The MCP interface exposes `capability.describe` for search and contract
-inspection, `capability.invoke` for execution, and `capability://catalog` for
+The MCP interface exposes `math.find` for search and contract
+inspection, `math.run` for execution, and `capability://catalog` for
 the complete machine-readable inventory. These are composable access paths,
 not a required sequence: an agent may invoke a known capability directly,
 search, browse, or revisit discovery as its investigation requires. Prefer
@@ -75,7 +75,7 @@ explicit `__all__` values, and cover namespace and import isolation in the
 public-API tests. Do not re-export domain APIs from the root `jacobian`
 namespace. Native functions accept and return Python or maintained
 backend-native values and call typed mathematical kernels directly; they must
-not invoke `capability.invoke`, construct a capability runtime, or expose MCP,
+not invoke `math.run`, construct a capability runtime, or expose MCP,
 artifact, provider-loading, or installation objects.
 
 Keep Pydantic models authoritative at capability, persistence, artifact, and

--- a/Makefile
+++ b/Makefile
@@ -50,17 +50,17 @@ setup-agent: ## Configure an agent against this source checkout (ARGS="--client 
 JACOBIAN_REGISTRY_IMAGE ?= ghcr.io/morluto/jacobian
 
 container-image: ## Build jacobian:local from the current tree, including dirty changes.
-	$(UV_RUN) python tools/manage_jacobian_image.py build --image "$(or $(IMAGE),jacobian:local)"
+	$(UV_RUN) python -m tools.manage_jacobian_image build --image "$(or $(IMAGE),jacobian:local)"
 
 eval-image: ## Select a published digest for a clean tree or build jacobian:local when dirty.
-	$(UV_RUN) python tools/manage_jacobian_image.py select --registry-image "$(JACOBIAN_REGISTRY_IMAGE)"
+	$(UV_RUN) python -m tools.manage_jacobian_image select --registry-image "$(JACOBIAN_REGISTRY_IMAGE)"
 
 eval-image-pull: ## Pull the current clean revision and print its digest-pinned image reference.
-	$(UV_RUN) python tools/manage_jacobian_image.py pull --registry-image "$(JACOBIAN_REGISTRY_IMAGE)"
+	$(UV_RUN) python -m tools.manage_jacobian_image pull --registry-image "$(JACOBIAN_REGISTRY_IMAGE)"
 
 eval-image-bind: ## Bind image identity into RUNTIME_SNAPSHOT (JACOBIAN_IMAGE=..., RUNTIME_SNAPSHOT=...).
 	@test -n "$(JACOBIAN_IMAGE)" -a -n "$(RUNTIME_SNAPSHOT)" || { echo "JACOBIAN_IMAGE and RUNTIME_SNAPSHOT are required" >&2; exit 2; }
-	$(UV_RUN) python tools/manage_jacobian_image.py bind-runtime \
+	$(UV_RUN) python -m tools.manage_jacobian_image bind-runtime \
 		--image "$(JACOBIAN_IMAGE)" --runtime-snapshot "$(RUNTIME_SNAPSHOT)"
 
 deploy-check: ## Validate the clone-to-systemd deployment entrypoint.
@@ -430,6 +430,7 @@ endif
 
 CODEX_WEB_SEARCH ?= disabled
 JACOBIAN_EVAL_PROXY ?= 0
+JACOBIAN_EVAL_CODEX_BINARY ?= $(shell command -v codex 2>/dev/null | xargs -r readlink -f)
 define _jacobian_eval_container_proxy
 $(subst localhost,host.docker.internal,$(subst 127.0.0.1,host.docker.internal,$1))
 endef
@@ -437,6 +438,8 @@ JACOBIAN_EVAL_HTTP_PROXY ?= $(call _jacobian_eval_container_proxy,$(HTTP_PROXY))
 JACOBIAN_EVAL_HTTPS_PROXY ?= $(call _jacobian_eval_container_proxy,$(HTTPS_PROXY))
 JACOBIAN_EVAL_ALL_PROXY ?= $(call _jacobian_eval_container_proxy,$(ALL_PROXY))
 JACOBIAN_EVAL_NO_PROXY ?= localhost,127.0.0.1,jacobian
+JACOBIAN_EVAL_UPSTREAM_PROXY ?= $(or $(JACOBIAN_EVAL_HTTPS_PROXY),$(JACOBIAN_EVAL_ALL_PROXY),$(JACOBIAN_EVAL_HTTP_PROXY))
+JACOBIAN_EVAL_GOST_CONFIG ?= $(abspath benchmarks/results/.runtime/agent-eval-gost.yaml)
 ifneq ($(filter 0 1,$(JACOBIAN_EVAL_PROXY)),$(JACOBIAN_EVAL_PROXY))
 $(error JACOBIAN_EVAL_PROXY must be exactly 0 or 1 (got '$(JACOBIAN_EVAL_PROXY)'))
 endif
@@ -458,14 +461,16 @@ override MCP_CONFIG :=
 else
 ifeq ($(JACOBIAN_EVAL_PROXY),1)
 EVAL_CONFIG ?= benchmarks/datasets/$(or $(DATASET),agent-workflow-v1)/jobs/jacobian-observation-proxy.json
+MCP_CONFIG ?= benchmarks/config/jacobian-loopback.mcp.json
 else
 EVAL_CONFIG ?= benchmarks/datasets/$(or $(DATASET),agent-workflow-v1)/jobs/jacobian-observation.json
-endif
 MCP_CONFIG ?= benchmarks/config/jacobian.mcp.json
+endif
 endif
 
 agent-eval: ## Run a Harbor evaluation (JACOBIAN_ENABLED=0|1, JACOBIAN_EVAL_PROXY=0|1, DATASET=agent-workflow-v1, EVAL_EXECUTE=1).
-	@if [ "$(EVAL_EXECUTE)" != "1" ]; then \
+	@set -e; \
+	if [ "$(EVAL_EXECUTE)" != "1" ]; then \
 		echo "Model execution is opt-in. Review the job, then run: make agent-eval DATASET=agent-workflow-v1 EVAL_EXECUTE=1"; \
 		exit 0; \
 	fi; \
@@ -473,16 +478,27 @@ agent-eval: ## Run a Harbor evaluation (JACOBIAN_ENABLED=0|1, JACOBIAN_EVAL_PROX
 		echo "JACOBIAN_MODEL must be exported" >&2; \
 		exit 2; \
 	fi; \
+	if [ "$(JACOBIAN_EVAL_PROXY)" = "1" ]; then \
+		test -x "$(JACOBIAN_EVAL_CODEX_BINARY)" || { \
+			echo "JACOBIAN_EVAL_CODEX_BINARY must resolve to a Linux standalone Codex binary when JACOBIAN_EVAL_PROXY=1" >&2; \
+			exit 2; \
+		}; \
+		JACOBIAN_EVAL_UPSTREAM_PROXY="$(JACOBIAN_EVAL_UPSTREAM_PROXY)" \
+			$(UV_RUN) python -m benchmarks.tooling.harbor_proxy \
+			--output "$(JACOBIAN_EVAL_GOST_CONFIG)"; \
+	fi; \
 	if [ "$(JACOBIAN_ENABLED)" = "1" ]; then \
 		test -n "$${JACOBIAN_IMAGE:-}" || { echo "JACOBIAN_IMAGE must be exported" >&2; exit 2; }; \
 		test -n "$(RUNTIME_SNAPSHOT)" || { echo "RUNTIME_SNAPSHOT is required for a Jacobian-enabled run" >&2; exit 2; }; \
-		$(UV_RUN) python tools/manage_jacobian_image.py bind-runtime \
+		$(UV_RUN) python -m tools.manage_jacobian_image bind-runtime \
 			--image "$${JACOBIAN_IMAGE}" --runtime-snapshot "$(RUNTIME_SNAPSHOT)"; \
 	fi; \
 	JACOBIAN_EVAL_HTTP_PROXY="$(JACOBIAN_EVAL_HTTP_PROXY)" \
 	JACOBIAN_EVAL_HTTPS_PROXY="$(JACOBIAN_EVAL_HTTPS_PROXY)" \
 	JACOBIAN_EVAL_ALL_PROXY="$(JACOBIAN_EVAL_ALL_PROXY)" \
 	JACOBIAN_EVAL_NO_PROXY="$(JACOBIAN_EVAL_NO_PROXY)" \
+	JACOBIAN_EVAL_CODEX_BINARY="$(JACOBIAN_EVAL_CODEX_BINARY)" \
+	JACOBIAN_EVAL_GOST_CONFIG="$(JACOBIAN_EVAL_GOST_CONFIG)" \
 	$(HARBOR_RUNNER) run \
 		-c "$(EVAL_CONFIG)" \
 		-a codex \

--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ for a runnable example.
 ## Capabilities
 
 Capabilities are discovered at runtime through `capability://catalog`,
-described with `capability.describe`, and executed with
-`capability.invoke`. The installed catalog is the source of truth because
+described with `math.find`, and executed with
+`math.run`. The installed catalog is the source of truth because
 availability can depend on local backends.
 
 | Domain | Agent-visible outcomes |
@@ -165,7 +165,7 @@ Jacobian keeps four responsibilities separate:
   change verification policy.
 
 The public MCP surface stays small: the capability catalog plus the two
-capability entry points, `capability.describe` and `capability.invoke`.
+capability entry points, `math.find` and `math.run`.
 
 ## Documentation
 
@@ -204,8 +204,8 @@ full-python` explicitly binds the client to that source environment;
 the maintained `scripts/setup-agent` wrapper performs the required locked sync
 and doctor checks first.
 The server advertises only the capability entry points.
-`capability.describe` searches, browses, or inspects installed operations, while
-`capability.invoke` runs one selected operation. These are composable access
+`math.find` searches, browses, or inspects installed operations, while
+`math.run` runs one selected operation. These are composable access
 paths, not a required sequence: agents own mathematical representation,
 decomposition, exploration, composition, verification timing, and stopping.
 

--- a/README.md
+++ b/README.md
@@ -203,10 +203,11 @@ For a clone, `jacobian setup --source <checkout> --state-dir <path> --profile
 full-python` explicitly binds the client to that source environment;
 the maintained `scripts/setup-agent` wrapper performs the required locked sync
 and doctor checks first.
-The server advertises only the capability entry points;
-`capability.describe(query=...)` searches compact installed outcomes before an
-agent inspects an exact contract and invokes it. This is a toolbox interface:
-agents own mathematical decomposition, exploration, and composition.
+The server advertises only the capability entry points.
+`capability.describe` searches, browses, or inspects installed operations, while
+`capability.invoke` runs one selected operation. These are composable access
+paths, not a required sequence: agents own mathematical representation,
+decomposition, exploration, composition, verification timing, and stopping.
 
 Clients with MCP resource support can read `jacobian://instructions` for the
 operating guide and `capability://catalog` for the complete machine inventory.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -114,7 +114,7 @@ witness.verify   →  FALSE  · VERIFIED
 
 ## 能力
 
-能力通过 `capability://catalog` 在运行时发现，使用 `capability.describe` 描述，并使用 `capability.invoke` 执行。已安装的 catalog 是事实来源，因为可用性可能取决于本地 backend。
+能力通过 `capability://catalog` 在运行时发现，使用 `math.find` 描述，并使用 `math.run` 执行。已安装的 catalog 是事实来源，因为可用性可能取决于本地 backend。
 
 | 领域 | 面向智能体的结果 |
 | --- | --- |
@@ -139,7 +139,7 @@ Jacobian 将四项职责分开：
 - **值可以直接组合。** 小型、有界的数学结果保持内联；artifact 用于可复用对象、可重放证据和大型载荷。
 - **检查器负责信任。** 插件和搜索代码不能授权检查器，也不能更改验证策略。
 
-公共 MCP 接口保持精简：能力 catalog，以及两个能力入口 `capability.describe` 和 `capability.invoke`。
+公共 MCP 接口保持精简：能力 catalog，以及两个能力入口 `math.find` 和 `math.run`。
 
 <a id="documentation"></a>
 
@@ -164,7 +164,7 @@ Jacobian 将四项职责分开：
 
 对于代码仓库副本，`jacobian setup --source <checkout> --state-dir <path> --profile full-python` 会显式地将客户端绑定到该源代码环境；受维护的 `scripts/setup-agent` 封装器会先完成所需的锁定同步和 doctor 检查。
 
-服务器只公布能力入口；`capability.describe(query=...)` 会先搜索已安装的精简结果，智能体再检查精确契约并调用它。这是一个工具箱接口：数学分解、探索和组合由智能体负责。
+服务器只公布两个能力入口：`math.find` 用于搜索、浏览或检查已安装的数学操作，`math.run` 用于执行其中一个操作。两者是可以自由组合的工具，不规定研究顺序；数学表示、分解、探索、验证时机和停止条件都由智能体决定。
 
 支持 MCP resource 的客户端可以读取 `jacobian://instructions` 获取操作指南，读取 `capability://catalog` 获取完整的机器可读 inventory。支持 prompt 的客户端还可以选择请求 `jacobian-discover` 或 `jacobian-check-evidence`，以获得协议脚手架。
 

--- a/benchmarks/config/agent-eval-codex.compose.yaml
+++ b/benchmarks/config/agent-eval-codex.compose.yaml
@@ -1,0 +1,7 @@
+services:
+  main:
+    volumes:
+      - type: bind
+        source: ${JACOBIAN_EVAL_CODEX_BINARY:?set JACOBIAN_EVAL_CODEX_BINARY to the standalone Codex executable}
+        target: /usr/local/bin/codex
+        read_only: true

--- a/benchmarks/config/agent-eval-egress-proxy.compose.yaml
+++ b/benchmarks/config/agent-eval-egress-proxy.compose.yaml
@@ -1,0 +1,19 @@
+services:
+  main:
+    environment:
+      HTTP_PROXY: ""
+      HTTPS_PROXY: ""
+      ALL_PROXY: ""
+      NO_PROXY: ${JACOBIAN_EVAL_NO_PROXY:-localhost,127.0.0.1,jacobian}
+      http_proxy: ""
+      https_proxy: ""
+      all_proxy: ""
+      no_proxy: ${JACOBIAN_EVAL_NO_PROXY:-localhost,127.0.0.1,jacobian}
+  harbor-docker-egress-control-sidecar:
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - type: bind
+        source: ${JACOBIAN_EVAL_GOST_CONFIG:?set JACOBIAN_EVAL_GOST_CONFIG to the rendered GOST configuration}
+        target: /opt/egress-sidecar/gost.yaml
+        read_only: true

--- a/benchmarks/config/agent-workflow-v1-control-proxy.json
+++ b/benchmarks/config/agent-workflow-v1-control-proxy.json
@@ -12,7 +12,8 @@
     "force_build": true,
     "delete": true,
     "extra_docker_compose": [
-      "benchmarks/config/agent-eval-proxy.compose.yaml"
+      "benchmarks/config/agent-eval-codex.compose.yaml",
+      "benchmarks/config/agent-eval-egress-proxy.compose.yaml"
     ],
     "extra_allowed_hosts": [
       "api.openai.com",

--- a/benchmarks/config/jacobian-loopback.mcp.json
+++ b/benchmarks/config/jacobian-loopback.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcp_servers": [
+    {
+      "name": "jacobian",
+      "transport": "streamable-http",
+      "url": "http://127.0.0.1:8000/mcp"
+    }
+  ]
+}

--- a/benchmarks/datasets/agent-workflow-v1/README.md
+++ b/benchmarks/datasets/agent-workflow-v1/README.md
@@ -75,6 +75,30 @@ requires a structurally complete `PLAN`/call-cycle/`FINAL` trace for every
 workflow observations remain non-causal; protected runs must also freeze the
 model, prompt, agent version, task digests, sampling settings, and budgets.
 
+To screen the agent-visible tool names, keep Jacobian enabled in both arms and
+vary only `JACOBIAN_TOOL_NAME_PROFILE`. Use separate job names and result roots
+so one profile cannot overwrite or be mistaken for the other:
+
+```sh
+# Existing-name control.
+JACOBIAN_TOOL_NAME_PROFILE=capability make agent-eval \
+  DATASET=agent-workflow-v1 JACOBIAN_ENABLED=1 \
+  TASKS=graph-counterexample EVAL_EXECUTE=1 \
+  EVAL_ARGS="--job-name name-capability --jobs-dir benchmarks/results/name-capability"
+
+# Short mathematical-name treatment.
+JACOBIAN_TOOL_NAME_PROFILE=math make agent-eval \
+  DATASET=agent-workflow-v1 JACOBIAN_ENABLED=1 \
+  TASKS=graph-counterexample EVAL_EXECUTE=1 \
+  EVAL_ARGS="--job-name name-math --jobs-dir benchmarks/results/name-math"
+```
+
+Bind `tool_name_profile` in each runtime snapshot's condition. Both profiles
+render the same descriptions, instructions, schemas, handlers, and result
+semantics with different exposed names; a server never advertises both pairs.
+This public-suite screen is directional workflow evidence, not a causal rename
+decision.
+
 Five tasks have an operator-authorized verification record and may accept
 `VERIFIED`; the remaining tasks are capped at `COMPUTED`. A wrong result or an
 unsupported certification claim forces reward to zero. These are workflow

--- a/benchmarks/datasets/agent-workflow-v1/README.md
+++ b/benchmarks/datasets/agent-workflow-v1/README.md
@@ -75,29 +75,22 @@ requires a structurally complete `PLAN`/call-cycle/`FINAL` trace for every
 workflow observations remain non-causal; protected runs must also freeze the
 model, prompt, agent version, task digests, sampling settings, and budgets.
 
-To screen the agent-visible tool names, keep Jacobian enabled in both arms and
-vary only `JACOBIAN_TOOL_NAME_PROFILE`. Use separate job names and result roots
-so one profile cannot overwrite or be mistaken for the other:
+To evaluate the canonical `math.find` and `math.run` surface, keep each model,
+task set, and prompt condition in a separate result root:
 
 ```sh
-# Existing-name control.
-JACOBIAN_TOOL_NAME_PROFILE=capability make agent-eval \
+make agent-eval \
   DATASET=agent-workflow-v1 JACOBIAN_ENABLED=1 \
   TASKS=graph-counterexample EVAL_EXECUTE=1 \
-  EVAL_ARGS="--job-name name-capability --jobs-dir benchmarks/results/name-capability"
-
-# Short mathematical-name treatment.
-JACOBIAN_TOOL_NAME_PROFILE=math make agent-eval \
-  DATASET=agent-workflow-v1 JACOBIAN_ENABLED=1 \
-  TASKS=graph-counterexample EVAL_EXECUTE=1 \
-  EVAL_ARGS="--job-name name-math --jobs-dir benchmarks/results/name-math"
+  EVAL_ARGS="--job-name adoption --jobs-dir benchmarks/results/adoption"
 ```
 
-Bind `tool_name_profile` in each runtime snapshot's condition. Both profiles
-render the same descriptions, instructions, schemas, handlers, and result
-semantics with different exposed names; a server never advertises both pairs.
-This public-suite screen is directional workflow evidence, not a causal rename
-decision.
+Inspect appropriate adoption, argument validity, discovery-to-execution
+continuation, irrelevant calls, native-tool fallback, correctness, tokens, and
+elapsed time. A correct no-call run may mean the task does not require a
+Jacobian affordance, so include negative controls and tasks that discriminate
+tool adoption. Public-suite observations remain directional workflow evidence,
+not a causal performance claim.
 
 Five tasks have an operator-authorized verification record and may accept
 `VERIFIED`; the remaining tasks are capped at `COMPUTED`. A wrong result or an

--- a/benchmarks/datasets/agent-workflow-v1/jacobian-observation.compose.yaml
+++ b/benchmarks/datasets/agent-workflow-v1/jacobian-observation.compose.yaml
@@ -15,8 +15,6 @@ services:
       - --allow-anonymous
       - --reasoning-log-mode
       - ${JACOBIAN_REASONING_LOG_MODE:-off}
-      - --tool-name-profile
-      - ${JACOBIAN_TOOL_NAME_PROFILE:-capability}
       - --state-dir
       - /state
     volumes:

--- a/benchmarks/datasets/agent-workflow-v1/jacobian-observation.compose.yaml
+++ b/benchmarks/datasets/agent-workflow-v1/jacobian-observation.compose.yaml
@@ -1,4 +1,8 @@
 services:
+  main:
+    depends_on:
+      jacobian:
+        condition: service_healthy
   jacobian:
     image: ${JACOBIAN_IMAGE:-jacobian:local}
     command:
@@ -11,9 +15,20 @@ services:
       - --allow-anonymous
       - --reasoning-log-mode
       - ${JACOBIAN_REASONING_LOG_MODE:-off}
+      - --tool-name-profile
+      - ${JACOBIAN_TOOL_NAME_PROFILE:-capability}
       - --state-dir
       - /state
     volumes:
       - jacobian-state:/state
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - import socket; socket.create_connection(('127.0.0.1', 8000), 2).close()
+      interval: 1s
+      timeout: 3s
+      retries: 30
 volumes:
   jacobian-state: {}

--- a/benchmarks/datasets/agent-workflow-v1/jobs/jacobian-observation-proxy.json
+++ b/benchmarks/datasets/agent-workflow-v1/jobs/jacobian-observation-proxy.json
@@ -22,7 +22,8 @@
       "raw.githubusercontent.com"
     ],
     "extra_docker_compose": [
-      "benchmarks/config/agent-eval-proxy.compose.yaml",
+      "benchmarks/config/agent-eval-codex.compose.yaml",
+      "benchmarks/config/agent-eval-egress-proxy.compose.yaml",
       "benchmarks/datasets/agent-workflow-v1/jacobian-observation.compose.yaml"
     ]
   },

--- a/benchmarks/tooling/harbor_proxy.py
+++ b/benchmarks/tooling/harbor_proxy.py
@@ -1,0 +1,117 @@
+"""Render Harbor's transparent egress configuration with an upstream proxy."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+
+import yaml
+
+
+def _proxy_node(proxy_url: str) -> dict[str, object]:
+    parsed = urlsplit(proxy_url)
+    if parsed.scheme not in {"http", "socks5", "socks5h"}:
+        raise ValueError("upstream proxy must use http://, socks5://, or socks5h://")
+    if parsed.hostname is None:
+        raise ValueError("upstream proxy URL must include a hostname")
+    if parsed.path not in {"", "/"} or parsed.query or parsed.fragment:
+        raise ValueError(
+            "upstream proxy URL must not include a path, query, or fragment"
+        )
+
+    default_port = 80 if parsed.scheme == "http" else 1080
+    port = parsed.port or default_port
+    host = f"[{parsed.hostname}]" if ":" in parsed.hostname else parsed.hostname
+    connector: dict[str, object] = {
+        "type": "http" if parsed.scheme == "http" else "socks5"
+    }
+    if parsed.username is not None:
+        connector["auth"] = {
+            "username": unquote(parsed.username),
+            "password": unquote(parsed.password or ""),
+        }
+
+    return {
+        "name": "upstream-proxy",
+        "addr": f"{host}:{port}",
+        "connector": connector,
+        "dialer": {"type": "tcp"},
+    }
+
+
+def render_config(proxy_url: str) -> dict[str, object]:
+    """Return a GOST config that preserves Harbor's allowlist and chains egress."""
+    return {
+        "services": [
+            {
+                "name": "transparent-egress",
+                "addr": ":12345",
+                "bypass": "allowlist",
+                "sockopts": {"mark": 114514},
+                "handler": {
+                    "type": "red",
+                    "chain": "upstream-proxy",
+                    "metadata": {
+                        "sniffing": True,
+                        "sniffing.timeout": "5s",
+                        "sniffing.fallback": True,
+                    },
+                },
+                "listener": {"type": "red"},
+            }
+        ],
+        "chains": [
+            {
+                "name": "upstream-proxy",
+                "hops": [
+                    {
+                        "name": "upstream-proxy",
+                        "bypass": "direct-private",
+                        "sockopts": {"mark": 114514},
+                        "nodes": [_proxy_node(proxy_url)],
+                    }
+                ],
+            }
+        ],
+        "bypasses": [
+            {
+                "name": "allowlist",
+                "whitelist": True,
+                "reload": "1s",
+                "file": {"path": "/opt/egress-sidecar/allowlist.txt"},
+            },
+            {
+                "name": "direct-private",
+                "matchers": [
+                    "127.0.0.0/8",
+                    "10.0.0.0/8",
+                    "172.16.0.0/12",
+                    "192.168.0.0/16",
+                    "169.254.0.0/16",
+                    "::1/128",
+                    "fc00::/7",
+                    "fe80::/10",
+                ],
+            },
+        ],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    proxy_url = os.environ.get("JACOBIAN_EVAL_UPSTREAM_PROXY", "")
+    if not proxy_url:
+        parser.error("JACOBIAN_EVAL_UPSTREAM_PROXY is required")
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(yaml.safe_dump(render_config(proxy_url), sort_keys=False))
+    args.output.chmod(0o600)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/tooling/heldout_bundle.py
+++ b/benchmarks/tooling/heldout_bundle.py
@@ -526,7 +526,7 @@ def math_isclose(left: float, right: float) -> bool:
     return abs(float(left) - float(right)) <= 1e-9
 
 
-_REQUIRED_MCP_TOOLS = {"capability.describe", "capability.invoke"}
+_REQUIRED_MCP_TOOLS = {"math.find", "math.run"}
 _PROBE_SCRIPT = ROOT / "deploy" / "smoke_remote.py"
 _ZERO_DIGEST = "sha256:" + "0" * 64
 
@@ -745,7 +745,7 @@ def _probe_match_checks(
     if not checks["required_tools_present"]:
         failures.append("probe is missing required MCP tools")
     if not checks["describe_responded"]:
-        failures.append("probe capability.describe did not respond")
+        failures.append("probe math.find did not respond")
     return checks, failures
 
 

--- a/benchmarks/tooling/observation_results.py
+++ b/benchmarks/tooling/observation_results.py
@@ -764,7 +764,7 @@ def _heldout_runtime_invariants(plan: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-_CAPABILITY_INVOKE_TOOL = "capability.invoke"
+_MATH_RUN_TOOL = "math.run"
 
 
 def _mark_invoked_if_capability_used(
@@ -779,14 +779,14 @@ def _mark_invoked_if_capability_used(
     preflight proves AVAILABLE_UNUSED and the runner must not override it.
     Persists the updated contract to ``routing-status-c2.json``.
 
-    Fail closed: a trial with ``capability.invoke`` calls but non-COMPLETED
+    Fail closed: a trial with ``math.run`` calls but non-COMPLETED
     status or nonzero ``tool_errors`` does not evidence a successful
     invocation and must not transition the routing status.
     """
 
     invoked = any(
         isinstance(trial.get("tool_calls"), dict)
-        and trial["tool_calls"].get(_CAPABILITY_INVOKE_TOOL, 0) > 0
+        and trial["tool_calls"].get(_MATH_RUN_TOOL, 0) > 0
         and trial.get("status") == "COMPLETED"
         and trial.get("tool_errors") == 0
         for trial in trials

--- a/benchmarks/validation/test_heldout_bundle.py
+++ b/benchmarks/validation/test_heldout_bundle.py
@@ -579,7 +579,7 @@ def _ready_probe(
         "reachable": True,
         "report": {
             "server": {"name": "jacobian", "version": "1.2.3"},
-            "tool_names": ["capability.describe", "capability.invoke"],
+            "tool_names": ["math.find", "math.run"],
             "catalog": {
                 "catalog_version": "1",
                 "capabilities": 1,
@@ -738,7 +738,7 @@ def test_treatment_readiness_preflight_misconfigured_on_digest_mismatch(
             "reachable": True,
             "report": {
                 "server": {"name": "jacobian", "version": "1.2.3"},
-                "tool_names": ["capability.describe", "capability.invoke"],
+                "tool_names": ["math.find", "math.run"],
                 "catalog": {
                     "catalog_version": "1",
                     "capabilities": 1,
@@ -839,7 +839,7 @@ def _c2_routing_contract(routing_status: str = "AVAILABLE_UNUSED") -> dict:
             "catalog_digest_observed": "sha256:" + "2" * 64,
             "policy_digest_observed": "sha256:" + "3" * 64,
             "policy_profile_observed": "DEFAULT",
-            "tool_names": ["capability.describe", "capability.invoke"],
+            "tool_names": ["math.find", "math.run"],
             "discovery_matches": ["cap-1"],
             "probe_digest": "sha256:" + "0" * 64,
             "diagnostic": None,
@@ -867,7 +867,7 @@ def test_mark_invoked_transitions_on_successful_capability_invoke(
     trials = [
         {
             "status": "COMPLETED",
-            "tool_calls": {"capability.invoke": 1},
+            "tool_calls": {"math.run": 1},
             "tool_errors": 0,
         }
     ]
@@ -878,13 +878,13 @@ def test_mark_invoked_transitions_on_successful_capability_invoke(
 
 
 def test_mark_invoked_fail_closed_on_errored_invocation(tmp_path: Path) -> None:
-    """A failed/errored capability.invoke must not transition to AVAILABLE_INVOKED."""
+    """A failed/errored math.run must not transition to AVAILABLE_INVOKED."""
 
     ledger = {"routing_status": {"C2": _c2_routing_contract()}}
     trials = [
         {
             "status": "COMPLETED",
-            "tool_calls": {"capability.invoke": 1},
+            "tool_calls": {"math.run": 1},
             "tool_errors": 2,
         }
     ]
@@ -895,13 +895,13 @@ def test_mark_invoked_fail_closed_on_errored_invocation(tmp_path: Path) -> None:
 
 
 def test_mark_invoked_fail_closed_on_non_completed_trial(tmp_path: Path) -> None:
-    """A non-COMPLETED trial with capability.invoke must not transition."""
+    """A non-COMPLETED trial with math.run must not transition."""
 
     ledger = {"routing_status": {"C2": _c2_routing_contract()}}
     trials = [
         {
             "status": "ERROR",
-            "tool_calls": {"capability.invoke": 1},
+            "tool_calls": {"math.run": 1},
             "tool_errors": 0,
         }
     ]
@@ -911,13 +911,13 @@ def test_mark_invoked_fail_closed_on_non_completed_trial(tmp_path: Path) -> None
 
 
 def test_mark_invoked_fail_closed_on_timeout_trial(tmp_path: Path) -> None:
-    """A timed-out trial with capability.invoke must not transition."""
+    """A timed-out trial with math.run must not transition."""
 
     ledger = {"routing_status": {"C2": _c2_routing_contract()}}
     trials = [
         {
             "status": "TIMEOUT",
-            "tool_calls": {"capability.invoke": 3},
+            "tool_calls": {"math.run": 3},
             "tool_errors": 0,
         }
     ]
@@ -933,7 +933,7 @@ def test_mark_invoked_no_transition_when_already_invoked(tmp_path: Path) -> None
     trials = [
         {
             "status": "COMPLETED",
-            "tool_calls": {"capability.invoke": 1},
+            "tool_calls": {"math.run": 1},
             "tool_errors": 0,
         }
     ]
@@ -950,12 +950,12 @@ def test_mark_invoked_mixed_trials_one_success_transitions(tmp_path: Path) -> No
     trials = [
         {
             "status": "COMPLETED",
-            "tool_calls": {"capability.invoke": 1},
+            "tool_calls": {"math.run": 1},
             "tool_errors": 2,
         },
         {
             "status": "COMPLETED",
-            "tool_calls": {"capability.invoke": 1},
+            "tool_calls": {"math.run": 1},
             "tool_errors": 0,
         },
     ]

--- a/benchmarks/validation/test_heldout_runner.py
+++ b/benchmarks/validation/test_heldout_runner.py
@@ -157,7 +157,7 @@ def _ready_probe(
         "reachable": True,
         "report": {
             "server": {"name": "jacobian", "version": "1.0.0"},
-            "tool_names": ["capability.describe", "capability.invoke"],
+            "tool_names": ["math.find", "math.run"],
             "catalog": {
                 "catalog_version": "1",
                 "capabilities": 1,

--- a/benchmarks/validation/test_observation_manifests.py
+++ b/benchmarks/validation/test_observation_manifests.py
@@ -199,7 +199,7 @@ def test_reasoning_protocol_is_extracted_without_summary_text(tmp_path: Path) ->
             {"run_id": run_id, "call_id": call_id},
         ),
         _tool_event(
-            "capability.invoke",
+            "math.run",
             {"reasoning_run_id": run_id, "reasoning_call_id": call_id},
             {"execution": {"status": "COMPLETED"}},
         ),

--- a/deploy/smoke_remote.py
+++ b/deploy/smoke_remote.py
@@ -18,8 +18,8 @@ from jacobian import __version__
 from jacobian.canonical import canonicalize_json
 
 REQUIRED_TOOLS = {
-    "capability.describe",
-    "capability.invoke",
+    "math.find",
+    "math.run",
 }
 OPTIONAL_TOOLS = {"reasoning.write"}
 DISCOVERY_RESPONSE_BYTE_LIMIT = 16_384
@@ -145,7 +145,7 @@ async def inspect(
             )
 
         discovery_result = await client.call_tool(
-            "capability.describe",
+            "math.find",
             {"query": query, "limit": 5},
         )
         if discovery_result.is_error:

--- a/docs/contributing/atomic-capability-portfolio.md
+++ b/docs/contributing/atomic-capability-portfolio.md
@@ -12,8 +12,8 @@
 ## Decision
 
 Keep the five-tool MCP surface small. External systems should appear as
-versioned capability adapters behind `capability.describe` and
-`capability.invoke`, not as one new MCP tool per backend.
+versioned capability adapters behind `math.find` and
+`math.run`, not as one new MCP tool per backend.
 
 Build in this order:
 

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -147,7 +147,7 @@ broad portfolio of mathematical capabilities. Each adapter declares a
 namespaced operation ID, version, supported `EXPLORE` and `VERIFY` modes, input
 and output JSON Schemas, and discovery metadata. The MCP projection exposes the
 installed descriptors through `capability://catalog` and the tool-callable
-`capability.describe` and `capability.invoke` pair, so a new Alloy, Lean,
+`math.find` and `math.run` pair, so a new Alloy, Lean,
 SAT/SMT, CAS, or domain adapter does not require another MCP tool or a
 generic-core type. The current catalog returns full descriptors. As the
 portfolio grows, discovery should add compact summaries, search, and ranking
@@ -339,7 +339,7 @@ registry is operator-managed and binds checker digests to supported claim,
 semantics, and certificate versions.
 
 Plugins define mathematical meaning; adapters present their operations through
-`capability.describe` and `capability.invoke`; the runtime enforces the common
+`math.find` and `math.run`; the runtime enforces the common
 artifact and assurance contract.
 
 ### Sealed plugin identity
@@ -510,8 +510,8 @@ the generic runtime only enforces bindings and evidence state.
 The engine is also available as a Python library and CLI. The public MCP
 surface is deliberately small:
 
-- `capability.describe` returns the exact contract for an installed capability.
-- `capability.invoke` performs the selected bounded operation.
+- `math.find` returns the exact contract for an installed capability.
+- `math.run` performs the selected bounded operation.
 - `capability://catalog` exposes installed capability descriptors.
 - Resources expose large artifacts, traces, and experiment state.
 - Tool responses return typed mathematical values in MCP structured content;
@@ -523,7 +523,7 @@ surface is deliberately small:
 The MCP Python SDK `2.0.0` owns statically declared tool schemas, typed result
 serialization and validation, structured content, progress, and transport
 cancellation. Jacobian retains descriptor-selected validation for the dynamic
-`capability.invoke` payload because the selected mathematical schema is not
+`math.run` payload because the selected mathematical schema is not
 known when the MCP tool is registered. Ordinary responses return the Pydantic
 `CapabilityResult` directly so the SDK produces synchronized model-visible
 `content` and application-facing `structured_content`. An explicit

--- a/docs/explanation/goals.md
+++ b/docs/explanation/goals.md
@@ -60,7 +60,7 @@ or independent verification boundaries.
 ### Keep the public surface small
 
 Expose mathematical breadth through namespaced capabilities behind
-`capability.describe` and `capability.invoke`, not through a growing set of
+`math.find` and `math.run`, not through a growing set of
 top-level MCP tools. Remove compatibility wrappers and duplicate interfaces
 when they no longer serve a supported contract. Reuse maintained mathematical
 backends rather than accumulating custom infrastructure.

--- a/docs/explanation/product-blueprint.md
+++ b/docs/explanation/product-blueprint.md
@@ -118,8 +118,8 @@ Codex CLI              ChatGPT / remote agent
                        │
                        ▼
           capability://catalog
-          capability.describe
-          capability.invoke
+          math.find
+          math.run
                        │
                        ▼
                CapabilityService
@@ -241,7 +241,7 @@ non-verified result or operational error.
 ## Local and remote hosts
 
 The local Codex host uses STDIO. It exposes `capability://catalog`,
-`capability.describe`, and `capability.invoke` rather than projecting backend
+`math.find`, and `math.run` rather than projecting backend
 mathematical operations or workflows as additional top-level MCP tools.
 
 Remote hosts use Streamable HTTP and subject-bound tenant state. Authentication,

--- a/docs/explanation/search-runtime.md
+++ b/docs/explanation/search-runtime.md
@@ -13,8 +13,8 @@ composes search, evaluation, transformation, or verification capabilities, and
 search output never self-certifies.
 
 This runtime is not a separate public MCP workflow. Agents discover the
-namespaced capability with `capability.describe`, invoke it with
-`capability.invoke`, and inspect returned experiment and artifact resources.
+namespaced capability with `math.find`, invoke it with
+`math.run`, and inspect returned experiment and artifact resources.
 
 ## Ownership model
 

--- a/docs/how-to/deploy-remote-mcp.md
+++ b/docs/how-to/deploy-remote-mcp.md
@@ -15,6 +15,12 @@ Clients may read installed descriptors from `capability://catalog` and inspect
 exact contracts before invoking mathematical operations, which remain behind
 namespaced capability IDs.
 
+For controlled name-selection evaluations, `--tool-name-profile math` exposes
+the same two contracts as `math.find` and `math.run`. Do not expose both profiles
+to one model or interpret the treatment profile as a compatibility alias or
+public rename. Production deployments should retain the default until the
+evaluation and migration decision are complete.
+
 `--reasoning-log-mode off` is the default. Use `required` to enforce the
 operational `reasoning.write` protocol (PLAN → BEFORE_TOOL → invoke →
 AFTER_TOOL → FINAL) and expose the `reasoning.write` tool, or `audit` for

--- a/docs/how-to/deploy-remote-mcp.md
+++ b/docs/how-to/deploy-remote-mcp.md
@@ -10,16 +10,10 @@ deployment source of truth. Keep host-specific copies, smoke output, and
 last-deployed notes outside source control; do not install configuration from
 operator scratch space or treat it as current.
 
-By default the server exposes `capability.describe` and `capability.invoke`.
+The server exposes `math.find` and `math.run`.
 Clients may read installed descriptors from `capability://catalog` and inspect
 exact contracts before invoking mathematical operations, which remain behind
 namespaced capability IDs.
-
-For controlled name-selection evaluations, `--tool-name-profile math` exposes
-the same two contracts as `math.find` and `math.run`. Do not expose both profiles
-to one model or interpret the treatment profile as a compatibility alias or
-public rename. Production deployments should retain the default until the
-evaluation and migration decision are complete.
 
 `--reasoning-log-mode off` is the default. Use `required` to enforce the
 operational `reasoning.write` protocol (PLAN → BEFORE_TOOL → invoke →
@@ -343,7 +337,7 @@ startup.
 Lean results are cached only for an exact content-addressed certificate and
 the currently active checker digest. The bounded in-memory cache holds 128
 entries; a changed proof, statement, environment, checker, or authorization
-state cannot reuse an entry. `capability.describe` for `lean.check` reports the
+state cannot reuse an entry. `math.find` for `lean.check` reports the
 cache policy and the MATHLIB warm-up state (`RUNNING`, `HEALTHY`, or
 `UNHEALTHY`). Before advertising a deployment, wait for `HEALTHY` and invoke a
 deployed smoke check with `statement: "True"`, `proof: "by trivial"`, and

--- a/docs/how-to/invoke-domain-capabilities.md
+++ b/docs/how-to/invoke-domain-capabilities.md
@@ -18,7 +18,7 @@ the installed catalog.
 
 ## Discover and describe
 
-Call `capability.describe` without a capability ID to receive the installed
+Call `math.find` without a capability ID to receive the installed
 catalog. Select by mathematical outcome and domain tags, then describe the
 exact ID:
 
@@ -92,14 +92,14 @@ async def main() -> None:
     async with Client(server, raise_exceptions=True) as client:
         described = await tool(
             client,
-            "capability.describe",
+            "math.find",
             {"capability_id": "polynomial.compute.gcd"},
         )
         assert described["capability"]["modes"] == ["EXPLORE"]
 
         computed = await tool(
             client,
-            "capability.invoke",
+            "math.run",
             {
                 "capability_id": "polynomial.compute.gcd",
                 "mode": "EXPLORE",
@@ -114,14 +114,14 @@ async def main() -> None:
 
         verification_descriptor = await tool(
             client,
-            "capability.describe",
+            "math.find",
             {"capability_id": "polynomial.gcd.verify"},
         )
         assert verification_descriptor["capability"]["modes"] == ["VERIFY"]
 
         verified = await tool(
             client,
-            "capability.invoke",
+            "math.run",
             {
                 "capability_id": "polynomial.gcd.verify",
                 "mode": "VERIFY",

--- a/docs/how-to/run-agent-evaluations.md
+++ b/docs/how-to/run-agent-evaluations.md
@@ -122,33 +122,27 @@ make agent-eval DATASET=agent-workflow-v1 \
 Use `TASKS=graph-counterexample` for a small smoke run. The treatment run uses
 `benchmarks/config/jacobian.mcp.json`; task TOMLs remain agent-agnostic.
 
-### Compare tool-name profiles
+### Evaluate tool adoption and task design
 
-The default `capability` profile exposes `capability.describe` and
-`capability.invoke`. The experimental `math` profile exposes the same server
-instructions, descriptions, schemas, handlers, and result semantics as
-`math.find` and `math.run`. Run the profiles separately and bind
-`tool_name_profile` in each runtime snapshot's `condition` object:
+Jacobian exposes the canonical `math.find` and `math.run` tools in every
+observation run. Use a separate result root for each model, task set, or prompt
+condition so evidence from distinct runs cannot overwrite each other:
 
 ```sh
-JACOBIAN_TOOL_NAME_PROFILE=capability make agent-eval \
+make agent-eval \
   DATASET=agent-workflow-v1 JACOBIAN_ENABLED=1 \
   TASKS=graph-counterexample EVAL_EXECUTE=1 \
-  RUNTIME_SNAPSHOT=benchmarks/results/name-capability/runtime.json \
-  EVAL_ARGS="--job-name name-capability --jobs-dir benchmarks/results/name-capability"
-
-JACOBIAN_TOOL_NAME_PROFILE=math make agent-eval \
-  DATASET=agent-workflow-v1 JACOBIAN_ENABLED=1 \
-  TASKS=graph-counterexample EVAL_EXECUTE=1 \
-  RUNTIME_SNAPSHOT=benchmarks/results/name-math/runtime.json \
-  EVAL_ARGS="--job-name name-math --jobs-dir benchmarks/results/name-math"
+  RUNTIME_SNAPSHOT=benchmarks/results/adoption/runtime.json \
+  EVAL_ARGS="--job-name adoption --jobs-dir benchmarks/results/adoption"
 ```
 
-Keep the model, task digests, prompt, reasoning budget, agent version, image,
-reasoning-log mode, attempts, and network policy fixed. Compare appropriate
-Jacobian adoption, valid calls, discovery-to-execution continuation, irrelevant
-calls, fallback behavior, mathematical correctness, tokens, and elapsed time.
-Do not score adherence to a preferred tool sequence.
+Measure appropriate Jacobian adoption, valid calls, discovery-to-execution
+continuation, irrelevant calls, fallback behavior, mathematical correctness,
+tokens, and elapsed time. A correct run with no Jacobian calls may show that the
+task is too easy or that native tools are a better fit; it does not by itself
+show that the tool surface was misunderstood. Use negative-control tasks and
+tasks where Jacobian offers a material mathematical affordance. Do not score
+adherence to a preferred tool sequence.
 
 ### Held-out treatment readiness
 

--- a/docs/how-to/run-agent-evaluations.md
+++ b/docs/how-to/run-agent-evaluations.md
@@ -42,10 +42,13 @@ prompt, budget, and environment before running either condition. The default
 run is direct networking. Use `JACOBIAN_EVAL_PROXY=1` only when the host or
 region requires a proxy for Codex's outbound model connection.
 
-If a run needs a host proxy for package installation or model access, set the
-flag before both conditions. The flag automatically reuses standard
+If a run needs a host proxy for model access, set the flag before both
+conditions. The flag automatically reuses standard
 `HTTP_PROXY`, `HTTPS_PROXY`, and `ALL_PROXY` variables; use the explicit
 `JACOBIAN_EVAL_*` variables when the evaluation should use different values.
+The proxy profile chooses `JACOBIAN_EVAL_HTTPS_PROXY`, then
+`JACOBIAN_EVAL_ALL_PROXY`, then `JACOBIAN_EVAL_HTTP_PROXY`, and accepts
+`http://`, `socks5://`, or `socks5h://` upstream URLs.
 When inherited proxy URLs use `localhost` or `127.0.0.1`, the Makefile maps
 them to `host.docker.internal` for the container automatically:
 
@@ -55,22 +58,30 @@ export CODEX_FORCE_AUTH_JSON=1
 
 export JACOBIAN_EVAL_HTTP_PROXY='http://host.docker.internal:7890'
 export JACOBIAN_EVAL_HTTPS_PROXY='http://host.docker.internal:7890'
-export JACOBIAN_EVAL_NO_PROXY='localhost,127.0.0.1,jacobian'
 export JACOBIAN_EVAL_PROXY=1
 ```
 
 Unset `JACOBIAN_EVAL_PROXY` and the proxy variables for direct networking. On
 Linux, the host proxy must accept connections from Docker's bridge interface;
 a proxy listening only on `127.0.0.1` is not reachable from the container.
-Jacobian's service name is included in `NO_PROXY`, so MCP traffic remains on
-the local Compose network.
+
+This proxy profile is optional host integration, not part of a task contract.
+It renders a private runtime configuration that chains Harbor's transparent
+egress controller through the upstream proxy, so Harbor's task allowlist stays
+in force. Codex and Jacobian share Harbor's controlled network namespace, and
+MCP uses its loopback interface, so local tool traffic never enters the
+upstream chain. All jobs also mount the host's standalone Codex executable to
+avoid a trial-time package install; override its resolved path with
+`JACOBIAN_EVAL_CODEX_BINARY`. Keep machine-specific Clash addresses in local
+environment variables rather than committed configuration.
 
 ## Run with Jacobian
 
 The local path uses Harbor's Docker environment, a Jacobian Compose sidecar,
 and Harbor's external MCP configuration. The treatment contract is deliberately
-small: Codex has Jacobian at `http://jacobian:8000/mcp`, and Codex web search is
-disabled.
+small: direct runs address Jacobian by its Compose service name, while the
+controlled proxy profile uses loopback because both containers share Harbor's
+egress namespace. Codex web search is disabled in both profiles.
 
 Choose the image from the source tree state. A clean revision pulls its
 published full-SHA tag and resolves it to an immutable OCI digest. A dirty tree
@@ -110,6 +121,34 @@ make agent-eval DATASET=agent-workflow-v1 \
 
 Use `TASKS=graph-counterexample` for a small smoke run. The treatment run uses
 `benchmarks/config/jacobian.mcp.json`; task TOMLs remain agent-agnostic.
+
+### Compare tool-name profiles
+
+The default `capability` profile exposes `capability.describe` and
+`capability.invoke`. The experimental `math` profile exposes the same server
+instructions, descriptions, schemas, handlers, and result semantics as
+`math.find` and `math.run`. Run the profiles separately and bind
+`tool_name_profile` in each runtime snapshot's `condition` object:
+
+```sh
+JACOBIAN_TOOL_NAME_PROFILE=capability make agent-eval \
+  DATASET=agent-workflow-v1 JACOBIAN_ENABLED=1 \
+  TASKS=graph-counterexample EVAL_EXECUTE=1 \
+  RUNTIME_SNAPSHOT=benchmarks/results/name-capability/runtime.json \
+  EVAL_ARGS="--job-name name-capability --jobs-dir benchmarks/results/name-capability"
+
+JACOBIAN_TOOL_NAME_PROFILE=math make agent-eval \
+  DATASET=agent-workflow-v1 JACOBIAN_ENABLED=1 \
+  TASKS=graph-counterexample EVAL_EXECUTE=1 \
+  RUNTIME_SNAPSHOT=benchmarks/results/name-math/runtime.json \
+  EVAL_ARGS="--job-name name-math --jobs-dir benchmarks/results/name-math"
+```
+
+Keep the model, task digests, prompt, reasoning budget, agent version, image,
+reasoning-log mode, attempts, and network policy fixed. Compare appropriate
+Jacobian adoption, valid calls, discovery-to-execution continuation, irrelevant
+calls, fallback behavior, mathematical correctness, tokens, and elapsed time.
+Do not score adherence to a preferred tool sequence.
 
 ### Held-out treatment readiness
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -81,7 +81,7 @@ performance measurement, and regression policy.
 **Reference scenarios:** [Worked cases](reference/scenarios/index.md) —
 mathematical scenario catalog and certified-homology case.
 
-Use the runtime `capability://catalog` and `capability.describe` for the
+Use the runtime `capability://catalog` and `math.find` for the
 installed capability inventory and exact operation schemas.
 
 ## Explanation

--- a/docs/reference/capabilities/lean/lean-formal-intermediates.md
+++ b/docs/reference/capabilities/lean/lean-formal-intermediates.md
@@ -12,7 +12,7 @@ proof edits remain inspectable evidence. Only successful `lean.check` replay,
 or a proof-edit capability bound to that checker, returns `VERIFIED`.
 
 Availability depends on the pinned Lean profile and bundled-reference
-installation. Inspect `capability://catalog` and call `capability.describe`
+installation. Inspect `capability://catalog` and call `math.find`
 before using any payload below.
 
 ## Capability roles

--- a/docs/reference/domain-operation-library.md
+++ b/docs/reference/domain-operation-library.md
@@ -14,7 +14,7 @@ completeness, provider provenance, and visible proof obligations.
 
 This document describes the shared installation contract. It is not a static
 capability inventory. Read `capability://catalog`, then use
-`capability.describe` for the IDs, schemas, modes, provider identities, and
+`math.find` for the IDs, schemas, modes, provider identities, and
 checker requirements installed in a particular runtime.
 
 ## Bundle contract
@@ -96,7 +96,7 @@ The supported native-value interface is the deliberately small
 [`jacobian.math`](python-api.md) namespace. Its functions accept Python,
 SymPy, or NetworkX values as documented and call typed mathematical kernels
 directly. They do not construct the capability runtime or route through
-`capability.invoke`.
+`math.run`.
 
 When a native function corresponds to a capability, both paths share the same
 domain-owned mathematical kernel. Explicit adapters translate between native
@@ -181,7 +181,7 @@ format. Unsupported formats, rejected evidence, timeout, cancellation,
 runtime-identity drift, malformed output, and worker failure return
 non-verifying outcomes and cannot create that record.
 
-Use `capability.describe` on the producer and candidate verification capability
+Use `math.find` on the producer and candidate verification capability
 before invocation. Do not infer a verifier ID or payload from naming
 conventions: checker availability depends on operator authorization and the
 installed runtime.

--- a/docs/reference/evaluations/evaluation-methods.md
+++ b/docs/reference/evaluations/evaluation-methods.md
@@ -261,8 +261,8 @@ Measure:
 
 - installed CLI startup;
 - local MCP stdio startup;
-- `capability.describe` for one installed descriptor;
-- one small `capability.invoke` request;
+- `math.find` for one installed descriptor;
+- one small `math.run` request;
 - batch request encoding and decoding;
 - resource-handle response construction.
 

--- a/docs/reference/plugin-conformance.md
+++ b/docs/reference/plugin-conformance.md
@@ -8,8 +8,8 @@ The conformance kit tests whether an independently installed package crosses
 Jacobian's registry, execution, artifact, and assurance boundaries without core
 or MCP changes. It is an executable extension gate, not a second unit-test
 framework. A conforming package exposes namespaced capability IDs through the
-installed catalog; agents inspect them with `capability.describe` and execute
-them with `capability.invoke`.
+installed catalog; agents inspect them with `math.find` and execute
+them with `math.run`.
 
 ## Scope
 
@@ -72,8 +72,8 @@ execution and assurance contract.
 
 | Check | Boundary exercised | Passing result |
 | --- | --- | --- |
-| Discovery | Installed catalog and `capability.describe` | Exact descriptor for each declared namespaced capability ID |
-| Execution success | Registry resolution and `capability.invoke` | Schema-valid result with no verification promotion |
+| Discovery | Installed catalog and `math.find` | Exact descriptor for each declared namespaced capability ID |
+| Execution success | Registry resolution and `math.run` | Schema-valid result with no verification promotion |
 | Declared failure | Capability worker lifecycle | `ERROR` with the declared detail |
 | Malformed output | Capability worker JSON boundary | `ERROR`; response is not accepted as mathematical evidence |
 | Timeout | Worker and durable budget | `TIMEOUT` with wall-limit stop reason |

--- a/docs/reference/python-api.md
+++ b/docs/reference/python-api.md
@@ -31,7 +31,7 @@ functions accept undirected simple NetworkX `Graph` objects. Each module's
 modules remain internal.
 
 This API shares typed mathematical kernels with the corresponding capability
-implementations, but it is not a facade over `capability.invoke`. Capability
+implementations, but it is not a facade over `math.run`. Capability
 requests, result contracts, artifacts, provenance, completeness, and
 verification remain available through the capability runtime and retain their
 existing wire semantics.

--- a/docs/reference/reasoning-log.md
+++ b/docs/reference/reasoning-log.md
@@ -11,7 +11,7 @@ operational and unverified and never change mathematical assurance.
 1. Call `reasoning.write` with `phase: "PLAN"`; retain its `run_id`.
 2. Before each capability execution, write `BEFORE_TOOL` with that run ID,
    exact capability ID, mode, and a short purpose. Retain the returned `call_id`.
-3. Add both IDs to the matching `capability.invoke` request.
+3. Add both IDs to the matching `math.run` request.
 4. After every result, write `AFTER_TOOL` with `interpretation_status:
    "INTERPRETED"`, the same IDs, a concise interpretation, and the reported
    execution status, assurance level, and completeness status. If the result

--- a/docs/reference/scenarios/math-scenarios.md
+++ b/docs/reference/scenarios/math-scenarios.md
@@ -46,7 +46,7 @@ checker conformance.
 Capability IDs below name candidate agent-facing contracts for the scenario.
 They do not imply that a capability is installed; agents must discover
 availability through `capability://catalog` and inspect the exact contract with
-`capability.describe`.
+`math.find`.
 
 ## Scenario record
 

--- a/docs/reference/testing-strategy.md
+++ b/docs/reference/testing-strategy.md
@@ -591,9 +591,9 @@ Required examples and state sequences:
 
 The CLI and MCP layer must be thin enough to test by equivalence:
 
-- the Python API, CLI, and `capability.invoke` return the same semantic result
+- the Python API, CLI, and `math.run` return the same semantic result
   envelope for the same descriptor version and artifact inputs;
-- `capability.describe`, `capability://catalog`, and invocation schemas agree;
+- `math.find`, `capability://catalog`, and invocation schemas agree;
 - boundary tests assert the exact tool, resource, template, and prompt inventories,
   their safety annotations and schemas, the operating guide, and representative
   browse, query, and exact-description behavior through their public MCP seams;
@@ -722,7 +722,7 @@ This work ships with the schema and artifact issues, not after them.
 - add mixed-batch and resource-failure scenarios;
 - add oracle outcome and `NONE_CERTIFIED` protocol tests;
 - add reduction state machines, cycle detection, and minimality-label tests;
-- compare Python API, CLI, and `capability.invoke` results.
+- compare Python API, CLI, and `math.run` results.
 
 ### Cross-domain fixtures
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -11,8 +11,8 @@ model-facing MCP surface contains two capability tools and, in `REQUIRED` or
 
 | MCP tool | Purpose |
 | --- | --- |
-| `capability.describe` | Search the compact installed index, or read one capability's exact schemas by ID. |
-| `capability.invoke` | Invoke an installed capability in `EXPLORE` or `VERIFY` mode. |
+| `capability.describe` | Find or inspect installed mathematical operations by desired outcome or exact ID. |
+| `capability.invoke` | Run one installed mathematical operation in `EXPLORE` or `VERIFY` mode. |
 | `reasoning.write` | Append a bounded model-authored `PLAN`, `BEFORE_TOOL`, `AFTER_TOOL`, or `FINAL` summary. Available only in `REQUIRED` or `AUDIT` mode. |
 
 The reasoning log is not a mathematical capability, proof object, workspace, or
@@ -30,11 +30,18 @@ that an operation is installed and invocable. It does not imply compatibility
 support, recommendation, conformance coverage, or authority to return
 `VERIFIED`.
 
-There are no alternate mathematical capability profiles and no public top-level
-MCP commands for individual mathematical operations. The operator may set the
-reasoning-log enforcement mode to `REQUIRED`, `AUDIT`, or `OFF`; `OFF` is the
-default and preserves the legacy two-tool surface. Adding a capability does not
-add a new MCP tool.
+The supported default names are `capability.describe` and `capability.invoke`.
+Controlled tool-selection evaluations may start the server with
+`--tool-name-profile math`, which exposes the same contracts exclusively as
+`math.find` and `math.run`. A server exposes one profile at a time, never both
+name pairs as aliases. The treatment profile is evaluation infrastructure, not
+evidence that the public default has changed. Adding a capability does not add a
+new MCP tool.
+
+The operator may separately set the reasoning-log enforcement mode to
+`REQUIRED`, `AUDIT`, or `OFF`; `OFF` is the default. Name profiles and reasoning
+logging do not change capability membership, mathematical behavior, assurance,
+or checker authority.
 
 ## Capability contract
 
@@ -81,8 +88,8 @@ enabled bundled references, configured exclusions, and operator-installed
 adapters. A static list in this document would therefore describe only one
 installation snapshot.
 
-`capability.describe` has two forms. Search or browse to retrieve compact
-installed outcomes without loading every schema:
+`capability.describe` supports search, browse, and exact inspection. Search or
+browse retrieves compact installed outcomes without loading every schema:
 
 ```json
 {
@@ -107,8 +114,13 @@ result-level `portfolio_fit` distinguishes strong candidates, only weak lexical
 matches, and no lexical matches. These are transparent descriptor-retrieval
 signals, not a proof that an operation is mathematically suitable or absent.
 In particular, top-N ordering among `WEAK_LEXICAL_MATCH` entries must not be
-treated as capability fit. Start with five results, inspect only the strongest
-one or two relevant contracts, then search again only when useful.
+treated as capability fit.
+
+Each match is an operation card containing accepted input and artifact kinds,
+an output-schema summary, provider availability, exact-input scope, assurance
+ceiling, and factual relationships to installed compatible operations. These
+fields support the agent's decision; they do not recommend what it should do
+next.
 
 Discovery can also be constrained by `input_kind`. Installed descriptors
 declare whether they accept a structured request, formal proposition, or typed
@@ -118,21 +130,26 @@ General natural-language proof prose is not a formal artifact: declaring
 `NATURAL_LANGUAGE_PROOF`, or using an unambiguous phrase such as “informal
 proof” or “proof prose,” returns typed `NO_ROUTE` unless an installed provider
 explicitly accepts that input. The response's `routing_status` and
-`routing_basis` are separate from lexical `portfolio_fit`.
+`routing_basis` are separate from lexical `portfolio_fit`. Weak, empty, or
+incompatible results expose unranked recovery paths: reformulate the query,
+remove applicable filters, browse without arguments, or inspect
+`capability://catalog`. These paths do not imply that the requested operation is
+mathematically impossible or absent in principle.
 
-Call `capability.describe` again with one returned `capability_id` to receive
-the default `SUMMARY` exact projection. It is for judging fit and contains the
-one-line outcome, modes, tags, provider availability, input/output field
-summaries, and whether descriptor-owned invocation examples are available:
+Passing one `capability_id` returns the default `SUMMARY` exact projection. It
+contains the one-line outcome, modes, tags, provider availability, input/output
+field summaries, and whether descriptor-owned invocation examples are
+available:
 
 ```json
 {"capability_id": "universal_algebra.search.countermodel"}
 ```
 
-Once the outcome fits, request `view: "CONTRACT"` before invoking. It adds the
-complete validation-equivalent input schema (annotation/default and
-discriminator routing metadata are omitted), concise output/runtime summaries,
-related operations, and descriptor-owned validated invocation examples:
+The `CONTRACT` view adds the complete validation-equivalent input schema
+(annotation/default and discriminator routing metadata are omitted), concise
+output/runtime summaries, related operations, and descriptor-owned validated
+invocation examples. It is available whenever an agent does not already have
+the exact contract needed to construct a call:
 
 ```json
 {
@@ -141,8 +158,8 @@ related operations, and descriptor-owned validated invocation examples:
 }
 ```
 
-Use `view: "FULL"` when complete output schema, provider
-configuration, licensing, or other audit metadata is required:
+The `FULL` view adds complete output schema, provider configuration, licensing,
+and other audit metadata:
 
 ```json
 {
@@ -151,16 +168,14 @@ configuration, licensing, or other audit metadata is required:
 }
 ```
 
-Once a domain-owned producer fits the outcome, invoke it before separately
-searching for a checker. Follow the checker, certificate, and verification
-fields in the producer result rather than guessing that a generic verifier
-accepts its artifact.
-
 `capability.invoke` returns the Pydantic `CapabilityResult`. MCP Python SDK 2.0
 derives its output schema, validates the returned value, serializes
 model-visible `content`, and supplies the same typed value in
 `structured_content`. Small, bounded mathematical outputs remain inline in the
 result. An empty `artifact_uris` means the value was not retained.
+An agent that already has an exact operation contract may invoke it directly;
+search, browse, and inspection are composable access paths, not a required
+sequence.
 
 Capabilities return resource URIs only when their mathematical outcome needs
 durable identity, independent retrieval, replay, resumability, evidence

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -11,12 +11,12 @@ model-facing MCP surface contains two capability tools and, in `REQUIRED` or
 
 | MCP tool | Purpose |
 | --- | --- |
-| `capability.describe` | Find or inspect installed mathematical operations by desired outcome or exact ID. |
-| `capability.invoke` | Run one installed mathematical operation in `EXPLORE` or `VERIFY` mode. |
+| `math.find` | Find or inspect installed mathematical operations by desired outcome or exact ID. |
+| `math.run` | Run one installed mathematical operation in `EXPLORE` or `VERIFY` mode. |
 | `reasoning.write` | Append a bounded model-authored `PLAN`, `BEFORE_TOOL`, `AFTER_TOOL`, or `FINAL` summary. Available only in `REQUIRED` or `AUDIT` mode. |
 
 The reasoning log is not a mathematical capability, proof object, workspace, or
-chain-of-thought collector. In `REQUIRED` mode, every `capability.invoke` must
+chain-of-thought collector. In `REQUIRED` mode, every `math.run` must
 carry the `reasoning_run_id` and `reasoning_call_id` returned by the current
 `BEFORE_TOOL`. The server binds the actual execution status, assurance,
 completeness, result digest, and artifact URIs, then records whether the model's
@@ -30,18 +30,14 @@ that an operation is installed and invocable. It does not imply compatibility
 support, recommendation, conformance coverage, or authority to return
 `VERIFIED`.
 
-The supported default names are `capability.describe` and `capability.invoke`.
-Controlled tool-selection evaluations may start the server with
-`--tool-name-profile math`, which exposes the same contracts exclusively as
-`math.find` and `math.run`. A server exposes one profile at a time, never both
-name pairs as aliases. The treatment profile is evaluation infrastructure, not
-evidence that the public default has changed. Adding a capability does not add a
-new MCP tool.
+The supported names are `math.find` and `math.run`. The superseded
+`capability.*` names are not exposed as aliases, so agents never choose between
+equivalent top-level tools. Adding a capability does not add a new MCP tool.
 
 The operator may separately set the reasoning-log enforcement mode to
-`REQUIRED`, `AUDIT`, or `OFF`; `OFF` is the default. Name profiles and reasoning
-logging do not change capability membership, mathematical behavior, assurance,
-or checker authority.
+`REQUIRED`, `AUDIT`, or `OFF`; `OFF` is the default. Reasoning logging does not
+change capability membership, mathematical behavior, assurance, or checker
+authority.
 
 ## Capability contract
 
@@ -88,7 +84,7 @@ enabled bundled references, configured exclusions, and operator-installed
 adapters. A static list in this document would therefore describe only one
 installation snapshot.
 
-`capability.describe` supports search, browse, and exact inspection. Search or
+`math.find` supports search, browse, and exact inspection. Search or
 browse retrieves compact installed outcomes without loading every schema:
 
 ```json
@@ -168,7 +164,7 @@ and other audit metadata:
 }
 ```
 
-`capability.invoke` returns the Pydantic `CapabilityResult`. MCP Python SDK 2.0
+`math.run` returns the Pydantic `CapabilityResult`. MCP Python SDK 2.0
 derives its output schema, validates the returned value, serializes
 model-visible `content`, and supplies the same typed value in
 `structured_content`. Small, bounded mathematical outputs remain inline in the
@@ -240,7 +236,7 @@ Z3 search. Larger inputs return an unsupported non-conclusion.
 Useful low-level operations may retain descriptive IDs such as
 `claim.validate`, `witness.find`, `witness.verify`, or
 `certificate.verify`. Those names identify capabilities invoked through
-`capability.invoke`; they are not separate MCP tools.
+`math.run`; they are not separate MCP tools.
 
 `claim.conjunction.split` and `claim.implication.obligations` operate on the
 registered v1 `PROPOSITIONAL_STRUCTURE` artifact. They return only immediate,

--- a/docs/tutorials/first-verified-result.md
+++ b/docs/tutorials/first-verified-result.md
@@ -66,7 +66,7 @@ async def main() -> None:
         for capability_id in capability_ids:
             description = await tool(
                 client,
-                "capability.describe",
+                "math.find",
                 {"capability_id": capability_id},
             )
             assert description["capability"]["capability_id"] == capability_id
@@ -77,7 +77,7 @@ async def main() -> None:
 
         claim = await tool(
             client,
-            "capability.invoke",
+            "math.run",
             {
                 "capability_id": "artifact.put",
                 "mode": "EXPLORE",
@@ -108,7 +108,7 @@ async def main() -> None:
 
         candidate = await tool(
             client,
-            "capability.invoke",
+            "math.run",
             {
                 "capability_id": "artifact.put",
                 "mode": "EXPLORE",
@@ -139,7 +139,7 @@ async def main() -> None:
 
         validation = await tool(
             client,
-            "capability.invoke",
+            "math.run",
             {
                 "capability_id": "claim.validate",
                 "mode": "EXPLORE",
@@ -153,7 +153,7 @@ async def main() -> None:
 
         evaluation = await tool(
             client,
-            "capability.invoke",
+            "math.run",
             {
                 "capability_id": "evaluate.batch",
                 "mode": "EXPLORE",
@@ -176,7 +176,7 @@ async def main() -> None:
 
         found = await tool(
             client,
-            "capability.invoke",
+            "math.run",
             {
                 "capability_id": "witness.find",
                 "mode": "EXPLORE",
@@ -194,7 +194,7 @@ async def main() -> None:
 
         verified = await tool(
             client,
-            "capability.invoke",
+            "math.run",
             {
                 "capability_id": "witness.verify",
                 "mode": "VERIFY",

--- a/docs/tutorials/lean-declaration-discovery.md
+++ b/docs/tutorials/lean-declaration-discovery.md
@@ -44,7 +44,7 @@ async def main() -> None:
     async with Client(server, raise_exceptions=True) as client:
         searched = await tool(
             client,
-            "capability.invoke",
+            "math.run",
             {
                 "capability_id": "lean.declaration.search",
                 "mode": "EXPLORE",
@@ -61,7 +61,7 @@ async def main() -> None:
 
         inspected = await tool(
             client,
-            "capability.invoke",
+            "math.run",
             {
                 "capability_id": "lean.declaration.inspect",
                 "mode": "EXPLORE",
@@ -79,7 +79,7 @@ async def main() -> None:
 
         checked = await tool(
             client,
-            "capability.invoke",
+            "math.run",
             {
                 "capability_id": "lean.check",
                 "mode": "VERIFY",

--- a/npm/bin/doctor.cjs
+++ b/npm/bin/doctor.cjs
@@ -18,8 +18,8 @@ const HANDSHAKE_TIMEOUT_MS = 60_000;
 const RESPONSE_TIMEOUT_MS = 10_000;
 
 const EXPECTED_TOOLS = [
-  "capability.describe",
-  "capability.invoke",
+  "math.find",
+  "math.run",
 ];
 
 /**

--- a/npm/npm-packaging.test.mjs
+++ b/npm/npm-packaging.test.mjs
@@ -323,10 +323,10 @@ test("doctor classifies a missing managed Jacobian runtime", () => {
   assert.match(diagnostic.recovery, /source-agent doctor/);
 });
 
-test("doctor validates the default capability-first MCP profile", () => {
+test("doctor validates the canonical math MCP surface", () => {
   assert.deepEqual(EXPECTED_TOOLS, [
-    "capability.describe",
-    "capability.invoke",
+    "math.find",
+    "math.run",
   ]);
 });
 

--- a/src/jacobian/adapters/mcp/cli.py
+++ b/src/jacobian/adapters/mcp/cli.py
@@ -149,6 +149,12 @@ def _parser() -> argparse.ArgumentParser:
             "Accepts case-insensitive values: required, audit, off."
         ),
     )
+    parser.add_argument(
+        "--tool-name-profile",
+        choices=("capability", "math"),
+        default="capability",
+        help="agent-visible capability tool names; defaults to capability",
+    )
     return parser
 
 
@@ -195,6 +201,7 @@ def main() -> None:
             capability_adapter_entrypoints=tuple(args.capability_adapter),
             capability_policy=capability_policy,
             reasoning_log_mode=reasoning_log_mode,
+            tool_name_profile=args.tool_name_profile,
         ).run("stdio")
         return
 
@@ -236,6 +243,7 @@ def main() -> None:
         max_tenant_runtimes=args.max_tenant_runtimes,
         tenant_idle_timeout_seconds=args.tenant_idle_timeout_seconds,
         reasoning_log_mode=reasoning_log_mode,
+        tool_name_profile=args.tool_name_profile,
     )
     if args.transport == "streamable-http":
         server.run(

--- a/src/jacobian/adapters/mcp/cli.py
+++ b/src/jacobian/adapters/mcp/cli.py
@@ -149,12 +149,6 @@ def _parser() -> argparse.ArgumentParser:
             "Accepts case-insensitive values: required, audit, off."
         ),
     )
-    parser.add_argument(
-        "--tool-name-profile",
-        choices=("capability", "math"),
-        default="capability",
-        help="agent-visible capability tool names; defaults to capability",
-    )
     return parser
 
 
@@ -201,7 +195,6 @@ def main() -> None:
             capability_adapter_entrypoints=tuple(args.capability_adapter),
             capability_policy=capability_policy,
             reasoning_log_mode=reasoning_log_mode,
-            tool_name_profile=args.tool_name_profile,
         ).run("stdio")
         return
 
@@ -243,7 +236,6 @@ def main() -> None:
         max_tenant_runtimes=args.max_tenant_runtimes,
         tenant_idle_timeout_seconds=args.tenant_idle_timeout_seconds,
         reasoning_log_mode=reasoning_log_mode,
-        tool_name_profile=args.tool_name_profile,
     )
     if args.transport == "streamable-http":
         server.run(

--- a/src/jacobian/adapters/mcp/context.py
+++ b/src/jacobian/adapters/mcp/context.py
@@ -174,7 +174,7 @@ def _classify_public_tool_error(
         return (
             "INVALID_INPUT",
             "The tool input is not valid for this operation.",
-            "Check the tool input schema or call capability.describe, then retry.",
+            "Check the tool input schema or call math.find, then retry.",
         )
     return (
         "OPERATION_FAILED",

--- a/src/jacobian/adapters/mcp/guidance.py
+++ b/src/jacobian/adapters/mcp/guidance.py
@@ -2,52 +2,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-
-
-@dataclass(frozen=True)
-class ToolNames:
-    """Agent-visible names for the two stable capability tools."""
-
-    profile: str
-    describe: str
-    invoke: str
-
-
-TOOL_NAME_PROFILES = {
-    "capability": ToolNames(
-        profile="capability",
-        describe="capability.describe",
-        invoke="capability.invoke",
-    ),
-    "math": ToolNames(
-        profile="math",
-        describe="math.find",
-        invoke="math.run",
-    ),
-}
-
-
-def tool_names(profile: str) -> ToolNames:
-    """Resolve one explicit MCP tool-name profile."""
-
-    try:
-        return TOOL_NAME_PROFILES[profile]
-    except KeyError:
-        choices = ", ".join(sorted(TOOL_NAME_PROFILES))
-        raise ValueError(
-            f"invalid tool_name_profile: {profile!r} (choose from {choices})"
-        ) from None
-
-
-def render_tool_names(text: str, names: ToolNames) -> str:
-    """Apply a name profile without changing the surrounding guidance."""
-
-    return text.replace("capability.describe", names.describe).replace(
-        "capability.invoke", names.invoke
-    )
-
-
 SERVER_DESCRIPTION = (
     "Discover and execute installed mathematical operations with explicit scope, "
     "completeness, assurance, and optional independent verification."
@@ -57,9 +11,9 @@ SERVER_INSTRUCTIONS = (
     "Jacobian provides searchable and executable mathematical operations for exact "
     "computation, transformation, structure discovery, examples and counterexamples, "
     "bounded search, formal-environment inspection, and independent checking. "
-    "capability.describe searches, browses, or inspects installed operations using a "
+    "math.find searches, browses, or inspects installed operations using a "
     "plain-language description of the desired local mathematical outcome. "
-    "capability.invoke executes a selected operation using its typed input contract. "
+    "math.run executes a selected operation using its typed input contract. "
     "Search or browse again whenever the objective or available evidence changes. "
     "The model owns representation, decomposition, composition, iteration, verification "
     "timing, and stopping. Results keep execution status, scope, completeness, "
@@ -69,7 +23,7 @@ SERVER_INSTRUCTIONS = (
     "verified. Read jacobian://instructions for the complete operating guide."
 )
 
-CAPABILITY_DESCRIBE_DESCRIPTION = """\
+MATH_FIND_DESCRIPTION = """\
 Find or inspect an installed mathematical operation that can produce a desired outcome.
 
 Choose this when mathematical work may benefit from exact computation, structural
@@ -105,11 +59,11 @@ Examples:
 - `{"capability_id":"polynomial.compute.gcd","view":"CONTRACT"}`
 """
 
-CAPABILITY_INVOKE_DESCRIPTION = """\
+MATH_RUN_DESCRIPTION = """\
 Run one installed mathematical operation and return its typed result, scope,
 completeness, assurance, diagnostics, intermediates, relationships, and artifacts.
 
-Use the selected operation's exact input contract; capability.describe can inspect an
+Use the selected operation's exact input contract; math.find can inspect an
 unfamiliar contract without making inspection a required research step. EXPLORE
 returns proposed, heuristic, or computed evidence. VERIFY is valid only for an
 installed checker-backed contract. The canonical `CapabilityResult` keeps execution,
@@ -147,7 +101,7 @@ independent checking. An installed capability ID is not required for search or b
 
 ## Search, browse, inspect, and run
 
-Search with `capability.describe(query=...)`, optionally filtered by `domain` and
+Search with `math.find(query=...)`, optionally filtered by `domain` and
 `mode`. Results are compact candidates ranked by deterministic matches against
 published descriptor metadata; `matched_on` and `matched_terms` make that retrieval
 visible. Ranking is not a recommendation. Follow `next_cursor` with unchanged filters
@@ -159,14 +113,14 @@ FULL adds complete provider and audit metadata. An agent that already has an exa
 contract may invoke the operation directly. Related operations describe compatibility
 and evidence flow; they do not prescribe what to do next.
 
-`capability.invoke` returns the canonical complete `CapabilityResult` directly as MCP
+`math.run` returns the canonical complete `CapabilityResult` directly as MCP
 structured content. Calls may be composed in any sequence the mathematical
 investigation requires. Inspect execution, scope, completeness, relationships,
 obligations, assurance, diagnostics, intermediates, and artifacts as separate result
 dimensions. Follow returned `artifact://` references to read durable results.
 
 `capability://catalog` is the complete machine-readable installed inventory.
-`capability.describe` is the agent-oriented discovery and exact-inspection surface.
+`math.find` is the agent-oriented discovery and exact-inspection surface.
 Weak or empty discovery results expose query reformulation, filter removal, browse,
 and catalog-inspection paths. They do not establish operation absence or mathematical
 impossibility.
@@ -219,9 +173,9 @@ raw tool output into summary.
 
 _REASONING_PREFIX = (
     "Before using Jacobian, call reasoning.write with phase PLAN and a concise "
-    "external work summary. Before each capability.invoke call, write BEFORE_TOOL "
+    "external work summary. Before each math.run call, write BEFORE_TOOL "
     "with the selected capability ID and mode, then pass the returned run_id and "
-    "call_id to capability.invoke. Write AFTER_TOOL after every result with the "
+    "call_id to math.run. Write AFTER_TOOL after every result with the "
     "reported status, assurance, and completeness; use RESULT_UNAVAILABLE only when "
     "result content was lost. Write FINAL before completing the task. These are summaries, "
     "not hidden chain-of-thought. Do not copy raw tool output. "
@@ -241,7 +195,7 @@ def operating_guide(*, reasoning_enabled: bool) -> str:
     ).replace(
         "## Mathematical affordances",
         "## External reasoning log\n\n"
-        "Start with one concise `PLAN`. Surround every `capability.invoke` with "
+        "Start with one concise `PLAN`. Surround every `math.run` with "
         "`BEFORE_TOOL` and `AFTER_TOOL`, then write one `FINAL` audit. The server "
         "binds actual status, assurance, completeness, and artifact URIs and records "
         "whether the model's structured interpretation matches them, without "
@@ -265,11 +219,11 @@ Keep task decomposition, representation, research strategy, iteration, verificat
 timing, and stopping criteria under your control.
 
 Available affordances:
-- `capability.describe(query=...)` searches by a desired local mathematical outcome.
-- `capability.describe()` browses when the installed vocabulary is unknown.
-- `capability.describe(capability_id=...)` inspects an exact operation and its typed
+- `math.find(query=...)` searches by a desired local mathematical outcome.
+- `math.find()` browses when the installed vocabulary is unknown.
+- `math.find(capability_id=...)` inspects an exact operation and its typed
   contract.
-- `capability.invoke(...)` runs one selected operation.
+- `math.run(...)` runs one selected operation.
 
 Compact matches are retrieval candidates, not recommendations. Compose operations as
 the investigation demands, and interpret execution, scope, completeness, assurance,
@@ -291,7 +245,7 @@ Use Jacobian to look for an independent checking path for this claim:
 {claim}
 </claim>
 {artifact_context}
-1. Search with `capability.describe(query=..., mode="VERIFY")`.
+1. Search with `math.find(query=..., mode="VERIFY")`.
 2. Treat an empty result as checker unavailability, not evidence for or against the
    claim.
 3. Describe the selected exact capability. Confirm that its semantics, scope,

--- a/src/jacobian/adapters/mcp/guidance.py
+++ b/src/jacobian/adapters/mcp/guidance.py
@@ -2,93 +2,130 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ToolNames:
+    """Agent-visible names for the two stable capability tools."""
+
+    profile: str
+    describe: str
+    invoke: str
+
+
+TOOL_NAME_PROFILES = {
+    "capability": ToolNames(
+        profile="capability",
+        describe="capability.describe",
+        invoke="capability.invoke",
+    ),
+    "math": ToolNames(
+        profile="math",
+        describe="math.find",
+        invoke="math.run",
+    ),
+}
+
+
+def tool_names(profile: str) -> ToolNames:
+    """Resolve one explicit MCP tool-name profile."""
+
+    try:
+        return TOOL_NAME_PROFILES[profile]
+    except KeyError:
+        choices = ", ".join(sorted(TOOL_NAME_PROFILES))
+        raise ValueError(
+            f"invalid tool_name_profile: {profile!r} (choose from {choices})"
+        ) from None
+
+
+def render_tool_names(text: str, names: ToolNames) -> str:
+    """Apply a name profile without changing the surrounding guidance."""
+
+    return text.replace("capability.describe", names.describe).replace(
+        "capability.invoke", names.invoke
+    )
+
+
 SERVER_DESCRIPTION = (
     "Discover and execute installed mathematical operations with explicit scope, "
     "completeness, assurance, and optional independent verification."
 )
 
 SERVER_INSTRUCTIONS = (
-    "When a task involves exact computation, structure discovery, transformation, "
-    "bounded search, counterexample generation, formal-environment inspection, or "
-    "independent checking, begin with capability.describe. You do not need to know a "
-    "capability ID. Start discovery with limit 5, inspect only the strongest one or "
-    "two relevant summaries, then request one CONTRACT view before invoking. Compose "
-    "capability.invoke calls as you judge useful. "
-    "Jacobian does not choose the task decomposition or research strategy. "
-    "EXPLORE returns proposed, heuristic, or computed evidence; use VERIFY "
-    "only with an installed independent checker. Execution status, completeness, "
-    "mathematical conclusion, and assurance are separate. Failure to find a witness "
-    "and bounded or exhausted search are not mathematical conclusions. Synchronous "
-    "SAT/SMT calls are capped at 150 seconds; partition larger searches. Only assurance "
-    "level VERIFIED with a local verification record is verified. Repeating finite or "
-    "bounded instances does not establish an all-orders or all-parameters theorem. Read "
-    "jacobian://instructions for the complete operating guide."
+    "Jacobian provides searchable and executable mathematical operations for exact "
+    "computation, transformation, structure discovery, examples and counterexamples, "
+    "bounded search, formal-environment inspection, and independent checking. "
+    "capability.describe searches, browses, or inspects installed operations using a "
+    "plain-language description of the desired local mathematical outcome. "
+    "capability.invoke executes a selected operation using its typed input contract. "
+    "Search or browse again whenever the objective or available evidence changes. "
+    "The model owns representation, decomposition, composition, iteration, verification "
+    "timing, and stopping. Results keep execution status, scope, completeness, "
+    "mathematical conclusion, and assurance separate. No descriptor match, timeout, "
+    "bounded or exhausted search, or failure to find a witness is a mathematical "
+    "conclusion. Only assurance level VERIFIED with a local verification record is "
+    "verified. Read jacobian://instructions for the complete operating guide."
 )
 
 CAPABILITY_DESCRIBE_DESCRIPTION = """\
-Discover installed mathematical outcomes or inspect one exact capability contract.
+Find or inspect an installed mathematical operation that can produce a desired outcome.
 
-Use this first when a task may benefit from exact computation, structural analysis,
-transformation, bounded search, counterexample generation, formal-environment
-inspection, or independent checking. You do not need to know a capability ID.
+Choose this when mathematical work may benefit from exact computation, structural
+analysis, transformation, examples or counterexamples, bounded search,
+formal-environment inspection, or independent checking and the useful installed
+operation is not yet known. A capability ID is not required for search or browse.
 
-Discovery:
-- Pass `query` to rank compact installed outcomes by mathematical intent.
+Available forms:
+- Pass `query` as a plain-language description of the desired local mathematical
+  outcome. The response contains compact operation cards with accepted inputs, output
+  summary, availability, scope, assurance ceiling, and factual relationships.
 - Optionally filter with `domain` and `mode`; `limit` is between 1 and 20 and
   defaults to 5.
 - Omit all arguments to browse a compact installed catalog.
 - When `next_cursor` is present, pass it back with the same filters and limit to
   continue without loading the complete catalog.
 - Ranking is deterministic retrieval over published IDs, titles, descriptions, and
-  tags. Match fields and terms are returned; results are candidates, not
-  recommendations.
-- Once a domain-owned match fits the required outcome, inspect only the strongest one
-  or two candidates. Search again when none fits. Invoke a producer before looking
-  for its checker, then follow the checker, certificate, and verification fields in
-  the producer result instead of guessing a generic verifier.
-- Compose capabilities as the investigation requires; Jacobian does not prescribe a
-  mathematical workflow.
+  tags. Match fields and terms are returned; candidates are not recommendations.
+- Pass `capability_id` to inspect the exact operation. SUMMARY is compact, CONTRACT
+  adds the validation-equivalent input schema and validated invocation examples, and
+  FULL adds complete provider and audit metadata.
 
-Exact inspection:
-- Pass `capability_id` for the small default SUMMARY projection when judging fit.
-- Request `view="CONTRACT"` once a capability fits and before invoking it. CONTRACT
-  adds the validation-equivalent input schema, runtime identity, related operations,
-  and validated invocation examples.
-- Add `view="FULL"` only when complete output schema, provider configuration, licensing,
-  or audit metadata is needed.
-- Every exact response states the scope rule: repeated bounded invocations remain
-  finite evidence and do not establish an all-orders or all-parameters conclusion.
+Weak and empty search results do not imply that an operation or mathematical outcome
+is impossible or absent in principle. They include unranked recovery paths for query
+reformulation, filter removal, browsing, and complete catalog inspection. Every exact
+response states the operation's scope rule.
 
 Examples:
 - `{"query":"find a counterexample to associativity","domain":"universal_algebra","mode":"EXPLORE","limit":5}`
-- `{"query":"verify a polynomial identity","mode":"VERIFY","limit":5}`
+- `{"query":"eliminate this denominator using the defining relations"}`
+- `{}`
 - `{"capability_id":"polynomial.compute.gcd"}`
 - `{"capability_id":"polynomial.compute.gcd","view":"CONTRACT"}`
-- `{"capability_id":"polynomial.compute.gcd","view":"FULL"}`
 """
 
 CAPABILITY_INVOKE_DESCRIPTION = """\
-Execute one installed mathematical capability after inspecting its exact descriptor.
+Run one installed mathematical operation and return its typed result, scope,
+completeness, assurance, diagnostics, intermediates, relationships, and artifacts.
 
-Call capability.describe first; do not guess payload fields or aliases. Use EXPLORE
-for proposed, heuristic, or computed evidence and VERIFY only for an installed
-checker-backed contract. After invocation, inspect execution, scope, completeness,
-relationships, open obligations, assurance, diagnostics, and artifact URIs
-independently. COMPLETED does not by itself establish a mathematical conclusion.
-One invocation covers only its exact supplied input or claim. Repeating finite or
-bounded instances does not widen that scope to an all-orders or all-parameters claim.
-The canonical complete `CapabilityResult` is returned directly as MCP structured
-content; follow returned `artifact://` references instead of
-requesting large payloads inline. Synchronous SAT and SMT requests are capped at 150
-seconds so structured TIMEOUT or CANCELLED diagnostics can arrive before remote
-transport deadlines. Partition larger searches; retrying a cancelled call starts a
-new computation.
+Use the selected operation's exact input contract; capability.describe can inspect an
+unfamiliar contract without making inspection a required research step. EXPLORE
+returns proposed, heuristic, or computed evidence. VERIFY is valid only for an
+installed checker-backed contract. The canonical `CapabilityResult` keeps execution,
+scope, completeness, mathematical conclusion, assurance, open obligations,
+diagnostics, intermediates, relationships, and artifact URIs distinct.
+
+COMPLETED does not by itself establish a mathematical conclusion. One invocation
+covers only its exact supplied input or claim, and repeated finite or bounded calls do
+not widen that scope. Follow returned `artifact://` references when durable evidence
+or a size-separated result is provided.
 
 Examples:
 - `{"capability_id":"integer.compute.gcd","mode":"EXPLORE","payload":{"left":"84","right":"30"}}`
 - `{"capability_id":"polynomial.identity.verify","mode":"VERIFY","payload":{"variables":["x"],"left":{"terms":[]},"right":{"terms":[]}}}`
 
-These demonstrate valid envelopes, not a required sequence or research strategy.
+These are valid envelopes, not a required sequence or research strategy.
 """
 
 OPERATING_GUIDE = """\
@@ -102,39 +139,37 @@ The agent owns decomposition, mathematical strategy, capability composition,
 iteration, stopping criteria, and the decision to pursue independent checking.
 Jacobian exposes operations and feedback; it does not prescribe a research workflow.
 
-## When to use Jacobian
+## Mathematical affordances
 
-Begin with `capability.describe` when a task involves exact computation, structure
-discovery, transformation, bounded search, counterexample generation,
-formal-environment inspection, or independent checking. You do not need to know an
-installed capability ID.
+Jacobian may be useful for exact computation, structure discovery, transformation,
+examples and counterexamples, bounded search, formal-environment inspection, or
+independent checking. An installed capability ID is not required for search or browse.
 
-## Discover, inspect, and invoke
+## Search, browse, inspect, and run
 
 Search with `capability.describe(query=...)`, optionally filtered by `domain` and
 `mode`. Results are compact candidates ranked by deterministic matches against
 published descriptor metadata; `matched_on` and `matched_terms` make that retrieval
-visible. Ranking is not a recommendation. Follow `next_cursor` with unchanged
-filters and limit when a discovery result is truncated. Start with `limit=5`; inspect
-only the strongest one or two relevant candidates before broadening or paging.
+visible. Ranking is not a recommendation. Follow `next_cursor` with unchanged filters
+and limit when a discovery result is truncated. Omit all arguments to browse.
 
-Search as many outcomes, concepts, or domains as useful. For any candidate, call
-`capability.describe(capability_id=...)` for the small exact SUMMARY. Once the
-outcome fits, request `view="CONTRACT"` and follow its validation-equivalent input
-schema or validated invocation example. Request `view="FULL"` only when complete output
-schema or provider audit metadata is needed. Once one domain-owned outcome fits,
-invoke it before searching for a checker; follow the checker, certificate, and
-verification fields returned by the producer instead of guessing a generic verifier.
-Compose `capability.invoke` calls in whatever sequence the mathematical investigation
-requires. Inspect execution, scope, completeness, relationships, obligations,
-assurance, diagnostics, and artifacts as separate result dimensions.
+The same tool accepts `capability_id` for exact inspection. SUMMARY is the compact
+projection, CONTRACT adds the validation-equivalent input schema and examples, and
+FULL adds complete provider and audit metadata. An agent that already has an exact
+contract may invoke the operation directly. Related operations describe compatibility
+and evidence flow; they do not prescribe what to do next.
 
 `capability.invoke` returns the canonical complete `CapabilityResult` directly as MCP
-structured content. Follow returned `artifact://` references to
-read durable results instead of requesting large payloads inline.
+structured content. Calls may be composed in any sequence the mathematical
+investigation requires. Inspect execution, scope, completeness, relationships,
+obligations, assurance, diagnostics, intermediates, and artifacts as separate result
+dimensions. Follow returned `artifact://` references to read durable results.
 
 `capability://catalog` is the complete machine-readable installed inventory.
 `capability.describe` is the agent-oriented discovery and exact-inspection surface.
+Weak or empty discovery results expose query reformulation, filter removal, browse,
+and catalog-inspection paths. They do not establish operation absence or mathematical
+impossibility.
 
 ## Exploration and verification
 
@@ -204,7 +239,7 @@ def operating_guide(*, reasoning_enabled: bool) -> str:
         "through two MCP tools.",
         "through two capability tools plus the operational `reasoning.write` log tool.",
     ).replace(
-        "## When to use Jacobian",
+        "## Mathematical affordances",
         "## External reasoning log\n\n"
         "Start with one concise `PLAN`. Surround every `capability.invoke` with "
         "`BEFORE_TOOL` and `AFTER_TOOL`, then write one `FINAL` audit. The server "
@@ -212,7 +247,7 @@ def operating_guide(*, reasoning_enabled: bool) -> str:
         "whether the model's structured interpretation matches them, without "
         "storing raw payload or output. This log is operational and unverified; it "
         "is not hidden chain-of-thought or mathematical evidence.\n\n"
-        "## When to use Jacobian",
+        "## Mathematical affordances",
     )
 
 
@@ -226,19 +261,20 @@ Use Jacobian's capability protocol for this mathematical task:
 {task}
 </task>
 
-1. Keep task decomposition, research strategy, iteration, and stopping criteria
-   under your control.
-2. Search any outcomes or concepts that may help with `capability.describe(query=...)`.
-   Add `domain` or `mode` only when those filters are useful.
-3. Treat compact matches as retrieval candidates, not recommendations. Search again
-   across other concepts or domains whenever useful.
-4. Inspect any candidate with `capability.describe(capability_id=...)`.
-5. Once it fits, request `view="CONTRACT"` and construct `capability.invoke` from the
-   exact input schema or a returned validated invocation example. Do not guess fields.
-6. Compose operations as the investigation demands. Interpret execution,
-   completeness, assurance, obligations, and artifacts separately. If independent
-   checking is useful, discover an installed VERIFY capability rather than treating
-   computed evidence as verified.
+Keep task decomposition, representation, research strategy, iteration, verification
+timing, and stopping criteria under your control.
+
+Available affordances:
+- `capability.describe(query=...)` searches by a desired local mathematical outcome.
+- `capability.describe()` browses when the installed vocabulary is unknown.
+- `capability.describe(capability_id=...)` inspects an exact operation and its typed
+  contract.
+- `capability.invoke(...)` runs one selected operation.
+
+Compact matches are retrieval candidates, not recommendations. Compose operations as
+the investigation demands, and interpret execution, scope, completeness, assurance,
+obligations, intermediates, relationships, and artifacts separately. Computed evidence
+is not independently verified evidence.
 """
 
 

--- a/src/jacobian/adapters/mcp/projections.py
+++ b/src/jacobian/adapters/mcp/projections.py
@@ -52,7 +52,7 @@ _RELATED_CAPABILITIES: dict[str, tuple[tuple[str, str], ...]] = {
         ("smt.unsat_proof.verify", "independently verify compatible proof evidence"),
         (
             "sat.cnf.materialize",
-            "prefer named Boolean CNF for finite colorings and forbidden patterns",
+            "materialize named Boolean CNF for finite colorings and forbidden patterns",
         ),
     ),
     "graph.invariant.maximum_matching.compute": (
@@ -135,11 +135,11 @@ def _capability_inspection_extensions(
         extensions["synchronous_execution"] = {
             "remote_safe_wall_seconds_max": 150,
             "timeout_is_a_non_conclusion": True,
-            "partition_larger_searches": True,
+            "larger_search_requires_multiple_bounded_invocations": True,
             "backend_suitability": (
-                "Named Boolean CNF is preferred for finite colorings and forbidden "
-                "finite configurations; use SMT when arithmetic or "
-                "uninterpreted-function structure is essential."
+                "Named Boolean CNF represents finite colorings and forbidden finite "
+                "configurations; SMT represents arithmetic and uninterpreted-function "
+                "structure."
             ),
         }
     return extensions
@@ -193,6 +193,93 @@ def _input_schema_summary(schema: dict[str, Any]) -> dict[str, Any]:
         "required": schema.get("required", []),
         "property_names": sorted(properties) if isinstance(properties, dict) else [],
     }
+
+
+def _discovery_operation_card(
+    match: dict[str, Any],
+    descriptor: CapabilityDescriptor,
+    descriptors: dict[str, CapabilityDescriptor],
+) -> dict[str, Any]:
+    """Add compact decision facts without recommending a research action."""
+
+    runtime = descriptor.provider_runtime
+    related = [
+        {
+            "capability_id": related_id,
+            "relationship": relationship,
+        }
+        for related_id, relationship in _RELATED_CAPABILITIES.get(
+            descriptor.capability_id, ()
+        )
+        if related_id in descriptors
+    ]
+    return {
+        **match,
+        "accepted_input_kinds": [
+            kind.value for kind in descriptor.accepted_input_kinds
+        ],
+        "accepted_artifact_types": list(descriptor.accepted_artifact_types),
+        "output_schema_summary": _output_schema_summary(descriptor.output_schema),
+        "scope": "EXACT_SUPPLIED_INPUT_OR_CLAIM",
+        "assurance_ceiling": (
+            "VERIFIED" if CapabilityMode.VERIFY in descriptor.modes else "COMPUTED"
+        ),
+        "provider_availability": (
+            runtime.availability.value if runtime is not None else "UNKNOWN"
+        ),
+        "related_capabilities": related,
+    }
+
+
+def _discovery_recovery_paths(
+    request: CapabilityDiscoveryRequest,
+    *,
+    portfolio_fit: str,
+    routing_status: str,
+) -> list[dict[str, Any]]:
+    """Return unranked access choices for weak, empty, or incompatible discovery."""
+
+    if portfolio_fit not in {"ONLY_WEAK_LEXICAL_MATCHES", "NO_LEXICAL_MATCHES"} and (
+        routing_status != "NO_ROUTE"
+    ):
+        return []
+    paths: list[dict[str, Any]] = [
+        {
+            "action": "reformulate_query",
+            "tool": "capability.describe",
+            "change": "Use different or broader mathematical language for query.",
+        }
+    ]
+    if any(
+        value is not None
+        for value in (
+            request.domain,
+            request.mode,
+            request.input_kind,
+            request.artifact_type,
+        )
+    ):
+        paths.append(
+            {
+                "action": "remove_filters",
+                "tool": "capability.describe",
+                "change": "Remove domain, mode, input_kind, or artifact_type filters.",
+            }
+        )
+    paths.extend(
+        (
+            {
+                "action": "browse",
+                "tool": "capability.describe",
+                "arguments": {},
+            },
+            {
+                "action": "inspect_catalog",
+                "resource_uri": "capability://catalog",
+            },
+        )
+    )
+    return paths
 
 
 def _capability_descriptor_view(
@@ -291,18 +378,17 @@ def _capability_discovery_response(
     cursor: str | None,
 ) -> dict[str, Any]:
     catalog = runtime.core.capabilities.catalog()
+    discovery_request = CapabilityDiscoveryRequest(
+        query=query,
+        domain=domain,
+        mode=mode,
+        input_kind=input_kind,
+        artifact_type=artifact_type,
+        limit=limit if limit is not None else 5,
+        cursor=cursor,
+    )
     try:
-        discovered = runtime.core.capabilities.discover(
-            CapabilityDiscoveryRequest(
-                query=query,
-                domain=domain,
-                mode=mode,
-                input_kind=input_kind,
-                artifact_type=artifact_type,
-                limit=limit if limit is not None else 5,
-                cursor=cursor,
-            )
-        )
+        discovered = runtime.core.capabilities.discover(discovery_request)
     except CapabilityDiscoveryCursorError:
         return {
             "error": {
@@ -316,6 +402,21 @@ def _capability_discovery_response(
                 ),
             }
         }
+    descriptors = {
+        descriptor.capability_id: descriptor for descriptor in catalog.capabilities
+    }
+    discovered_payload = discovered.model_dump(mode="json")
+    discovered_payload["matches"] = [
+        _discovery_operation_card(
+            match, descriptors[match["capability_id"]], descriptors
+        )
+        for match in cast(list[dict[str, Any]], discovered_payload["matches"])
+    ]
+    recovery_paths = _discovery_recovery_paths(
+        discovery_request,
+        portfolio_fit=discovered.portfolio_fit,
+        routing_status=discovered.routing_status,
+    )
     response = {
         "kind": "discovery",
         "catalog_version": catalog.catalog_version,
@@ -325,23 +426,9 @@ def _capability_discovery_response(
             catalog.catalog_version,
             catalog.capabilities,
         ),
-        **discovered.model_dump(mode="json"),
-        "next_step": {
-            "tool": "capability.describe",
-            "argument": "capability_id",
-            "choose_from": "matches[].capability_id",
-        },
-        "routing_guidance": {
-            "inspect_candidates": (
-                "Inspect only the strongest one or two domain-relevant matches; "
-                "search again only when none fits the required outcome."
-            ),
-            "verification_handoff": (
-                "Invoke the selected producer before searching for a checker; "
-                "follow checker, certificate, and verification fields returned by "
-                "the producer result instead of guessing a generic verifier."
-            ),
-        },
+        **discovered_payload,
+        "available_recovery_paths": recovery_paths,
+        "recovery_paths_are_unranked": True,
         "response_byte_limit": CAPABILITY_DISCOVERY_RESPONSE_BYTE_LIMIT,
         "truncation_reason": None,
     }

--- a/src/jacobian/adapters/mcp/projections.py
+++ b/src/jacobian/adapters/mcp/projections.py
@@ -246,7 +246,7 @@ def _discovery_recovery_paths(
     paths: list[dict[str, Any]] = [
         {
             "action": "reformulate_query",
-            "tool": "capability.describe",
+            "tool": "math.find",
             "change": "Use different or broader mathematical language for query.",
         }
     ]
@@ -262,7 +262,7 @@ def _discovery_recovery_paths(
         paths.append(
             {
                 "action": "remove_filters",
-                "tool": "capability.describe",
+                "tool": "math.find",
                 "change": "Remove domain, mode, input_kind, or artifact_type filters.",
             }
         )
@@ -270,7 +270,7 @@ def _discovery_recovery_paths(
         (
             {
                 "action": "browse",
-                "tool": "capability.describe",
+                "tool": "math.find",
                 "arguments": {},
             },
             {

--- a/src/jacobian/adapters/mcp/resources.py
+++ b/src/jacobian/adapters/mcp/resources.py
@@ -10,10 +10,8 @@ from pydantic import Field
 
 from jacobian.adapters.mcp.context import _experiment_scope_content, _resource_runtime
 from jacobian.adapters.mcp.guidance import (
-    ToolNames,
     discovery_prompt,
     evidence_check_prompt,
-    render_tool_names,
 )
 from jacobian.adapters.mcp.tooling import _run_blocking
 from jacobian.runtime.model import JacobianRuntime
@@ -25,7 +23,6 @@ def _register_resources_and_prompts(
     server: Any,
     runtime: JacobianRuntime | None,
     tenant_router: Any,
-    names: ToolNames,
 ) -> None:
     """Register all MCP resource and prompt handlers on the server."""
 
@@ -177,7 +174,7 @@ def _register_resources_and_prompts(
             Field(description="The mathematical task or desired outcome."),
         ],
     ) -> str:
-        return render_tool_names(discovery_prompt(task), names)
+        return discovery_prompt(task)
 
     @server.prompt(  # type: ignore[untyped-decorator]
         name="jacobian-check-evidence",
@@ -197,7 +194,7 @@ def _register_resources_and_prompts(
             Field(description="Optional artifact:// URI carrying candidate evidence."),
         ] = None,
     ) -> str:
-        return render_tool_names(evidence_check_prompt(claim, artifact_uri), names)
+        return evidence_check_prompt(claim, artifact_uri)
 
 
 def _register_reasoning_resource(

--- a/src/jacobian/adapters/mcp/resources.py
+++ b/src/jacobian/adapters/mcp/resources.py
@@ -10,8 +10,10 @@ from pydantic import Field
 
 from jacobian.adapters.mcp.context import _experiment_scope_content, _resource_runtime
 from jacobian.adapters.mcp.guidance import (
+    ToolNames,
     discovery_prompt,
     evidence_check_prompt,
+    render_tool_names,
 )
 from jacobian.adapters.mcp.tooling import _run_blocking
 from jacobian.runtime.model import JacobianRuntime
@@ -23,6 +25,7 @@ def _register_resources_and_prompts(
     server: Any,
     runtime: JacobianRuntime | None,
     tenant_router: Any,
+    names: ToolNames,
 ) -> None:
     """Register all MCP resource and prompt handlers on the server."""
 
@@ -174,7 +177,7 @@ def _register_resources_and_prompts(
             Field(description="The mathematical task or desired outcome."),
         ],
     ) -> str:
-        return discovery_prompt(task)
+        return render_tool_names(discovery_prompt(task), names)
 
     @server.prompt(  # type: ignore[untyped-decorator]
         name="jacobian-check-evidence",
@@ -194,7 +197,7 @@ def _register_resources_and_prompts(
             Field(description="Optional artifact:// URI carrying candidate evidence."),
         ] = None,
     ) -> str:
-        return evidence_check_prompt(claim, artifact_uri)
+        return render_tool_names(evidence_check_prompt(claim, artifact_uri), names)
 
 
 def _register_reasoning_resource(

--- a/src/jacobian/adapters/mcp/server.py
+++ b/src/jacobian/adapters/mcp/server.py
@@ -32,8 +32,11 @@ from jacobian.adapters.mcp.guidance import (
     CAPABILITY_INVOKE_DESCRIPTION,
     REASONING_WRITE_DESCRIPTION,
     SERVER_DESCRIPTION,
+    ToolNames,
     operating_guide,
+    render_tool_names,
     server_instructions,
+    tool_names,
 )
 from jacobian.adapters.mcp.remote import TenantRuntimeRouter
 from jacobian.adapters.mcp.resources import (
@@ -98,13 +101,19 @@ class JacobianCoreExtension(Extension):
         runtime: JacobianRuntime | None,
         tenant_router: TenantRuntimeRouter | None,
         reasoning_log_mode: ReasoningLogMode = ReasoningLogMode.REQUIRED,
+        names: ToolNames | None = None,
     ) -> None:
         self._runtime = runtime
         self._tenant_router = tenant_router
         self._reasoning_log_mode = reasoning_log_mode
+        self._tool_names = names or tool_names("capability")
 
     def settings(self) -> dict[str, Any]:
-        return {"version": "2", "reasoning_log_mode": self._reasoning_log_mode.value}
+        return {
+            "version": "2",
+            "reasoning_log_mode": self._reasoning_log_mode.value,
+            "tool_name_profile": self._tool_names.profile,
+        }
 
     def tools(self) -> tuple[ToolBinding, ...]:
         invoke_handler = {
@@ -112,23 +121,36 @@ class JacobianCoreExtension(Extension):
             ReasoningLogMode.AUDIT: capability_invoke_audit,
             ReasoningLogMode.OFF: capability_invoke,
         }[self._reasoning_log_mode]
+        describe_handler = _rewrite_tool_result(capability_describe, self._tool_names)
         bindings = [
             ToolBinding(
-                _safe_tool_handler("capability.describe", capability_describe),
+                _safe_tool_handler(
+                    self._tool_names.describe,
+                    describe_handler,
+                    names=self._tool_names,
+                ),
                 kwargs={
-                    "name": "capability.describe",
-                    "title": "Discover mathematical capabilities",
-                    "description": CAPABILITY_DESCRIBE_DESCRIPTION,
+                    "name": self._tool_names.describe,
+                    "title": "Find or inspect mathematical operations",
+                    "description": render_tool_names(
+                        CAPABILITY_DESCRIBE_DESCRIPTION, self._tool_names
+                    ),
                     "annotations": _tool_annotations(read_only=True, idempotent=True),
                     "structured_output": True,
                 },
             ),
             ToolBinding(
-                _safe_tool_handler("capability.invoke", invoke_handler),
+                _safe_tool_handler(
+                    self._tool_names.invoke,
+                    invoke_handler,
+                    names=self._tool_names,
+                ),
                 kwargs={
-                    "name": "capability.invoke",
-                    "title": "Execute a mathematical capability",
-                    "description": CAPABILITY_INVOKE_DESCRIPTION,
+                    "name": self._tool_names.invoke,
+                    "title": "Run a mathematical operation",
+                    "description": render_tool_names(
+                        CAPABILITY_INVOKE_DESCRIPTION, self._tool_names
+                    ),
                     "annotations": _tool_annotations(),
                     "structured_output": True,
                 },
@@ -164,6 +186,14 @@ class JacobianCoreExtension(Extension):
                     text=operating_guide(
                         reasoning_enabled=self._reasoning_log_mode
                         is not ReasoningLogMode.OFF
+                    )
+                    if self._tool_names.profile == "capability"
+                    else render_tool_names(
+                        operating_guide(
+                            reasoning_enabled=self._reasoning_log_mode
+                            is not ReasoningLogMode.OFF
+                        ),
+                        self._tool_names,
                     ),
                 )
             ),
@@ -270,7 +300,11 @@ class JacobianCoreExtension(Extension):
                 argument_digest,
                 status="error",
             )
-            raise ToolError(_public_tool_error(params.name, exc)) from exc
+            raise ToolError(
+                render_tool_names(
+                    _public_tool_error(params.name, exc), self._tool_names
+                )
+            ) from exc
         _log_tool_call(
             params.name,
             started,
@@ -281,7 +315,34 @@ class JacobianCoreExtension(Extension):
         return result
 
 
-def _safe_tool_handler(tool_name: str, handler: Any) -> Any:
+def _rewrite_tool_result(handler: Any, names: ToolNames) -> Any:
+    """Rewrite agent-facing tool references while preserving the tool signature."""
+
+    @wraps(handler)
+    async def wrapped(*args: Any, **kwargs: Any) -> Any:
+        return _rewrite_tool_value(await handler(*args, **kwargs), names)
+
+    return wrapped
+
+
+def _rewrite_tool_value(value: Any, names: ToolNames) -> Any:
+    if isinstance(value, str):
+        return render_tool_names(value, names)
+    if isinstance(value, list):
+        return [_rewrite_tool_value(item, names) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_rewrite_tool_value(item, names) for item in value)
+    if isinstance(value, dict):
+        return {key: _rewrite_tool_value(item, names) for key, item in value.items()}
+    return value
+
+
+def _safe_tool_handler(
+    tool_name: str,
+    handler: Any,
+    *,
+    names: ToolNames | None = None,
+) -> Any:
     """Translate internal failures at the handler boundary before SDK rendering."""
 
     @wraps(handler)
@@ -292,7 +353,10 @@ def _safe_tool_handler(tool_name: str, handler: Any) -> Any:
             raise
         except Exception as exc:
             _LOGGER.warning("MCP tool %s failed", tool_name, exc_info=exc)
-            raise ToolError(_public_tool_error(tool_name, exc)) from exc
+            message = _public_tool_error(tool_name, exc)
+            if names is not None:
+                message = render_tool_names(message, names)
+            raise ToolError(message) from exc
 
     return wrapped
 
@@ -364,10 +428,12 @@ def create_server(
     max_tenant_runtimes: int | None = None,
     tenant_idle_timeout_seconds: float | None = None,
     reasoning_log_mode: ReasoningLogMode | str = ReasoningLogMode.OFF,
+    tool_name_profile: str = "capability",
 ) -> MCPServer[AppState]:
     """Create a local or tenant-routed adapter over a Jacobian runtime."""
 
     selected_reasoning_mode = _normalize_reasoning_log_mode(reasoning_log_mode)
+    selected_tool_names = tool_names(tool_name_profile)
     if tenant_isolation and capability_exclusions:
         raise ValueError("capability exclusions are supported only by local evaluation")
 
@@ -441,17 +507,34 @@ def create_server(
         description=SERVER_DESCRIPTION,
         instructions=server_instructions(
             reasoning_enabled=selected_reasoning_mode is not ReasoningLogMode.OFF
+        )
+        if selected_tool_names.profile == "capability"
+        else render_tool_names(
+            server_instructions(
+                reasoning_enabled=selected_reasoning_mode is not ReasoningLogMode.OFF
+            ),
+            selected_tool_names,
         ),
         version=__version__,
         lifespan=lifespan,
         token_verifier=token_verifier,
         auth=auth,
         extensions=[
-            JacobianCoreExtension(runtime, tenant_router, selected_reasoning_mode)
+            JacobianCoreExtension(
+                runtime,
+                tenant_router,
+                selected_reasoning_mode,
+                selected_tool_names,
+            )
         ],
     )
 
-    _register_resources_and_prompts(server, runtime, tenant_router)
+    _register_resources_and_prompts(
+        server,
+        runtime,
+        tenant_router,
+        selected_tool_names,
+    )
     if selected_reasoning_mode is not ReasoningLogMode.OFF:
         _register_reasoning_resource(server, runtime, tenant_router)
     return server

--- a/src/jacobian/adapters/mcp/server.py
+++ b/src/jacobian/adapters/mcp/server.py
@@ -28,15 +28,12 @@ from jacobian.adapters.mcp.context import (
     _start_lean_warmup,
 )
 from jacobian.adapters.mcp.guidance import (
-    CAPABILITY_DESCRIBE_DESCRIPTION,
-    CAPABILITY_INVOKE_DESCRIPTION,
+    MATH_FIND_DESCRIPTION,
+    MATH_RUN_DESCRIPTION,
     REASONING_WRITE_DESCRIPTION,
     SERVER_DESCRIPTION,
-    ToolNames,
     operating_guide,
-    render_tool_names,
     server_instructions,
-    tool_names,
 )
 from jacobian.adapters.mcp.remote import TenantRuntimeRouter
 from jacobian.adapters.mcp.resources import (
@@ -101,18 +98,15 @@ class JacobianCoreExtension(Extension):
         runtime: JacobianRuntime | None,
         tenant_router: TenantRuntimeRouter | None,
         reasoning_log_mode: ReasoningLogMode = ReasoningLogMode.REQUIRED,
-        names: ToolNames | None = None,
     ) -> None:
         self._runtime = runtime
         self._tenant_router = tenant_router
         self._reasoning_log_mode = reasoning_log_mode
-        self._tool_names = names or tool_names("capability")
 
     def settings(self) -> dict[str, Any]:
         return {
             "version": "2",
             "reasoning_log_mode": self._reasoning_log_mode.value,
-            "tool_name_profile": self._tool_names.profile,
         }
 
     def tools(self) -> tuple[ToolBinding, ...]:
@@ -121,36 +115,23 @@ class JacobianCoreExtension(Extension):
             ReasoningLogMode.AUDIT: capability_invoke_audit,
             ReasoningLogMode.OFF: capability_invoke,
         }[self._reasoning_log_mode]
-        describe_handler = _rewrite_tool_result(capability_describe, self._tool_names)
         bindings = [
             ToolBinding(
-                _safe_tool_handler(
-                    self._tool_names.describe,
-                    describe_handler,
-                    names=self._tool_names,
-                ),
+                _safe_tool_handler("math.find", capability_describe),
                 kwargs={
-                    "name": self._tool_names.describe,
+                    "name": "math.find",
                     "title": "Find or inspect mathematical operations",
-                    "description": render_tool_names(
-                        CAPABILITY_DESCRIBE_DESCRIPTION, self._tool_names
-                    ),
+                    "description": MATH_FIND_DESCRIPTION,
                     "annotations": _tool_annotations(read_only=True, idempotent=True),
                     "structured_output": True,
                 },
             ),
             ToolBinding(
-                _safe_tool_handler(
-                    self._tool_names.invoke,
-                    invoke_handler,
-                    names=self._tool_names,
-                ),
+                _safe_tool_handler("math.run", invoke_handler),
                 kwargs={
-                    "name": self._tool_names.invoke,
+                    "name": "math.run",
                     "title": "Run a mathematical operation",
-                    "description": render_tool_names(
-                        CAPABILITY_INVOKE_DESCRIPTION, self._tool_names
-                    ),
+                    "description": MATH_RUN_DESCRIPTION,
                     "annotations": _tool_annotations(),
                     "structured_output": True,
                 },
@@ -186,14 +167,6 @@ class JacobianCoreExtension(Extension):
                     text=operating_guide(
                         reasoning_enabled=self._reasoning_log_mode
                         is not ReasoningLogMode.OFF
-                    )
-                    if self._tool_names.profile == "capability"
-                    else render_tool_names(
-                        operating_guide(
-                            reasoning_enabled=self._reasoning_log_mode
-                            is not ReasoningLogMode.OFF
-                        ),
-                        self._tool_names,
                     ),
                 )
             ),
@@ -300,11 +273,7 @@ class JacobianCoreExtension(Extension):
                 argument_digest,
                 status="error",
             )
-            raise ToolError(
-                render_tool_names(
-                    _public_tool_error(params.name, exc), self._tool_names
-                )
-            ) from exc
+            raise ToolError(_public_tool_error(params.name, exc)) from exc
         _log_tool_call(
             params.name,
             started,
@@ -315,33 +284,9 @@ class JacobianCoreExtension(Extension):
         return result
 
 
-def _rewrite_tool_result(handler: Any, names: ToolNames) -> Any:
-    """Rewrite agent-facing tool references while preserving the tool signature."""
-
-    @wraps(handler)
-    async def wrapped(*args: Any, **kwargs: Any) -> Any:
-        return _rewrite_tool_value(await handler(*args, **kwargs), names)
-
-    return wrapped
-
-
-def _rewrite_tool_value(value: Any, names: ToolNames) -> Any:
-    if isinstance(value, str):
-        return render_tool_names(value, names)
-    if isinstance(value, list):
-        return [_rewrite_tool_value(item, names) for item in value]
-    if isinstance(value, tuple):
-        return tuple(_rewrite_tool_value(item, names) for item in value)
-    if isinstance(value, dict):
-        return {key: _rewrite_tool_value(item, names) for key, item in value.items()}
-    return value
-
-
 def _safe_tool_handler(
     tool_name: str,
     handler: Any,
-    *,
-    names: ToolNames | None = None,
 ) -> Any:
     """Translate internal failures at the handler boundary before SDK rendering."""
 
@@ -353,10 +298,7 @@ def _safe_tool_handler(
             raise
         except Exception as exc:
             _LOGGER.warning("MCP tool %s failed", tool_name, exc_info=exc)
-            message = _public_tool_error(tool_name, exc)
-            if names is not None:
-                message = render_tool_names(message, names)
-            raise ToolError(message) from exc
+            raise ToolError(_public_tool_error(tool_name, exc)) from exc
 
     return wrapped
 
@@ -428,12 +370,10 @@ def create_server(
     max_tenant_runtimes: int | None = None,
     tenant_idle_timeout_seconds: float | None = None,
     reasoning_log_mode: ReasoningLogMode | str = ReasoningLogMode.OFF,
-    tool_name_profile: str = "capability",
 ) -> MCPServer[AppState]:
     """Create a local or tenant-routed adapter over a Jacobian runtime."""
 
     selected_reasoning_mode = _normalize_reasoning_log_mode(reasoning_log_mode)
-    selected_tool_names = tool_names(tool_name_profile)
     if tenant_isolation and capability_exclusions:
         raise ValueError("capability exclusions are supported only by local evaluation")
 
@@ -507,13 +447,6 @@ def create_server(
         description=SERVER_DESCRIPTION,
         instructions=server_instructions(
             reasoning_enabled=selected_reasoning_mode is not ReasoningLogMode.OFF
-        )
-        if selected_tool_names.profile == "capability"
-        else render_tool_names(
-            server_instructions(
-                reasoning_enabled=selected_reasoning_mode is not ReasoningLogMode.OFF
-            ),
-            selected_tool_names,
         ),
         version=__version__,
         lifespan=lifespan,
@@ -524,7 +457,6 @@ def create_server(
                 runtime,
                 tenant_router,
                 selected_reasoning_mode,
-                selected_tool_names,
             )
         ],
     )
@@ -533,7 +465,6 @@ def create_server(
         server,
         runtime,
         tenant_router,
-        selected_tool_names,
     )
     if selected_reasoning_mode is not ReasoningLogMode.OFF:
         _register_reasoning_resource(server, runtime, tenant_router)

--- a/src/jacobian/adapters/mcp/tooling.py
+++ b/src/jacobian/adapters/mcp/tooling.py
@@ -188,7 +188,7 @@ def _claim_reasoning_call(
         if required:
             raise ReasoningProtocolError(
                 "REASONING_LOG_REQUIRED",
-                "capability.invoke requires the run_id and call_id from BEFORE_TOOL.",
+                "math.run requires the run_id and call_id from BEFORE_TOOL.",
                 "Call reasoning.write with PLAN, then BEFORE_TOOL, and retry with its IDs.",
             )
         if audit:

--- a/src/jacobian/adapters/mcp/tools.py
+++ b/src/jacobian/adapters/mcp/tools.py
@@ -92,8 +92,8 @@ async def capability_describe(
             ge=1,
             le=20,
             description=(
-                "Maximum compact discovery matches; defaults to 5. Start with "
-                "5 and inspect only the strongest one or two candidates."
+                "Maximum compact discovery matches; defaults to 5. This bounds "
+                "the result and does not rank the agent's research choices."
             ),
         ),
     ] = None,
@@ -115,9 +115,9 @@ async def capability_describe(
                 "Exact-lookup projection. SUMMARY is the small agent-facing "
                 "default for judging fit. CONTRACT adds the validation-equivalent "
                 "input schema, runtime identity, related operations, and validated "
-                "invocation examples; request it before invoking. FULL returns "
-                "the complete installed descriptor for audit or client generation. "
-                "Omit for discovery."
+                "invocation examples for constructing an unfamiliar request. FULL "
+                "returns the complete installed descriptor for audit or client "
+                "generation. Omit for discovery."
             )
         ),
     ] = "SUMMARY",
@@ -138,9 +138,8 @@ async def capability_describe(
     ):
         raise AgentRecoveryError(
             "capability_id is an exact lookup and cannot be combined with query, "
-            "domain, mode, input_kind, artifact_type, limit, or cursor. Use one "
-            "discovery call followed by "
-            "one exact description call."
+            "domain, mode, input_kind, artifact_type, limit, or cursor. Use either "
+            "discovery arguments or one exact capability_id in this call."
         )
     if capability_id is None:
         return _capability_discovery_response(

--- a/src/jacobian/adapters/mcp/tools.py
+++ b/src/jacobian/adapters/mcp/tools.py
@@ -158,8 +158,7 @@ async def capability_describe(
         descriptor = descriptors[capability_id]
     except KeyError:
         hint = (
-            "Call capability.describe with a mathematical query to search "
-            "installed capabilities."
+            "Call math.find with a mathematical query to search installed capabilities."
         )
         return {
             "error": {
@@ -202,7 +201,7 @@ async def capability_describe(
                     if view == "FULL"
                     else {}
                 ),
-                "tool": "capability.invoke",
+                "tool": "math.run",
                 "arguments": {
                     "capability_id": descriptor.capability_id,
                     "mode": example.mode.value,
@@ -212,7 +211,7 @@ async def capability_describe(
             if reasoning_mode is ReasoningLogMode.REQUIRED:
                 entry["requires_reasoning_ids"] = True
                 entry["protocol_note"] = (
-                    "In REQUIRED mode, capability.invoke also requires "
+                    "In REQUIRED mode, math.run also requires "
                     "reasoning_run_id and reasoning_call_id. Create a "
                     "reasoning run with reasoning.write (PLAN), then call "
                     "reasoning.write (BEFORE_TOOL) to obtain the IDs before "
@@ -332,7 +331,7 @@ async def reasoning_write(
         descriptor = descriptors.get(str(capability_id))
         if descriptor is None:
             raise AgentRecoveryError(
-                "BEFORE_TOOL names an unavailable capability. Use capability.describe "
+                "BEFORE_TOOL names an unavailable capability. Use math.find "
                 "to select an installed capability ID."
             )
         if mode not in descriptor.modes:

--- a/src/jacobian/builtin_capabilities.py
+++ b/src/jacobian/builtin_capabilities.py
@@ -402,7 +402,7 @@ def _declaration_invocation_error(
             stage="lean_declaration_query",
             message=error.message,
             hint=(
-                "Call capability.describe for the exact query contract and verify "
+                "Call math.find for the exact query contract and verify "
                 "that the requested pinned environment is installed."
             ),
         )

--- a/src/jacobian/capability_dispatch.py
+++ b/src/jacobian/capability_dispatch.py
@@ -52,7 +52,7 @@ class CapabilityDispatchMixin:
                     stage="capability_resolution",
                     message=(f"Capability {request.capability_id!r} is not installed."),
                     hint=(
-                        "Call capability.describe without capability_id to list "
+                        "Call math.find without capability_id to list "
                         "installed capabilities, then retry with one of those IDs."
                     ),
                 ),
@@ -82,7 +82,7 @@ class CapabilityDispatchMixin:
                         "operator-controlled capability policy."
                     ),
                     hint=(
-                        "Choose a capability visible in capability.describe, or ask "
+                        "Choose a capability visible in math.find, or ask "
                         "the operator to change the evaluation/runtime policy."
                     ),
                     details={
@@ -109,7 +109,7 @@ class CapabilityDispatchMixin:
                         f"{request.mode.value} mode."
                     ),
                     hint=(
-                        "Call capability.describe for this capability, then retry "
+                        "Call math.find for this capability, then retry "
                         "with one of its advertised modes."
                     ),
                 ),

--- a/src/jacobian/claims.py
+++ b/src/jacobian/claims.py
@@ -98,7 +98,7 @@ class ClaimValidationService:
                 )
             elif isinstance(exc, PluginRegistryError):
                 errors.append(
-                    "The selected plugin is unavailable. Call capability.describe, "
+                    "The selected plugin is unavailable. Call math.find, "
                     "choose an installed reference domain, and retry."
                 )
             else:
@@ -117,7 +117,7 @@ class ClaimValidationService:
             errors.append(
                 "The selected plugin is missing required capabilities: "
                 + ", ".join(item.value for item in missing)
-                + ". Call capability.describe and choose a plugin that advertises "
+                + ". Call math.find and choose a plugin that advertises "
                 "all required capabilities."
             )
         valid = not errors

--- a/src/jacobian/conjectures.py
+++ b/src/jacobian/conjectures.py
@@ -636,7 +636,7 @@ class ConjectureService:
             if not validation.valid:
                 raise ConjectureError(
                     "The plugin generated an invalid claim. Check its output against "
-                    "capability.describe, then retry. Validation: "
+                    "math.find, then retry. Validation: "
                     + "; ".join(validation.input.errors)
                 )
             seen_digests.add(claim.object_digest)
@@ -825,7 +825,7 @@ def _workflow_failure_detail(exc: Exception) -> str:
     if isinstance(exc, (PluginRegistryError, SchemaRegistryError)):
         return (
             "The selected plugin or reference contract is unavailable. Call "
-            "capability.describe, choose an installed option, and retry."
+            "math.find, choose an installed option, and retry."
         )
     if isinstance(exc, SearchError):
         return (
@@ -846,7 +846,7 @@ def _workflow_failure_detail(exc: Exception) -> str:
             )
     return (
         "The conjecture workflow received invalid data. Check the request and plugin "
-        "output against capability.describe, then retry."
+        "output against math.find, then retry."
     )
 
 
@@ -859,7 +859,7 @@ def _model_validation_detail(exc: ValidationError, subject: str) -> str:
     path = ".".join(str(part) for part in first["loc"]) or "request"
     return (
         f"The {subject} is invalid at {path}: {first['msg']}. Check "
-        "capability.describe, correct that field, and retry."
+        "math.find, correct that field, and retry."
     )
 
 

--- a/src/jacobian/eval/telemetry.py
+++ b/src/jacobian/eval/telemetry.py
@@ -54,7 +54,7 @@ class _ReasoningProtocolTelemetry:
     reported_actual_mismatch_count: int = 0
 
     def record_attempt(self, tool: str, arguments: object) -> None:
-        if tool != "capability.invoke" or not isinstance(arguments, Mapping):
+        if tool != "math.run" or not isinstance(arguments, Mapping):
             return
         if isinstance(arguments.get("reasoning_run_id"), str) and isinstance(
             arguments.get("reasoning_call_id"), str
@@ -365,8 +365,8 @@ def _reasoning_tool_name(value: object) -> str | None:
     normalized = value.replace("__", ".").replace("_", ".").lower()
     if normalized.endswith("reasoning.write"):
         return "reasoning.write"
-    if normalized.endswith("capability.invoke"):
-        return "capability.invoke"
+    if normalized.endswith("math.run"):
+        return "math.run"
     return None
 
 
@@ -524,7 +524,7 @@ def parse_agent_transcript(path: Path) -> dict[str, Any]:
                 mcp_logical_payload_bytes += logical_bytes
                 mcp_logical_payload_bytes_by_tool[tool] += logical_bytes
             mcp_call_signatures[_mcp_call_signature(tool, arguments)] += 1
-            if tool == "capability.describe":
+            if tool == "math.find":
                 if isinstance(arguments, Mapping) and isinstance(
                     arguments.get("capability_id"), str
                 ):
@@ -532,7 +532,7 @@ def parse_agent_transcript(path: Path) -> dict[str, Any]:
                 else:
                     capability_describe_index_calls += 1
             if (
-                tool == "capability.invoke"
+                tool == "math.run"
                 and isinstance(arguments, Mapping)
                 and isinstance(arguments.get("capability_id"), str)
             ):
@@ -563,7 +563,7 @@ def parse_agent_transcript(path: Path) -> dict[str, Any]:
             else:
                 successful_calls.append(tool)
                 reasoning_telemetry.record_write(tool, arguments, response)
-                if tool == "capability.describe" and isinstance(arguments, Mapping):
+                if tool == "math.find" and isinstance(arguments, Mapping):
                     matches = (
                         response.get("matches")
                         if isinstance(response, Mapping)
@@ -608,7 +608,7 @@ def parse_agent_transcript(path: Path) -> dict[str, Any]:
                         }
                     )
                 if (
-                    tool == "capability.invoke"
+                    tool == "math.run"
                     and isinstance(response, Mapping)
                     and _contains_value(
                         response.get("output"),
@@ -621,7 +621,7 @@ def parse_agent_transcript(path: Path) -> dict[str, Any]:
                     response.get("execution") if isinstance(response, Mapping) else None
                 )
                 if (
-                    tool == "capability.invoke"
+                    tool == "math.run"
                     and isinstance(arguments, Mapping)
                     and isinstance(arguments.get("capability_id"), str)
                     and isinstance(response, Mapping)

--- a/src/jacobian/evaluation.py
+++ b/src/jacobian/evaluation.py
@@ -376,7 +376,7 @@ def _evaluation_failure_detail(exc: Exception) -> str:
         )
     if isinstance(exc, PluginRegistryError):
         return (
-            "The evaluator plugin is unavailable. Call capability.describe, choose "
+            "The evaluator plugin is unavailable. Call math.find, choose "
             "an installed reference domain, and retry."
         )
     return (

--- a/src/jacobian/experiments/_helpers.py
+++ b/src/jacobian/experiments/_helpers.py
@@ -45,7 +45,7 @@ def _enumeration_failure_detail(exc: Exception, experiment_uri: str) -> str:
     if isinstance(exc, PluginRegistryError):
         return (
             "The enumeration stopped because a required plugin is unavailable. "
-            "Call capability.describe, reload the current plugin version, and start "
+            "Call math.find, reload the current plugin version, and start "
             "a new experiment."
         )
     return (

--- a/src/jacobian/experiments/service.py
+++ b/src/jacobian/experiments/service.py
@@ -349,7 +349,7 @@ class ExperimentService:
             )
             raise ExperimentError(
                 "The enumeration plugin is unavailable or incomplete. Call "
-                "capability.describe, choose a reference domain with "
+                "math.find, choose a reference domain with "
                 f"{capability_hint}, then retry."
             ) from exc
 

--- a/src/jacobian/lean_frontend/service.py
+++ b/src/jacobian/lean_frontend/service.py
@@ -70,7 +70,7 @@ class LeanService:
         if installation is None:
             raise ValueError(
                 f"Lean environment {environment.value} is not installed. Call "
-                "capability.describe with capability_id='lean.check' to list "
+                "math.find with capability_id='lean.check' to list "
                 "installed environments."
             )
         claim_payload = LeanClaim(

--- a/src/jacobian/sat_smt/sat_capabilities.py
+++ b/src/jacobian/sat_smt/sat_capabilities.py
@@ -154,7 +154,7 @@ class SatCnfMaterializationAdapter:
                         "literals referring only to declared variables"
                     ),
                     hint=(
-                        "Call capability.describe for sat.cnf.materialize and correct "
+                        "Call math.find for sat.cnf.materialize and correct "
                         "the variable_names or clauses."
                     ),
                 )

--- a/src/jacobian/search/_helpers.py
+++ b/src/jacobian/search/_helpers.py
@@ -60,7 +60,7 @@ def _search_failure_detail(exc: Exception, experiment_uri: str) -> str:
     if isinstance(exc, PluginRegistryError):
         return (
             "The search stopped because a required plugin is unavailable. Call "
-            "capability.describe, reload the current plugin version, and start a "
+            "math.find, reload the current plugin version, and start a "
             "new search."
         )
     return (

--- a/src/jacobian/search/service.py
+++ b/src/jacobian/search/service.py
@@ -404,7 +404,7 @@ class SearchService:
             _LOGGER.warning("search capability resolution failed", exc_info=exc)
             raise SearchError(
                 "The search plugin is unavailable or incomplete. Call "
-                "capability.describe, choose a reference domain with proposer, "
+                "math.find, choose a reference domain with proposer, "
                 "refiner, and evaluator capabilities, then retry."
             ) from exc
 

--- a/src/jacobian/shrinking.py
+++ b/src/jacobian/shrinking.py
@@ -561,7 +561,7 @@ def _shrink_failure_detail(exc: Exception) -> str:
         )
     if isinstance(exc, PluginRegistryError):
         return (
-            "The reducer plugin is unavailable. Call capability.describe, choose an "
+            "The reducer plugin is unavailable. Call math.find, choose an "
             "installed reference domain, and retry."
         )
     return (

--- a/src/jacobian/structures.py
+++ b/src/jacobian/structures.py
@@ -240,7 +240,7 @@ def _structure_failure_detail(exc: Exception) -> str:
         )
     if isinstance(exc, PluginRegistryError):
         return (
-            "The canonicalizer plugin is unavailable. Call capability.describe, "
+            "The canonicalizer plugin is unavailable. Call math.find, "
             "choose an installed reference domain, and retry."
         )
     return (

--- a/src/jacobian/transformations.py
+++ b/src/jacobian/transformations.py
@@ -312,7 +312,7 @@ def _transformation_failure_detail(exc: Exception) -> str:
         )
     if isinstance(exc, PluginRegistryError):
         return (
-            "The transformer plugin is unavailable. Call capability.describe, "
+            "The transformer plugin is unavailable. Call math.find, "
             "choose an installed reference domain, and retry."
         )
     return (

--- a/src/jacobian/witnesses.py
+++ b/src/jacobian/witnesses.py
@@ -205,7 +205,7 @@ class WitnessSearchService:
                 if response.role != role:
                     raise ValueError(
                         "The plugin returned a different witness role than requested. "
-                        "Call capability.describe and retry with a supported role."
+                        "Call math.find and retry with a supported role."
                     )
                 if (
                     response.witness is None
@@ -347,7 +347,7 @@ def _witness_failure_detail(exc: Exception) -> str:
         )
     if isinstance(exc, PluginRegistryError):
         return (
-            "The witness plugin is unavailable. Call capability.describe, choose "
+            "The witness plugin is unavailable. Call math.find, choose "
             "an installed reference domain, and retry."
         )
     return (

--- a/tests/boundary/mcp/test_mcp_adapter.py
+++ b/tests/boundary/mcp/test_mcp_adapter.py
@@ -17,6 +17,65 @@ CAPABILITY_TOOL_NAMES = {"capability.describe", "capability.invoke"}
 MCP_TOOL_NAMES = CAPABILITY_TOOL_NAMES
 
 
+def test_math_tool_name_profile_is_consistent_across_discovery(tmp_path: Path) -> None:
+    server = create_server(tmp_path, tool_name_profile="math")
+    assert server.instructions is not None
+    assert "math.find" in server.instructions
+    assert "capability.describe" not in server.instructions
+
+    async def scenario() -> None:
+        from mcp import Client
+
+        async with Client(server, raise_exceptions=True) as client:
+            listed = await client.list_tools()
+            tools = {tool.name: tool for tool in listed.tools}
+            assert set(tools) == {"math.find", "math.run"}
+            assert tools["math.find"].title == "Find or inspect mathematical operations"
+            assert tools["math.run"].title == "Run a mathematical operation"
+            assert "math.find" in (tools["math.run"].description or "")
+            assert "capability.describe" not in (tools["math.run"].description or "")
+
+            discovery = await client.get_prompt(
+                "jacobian-discover",
+                {"task": "Find a finite counterexample."},
+            )
+            discovery_text = discovery.messages[0].content.text
+            assert "math.find" in discovery_text
+            assert "math.run" in discovery_text
+            assert "capability.describe" not in discovery_text
+
+            evidence = await client.get_prompt(
+                "jacobian-check-evidence",
+                {"claim": "The candidate satisfies the defining identity."},
+            )
+            evidence_text = evidence.messages[0].content.text
+            assert "math.find" in evidence_text
+            assert "capability.describe" not in evidence_text
+
+            described = await client.call_tool(
+                "math.find",
+                {"capability_id": "integer.compute.gcd", "view": "CONTRACT"},
+            )
+            assert described.structured_content is not None
+            invocations = described.structured_content["invocations"]
+            assert invocations
+            assert {item["tool"] for item in invocations} == {"math.run"}
+
+            absent = await client.call_tool(
+                "math.find",
+                {"query": "quuxonium frobnicator"},
+            )
+            assert absent.structured_content is not None
+            recovery_tools = {
+                item["tool"]
+                for item in absent.structured_content["available_recovery_paths"]
+                if "tool" in item
+            }
+            assert recovery_tools == {"math.find"}
+
+    asyncio.run(scenario())
+
+
 def test_mcp_exposes_only_capability_tools_with_read_only_resources(
     tmp_path: Path,
 ) -> None:
@@ -31,7 +90,11 @@ def test_mcp_exposes_only_capability_tools_with_read_only_resources(
             assert client.instructions == server.instructions
             assert client.server_info.version == version("jacobian")
             assert client.server_capabilities.extensions == {
-                "io.jacobian/core": {"version": "2", "reasoning_log_mode": "OFF"}
+                "io.jacobian/core": {
+                    "version": "2",
+                    "reasoning_log_mode": "OFF",
+                    "tool_name_profile": "capability",
+                }
             }
             listed = await client.list_tools()
             tools = {tool.name: tool for tool in listed.tools}
@@ -153,7 +216,8 @@ def test_mcp_exposes_only_capability_tools_with_read_only_resources(
             )
             rendered_prompt = discovery_prompt.messages[0].content.text
             assert "research strategy" in rendered_prompt
-            assert "Search any outcomes or concepts" in rendered_prompt
+            assert "desired local mathematical outcome" in rendered_prompt
+            assert "Available affordances" in rendered_prompt
 
             discovery_result = await client.call_tool(
                 "capability.describe",
@@ -163,19 +227,42 @@ def test_mcp_exposes_only_capability_tools_with_read_only_resources(
             assert discovery["kind"] == "discovery"
             assert 0 < len(discovery["matches"]) <= 3
             assert "input_schema" not in discovery["matches"][0]
-            assert discovery["next_step"] == {
-                "tool": "capability.describe",
-                "argument": "capability_id",
-                "choose_from": "matches[].capability_id",
+            assert "next_step" not in discovery
+            assert "routing_guidance" not in discovery
+            operation_card = discovery["matches"][0]
+            assert operation_card["accepted_input_kinds"]
+            assert "output_schema_summary" in operation_card
+            assert operation_card["scope"] == "EXACT_SUPPLIED_INPUT_OR_CLAIM"
+            assert operation_card["assurance_ceiling"] in {"COMPUTED", "VERIFIED"}
+            assert operation_card["provider_availability"] == "AVAILABLE"
+            assert isinstance(operation_card["related_capabilities"], list)
+
+            absent_result = await client.call_tool(
+                "capability.describe",
+                {"query": "quuxonium frobnicator", "domain": "polynomial"},
+            )
+            absent = json.loads(absent_result.content[0].text)
+            assert absent["portfolio_fit"] == "NO_LEXICAL_MATCHES"
+            assert absent["matches"] == []
+            recovery_actions = {
+                option["action"] for option in absent["available_recovery_paths"]
             }
-            assert discovery["routing_guidance"]["inspect_candidates"] == (
-                "Inspect only the strongest one or two domain-relevant matches; "
-                "search again only when none fits the required outcome."
+            assert recovery_actions == {
+                "reformulate_query",
+                "remove_filters",
+                "browse",
+                "inspect_catalog",
+            }
+            browse = next(
+                option
+                for option in absent["available_recovery_paths"]
+                if option["action"] == "browse"
             )
-            assert (
-                "producer result"
-                in discovery["routing_guidance"]["verification_handoff"]
-            )
+            assert browse == {
+                "action": "browse",
+                "tool": "capability.describe",
+                "arguments": {},
+            }
 
             catalog_result = await client.read_resource("capability://catalog")
             catalog = json.loads(catalog_result.contents[0].text)

--- a/tests/boundary/mcp/test_mcp_adapter.py
+++ b/tests/boundary/mcp/test_mcp_adapter.py
@@ -13,15 +13,14 @@ from jacobian.adapters.mcp.guidance import OPERATING_GUIDE
 from jacobian.adapters.mcp.server import create_server
 from jacobian.contracts.capabilities import CapabilityDescriptor
 
-CAPABILITY_TOOL_NAMES = {"capability.describe", "capability.invoke"}
-MCP_TOOL_NAMES = CAPABILITY_TOOL_NAMES
+MATH_TOOL_NAMES = {"math.find", "math.run"}
+MCP_TOOL_NAMES = MATH_TOOL_NAMES
 
 
-def test_math_tool_name_profile_is_consistent_across_discovery(tmp_path: Path) -> None:
-    server = create_server(tmp_path, tool_name_profile="math")
+def test_math_tool_surface_is_consistent_across_discovery(tmp_path: Path) -> None:
+    server = create_server(tmp_path)
     assert server.instructions is not None
     assert "math.find" in server.instructions
-    assert "capability.describe" not in server.instructions
 
     async def scenario() -> None:
         from mcp import Client
@@ -33,7 +32,6 @@ def test_math_tool_name_profile_is_consistent_across_discovery(tmp_path: Path) -
             assert tools["math.find"].title == "Find or inspect mathematical operations"
             assert tools["math.run"].title == "Run a mathematical operation"
             assert "math.find" in (tools["math.run"].description or "")
-            assert "capability.describe" not in (tools["math.run"].description or "")
 
             discovery = await client.get_prompt(
                 "jacobian-discover",
@@ -42,7 +40,6 @@ def test_math_tool_name_profile_is_consistent_across_discovery(tmp_path: Path) -
             discovery_text = discovery.messages[0].content.text
             assert "math.find" in discovery_text
             assert "math.run" in discovery_text
-            assert "capability.describe" not in discovery_text
 
             evidence = await client.get_prompt(
                 "jacobian-check-evidence",
@@ -50,7 +47,6 @@ def test_math_tool_name_profile_is_consistent_across_discovery(tmp_path: Path) -
             )
             evidence_text = evidence.messages[0].content.text
             assert "math.find" in evidence_text
-            assert "capability.describe" not in evidence_text
 
             described = await client.call_tool(
                 "math.find",
@@ -76,7 +72,7 @@ def test_math_tool_name_profile_is_consistent_across_discovery(tmp_path: Path) -
     asyncio.run(scenario())
 
 
-def test_mcp_exposes_only_capability_tools_with_read_only_resources(
+def test_mcp_exposes_only_math_tools_with_read_only_resources(
     tmp_path: Path,
 ) -> None:
     server = create_server(tmp_path)
@@ -93,7 +89,6 @@ def test_mcp_exposes_only_capability_tools_with_read_only_resources(
                 "io.jacobian/core": {
                     "version": "2",
                     "reasoning_log_mode": "OFF",
-                    "tool_name_profile": "capability",
                 }
             }
             listed = await client.list_tools()
@@ -113,13 +108,13 @@ def test_mcp_exposes_only_capability_tools_with_read_only_resources(
                 and tool.annotations.open_world_hint is False
                 for tool in tools.values()
             )
-            assert tools["capability.describe"].annotations is not None
-            assert tools["capability.describe"].annotations.read_only_hint is True
+            assert tools["math.find"].annotations is not None
+            assert tools["math.find"].annotations.read_only_hint is True
             assert (
                 "ranking is deterministic retrieval"
-                in (tools["capability.describe"].description or "").lower()
+                in (tools["math.find"].description or "").lower()
             )
-            describe_schema = tools["capability.describe"].input_schema
+            describe_schema = tools["math.find"].input_schema
             assert all(
                 tool.input_schema.get("additionalProperties") is False
                 for tool in tools.values()
@@ -135,14 +130,14 @@ def test_mcp_exposes_only_capability_tools_with_read_only_resources(
                 "cursor",
                 "view",
             }
-            assert set(tools["capability.invoke"].input_schema["properties"]) == {
+            assert set(tools["math.run"].input_schema["properties"]) == {
                 "capability_id",
                 "payload",
                 "mode",
             }
             with pytest.raises(MCPError) as unknown_argument:
                 await client.call_tool(
-                    "capability.describe",
+                    "math.find",
                     {"capabilty_id": "polynomial.compute.gcd"},
                 )
             assert '"code": "INVALID_INPUT"' in str(unknown_argument.value)
@@ -220,7 +215,7 @@ def test_mcp_exposes_only_capability_tools_with_read_only_resources(
             assert "Available affordances" in rendered_prompt
 
             discovery_result = await client.call_tool(
-                "capability.describe",
+                "math.find",
                 {"query": "search mathematical knowledge", "limit": 3},
             )
             discovery = json.loads(discovery_result.content[0].text)
@@ -238,7 +233,7 @@ def test_mcp_exposes_only_capability_tools_with_read_only_resources(
             assert isinstance(operation_card["related_capabilities"], list)
 
             absent_result = await client.call_tool(
-                "capability.describe",
+                "math.find",
                 {"query": "quuxonium frobnicator", "domain": "polynomial"},
             )
             absent = json.loads(absent_result.content[0].text)
@@ -260,7 +255,7 @@ def test_mcp_exposes_only_capability_tools_with_read_only_resources(
             )
             assert browse == {
                 "action": "browse",
-                "tool": "capability.describe",
+                "tool": "math.find",
                 "arguments": {},
             }
 
@@ -275,7 +270,7 @@ def test_mcp_exposes_only_capability_tools_with_read_only_resources(
             )
             if "lean.check" in capability_ids:
                 lean_result = await client.call_tool(
-                    "capability.describe",
+                    "math.find",
                     {"capability_id": "lean.check", "view": "FULL"},
                 )
                 lean_contract = json.loads(lean_result.content[0].text)
@@ -303,7 +298,7 @@ def test_mcp_describes_and_invokes_capabilities(tmp_path: Path) -> None:
 
         async with Client(create_server(tmp_path), raise_exceptions=True) as client:
             described = await client.call_tool(
-                "capability.describe",
+                "math.find",
                 {"capability_id": "integer.compute.gcd", "view": "CONTRACT"},
             )
             contract = json.loads(described.content[0].text)
@@ -317,7 +312,7 @@ def test_mcp_describes_and_invokes_capabilities(tmp_path: Path) -> None:
             assert "output_schema_summary" in contract["capability"]
 
             result = await client.call_tool(
-                "capability.invoke",
+                "math.run",
                 {
                     "capability_id": "integer.compute.gcd",
                     "mode": "EXPLORE",
@@ -337,7 +332,7 @@ def test_mcp_describes_and_invokes_capabilities(tmp_path: Path) -> None:
             assert response["provider_digest"] == runtime["digest"]
 
             matching_description = await client.call_tool(
-                "capability.describe",
+                "math.find",
                 {
                     "capability_id": ("graph.invariant.maximum_matching.compute"),
                     "view": "CONTRACT",
@@ -356,7 +351,7 @@ def test_mcp_describes_and_invokes_capabilities(tmp_path: Path) -> None:
             ]
 
             unknown = await client.call_tool(
-                "capability.invoke",
+                "math.run",
                 {
                     "capability_id": "missing.capability",
                     "mode": "EXPLORE",
@@ -380,7 +375,7 @@ def test_mcp_inline_results_do_not_emit_resource_links(
 
         async with Client(create_server(tmp_path), raise_exceptions=True) as client:
             result = await client.call_tool(
-                "capability.invoke",
+                "math.run",
                 {
                     "capability_id": "integer.compute.gcd",
                     "mode": "EXPLORE",
@@ -404,18 +399,18 @@ def test_mcp_exact_description_layers_summary_contract_and_full_views(
 
         async with Client(create_server(tmp_path), raise_exceptions=True) as client:
             summary_result = await client.call_tool(
-                "capability.describe",
+                "math.find",
                 {"capability_id": "polynomial.expression.normalize"},
             )
             contract_result = await client.call_tool(
-                "capability.describe",
+                "math.find",
                 {
                     "capability_id": "polynomial.expression.normalize",
                     "view": "CONTRACT",
                 },
             )
             full_result = await client.call_tool(
-                "capability.describe",
+                "math.find",
                 {
                     "capability_id": "polynomial.expression.normalize",
                     "view": "FULL",

--- a/tests/boundary/mcp/test_mcp_catalog_and_policy.py
+++ b/tests/boundary/mcp/test_mcp_catalog_and_policy.py
@@ -48,7 +48,7 @@ def test_mcp_compact_capability_index_is_searchable_and_paginated(
             }
 
             listed = await client.call_tool(
-                "capability.describe",
+                "math.find",
                 {"limit": 20},
             )
             index = json.loads(listed.content[0].text)
@@ -66,7 +66,7 @@ def test_mcp_compact_capability_index_is_searchable_and_paginated(
             cursor = index["next_cursor"]
             while cursor is not None:
                 next_page = await client.call_tool(
-                    "capability.describe",
+                    "math.find",
                     {"cursor": cursor, "limit": 20},
                 )
                 page = json.loads(next_page.content[0].text)
@@ -79,7 +79,7 @@ def test_mcp_compact_capability_index_is_searchable_and_paginated(
             assert indexed_ids == all_ids
 
             searched = await client.call_tool(
-                "capability.describe",
+                "math.find",
                 {
                     "query": "SAT UNSAT proof",
                     "input_kind": "STRUCTURED_REQUEST",
@@ -97,7 +97,7 @@ def test_mcp_compact_capability_index_is_searchable_and_paginated(
             assert expected_sat_ids.issubset(search_ids)
 
             coloring_search = await client.call_tool(
-                "capability.describe",
+                "math.find",
                 {
                     "query": (
                         "finite coloring forbidden monochromatic triples exact "
@@ -113,7 +113,7 @@ def test_mcp_compact_capability_index_is_searchable_and_paginated(
             assert expected_sat_ids.issubset(coloring_ids)
 
             materialize_description = await client.call_tool(
-                "capability.describe",
+                "math.find",
                 {
                     "capability_id": "sat.cnf.materialize",
                     "view": "CONTRACT",
@@ -130,14 +130,14 @@ def test_mcp_compact_capability_index_is_searchable_and_paginated(
             }.issuperset(expected_sat_ids - {"sat.cnf.materialize"})
 
             first_page = await client.call_tool(
-                "capability.describe",
+                "math.find",
                 {"limit": 20},
             )
             first = json.loads(first_page.content[0].text)
             assert len(first["matches"]) <= 20
             assert first["next_cursor"] is not None
             second_page = await client.call_tool(
-                "capability.describe",
+                "math.find",
                 {"cursor": first["next_cursor"], "limit": 20},
             )
             second = json.loads(second_page.content[0].text)
@@ -148,7 +148,7 @@ def test_mcp_compact_capability_index_is_searchable_and_paginated(
             )
 
             invalid_cursor = await client.call_tool(
-                "capability.describe",
+                "math.find",
                 {
                     "query": "definitely-no-matching-capability",
                     "cursor": first["next_cursor"],

--- a/tests/boundary/mcp/test_mcp_operations.py
+++ b/tests/boundary/mcp/test_mcp_operations.py
@@ -200,6 +200,7 @@ def test_mcp_entrypoint_has_nonstarting_help() -> None:
     assert completed.returncode == 0
     assert "Run the Jacobian MCP server" in completed.stdout
     assert "--tool-profile" not in completed.stdout
+    assert "--tool-name-profile" in completed.stdout
 
 
 def test_mcp_entrypoint_reports_distribution_version() -> None:

--- a/tests/boundary/mcp/test_mcp_operations.py
+++ b/tests/boundary/mcp/test_mcp_operations.py
@@ -18,8 +18,8 @@ from jacobian.adapters.mcp.server import create_server
 from jacobian.adapters.mcp.tooling import _request_trace_digest, _run_blocking
 
 MCP_TOOL_NAMES = {
-    "capability.describe",
-    "capability.invoke",
+    "math.find",
+    "math.run",
     "reasoning.write",
 }
 
@@ -52,11 +52,11 @@ def test_mcp_logs_bounded_tool_metrics_without_arguments(
 
         async with Client(create_server(tmp_path), raise_exceptions=True) as client:
             await client.call_tool(
-                "capability.describe",
+                "math.find",
                 {"query": "private-query-marker"},
             )
             failed = await client.call_tool(
-                "capability.invoke",
+                "math.run",
                 {
                     "capability_id": "missing.capability",
                     "mode": "EXPLORE",
@@ -72,7 +72,7 @@ def test_mcp_logs_bounded_tool_metrics_without_arguments(
     metric = next(
         message
         for message in messages
-        if "MCP tool call tool=capability.describe status=success" in message
+        if "MCP tool call tool=math.find status=success" in message
     )
     assert "duration_ms=" in metric
     assert "response_bytes=" in metric
@@ -97,7 +97,7 @@ def test_mcp_tool_failures_return_safe_actionable_errors(tmp_path: Path) -> None
 
         async with Client(create_server(tmp_path), raise_exceptions=False) as client:
             unknown_capability = await client.call_tool(
-                "capability.describe", {"capability_id": "missing.capability"}
+                "math.find", {"capability_id": "missing.capability"}
             )
             response = json.loads(unknown_capability.content[0].text)
             assert response["error"]["code"] == "UNKNOWN_CAPABILITY"
@@ -133,7 +133,7 @@ def test_mcp_protocol_and_authentication_errors_remain_distinct(tmp_path: Path) 
             raise_exceptions=False,
         ) as client:
             with pytest.raises(MCPError) as authentication_error:
-                await client.call_tool("capability.describe", {})
+                await client.call_tool("math.find", {})
             assert str(authentication_error.value) == "Internal server error"
 
     asyncio.run(scenario())
@@ -152,7 +152,7 @@ def test_direct_tool_calls_reject_removed_and_malformed_arguments(
 
         with pytest.raises(ToolError):
             await server.call_tool(
-                "capability.describe",
+                "math.find",
                 {"limit": "not-an-integer"},
             )
 
@@ -200,7 +200,7 @@ def test_mcp_entrypoint_has_nonstarting_help() -> None:
     assert completed.returncode == 0
     assert "Run the Jacobian MCP server" in completed.stdout
     assert "--tool-profile" not in completed.stdout
-    assert "--tool-name-profile" in completed.stdout
+    assert "--tool-name-profile" not in completed.stdout
 
 
 def test_mcp_entrypoint_reports_distribution_version() -> None:

--- a/tests/boundary/mcp/test_mcp_reasoning_log.py
+++ b/tests/boundary/mcp/test_mcp_reasoning_log.py
@@ -17,11 +17,11 @@ def test_required_reasoning_log_binds_actual_capability_result(tmp_path: Path) -
         ) as client:
             tools = {tool.name: tool for tool in (await client.list_tools()).tools}
             assert set(tools) == {
-                "capability.describe",
-                "capability.invoke",
+                "math.find",
+                "math.run",
                 "reasoning.write",
             }
-            assert set(tools["capability.invoke"].input_schema["required"]) >= {
+            assert set(tools["math.run"].input_schema["required"]) >= {
                 "reasoning_run_id",
                 "reasoning_call_id",
             }
@@ -45,7 +45,7 @@ def test_required_reasoning_log_binds_actual_capability_result(tmp_path: Path) -
             assert isinstance(before.structured_content, dict)
             call_id = before.structured_content["call_id"]
             result = await client.call_tool(
-                "capability.invoke",
+                "math.run",
                 {
                     "capability_id": "integer.compute.gcd",
                     "mode": "EXPLORE",
@@ -109,8 +109,8 @@ def test_off_mode_preserves_the_legacy_two_tool_surface(tmp_path: Path) -> None:
             raise_exceptions=True,
         ) as client:
             tools = {tool.name: tool for tool in (await client.list_tools()).tools}
-            assert set(tools) == {"capability.describe", "capability.invoke"}
-            assert set(tools["capability.invoke"].input_schema["properties"]) == {
+            assert set(tools) == {"math.find", "math.run"}
+            assert set(tools["math.run"].input_schema["properties"]) == {
                 "capability_id",
                 "payload",
                 "mode",
@@ -128,7 +128,7 @@ def test_audit_mode_allows_unbound_legacy_invocation(tmp_path: Path) -> None:
             raise_exceptions=True,
         ) as client:
             result = await client.call_tool(
-                "capability.invoke",
+                "math.run",
                 {
                     "capability_id": "integer.compute.gcd",
                     "mode": "EXPLORE",
@@ -171,7 +171,7 @@ def test_required_mode_rejects_mismatched_call_binding_without_consuming_it(
             call_id = before.structured_content["call_id"]
 
             mismatch = await client.call_tool(
-                "capability.invoke",
+                "math.run",
                 {
                     "capability_id": "integer.factorization.factor",
                     "mode": "EXPLORE",
@@ -184,7 +184,7 @@ def test_required_mode_rejects_mismatched_call_binding_without_consuming_it(
             assert "REASONING_CALL_MISMATCH" in mismatch.content[0].text
 
             result = await client.call_tool(
-                "capability.invoke",
+                "math.run",
                 {
                     "capability_id": "integer.compute.gcd",
                     "mode": "EXPLORE",

--- a/tests/boundary/mcp/test_mcp_sdk_2_conformance.py
+++ b/tests/boundary/mcp/test_mcp_sdk_2_conformance.py
@@ -25,15 +25,14 @@ def test_mcp_sdk_is_exactly_pinned_and_v2_bindings_are_used() -> None:
     assert extension.settings() == {
         "version": "2",
         "reasoning_log_mode": "OFF",
-        "tool_name_profile": "capability",
     }
     assert all(isinstance(binding, ToolBinding) for binding in extension.tools())
     assert all(
         isinstance(binding, ResourceBinding) for binding in extension.resources()
     )
     assert tuple(binding.kwargs["name"] for binding in extension.tools()) == (
-        "capability.describe",
-        "capability.invoke",
+        "math.find",
+        "math.run",
     )
 
 
@@ -50,21 +49,17 @@ def test_mcp_v2_static_validation_context_errors_and_structured_resources(
                 tool.input_schema.get("additionalProperties") is False
                 for tool in listed.tools
             )
-            invoke = next(
-                tool for tool in listed.tools if tool.name == "capability.invoke"
-            )
+            invoke = next(tool for tool in listed.tools if tool.name == "math.run")
             assert invoke.output_schema == CapabilityResult.model_json_schema()
 
             with pytest.raises(MCPError) as unknown:
-                await client.call_tool(
-                    "capability.describe", {"unknown_key": "rejected"}
-                )
+                await client.call_tool("math.find", {"unknown_key": "rejected"})
             assert '"code": "INVALID_INPUT"' in str(unknown.value)
 
             contract = json.loads(
                 (
                     await client.call_tool(
-                        "capability.describe",
+                        "math.find",
                         {
                             "capability_id": "polynomial.expression.normalize",
                             "view": "CONTRACT",
@@ -75,7 +70,7 @@ def test_mcp_v2_static_validation_context_errors_and_structured_resources(
                 .text
             )
             result = await client.call_tool(
-                "capability.invoke",
+                "math.run",
                 {
                     "capability_id": "polynomial.expression.normalize",
                     "mode": "EXPLORE",

--- a/tests/boundary/mcp/test_mcp_sdk_2_conformance.py
+++ b/tests/boundary/mcp/test_mcp_sdk_2_conformance.py
@@ -22,7 +22,11 @@ def test_mcp_sdk_is_exactly_pinned_and_v2_bindings_are_used() -> None:
     extension = JacobianCoreExtension(None, None, ReasoningLogMode.OFF)
     assert isinstance(extension, Extension)
     assert extension.identifier == "io.jacobian/core"
-    assert extension.settings() == {"version": "2", "reasoning_log_mode": "OFF"}
+    assert extension.settings() == {
+        "version": "2",
+        "reasoning_log_mode": "OFF",
+        "tool_name_profile": "capability",
+    }
     assert all(isinstance(binding, ToolBinding) for binding in extension.tools())
     assert all(
         isinstance(binding, ResourceBinding) for binding in extension.resources()

--- a/tests/boundary/mcp/test_remote_mcp_http.py
+++ b/tests/boundary/mcp/test_remote_mcp_http.py
@@ -141,7 +141,7 @@ async def _remote_tenant_scenario(port: int) -> None:
             catalog = await client.read_resource("capability://catalog")
             assert "fixture.increment" in catalog.contents[0].text
             result = await client.call_tool(
-                "capability.invoke",
+                "math.run",
                 {
                     "capability_id": "fixture.increment",
                     "mode": "EXPLORE",

--- a/tests/boundary/providers/lean/startup/test_lean.py
+++ b/tests/boundary/providers/lean/startup/test_lean.py
@@ -304,7 +304,7 @@ def test_core_lean_check_runs_through_capability_mcp_surface(tmp_path: Path) -> 
             raise_exceptions=True,
         ) as client:
             described = await client.call_tool(
-                "capability.describe",
+                "math.find",
                 {"capability_id": "lean.check", "view": "CONTRACT"},
             )
             descriptor = json.loads(described.content[0].text)
@@ -312,7 +312,7 @@ def test_core_lean_check_runs_through_capability_mcp_surface(tmp_path: Path) -> 
             assert descriptor["cache"]["mathlib_warmup"]["status"] == "NOT_STARTED"
 
             response = await client.call_tool(
-                "capability.invoke",
+                "math.run",
                 {
                     "capability_id": "lean.check",
                     "mode": "VERIFY",

--- a/tests/component/plugins/test_claim_validation.py
+++ b/tests/component/plugins/test_claim_validation.py
@@ -93,4 +93,4 @@ def test_claim_validation_rejects_missing_plugin_capability(tmp_path: Path) -> N
     assert not result.valid
     assert result.input.status.value == "REJECTED"
     assert "WitnessOracle" in result.missing_capabilities
-    assert "capability.describe" in result.input.errors[0]
+    assert "math.find" in result.input.errors[0]

--- a/tests/component/providers/lean/test_lean_errors.py
+++ b/tests/component/providers/lean/test_lean_errors.py
@@ -15,7 +15,7 @@ def test_partial_lean_service_explains_how_to_list_environments() -> None:
 
     with pytest.raises(
         ValueError,
-        match=r"capability\.describe with capability_id='lean\.check'",
+        match=r"math\.find with capability_id='lean\.check'",
     ):
         service.verify(
             statement="1 + 1 = 2",

--- a/tests/composition/runtime/test_capability_adapter_authority.py
+++ b/tests/composition/runtime/test_capability_adapter_authority.py
@@ -89,7 +89,7 @@ def test_unknown_capability_returns_an_actionable_result(
     assert result.diagnostics[0].message == (
         "Capability 'missing.capability' is not installed."
     )
-    assert "capability.describe" in (result.diagnostics[0].hint or "")
+    assert "math.find" in (result.diagnostics[0].hint or "")
     assert result.output["available_capability_ids"]
 
 
@@ -109,7 +109,7 @@ def test_unsupported_capability_mode_lists_available_modes(
 
     assert result.execution.status is ExecutionStatus.ERROR
     assert result.diagnostics[0].code == "UNSUPPORTED_MODE"
-    assert "capability.describe" in (result.diagnostics[0].hint or "")
+    assert "math.find" in (result.diagnostics[0].hint or "")
     assert result.output["available_modes"] == ["EXPLORE"]
 
 

--- a/tests/e2e/capability_workflows/test_capability_round_trips.py
+++ b/tests/e2e/capability_workflows/test_capability_round_trips.py
@@ -68,12 +68,12 @@ def test_exact_domain_result_verifies_and_replays_after_restart(
 
             producer = await _tool(
                 client,
-                "capability.describe",
+                "math.find",
                 {"capability_id": "polynomial.compute.gcd"},
             )
             verifier = await _tool(
                 client,
-                "capability.describe",
+                "math.find",
                 {"capability_id": "polynomial.gcd.verify"},
             )
             assert producer["capability"]["modes"] == ["EXPLORE"]
@@ -85,7 +85,7 @@ def test_exact_domain_result_verifies_and_replays_after_restart(
             }
             computed = await _tool(
                 client,
-                "capability.invoke",
+                "math.run",
                 {
                     "capability_id": "polynomial.compute.gcd",
                     "mode": "EXPLORE",
@@ -98,7 +98,7 @@ def test_exact_domain_result_verifies_and_replays_after_restart(
 
             verified = await _tool(
                 client,
-                "capability.invoke",
+                "math.run",
                 {
                     "capability_id": "polynomial.gcd.verify",
                     "mode": "VERIFY",
@@ -119,7 +119,7 @@ def test_exact_domain_result_verifies_and_replays_after_restart(
         async with Client(restarted, raise_exceptions=True) as client:
             replayed = await _tool(
                 client,
-                "capability.invoke",
+                "math.run",
                 {
                     "capability_id": "polynomial.gcd.verify",
                     "mode": "VERIFY",
@@ -149,7 +149,7 @@ def test_computed_domain_operation_remains_available_without_checker_authority(
             }
             computed = await _tool(
                 client,
-                "capability.invoke",
+                "math.run",
                 {
                     "capability_id": "polynomial.compute.gcd",
                     "mode": "EXPLORE",
@@ -162,7 +162,7 @@ def test_computed_domain_operation_remains_available_without_checker_authority(
 
             unavailable = await _tool(
                 client,
-                "capability.invoke",
+                "math.run",
                 {
                     "capability_id": "polynomial.gcd.verify",
                     "mode": "VERIFY",
@@ -192,13 +192,13 @@ def test_lean_proof_edit_verifies_through_mcp_and_replays_after_restart(
         assert "lean.proof_edit.validate" in capability_ids
         descriptor = await _tool(
             client,
-            "capability.describe",
+            "math.find",
             {"capability_id": "lean.proof_edit.validate"},
         )
         assert descriptor["capability"]["modes"] == ["VERIFY"]
         return await _tool(
             client,
-            "capability.invoke",
+            "math.run",
             {
                 "capability_id": "lean.proof_edit.validate",
                 "mode": "VERIFY",

--- a/tests/e2e/capability_workflows/test_reasoning_log_round_trip.py
+++ b/tests/e2e/capability_workflows/test_reasoning_log_round_trip.py
@@ -34,7 +34,7 @@ def test_reasoning_run_survives_runtime_restart_and_finalizes(tmp_path: Path) ->
             assert isinstance(before.structured_content, dict)
             call_id = before.structured_content["call_id"]
             result = await client.call_tool(
-                "capability.invoke",
+                "math.run",
                 {
                     "capability_id": "integer.compute.gcd",
                     "payload": {"left": "84", "right": "30"},

--- a/tests/unit/tooling/test_eval_telemetry.py
+++ b/tests/unit/tooling/test_eval_telemetry.py
@@ -36,7 +36,7 @@ def test_agent_telemetry_preserves_discovery_to_invocation_dataflow(
 ) -> None:
     events = [
         _tool_event(
-            "capability.describe",
+            "math.find",
             {
                 "query": "find a graph counterexample",
                 "domain": "graph",
@@ -51,7 +51,7 @@ def test_agent_telemetry_preserves_discovery_to_invocation_dataflow(
             },
         ),
         _tool_event(
-            "capability.describe",
+            "math.find",
             {"capability_id": "graph.search.atlas"},
             {
                 "kind": "capability",
@@ -59,7 +59,7 @@ def test_agent_telemetry_preserves_discovery_to_invocation_dataflow(
             },
         ),
         _tool_event(
-            "capability.invoke",
+            "math.run",
             {
                 "capability_id": "graph.search.atlas",
                 "mode": "EXPLORE",
@@ -113,17 +113,17 @@ def test_agent_telemetry_counts_response_bytes_and_repeated_calls(
 ) -> None:
     events = [
         _tool_event(
-            "capability.describe",
+            "math.find",
             {},
             {"matches": [{"capability_id": "sat.cnf.materialize"}]},
         ),
         _tool_event(
-            "capability.describe",
+            "math.find",
             {},
             {"matches": [{"capability_id": "sat.cnf.materialize"}]},
         ),
         _tool_event(
-            "capability.describe",
+            "math.find",
             {"capability_id": "sat.cnf.materialize"},
             {"capability": {"capability_id": "sat.cnf.materialize"}},
         ),
@@ -138,11 +138,10 @@ def test_agent_telemetry_counts_response_bytes_and_repeated_calls(
 
     assert telemetry["mcp_wire_bytes"] > 0
     assert (
-        telemetry["mcp_wire_bytes_by_tool"]["capability.describe"]
-        == telemetry["mcp_wire_bytes"]
+        telemetry["mcp_wire_bytes_by_tool"]["math.find"] == telemetry["mcp_wire_bytes"]
     )
     assert telemetry["repeated_mcp_call_count"] == 1
-    assert telemetry["repeated_mcp_calls"][0]["tool"] == "capability.describe"
+    assert telemetry["repeated_mcp_calls"][0]["tool"] == "math.find"
     assert telemetry["repeated_mcp_calls"][0]["count"] == 2
     assert telemetry["capability_describe_index_calls"] == 2
     assert telemetry["capability_describe_exact_calls"] == 1
@@ -171,7 +170,7 @@ def test_agent_telemetry_reports_reasoning_protocol_without_summary_text(
             {"run_id": run_id, "call_id": call_id},
         ),
         _tool_event(
-            "capability.invoke",
+            "math.run",
             {
                 "capability_id": "integer.compute.gcd",
                 "payload": {},
@@ -279,7 +278,7 @@ def test_agent_telemetry_separates_wire_model_and_logical_invocation_bytes(
         "type": "item.completed",
         "item": {
             "type": "mcp_tool_call",
-            "tool": "capability.invoke",
+            "tool": "math.run",
             "arguments": {
                 "capability_id": "graph.search.atlas",
                 "mode": "EXPLORE",
@@ -346,7 +345,7 @@ def test_agent_telemetry_tracks_resource_link_follow_through_and_identity(
             "type": "item.completed",
             "item": {
                 "type": "mcp_tool_call",
-                "tool": "capability.invoke",
+                "tool": "math.run",
                 "arguments": {"capability_id": "graph.search.atlas"},
                 "status": "completed",
                 "result": {

--- a/tests/unit/tooling/test_harbor_job_config.py
+++ b/tests/unit/tooling/test_harbor_job_config.py
@@ -16,6 +16,7 @@ JOB = (
 )
 CONTROL_JOB = ROOT / "benchmarks" / "config" / "agent-workflow-v1-control.json"
 MCP_CONFIG = ROOT / "benchmarks" / "config" / "jacobian.mcp.json"
+LOOPBACK_MCP_CONFIG = ROOT / "benchmarks" / "config" / "jacobian-loopback.mcp.json"
 
 
 def test_observation_job_uses_harbor_dataset_selection() -> None:
@@ -46,7 +47,7 @@ def test_observation_job_keeps_the_minimal_jacobian_treatment() -> None:
 
     assert job["agents"] == [{"name": "codex", "kwargs": {"web_search": "disabled"}}]
     assert job["environment"]["extra_docker_compose"] == [
-        "benchmarks/datasets/agent-workflow-v1/jacobian-observation.compose.yaml"
+        "benchmarks/datasets/agent-workflow-v1/jacobian-observation.compose.yaml",
     ]
 
 
@@ -67,9 +68,14 @@ def test_agent_eval_forwards_web_search_setting_to_harbor() -> None:
         "JACOBIAN_EVAL_ALL_PROXY ?= $(call _jacobian_eval_container_proxy,$(ALL_PROXY))"
         in makefile
     )
+    assert "JACOBIAN_EVAL_CODEX_BINARY" in makefile
+    assert "JACOBIAN_EVAL_UPSTREAM_PROXY" in makefile
+    assert "benchmarks.tooling.harbor_proxy" in makefile
+    assert 'if [ "$(JACOBIAN_EVAL_PROXY)" = "1" ]; then' in makefile
     assert 'JACOBIAN_EVAL_NO_PROXY="$(JACOBIAN_EVAL_NO_PROXY)"' in makefile
     assert "agent-workflow-v1-control-proxy.json" in makefile
     assert "jacobian-observation-proxy.json" in makefile
+    assert "jacobian-loopback.mcp.json" in makefile
 
 
 def test_proxy_observation_job_is_opt_in_and_preserves_local_mcp_access() -> None:
@@ -84,21 +90,47 @@ def test_proxy_observation_job_is_opt_in_and_preserves_local_mcp_access() -> Non
         ).read_text()
     )
     proxy_overlay = (
-        ROOT / "benchmarks" / "config" / "agent-eval-proxy.compose.yaml"
+        ROOT / "benchmarks" / "config" / "agent-eval-egress-proxy.compose.yaml"
     ).read_text()
-
+    codex_overlay = (
+        ROOT / "benchmarks" / "config" / "agent-eval-codex.compose.yaml"
+    ).read_text()
     assert proxy_job["environment"]["extra_docker_compose"] == [
-        "benchmarks/config/agent-eval-proxy.compose.yaml",
+        "benchmarks/config/agent-eval-codex.compose.yaml",
+        "benchmarks/config/agent-eval-egress-proxy.compose.yaml",
         "benchmarks/datasets/agent-workflow-v1/jacobian-observation.compose.yaml",
     ]
     assert "NO_PROXY" in proxy_overlay
+    assert "127.0.0.1" in proxy_overlay
     assert "jacobian" in proxy_overlay
+    assert "host.docker.internal:host-gateway" in proxy_overlay
+    assert "harbor-docker-egress-control-sidecar:" in proxy_overlay
+    assert "JACOBIAN_EVAL_GOST_CONFIG" in proxy_overlay
+    assert 'HTTPS_PROXY: ""' in proxy_overlay
+    assert "JACOBIAN_EVAL_CODEX_BINARY" in codex_overlay
+    assert "target: /usr/local/bin/codex" in codex_overlay
+
+
+def test_jacobian_sidecar_keeps_its_project_network_under_egress_control() -> None:
+    observation_overlay = (
+        ROOT
+        / "benchmarks"
+        / "datasets"
+        / "agent-workflow-v1"
+        / "jacobian-observation.compose.yaml"
+    ).read_text()
+
+    assert "jacobian:" in observation_overlay
+    assert "networks:" not in observation_overlay
+    assert "condition: service_healthy" in observation_overlay
+    assert "socket.create_connection" in observation_overlay
 
 
 def test_observation_mcp_config_is_external_to_the_task_job() -> None:
     job = json.loads(JOB.read_text())
     control = json.loads(CONTROL_JOB.read_text())
     mcp = json.loads(MCP_CONFIG.read_text())
+    loopback_mcp = json.loads(LOOPBACK_MCP_CONFIG.read_text())
 
     assert "mcp_servers" not in job["agents"][0]
     assert "mcp_servers" not in control["agents"][0]
@@ -107,6 +139,13 @@ def test_observation_mcp_config_is_external_to_the_task_job() -> None:
             "name": "jacobian",
             "transport": "streamable-http",
             "url": "http://jacobian:8000/mcp",
+        }
+    ]
+    assert loopback_mcp["mcp_servers"] == [
+        {
+            "name": "jacobian",
+            "transport": "streamable-http",
+            "url": "http://127.0.0.1:8000/mcp",
         }
     ]
 
@@ -123,3 +162,13 @@ def test_paired_jobs_use_three_attempts_per_condition() -> None:
 
     assert treatment["n_attempts"] == 3
     assert control["n_attempts"] == 3
+
+
+def test_paired_jobs_keep_the_same_egress_allowlist() -> None:
+    treatment = json.loads(JOB.read_text())
+    control = json.loads(CONTROL_JOB.read_text())
+
+    assert (
+        treatment["environment"]["extra_allowed_hosts"]
+        == control["environment"]["extra_allowed_hosts"]
+    )

--- a/tests/unit/tooling/test_harbor_proxy.py
+++ b/tests/unit/tooling/test_harbor_proxy.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pytest
+from benchmarks.tooling.harbor_proxy import render_config
+
+
+def test_render_config_chains_transparent_egress_through_http_proxy() -> None:
+    config = render_config("http://docker-host:7890")
+
+    service = config["services"][0]
+    hop = config["chains"][0]["hops"][0]
+    node = hop["nodes"][0]
+    assert service["handler"]["chain"] == "upstream-proxy"
+    assert service["bypass"] == "allowlist"
+    assert service["sockopts"] == {"mark": 114514}
+    assert hop["bypass"] == "direct-private"
+    assert hop["sockopts"] == {"mark": 114514}
+    assert node["addr"] == "docker-host:7890"
+    assert node["connector"] == {"type": "http"}
+    assert config["bypasses"][1]["matchers"] == [
+        "127.0.0.0/8",
+        "10.0.0.0/8",
+        "172.16.0.0/12",
+        "192.168.0.0/16",
+        "169.254.0.0/16",
+        "::1/128",
+        "fc00::/7",
+        "fe80::/10",
+    ]
+
+
+def test_render_config_rejects_unsupported_proxy_scheme() -> None:
+    with pytest.raises(ValueError, match="upstream proxy must use"):
+        render_config("https://docker-host:7890")

--- a/tests/unit/tooling/test_mcp_tool_surface.py
+++ b/tests/unit/tooling/test_mcp_tool_surface.py
@@ -4,66 +4,23 @@ from __future__ import annotations
 
 from jacobian.adapters.mcp.constants import ReasoningLogMode
 from jacobian.adapters.mcp.guidance import (
-    CAPABILITY_DESCRIBE_DESCRIPTION,
-    CAPABILITY_INVOKE_DESCRIPTION,
+    MATH_FIND_DESCRIPTION,
+    MATH_RUN_DESCRIPTION,
     SERVER_INSTRUCTIONS,
-    render_tool_names,
-    tool_names,
 )
 from jacobian.adapters.mcp.server import JacobianCoreExtension
 
 
-def test_core_extension_exposes_exactly_the_stable_capability_tools() -> None:
+def test_core_extension_exposes_exactly_the_stable_math_tools() -> None:
     extension = JacobianCoreExtension(None, None, ReasoningLogMode.OFF)
     assert extension.identifier == "io.jacobian/core"
     assert extension.settings() == {
         "version": "2",
         "reasoning_log_mode": "OFF",
-        "tool_name_profile": "capability",
     }
     assert tuple(binding.kwargs["name"] for binding in extension.tools()) == (
-        "capability.describe",
-        "capability.invoke",
-    )
-
-
-def test_core_extension_can_expose_math_names_without_changing_contracts() -> None:
-    extension = JacobianCoreExtension(
-        None,
-        None,
-        ReasoningLogMode.OFF,
-        tool_names("math"),
-    )
-
-    bindings = extension.tools()
-    assert tuple(binding.kwargs["name"] for binding in bindings) == (
         "math.find",
         "math.run",
-    )
-    assert extension.settings()["tool_name_profile"] == "math"
-    assert "capability.describe" not in bindings[1].kwargs["description"]
-    assert "math.find" in bindings[1].kwargs["description"]
-
-
-def test_name_profiles_change_names_without_changing_guidance_semantics() -> None:
-    names = tool_names("math")
-    assert (
-        render_tool_names(SERVER_INSTRUCTIONS, names)
-        .replace("math.find", "capability.describe")
-        .replace("math.run", "capability.invoke")
-        == SERVER_INSTRUCTIONS
-    )
-    assert (
-        render_tool_names(CAPABILITY_DESCRIBE_DESCRIPTION, names)
-        .replace("math.find", "capability.describe")
-        .replace("math.run", "capability.invoke")
-        == CAPABILITY_DESCRIBE_DESCRIPTION
-    )
-    assert (
-        render_tool_names(CAPABILITY_INVOKE_DESCRIPTION, names)
-        .replace("math.find", "capability.describe")
-        .replace("math.run", "capability.invoke")
-        == CAPABILITY_INVOKE_DESCRIPTION
     )
 
 
@@ -71,15 +28,15 @@ def test_model_visible_guidance_exposes_affordances_without_research_order() -> 
     combined = "\n".join(
         (
             SERVER_INSTRUCTIONS,
-            CAPABILITY_DESCRIBE_DESCRIPTION,
-            CAPABILITY_INVOKE_DESCRIPTION,
+            MATH_FIND_DESCRIPTION,
+            MATH_RUN_DESCRIPTION,
         )
     ).lower()
     assert "desired local mathematical outcome" in combined
     assert "not recommendations" in combined
     assert "begin with" not in combined
     assert "use this first" not in combined
-    assert "call capability.describe first" not in combined
+    assert "call math.find first" not in combined
     assert "strongest one or two" not in combined
     assert "before searching for a checker" not in combined
     assert "partition larger searches" not in combined

--- a/tests/unit/tooling/test_mcp_tool_surface.py
+++ b/tests/unit/tooling/test_mcp_tool_surface.py
@@ -3,14 +3,83 @@
 from __future__ import annotations
 
 from jacobian.adapters.mcp.constants import ReasoningLogMode
+from jacobian.adapters.mcp.guidance import (
+    CAPABILITY_DESCRIBE_DESCRIPTION,
+    CAPABILITY_INVOKE_DESCRIPTION,
+    SERVER_INSTRUCTIONS,
+    render_tool_names,
+    tool_names,
+)
 from jacobian.adapters.mcp.server import JacobianCoreExtension
 
 
 def test_core_extension_exposes_exactly_the_stable_capability_tools() -> None:
     extension = JacobianCoreExtension(None, None, ReasoningLogMode.OFF)
     assert extension.identifier == "io.jacobian/core"
-    assert extension.settings() == {"version": "2", "reasoning_log_mode": "OFF"}
+    assert extension.settings() == {
+        "version": "2",
+        "reasoning_log_mode": "OFF",
+        "tool_name_profile": "capability",
+    }
     assert tuple(binding.kwargs["name"] for binding in extension.tools()) == (
         "capability.describe",
         "capability.invoke",
     )
+
+
+def test_core_extension_can_expose_math_names_without_changing_contracts() -> None:
+    extension = JacobianCoreExtension(
+        None,
+        None,
+        ReasoningLogMode.OFF,
+        tool_names("math"),
+    )
+
+    bindings = extension.tools()
+    assert tuple(binding.kwargs["name"] for binding in bindings) == (
+        "math.find",
+        "math.run",
+    )
+    assert extension.settings()["tool_name_profile"] == "math"
+    assert "capability.describe" not in bindings[1].kwargs["description"]
+    assert "math.find" in bindings[1].kwargs["description"]
+
+
+def test_name_profiles_change_names_without_changing_guidance_semantics() -> None:
+    names = tool_names("math")
+    assert (
+        render_tool_names(SERVER_INSTRUCTIONS, names)
+        .replace("math.find", "capability.describe")
+        .replace("math.run", "capability.invoke")
+        == SERVER_INSTRUCTIONS
+    )
+    assert (
+        render_tool_names(CAPABILITY_DESCRIBE_DESCRIPTION, names)
+        .replace("math.find", "capability.describe")
+        .replace("math.run", "capability.invoke")
+        == CAPABILITY_DESCRIBE_DESCRIPTION
+    )
+    assert (
+        render_tool_names(CAPABILITY_INVOKE_DESCRIPTION, names)
+        .replace("math.find", "capability.describe")
+        .replace("math.run", "capability.invoke")
+        == CAPABILITY_INVOKE_DESCRIPTION
+    )
+
+
+def test_model_visible_guidance_exposes_affordances_without_research_order() -> None:
+    combined = "\n".join(
+        (
+            SERVER_INSTRUCTIONS,
+            CAPABILITY_DESCRIBE_DESCRIPTION,
+            CAPABILITY_INVOKE_DESCRIPTION,
+        )
+    ).lower()
+    assert "desired local mathematical outcome" in combined
+    assert "not recommendations" in combined
+    assert "begin with" not in combined
+    assert "use this first" not in combined
+    assert "call capability.describe first" not in combined
+    assert "strongest one or two" not in combined
+    assert "before searching for a checker" not in combined
+    assert "partition larger searches" not in combined


### PR DESCRIPTION
## Problem

Jacobian's MCP surface used the product-internal names `capability.describe` and `capability.invoke`. Models should instead see a small mathematical interface whose purpose is apparent from the tool names, without having to translate Jacobian's internal capability vocabulary before selecting a tool.

The agent-evaluation path also needed a reproducible way to observe whether models use that finished interface. Codex setup depended on runtime package installation, and controlled-egress jobs did not have a stable route through a host HTTP or SOCKS proxy while preserving Harbor's allowlist.

Relates to #503.

## Solution

This PR makes `math.find` and `math.run` the canonical MCP tools:

- `math.find` searches, browses, or inspects installed mathematical operations.
- `math.run` executes one selected operation using its typed contract.

The old top-level names are removed rather than retained as aliases, and the temporary name-profile switch is gone. Capability IDs and `capability://catalog` remain unchanged because they identify installed operations and the catalog, not top-level tools.

The canonical names now flow through initialization instructions, tool descriptions, prompts, resources, recovery results, telemetry normalization, held-out readiness checks, deployment smoke, npm doctor, tutorials, reference documentation, and conformance fixtures. The guidance describes mathematical affordances and evidence semantics without prescribing a research sequence. Discovery results expose bounded operation cards and recovery choices when no descriptor matches; a no-match result remains distinct from a mathematical conclusion.

The Harbor workflow gains a standalone Codex overlay and controlled-egress GOST configuration that can chain through a configured host HTTP or SOCKS proxy without bypassing the task allowlist. Direct runs use the service-name MCP endpoint; controlled-egress runs use a loopback endpoint because Harbor places the agent and Jacobian server in the same egress namespace.

Harbor now evaluates adoption of the finished interface and the quality of the selected tasks. It is not a gate on the rename. A correct no-call run may mean the task is too easy or that native tools are a better fit, so useful adoption evaluation needs negative controls and tasks where Jacobian offers a material mathematical affordance.

Suggested review order:

1. Canonical MCP registration and guidance in `src/jacobian/adapters/mcp/`.
2. Repository-wide consumers of the public tool names: telemetry, readiness, deployment, npm, docs, and tests.
3. Harbor routing and proxy generation in the `Makefile`, compose overlays, and `harbor_proxy.py`.

## Testing

- `make check` — Ruff, formatting, mypy, and 610 unit tests passed.
- `make test-mcp` — 32 tests passed.
- `make test-composition` — 446 passed and 2 Lean-dependent tests skipped.
- `make test-e2e` — 8 passed and 1 Lean-dependent test skipped.
- `make harbor-contracts` — Harbor dataset and benchmark contracts passed.
- `make npm-test` — 34 tests passed and the package dry-run succeeded.
- `make docs-linkcheck` — documentation commands and links passed.
- `make deploy-check` — shell validation and 12 deployment tests passed.
- A controlled-proxy MCP smoke completed initialization and listed `math.find` and `math.run`.
- A one-attempt `gpt-5.6-luna` Harbor run completed with reward 0.9 and no Jacobian calls. This is evidence that the selected finite task did not discriminate tool adoption, not evidence against the canonical names.

## Trust & Compatibility Impact

This is a pre-stable breaking change to the public MCP tool names. Clients and fixtures that call `capability.describe` or `capability.invoke` must use `math.find` or `math.run`; no aliases are exposed.

Capability contracts, mathematical kernels, checker authorization, artifact formats, assurance semantics, and verification policy are unchanged. The proxy path preserves controlled egress, and failures, timeouts, missing witnesses, and no-match discovery results remain separate from mathematical conclusions.

## Checklist

- [x] Routine local validation passes (`make check`)
- [x] Relevant focused tests are listed above
