### PR TITLE
test(harbor): bound full contract scans separately

### DIFF
--- a/tests/unit/tooling/test_harbor_jobs.py
+++ b/tests/unit/tooling/test_harbor_jobs.py
@@ -39,6 +39,7 @@ def test_observation_job_uses_harbor_dataset_selection() -> None:
     assert job["agents"] == [{"name": "codex", "kwargs": {"web_search": "disabled"}}]
 
 
+@pytest.mark.timeout(30)
 def test_validate_all_covers_proxy_control_and_observation_jobs() -> None:
     """The execution-config gate must validate proxied job configs, not skip them.
 
@@ -53,6 +54,7 @@ def test_validate_all_covers_proxy_control_and_observation_jobs() -> None:
     assert failures == [], "benchmark contract failures:\n" + "\n".join(failures)
 
 
+@pytest.mark.timeout(30)
 def test_validate_all_catches_a_malformed_proxy_control_job(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- give the two repository-wide Harbor contract scans an explicit 30-second test bound
- retain the 10-second default for ordinary unit tests
- avoid accepting a repeated CI flake as release evidence

These tests validate 219 task submission schemas plus repository schemas and jobs. They remain fully fail-closed; only their pytest containment bound changes.

## Validation

- `make test-unit TESTS=tests/unit/tooling/test_harbor_jobs.py` (4 passed)
- Ruff lint and format checks
- `git diff --check`