### PR TITLE
feat(benchmarks): add selected-task prepare and validation commands

### DIFF
--- a/.agents/skills/harbor-benchmarks/SKILL.md
+++ b/.agents/skills/harbor-benchmarks/SKILL.md
@@ -111,17 +111,26 @@ Use the pinned Harbor runner from the repository:
 ```sh
 uvx --from harbor==0.20.0 harbor --version
 make harbor-plan BASE=origin/main
-make harbor-sync
-make harbor-check-task DATASET=mathematical-benchmarks-v1 TASKS="task-id"
-make harbor-oracle-task DATASET=mathematical-benchmarks-v1 TASKS="task-id"
+make harbor-prepare-task DATASET=mathematical-benchmarks-v1 TASKS="task-id"
+make harbor-validate-task DATASET=mathematical-benchmarks-v1 TASKS="task-id"
 ```
 
-The selected-task commands are the normal leaf-task gates and require an
-explicit task selection. Use the full `make harbor-check` and explicitly
+`harbor-prepare-task` is the explicitly mutating authoring step. It formats only
+the selected task Python and dedicated validation leaf, performs scoped public
+contract and verifier checksum synchronization, and reports exactly which
+generated files changed. `harbor-validate-task` is the complete source-read-only
+leaf gate: it resolves membership and planner-owned host selectors once, runs
+static quality before contracts, executes the selected leaf and generic tests
+with an isolated worktree-local pytest directory, then runs exact task Oracles
+serially and reports timings, digests, and evidence paths.
+
+Both commands require an explicit task selection. The lower-level
+`harbor-sync`, `harbor-check-task`, and `harbor-oracle-task` targets remain
+available for a narrow edit loop. Use the full `make harbor-check` and explicitly
 scoped `make harbor-oracle` paths for shared tooling, schemas, registry, suite
-policy, or other control-plane changes. A full dataset Oracle requires
-`FULL=1`; ordinary Oracle runs require `TASKS` and never expand an omitted
-selection implicitly.
+policy, or other control-plane changes. A full dataset Oracle requires `FULL=1`;
+ordinary Oracle runs require `TASKS` and never expand an omitted selection
+implicitly.
 
 After any input, instruction, metadata, verifier, dependency, image, or task
 contract change:
@@ -157,9 +166,11 @@ formatting applies to the entire `benchmarks/` tree, including task verifier
 code under `benchmarks/datasets/<dataset>/<task-id>/tests/verifier.py`.
 
 After any verifier Python (`tests/verifier.py`) or Dockerfile change, run
-`make harbor-sync` to update the verifier checksum label embedded in each
-task's `tests/Dockerfile`. The `harbor-contracts` gate rejects stale checksum
-labels; `harbor-sync` recomputes them from the current verifier source.
+`make harbor-prepare-task DATASET=... TASKS="..."` to update the verifier
+checksum label embedded in each task's `tests/Dockerfile`. The
+`harbor-contracts` gate rejects stale checksum labels; the preparation command
+uses the scoped `harbor-sync` operations to recompute them from current verifier
+source.
 
 ### Validation regression layout
 

--- a/.agents/skills/verifier-evaluations/SKILL.md
+++ b/.agents/skills/verifier-evaluations/SKILL.md
@@ -23,6 +23,15 @@ the Harbor skill owns dataset layout and repository commands.
    solution, hidden verifier logic, private authorization records, or Oracle
    fixtures merely to explain the format.
 
+   Use `tests/verifier_contract.json` as the sole task-local declaration of
+   behavior consumed by generic verifier tests. Keep it versioned and validate
+   it against a closed schema: boolean fields must be exact JSON booleans,
+   unknown keys and unsupported versions fail closed, and missing metadata must
+   not silently opt a task into exceptional behavior. Do not add parallel
+   metadata files, fields on unrelated public-contract models, or global
+   task-name registries for input-binding, scope, assurance, or diagnostic
+   exceptions.
+
 2. Trace every acceptance path:
 
    `input file → envelope → typed structure → semantic claim → evidence/scope → metrics → reward`
@@ -63,6 +72,15 @@ the Harbor skill owns dataset layout and repository commands.
    documented in the visible contract, reject unrelated text, and accept
    mathematically equivalent phrasing.
 
+   Minimize the semantic obligations before implementing prose checks. Require
+   only logically independent facts that the evidence must contribute. If the
+   typed certificate plus one checked fact already entails a conclusion, do
+   not also require a rhetorical sentence restating that conclusion. For
+   example, a verifier that proves the submitted corrected condition fails
+   must not additionally require the solver to say “therefore this does not
+   refute the repair.” Keep such implications in verifier-owned mathematics,
+   not in preferred wording.
+
    For streamed prose verifiers, preserve the local relationship between the
    claim, its scope, and any negation; independent lexical matches are not a
    sufficient semantic parser. Add regressions for scope-before-claim and
@@ -86,6 +104,13 @@ the Harbor skill owns dataset layout and repository commands.
    verifier still emits `reward.json` without crashing. Include a large valid
    evidence artifact to prove that no undocumented byte cap is present.
 
+   Include at least one terse numeric or structural explanation fixture built
+   independently from the public contract. It must express the required facts
+   without reusing the canonical answer's labels, rhetorical conclusions, or
+   sentence fragments. Do not inspect hidden solution text solely to construct
+   this fixture; the point is to prove semantic acceptance rather than encode a
+   second preferred answer.
+
 7. Validate the final tree and handoff. Run focused tests, deliberate negative
    cases, the selected Oracle, and the repository's planned gate. If shared
    verifier support changes, migrate only deliberately selected task-local
@@ -96,6 +121,15 @@ the Harbor skill owns dataset layout and repository commands.
    task-local Dockerfile checksum label (e.g. `make harbor-sync`) and verify
    it matches `sha256sum` of the final `verifier.py`; a stale label fails
    `validate_task_topology` and blocks the task.
+
+   If an Oracle run earns full mathematical correctness but zero evidence
+   validity, diagnose the prose recognizer without reading or copying hidden
+   answer text. Instrument or invoke the matcher to report only a boolean map
+   of documented semantic clauses and contradiction checks. Do not print,
+   tokenize, quote, or mine n-grams from the Oracle artifact. Repair the public
+   semantic rule, write a fresh regression from the visible contract, and then
+   rerun every check invalidated by the verifier change, including the exact
+   Oracle.
 
 Read [references/verifier-contract.md](references/verifier-contract.md) for the
 detailed checklist and anti-pattern catalogue.

--- a/.github/scripts/plan-benchmarks
+++ b/.github/scripts/plan-benchmarks
@@ -64,6 +64,7 @@ BENCHMARK_CONTROL_PATHS = frozenset(
         "tools/check_benchmark_contracts.py",
         "tools/check_benchmark_static.py",
         "tools/check_harbor_dataset.py",
+        "tools/harbor_task_workflow.py",
         "tools/sync_harbor_verifier_support.py",
     }
 )

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ capability membership.
 | Documentation, benchmark README, or `benchmarks/validation/` | `make docs-linkcheck` | None |
 | Focused Python behavior | `make test-plan BASE=<revision>`, the selected lane, then `make check` | None |
 | Harbor job JSON, MCP config, job-level Compose overlay, or execution helper | `make harbor-execution-check` | None |
-| Benchmark task input or verifier | `make harbor-check-task DATASET=... TASKS=...`, then `make harbor-oracle-task DATASET=... TASKS=...` | Exact selected-task Oracle |
+| Benchmark task input or verifier | `make harbor-prepare-task DATASET=... TASKS="..."`, then `make harbor-validate-task DATASET=... TASKS="..."` | Exact selected-task Oracle |
 | Deployment entrypoint | `make deploy-check` | None |
 | CI, dependencies, or unknown paths | `make check-static` plus affected tests | As required by the selected plan |
 
@@ -77,6 +77,18 @@ modules for focused changes, the changed validation file itself, and the full
 `benchmarks/validation` suite, sharded in hosted CI, for shared or unclassified
 infrastructure. To reproduce one selected host check locally, run
 `make harbor-validation-tests TESTS=<pytest-file-or-directory>`.
+
+For task authoring, `make harbor-prepare-task DATASET=... TASKS="..."` is the
+explicitly mutating preparation step. It formats only Python owned by the
+selected task and its dedicated validation leaf, runs scoped public-contract
+and verifier-checksum synchronization, and reports every generated file that
+changed. Follow it with `make harbor-validate-task DATASET=... TASKS="..."` for
+the complete source-read-only leaf gate. That command resolves membership and
+planner selectors once, fails fast through static quality and contracts, runs
+the selected host tests serially in a worktree-local temporary pytest directory,
+then runs each exact Oracle serially. Its summary includes per-stage timings and
+the resulting task digest and Oracle evidence path.
+
 Tests can be narrowed without learning another wrapper:
 
 ```sh
@@ -151,7 +163,7 @@ aid; `make check` and CI remain the handoff gates.
 | --- | --- | --- |
 | Docs only | `make docs-linkcheck` | Documentation |
 | Focused Python | affected target, then `make check` | Planned Python/static/package lanes |
-| Benchmark task or verifier | `make harbor-check-task DATASET=... TASKS=...` and `make harbor-oracle-task DATASET=... TASKS=...` | Exact task contract and Oracle |
+| Benchmark task or verifier | `make harbor-prepare-task DATASET=... TASKS="..."`, then `make harbor-validate-task DATASET=... TASKS="..."` | Exact task contract, planner-selected host tests, and Oracle |
 | Benchmark README or validation regression | focused Harbor checks | Contract checks; no Oracle |
 | Lean runtime | focused `make test-lean`, then `make check` | Lean plus affected lanes |
 | CI, dependencies, or unknown paths | `make check-static` plus affected tests | Fail-closed functional lanes |

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ ORDERING_DEFAULT_SEED := --randomly-seed=17
 PYTEST_DIAGNOSTIC_ARGS ?= --durations=10
 RUFF_PATHS := src tests benchmarks
 TOPOLOGY_RUNNER := $(UV_RUN) python tools/test_topology.py
-PUBLIC_COMMANDS := help setup check check-changed ci-plan test-plan test-changed test-unit test-component test-domain test-composition test-storage test-process test-mcp test-provider test-lean test-e2e docs-command-check docs-linkcheck harbor-plan harbor-execution-check harbor-check-task harbor-oracle-task npm-test test-all-ci check-static deploy-check
+PUBLIC_COMMANDS := help setup check check-changed ci-plan test-plan test-changed test-unit test-component test-domain test-composition test-storage test-process test-mcp test-provider test-lean test-e2e docs-command-check docs-linkcheck harbor-plan harbor-prepare-task harbor-validate-task harbor-execution-check harbor-check-task harbor-oracle-task npm-test test-all-ci check-static deploy-check
 
 ifneq ($(strip $(PATHS)),)
 PATHS_FILE := $(shell mktemp)
@@ -26,7 +26,7 @@ endif
 # in pyproject.toml: direct pytest invocations must not silently inherit a
 # signal-based deadline that cannot interrupt a native solver.  Process and
 # provider lanes run risky work in killable children and set their own deadline.
-.PHONY: help help-all uv-version-check setup setup-agent container-image eval-image eval-image-pull eval-image-bind hooks fix lint complexity-check lint-full security-audit typecheck test-architecture architecture ci-plan test-plan test-changed check-changed test-unit test-component test-domain test-composition test-storage test-process test-mcp test-provider test-lean test-e2e test-affected test-all-ci test-compatibility test-stress test-ordering duplicate-code npm-test todo-check coverage build check precommit check-static harbor-plan harbor-sync harbor-contracts harbor-execution-check harbor-adapter-checks harbor-validation-tests harbor-validate harbor-check harbor-check-task benchmark-inventory benchmark-snapshot benchmark-snapshot-validate benchmark-publish harbor-oracle harbor-oracle-task harbor-oracle-run harbor-oracle-all harbor-adapter-check heldout-validate heldout-render heldout-smoke agent-eval agent-eval-validate agent-eval-compare codex-visibility provider-eval clean docs-command-check docs-linkcheck deploy-check
+.PHONY: help help-all uv-version-check setup setup-agent container-image eval-image eval-image-pull eval-image-bind hooks fix lint complexity-check lint-full security-audit typecheck test-architecture architecture ci-plan test-plan test-changed check-changed test-unit test-component test-domain test-composition test-storage test-process test-mcp test-provider test-lean test-e2e test-affected test-all-ci test-compatibility test-stress test-ordering duplicate-code npm-test todo-check coverage build check precommit check-static harbor-plan harbor-prepare-task harbor-validate-task harbor-sync harbor-contracts harbor-execution-check harbor-adapter-checks harbor-validation-tests harbor-validate harbor-check harbor-check-task benchmark-inventory benchmark-snapshot benchmark-snapshot-validate benchmark-publish harbor-oracle harbor-oracle-task harbor-oracle-run harbor-oracle-all harbor-adapter-check heldout-validate heldout-render heldout-smoke agent-eval agent-eval-validate agent-eval-compare codex-visibility provider-eval clean docs-command-check docs-linkcheck deploy-check
 
 help: ## Show available developer commands.
 	@awk -v public="$(PUBLIC_COMMANDS)" 'BEGIN {FS = ":.*## "; n = split(public, names, " "); for (i = 1; i <= n; i++) wanted[names[i]] = 1; printf "Jacobian common developer commands:\n\n"} /^[a-zA-Z_-]+:.*## / && ($$1 in wanted) {printf "  %-18s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -302,6 +302,18 @@ harbor-plan: ## Print the independent Harbor benchmark plan (BASE=... optional).
 	cat "$$tmp_dir/plan.txt"; \
 	echo "Plan receipt:"; \
 	cat "$$tmp_dir/receipt.json"
+
+harbor-prepare-task: ## Format and sync selected Harbor tasks (DATASET=..., TASKS="...").
+	@test -n "$(DATASET)" || { echo "DATASET is required" >&2; exit 2; }
+	@test -n "$(TASKS)" || { echo "TASKS is required; refusing an unscoped preparation" >&2; exit 2; }
+	$(HARBOR_PYTHON) tools/harbor_task_workflow.py prepare \
+		--dataset "$(DATASET)" --tasks $(TASKS)
+
+harbor-validate-task: ## Run the complete selected-task static, host, and Oracle gate.
+	@test -n "$(DATASET)" || { echo "DATASET is required" >&2; exit 2; }
+	@test -n "$(TASKS)" || { echo "TASKS is required; refusing an implicit full-dataset validation" >&2; exit 2; }
+	$(HARBOR_PYTHON) tools/harbor_task_workflow.py validate \
+		--dataset "$(DATASET)" --tasks $(TASKS)
 
 harbor-sync: ## Update verifier checksum labels for selected tasks (DATASET=... TASKS="...").
 	@test -n "$(DATASET)" || { echo "DATASET is required" >&2; exit 2; }

--- a/benchmarks/validation/test_benchmark_planner.py
+++ b/benchmarks/validation/test_benchmark_planner.py
@@ -129,6 +129,7 @@ def test_planner_digest_binds_to_planner_and_path_policy_sources() -> None:
         ".github/scripts/validate-benchmark-plan",
         ".github/workflows/benchmarks.yml",
         "Makefile",
+        "tools/harbor_task_workflow.py",
     ],
 )
 def test_benchmark_control_plane_changes_run_contract_checks(path: str) -> None:

--- a/benchmarks/validation/test_harbor_task_workflow.py
+++ b/benchmarks/validation/test_harbor_task_workflow.py
@@ -1,0 +1,213 @@
+"""Tests for the selected-task Harbor developer workflow."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL_PATH = ROOT / "tools" / "harbor_task_workflow.py"
+_SPEC = importlib.util.spec_from_loader(
+    "harbor_task_workflow", SourceFileLoader("harbor_task_workflow", str(TOOL_PATH))
+)
+assert _SPEC is not None and _SPEC.loader is not None
+workflow = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = workflow
+_SPEC.loader.exec_module(workflow)
+
+
+def test_resolve_selection_uses_planner_owned_host_matrix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    planner = workflow._load_planner()
+    monkeypatch.setattr(planner, "_digest", lambda path: f"sha256:{path.name}")
+    monkeypatch.setattr(workflow, "_load_planner", lambda: planner)
+
+    selection = workflow.resolve_selection(
+        "mathematical-benchmarks-v1", ("parameterized-sharp-bound-audit",)
+    )
+
+    assert selection.tasks == ("parameterized-sharp-bound-audit",)
+    assert [(item.selector, item.keyword) for item in selection.host_validations] == [
+        (
+            "benchmarks/validation/mathematical_benchmarks_v1/"
+            "test_generic_verifier_contracts.py",
+            "parameterized-sharp-bound-audit",
+        ),
+        (
+            "benchmarks/validation/mathematical_benchmarks_v1/"
+            "test_parameterized_sharp_bound_audit.py",
+            "",
+        ),
+    ]
+
+
+def test_prepare_formats_owned_python_and_reports_generated_changes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    task = tmp_path / "benchmarks/datasets/dataset-one/task-a"
+    verifier = task / "tests/verifier.py"
+    verifier.parent.mkdir(parents=True)
+    verifier.write_text("unformatted")
+    dockerfile = task / "environment/Dockerfile"
+    dockerfile.parent.mkdir()
+    dockerfile.write_text("checksum=old")
+    leaf = tmp_path / "benchmarks/validation/dataset_one/test_task_a.py"
+    leaf.parent.mkdir(parents=True)
+    leaf.write_text("unformatted")
+    shared = leaf.parent / "test_generic_verifier_contracts.py"
+    shared.write_text("shared")
+    selection = workflow.TaskSelection("dataset-one", ("task-a",), (task,), ())
+    calls: list[tuple[str, tuple[str, ...]]] = []
+
+    def fake_run(
+        label: str,
+        arguments: tuple[str, ...],
+        *,
+        timings: list[Any],
+        timeout_seconds: float,
+        executable: str | None = None,
+    ) -> None:
+        del timeout_seconds, executable
+        calls.append((label, arguments))
+        if label == "format":
+            verifier.write_text("formatted")
+            leaf.write_text("formatted")
+        if label == "sync-verifier-checksum":
+            dockerfile.write_text("checksum=new")
+        timings.append(workflow.StageTiming(label, 0.1))
+
+    monkeypatch.setattr(workflow, "ROOT", tmp_path)
+    monkeypatch.setattr(workflow, "_run_checked", fake_run)
+
+    changed = workflow.prepare(selection)
+
+    format_arguments = calls[0][1]
+    assert verifier.relative_to(tmp_path).as_posix() in format_arguments
+    assert leaf.relative_to(tmp_path).as_posix() in format_arguments
+    assert shared.relative_to(tmp_path).as_posix() not in format_arguments
+    assert changed == (
+        "benchmarks/datasets/dataset-one/task-a/environment/Dockerfile",
+        "benchmarks/datasets/dataset-one/task-a/tests/verifier.py",
+        "benchmarks/validation/dataset_one/test_task_a.py",
+    )
+    output = capsys.readouterr().out
+    assert (
+        "formatted: benchmarks/datasets/dataset-one/task-a/tests/verifier.py" in output
+    )
+    assert (
+        "generated: benchmarks/datasets/dataset-one/task-a/environment/Dockerfile"
+        in output
+    )
+
+
+def test_validate_orders_stages_isolates_pytest_and_reports_oracle_evidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    selection = workflow.TaskSelection(
+        "dataset-one",
+        ("task-a",),
+        (tmp_path / "benchmarks/datasets/dataset-one/task-a",),
+        (
+            workflow.HostValidation(
+                "specific", "benchmarks/validation/test_leaf.py", ""
+            ),
+            workflow.HostValidation(
+                "generic", "benchmarks/validation/test_generic.py", "task-a"
+            ),
+        ),
+    )
+    calls: list[tuple[str, tuple[str, ...]]] = []
+
+    def fake_run(
+        label: str,
+        arguments: tuple[str, ...],
+        *,
+        timings: list[Any],
+        timeout_seconds: float,
+        executable: str | None = None,
+    ) -> None:
+        del timeout_seconds, executable
+        calls.append((label, arguments))
+        timings.append(workflow.StageTiming(label, 0.1))
+        if label == "oracle:task-a":
+            evidence = (
+                tmp_path
+                / "benchmarks/results/dataset-one-oracle/job/oracle-evidence.json"
+            )
+            evidence.parent.mkdir(parents=True)
+            evidence.write_text(
+                json.dumps(
+                    {
+                        "dataset": "dataset-one",
+                        "tasks": [{"task": "task-a", "digest": "sha256:digest"}],
+                    }
+                )
+            )
+
+    monkeypatch.setattr(workflow, "ROOT", tmp_path)
+    monkeypatch.setattr(
+        workflow, "PYTEST_ROOT", tmp_path / ".pytest_cache/harbor-validation"
+    )
+    monkeypatch.setattr(workflow, "_run_checked", fake_run)
+
+    evidence = workflow.validate(selection)
+
+    assert [label for label, _ in calls] == [
+        "static-quality",
+        "contracts",
+        "host:specific",
+        "host:generic",
+        "oracle:task-a",
+    ]
+    host_commands = [
+        arguments for label, arguments in calls if label.startswith("host:")
+    ]
+    assert host_commands[0][-1] == "benchmarks/validation/test_leaf.py"
+    assert host_commands[1][-2:] == ("-k", "task-a")
+    assert all("-n" in command and "0" in command for command in host_commands)
+    assert not list((tmp_path / ".pytest_cache/harbor-validation").glob("run-*"))
+    assert evidence == (
+        (
+            "task-a",
+            "sha256:digest",
+            "benchmarks/results/dataset-one-oracle/job/oracle-evidence.json",
+        ),
+    )
+    assert "digest=sha256:digest" in capsys.readouterr().out
+
+
+def test_validate_fails_fast_after_static_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    selection = workflow.TaskSelection("dataset-one", ("task-a",), (tmp_path,), ())
+    calls: list[str] = []
+
+    def fail_static(
+        label: str,
+        arguments: tuple[str, ...],
+        *,
+        timings: list[Any],
+        timeout_seconds: float,
+        executable: str | None = None,
+    ) -> None:
+        del arguments, timings, timeout_seconds, executable
+        calls.append(label)
+        raise workflow.TaskWorkflowError("static failed")
+
+    monkeypatch.setattr(workflow, "ROOT", tmp_path)
+    monkeypatch.setattr(
+        workflow, "PYTEST_ROOT", tmp_path / ".pytest_cache/harbor-validation"
+    )
+    monkeypatch.setattr(workflow, "_run_checked", fail_static)
+
+    with pytest.raises(workflow.TaskWorkflowError, match="static failed"):
+        workflow.validate(selection)
+
+    assert calls == ["static-quality"]

--- a/tools/check_benchmark_static.py
+++ b/tools/check_benchmark_static.py
@@ -24,11 +24,16 @@ from benchmarks.tooling.command_runner import (  # noqa: E402
     run_tool_command,
 )
 
-RUFF_TARGETS = ("benchmarks", "tools/check_benchmark_static.py")
+RUFF_TARGETS = (
+    "benchmarks",
+    "tools/check_benchmark_static.py",
+    "tools/harbor_task_workflow.py",
+)
 MYPY_TARGETS = (
     "tools/check_benchmark_adapters.py",
     "tools/check_benchmark_contracts.py",
     "tools/check_benchmark_static.py",
+    "tools/harbor_task_workflow.py",
 )
 
 

--- a/tools/harbor_task_workflow.py
+++ b/tools/harbor_task_workflow.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env python3
+"""Prepare and validate explicitly selected Harbor benchmark tasks."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import shutil
+import sys
+import time
+from dataclasses import dataclass
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from benchmarks.tooling.command_runner import (  # noqa: E402
+    ToolCommandRequest,
+    ToolCommandStatus,
+    operator_environment,
+    run_tool_command,
+)
+from benchmarks.tooling.harbor_suite import (  # noqa: E402
+    HarborSuiteError,
+    get_suite,
+    select_task_refs,
+)
+
+PLANNER_PATH = ROOT / ".github" / "scripts" / "plan-benchmarks"
+PYTEST_ROOT = ROOT / ".pytest_cache" / "harbor-validation"
+OUTPUT_LIMIT = 8 * 1024 * 1024
+OPERATOR_ENVIRONMENT = (
+    "PATH",
+    "HOME",
+    "DOCKER_CONFIG",
+    "DOCKER_CONTEXT",
+    "DOCKER_HOST",
+    "XDG_CACHE_HOME",
+    "XDG_CONFIG_HOME",
+)
+
+
+class TaskWorkflowError(RuntimeError):
+    """A selected-task workflow contract was invalid or a stage failed."""
+
+
+@dataclass(frozen=True, slots=True)
+class HostValidation:
+    """One planner-owned host validation selector."""
+
+    name: str
+    selector: str
+    keyword: str
+
+
+@dataclass(frozen=True, slots=True)
+class TaskSelection:
+    """Resolved dataset tasks and their planner-owned host validation."""
+
+    dataset: str
+    tasks: tuple[str, ...]
+    task_paths: tuple[Path, ...]
+    host_validations: tuple[HostValidation, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class StageTiming:
+    """Elapsed time for one completed workflow stage."""
+
+    label: str
+    seconds: float
+
+
+def _load_planner() -> ModuleType:
+    spec = importlib.util.spec_from_loader(
+        "harbor_task_workflow_planner",
+        SourceFileLoader("harbor_task_workflow_planner", str(PLANNER_PATH)),
+    )
+    if spec is None or spec.loader is None:
+        raise TaskWorkflowError(f"could not load benchmark planner: {PLANNER_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _parse_host_validations(raw: str) -> tuple[HostValidation, ...]:
+    try:
+        entries = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise TaskWorkflowError(
+            "benchmark planner returned invalid host matrix JSON"
+        ) from exc
+    if not isinstance(entries, list) or not entries:
+        raise TaskWorkflowError("benchmark planner selected no host validation")
+
+    result: list[HostValidation] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise TaskWorkflowError("benchmark host matrix entries must be objects")
+        name = entry.get("name")
+        selector = entry.get("selector")
+        keyword = entry.get("keyword", "")
+        splits = entry.get("splits", 0)
+        group = entry.get("group", 0)
+        if (
+            not isinstance(name, str)
+            or not isinstance(selector, str)
+            or not isinstance(keyword, str)
+        ):
+            raise TaskWorkflowError("benchmark host matrix strings are malformed")
+        if splits != 0 or group != 0:
+            raise TaskWorkflowError(
+                "selected-task validation may not use sharded selectors"
+            )
+        selector_path = Path(selector)
+        if selector_path.is_absolute() or ".." in selector_path.parts:
+            raise TaskWorkflowError(f"unsafe benchmark host selector: {selector}")
+        result.append(HostValidation(name=name, selector=selector, keyword=keyword))
+    return tuple(result)
+
+
+def resolve_selection(dataset: str, tasks: tuple[str, ...]) -> TaskSelection:
+    """Resolve task membership and host selectors once through canonical owners."""
+    if not dataset:
+        raise TaskWorkflowError("DATASET is required")
+    try:
+        suite = get_suite(dataset)
+        refs = select_task_refs(suite, tasks)
+    except HarborSuiteError as exc:
+        raise TaskWorkflowError(str(exc)) from exc
+
+    changed_paths = []
+    for ref in refs:
+        verifier = ref.path / "tests" / "verifier.py"
+        source = verifier if verifier.is_file() else ref.path / "task.toml"
+        changed_paths.append(source.relative_to(ROOT).as_posix())
+
+    planner = _load_planner()
+    plan_function = getattr(planner, "plan", None)
+    if not callable(plan_function):
+        raise TaskWorkflowError("benchmark planner does not expose plan()")
+    plan = plan_function(changed_paths, event="pull_request")
+    if not isinstance(plan, dict):
+        raise TaskWorkflowError("benchmark planner returned a malformed plan")
+    raw_host_matrix = plan.get("benchmark-host-validation-matrix")
+    if not isinstance(raw_host_matrix, str):
+        raise TaskWorkflowError("benchmark planner omitted the host validation matrix")
+
+    return TaskSelection(
+        dataset=suite.id,
+        tasks=tuple(ref.path.name for ref in refs),
+        task_paths=tuple(ref.path for ref in refs),
+        host_validations=_parse_host_validations(raw_host_matrix),
+    )
+
+
+def _run_checked(
+    label: str,
+    arguments: tuple[str, ...],
+    *,
+    timings: list[StageTiming],
+    timeout_seconds: float,
+    executable: str | None = None,
+) -> None:
+    print(f"[{label}] {' '.join(arguments)}", flush=True)
+    started = time.monotonic()
+    result = run_tool_command(
+        ToolCommandRequest(
+            # Keep an uvx-selected interpreter path intact. Resolving its symlink
+            # escapes the ephemeral environment and loses Harbor dependencies.
+            executable=executable or sys.executable,
+            arguments=arguments,
+            environment=operator_environment(include=OPERATOR_ENVIRONMENT),
+            cwd=str(ROOT),
+            timeout_seconds=timeout_seconds,
+            stdout_limit_bytes=OUTPUT_LIMIT,
+            stderr_limit_bytes=OUTPUT_LIMIT,
+        )
+    )
+    elapsed = time.monotonic() - started
+    output = (result.stdout + result.stderr).decode(errors="replace").strip()
+    if output:
+        print(output)
+    if result.status is not ToolCommandStatus.EXITED or result.exit_code != 0:
+        detail = result.diagnostic or f"status={result.status}, exit={result.exit_code}"
+        raise TaskWorkflowError(f"{label} failed after {elapsed:.2f}s ({detail})")
+    timings.append(StageTiming(label=label, seconds=elapsed))
+
+
+def _uv_executable() -> str:
+    uv = shutil.which("uv")
+    if uv is None:
+        raise TaskWorkflowError("uv is required to run repository validation")
+    return uv
+
+
+def _task_tree_files(selection: TaskSelection, *, root: Path) -> tuple[Path, ...]:
+    files = {
+        path
+        for task_path in selection.task_paths
+        for path in task_path.rglob("*")
+        if path.is_file()
+    }
+    for task in selection.tasks:
+        leaf = (
+            root
+            / "benchmarks"
+            / "validation"
+            / selection.dataset.replace("-", "_")
+            / f"test_{task.replace('-', '_')}.py"
+        )
+        if leaf.is_file():
+            files.add(leaf)
+    return tuple(sorted(files))
+
+
+def _snapshot(paths: tuple[Path, ...], *, root: Path) -> dict[str, str]:
+    return {
+        path.relative_to(root).as_posix(): hashlib.sha256(path.read_bytes()).hexdigest()
+        for path in paths
+    }
+
+
+def _changed_paths(before: dict[str, str], after: dict[str, str]) -> tuple[str, ...]:
+    return tuple(
+        path
+        for path in sorted(before.keys() | after.keys())
+        if before.get(path) != after.get(path)
+    )
+
+
+def _python_paths(selection: TaskSelection, *, root: Path) -> tuple[str, ...]:
+    return tuple(
+        path.relative_to(root).as_posix()
+        for path in _task_tree_files(selection, root=root)
+        if path.suffix == ".py"
+    )
+
+
+def prepare(selection: TaskSelection) -> tuple[str, ...]:
+    """Format and synchronize only the explicitly selected task surface."""
+    timings: list[StageTiming] = []
+    before = _snapshot(_task_tree_files(selection, root=ROOT), root=ROOT)
+    python_paths = _python_paths(selection, root=ROOT)
+    if python_paths:
+        _run_checked(
+            "format",
+            ("run", "--locked", "ruff", "format", *python_paths),
+            timings=timings,
+            timeout_seconds=120.0,
+            executable=_uv_executable(),
+        )
+    after_format = _snapshot(_task_tree_files(selection, root=ROOT), root=ROOT)
+    formatted = _changed_paths(before, after_format)
+
+    _run_checked(
+        "sync-public-contract",
+        (
+            "-m",
+            "benchmarks.tooling.public_contract",
+            "sync-dataset",
+            "--dataset-root",
+            f"benchmarks/datasets/{selection.dataset}",
+            "--tasks",
+            *selection.tasks,
+        ),
+        timings=timings,
+        timeout_seconds=120.0,
+    )
+    _run_checked(
+        "sync-verifier-checksum",
+        (
+            "tools/sync_harbor_verifier_support.py",
+            "--dataset",
+            selection.dataset,
+            "--tasks",
+            *selection.tasks,
+        ),
+        timings=timings,
+        timeout_seconds=120.0,
+    )
+    after_sync = _snapshot(_task_tree_files(selection, root=ROOT), root=ROOT)
+    generated = _changed_paths(after_format, after_sync)
+    changed = _changed_paths(before, after_sync)
+
+    print("\nPreparation changes:")
+    print("  formatted: " + (", ".join(formatted) if formatted else "none"))
+    print("  generated: " + (", ".join(generated) if generated else "none"))
+    print("  all changed: " + (", ".join(changed) if changed else "none"))
+    _print_timings(timings)
+    return changed
+
+
+def _fresh_oracle_evidence(
+    selection: TaskSelection, task: str, *, started_ns: int
+) -> tuple[str, str]:
+    evidence_root = ROOT / "benchmarks" / "results" / f"{selection.dataset}-oracle"
+    candidates = sorted(
+        evidence_root.glob("*/oracle-evidence.json"),
+        key=lambda path: path.stat().st_mtime_ns,
+        reverse=True,
+    )
+    for path in candidates:
+        if path.stat().st_mtime_ns < started_ns:
+            continue
+        try:
+            payload: Any = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(payload, dict) or payload.get("dataset") != selection.dataset:
+            continue
+        task_entries = payload.get("tasks")
+        if not isinstance(task_entries, list):
+            continue
+        for entry in task_entries:
+            if isinstance(entry, dict) and entry.get("task") == task:
+                digest = entry.get("digest")
+                if isinstance(digest, str):
+                    return digest, path.relative_to(ROOT).as_posix()
+    raise TaskWorkflowError(
+        f"Oracle produced no fresh evidence for {selection.dataset}/{task}"
+    )
+
+
+def _print_timings(timings: list[StageTiming]) -> None:
+    print("\nStage timings:")
+    for timing in timings:
+        print(f"  {timing.label}: {timing.seconds:.2f}s")
+    print(f"  total: {sum(timing.seconds for timing in timings):.2f}s")
+
+
+def validate(selection: TaskSelection) -> tuple[tuple[str, str, str], ...]:
+    """Run the complete selected-task gate without changing tracked sources."""
+    timings: list[StageTiming] = []
+    oracle_evidence: list[tuple[str, str, str]] = []
+    PYTEST_ROOT.mkdir(parents=True, exist_ok=True)
+    pytest_temp = PYTEST_ROOT / f"run-{time.time_ns()}"
+    pytest_temp.mkdir()
+    try:
+        _run_checked(
+            "static-quality",
+            ("run", "--locked", "python", "tools/check_benchmark_static.py"),
+            timings=timings,
+            timeout_seconds=360.0,
+            executable=_uv_executable(),
+        )
+        _run_checked(
+            "contracts",
+            (
+                "tools/check_harbor_dataset.py",
+                "--dataset",
+                selection.dataset,
+                "--tasks",
+                *selection.tasks,
+            ),
+            timings=timings,
+            timeout_seconds=300.0,
+        )
+        for host in selection.host_validations:
+            arguments: tuple[str, ...] = (
+                "run",
+                "--locked",
+                "pytest",
+                "-n",
+                "0",
+                "--durations=10",
+                f"--basetemp={pytest_temp / host.name}",
+                host.selector,
+            )
+            if host.keyword:
+                arguments += ("-k", host.keyword)
+            _run_checked(
+                f"host:{host.name}",
+                arguments,
+                timings=timings,
+                timeout_seconds=600.0,
+                executable=_uv_executable(),
+            )
+        for task in selection.tasks:
+            started_ns = time.time_ns()
+            make = shutil.which("make")
+            if make is None:
+                raise TaskWorkflowError("make is required to run the exact Oracle")
+            _run_checked(
+                f"oracle:{task}",
+                (
+                    "--no-print-directory",
+                    "harbor-oracle-run",
+                    f"DATASET={selection.dataset}",
+                    f"TASKS={task}",
+                ),
+                timings=timings,
+                timeout_seconds=1800.0,
+                executable=make,
+            )
+            digest, evidence_path = _fresh_oracle_evidence(
+                selection, task, started_ns=started_ns
+            )
+            oracle_evidence.append((task, digest, evidence_path))
+    finally:
+        shutil.rmtree(pytest_temp, ignore_errors=True)
+        if PYTEST_ROOT.is_dir() and not any(PYTEST_ROOT.iterdir()):
+            PYTEST_ROOT.rmdir()
+
+    print("\nOracle evidence:")
+    for task, digest, evidence_path in oracle_evidence:
+        print(f"  {task}: digest={digest} evidence={evidence_path}")
+    _print_timings(timings)
+    return tuple(oracle_evidence)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    for command in ("prepare", "validate"):
+        subparser = subparsers.add_parser(command)
+        subparser.add_argument("--dataset", required=True)
+        subparser.add_argument("--tasks", nargs="+", required=True)
+    return parser
+
+
+def main() -> int:
+    """Run the selected preparation or validation workflow."""
+    args = _parser().parse_args()
+    try:
+        selection = resolve_selection(args.dataset, tuple(args.tasks))
+        if args.command == "prepare":
+            prepare(selection)
+        else:
+            validate(selection)
+    except TaskWorkflowError as exc:
+        print(f"harbor task workflow failed: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Problem

Harbor task authors currently have to coordinate formatting, contract generation, checksum synchronization, planner-derived pytest selectors, temporary pytest state, and exact Oracle runs by hand. The ordering is easy to get wrong: cheap static failures can surface after more expensive checks, selector logic can drift from CI, and pytest can leave shared state under `/tmp`.

## Solution

Add two explicit selected-task workflows:

- `make harbor-prepare-task DATASET=... TASKS="..."` formats only selected task and dedicated validation Python, runs scoped public-contract and verifier-checksum synchronization, and reports the exact changed files.
- `make harbor-validate-task DATASET=... TASKS="..."` resolves membership and host selectors once through the production benchmark planner, then runs static quality, selected contracts, planner-owned host tests, and serial exact Oracles. Pytest uses a worktree-local temporary directory that is removed on exit; successful runs print per-stage timings, task digests, and Oracle evidence paths.

The existing lower-level Harbor targets remain available. This also records the verifier-review rules learned from recent task failures: minimal independent semantic obligations, canonical strict task metadata, wording-independent fixtures, and contamination-safe Oracle diagnostics.

## Testing

- `uv run --locked pytest -n 0 -q benchmarks/validation/test_harbor_task_workflow.py benchmarks/validation/test_benchmark_planner.py` — 45 passed on the final branch.
- `uv run --locked python tools/check_benchmark_static.py` — passed on the final branch.
- `quick_validate.py .agents/skills/verifier-evaluations` and `quick_validate.py .agents/skills/harbor-benchmarks` — both skills valid.
- `make harbor-prepare-task DATASET=mathematical-benchmarks-v1 TASKS="parameterized-sharp-bound-audit"` — completed with no generated changes.
- `make harbor-validate-task DATASET=mathematical-benchmarks-v1 TASKS="parameterized-sharp-bound-audit"` — full source-tree run passed static checks, contracts, 13 generic tests, 5 task tests, and the exact Oracle with reward 1.0. After rebasing onto current `main`, static checks, contracts, and both host-test stages passed again; the repeated Oracle was interrupted during local Docker setup and is not claimed as final-branch evidence.

## Trust & Compatibility Impact

This changes repository task-authoring tooling and guidance, not task semantics, the verification kernel, checker authorization, artifact formats, or public APIs. Validation writes only ignored Oracle evidence and temporary pytest state; tracked source files remain unchanged.

## Checklist

- [ ] Routine local validation passes (`make check`)
- [x] Relevant focused tests are listed above
