### PR TITLE
chore: synchronize fiber complexity baseline

### DIFF
--- a/tools/c901-baseline.json
+++ b/tools/c901-baseline.json
@@ -28,6 +28,11 @@
       "complexity": 11
     },
     {
+      "path": "benchmarks/datasets/mathematical-benchmarks-v1/fiber-dimension-semicontinuity-repair/tests/verifier.py",
+      "symbol": "_fiber_checks",
+      "complexity": 12
+    },
+    {
       "path": "benchmarks/datasets/mathematical-benchmarks-v1/finite-partition/tests/verifier.py",
       "symbol": "main",
       "complexity": 12


### PR DESCRIPTION
## Summary

Add the C901 baseline entry for `_fiber_checks` introduced by #514. The current `main` CI and PR merge checks fail in `make lint-full` without it.

## Validation

- `make complexity-check` (132 known violations, limit 10)