### PR TITLE
test(verification): align timeout fixtures with process policy

### DIFF
--- a/tests/boundary/providers/external_sat/startup/test_sat_unsat_proof_verification.py
+++ b/tests/boundary/providers/external_sat/startup/test_sat_unsat_proof_verification.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -270,7 +269,7 @@ def test_proof_verify_requires_runtime_and_operator_authorization(
     ("exception", "expected_status", "expected_output_status"),
     [
         (
-            subprocess.TimeoutExpired(cmd=("drat-trim",), timeout=1),
+            TimeoutError("checker execution timed out"),
             ExecutionStatus.TIMEOUT,
             "TIMEOUT",
         ),

--- a/tests/boundary/providers/external_sat/startup/test_smt_unsat_proof_verification.py
+++ b/tests/boundary/providers/external_sat/startup/test_smt_unsat_proof_verification.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -283,7 +282,7 @@ def test_proof_verify_requires_runtime_and_operator_authorization(
     ("exception", "expected_status", "expected_output_status"),
     [
         (
-            subprocess.TimeoutExpired(cmd=("carcara",), timeout=1),
+            TimeoutError("checker execution timed out"),
             ExecutionStatus.TIMEOUT,
             "TIMEOUT",
         ),


### PR DESCRIPTION
## Summary

- align external SAT and SMT checker timeout fixtures with the current `VerificationService._run_checker` contract
- remove stale direct `subprocess.TimeoutExpired` injections left behind by the process-policy migration
- preserve observable fail-closed assertions for `TIMEOUT`, `ERROR`, `UNKNOWN`, and unverified assurance

## Validation

- focused operational failure matrix: 4 passed
- planned provider selectors: 18 passed
- Ruff lint and format checks
- `git diff --check`