### PR TITLE
refactor: remove redundant work from local validation plans

### DIFF
--- a/.github/ci-impact.json
+++ b/.github/ci-impact.json
@@ -34,7 +34,11 @@
     "e2e": {"command": "make test-e2e", "topology_lane": "e2e"},
     "lean": {"command": "make test-lean", "topology_lane": "lean"},
     "npm": {"command": "make npm-test", "topology_lane": null},
-    "static": {"command": "make check-static", "topology_lane": null},
+    "static": {
+      "command": "make check-static",
+      "topology_lane": null,
+      "local_subsumes": ["build"]
+    },
     "build": {"command": "make build", "topology_lane": null},
     "security": {"command": "make security-audit", "topology_lane": null},
     "duplicate": {"command": "make duplicate-code", "topology_lane": null},

--- a/.github/scripts/plan-local-tests
+++ b/.github/scripts/plan-local-tests
@@ -31,6 +31,33 @@ def _catalog() -> dict[str, dict[str, object]]:
     catalog = data["catalog"]
     if not isinstance(catalog, dict):
         raise ValueError("CI catalog must be an object")
+    for name, entry in catalog.items():
+        if not isinstance(entry, dict):
+            raise ValueError(f"CI catalog entry {name} must be an object")
+        subsumes = entry.get("local_subsumes", [])
+        if (
+            not isinstance(subsumes, list)
+            or not all(isinstance(item, str) and item for item in subsumes)
+            or name in subsumes
+            or any(item not in catalog for item in subsumes)
+        ):
+            raise ValueError(f"CI catalog entry {name} has invalid local_subsumes")
+    visiting: set[str] = set()
+    visited: set[str] = set()
+
+    def visit(name: str) -> None:
+        if name in visiting:
+            raise ValueError("CI catalog local_subsumes must be acyclic")
+        if name in visited:
+            return
+        visiting.add(name)
+        for child in catalog[name].get("local_subsumes", []):
+            visit(str(child))
+        visiting.remove(name)
+        visited.add(name)
+
+    for name in catalog:
+        visit(name)
     return catalog
 
 
@@ -54,6 +81,19 @@ TOPOLOGY_LANES = (
     "lean",
     "e2e",
 )
+
+
+def local_command_lanes(lanes: list[str]) -> list[str]:
+    """Remove lanes whose local command is already owned by a selected gate."""
+
+    selected = set(lanes)
+    subsumed = {
+        str(subsumed_lane)
+        for lane in lanes
+        for subsumed_lane in _CATALOG[lane].get("local_subsumes", [])
+        if str(subsumed_lane) in selected
+    }
+    return [lane for lane in lanes if lane not in subsumed]
 
 HIGH_IMPACT_PATHS = {
     "src/jacobian/__init__.py",
@@ -440,6 +480,7 @@ def main() -> None:
     paths = sorted({entry.path for entry in entries})
     plan = classify(paths)
     lanes = [suite for suite in COMMANDS if plan.get(f"run-{suite}") == "true"]
+    command_lanes = local_command_lanes(lanes)
     tests, fallback = exact_tests(entries)
     # The classifier already owns deployment routing (run-deploy); re-deriving
     # it here would duplicate the deployment rule and could drift from it.
@@ -458,8 +499,10 @@ def main() -> None:
         print("  focused")
         for test in tests:
             print(f"  {test}")
-    elif fallback:
+    elif fallback and any(lane in TOPOLOGY_LANES for lane in lanes):
         print(f"  suite fallback ({fallback})")
+    elif fallback:
+        print("  not applicable (no pytest lane selected)")
     else:
         print("  none")
     print("commands:")
@@ -469,7 +512,7 @@ def main() -> None:
             print(f"    {command}")
     else:
         print("  planned lanes:")
-        for lane in lanes:
+        for lane in command_lanes:
             for command in COMMANDS[lane]:
                 print(f"    {command}")
     if deployment:
@@ -485,7 +528,9 @@ def main() -> None:
                 )
                 raise SystemExit(2)
         elif fallback:
-            commands = [command for lane in lanes for command in COMMANDS[lane]]
+            commands = [
+                command for lane in command_lanes for command in COMMANDS[lane]
+            ]
         else:
             commands = []
         if deployment:

--- a/.github/scripts/validate-ci-plan
+++ b/.github/scripts/validate-ci-plan
@@ -127,6 +127,31 @@ def _validate_catalog() -> None:
             argv = shlex.split(command)
             if len(argv) != 2 or argv[0] != "make" or argv[1] not in targets:
                 fail(f"CI catalog command for {name} is not a Make target: {command}")
+            subsumes = entry.get("local_subsumes", [])
+            if (
+                not isinstance(subsumes, list)
+                or not all(isinstance(item, str) and item for item in subsumes)
+                or name in subsumes
+                or any(item not in catalog_suites for item in subsumes)
+            ):
+                fail(f"CI catalog entry {name} has invalid local_subsumes")
+
+        visiting: set[str] = set()
+        visited: set[str] = set()
+
+        def visit_subsumptions(name: str) -> None:
+            if name in visiting:
+                fail("CI catalog local_subsumes must be acyclic")
+            if name in visited:
+                return
+            visiting.add(name)
+            for child in catalog[name].get("local_subsumes", []):
+                visit_subsumptions(str(child))
+            visiting.remove(name)
+            visited.add(name)
+
+        for name in catalog:
+            visit_subsumptions(name)
 
         provider = catalog.get("provider", {})
         if not isinstance(provider, dict) or not provider.get("providers"):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ capability membership.
 
 | Change | Start here | Oracle requirement |
 | --- | --- | --- |
-| Documentation, benchmark README, or `benchmarks/validation/` | `make docs-command-check` (and `make docs-linkcheck` for Markdown links) | None |
+| Documentation, benchmark README, or `benchmarks/validation/` | `make docs-linkcheck` | None |
 | Focused Python behavior | `make test-plan BASE=<revision>`, the selected lane, then `make check` | None |
 | Benchmark task input or verifier | `make harbor-check-task DATASET=... TASKS=...`, then `make harbor-oracle-task DATASET=... TASKS=...` | Exact selected-task Oracle |
 | Deployment entrypoint | `make deploy-check` | None |
@@ -143,7 +143,7 @@ aid; `make check` and CI remain the handoff gates.
 
 | Change | Local handoff | CI adds |
 | --- | --- | --- |
-| Docs only | `make docs-command-check` and `make docs-linkcheck` | Documentation |
+| Docs only | `make docs-linkcheck` | Documentation |
 | Focused Python | affected target, then `make check` | Planned Python/static/package lanes |
 | Benchmark task or verifier | `make harbor-check-task DATASET=... TASKS=...` and `make harbor-oracle-task DATASET=... TASKS=...` | Exact task contract and Oracle |
 | Benchmark README or validation regression | focused Harbor checks | Contract checks; no Oracle |

--- a/docs/reference/testing-strategy.md
+++ b/docs/reference/testing-strategy.md
@@ -6,7 +6,7 @@
 
 | Change | First local check | Escalate when |
 | --- | --- | --- |
-| Documentation or benchmark README/validation | `make docs-command-check` and `make docs-linkcheck` | No Oracle is needed |
+| Documentation or benchmark README/validation | `make docs-linkcheck` | No Oracle is needed |
 | Python behavior | `make test-plan BASE=<revision>` and the selected semantic lane | Finish with `make check` |
 | Benchmark task input or verifier | `make harbor-check-task DATASET=... TASKS=...` | Run `make harbor-oracle-task ...` for the selected task |
 | Deployment entrypoint | `make deploy-check` | Include affected process checks for code changes |

--- a/tests/unit/tooling/test_ci_planner_catalog.py
+++ b/tests/unit/tooling/test_ci_planner_catalog.py
@@ -260,6 +260,36 @@ def test_plan_local_tests_omits_deploy_gate_without_deployment_paths(
     assert "make docs-linkcheck" in output
 
 
+def test_plan_local_tests_labels_documentation_as_non_pytest_work(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    planner = _load_script("plan-local-tests")
+    monkeypatch.setenv("PATHS", '["README.md"]')
+    monkeypatch.setattr(sys, "argv", ["plan-local-tests"])
+
+    planner.main()
+    output = capsys.readouterr().out
+
+    assert "not applicable (no pytest lane selected)" in output
+    assert "suite fallback" not in output
+
+
+def test_plan_local_tests_omits_commands_subsumed_by_another_local_gate(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    planner = _load_script("plan-local-tests")
+    monkeypatch.setenv("PATHS", '["Makefile"]')
+    monkeypatch.setattr(sys, "argv", ["plan-local-tests"])
+
+    planner.main()
+    output = capsys.readouterr().out
+
+    assert "make check-static" in output
+    assert "    make build\n" not in output
+
+
 def _write_validator_tree(tmp_path: Path) -> None:
     """Materialize the minimal tree validate-ci-plan reads from ROOT."""
 
@@ -291,4 +321,21 @@ def test_ci_validator_enforces_local_only_deploy_catalog_contract(
     monkeypatch.setattr(sys, "stdin", io.StringIO(""))
 
     with pytest.raises(SystemExit):
+        validator.main()
+
+
+def test_ci_validator_rejects_cyclic_local_command_subsumption(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_validator_tree(tmp_path)
+    manifest_path = tmp_path / ".github" / "ci-impact.json"
+    manifest = json.loads(manifest_path.read_text("utf-8"))
+    manifest["catalog"]["build"]["local_subsumes"] = ["static"]
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    validator = _load_script("validate-ci-plan")
+    monkeypatch.setattr(validator, "ROOT", tmp_path)
+    monkeypatch.setattr(sys, "stdin", io.StringIO(""))
+
+    with pytest.raises(SystemExit, match="local_subsumes must be acyclic"):
         validator.main()


### PR DESCRIPTION
Closes #510.

## Problem

The local planner could emit both `make check-static` and `make build`, even though the static handoff already builds the package. Documentation guidance similarly asked contributors to run `docs-command-check` before `docs-linkcheck`, although the link target already owns command validation.

Known documentation and benchmark-only paths were also labeled as a pytest `suite fallback`, making intentional non-pytest work look like ambiguous ownership.

## Solution

- Add checked-in `local_subsumes` metadata to the CI catalog and use it only when rendering or executing local commands. Hosted CI lane selection remains unchanged.
- Validate subsumption references and reject self-reference, unknown lanes, and cycles.
- Report `not applicable (no pytest lane selected)` when the selected plan has no pytest owner; retain fail-closed fallback wording when a pytest lane is selected but exact ownership is ambiguous.
- Recommend only `make docs-linkcheck` for documentation handoff. Its existing prerequisite still runs command validation.

For a Makefile change, the plan continues to show both hosted `static` and `build` evidence lanes but now emits only `make check-static` locally. For README-only work, it emits `make docs-linkcheck` and no fallback warning.

## Testing

- Unit lane — 608 passed.
- Component lane — 692 passed.
- Domain lane — 153 passed.
- Composition lane — 446 passed, 2 expected Lean-runtime skips.
- Storage lane — 114 passed.
- Process lane — 249 passed.
- MCP lane — 31 passed.
- End-to-end lane — 8 passed, 1 expected Lean-runtime skip.
- `make check-static` — lint, formatting, complexity, dependency analysis, Vulture, mypy, architecture checks, sdist, and wheel passed.
- `make docs-linkcheck` — command examples and Markdown links passed.
- `git diff --check` — passed.

## Trust & Compatibility Impact

Hosted CI selection, required checks, test ownership, and mathematical verification are unchanged. The new metadata affects only local command rendering and execution, and invalid graphs fail closed.