### PR TITLE
ci(benchmarks): focus and shard benchmark host validation

### DIFF
--- a/.github/scripts/plan-benchmarks
+++ b/.github/scripts/plan-benchmarks
@@ -10,10 +10,11 @@ lanes to the triggering event and the base/head (or merge-group) SHA, records a
 digest of the planner itself, and records a digest of the benchmark topology so
 downstream jobs can confirm they are validating the exact tree the planner saw.
 The plan selects independent evidence roles -- record/schema conformance,
-prospective digest/record freshness, merge-group inventory validation, and the
-Docker Oracle lane. CI may execute deterministic roles in one checkout when
-they share the same contract gate; it must not duplicate the expensive work.
-Unknown benchmark paths fail closed to the full portfolio.
+focused or full host-verifier regressions, prospective digest/record freshness,
+merge-group inventory validation, and the Docker Oracle lane. CI may execute
+deterministic roles in one checkout when they share the same contract gate; it
+must not duplicate the expensive work. Unknown benchmark paths fail closed to
+the full portfolio.
 """
 
 from __future__ import annotations
@@ -39,7 +40,7 @@ if _SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, _SCRIPTS_DIR)
 from _ci_paths import normalize_paths, path_values  # noqa: E402
 
-PLAN_VERSION = "1"
+PLAN_VERSION = "2"
 EVENTS = ("pull_request", "merge_group", "push", "schedule", "workflow_dispatch")
 MODES = ("none", "changed", "integration", "full")
 MAX_PULL_REQUEST_ORACLE_TASKS = 8
@@ -75,6 +76,19 @@ BENCHMARK_EXECUTION_CONTROL_PATHS = frozenset(
     }
 )
 BENCHMARK_CONFIG_PREFIX = "benchmarks/config/"
+HOST_VALIDATION_ROOT = "benchmarks/validation"
+HOST_VALIDATION_FULL_SHARDS = 4
+HOST_VALIDATION_DATASET_FILES = {
+    "symbolic-coordination-v1": (
+        "benchmarks/validation/symbolic_coordination_v1/test_pilot_contract.py",
+    ),
+    "research-diagnostics-v1": (
+        "benchmarks/validation/research_diagnostics_v1/test_structured_verifiers.py",
+    ),
+    "provider-feasibility-v1": (
+        "benchmarks/validation/test_provider_download_integrity.py",
+    ),
+}
 
 
 def _json(value: object) -> str:
@@ -220,6 +234,7 @@ def _emit(
     record_schema: bool,
     prospective_digest: bool,
     inventory: bool,
+    host_validation: list[dict[str, Any]],
     run_oracle: bool,
     scope: str,
     matrix: list[dict[str, Any]],
@@ -237,11 +252,153 @@ def _emit(
         "run-benchmark-record-schema": str(record_schema).lower(),
         "run-benchmark-prospective-digest": str(prospective_digest).lower(),
         "run-benchmark-inventory": str(inventory).lower(),
+        "run-benchmark-host-validation": str(bool(host_validation)).lower(),
+        "benchmark-host-validation-matrix": _json(host_validation),
         "run-benchmark-oracle": str(run_oracle).lower(),
         "benchmark-oracle-scope": scope,
         "benchmark-oracle-matrix": _json(matrix),
         "benchmark-plan-reasons": _json(list(dict.fromkeys(reasons))),
     }
+
+
+def _host_entry(
+    *,
+    name: str,
+    selector: str,
+    keyword: str = "",
+    splits: int = 0,
+    group: int = 0,
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "selector": selector,
+        "keyword": keyword,
+        "splits": splits,
+        "group": group,
+    }
+
+
+def _full_host_validation() -> list[dict[str, Any]]:
+    return [
+        _host_entry(
+            name=f"full-{group}-of-{HOST_VALIDATION_FULL_SHARDS}",
+            selector=HOST_VALIDATION_ROOT,
+            splits=HOST_VALIDATION_FULL_SHARDS,
+            group=group,
+        )
+        for group in range(1, HOST_VALIDATION_FULL_SHARDS + 1)
+    ]
+
+
+def _dataset_host_validation(dataset: str) -> list[dict[str, Any]]:
+    return [
+        _host_entry(name=f"{dataset}-{index}", selector=selector)
+        for index, selector in enumerate(
+            HOST_VALIDATION_DATASET_FILES.get(dataset, ()), start=1
+        )
+    ]
+
+
+def _task_host_validation(dataset: str, task: str) -> list[dict[str, Any]]:
+    if dataset == "agent-workflow-v1":
+        dedicated = (
+            ROOT
+            / "benchmarks"
+            / "validation"
+            / "agent_workflow_v1"
+            / f"test_{task.replace('-', '_')}.py"
+        )
+        entries: list[dict[str, Any]] = []
+        if dedicated.is_file():
+            entries.append(
+                _host_entry(
+                    name=f"{task}-specific",
+                    selector=dedicated.relative_to(ROOT).as_posix(),
+                )
+            )
+        entries.append(
+            _host_entry(
+                name=f"{task}-generic",
+                selector=(
+                    "benchmarks/validation/agent_workflow_v1/"
+                    "test_generic_verifier_contracts.py"
+                ),
+                keyword=task,
+            )
+        )
+        return entries
+    if dataset == "public-reproductions-v1" and task == "sat-erdos-schur-f4":
+        return [
+            _host_entry(
+                name=task,
+                selector="benchmarks/validation/test_sat_erdos_schur_f4.py",
+            )
+        ]
+    return _dataset_host_validation(dataset)
+
+
+def _host_validation_plan(
+    benchmark_paths: list[str], suites_by_id: dict[str, Any]
+) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    full = False
+    for path in benchmark_paths:
+        if path.startswith("benchmarks/validation/"):
+            candidate = ROOT / path
+            if candidate.is_file() and candidate.name.startswith("test_"):
+                entries.append(_host_entry(name=candidate.stem, selector=path))
+            elif candidate.suffix == ".py":
+                parent = candidate.parent.relative_to(ROOT).as_posix()
+                entries.append(_host_entry(name=candidate.parent.name, selector=parent))
+            else:
+                full = True
+            continue
+        parts = Path(path).parts
+        if len(parts) >= 4 and parts[:2] == ("benchmarks", "datasets"):
+            dataset = parts[2]
+            suite = suites_by_id.get(dataset)
+            task_ids = {ref.path.name for ref in suite.tasks} if suite else set()
+            relative = parts[3:]
+            task = relative[0] if len(relative) >= 2 else None
+            if task in task_ids:
+                if relative[1:] != ("README.md",):
+                    entries.extend(_task_host_validation(dataset, task))
+                continue
+            if relative[:1] == ("members",) and len(relative) == 2:
+                member = Path(relative[1]).stem
+                if member in task_ids:
+                    entries.extend(_task_host_validation(dataset, member))
+                    continue
+            if relative[:1] in {("README.md",), ("dataset.toml",)}:
+                continue
+            dataset_entries = _dataset_host_validation(dataset)
+            if dataset_entries:
+                entries.extend(dataset_entries)
+            else:
+                full = True
+            continue
+        if path in {
+            "benchmarks/README.md",
+            "benchmarks/__init__.py",
+        } or path.startswith("benchmarks/templates/"):
+            continue
+        if path == "benchmarks/adapters/README.md":
+            continue
+        if path.startswith("benchmarks/adapters/"):
+            entries.append(
+                _host_entry(
+                    name="benchmark-adapters",
+                    selector="benchmarks/validation/test_benchmark_adapters.py",
+                )
+            )
+            continue
+        full = True
+    if full:
+        return _full_host_validation()
+    unique = {(entry["selector"], entry["keyword"]): entry for entry in entries}
+    return sorted(
+        unique.values(), key=lambda entry: (entry["selector"], entry["keyword"])
+    )
 
 
 def _oracle_matrix(
@@ -540,6 +697,7 @@ def plan(
             record_schema=True,
             prospective_digest=True,
             inventory=True,
+            host_validation=_full_host_validation(),
             run_oracle=True,
             scope="all",
             matrix=matrix,
@@ -565,6 +723,7 @@ def plan(
             record_schema=False,
             prospective_digest=False,
             inventory=False,
+            host_validation=[],
             run_oracle=False,
             scope="none",
             matrix=[],
@@ -585,6 +744,7 @@ def plan(
     classification = _classify_benchmark_paths(
         benchmark_paths, suites_by_id, integration=integration
     )
+    host_validation = _host_validation_plan(benchmark_paths, suites_by_id)
     oracle_tasks = classification.oracle_tasks
     affected_datasets = classification.affected_datasets
     reasons = classification.reasons
@@ -641,6 +801,7 @@ def plan(
         record_schema=True,
         prospective_digest=digest_relevant,
         inventory=mode in {"integration", "full"},
+        host_validation=host_validation,
         run_oracle=run_oracle,
         scope=scope,
         matrix=matrix if run_oracle else [],

--- a/.github/scripts/validate-benchmark-plan
+++ b/.github/scripts/validate-benchmark-plan
@@ -5,8 +5,9 @@ The planner emits a versioned plan bound to the triggering event and the
 base/head (or merge-group) SHA, a digest of the planner, and a digest of the
 benchmark topology.  This validator enforces the full fail-closed contract:
 every expected key is present, SHA bindings are well formed, the record/schema,
-prospective-digest, inventory, and Oracle evidence roles are mutually
-consistent, and an unselected role is never confused with a failed one.
+host-verifier, prospective-digest, inventory, and Oracle evidence roles are
+mutually consistent, and an unselected role is never confused with a failed
+one.
 """
 
 from __future__ import annotations
@@ -16,12 +17,15 @@ import re
 import sys
 from typing import Any
 
-PLAN_VERSION = "1"
+PLAN_VERSION = "2"
 EVENTS = ("pull_request", "merge_group", "push", "schedule", "workflow_dispatch")
 MODES = ("none", "changed", "integration", "full")
 SCOPES = {"none", "changed-tasks", "affected-datasets", "all"}
 DIGEST = re.compile(r"sha256:[0-9a-f]{64}\Z")
 SHA = re.compile(r"[0-9a-f]{40,64}\Z")
+HOST_NAME = re.compile(r"[A-Za-z0-9_.-]+\Z")
+HOST_SELECTOR = re.compile(r"benchmarks/validation(?:/[A-Za-z0-9_./-]+)?\Z")
+HOST_KEYWORD = re.compile(r"[A-Za-z0-9_.-]*\Z")
 MAX_MATRIX_JOBS = 256
 
 KEYS = {
@@ -36,6 +40,8 @@ KEYS = {
     "run-benchmark-record-schema",
     "run-benchmark-prospective-digest",
     "run-benchmark-inventory",
+    "run-benchmark-host-validation",
+    "benchmark-host-validation-matrix",
     "run-benchmark-oracle",
     "benchmark-oracle-scope",
     "benchmark-oracle-matrix",
@@ -125,6 +131,80 @@ def _validate_matrix(matrix: list[Any]) -> None:
         fail(f"benchmark Oracle matrix exceeds {MAX_MATRIX_JOBS} jobs")
 
 
+def _validate_host_matrix(matrix: list[Any]) -> None:
+    names: set[str] = set()
+    shard_groups: dict[tuple[str, str], tuple[int, set[int]]] = {}
+    for index, entry in enumerate(matrix):
+        if not isinstance(entry, dict) or set(entry) != {
+            "name",
+            "selector",
+            "keyword",
+            "splits",
+            "group",
+        }:
+            fail(f"benchmark host validation matrix entry {index} has an invalid shape")
+        name = entry["name"]
+        selector = entry["selector"]
+        keyword = entry["keyword"]
+        splits = entry["splits"]
+        group = entry["group"]
+        if not isinstance(name, str) or HOST_NAME.fullmatch(name) is None:
+            fail(f"benchmark host validation matrix entry {index} has an invalid name")
+        if name in names:
+            fail(f"duplicate benchmark host validation matrix name: {name}")
+        names.add(name)
+        if (
+            not isinstance(selector, str)
+            or HOST_SELECTOR.fullmatch(selector) is None
+            or ".." in selector.split("/")
+        ):
+            fail(
+                f"benchmark host validation matrix entry {index} has an invalid selector"
+            )
+        if not isinstance(keyword, str) or HOST_KEYWORD.fullmatch(keyword) is None:
+            fail(
+                f"benchmark host validation matrix entry {index} has an invalid keyword"
+            )
+        if (
+            not isinstance(splits, int)
+            or isinstance(splits, bool)
+            or not isinstance(group, int)
+            or isinstance(group, bool)
+            or (splits == 0 and group != 0)
+            or (splits > 0 and not 1 <= group <= splits)
+            or splits < 0
+            or splits > MAX_MATRIX_JOBS
+        ):
+            fail(f"benchmark host validation matrix entry {index} has invalid sharding")
+        key = (selector, keyword)
+        expected_splits, groups = shard_groups.setdefault(key, (splits, set()))
+        if expected_splits != splits:
+            fail(f"inconsistent benchmark host validation sharding: {selector}")
+        if group in groups:
+            fail(f"duplicate benchmark host validation matrix entry: {selector}")
+        groups.add(group)
+    if len(matrix) > MAX_MATRIX_JOBS:
+        fail(f"benchmark host validation matrix exceeds {MAX_MATRIX_JOBS} jobs")
+    for (selector, _keyword), (splits, groups) in shard_groups.items():
+        expected_groups = {0} if splits == 0 else set(range(1, splits + 1))
+        if groups != expected_groups:
+            fail(f"incomplete benchmark host validation sharding: {selector}")
+
+
+def _host_validation_selection(plan: dict[str, str], *, run_check: bool) -> bool:
+    selected = _bool(plan, "run-benchmark-host-validation")
+    matrix = _json_array(
+        plan["benchmark-host-validation-matrix"],
+        "benchmark host validation matrix",
+    )
+    if selected and not run_check:
+        fail("benchmark host validation requires benchmark checks")
+    if selected != bool(matrix):
+        fail("benchmark host validation flag and matrix disagree")
+    _validate_host_matrix(matrix)
+    return selected
+
+
 def main() -> None:
     plan: dict[str, str] = {}
     for raw_line in sys.stdin:
@@ -155,6 +235,7 @@ def main() -> None:
     prospective_digest = _bool(plan, "run-benchmark-prospective-digest")
     inventory = _bool(plan, "run-benchmark-inventory")
     run_oracle = _bool(plan, "run-benchmark-oracle")
+    host_validation = _host_validation_selection(plan, run_check=run_check)
 
     scope = plan["benchmark-oracle-scope"]
     if scope not in SCOPES:
@@ -204,7 +285,12 @@ def main() -> None:
             fail("disabled benchmark Oracle work must have none scope and empty matrix")
 
     if not run_check and (
-        record_schema or prospective_digest or inventory or run_oracle or reasons
+        record_schema
+        or prospective_digest
+        or inventory
+        or host_validation
+        or run_oracle
+        or reasons
     ):
         fail("a skipped benchmark plan cannot contain work or reasons")
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -36,6 +36,8 @@ jobs:
       run-benchmark-record-schema: ${{ steps.plan.outputs.run-benchmark-record-schema }}
       run-benchmark-prospective-digest: ${{ steps.plan.outputs.run-benchmark-prospective-digest }}
       run-benchmark-inventory: ${{ steps.plan.outputs.run-benchmark-inventory }}
+      run-benchmark-host-validation: ${{ steps.plan.outputs.run-benchmark-host-validation }}
+      benchmark-host-validation-matrix: ${{ steps.plan.outputs.benchmark-host-validation-matrix }}
       run-benchmark-oracle: ${{ steps.plan.outputs.run-benchmark-oracle }}
       benchmark-oracle-scope: ${{ steps.plan.outputs.benchmark-oracle-scope }}
       benchmark-oracle-matrix: ${{ steps.plan.outputs.benchmark-oracle-matrix }}
@@ -157,7 +159,7 @@ jobs:
         run: uv run --locked python tools/check_benchmark_static.py
 
   contracts:
-    name: Benchmark Contracts, Records & Digests
+    name: Benchmark Contracts, Adapters, Records & Digests
     needs: plan
     if: needs.plan.outputs.run-benchmark-record-schema == 'true'
     runs-on: ubuntu-latest
@@ -170,8 +172,44 @@ jobs:
         with:
           python-version: "3.12"
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
-      - name: Validate benchmark contracts, schemas, records, and digests
-        run: make harbor-validate
+      - name: Validate benchmark contracts, adapters, schemas, records, and digests
+        run: make harbor-contracts harbor-adapter-checks
+
+  host_validation:
+    name: Host Verifiers (${{ matrix.name }})
+    needs: plan
+    if: needs.plan.outputs.run-benchmark-host-validation == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        include: ${{ fromJSON(needs.plan.outputs.benchmark-host-validation-matrix) }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - name: Run selected host-side verifier regressions
+        env:
+          SELECTOR: ${{ matrix.selector }}
+          KEYWORD: ${{ matrix.keyword }}
+          SPLITS: ${{ matrix.splits }}
+          GROUP: ${{ matrix.group }}
+        run: |
+          set -eu
+          pytest_args=()
+          if [ -n "$KEYWORD" ]; then
+            pytest_args=(-k "$KEYWORD")
+          fi
+          if [ "$SPLITS" -gt 0 ]; then
+            pytest_args+=(--splits "$SPLITS" --group "$GROUP")
+          fi
+          make harbor-validation-tests TESTS="$SELECTOR" PYTEST_ARGS="${pytest_args[*]}"
 
   inventory:
     name: Benchmark Inventory Validation
@@ -234,7 +272,7 @@ jobs:
   validation:
     name: Benchmark Validation
     if: ${{ always() }}
-    needs: [plan, static, contracts, inventory, oracle]
+    needs: [plan, static, contracts, host_validation, inventory, oracle]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -245,9 +283,11 @@ jobs:
           RECORD_SCHEMA_FLAG: ${{ needs.plan.outputs.run-benchmark-record-schema }}
           PROSPECTIVE_DIGEST_FLAG: ${{ needs.plan.outputs.run-benchmark-prospective-digest }}
           INVENTORY_FLAG: ${{ needs.plan.outputs.run-benchmark-inventory }}
+          HOST_VALIDATION_FLAG: ${{ needs.plan.outputs.run-benchmark-host-validation }}
           ORACLE_FLAG: ${{ needs.plan.outputs.run-benchmark-oracle }}
           STATIC_RESULT: ${{ needs.static.result }}
           CONTRACTS_RESULT: ${{ needs.contracts.result }}
+          HOST_VALIDATION_RESULT: ${{ needs.host_validation.result }}
           INVENTORY_RESULT: ${{ needs.inventory.result }}
           ORACLE_RESULT: ${{ needs.oracle.result }}
         run: |
@@ -291,12 +331,14 @@ jobs:
             *) echo "invalid record-schema plan flag: $RECORD_SCHEMA_FLAG" >&2; exit 1 ;;
           esac
           check_lane "$PLAN_CHECK" "$STATIC_RESULT" "static"
+          check_lane "$HOST_VALIDATION_FLAG" "$HOST_VALIDATION_RESULT" "host-validation"
           check_lane "$INVENTORY_FLAG" "$INVENTORY_RESULT" "inventory"
           check_lane "$ORACLE_FLAG" "$ORACLE_RESULT" "oracle"
           case "$PLAN_CHECK" in
             true) ;;
             false)
               test "$CONTRACTS_RESULT" = skipped
+              test "$HOST_VALIDATION_RESULT" = skipped
               test "$INVENTORY_RESULT" = skipped
               test "$ORACLE_RESULT" = skipped
               ;;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,11 @@ owns required semantic lanes and fail-closed infrastructure coverage. Use
 `make harbor-plan BASE=origin/main`
 for benchmark contracts and Oracle scope; run it through Make because the
 planner requires the pinned Harbor runtime to compute task digests.
+The plan also selects host-side verifier regressions: task- or dataset-owned
+modules for focused changes, the changed validation file itself, and the full
+`benchmarks/validation` suite, sharded in hosted CI, for shared or unclassified
+infrastructure. To reproduce one selected host check locally, run
+`make harbor-validation-tests TESTS=<pytest-file-or-directory>`.
 Tests can be narrowed without learning another wrapper:
 
 ```sh

--- a/Makefile
+++ b/Makefile
@@ -323,7 +323,7 @@ harbor-adapter-checks: ## Check every repository-owned Harbor adapter.
 
 harbor-validation-tests: ## Run Harbor's host-side validation test suite.
 	$(UV_RUN) pytest -n $(HARBOR_VALIDATION_WORKERS) \
-		$(PYTEST_DIAGNOSTIC_ARGS) benchmarks/validation $(PYTEST_ARGS)
+		$(PYTEST_DIAGNOSTIC_ARGS) $(if $(TESTS),$(TESTS),benchmarks/validation) $(PYTEST_ARGS)
 
 harbor-validate: harbor-contracts harbor-adapter-checks harbor-validation-tests ## Run all repository-owned Harbor checks under the pinned Harbor runtime.
 

--- a/benchmarks/validation/test_benchmark_plan_validation.py
+++ b/benchmarks/validation/test_benchmark_plan_validation.py
@@ -27,7 +27,7 @@ def _run(plan: dict[str, str]) -> subprocess.CompletedProcess[str]:
 
 def _plan() -> dict[str, str]:
     return {
-        "benchmark-plan-version": "1",
+        "benchmark-plan-version": "2",
         "benchmark-plan-event": "pull_request",
         "benchmark-plan-base-sha": SHA,
         "benchmark-plan-head-sha": "1" * 40,
@@ -38,6 +38,18 @@ def _plan() -> dict[str, str]:
         "run-benchmark-record-schema": "true",
         "run-benchmark-prospective-digest": "true",
         "run-benchmark-inventory": "false",
+        "run-benchmark-host-validation": "true",
+        "benchmark-host-validation-matrix": json.dumps(
+            [
+                {
+                    "name": "task",
+                    "selector": "benchmarks/validation/test_task.py",
+                    "keyword": "",
+                    "splits": 0,
+                    "group": 0,
+                }
+            ]
+        ),
         "run-benchmark-oracle": "true",
         "benchmark-oracle-scope": "changed-tasks",
         "benchmark-oracle-matrix": json.dumps(
@@ -62,7 +74,7 @@ def test_valid_benchmark_plan_is_accepted() -> None:
 
 def test_skipped_plan_is_accepted_with_empty_topology_and_no_lanes() -> None:
     plan = {
-        "benchmark-plan-version": "1",
+        "benchmark-plan-version": "2",
         "benchmark-plan-event": "pull_request",
         "benchmark-plan-base-sha": "",
         "benchmark-plan-head-sha": "",
@@ -73,6 +85,8 @@ def test_skipped_plan_is_accepted_with_empty_topology_and_no_lanes() -> None:
         "run-benchmark-record-schema": "false",
         "run-benchmark-prospective-digest": "false",
         "run-benchmark-inventory": "false",
+        "run-benchmark-host-validation": "false",
+        "benchmark-host-validation-matrix": "[]",
         "run-benchmark-oracle": "false",
         "benchmark-oracle-scope": "none",
         "benchmark-oracle-matrix": "[]",
@@ -86,7 +100,7 @@ def test_skipped_plan_is_accepted_with_empty_topology_and_no_lanes() -> None:
 
 def test_unknown_plan_version_is_rejected() -> None:
     plan = _plan()
-    plan["benchmark-plan-version"] = "2"
+    plan["benchmark-plan-version"] = "3"
 
     result = _run(plan)
 
@@ -130,6 +144,8 @@ def test_skipped_plan_must_not_carry_a_topology_digest() -> None:
     plan["run-benchmark-record-schema"] = "false"
     plan["run-benchmark-prospective-digest"] = "false"
     plan["run-benchmark-inventory"] = "false"
+    plan["run-benchmark-host-validation"] = "false"
+    plan["benchmark-host-validation-matrix"] = "[]"
     plan["run-benchmark-oracle"] = "false"
     plan["benchmark-oracle-scope"] = "none"
     plan["benchmark-oracle-matrix"] = "[]"
@@ -179,6 +195,8 @@ def test_prospective_digest_lane_requires_checks() -> None:
     plan = _plan()
     plan["run-benchmark-check"] = "false"
     plan["run-benchmark-record-schema"] = "false"
+    plan["run-benchmark-host-validation"] = "false"
+    plan["benchmark-host-validation-matrix"] = "[]"
     plan["run-benchmark-oracle"] = "false"
     plan["benchmark-oracle-scope"] = "none"
     plan["benchmark-oracle-matrix"] = "[]"
@@ -234,6 +252,40 @@ def test_disabled_oracle_must_have_none_scope_and_empty_matrix() -> None:
 
     assert result.returncode != 0
     assert "disabled" in result.stderr.lower()
+
+
+def test_host_validation_flag_requires_a_nonempty_matrix() -> None:
+    plan = _plan()
+    plan["benchmark-host-validation-matrix"] = "[]"
+
+    result = _run(plan)
+
+    assert result.returncode != 0
+    assert "host validation flag and matrix disagree" in result.stderr
+
+
+def test_host_validation_selector_cannot_escape_validation_tree() -> None:
+    plan = _plan()
+    matrix = json.loads(plan["benchmark-host-validation-matrix"])
+    matrix[0]["selector"] = "benchmarks/validation/../datasets"
+    plan["benchmark-host-validation-matrix"] = json.dumps(matrix)
+
+    result = _run(plan)
+
+    assert result.returncode != 0
+    assert "invalid selector" in result.stderr
+
+
+def test_host_validation_requires_every_declared_shard() -> None:
+    plan = _plan()
+    matrix = json.loads(plan["benchmark-host-validation-matrix"])
+    matrix[0].update({"splits": 2, "group": 1})
+    plan["benchmark-host-validation-matrix"] = json.dumps(matrix)
+
+    result = _run(plan)
+
+    assert result.returncode != 0
+    assert "incomplete" in result.stderr
 
 
 def test_duplicate_dataset_task_pair_is_rejected() -> None:

--- a/benchmarks/validation/test_benchmark_planner.py
+++ b/benchmarks/validation/test_benchmark_planner.py
@@ -45,6 +45,10 @@ def _matrix_tasks(result: dict[str, str]) -> set[str]:
     return {str(task) for item in _matrix(result) for task in item["tasks"]}
 
 
+def _host_matrix(result: dict[str, str]) -> list[dict[str, object]]:
+    return json.loads(result["benchmark-host-validation-matrix"])
+
+
 def _assert_plan_valid(result: dict[str, str]) -> None:
     payload = "\n".join(f"{key}={value}" for key, value in result.items()) + "\n"
     proc = subprocess.run(
@@ -64,7 +68,7 @@ def _lane(result: dict[str, str], key: str) -> bool:
 def test_product_only_changes_skip_benchmark_work() -> None:
     result = planner.plan(["src/jacobian/math.py"], event="pull_request")
 
-    assert result["benchmark-plan-version"] == "1"
+    assert result["benchmark-plan-version"] == "2"
     assert result["benchmark-plan-event"] == "pull_request"
     assert result["benchmark-plan-mode"] == "none"
     assert result["benchmark-topology-digest"] == ""
@@ -91,7 +95,7 @@ def test_plan_is_versioned_and_bound_to_event_base_head_sha() -> None:
         head=head,
     )
 
-    assert result["benchmark-plan-version"] == "1"
+    assert result["benchmark-plan-version"] == "2"
     assert result["benchmark-plan-event"] == "pull_request"
     assert result["benchmark-plan-base-sha"] == base
     assert result["benchmark-plan-head-sha"] == head
@@ -248,6 +252,75 @@ def test_executable_task_change_selects_exact_task_without_version_bump() -> Non
     assert len(matrix) == 1
     assert matrix[0]["dataset"] == "agent-workflow-v1"
     assert matrix[0]["tasks"] == ["parameterized-sharp-bound-audit"]
+    host_matrix = _host_matrix(result)
+    assert result["run-benchmark-host-validation"] == "true"
+    assert {(entry["selector"], entry["keyword"]) for entry in host_matrix} == {
+        (
+            "benchmarks/validation/agent_workflow_v1/"
+            "test_parameterized_sharp_bound_audit.py",
+            "",
+        ),
+        (
+            "benchmarks/validation/agent_workflow_v1/"
+            "test_generic_verifier_contracts.py",
+            "parameterized-sharp-bound-audit",
+        ),
+    }
+    _assert_plan_valid(result)
+
+
+def test_dataset_owned_task_selects_shared_host_regression() -> None:
+    result = planner.plan(
+        [
+            "benchmarks/datasets/symbolic-coordination-v1/"
+            "symbolic-coordination-valid-inverse-01/tests/verifier.py"
+        ],
+        event="pull_request",
+    )
+
+    assert _host_matrix(result) == [
+        {
+            "name": "symbolic-coordination-v1-1",
+            "selector": (
+                "benchmarks/validation/symbolic_coordination_v1/test_pilot_contract.py"
+            ),
+            "keyword": "",
+            "splits": 0,
+            "group": 0,
+        }
+    ]
+    _assert_plan_valid(result)
+
+
+def test_changed_validation_test_selects_itself() -> None:
+    path = "benchmarks/validation/test_benchmark_timings.py"
+    result = planner.plan([path], event="pull_request")
+
+    assert _host_matrix(result) == [
+        {
+            "name": "test_benchmark_timings",
+            "selector": path,
+            "keyword": "",
+            "splits": 0,
+            "group": 0,
+        }
+    ]
+    _assert_plan_valid(result)
+
+
+def test_shared_benchmark_support_falls_back_to_full_host_validation() -> None:
+    result = planner.plan(["benchmarks/tooling/harbor_suite.py"], event="pull_request")
+
+    assert _host_matrix(result) == [
+        {
+            "name": f"full-{group}-of-4",
+            "selector": "benchmarks/validation",
+            "keyword": "",
+            "splits": 4,
+            "group": group,
+        }
+        for group in range(1, 5)
+    ]
     _assert_plan_valid(result)
 
 
@@ -518,7 +591,7 @@ def test_unknown_benchmark_path_fails_closed_to_full_portfolio() -> None:
 def test_force_full_includes_each_dataset_task_pair() -> None:
     result = planner.plan([], event="workflow_dispatch", force_full=True)
 
-    assert result["benchmark-plan-version"] == "1"
+    assert result["benchmark-plan-version"] == "2"
     assert result["benchmark-oracle-scope"] == "all"
     assert result["benchmark-plan-mode"] == "full"
     assert result["run-benchmark-check"] == "true"

--- a/tests/unit/tooling/test_ci_execution_policy.py
+++ b/tests/unit/tooling/test_ci_execution_policy.py
@@ -140,8 +140,12 @@ def test_oracle_artifact_preserves_augmented_task_digest_manifest() -> None:
 def test_benchmark_contracts_run_once_for_record_and_digest_evidence() -> None:
     workflow = (ROOT / ".github/workflows/benchmarks.yml").read_text(encoding="utf-8")
 
-    assert workflow.count("run: make harbor-validate") == 1
+    assert "run: make harbor-validate" not in workflow
+    assert workflow.count("run: make harbor-contracts harbor-adapter-checks") == 1
     assert "  contracts:" in workflow
+    assert "  host_validation:" in workflow
+    assert "make harbor-validation-tests TESTS=" in workflow
+    assert 'pytest_args+=(--splits "$SPLITS" --group "$GROUP")' in workflow
     assert "  prospective-digest:" not in workflow
     assert "python .github/scripts/emit-plan-receipt" in workflow
     assert "benchmark-plan-receipt" in workflow


### PR DESCRIPTION
Closes #513.

## Motivation

The benchmark contracts job currently runs `make harbor-validate`, so every benchmark change pays for all host-side verifier regressions. A focused task change therefore collects roughly 2,900 tests inside a job whose name only mentions contracts, records, and digests. Recent task PRs spent about 6–11 minutes in that combined job.

## What changed

- Split host-verifier regressions from the contract and adapter job.
- Add a versioned, validated host-validation matrix to the benchmark plan.
- Select dedicated task regressions plus task-filtered shared contract cases for `agent-workflow-v1` changes.
- Select dataset-owned regression modules for symbolic coordination, research diagnostics, and provider feasibility; directly changed validation tests select themselves.
- Preserve a fail-closed full-suite fallback for shared, unclassified, scheduled, and forced-full changes, but distribute it across four complete pytest-split groups.
- Let `make harbor-validation-tests TESTS=...` reproduce a focused selector locally.

The validator constrains selectors to `benchmarks/validation`, rejects unsafe names and keywords, and requires every declared shard group exactly once. No Oracle, assurance, verifier, or mathematical-result semantics change.

## Evidence

A representative `agent-workflow-v1` task now selects:

- 5 dedicated regressions: 2.49 seconds locally;
- 13 task-filtered shared contract cases: 4.05 seconds locally.

The full fallback collects 2,903 tests exactly once across four groups of 726, 726, 726, and 725 tests. Hosted CI can execute those groups in parallel.

Validation on the final rebased tree:

- 92 benchmark planner, plan-validator, workflow-policy, and process-boundary tests passed.
- 605 unit tests passed.
- 249 process-boundary tests passed.
- `make check-static` passed (Ruff, formatting, dependency checks, dead-code checks, mypy, architecture checks, and package build).
- `make docs-linkcheck` passed.
- actionlint passed.
- Representative focused verifier runs passed (5 dedicated and 13 shared-contract cases).

## Compatibility

The benchmark plan contract advances from version 1 to version 2 because it adds the host-validation flag and matrix. The default local `make harbor-validation-tests` behavior remains the complete host suite when `TESTS` is omitted.