### PR TITLE
docs(agents): make Jacobian math affordances visible to Codex

### DIFF
--- a/.agents/skills/jacobian-math/SKILL.md
+++ b/.agents/skills/jacobian-math/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: jacobian-math
+description: Use Jacobian for mathematical work involving exact computation, symbolic transformation, structural analysis, examples or counterexamples, bounded search, formal-environment inspection, or independent verification. Trigger even when the user does not name Jacobian and ordinary shell code could attempt the calculation.
+---
+
+# Jacobian Math
+
+<!-- Managed by Jacobian's Codex integration. -->
+
+Use `math.find` with a plain-language description when a useful installed
+operation is not already known; a capability ID is not required. Inspect the
+`CONTRACT` view before `math.run` when the typed input is unfamiliar.
+
+Keep representation, decomposition, composition, iteration, verification
+timing, and stopping decisions agent-owned. Treat timeouts, errors, incomplete
+searches, and missing witnesses as non-conclusions.
+
+When independent checking is requested, calculations or programs authored by
+the same model are not independent checker evidence. Search for an installed
+`VERIFY` capability. Claim `VERIFIED` only when the result has assurance level
+`VERIFIED` and a local verification record.

--- a/.agents/skills/jacobian-math/agents/openai.yaml
+++ b/.agents/skills/jacobian-math/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Jacobian Math"
+  short_description: "Discover and run exact mathematical operations"
+  default_prompt: "Use Jacobian when its installed mathematical operations are relevant."

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ endif
 # in pyproject.toml: direct pytest invocations must not silently inherit a
 # signal-based deadline that cannot interrupt a native solver.  Process and
 # provider lanes run risky work in killable children and set their own deadline.
-.PHONY: help help-all uv-version-check setup setup-agent container-image eval-image eval-image-pull eval-image-bind hooks fix lint complexity-check lint-full security-audit typecheck test-architecture architecture ci-plan test-plan test-changed check-changed test-unit test-component test-domain test-composition test-storage test-process test-mcp test-provider test-lean test-e2e test-affected test-all-ci test-compatibility test-stress test-ordering duplicate-code npm-test todo-check coverage build check precommit check-static harbor-plan harbor-sync harbor-contracts harbor-execution-check harbor-adapter-checks harbor-validation-tests harbor-validate harbor-check harbor-check-task benchmark-inventory benchmark-snapshot benchmark-snapshot-validate benchmark-publish harbor-oracle harbor-oracle-task harbor-oracle-run harbor-oracle-all harbor-adapter-check heldout-validate heldout-render heldout-smoke agent-eval agent-eval-validate agent-eval-compare provider-eval clean docs-command-check docs-linkcheck deploy-check
+.PHONY: help help-all uv-version-check setup setup-agent container-image eval-image eval-image-pull eval-image-bind hooks fix lint complexity-check lint-full security-audit typecheck test-architecture architecture ci-plan test-plan test-changed check-changed test-unit test-component test-domain test-composition test-storage test-process test-mcp test-provider test-lean test-e2e test-affected test-all-ci test-compatibility test-stress test-ordering duplicate-code npm-test todo-check coverage build check precommit check-static harbor-plan harbor-sync harbor-contracts harbor-execution-check harbor-adapter-checks harbor-validation-tests harbor-validate harbor-check harbor-check-task benchmark-inventory benchmark-snapshot benchmark-snapshot-validate benchmark-publish harbor-oracle harbor-oracle-task harbor-oracle-run harbor-oracle-all harbor-adapter-check heldout-validate heldout-render heldout-smoke agent-eval agent-eval-validate agent-eval-compare codex-visibility provider-eval clean docs-command-check docs-linkcheck deploy-check
 
 help: ## Show available developer commands.
 	@awk -v public="$(PUBLIC_COMMANDS)" 'BEGIN {FS = ":.*## "; n = split(public, names, " "); for (i = 1; i <= n; i++) wanted[names[i]] = 1; printf "Jacobian common developer commands:\n\n"} /^[a-zA-Z_-]+:.*## / && ($$1 in wanted) {printf "  %-18s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -526,6 +526,27 @@ agent-eval-compare: ## Compare normalized observations (CONTROL=..., TREATMENT=.
 	@test -n "$(CONTROL)" -a -n "$(TREATMENT)" -a -n "$(OUTPUT)" || { echo "CONTROL, TREATMENT, and OUTPUT are required" >&2; exit 2; }
 	$(UV_RUN) python -m benchmarks.tooling.observation_results compare \
 		--control "$(CONTROL)" --treatment "$(TREATMENT)" --output "$(OUTPUT)"
+
+VISIBILITY_CASES ?= benchmarks/config/codex-visibility-v1.json
+VISIBILITY_REPETITIONS ?= 1
+VISIBILITY_REASONING_EFFORT ?= high
+
+codex-visibility: ## Measure Codex adoption of Jacobian (VISIBILITY_EXECUTE=1, VISIBILITY_MCP_URL=..., VISIBILITY_MODEL=..., VISIBILITY_OUTPUT=...).
+	@set -e; \
+	if [ "$(VISIBILITY_EXECUTE)" != "1" ]; then \
+		echo "Model execution is opt-in. Set VISIBILITY_EXECUTE=1 after reviewing $(VISIBILITY_CASES)."; \
+		exit 0; \
+	fi; \
+	test -n "$(VISIBILITY_MCP_URL)" -a -n "$(VISIBILITY_MODEL)" -a -n "$(VISIBILITY_OUTPUT)" || { \
+		echo "VISIBILITY_MCP_URL, VISIBILITY_MODEL, and VISIBILITY_OUTPUT are required" >&2; \
+		exit 2; \
+	}; \
+	$(UV_RUN) python -m benchmarks.tooling.codex_visibility \
+		--execute --cases "$(VISIBILITY_CASES)" --mcp-url "$(VISIBILITY_MCP_URL)" \
+		--model "$(VISIBILITY_MODEL)" --reasoning-effort "$(VISIBILITY_REASONING_EFFORT)" \
+		--repetitions "$(VISIBILITY_REPETITIONS)" --output "$(VISIBILITY_OUTPUT)" \
+		$(foreach case,$(VISIBILITY_CASES_SELECTED),--case "$(case)") \
+		$(if $(VISIBILITY_SKILL),--skill "$(VISIBILITY_SKILL)",)
 
 provider-eval: ## Run pinned provider feasibility jobs (PROVIDER=cddlib|cgal|gudhi|lean-repl|nauty|regina).
 	@test -n "$(PROVIDER)" || { echo "PROVIDER is required" >&2; exit 2; }

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -76,7 +76,14 @@ make harbor-check
 make harbor-oracle DATASET=mathematical-benchmarks-v1 FULL=1
 make harbor-oracle-all
 make provider-eval PROVIDER=cgal
+make codex-visibility
 ```
+
+`codex-visibility` is a separate opt-in agent-adoption diagnostic, not a Harbor
+mathematical correctness task. It snapshots the advertised MCP surface and
+measures whether Codex discovers, inspects, invokes, completes, or independently
+verifies relevant operations under explicit, affordance, and latent cues. See
+[Run the Codex visibility evaluation](../docs/how-to/run-codex-visibility-evaluation.md).
 
 `symbolic-coordination-v1` keeps its deterministic 26-case pilot separate
 from the fixed `mathematical-benchmarks-v1` snapshots. Its task bundles are solvable

--- a/benchmarks/config/codex-visibility-v1.json
+++ b/benchmarks/config/codex-visibility-v1.json
@@ -1,0 +1,43 @@
+{
+  "schema_version": "1",
+  "suite_id": "codex-jacobian-visibility-v1",
+  "cases": [
+    {
+      "case_id": "explicit-determinant-canary",
+      "cue_level": "EXPLICIT",
+      "prompt": "Use available Jacobian mathematical tools to compute the exact determinant of [[31, -7, 12, 5], [4, 19, -3, 8], [11, 6, 23, -9], [-5, 14, 2, 17]]. Return the determinant and the capability ID used.",
+      "expected_capability_ids": [
+        "matrix.determinant.compute"
+      ],
+      "require_verified": false
+    },
+    {
+      "case_id": "affordance-determinant",
+      "cue_level": "AFFORDANCE",
+      "prompt": "Compute the exact determinant of [[31, -7, 12, 5], [4, 19, -3, 8], [11, 6, 23, -9], [-5, 14, 2, 17]]. Use any available specialized mathematical tool when it provides a relevant exact operation. Return only the determinant and a one-sentence method summary.",
+      "expected_capability_ids": [
+        "matrix.determinant.compute"
+      ],
+      "require_verified": false
+    },
+    {
+      "case_id": "latent-determinant",
+      "cue_level": "LATENT",
+      "prompt": "Compute the exact determinant of [[31, -7, 12, 5], [4, 19, -3, 8], [11, 6, 23, -9], [-5, 14, 2, 17]]. Return only the determinant and a one-sentence method summary.",
+      "expected_capability_ids": [
+        "matrix.determinant.compute"
+      ],
+      "require_verified": false
+    },
+    {
+      "case_id": "latent-independent-verification",
+      "cue_level": "LATENT",
+      "prompt": "Compute and independently verify the exact determinant of [[31, -7, 12, 5], [4, 19, -3, 8], [11, 6, 23, -9], [-5, 14, 2, 17]]. State the determinant and the assurance level supported by the evidence.",
+      "expected_capability_ids": [
+        "matrix.determinant.compute",
+        "matrix.determinant.verify"
+      ],
+      "require_verified": true
+    }
+  ]
+}

--- a/benchmarks/tooling/codex_visibility.py
+++ b/benchmarks/tooling/codex_visibility.py
@@ -1,0 +1,525 @@
+"""Operator-run diagnostic for Codex visibility of Jacobian's MCP affordances."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+import tempfile
+from collections.abc import Mapping
+from enum import StrEnum
+from pathlib import Path
+from typing import Any, Literal
+from urllib.parse import urlsplit
+
+import httpx2
+from mcp import Client
+from mcp.client.streamable_http import streamable_http_client
+from mcp_types import TextResourceContents
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from benchmarks.tooling.command_runner import (
+    ToolCommandStatus,
+    git_head_sha,
+    operator_environment,
+    run_operator_command,
+)
+from jacobian.canonical import canonicalize_json
+from jacobian.eval.telemetry import parse_agent_transcript
+
+_ROOT = Path(__file__).resolve().parents[2]
+_DEFAULT_CASES = _ROOT / "benchmarks/config/codex-visibility-v1.json"
+_REQUIRED_TOOLS = frozenset({"math.find", "math.run"})
+_LOCAL_VERIFICATION_URI_PREFIX = "artifact://"
+_CODEX_ENVIRONMENT = (
+    "HOME",
+    "PATH",
+    "CODEX_HOME",
+    "JACOBIAN_MCP_BEARER_TOKEN",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+    "NO_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "all_proxy",
+    "no_proxy",
+)
+
+
+class CueLevel(StrEnum):
+    """How directly a case exposes the existence of a specialized tool."""
+
+    EXPLICIT = "EXPLICIT"
+    AFFORDANCE = "AFFORDANCE"
+    LATENT = "LATENT"
+
+
+class VisibilityCase(BaseModel):
+    """One agent-visible prompt plus hidden trajectory expectations."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    case_id: str = Field(pattern=r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+    cue_level: CueLevel
+    prompt: str = Field(min_length=1)
+    expected_capability_ids: tuple[str, ...] = Field(min_length=1)
+    require_verified: bool = False
+
+    @model_validator(mode="after")
+    def _unique_capabilities(self) -> VisibilityCase:
+        if len(set(self.expected_capability_ids)) != len(self.expected_capability_ids):
+            raise ValueError("expected_capability_ids must be unique")
+        return self
+
+
+class VisibilitySuite(BaseModel):
+    """Versioned visibility prompt suite."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal["1"]
+    suite_id: str = Field(pattern=r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+    cases: tuple[VisibilityCase, ...] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def _unique_cases(self) -> VisibilitySuite:
+        case_ids = [case.case_id for case in self.cases]
+        if len(set(case_ids)) != len(case_ids):
+            raise ValueError("case_id values must be unique")
+        return self
+
+
+def load_suite(path: Path) -> VisibilitySuite:
+    """Load and fully validate a visibility suite."""
+
+    return VisibilitySuite.model_validate_json(path.read_text(encoding="utf-8"))
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return f"sha256:{hashlib.sha256(value).hexdigest()}"
+
+
+def _json_digest(value: object) -> str:
+    return _sha256_bytes(canonicalize_json(value))
+
+
+def _is_verified_invocation(invocation: object) -> bool:
+    if not isinstance(invocation, Mapping):
+        return False
+    assurance = invocation.get("assurance")
+    if not isinstance(assurance, Mapping) or assurance.get("level") != "VERIFIED":
+        return False
+    uri = assurance.get("verification_record_uri")
+    return isinstance(uri, str) and uri.startswith(_LOCAL_VERIFICATION_URI_PREFIX)
+
+
+def classify_visibility(
+    case: VisibilityCase,
+    telemetry: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Classify only observable adoption stages; do not grade answer prose."""
+
+    expected = set(case.expected_capability_ids)
+    described = {
+        capability_id
+        for description in telemetry.get("capability_descriptions", [])
+        if isinstance(description, Mapping)
+        for capability_id in (
+            [description.get("capability_id")]
+            if description.get("capability_id") is not None
+            else description.get("match_ids", [])
+        )
+        if isinstance(capability_id, str)
+    }
+    attempted = {
+        value
+        for value in telemetry.get("capability_attempt_ids", [])
+        if isinstance(value, str)
+    }
+    completed = {
+        value for value in telemetry.get("capability_ids", []) if isinstance(value, str)
+    }
+    verified = any(
+        isinstance(invocation, Mapping)
+        and isinstance(invocation.get("capability_id"), str)
+        and invocation.get("capability_id") in expected
+        and _is_verified_invocation(invocation)
+        for invocation in telemetry.get("capability_invocations", [])
+    )
+    observed = {
+        "discovered": bool(telemetry.get("capability_describe_index_calls", 0)),
+        "inspected": bool(telemetry.get("capability_describe_exact_calls", 0)),
+        "invoked": bool(attempted),
+        "completed": bool(completed),
+        "verified": verified,
+    }
+    expected_observed = {
+        "described": sorted(expected & described),
+        "attempted": sorted(expected & attempted),
+        "completed": sorted(expected & completed),
+        "missing_completed": sorted(expected - completed),
+    }
+    contract_satisfied = not expected_observed["missing_completed"] and (
+        verified or not case.require_verified
+    )
+    return {
+        "observed": observed,
+        "expected_capabilities": expected_observed,
+        "contract_satisfied": contract_satisfied,
+        "tool_error_count": telemetry.get("tool_error_count", 0),
+        "parameter_error_count": telemetry.get("parameter_error_count", 0),
+        "shell_call_count": len(telemetry.get("shell_calls", [])),
+        "usage": telemetry.get("usage"),
+        "mcp_wire_bytes": telemetry.get("mcp_wire_bytes", 0),
+        "mcp_model_visible_bytes": telemetry.get("mcp_model_visible_bytes", 0),
+        "mcp_logical_payload_bytes": telemetry.get("mcp_logical_payload_bytes", 0),
+    }
+
+
+async def inspect_surface(url: str, timeout_seconds: float) -> dict[str, Any]:
+    """Snapshot the exact MCP surface used by a visibility run."""
+
+    token = os.environ.get("JACOBIAN_MCP_BEARER_TOKEN")
+    headers = {"Authorization": f"Bearer {token}"} if token else None
+    async with (
+        httpx2.AsyncClient(
+            headers=headers,
+            trust_env=False,
+            timeout=timeout_seconds,
+        ) as http,
+        Client(
+            streamable_http_client(url, http_client=http),
+            raise_exceptions=True,
+        ) as client,
+    ):
+        server_info = client.server_info
+        if server_info is None:
+            raise RuntimeError("MCP server omitted implementation metadata")
+        listed = await client.list_tools()
+        tool_records = [
+            tool.model_dump(mode="json", by_alias=True, exclude_none=True)
+            for tool in listed.tools
+        ]
+        tool_names = {record["name"] for record in tool_records}
+        missing = sorted(_REQUIRED_TOOLS - tool_names)
+        if missing:
+            raise RuntimeError(f"MCP surface is missing required tools: {missing}")
+        catalog_result = await client.read_resource("capability://catalog")
+        catalog_content = catalog_result.contents[0]
+        if not isinstance(catalog_content, TextResourceContents):
+            raise RuntimeError("capability catalog is not text")
+        catalog = json.loads(catalog_content.text)
+        catalog_digest = _sha256_bytes(
+            canonicalize_json(
+                {
+                    "catalog_version": catalog["catalog_version"],
+                    "capabilities": catalog["capabilities"],
+                }
+            )
+        )
+        snapshot = {
+            "server": server_info.model_dump(
+                mode="json", by_alias=True, exclude_none=True
+            ),
+            "instructions": client.instructions,
+            "tools": sorted(tool_records, key=lambda item: item["name"]),
+            "catalog": {
+                "catalog_version": catalog["catalog_version"],
+                "catalog_digest": catalog_digest,
+                "policy_profile": catalog["policy_profile"],
+                "policy_digest": catalog["policy_digest"],
+                "capability_count": len(catalog["capabilities"]),
+                "content_sha256": _sha256_bytes(catalog_content.text.encode("utf-8")),
+            },
+        }
+    return {**snapshot, "surface_digest": _json_digest(snapshot)}
+
+
+def _copy_skill(skill: Path, workspace: Path) -> str | None:
+    if not skill.exists():
+        raise ValueError(f"skill directory does not exist: {skill}")
+    entries = sorted(skill.rglob("*"))
+    if any(path.is_symlink() for path in entries):
+        raise ValueError(f"skill directory contains a symbolic link: {skill}")
+    files = [path for path in entries if path.is_file()]
+    if not files or not (skill / "SKILL.md").is_file():
+        raise ValueError(f"skill directory has no SKILL.md: {skill}")
+    target = workspace / ".agents/skills" / skill.name
+    records: list[dict[str, str]] = []
+    for source in files:
+        relative = source.relative_to(skill)
+        destination = target / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        content = source.read_bytes()
+        destination.write_bytes(content)
+        records.append({"path": relative.as_posix(), "sha256": _sha256_bytes(content)})
+    return _json_digest(records)
+
+
+def _codex_arguments(
+    *,
+    workspace: Path,
+    model: str,
+    reasoning_effort: str,
+    mcp_url: str,
+    prompt: str,
+) -> tuple[str, ...]:
+    arguments = [
+        "-a",
+        "never",
+        "exec",
+        "--ephemeral",
+        "--skip-git-repo-check",
+        "--ignore-user-config",
+        "-C",
+        str(workspace),
+        "-s",
+        "read-only",
+        "--json",
+        "-m",
+        model,
+        "-c",
+        f"model_reasoning_effort={json.dumps(reasoning_effort)}",
+        "-c",
+        f"mcp_servers.jacobian.url={json.dumps(mcp_url)}",
+    ]
+    if os.environ.get("JACOBIAN_MCP_BEARER_TOKEN"):
+        arguments.extend(
+            (
+                "-c",
+                'mcp_servers.jacobian.bearer_token_env_var="JACOBIAN_MCP_BEARER_TOKEN"',
+            )
+        )
+    return (*arguments, prompt)
+
+
+def _command_version(workspace: Path) -> str:
+    result = run_operator_command(
+        "codex",
+        ("--version",),
+        cwd=workspace,
+        timeout_seconds=30,
+        environment=operator_environment(include=_CODEX_ENVIRONMENT),
+    )
+    if result.status is not ToolCommandStatus.EXITED or result.exit_code != 0:
+        raise RuntimeError("codex --version failed")
+    return result.stdout.decode("utf-8", errors="replace").strip()
+
+
+def _run_case(
+    *,
+    case: VisibilityCase,
+    repetition: int,
+    workspace: Path,
+    output: Path,
+    model: str,
+    reasoning_effort: str,
+    mcp_url: str,
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    stem = f"{case.case_id}-r{repetition:02d}"
+    transcript_path = output / f"{stem}.jsonl"
+    stderr_path = output / f"{stem}.stderr"
+    environment = operator_environment(include=_CODEX_ENVIRONMENT)
+    result = run_operator_command(
+        "codex",
+        _codex_arguments(
+            workspace=workspace,
+            model=model,
+            reasoning_effort=reasoning_effort,
+            mcp_url=mcp_url,
+            prompt=case.prompt,
+        ),
+        cwd=workspace,
+        timeout_seconds=timeout_seconds,
+        stdout_limit_bytes=16 * 1024 * 1024,
+        stderr_limit_bytes=2 * 1024 * 1024,
+        environment=environment,
+    )
+    transcript_path.write_bytes(result.stdout)
+    stderr_path.write_bytes(result.stderr)
+    telemetry = parse_agent_transcript(transcript_path)
+    classification = classify_visibility(case, telemetry)
+    command_completed = (
+        result.status is ToolCommandStatus.EXITED and result.exit_code == 0
+    )
+    return {
+        "case_id": case.case_id,
+        "cue_level": case.cue_level,
+        "repetition": repetition,
+        "command": {
+            "status": result.status,
+            "exit_code": result.exit_code,
+            "diagnostic": result.diagnostic,
+            "stdout_exceeded": result.stdout_exceeded,
+            "stderr_exceeded": result.stderr_exceeded,
+        },
+        "classification": {
+            **classification,
+            "contract_satisfied": (
+                command_completed and classification["contract_satisfied"]
+            ),
+        },
+        "artifacts": {
+            "transcript": transcript_path.name,
+            "transcript_sha256": _sha256_bytes(result.stdout),
+            "stderr": stderr_path.name,
+            "stderr_sha256": _sha256_bytes(result.stderr),
+        },
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Measure whether Codex discovers and invokes Jacobian without grading "
+            "mathematical answer prose. Model execution is opt-in."
+        )
+    )
+    parser.add_argument("--cases", type=Path, default=_DEFAULT_CASES)
+    parser.add_argument("--mcp-url", required=True)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--reasoning-effort", default="high")
+    parser.add_argument("--repetitions", type=int, default=1)
+    parser.add_argument(
+        "--case",
+        action="append",
+        default=[],
+        help="case ID to run; repeatable, defaults to the complete suite",
+    )
+    parser.add_argument("--timeout-seconds", type=float, default=300)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument(
+        "--skill",
+        type=Path,
+        help="optional Codex skill copied into the isolated evaluation workspace",
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="confirm that paid/external Codex model calls may run",
+    )
+    return parser
+
+
+def _validate_mcp_url(value: str) -> None:
+    parsed = urlsplit(value)
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise SystemExit(
+            "--mcp-url must be an HTTP(S) URL without credentials, query, or fragment"
+        )
+
+
+def main() -> None:
+    args = _parser().parse_args()
+    if not args.execute:
+        raise SystemExit("refusing model execution without --execute")
+    if not 1 <= args.repetitions <= 20:
+        raise SystemExit("--repetitions must be between 1 and 20")
+    if args.timeout_seconds <= 0:
+        raise SystemExit("--timeout-seconds must be positive")
+    _validate_mcp_url(args.mcp_url)
+    suite = load_suite(args.cases.resolve(strict=True))
+    available_case_ids = {case.case_id for case in suite.cases}
+    unknown_case_ids = sorted(set(args.case) - available_case_ids)
+    if unknown_case_ids:
+        raise SystemExit(f"unknown case IDs: {unknown_case_ids}")
+    selected_cases = tuple(
+        case for case in suite.cases if not args.case or case.case_id in args.case
+    )
+    output = args.output.resolve()
+    if output.exists():
+        raise SystemExit(f"output directory already exists: {output}")
+    surface = asyncio.run(inspect_surface(args.mcp_url, args.timeout_seconds))
+    output.mkdir(parents=True)
+    with tempfile.TemporaryDirectory(prefix="jacobian-codex-visibility-") as raw:
+        workspace = Path(raw)
+        skill_digest = (
+            _copy_skill(args.skill.resolve(strict=True), workspace)
+            if args.skill is not None
+            else None
+        )
+        codex_version = _command_version(workspace)
+        runs = [
+            _run_case(
+                case=case,
+                repetition=repetition,
+                workspace=workspace,
+                output=output,
+                model=args.model,
+                reasoning_effort=args.reasoning_effort,
+                mcp_url=args.mcp_url,
+                timeout_seconds=args.timeout_seconds,
+            )
+            for case in selected_cases
+            for repetition in range(1, args.repetitions + 1)
+        ]
+    suite_payload = suite.model_dump(mode="json")
+    command_failure_count = sum(
+        run["command"]["status"] != ToolCommandStatus.EXITED
+        or run["command"]["exit_code"] != 0
+        for run in runs
+    )
+    report = {
+        "schema_version": "1",
+        "suite": {
+            "suite_id": suite.suite_id,
+            "digest": _json_digest(suite_payload),
+            "case_count": len(suite.cases),
+            "selected_case_ids": [case.case_id for case in selected_cases],
+        },
+        "condition": {
+            "mcp_url": args.mcp_url,
+            "surface": surface,
+            "skill_digest": skill_digest,
+            "evaluator": {
+                "runner_sha256": _sha256_bytes(Path(__file__).read_bytes()),
+                "telemetry_parser_sha256": _sha256_bytes(
+                    (_ROOT / "src/jacobian/eval/telemetry.py").read_bytes()
+                ),
+            },
+            "codex_version": codex_version,
+            "model": args.model,
+            "reasoning_effort": args.reasoning_effort,
+            "repetitions": args.repetitions,
+            "repository_revision": git_head_sha(_ROOT),
+        },
+        "runs": runs,
+        "summary": {
+            "run_count": len(runs),
+            "command_failure_count": command_failure_count,
+            "contract_satisfied_count": sum(
+                run["classification"]["contract_satisfied"] for run in runs
+            ),
+            "discovered_count": sum(
+                run["classification"]["observed"]["discovered"] for run in runs
+            ),
+            "invoked_count": sum(
+                run["classification"]["observed"]["invoked"] for run in runs
+            ),
+            "verified_count": sum(
+                run["classification"]["observed"]["verified"] for run in runs
+            ),
+        },
+    }
+    (output / "report.json").write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(report["summary"], sort_keys=True))
+    if command_failure_count:
+        raise SystemExit("one or more Codex commands failed; inspect report.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/how-to/run-codex-visibility-evaluation.md
+++ b/docs/how-to/run-codex-visibility-evaluation.md
@@ -1,0 +1,45 @@
+# Run the Codex visibility evaluation
+
+Use this operator-run diagnostic to measure whether Codex notices Jacobian's MCP
+affordances before a capability ID or Jacobian-specific workflow is supplied. It
+records adoption and transport cost; it does not grade mathematical answer prose
+or replace the Harbor correctness evaluations.
+
+Start with a deployed or local Streamable HTTP endpoint, then run a control:
+
+```sh
+make codex-visibility VISIBILITY_EXECUTE=1 \
+  VISIBILITY_MCP_URL=http://127.0.0.1:8000/mcp \
+  VISIBILITY_MODEL=gpt-5.6-sol \
+  VISIBILITY_OUTPUT=benchmarks/results/visibility-control
+```
+
+Run the treatment with the repository's thin Codex skill:
+
+```sh
+make codex-visibility VISIBILITY_EXECUTE=1 \
+  VISIBILITY_MCP_URL=http://127.0.0.1:8000/mcp \
+  VISIBILITY_MODEL=gpt-5.6-sol \
+  VISIBILITY_SKILL=.agents/skills/jacobian-math \
+  VISIBILITY_OUTPUT=benchmarks/results/visibility-skill
+```
+
+The runner refuses to overwrite an existing output directory. Each output binds
+the prompt-suite digest, Git revision, Codex version, model, reasoning effort,
+skill digest, evaluator and telemetry-parser digests, MCP server metadata, tool
+schemas and descriptions, and catalog digest. Raw JSONL and stderr are retained
+with SHA-256 digests.
+
+The v1 suite separates an explicit integration canary from affordance and latent
+cases. Per-run observations report discovery, exact contract inspection,
+invocation, completion, and independently bound `VERIFIED` evidence. Shell calls,
+tool errors, tokens, MCP wire bytes, model-visible bytes, and logical payload bytes
+are independent diagnostics rather than proxies for mathematical correctness.
+The cumulative Codex input-token count may grow much faster than MCP payload
+bytes because each later model turn includes earlier tool results; compare both
+dimensions rather than treating adoption alone as a win.
+
+For an A/B claim, hold the suite digest, Codex version, model, reasoning effort,
+MCP catalog, budgets, and repetition count fixed. Change only the visibility
+condition, use multiple repetitions, and report each cue level separately. Public
+v1 results are regression evidence, not held-out causal evidence.

--- a/docs/how-to/setup-agent-from-source.md
+++ b/docs/how-to/setup-agent-from-source.md
@@ -47,6 +47,12 @@ bootstrap discovery. The `lean` profile likewise records a nondefault
 `ELAN_HOME` and any `JACOBIAN_LEAN_RUNTIME` override, so a GUI restart uses the
 toolchain home and mathlib checkout that doctor audited.
 
+For Codex, setup also installs the `jacobian-math` visibility skill under
+`~/.codex/skills`. MCP server instructions are not guaranteed to be present in
+Codex's always-visible prompt, so this thin skill lets mathematical requests
+surface `math.find` even when the user does not name Jacobian. Setup refuses to
+replace a same-named unmanaged skill; removal preserves a user-modified copy.
+
 ## Profiles
 
 | Profile | Installed or checked surface |

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,6 +50,7 @@ complete a specific task.
 - [Configure an agent from a source checkout](how-to/setup-agent-from-source.md)
 - [Install optional backends](how-to/install-optional-backends.md)
 - [Troubleshoot Z3 installation on macOS](how-to/troubleshoot-z3-macos.md)
+- [Run the Codex visibility evaluation](how-to/run-codex-visibility-evaluation.md)
 - [Deploy the remote MCP server](how-to/deploy-remote-mcp.md)
 - [Author a Harbor benchmark task](how-to/author-harbor-benchmark-task.md)
 - [Migrate the benchmark portfolio](how-to/migrate-agent-workflow-benchmark.md)

--- a/npm/README.md
+++ b/npm/README.md
@@ -44,6 +44,13 @@ jacobian <command> [args...]
 
 Supported clients: `claude`, `cursor`, `opencode`, `codex`, `gemini`.
 
+Codex setup also installs a small `jacobian-math` skill under
+`~/.codex/skills`. Codex does not guarantee that MCP server instructions are
+always visible before tool selection; the skill makes relevant mathematical
+requests surface Jacobian without prescribing a mathematical workflow. Setup
+refuses to overwrite a same-named unmanaged or modified skill, and removal
+deletes only the exact managed content.
+
 `--source` writes a launcher bound to an absolute Jacobian checkout and uses
 `uv run --project <checkout> --locked --no-sync jacobian-mcp`. Run the
 checkout's `scripts/setup-agent` command for the complete locked dependency,

--- a/npm/bin/setup.cjs
+++ b/npm/bin/setup.cjs
@@ -30,6 +30,14 @@ const { stdin, stdout, stderr } = require("node:process");
 
 const SERVER_NAME = "jacobian";
 const TOML_SERVER_ENTRY = /^jacobian\s*=/;
+const CODEX_SKILL_MARKER = "<!-- Managed by Jacobian's Codex integration. -->";
+const CODEX_SKILL_SOURCE = join(
+  __dirname,
+  "..",
+  "skills",
+  "jacobian-math",
+  "SKILL.md",
+);
 
 /**
  * @typedef {"claude" | "cursor" | "opencode" | "codex" | "gemini"} ClientId
@@ -517,6 +525,81 @@ function resolveClientEdit(operation, def, launcher) {
   };
 }
 
+/** Resolve the Codex visibility skill managed alongside its MCP entry. */
+function resolveCodexSkillEdit(operation, def) {
+  const path = join(homedir(), ".codex", "skills", "jacobian-math", "SKILL.md");
+  rejectSymlink(path);
+  const original = readOptional(path);
+  const expected = readFileSync(CODEX_SKILL_SOURCE, "utf8");
+  if (!expected.includes(CODEX_SKILL_MARKER)) {
+    throw new Error("packaged Codex visibility skill is missing its managed marker");
+  }
+  if (operation === "remove") {
+    if (original === null) {
+      return {
+        client: def,
+        kind: "visibility_skill",
+        action: "not_configured",
+        detected: isClientDetected(homedir(), def.id),
+        path,
+        original,
+        updated: null,
+        deleteTarget: false,
+      };
+    }
+    if (original !== expected) {
+      return {
+        client: def,
+        kind: "visibility_skill",
+        action: "preserve_modified",
+        detected: isClientDetected(homedir(), def.id),
+        path,
+        original,
+        updated: null,
+        deleteTarget: false,
+      };
+    }
+    return {
+      client: def,
+      kind: "visibility_skill",
+      action: "remove",
+      detected: isClientDetected(homedir(), def.id),
+      path,
+      original,
+      updated: null,
+      deleteTarget: true,
+    };
+  }
+  if (original === expected) {
+    return {
+      client: def,
+      kind: "visibility_skill",
+      action: "already_current",
+      detected: isClientDetected(homedir(), def.id),
+      path,
+      original,
+      updated: null,
+      deleteTarget: false,
+    };
+  }
+  if (original !== null) {
+    throw new Error(
+      `${path} differs from the managed Jacobian skill. Move or rename ` +
+        "that skill, then retry.",
+    );
+  }
+  return {
+    client: def,
+    kind: "visibility_skill",
+    action: "create",
+    detected: isClientDetected(homedir(), def.id),
+    path,
+    original,
+    updated: expected,
+    deleteTarget: false,
+  };
+}
+
 /**
  * Apply one client edit to disk.
  *
@@ -524,16 +607,21 @@ function resolveClientEdit(operation, def, launcher) {
  * @returns {boolean} Whether this edit changed disk.
  */
 function applyEdit(edit) {
-  if (edit.updated === null) return false;
+  if (edit.updated === null && !edit.deleteTarget) return false;
   if (readOptional(edit.path) !== edit.original) {
     throw new Error(`${edit.path} changed after setup preflight; no write was made`);
+  }
+  if (edit.deleteTarget) {
+    rmSync(edit.path, { force: true });
+    return true;
   }
   return writeIfChanged(edit.path, edit.updated);
 }
 
 /** Restore a config file to the content observed during preflight. */
 function restoreEdit(edit) {
-  if (readOptional(edit.path) !== edit.updated) {
+  const expectedCurrent = edit.deleteTarget ? null : edit.updated;
+  if (readOptional(edit.path) !== expectedCurrent) {
     throw new Error(
       "the config changed after Jacobian wrote it; the concurrent value was left untouched",
     );
@@ -588,7 +676,10 @@ function printPlan(plan) {
   stderr.write(`\n  Planned changes:\n`);
   for (const edit of plan.edits) {
     const det = edit.detected ? " [detected]" : "";
-    stderr.write(`    ${edit.client.displayName}${det}: ${edit.action} → ${edit.path}\n`);
+    const label = edit.kind === "visibility_skill" ? " visibility skill" : "";
+    stderr.write(
+      `    ${edit.client.displayName}${label}${det}: ${edit.action} → ${edit.path}\n`,
+    );
   }
   stderr.write("\n");
 }
@@ -705,7 +796,13 @@ async function run(options) {
     return { operation, cancelled: true, dryRun: false, results: [] };
   }
 
-  const edits = selected.map((def) => resolveClientEdit(operation, def, launcher));
+  const configEdits = selected.map((def) =>
+    resolveClientEdit(operation, def, launcher),
+  );
+  const skillEdits = selected
+    .filter((def) => def.id === "codex")
+    .map((def) => resolveCodexSkillEdit(operation, def));
+  const edits = [...configEdits, ...skillEdits];
   const plan = { operation, launcher, edits };
 
   if (options.dryRun) {
@@ -730,10 +827,18 @@ async function run(options) {
 
   // Apply all client edits as one transaction.
   applyEdits(edits);
-  const results = edits.map((edit) => ({
+  const results = configEdits.map((edit) => ({
     client: edit.client.id,
     path: edit.path,
     status: edit.action,
+    ...(edit.client.id === "codex"
+      ? {
+          visibilitySkill: {
+            path: skillEdits[0].path,
+            status: skillEdits[0].action,
+          },
+        }
+      : {}),
     error: null,
   }));
 
@@ -767,6 +872,7 @@ module.exports = {
   buildLauncher,
   buildSourceLauncher,
   applyEdits,
+  resolveCodexSkillEdit,
   resolveClientEdit,
   run,
 };

--- a/npm/cli-e2e.test.mjs
+++ b/npm/cli-e2e.test.mjs
@@ -118,6 +118,81 @@ test("npx jacobian setup writes and reapplies a client configuration", async () 
   }
 });
 
+test("npx jacobian setup manages the Codex visibility skill safely", async () => {
+  const base = await mkdtemp(join(tmpdir(), "jacobian-npx-codex-skill-"));
+  try {
+    await mkdir(join(base, "home", ".codex"), { recursive: true });
+    const tarball = await packNpmPackage(base);
+    const env = { XDG_CONFIG_HOME: join(base, "config") };
+    const skillPath = join(
+      base,
+      "home",
+      ".codex",
+      "skills",
+      "jacobian-math",
+      "SKILL.md",
+    );
+
+    const setup = await runNpx(
+      tarball,
+      ["setup", "--client", "codex", "--yes", "--json"],
+      base,
+      env,
+    );
+    assert.equal(setup.status, 0, setup.stderr);
+    const setupReport = JSON.parse(setup.stdout);
+    assert.equal(setupReport.results[0].visibilitySkill.status, "create");
+    const managedSkill = await readFile(skillPath, "utf8");
+    assert.match(managedSkill, /name: jacobian-math/);
+    assert.match(managedSkill, /Trigger even when the user does not name Jacobian/);
+
+    const remove = await runNpx(
+      tarball,
+      ["remove", "--client", "codex", "--yes", "--json"],
+      base,
+      env,
+    );
+    assert.equal(remove.status, 0, remove.stderr);
+    assert.equal(existsSync(skillPath), false);
+
+    const reinstall = await runNpx(
+      tarball,
+      ["setup", "--client", "codex", "--yes", "--json"],
+      base,
+      env,
+    );
+    assert.equal(reinstall.status, 0, reinstall.stderr);
+    const modifiedSkill = `${await readFile(skillPath, "utf8")}\nUser note.\n`;
+    await writeFile(skillPath, modifiedSkill, "utf8");
+
+    const refuseOverwrite = await runNpx(
+      tarball,
+      ["setup", "--client", "codex", "--yes", "--json"],
+      base,
+      env,
+    );
+    assert.equal(refuseOverwrite.status, 1);
+    assert.match(refuseOverwrite.stderr, /differs from the managed Jacobian skill/);
+    assert.equal(await readFile(skillPath, "utf8"), modifiedSkill);
+
+    const preserve = await runNpx(
+      tarball,
+      ["remove", "--client", "codex", "--yes", "--json"],
+      base,
+      env,
+    );
+    assert.equal(preserve.status, 0, preserve.stderr);
+    const preserveReport = JSON.parse(preserve.stdout);
+    assert.equal(
+      preserveReport.results[0].visibilitySkill.status,
+      "preserve_modified",
+    );
+    assert.equal(await readFile(skillPath, "utf8"), modifiedSkill);
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
 test(
   "npx jacobian upgrade refreshes the launcher-managed Python package",
   { skip: process.platform === "win32" },

--- a/npm/package.json
+++ b/npm/package.json
@@ -20,6 +20,7 @@
   },
   "files": [
     "bin",
-    "README.md"
+    "README.md",
+    "skills"
   ]
 }

--- a/npm/skills/jacobian-math/SKILL.md
+++ b/npm/skills/jacobian-math/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: jacobian-math
+description: Use Jacobian for mathematical work involving exact computation, symbolic transformation, structural analysis, examples or counterexamples, bounded search, formal-environment inspection, or independent verification. Trigger even when the user does not name Jacobian and ordinary shell code could attempt the calculation.
+---
+
+# Jacobian Math
+
+<!-- Managed by Jacobian's Codex integration. -->
+
+Use `math.find` with a plain-language description when a useful installed
+operation is not already known; a capability ID is not required. Inspect the
+`CONTRACT` view before `math.run` when the typed input is unfamiliar.
+
+Keep representation, decomposition, composition, iteration, verification
+timing, and stopping decisions agent-owned. Treat timeouts, errors, incomplete
+searches, and missing witnesses as non-conclusions.
+
+When independent checking is requested, calculations or programs authored by
+the same model are not independent checker evidence. Search for an installed
+`VERIFY` capability. Claim `VERIFIED` only when the result has assurance level
+`VERIFIED` and a local verification record.

--- a/src/jacobian/adapters/mcp/guidance.py
+++ b/src/jacobian/adapters/mcp/guidance.py
@@ -8,11 +8,14 @@ SERVER_DESCRIPTION = (
 )
 
 SERVER_INSTRUCTIONS = (
-    "Jacobian provides searchable and executable mathematical operations for exact "
-    "computation, transformation, structure discovery, examples and counterexamples, "
-    "bounded search, formal-environment inspection, and independent checking. "
-    "math.find searches, browses, or inspects installed operations using a "
-    "plain-language description of the desired local mathematical outcome. "
+    "Use Jacobian's math.find when mathematical work calls for exact computation, "
+    "transformation, structure discovery, examples or counterexamples, bounded search, "
+    "formal-environment inspection, or independent checking. A capability ID is not "
+    "required: math.find accepts a plain-language description of the desired local "
+    "mathematical outcome. Do not report that no specialized mathematical operation is "
+    "available without checking math.find. When independent checking is requested, "
+    "multiple calculations or programs authored by the same model are not independent "
+    "checker evidence. "
     "math.run executes a selected operation using its typed input contract. "
     "Search or browse again whenever the objective or available evidence changes. "
     "The model owns representation, decomposition, composition, iteration, verification "
@@ -24,12 +27,17 @@ SERVER_INSTRUCTIONS = (
 )
 
 MATH_FIND_DESCRIPTION = """\
-Find or inspect an installed mathematical operation that can produce a desired outcome.
+Search Jacobian for an installed mathematical operation by desired outcome, or inspect
+one exact operation contract.
 
-Choose this when mathematical work may benefit from exact computation, structural
-analysis, transformation, examples or counterexamples, bounded search,
-formal-environment inspection, or independent checking and the useful installed
-operation is not yet known. A capability ID is not required for search or browse.
+Use this for mathematical work that calls for exact computation, structural analysis,
+transformation, examples or counterexamples, bounded search, formal-environment
+inspection, or independent checking when the useful installed operation is not yet
+known. Do not claim that no specialized mathematical operation is available without
+checking this tool. When a user requests independent checking, calculations or programs
+authored by the same model are not independent checker evidence; use this tool to learn
+whether an operator-authorized checker is installed. A capability ID is not required
+for search or browse.
 
 Available forms:
 - Pass `query` as a plain-language description of the desired local mathematical

--- a/tests/unit/tooling/test_architecture_harbor_contracts.py
+++ b/tests/unit/tooling/test_architecture_harbor_contracts.py
@@ -14,8 +14,7 @@ _REAL_TASK = (
     / "benchmarks/datasets/mathematical-benchmarks-v1/finite-field-irreducibility-repair"
 )
 _REAL_CONJECTURE_TASK = (
-    _ROOT
-    / "benchmarks/datasets/conjecture-probes-v1/vizing-bounded-cartesian-products"
+    _ROOT / "benchmarks/datasets/conjecture-probes-v1/vizing-bounded-cartesian-products"
 )
 
 

--- a/tests/unit/tooling/test_codex_visibility.py
+++ b/tests/unit/tooling/test_codex_visibility.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from benchmarks.tooling.codex_visibility import (
+    CueLevel,
+    VisibilityCase,
+    classify_visibility,
+    load_suite,
+)
+from pydantic import ValidationError
+
+from jacobian.eval.telemetry import parse_agent_transcript
+
+_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _write_transcript(path: Path, *events: object) -> dict[str, object]:
+    path.write_text(
+        "".join(json.dumps(event) + "\n" for event in events),
+        encoding="utf-8",
+    )
+    return parse_agent_transcript(path)
+
+
+def _case(*, verified: bool = False) -> VisibilityCase:
+    return VisibilityCase(
+        case_id="exact-determinant",
+        cue_level=CueLevel.LATENT,
+        prompt="Compute an exact determinant.",
+        expected_capability_ids=("matrix.determinant.compute",),
+        require_verified=verified,
+    )
+
+
+def _mcp_event(
+    tool: str,
+    arguments: object,
+    response: object,
+    *,
+    status: str = "completed",
+) -> dict[str, object]:
+    return {
+        "type": "item.completed",
+        "item": {
+            "type": "mcp_tool_call",
+            "tool": tool,
+            "arguments": arguments,
+            "status": status,
+            "result": {
+                "structured_content": response,
+                "content": [{"type": "text", "text": json.dumps(response)}],
+            },
+        },
+    }
+
+
+def test_load_suite_rejects_duplicate_case_ids(tmp_path: Path) -> None:
+    suite = {
+        "schema_version": "1",
+        "suite_id": "visibility-v1",
+        "cases": [
+            {
+                "case_id": "same-case",
+                "cue_level": "LATENT",
+                "prompt": "first",
+                "expected_capability_ids": ["integer.compute.gcd"],
+            },
+            {
+                "case_id": "same-case",
+                "cue_level": "EXPLICIT",
+                "prompt": "second",
+                "expected_capability_ids": ["integer.compute.gcd"],
+            },
+        ],
+    }
+    path = tmp_path / "suite.json"
+    path.write_text(json.dumps(suite), encoding="utf-8")
+
+    with pytest.raises(ValidationError, match="case_id values must be unique"):
+        load_suite(path)
+
+
+def test_committed_visibility_suite_has_explicit_and_latent_cases() -> None:
+    suite = load_suite(_ROOT / "benchmarks/config/codex-visibility-v1.json")
+
+    assert {case.cue_level for case in suite.cases} == {
+        CueLevel.EXPLICIT,
+        CueLevel.AFFORDANCE,
+        CueLevel.LATENT,
+    }
+    assert any(case.require_verified for case in suite.cases)
+
+
+def test_packaged_codex_skill_matches_repository_skill() -> None:
+    repository_skill = _ROOT / ".agents/skills/jacobian-math/SKILL.md"
+    packaged_skill = _ROOT / "npm/skills/jacobian-math/SKILL.md"
+
+    assert packaged_skill.read_bytes() == repository_skill.read_bytes()
+
+
+def test_visibility_classification_records_adoption_without_grading_shell(
+    tmp_path: Path,
+) -> None:
+    telemetry = _write_transcript(
+        tmp_path / "trace.jsonl",
+        _mcp_event(
+            "math.find",
+            {"query": "exact determinant"},
+            {
+                "kind": "discovery",
+                "matches": [{"capability_id": "matrix.determinant.compute"}],
+            },
+        ),
+        _mcp_event(
+            "math.find",
+            {
+                "capability_id": "matrix.determinant.compute",
+                "view": "CONTRACT",
+            },
+            {"kind": "capability"},
+        ),
+        _mcp_event(
+            "math.run",
+            {
+                "capability_id": "matrix.determinant.compute",
+                "payload": {},
+            },
+            {
+                "capability_id": "matrix.determinant.compute",
+                "execution": {"status": "COMPLETED"},
+                "output": {"determinant": "7"},
+                "assurance": {
+                    "level": "COMPUTED",
+                    "verification_record_uri": None,
+                },
+            },
+        ),
+        {
+            "type": "item.completed",
+            "item": {"type": "command_execution", "command": "python check.py"},
+        },
+    )
+
+    result = classify_visibility(_case(), telemetry)
+
+    assert result["observed"] == {
+        "discovered": True,
+        "inspected": True,
+        "invoked": True,
+        "completed": True,
+        "verified": False,
+    }
+    assert result["expected_capabilities"]["missing_completed"] == []
+    assert result["contract_satisfied"] is True
+    assert result["shell_call_count"] == 1
+
+
+def test_visibility_classification_requires_bound_verified_evidence(
+    tmp_path: Path,
+) -> None:
+    telemetry = _write_transcript(
+        tmp_path / "trace.jsonl",
+        _mcp_event(
+            "math.run",
+            {
+                "capability_id": "matrix.determinant.compute",
+                "payload": {},
+            },
+            {
+                "capability_id": "matrix.determinant.compute",
+                "execution": {"status": "COMPLETED"},
+                "assurance": {
+                    "level": "VERIFIED",
+                    "verification_record_uri": None,
+                },
+            },
+        ),
+    )
+
+    result = classify_visibility(_case(verified=True), telemetry)
+
+    assert result["observed"]["verified"] is False
+    assert result["contract_satisfied"] is False
+
+
+def test_visibility_classification_rejects_unrelated_verified_invocation() -> None:
+    telemetry = {
+        "capability_ids": ["matrix.determinant.compute"],
+        "capability_attempt_ids": ["matrix.determinant.compute"],
+        "capability_invocations": [
+            {
+                "capability_id": "integer.gcd.verify",
+                "assurance": {
+                    "level": "VERIFIED",
+                    "verification_record_uri": "artifact://sha256/record",
+                },
+            }
+        ],
+    }
+
+    result = classify_visibility(_case(verified=True), telemetry)
+
+    assert result["observed"]["verified"] is False
+    assert result["contract_satisfied"] is False
+
+
+def test_visibility_classification_treats_timeout_as_non_completion(
+    tmp_path: Path,
+) -> None:
+    telemetry = _write_transcript(
+        tmp_path / "trace.jsonl",
+        _mcp_event(
+            "math.run",
+            {
+                "capability_id": "matrix.determinant.compute",
+                "payload": {},
+            },
+            {
+                "capability_id": "matrix.determinant.compute",
+                "execution": {"status": "TIMEOUT"},
+            },
+        ),
+    )
+
+    result = classify_visibility(_case(), telemetry)
+
+    assert result["observed"]["invoked"] is True
+    assert result["observed"]["completed"] is False
+    assert result["contract_satisfied"] is False

--- a/tools/c901-baseline.json
+++ b/tools/c901-baseline.json
@@ -23,6 +23,11 @@
       "complexity": 11
     },
     {
+      "path": "benchmarks/datasets/mathematical-benchmarks-v1/disjoint-closed-distance-scope-audit/tests/verifier.py",
+      "symbol": "result_ok",
+      "complexity": 11
+    },
+    {
       "path": "benchmarks/datasets/mathematical-benchmarks-v1/finite-partition/tests/verifier.py",
       "symbol": "main",
       "complexity": 12
@@ -76,6 +81,11 @@
       "path": "benchmarks/datasets/mathematical-benchmarks-v1/propositional-rewrite-trace-replay/tests/verifier.py",
       "symbol": "_rewrite",
       "complexity": 14
+    },
+    {
+      "path": "benchmarks/datasets/mathematical-benchmarks-v1/rank-one-spectral-limit-certificate/tests/verifier.py",
+      "symbol": "certificate_valid",
+      "complexity": 11
     },
     {
       "path": "benchmarks/datasets/mathematical-benchmarks-v1/subset-incidence-determinant/tests/verifier.py",


### PR DESCRIPTION
## Summary

- add a thin `jacobian-math` Codex skill so relevant mathematical tasks can surface `math.find` before MCP tool descriptions are selected
- install and remove the managed skill transactionally with `npx jacobian setup --client codex`, preserving modified or unmanaged copies
- add an opt-in Codex visibility benchmark that binds prompts, model/client identity, MCP surface, evaluator digests, trajectories, assurance, token usage, and payload costs
- strengthen MCP guidance around independent verification and false tool-unavailability claims

## Evidence

Fixed-condition one-run diagnostic on Codex CLI 0.146.0 / gpt-5.6-sol / high reasoning:

- control: 0/1 discovery, 0/1 invocation, 13,332 cumulative input tokens
- skill treatment: 1/1 discovery, 1/1 invocation, expected capability completed, 127,418 cumulative input tokens
- independent-verification probe selected `matrix.determinant.compute` and `matrix.determinant.verify` and returned bound `VERIFIED` evidence

This is public regression evidence, not a causal performance claim; the committed suite supports repeated explicit, affordance, latent, and verification cases.

## Validation

- `make test-unit`: 664 passed
- `make test-component`: 692 passed
- `make test-domain`: 153 passed
- `make test-composition`: 446 passed, 2 Lean-runtime skips
- `make test-storage`: 114 passed
- `make test-process`: 218 passed
- `make test-mcp`: 32 passed
- `make test-e2e`: 8 passed, 1 Lean-runtime skip
- `make npm-test`: 35 passed; npm tarball contains the skill
- Ruff, mypy, build, security audit, duplicate-code, skill validation, docs command/link checks passed
- post-rebase focused visibility/MCP/bootstrap tests: 14 passed

`tools/c901-baseline.json` also records the two C901=11 entries already present on `origin/main` from #550/#554; verifier code and mathematical semantics are unchanged.