### PR TITLE
feat(npm): add guided one-line installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,24 @@ same boundary in a runnable graph example.
 
 ## Quickstart
 
-For a one-off setup without a global install:
+For a guided user-local install:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/morluto/jacobian/main/npm/install.sh | sh
+```
+
+The installer resolves an npm release to an exact version, installs the small
+launcher without lifecycle scripts, configures selected MCP clients, and
+verifies the local server. The Python package environment is approximately 160
+MB; if Python 3.12 is not already available, uv's managed Python adds about 110
+MB. Add `--defer-runtime` to postpone both until first use:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/morluto/jacobian/main/npm/install.sh | \
+  sh -s -- --client codex --yes --defer-runtime
+```
+
+For a one-off setup without a persistent launcher:
 
 ```sh
 npx jacobian setup
@@ -79,12 +96,16 @@ python -m pip install jacobian
 ```
 
 The launcher supports Claude, Codex, Cursor, Gemini, and OpenCode. It requires
-Node.js 18 or newer, Python 3.12, and [`uv`](https://docs.astral.sh/uv/). Run
-`jacobian mcp` to start the server directly.
+Node.js 18 or newer plus Python 3.12 or
+[`uv`](https://docs.astral.sh/uv/); the guided installer can install its pinned
+`uv` release after confirmation. Run `jacobian mcp` to start the server
+directly.
 
 The Python distribution contains the mathematical kernel, CLI, and MCP server.
-The npm package is a thin launcher and MCP client installer for that same
-implementation; it is not a separate JavaScript API.
+The npm package is a sub-100 KB thin launcher and MCP client installer for that
+same implementation; it is not a separate JavaScript API. The npm tarball has
+no npm runtime dependencies. The larger download is the local Python
+mathematical runtime, not a JavaScript dependency tree.
 
 To run the exact code in a clone, follow
 [Configure an agent from a source checkout](docs/how-to/setup-agent-from-source.md).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -41,7 +41,20 @@ Jacobian 为 AI 智能体提供小型、可组合的数学操作，而不是一�
 
 ## 快速开始
 
-npm 启动器会安装 Jacobian，并配置受支持的 MCP 客户端。若只想临时使用而不进行全局安装，可以运行：
+npm 启动器会安装 Jacobian，并配置受支持的 MCP 客户端。推荐使用用户态引导安装器：
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/morluto/jacobian/main/npm/install.sh | sh
+```
+
+安装器会先把 npm release 解析为精确版本，以禁用 lifecycle script 的方式安装小型启动器，配置选中的 MCP 客户端，再验证本地服务器。当前 Python 数学环境约为 160 MB；若本机尚无 Python 3.12，uv 管理的 Python 还会增加约 110 MB。若希望推迟到第一次使用时再安装，可以运行：
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/morluto/jacobian/main/npm/install.sh | \
+  sh -s -- --client codex --yes --defer-runtime
+```
+
+若只想临时使用而不持久安装启动器，可以运行：
 
 ```sh
 npx jacobian setup
@@ -62,7 +75,7 @@ Python 发行版可以直接安装稳定版本：
 python -m pip install jacobian
 ```
 
-启动器支持 Claude、Codex、Cursor、Gemini 和 OpenCode。它需要 Node.js 18 或更高版本、Python 3.12 以及 [`uv`](https://docs.astral.sh/uv/)。运行 `jacobian mcp` 可以直接启动服务器。
+启动器支持 Claude、Codex、Cursor、Gemini 和 OpenCode。它需要 Node.js 18 或更高版本，以及 Python 3.12 或 [`uv`](https://docs.astral.sh/uv/)；引导安装器可以在确认后安装仓库固定的 `uv` 版本。运行 `jacobian mcp` 可以直接启动服务器。这个不足 100 KB 的 npm 启动器没有 npm 运行时依赖；较大的下载来自本地 Python 数学运行时，而不是 JavaScript 依赖树。
 
 <details>
 <summary><strong>从源代码安装</strong></summary>

--- a/npm/README.md
+++ b/npm/README.md
@@ -15,10 +15,32 @@ installs, registers, and forwards.
 ## Requirements
 
 - Node.js >= 18
-- Python 3.12 and `uv` on `$PATH` (the launcher installs the matching stable
+- Python 3.12 or `uv` on `$PATH` (the launcher installs the exactly matching
   kernel from PyPI on first use)
 
 ## Install
+
+Guided user-local install:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/morluto/jacobian/main/npm/install.sh | sh
+```
+
+The guided installer resolves `latest` or `alpha` to an exact npm version,
+installs the launcher under `~/.local/share/jacobian/npm-releases`, and
+atomically activates `~/.local/bin/jacobian`. It disables npm lifecycle
+scripts, refuses to replace an unmanaged command, and rolls activation back if
+setup fails. If `uv` is absent, the installer can download the repository-pinned
+official installer and verifies its SHA-256 digest before running it.
+
+By default, the final doctor check installs and verifies the local mathematical
+runtime. Its Python package environment is currently about 160 MB on Linux; a
+uv-managed Python 3.12 adds about 110 MB when the machine does not already have
+one. Pass `--defer-runtime` to leave those downloads until first use. Run
+`npm/install.sh --help` for non-interactive client, release, dry-run, and
+dependency options.
+
+Manual global install:
 
 ```sh
 npm install -g jacobian
@@ -61,6 +83,8 @@ state initialization, source doctor, and client configuration workflow.
 - `JACOBIAN_STATE_DIR` — state directory (default: `./.jacobian`)
 - `JACOBIAN_PACKAGE` — Python package spec override (default: the Python package
   version matching the installed npm launcher)
+- `JACOBIAN_DATA_DIR` — guided installer release data root
+- `JACOBIAN_BIN_DIR` — guided installer directory for the stable command
 
 ## Verification model
 

--- a/npm/install.sh
+++ b/npm/install.sh
@@ -1,0 +1,399 @@
+#!/bin/sh
+
+set -eu
+
+package_name="jacobian"
+release_selector="${JACOBIAN_RELEASE:-latest}"
+uv_version="0.11.28"
+uv_installer_sha256="b7b3fe80cad1142a2a5794050b7db7b3291d1bac1423b0732571dd9366e8ca8b"
+
+plain=0
+assume_yes=0
+dry_run=0
+defer_runtime=0
+install_uv=-1
+select_all=0
+select_claude=0
+select_codex=0
+select_cursor=0
+select_gemini=0
+select_opencode=0
+selected_clients=0
+
+candidate_dir=""
+temporary_dir=""
+lock_dir=""
+lock_held=0
+activation_changed=0
+binding_complete=0
+previous_link=""
+activated_target=""
+
+usage() {
+    cat <<'EOF'
+Install Jacobian for one or more coding agents.
+
+Usage:
+  curl -fsSL https://raw.githubusercontent.com/morluto/jacobian/main/npm/install.sh | sh
+  curl -fsSL https://raw.githubusercontent.com/morluto/jacobian/main/npm/install.sh | \
+    sh -s -- --client codex --yes
+
+Options:
+  --client ID          Configure claude, codex, cursor, gemini, or opencode.
+                       Repeat the option to configure multiple clients.
+  --all                Configure every supported client.
+  --yes, -y            Skip confirmations; requires --client or --all.
+  --release VERSION    Install an exact version, latest, or alpha.
+  --defer-runtime      Do not install and verify the local math runtime now.
+  --install-uv         Install the pinned uv release if uv is not on PATH.
+  --no-install-uv      Fail instead of offering to install uv.
+  --dry-run            Print the plan without downloading or changing files.
+  --plain              Disable terminal colors.
+  --help, -h           Show this help.
+
+Environment:
+  JACOBIAN_DATA_DIR    Guided installer release data root.
+  JACOBIAN_BIN_DIR     Directory for the stable jacobian command.
+  JACOBIAN_RELEASE     Default release selector.
+  NO_COLOR             Disable terminal colors.
+EOF
+}
+
+die() {
+    printf 'error: %s\n' "$*" >&2
+    exit 1
+}
+
+is_tty() {
+    [ -t 1 ] && [ -r /dev/tty ] && [ -w /dev/tty ]
+}
+
+init_style() {
+    if [ "$plain" -eq 1 ] || [ "${NO_COLOR+x}" = x ] || ! is_tty; then
+        bold=""
+        cyan=""
+        amber=""
+        green=""
+        reset=""
+        return
+    fi
+    esc=$(printf '\033')
+    bold="${esc}[1m"
+    cyan="${esc}[38;2;25;145;170m"
+    amber="${esc}[38;2;211;132;43m"
+    green="${esc}[38;2;67;160;71m"
+    reset="${esc}[0m"
+}
+
+banner() {
+    printf '\n%s%s  J A C O B I A N%s\n' "$bold" "$amber" "$reset"
+    printf '%s  exact math  ->  inspectable evidence  ->  your agent%s\n\n' \
+        "$cyan" "$reset"
+}
+
+step() {
+    printf '%s[%s/%s]%s %s\n' "$cyan" "$1" "$2" "$reset" "$3"
+}
+
+success() {
+    printf '%s%s%s\n' "$green" "$1" "$reset"
+}
+
+add_client() {
+    case "$1" in
+        claude)
+            [ "$select_claude" -eq 1 ] || selected_clients=$((selected_clients + 1))
+            select_claude=1
+            ;;
+        codex)
+            [ "$select_codex" -eq 1 ] || selected_clients=$((selected_clients + 1))
+            select_codex=1
+            ;;
+        cursor)
+            [ "$select_cursor" -eq 1 ] || selected_clients=$((selected_clients + 1))
+            select_cursor=1
+            ;;
+        gemini)
+            [ "$select_gemini" -eq 1 ] || selected_clients=$((selected_clients + 1))
+            select_gemini=1
+            ;;
+        opencode)
+            [ "$select_opencode" -eq 1 ] || selected_clients=$((selected_clients + 1))
+            select_opencode=1
+            ;;
+        *) die "unknown client '$1'; expected claude, codex, cursor, gemini, or opencode" ;;
+    esac
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --client)
+            [ "$#" -ge 2 ] || die "--client requires a value"
+            add_client "$2"
+            shift 2
+            ;;
+        --client=*)
+            add_client "${1#--client=}"
+            shift
+            ;;
+        --all)
+            select_all=1
+            shift
+            ;;
+        --yes|-y)
+            assume_yes=1
+            shift
+            ;;
+        --release)
+            [ "$#" -ge 2 ] || die "--release requires a value"
+            release_selector="$2"
+            shift 2
+            ;;
+        --release=*)
+            release_selector="${1#--release=}"
+            shift
+            ;;
+        --defer-runtime)
+            defer_runtime=1
+            shift
+            ;;
+        --install-uv)
+            install_uv=1
+            shift
+            ;;
+        --no-install-uv)
+            install_uv=0
+            shift
+            ;;
+        --dry-run)
+            dry_run=1
+            shift
+            ;;
+        --plain)
+            plain=1
+            shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *) die "unknown argument '$1'" ;;
+    esac
+done
+
+case "$release_selector" in
+    latest|alpha) ;;
+    *[!0-9A-Za-z.-]*|.*|*..*|*-|"")
+        die "unsafe release selector '$release_selector'"
+        ;;
+esac
+
+if [ "$assume_yes" -eq 1 ] && [ "$select_all" -eq 0 ] && [ "$selected_clients" -eq 0 ]; then
+    die "--yes requires --client or --all; client detection is not consent"
+fi
+if [ "$select_all" -eq 1 ] && [ "$selected_clients" -gt 0 ]; then
+    die "--all cannot be combined with --client"
+fi
+
+init_style
+banner
+
+data_dir="${JACOBIAN_DATA_DIR:-${XDG_DATA_HOME:-${HOME:-}/.local/share}/jacobian}"
+bin_dir="${JACOBIAN_BIN_DIR:-${HOME:-}/.local/bin}"
+release_root="$data_dir/npm-releases"
+command_path="$bin_dir/jacobian"
+
+if [ "$dry_run" -eq 1 ]; then
+    cat <<EOF
+Install plan
+  release:       $release_selector (resolved and pinned through npm)
+  launcher:      $release_root/<version>
+  command:       $command_path
+  clients:       $([ "$select_all" -eq 1 ] && printf all || { [ "$selected_clients" -gt 0 ] && printf '%s selected' "$selected_clients" || printf interactive; })
+  math runtime:  $([ "$defer_runtime" -eq 1 ] && printf deferred || printf 'installed and verified after setup (~160 MB; +~110 MB if Python 3.12 is needed)')
+  changes:       none (dry-run)
+EOF
+    exit 0
+fi
+
+[ -n "${HOME:-}" ] || die "HOME must be set"
+[ "$(id -u)" -ne 0 ] || die "run the local installer as your normal user, not root"
+if [ "$selected_clients" -eq 0 ] && [ "$select_all" -eq 0 ] && ! is_tty; then
+    die "non-interactive setup requires --client or --all"
+fi
+
+node_bin="${JACOBIAN_NODE_BIN:-$(command -v node || true)}"
+npm_bin="${JACOBIAN_NPM_BIN:-$(command -v npm || true)}"
+[ -n "$node_bin" ] || die "Node.js 18 or newer is required"
+[ -n "$npm_bin" ] || die "npm is required"
+
+node_major=$("$node_bin" -p 'Number(process.versions.node.split(".")[0])') \
+    || die "could not inspect Node.js"
+case "$node_major" in *[!0-9]*|"") die "could not inspect Node.js" ;; esac
+[ "$node_major" -ge 18 ] || die "Node.js 18 or newer is required; found major version $node_major"
+"$npm_bin" --version >/dev/null 2>&1 || die "npm is not usable"
+
+step 1 4 "Resolve an immutable launcher release"
+release_json=$("$npm_bin" view "$package_name@$release_selector" version --json) \
+    || die "npm could not resolve jacobian@$release_selector"
+resolved_version=$(printf '%s' "$release_json" | "$node_bin" -e '
+let value;
+try { value = JSON.parse(require("node:fs").readFileSync(0, "utf8")); }
+catch { process.exit(1); }
+if (typeof value !== "string" ||
+    !/^\d+\.\d+\.\d+(?:-(?:alpha|beta|rc)\.\d+)?$/.test(value)) process.exit(1);
+process.stdout.write(value);
+') || die "npm returned an unsupported Jacobian version"
+printf '      jacobian@%s\n' "$resolved_version"
+
+cleanup() {
+    status=$?
+    trap - 0
+    if [ "$status" -ne 0 ] && [ "$activation_changed" -eq 1 ] && \
+        [ "$binding_complete" -eq 0 ] && \
+        [ -L "$command_path" ] && [ "$(readlink "$command_path")" = "$activated_target" ]; then
+        if [ -n "$previous_link" ]; then
+            rollback_link="$bin_dir/.jacobian.rollback.$$"
+            ln -s "$previous_link" "$rollback_link" && mv -f "$rollback_link" "$command_path"
+        else
+            rm -f "$command_path"
+        fi
+    fi
+    [ -z "$candidate_dir" ] || rm -rf "$candidate_dir"
+    [ -z "$temporary_dir" ] || rm -rf "$temporary_dir"
+    if [ "$lock_held" -eq 1 ]; then
+        rm -rf "$lock_dir"
+    fi
+    if [ "$status" -ne 0 ] && [ "$activation_changed" -eq 1 ] && \
+        [ "$binding_complete" -eq 0 ]; then
+        printf 'Jacobian launcher activation was rolled back.\n' >&2
+    fi
+    exit "$status"
+}
+trap cleanup 0
+trap 'exit 130' INT HUP TERM
+
+mkdir -p "$data_dir" "$release_root" "$bin_dir"
+lock_dir="$data_dir/install.lock"
+if ! mkdir "$lock_dir" 2>/dev/null; then
+    die "another Jacobian install is active, or $lock_dir is stale"
+fi
+lock_held=1
+
+if [ -e "$command_path" ] && [ ! -L "$command_path" ]; then
+    die "$command_path exists and is not a managed symlink"
+fi
+if [ -L "$command_path" ]; then
+    previous_link=$(readlink "$command_path")
+    case "$previous_link" in
+        "$release_root"/*/bin/jacobian) ;;
+        *) die "$command_path is not managed by this installer" ;;
+    esac
+fi
+
+if [ "$defer_runtime" -eq 0 ]; then
+    uv_bin="${JACOBIAN_UV_BIN:-$(command -v uv || true)}"
+    if [ -z "$uv_bin" ]; then
+        if [ "$install_uv" -eq -1 ]; then
+            if [ "$assume_yes" -eq 1 ]; then
+                install_uv=1
+            elif is_tty; then
+                printf 'uv is required for the local math runtime. Install uv %s? [Y/n] ' \
+                    "$uv_version" >/dev/tty
+                IFS= read -r answer </dev/tty || answer=""
+                case "$answer" in n|N|no|NO|No) install_uv=0 ;; *) install_uv=1 ;; esac
+            else
+                install_uv=0
+            fi
+        fi
+        [ "$install_uv" -eq 1 ] || die "uv is required; install it or pass --install-uv"
+        command -v curl >/dev/null 2>&1 || die "curl is required to install uv"
+        temporary_dir=$(mktemp -d "${TMPDIR:-/tmp}/jacobian-install.XXXXXX") \
+            || die "could not create a temporary directory"
+        uv_script="$temporary_dir/uv-install.sh"
+        uv_url="https://astral.sh/uv/$uv_version/install.sh"
+        printf '      downloading pinned uv installer %s\n' "$uv_version"
+        curl -fsSL "$uv_url" -o "$uv_script"
+        if command -v sha256sum >/dev/null 2>&1; then
+            printf '%s  %s\n' "$uv_installer_sha256" "$uv_script" | sha256sum -c - >/dev/null
+        elif command -v shasum >/dev/null 2>&1; then
+            actual=$(shasum -a 256 "$uv_script" | awk '{print $1}')
+            [ "$actual" = "$uv_installer_sha256" ] || die "uv installer checksum mismatch"
+        else
+            die "sha256sum or shasum is required to verify the uv installer"
+        fi
+        UV_NO_MODIFY_PATH=1 sh "$uv_script"
+        PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+        export PATH
+        uv_bin=$(command -v uv || true)
+        [ -n "$uv_bin" ] || die "uv installed but was not found in the expected user directories"
+    fi
+    "$uv_bin" --version >/dev/null 2>&1 || die "uv is not usable"
+fi
+
+step 2 4 "Install the small launcher without lifecycle scripts"
+release_dir="$release_root/$resolved_version"
+if [ -d "$release_dir" ]; then
+    installed_version=$("$release_dir/bin/jacobian" --version 2>/dev/null || true)
+    [ "$installed_version" = "jacobian $resolved_version" ] \
+        || die "existing release $release_dir failed validation"
+    printf '      reusing %s\n' "$release_dir"
+else
+    if [ -e "$release_dir" ] || [ -L "$release_dir" ]; then
+        die "$release_dir exists and is not a valid release directory"
+    fi
+    candidate_dir=$(mktemp -d "$release_root/.${resolved_version}.XXXXXX") \
+        || die "could not create a release candidate"
+    "$npm_bin" install --global --prefix "$candidate_dir" --ignore-scripts \
+        --omit=dev --no-audit --no-fund "$package_name@$resolved_version"
+    installed_version=$("$candidate_dir/bin/jacobian" --version 2>/dev/null || true)
+    [ "$installed_version" = "jacobian $resolved_version" ] \
+        || die "installed launcher failed its version check"
+    mv "$candidate_dir" "$release_dir"
+    candidate_dir=""
+fi
+
+activated_target="$release_dir/bin/jacobian"
+new_link="$bin_dir/.jacobian.new.$$"
+ln -s "$activated_target" "$new_link"
+mv -f "$new_link" "$command_path"
+activation_changed=1
+
+step 3 4 "Bind Jacobian to coding agents"
+set -- setup
+[ "$select_all" -eq 0 ] || set -- "$@" --all
+[ "$select_claude" -eq 0 ] || set -- "$@" --client claude
+[ "$select_codex" -eq 0 ] || set -- "$@" --client codex
+[ "$select_cursor" -eq 0 ] || set -- "$@" --client cursor
+[ "$select_gemini" -eq 0 ] || set -- "$@" --client gemini
+[ "$select_opencode" -eq 0 ] || set -- "$@" --client opencode
+[ "$assume_yes" -eq 0 ] || set -- "$@" --yes
+if is_tty && [ "$assume_yes" -eq 0 ]; then
+    "$command_path" "$@" </dev/tty
+else
+    "$command_path" "$@"
+fi
+binding_complete=1
+
+if [ "$defer_runtime" -eq 1 ]; then
+    step 4 4 "Defer the local math runtime"
+    printf '      first use installs ~160 MB; add ~110 MB if Python 3.12 is needed\n'
+else
+    step 4 4 "Install the math runtime and verify the MCP handshake"
+    if [ -z "$temporary_dir" ]; then
+        temporary_dir=$(mktemp -d "${TMPDIR:-/tmp}/jacobian-install.XXXXXX") \
+            || die "could not create a temporary directory"
+    fi
+    mkdir -p "$temporary_dir/doctor-state"
+    JACOBIAN_STATE_DIR="$temporary_dir/doctor-state" "$command_path" doctor
+fi
+
+printf '\n'
+success "Jacobian $resolved_version is ready."
+if ! command -v jacobian >/dev/null 2>&1; then
+    printf 'Add the command to this shell with:\n\n  export PATH="%s:\$PATH"\n' "$bin_dir"
+fi
+if [ "$defer_runtime" -eq 1 ]; then
+    printf 'Run %s doctor when you are ready to install and verify the math runtime.\n' \
+        "$command_path"
+fi

--- a/npm/installer.test.mjs
+++ b/npm/installer.test.mjs
@@ -1,0 +1,264 @@
+import assert from "node:assert/strict";
+import { chmod, lstat, mkdir, mkdtemp, readFile, readlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = dirname(here);
+const installer = join(here, "install.sh");
+
+async function writeExecutable(path, source) {
+  await writeFile(path, source, "utf8");
+  await chmod(path, 0o755);
+}
+
+async function fakeEnvironment(base, version = "0.8.0") {
+  const fakeBin = join(base, "fake-bin");
+  const home = join(base, "home");
+  const dataDir = join(base, "data");
+  const binDir = join(base, "bin");
+  const log = join(base, "commands.log");
+  await mkdir(fakeBin, { recursive: true });
+  await mkdir(home, { recursive: true });
+
+  const npm = join(fakeBin, "npm");
+  await writeExecutable(
+    npm,
+    `#!/bin/sh
+set -eu
+printf 'npm:%s\\n' "$*" >> "$JACOBIAN_FAKE_LOG"
+case "\${1:-}" in
+  --version)
+    printf '10.0.0\\n'
+    ;;
+  view)
+    printf '"%s"\\n' "$JACOBIAN_FAKE_VERSION"
+    ;;
+  install)
+    shift
+    prefix=
+    while [ "$#" -gt 0 ]; do
+      if [ "$1" = --prefix ]; then
+        prefix="$2"
+        shift 2
+      else
+        shift
+      fi
+    done
+    mkdir -p "$prefix/bin"
+    cat > "$prefix/bin/jacobian" <<'SCRIPT'
+#!/bin/sh
+set -eu
+printf 'jacobian:%s\\n' "$*" >> "$JACOBIAN_FAKE_LOG"
+case "\${1:-}" in
+  --version) printf 'jacobian %s\\n' "$JACOBIAN_FAKE_VERSION" ;;
+  setup) [ "\${JACOBIAN_FAKE_SETUP_FAILURE:-0}" -eq 0 ] ;;
+  doctor)
+    printf 'doctor: ok\\n'
+    [ "\${JACOBIAN_FAKE_DOCTOR_FAILURE:-0}" -eq 0 ]
+    ;;
+  *) exit 2 ;;
+esac
+SCRIPT
+    chmod +x "$prefix/bin/jacobian"
+    ;;
+  *) exit 2 ;;
+esac
+`,
+  );
+
+  const uv = join(fakeBin, "uv");
+  await writeExecutable(uv, "#!/bin/sh\nprintf 'uv 0.11.28\\n'\n");
+
+  return {
+    env: {
+      ...process.env,
+      HOME: home,
+      JACOBIAN_BIN_DIR: binDir,
+      JACOBIAN_DATA_DIR: dataDir,
+      JACOBIAN_FAKE_LOG: log,
+      JACOBIAN_FAKE_VERSION: version,
+      JACOBIAN_NODE_BIN: process.execPath,
+      JACOBIAN_NPM_BIN: npm,
+      JACOBIAN_UV_BIN: uv,
+      NO_COLOR: "1",
+    },
+    binDir,
+    dataDir,
+    fakeBin,
+    home,
+    log,
+  };
+}
+
+function runInstaller(args, env) {
+  return spawnSync("sh", [installer, ...args], {
+    cwd: repositoryRoot,
+    encoding: "utf8",
+    env,
+  });
+}
+
+test("installer dry-run is mutation-free and describes the runtime cost", async () => {
+  const base = await mkdtemp(join(tmpdir(), "jacobian-installer-dry-"));
+  const home = join(base, "home");
+  const dataDir = join(base, "data");
+  const binDir = join(base, "bin");
+  await mkdir(home);
+
+  const result = runInstaller(
+    ["--client", "codex", "--yes", "--dry-run", "--plain"],
+    { ...process.env, HOME: home, JACOBIAN_DATA_DIR: dataDir, JACOBIAN_BIN_DIR: binDir },
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(
+    result.stdout,
+    /math runtime:\s+installed and verified.*~160 MB.*~110 MB.*Python 3\.12/,
+  );
+  assert.match(result.stdout, /changes:\s+none \(dry-run\)/);
+  await assert.rejects(lstat(dataDir), { code: "ENOENT" });
+  await assert.rejects(lstat(binDir), { code: "ENOENT" });
+});
+
+test("installer pins npm resolution, activates the launcher, configures Codex, and verifies", async () => {
+  const base = await mkdtemp(join(tmpdir(), "jacobian-installer-full-"));
+  const fixture = await fakeEnvironment(base);
+
+  const result = runInstaller(["--client", "codex", "--yes", "--plain"], fixture.env);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Jacobian 0\.8\.0 is ready/);
+  assert.equal(
+    await readlink(join(fixture.binDir, "jacobian")),
+    join(fixture.dataDir, "npm-releases", "0.8.0", "bin", "jacobian"),
+  );
+  const log = await readFile(fixture.log, "utf8");
+  assert.match(log, /npm:view jacobian@latest version --json/);
+  assert.match(
+    log,
+    /npm:install --global --prefix .* --ignore-scripts --omit=dev --no-audit --no-fund jacobian@0\.8\.0/,
+  );
+  assert.match(log, /jacobian:setup --client codex --yes/);
+  assert.match(log, /jacobian:doctor/);
+});
+
+test("installer can defer the heavy runtime and reuse a validated launcher release", async () => {
+  const base = await mkdtemp(join(tmpdir(), "jacobian-installer-defer-"));
+  const fixture = await fakeEnvironment(base);
+  const args = ["--client", "codex", "--yes", "--defer-runtime", "--plain"];
+
+  const first = runInstaller(args, fixture.env);
+  const second = runInstaller(args, fixture.env);
+
+  assert.equal(first.status, 0, first.stderr);
+  assert.equal(second.status, 0, second.stderr);
+  assert.match(second.stdout, /reusing .*npm-releases\/0\.8\.0/);
+  const log = await readFile(fixture.log, "utf8");
+  assert.equal((log.match(/npm:install /g) || []).length, 1);
+  assert.equal((log.match(/jacobian:doctor/g) || []).length, 0);
+  assert.match(first.stdout, /first use installs ~160 MB.*~110 MB.*Python 3\.12/);
+});
+
+test("installer rolls stable launcher activation back when setup fails", async () => {
+  const base = await mkdtemp(join(tmpdir(), "jacobian-installer-rollback-"));
+  const oldFixture = await fakeEnvironment(base, "0.7.0");
+  const args = ["--client", "codex", "--yes", "--defer-runtime", "--plain"];
+  const installed = runInstaller(args, oldFixture.env);
+  assert.equal(installed.status, 0, installed.stderr);
+  const command = join(oldFixture.binDir, "jacobian");
+  const oldTarget = await readlink(command);
+
+  const failed = runInstaller(args, {
+    ...oldFixture.env,
+    JACOBIAN_FAKE_VERSION: "0.8.0",
+    JACOBIAN_FAKE_SETUP_FAILURE: "1",
+  });
+
+  assert.notEqual(failed.status, 0);
+  assert.match(failed.stderr, /activation was rolled back/);
+  assert.equal(await readlink(command), oldTarget);
+});
+
+test("installer keeps the activated launcher when post-setup doctor fails", async () => {
+  const base = await mkdtemp(join(tmpdir(), "jacobian-installer-doctor-failure-"));
+  const fixture = await fakeEnvironment(base);
+  const command = join(fixture.binDir, "jacobian");
+
+  const failed = runInstaller(["--client", "codex", "--yes", "--plain"], {
+    ...fixture.env,
+    JACOBIAN_FAKE_DOCTOR_FAILURE: "1",
+  });
+
+  assert.notEqual(failed.status, 0);
+  assert.doesNotMatch(failed.stderr, /activation was rolled back/);
+  assert.equal(
+    await readlink(command),
+    join(fixture.dataDir, "npm-releases", "0.8.0", "bin", "jacobian"),
+  );
+});
+
+test("installer never executes an uv installer with the wrong checksum", async () => {
+  const base = await mkdtemp(join(tmpdir(), "jacobian-installer-uv-checksum-"));
+  const fixture = await fakeEnvironment(base);
+  const marker = join(base, "uv-installer-executed");
+  const curlBin = join(base, "curl-bin");
+  await mkdir(curlBin);
+  await writeExecutable(
+    join(curlBin, "curl"),
+    `#!/bin/sh
+set -eu
+output=
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = -o ]; then output="$2"; shift 2; else shift; fi
+done
+cat > "$output" <<'SCRIPT'
+#!/bin/sh
+printf executed > "$JACOBIAN_FAKE_UV_MARKER"
+SCRIPT
+`,
+  );
+
+  const failed = runInstaller(["--client", "codex", "--yes", "--install-uv", "--plain"], {
+    ...fixture.env,
+    JACOBIAN_FAKE_UV_MARKER: marker,
+    JACOBIAN_UV_BIN: "",
+    PATH: `${curlBin}:/usr/bin:/bin`,
+  });
+
+  assert.notEqual(failed.status, 0);
+  assert.match(failed.stderr, /FAILED|checksum/i);
+  await assert.rejects(lstat(marker), { code: "ENOENT" });
+});
+
+test("installer refuses noninteractive implicit consent and unmanaged commands", async () => {
+  const base = await mkdtemp(join(tmpdir(), "jacobian-installer-safety-"));
+  const fixture = await fakeEnvironment(base);
+  const implicit = runInstaller(["--plain"], fixture.env);
+  assert.notEqual(implicit.status, 0);
+  assert.match(implicit.stderr, /requires --client or --all/);
+
+  await mkdir(fixture.binDir, { recursive: true });
+  const command = join(fixture.binDir, "jacobian");
+  await writeFile(command, "unmanaged\n", "utf8");
+  const unmanaged = runInstaller(
+    ["--client", "codex", "--yes", "--defer-runtime", "--plain"],
+    fixture.env,
+  );
+  assert.notEqual(unmanaged.status, 0);
+  assert.match(unmanaged.stderr, /not a managed symlink/);
+  assert.equal(await readFile(command, "utf8"), "unmanaged\n");
+});
+
+test("installer uv pin matches the repository and the script is valid POSIX shell", async () => {
+  const source = await readFile(installer, "utf8");
+  const pinnedUv = (await readFile(join(repositoryRoot, ".uv-version"), "utf8")).trim();
+  assert.match(source, new RegExp(`uv_version="${pinnedUv.replaceAll(".", "\\.")}"`));
+  assert.match(source, /uv_installer_sha256="[0-9a-f]{64}"/);
+
+  const syntax = spawnSync("sh", ["-n", installer], { encoding: "utf8" });
+  assert.equal(syntax.status, 0, syntax.stderr);
+});

--- a/npm/package.json
+++ b/npm/package.json
@@ -16,10 +16,11 @@
     "jacobian": "bin/jacobian.cjs"
   },
   "scripts": {
-    "test": "node --test npm-packaging.test.mjs cli-e2e.test.mjs"
+    "test": "node --test npm-packaging.test.mjs cli-e2e.test.mjs installer.test.mjs"
   },
   "files": [
     "bin",
+    "install.sh",
     "README.md",
     "skills"
   ]


### PR DESCRIPTION
## Problem

Jacobian onboarding currently starts with `npx jacobian setup` or a global npm install. That works, but it does not distinguish the sub-100 KB npm launcher from the substantially larger local Python mathematical runtime, provide a durable user-local command, or give `curl | sh` users an inspectable install and rollback contract.

## Solution

Add a POSIX `npm/install.sh` entrypoint for macOS/Linux-style environments that:

- resolves `latest`, `alpha`, or an explicit release to an exact npm version;
- installs the launcher into a user-owned immutable release directory with npm lifecycle scripts disabled, then atomically activates `~/.local/bin/jacobian`;
- refuses to replace unmanaged commands and rolls activation back when transactional client setup fails;
- delegates MCP config and the Codex visibility Skill to the existing `jacobian setup` implementation;
- eagerly installs and checks the local runtime by default, with `--defer-runtime` for a fast launcher-only setup;
- can install the repository-pinned uv release only after consent and verifies the downloaded installer against a pinned SHA-256 digest;
- exposes plain/TTY output, exact-client noninteractive setup, dry-run, and explicit release selection.

The English, Chinese, and npm quickstarts document the one-line path and the measured cost boundary: approximately 160-190 MB for the Python environment, plus about 108-110 MB when uv must supply Python 3.12. The npm tarball remains 21.0 KB compressed / 74.4 KB unpacked with no npm runtime dependencies.

## Testing

```sh
make test-plan BASE=origin/main PATHS='["README.md","README.zh-CN.md","npm/README.md","npm/install.sh","npm/installer.test.mjs","npm/package.json"]'
make npm-test
make docs-linkcheck
sh -n npm/install.sh
dash -n npm/install.sh
git diff --check
```

`make npm-test` passed 43/43 tests and the npm dry-run pack. The installer suite covers exact npm pinning, disabled lifecycle scripts, repeat install reuse, Codex argument forwarding, eager/deferred runtime behavior, unmanaged-command refusal, setup rollback, post-setup doctor failure semantics, and uv checksum rejection.

Manual isolated checks also covered:

- a real npm registry `jacobian@0.8.0` install into temporary HOME/data/bin roots;
- an isolated cold Python install: 42 packages, 15.55s, 157 MB without managed Python;
- current `main` packaged with only base dependencies and no Lean/flint/cvc5 on PATH: MCP initialize handshake in 12.58s from a fresh state;
- deployed remote MCP `d4c08839f434`: active immutable release, version 0.8.0, 331 capabilities, and 4,266 model-visible discovery bytes for the determinant query.

The unrelated untracked `droid.resume.txt` made the default working-tree planner fail closed to all lanes, so the required final plan was rerun with the exact six PR paths shown above.

## Trust & Compatibility Impact

This does not change the mathematical kernel, checker authorization, evidence semantics, artifacts, MCP tool surface, or Python API. It adds an optional installer around the existing npm launcher/setup contracts. Existing global/npx/source installs remain supported and an unmanaged `~/.local/bin/jacobian` is never overwritten.

A new synchronized Python/npm release is required after merge before `latest` contains the already-merged Skill and MCP startup improvements; the current registry `0.8.0` predates those main-branch changes despite sharing the source version.

## Checklist

- [x] Planned local npm and documentation validation passes
- [x] Relevant focused tests and manual verification are listed above
