### PR TITLE
fix(benchmarks): repair proxied Harbor Codex observations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ UV_RUN := uv run --locked
 HARBOR_VERSION ?= 0.20.0
 HARBOR_RUNNER ?= uvx --from harbor==$(HARBOR_VERSION) harbor
 HARBOR_PYTHON ?= uvx --from harbor==$(HARBOR_VERSION) --with tomli-w==1.2.0 --with jsonschema python
+HARBOR_PROJECT_PYTHON ?= uv run --locked --with harbor==$(HARBOR_VERSION) --with tomli-w==1.2.0 --with jsonschema python
 # Validation pytest is process-isolated under xdist; Path monkeypatches stay
 # worker-local. Oracle/adapter Make targets remain serial.
 HARBOR_VALIDATION_WORKERS ?= 2
@@ -447,7 +448,7 @@ endif
 
 CODEX_WEB_SEARCH ?= disabled
 JACOBIAN_EVAL_PROXY ?= 0
-JACOBIAN_EVAL_CODEX_BINARY ?= $(shell command -v codex 2>/dev/null | xargs -r readlink -f)
+JACOBIAN_EVAL_CODEX_BINARY ?= $(shell command -v codex 2>/dev/null)
 define _jacobian_eval_container_proxy
 $(subst localhost,host.docker.internal,$(subst 127.0.0.1,host.docker.internal,$1))
 endef
@@ -487,6 +488,7 @@ endif
 
 agent-eval: ## Run a Harbor evaluation (JACOBIAN_ENABLED=0|1, JACOBIAN_EVAL_PROXY=0|1, DATASET=mathematical-benchmarks-v1, EVAL_EXECUTE=1).
 	@set -e; \
+	CODEX_BINARY="$(JACOBIAN_EVAL_CODEX_BINARY)"; \
 	if [ "$(EVAL_EXECUTE)" != "1" ]; then \
 		echo "Model execution is opt-in. Review the job, then run: make agent-eval DATASET=mathematical-benchmarks-v1 EVAL_EXECUTE=1"; \
 		exit 0; \
@@ -496,10 +498,7 @@ agent-eval: ## Run a Harbor evaluation (JACOBIAN_ENABLED=0|1, JACOBIAN_EVAL_PROX
 		exit 2; \
 	fi; \
 	if [ "$(JACOBIAN_EVAL_PROXY)" = "1" ]; then \
-		test -x "$(JACOBIAN_EVAL_CODEX_BINARY)" || { \
-			echo "JACOBIAN_EVAL_CODEX_BINARY must resolve to a Linux standalone Codex binary when JACOBIAN_EVAL_PROXY=1" >&2; \
-			exit 2; \
-		}; \
+		CODEX_BINARY="$$( $(UV_RUN) python -m benchmarks.tooling.codex_binary --candidate "$$CODEX_BINARY" )"; \
 		JACOBIAN_EVAL_UPSTREAM_PROXY="$(JACOBIAN_EVAL_UPSTREAM_PROXY)" \
 			$(UV_RUN) python -m benchmarks.tooling.harbor_proxy \
 			--output "$(JACOBIAN_EVAL_GOST_CONFIG)"; \
@@ -514,7 +513,7 @@ agent-eval: ## Run a Harbor evaluation (JACOBIAN_ENABLED=0|1, JACOBIAN_EVAL_PROX
 	JACOBIAN_EVAL_HTTPS_PROXY="$(JACOBIAN_EVAL_HTTPS_PROXY)" \
 	JACOBIAN_EVAL_ALL_PROXY="$(JACOBIAN_EVAL_ALL_PROXY)" \
 	JACOBIAN_EVAL_NO_PROXY="$(JACOBIAN_EVAL_NO_PROXY)" \
-	JACOBIAN_EVAL_CODEX_BINARY="$(JACOBIAN_EVAL_CODEX_BINARY)" \
+	JACOBIAN_EVAL_CODEX_BINARY="$$CODEX_BINARY" \
 	JACOBIAN_EVAL_GOST_CONFIG="$(JACOBIAN_EVAL_GOST_CONFIG)" \
 	$(HARBOR_RUNNER) run \
 		-c "$(EVAL_CONFIG)" \
@@ -527,7 +526,7 @@ agent-eval: ## Run a Harbor evaluation (JACOBIAN_ENABLED=0|1, JACOBIAN_EVAL_PROX
 
 agent-eval-validate: ## Normalize one observation (RESULTS=..., JOB=..., CONDITION=..., OUTPUT=...).
 	@test -n "$(RESULTS)" -a -n "$(JOB)" -a -n "$(CONDITION)" -a -n "$(OUTPUT)" || { echo "RESULTS, JOB, CONDITION, and OUTPUT are required" >&2; exit 2; }
-	$(UV_RUN) python -m benchmarks.tooling.observation_results validate \
+	$(HARBOR_PROJECT_PYTHON) -m benchmarks.tooling.observation_results validate \
 		--dataset "$(or $(DATASET),mathematical-benchmarks-v1)" --condition "$(CONDITION)" \
 		--job "$(JOB)" --jobs-dir "$(RESULTS)" --output "$(OUTPUT)" \
 		$(if $(RESULT),--result "$(RESULT)",) \

--- a/benchmarks/config/agent-eval-egress-proxy.compose.yaml
+++ b/benchmarks/config/agent-eval-egress-proxy.compose.yaml
@@ -1,12 +1,12 @@
 services:
   main:
     environment:
-      HTTP_PROXY: ""
-      HTTPS_PROXY: ""
+      HTTP_PROXY: http://127.0.0.1:12346
+      HTTPS_PROXY: http://127.0.0.1:12346
       ALL_PROXY: ""
       NO_PROXY: ${JACOBIAN_EVAL_NO_PROXY:-localhost,127.0.0.1,jacobian}
-      http_proxy: ""
-      https_proxy: ""
+      http_proxy: http://127.0.0.1:12346
+      https_proxy: http://127.0.0.1:12346
       all_proxy: ""
       no_proxy: ${JACOBIAN_EVAL_NO_PROXY:-localhost,127.0.0.1,jacobian}
   harbor-docker-egress-control-sidecar:

--- a/benchmarks/config/mathematical-benchmarks-v1-control-proxy.json
+++ b/benchmarks/config/mathematical-benchmarks-v1-control-proxy.json
@@ -2,6 +2,9 @@
   "jobs_dir": "benchmarks/results/mathematical-benchmarks-v1-control-proxy",
   "n_attempts": 3,
   "timeout_multiplier": 1,
+  "artifacts": [
+    "/logs/agent/trajectory.json"
+  ],
   "orchestrator": {
     "type": "local",
     "n_concurrent_trials": 1,

--- a/benchmarks/config/mathematical-benchmarks-v1-control.json
+++ b/benchmarks/config/mathematical-benchmarks-v1-control.json
@@ -2,6 +2,9 @@
   "jobs_dir": "benchmarks/results/mathematical-benchmarks-v1-control",
   "n_attempts": 3,
   "timeout_multiplier": 1,
+  "artifacts": [
+    "/logs/agent/trajectory.json"
+  ],
   "orchestrator": {
     "type": "local",
     "n_concurrent_trials": 1,

--- a/benchmarks/datasets/mathematical-benchmarks-v1/README.md
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/README.md
@@ -92,6 +92,13 @@ Jacobian affordance, so include negative controls and tasks that discriminate
 tool adoption. Public-suite observations remain directional workflow evidence,
 not a causal performance claim.
 
+Jacobian-enabled jobs collect both Codex ATIF and the Jacobian sidecar's MCP
+runtime log. The runtime log is authoritative for `math.find`, `math.run`, and
+`reasoning.write` counts and failed capability attempts; the normalizer does
+not infer executions from JavaScript source text. A missing configured trace or
+sidecar log makes the observation incomplete. Control jobs collect ATIF only
+because they do not start the Jacobian sidecar.
+
 Five tasks have an operator-authorized verification record and may accept
 `VERIFIED`; the remaining tasks are capped at `COMPUTED`. A wrong result or an
 unsupported certification claim forces reward to zero. These are workflow

--- a/benchmarks/datasets/mathematical-benchmarks-v1/jacobian-observation.compose.yaml
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/jacobian-observation.compose.yaml
@@ -5,7 +5,14 @@ services:
         condition: service_healthy
   jacobian:
     image: ${JACOBIAN_IMAGE:-jacobian:local}
+    entrypoint:
+      - /bin/sh
+      - -c
     command:
+      - |
+        mkdir -p /logs/jacobian
+        exec uv run --no-sync jacobian-mcp "$@" > /logs/jacobian/mcp.log 2>&1
+      - jacobian-mcp
       - --transport
       - streamable-http
       - --host

--- a/benchmarks/datasets/mathematical-benchmarks-v1/jobs/jacobian-observation-proxy.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/jobs/jacobian-observation-proxy.json
@@ -3,7 +3,11 @@
   "n_attempts": 3,
   "timeout_multiplier": 1,
   "artifacts": [
-    "/logs/agent/trajectory.json"
+    "/logs/agent/trajectory.json",
+    {
+      "source": "/logs/jacobian/mcp.log",
+      "service": "jacobian"
+    }
   ],
   "orchestrator": {
     "type": "local",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/jobs/jacobian-observation-proxy.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/jobs/jacobian-observation-proxy.json
@@ -2,6 +2,9 @@
   "jobs_dir": "benchmarks/results/mathematical-benchmarks-v1-proxy",
   "n_attempts": 3,
   "timeout_multiplier": 1,
+  "artifacts": [
+    "/logs/agent/trajectory.json"
+  ],
   "orchestrator": {
     "type": "local",
     "n_concurrent_trials": 1,

--- a/benchmarks/datasets/mathematical-benchmarks-v1/jobs/jacobian-observation.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/jobs/jacobian-observation.json
@@ -3,7 +3,11 @@
   "n_attempts": 3,
   "timeout_multiplier": 1,
   "artifacts": [
-    "/logs/agent/trajectory.json"
+    "/logs/agent/trajectory.json",
+    {
+      "source": "/logs/jacobian/mcp.log",
+      "service": "jacobian"
+    }
   ],
   "orchestrator": {
     "type": "local",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/jobs/jacobian-observation.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/jobs/jacobian-observation.json
@@ -2,6 +2,9 @@
   "jobs_dir": "benchmarks/results/mathematical-benchmarks-v1",
   "n_attempts": 3,
   "timeout_multiplier": 1,
+  "artifacts": [
+    "/logs/agent/trajectory.json"
+  ],
   "orchestrator": {
     "type": "local",
     "n_concurrent_trials": 1,

--- a/benchmarks/schemas/harbor-job.schema.json
+++ b/benchmarks/schemas/harbor-job.schema.json
@@ -18,8 +18,26 @@
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "items": {"type": "string", "pattern": "^/.+$"},
-      "description": "Absolute container paths collected by Harbor for observation evidence."
+      "items": {
+        "oneOf": [
+          {"type": "string", "pattern": "^/.+$"},
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["source", "service"],
+            "properties": {
+              "source": {"type": "string", "pattern": "^/.+$"},
+              "destination": {"type": "string", "minLength": 1},
+              "exclude": {
+                "type": "array",
+                "items": {"type": "string", "minLength": 1}
+              },
+              "service": {"type": "string", "minLength": 1}
+            }
+          }
+        ]
+      },
+      "description": "Absolute container paths collected by Harbor for observation evidence, optionally from a named Compose sidecar."
     },
     "orchestrator": {
       "type": "object",

--- a/benchmarks/schemas/harbor-job.schema.json
+++ b/benchmarks/schemas/harbor-job.schema.json
@@ -14,6 +14,13 @@
     "jobs_dir": {"type": "string", "minLength": 1},
     "n_attempts": {"type": "integer", "minimum": 1},
     "timeout_multiplier": {"type": "number", "exclusiveMinimum": 0},
+    "artifacts": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"type": "string", "pattern": "^/.+$"},
+      "description": "Absolute container paths collected by Harbor for observation evidence."
+    },
     "orchestrator": {
       "type": "object",
       "additionalProperties": false,

--- a/benchmarks/tooling/benchmark_contracts.py
+++ b/benchmarks/tooling/benchmark_contracts.py
@@ -233,7 +233,7 @@ def _observation_pair_failures() -> list[str]:
             copy["artifacts"] = [
                 entry
                 for entry in artifacts
-                if not (isinstance(entry, dict) and entry.get("service") == "jacobian")
+                if entry != {"source": "/logs/jacobian/mcp.log", "service": "jacobian"}
             ]
         environment = copy.get("environment")
         if isinstance(environment, dict):

--- a/benchmarks/tooling/benchmark_contracts.py
+++ b/benchmarks/tooling/benchmark_contracts.py
@@ -228,6 +228,13 @@ def _observation_pair_failures() -> list[str]:
     def normalized(value: dict[str, Any]) -> dict[str, Any]:
         copy: dict[str, Any] = json.loads(json.dumps(value))
         copy.pop("jobs_dir", None)
+        artifacts = copy.get("artifacts")
+        if isinstance(artifacts, list):
+            copy["artifacts"] = [
+                entry
+                for entry in artifacts
+                if not (isinstance(entry, dict) and entry.get("service") == "jacobian")
+            ]
         environment = copy.get("environment")
         if isinstance(environment, dict):
             compose = environment.get("extra_docker_compose")
@@ -242,7 +249,7 @@ def _observation_pair_failures() -> list[str]:
     if normalized(treatment) != normalized(control):
         return [
             "agent workflow control/treatment jobs differ outside the allowed "
-            "jobs_dir and Jacobian sidecar composition"
+            "jobs_dir, Jacobian sidecar composition, and sidecar telemetry artifact"
         ]
     return []
 

--- a/benchmarks/tooling/codex_binary.py
+++ b/benchmarks/tooling/codex_binary.py
@@ -1,0 +1,75 @@
+"""Resolve the Linux Codex executable that Harbor mounts into task containers."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+_ELF_MAGIC = b"\x7fELF"
+
+
+def _is_linux_executable(path: Path) -> bool:
+    if not path.is_file() or not os.access(path, os.X_OK):
+        return False
+    try:
+        with path.open("rb") as stream:
+            return stream.read(len(_ELF_MAGIC)) == _ELF_MAGIC
+    except OSError:
+        return False
+
+
+def _npm_payload_candidates(launcher: Path) -> tuple[Path, ...]:
+    if launcher.name != "codex.js" or launcher.parent.name != "bin":
+        return ()
+    package = launcher.parent.parent
+    roots = (package / "node_modules" / "@openai", package.parent)
+    matches = {
+        path.resolve()
+        for root in roots
+        for path in root.glob("codex-linux-*/vendor/*/bin/codex")
+        if _is_linux_executable(path)
+    }
+    return tuple(sorted(matches))
+
+
+def resolve_codex_binary(candidate: Path) -> Path:
+    """Resolve a native Linux Codex binary from a binary or npm launcher path."""
+    try:
+        resolved = candidate.expanduser().resolve(strict=True)
+    except OSError as exc:
+        raise ValueError(f"Codex executable does not exist: {candidate}") from exc
+    if not os.access(resolved, os.X_OK):
+        raise ValueError(f"Codex executable is not executable: {resolved}")
+    if _is_linux_executable(resolved):
+        return resolved
+
+    payloads = _npm_payload_candidates(resolved)
+    if len(payloads) == 1:
+        return payloads[0]
+    if len(payloads) > 1:
+        rendered = ", ".join(str(path) for path in payloads)
+        raise ValueError(
+            "multiple Linux standalone Codex binaries found; set "
+            f"JACOBIAN_EVAL_CODEX_BINARY explicitly: {rendered}"
+        )
+    raise ValueError(
+        "JACOBIAN_EVAL_CODEX_BINARY must resolve to a Linux standalone Codex "
+        f"binary; no native npm payload was found for {resolved}"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--candidate", required=True, type=Path)
+    args = parser.parse_args()
+    try:
+        resolved = resolve_codex_binary(args.candidate)
+    except ValueError as exc:
+        parser.error(str(exc))
+    print(resolved)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/tooling/harbor_proxy.py
+++ b/benchmarks/tooling/harbor_proxy.py
@@ -60,7 +60,13 @@ def render_config(proxy_url: str) -> dict[str, object]:
                     },
                 },
                 "listener": {"type": "red"},
-            }
+            },
+            {
+                "name": "explicit-egress",
+                "addr": "127.0.0.1:12346",
+                "handler": {"type": "http", "chain": "upstream-proxy"},
+                "listener": {"type": "tcp"},
+            },
         ],
         "chains": [
             {

--- a/benchmarks/tooling/harbor_proxy.py
+++ b/benchmarks/tooling/harbor_proxy.py
@@ -64,6 +64,7 @@ def render_config(proxy_url: str) -> dict[str, object]:
             {
                 "name": "explicit-egress",
                 "addr": "127.0.0.1:12346",
+                "bypass": "allowlist",
                 "handler": {"type": "http", "chain": "upstream-proxy"},
                 "listener": {"type": "tcp"},
             },

--- a/benchmarks/tooling/observation_artifacts.py
+++ b/benchmarks/tooling/observation_artifacts.py
@@ -11,12 +11,43 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from collections import Counter
 from pathlib import Path
 from typing import Any
 
 from benchmarks.tooling.errors import HarborSuiteError
 from jacobian.eval.telemetry import parse_reasoning_protocol_trace
+
+_UNIFIED_EXEC_JACOBIAN_CALL = re.compile(
+    r"\btools\.(mcp__jacobian__(?:math_find|math_run|reasoning_write))\s*\("
+)
+
+
+def _canonical_tool_name(value: str) -> str:
+    aliases = {
+        "mcp__jacobian__math_find": "math.find",
+        "mcp__jacobian__math_run": "math.run",
+        "mcp__jacobian__reasoning_write": "reasoning.write",
+    }
+    return aliases.get(value, value)
+
+
+def _record_atif_tool_call(value: dict[str, Any], calls: Counter[str]) -> None:
+    function_name = value.get("function_name")
+    if not isinstance(function_name, str) or not isinstance(
+        value.get("tool_call_id"), str
+    ):
+        return
+    calls[_canonical_tool_name(function_name)] += 1
+    if function_name != "exec":
+        return
+    arguments = value.get("arguments")
+    source = arguments.get("input") if isinstance(arguments, dict) else None
+    if not isinstance(source, str):
+        return
+    for match in _UNIFIED_EXEC_JACOBIAN_CALL.finditer(source):
+        calls[_canonical_tool_name(match.group(1))] += 1
 
 
 def _read_json(path: Path) -> Any:
@@ -37,12 +68,17 @@ def _walk_trace(value: Any, calls: Counter[str]) -> int:
         return 0
     tool_name = value.get("tool_name")
     if isinstance(tool_name, str):
-        calls[tool_name] += 1
-    if value.get("type") in {"tool_call", "tool_use"} and isinstance(
+        calls[_canonical_tool_name(tool_name)] += 1
+    elif value.get("type") in {"tool_call", "tool_use"} and isinstance(
         value.get("name"), str
     ):
-        calls[str(value["name"])] += 1
-    own_error = int(value.get("error") not in {None, False, ""})
+        calls[_canonical_tool_name(str(value["name"]))] += 1
+    elif value.get("type") == "mcp_tool_call" and isinstance(value.get("tool"), str):
+        calls[_canonical_tool_name(str(value["tool"]))] += 1
+    _record_atif_tool_call(value, calls)
+    own_error = int(
+        value.get("error") not in {None, False, ""} or value.get("isError") is True
+    )
     return own_error + sum(_walk_trace(child, calls) for child in value.values())
 
 
@@ -67,6 +103,20 @@ _STEPS_DIR = "steps"
 _MANIFEST_STATUSES_OK = {"ok"}
 _MANIFEST_STATUSES_NON_CONCLUSION = {"failed", "empty", "skipped"}
 _MANIFEST_STATUSES = _MANIFEST_STATUSES_OK | _MANIFEST_STATUSES_NON_CONCLUSION
+_HARBOR_CONVENTION_SOURCE = "/logs/artifacts"
+_HARBOR_CONVENTION_DESTINATION = "artifacts/logs/artifacts"
+
+
+def _is_empty_harbor_convention(entry: dict[str, Any]) -> bool:
+    """Identify Harbor's implicit, optional agent artifact directory."""
+
+    return (
+        entry.get("source") == _HARBOR_CONVENTION_SOURCE
+        and entry.get("destination") == _HARBOR_CONVENTION_DESTINATION
+        and entry.get("type") == "directory"
+        and entry.get("status") == "empty"
+        and entry.get("service") is None
+    )
 
 
 def _artifact_path_failures(path: Path, trial_root: Path) -> list[str]:
@@ -249,6 +299,10 @@ def _manifest_entry_artifacts(
     if not isinstance(entry, dict):
         return [], failures
     status = entry.get("status")
+    # Harbor 0.20 always injects its conventional publish directory. Agents do
+    # not have to use it, so its exact `empty` record carries no failed claim.
+    if not failures and _is_empty_harbor_convention(entry):
+        return [], []
     if status in _MANIFEST_STATUSES_NON_CONCLUSION:
         failures.append(
             f"trial {trial_name}: artifact manifest entry {index} has "
@@ -313,9 +367,10 @@ def _manifest_artifacts_for_dir(
     Harbor 0.20 writes ``manifest.json`` as a JSON array of entries
     ``{source, destination, type, status, service}``.  ``destination`` is the
     artifact-relative path (``artifacts/<relative>``); ``source`` is the
-    canonical container source path.  Only ``ok`` entries have a collected
+    canonical container source path. Only ``ok`` entries have a collected
     file on disk; ``failed``/``empty``/``skipped`` are non-conclusion records
-    that are surfaced as failures because evidence is incomplete.
+    that are surfaced as failures because evidence is incomplete, except for
+    Harbor's implicit optional convention directory when it is unused.
     """
 
     failures: list[str] = []

--- a/benchmarks/tooling/observation_artifacts.py
+++ b/benchmarks/tooling/observation_artifacts.py
@@ -19,8 +19,15 @@ from typing import Any
 from benchmarks.tooling.errors import HarborSuiteError
 from jacobian.eval.telemetry import parse_reasoning_protocol_trace
 
-_UNIFIED_EXEC_JACOBIAN_CALL = re.compile(
-    r"\btools\.(mcp__jacobian__(?:math_find|math_run|reasoning_write))\s*\("
+_MCP_TOOL_CALL = re.compile(
+    r"\bMCP tool call tool=(math\.(?:find|run)|reasoning\.write)\b"
+    r".{0,512}?\bstatus=(success|error)\b",
+    re.DOTALL,
+)
+_MCP_CAPABILITY_ATTEMPT = re.compile(
+    r"\bMCP capability attempt\b.{0,2048}?"
+    r"\bexecution_status=([A-Z_]+)\b",
+    re.DOTALL,
 )
 
 
@@ -33,21 +40,33 @@ def _canonical_tool_name(value: str) -> str:
     return aliases.get(value, value)
 
 
-def _record_atif_tool_call(value: dict[str, Any], calls: Counter[str]) -> None:
-    function_name = value.get("function_name")
-    if not isinstance(function_name, str) or not isinstance(
-        value.get("tool_call_id"), str
-    ):
-        return
-    calls[_canonical_tool_name(function_name)] += 1
-    if function_name != "exec":
-        return
-    arguments = value.get("arguments")
-    source = arguments.get("input") if isinstance(arguments, dict) else None
-    if not isinstance(source, str):
-        return
-    for match in _UNIFIED_EXEC_JACOBIAN_CALL.finditer(source):
-        calls[_canonical_tool_name(match.group(1))] += 1
+def _read_mcp_runtime_log(path: Path, calls: Counter[str]) -> int:
+    """Count server-observed MCP calls and failed mathematical attempts."""
+
+    errors = 0
+    pending_run_failures = 0
+    text = path.read_text(encoding="utf-8")
+    events = sorted(
+        [
+            (match.start(), "attempt", match)
+            for match in _MCP_CAPABILITY_ATTEMPT.finditer(text)
+        ]
+        + [(match.start(), "tool", match) for match in _MCP_TOOL_CALL.finditer(text)],
+        key=lambda item: item[0],
+    )
+    for _position, event_type, match in events:
+        if event_type == "attempt":
+            if match.group(1) != "COMPLETED":
+                pending_run_failures += 1
+            continue
+        tool, status = match.groups()
+        calls[tool] += 1
+        if tool == "math.run" and pending_run_failures:
+            errors += 1
+            pending_run_failures -= 1
+        elif status == "error":
+            errors += 1
+    return errors + pending_run_failures
 
 
 def _read_json(path: Path) -> Any:
@@ -61,37 +80,61 @@ def _sha256(path: Path) -> str:
     return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
 
 
-def _walk_trace(value: Any, calls: Counter[str]) -> int:
+def _walk_trace(
+    value: Any,
+    calls: Counter[str],
+    *,
+    ignored_tools: frozenset[str] = frozenset(),
+) -> int:
     if isinstance(value, list):
-        return sum(_walk_trace(child, calls) for child in value)
+        return sum(
+            _walk_trace(child, calls, ignored_tools=ignored_tools) for child in value
+        )
     if not isinstance(value, dict):
         return 0
+    observed_tool: str | None = None
     tool_name = value.get("tool_name")
     if isinstance(tool_name, str):
-        calls[_canonical_tool_name(tool_name)] += 1
+        observed_tool = _canonical_tool_name(tool_name)
     elif value.get("type") in {"tool_call", "tool_use"} and isinstance(
         value.get("name"), str
     ):
-        calls[_canonical_tool_name(str(value["name"]))] += 1
+        observed_tool = _canonical_tool_name(str(value["name"]))
     elif value.get("type") == "mcp_tool_call" and isinstance(value.get("tool"), str):
-        calls[_canonical_tool_name(str(value["tool"]))] += 1
-    _record_atif_tool_call(value, calls)
+        observed_tool = _canonical_tool_name(str(value["tool"]))
+    function_name = value.get("function_name")
+    if isinstance(function_name, str) and isinstance(value.get("tool_call_id"), str):
+        observed_tool = _canonical_tool_name(function_name)
+    if observed_tool in ignored_tools:
+        return 0
+    if observed_tool is not None:
+        calls[observed_tool] += 1
     own_error = int(
         value.get("error") not in {None, False, ""} or value.get("isError") is True
     )
-    return own_error + sum(_walk_trace(child, calls) for child in value.values())
+    return own_error + sum(
+        _walk_trace(child, calls, ignored_tools=ignored_tools)
+        for child in value.values()
+    )
 
 
-def _read_trace(path: Path, calls: Counter[str]) -> int:
+def _read_trace(
+    path: Path,
+    calls: Counter[str],
+    *,
+    ignored_tools: frozenset[str] = frozenset(),
+) -> int:
     try:
+        if path.suffix == ".log":
+            return _read_mcp_runtime_log(path, calls)
         if path.suffix == ".jsonl":
             return sum(
-                _walk_trace(json.loads(line), calls)
+                _walk_trace(json.loads(line), calls, ignored_tools=ignored_tools)
                 for line in path.read_text(encoding="utf-8").splitlines()
                 if line.strip()
             )
         if path.suffix == ".json":
-            return _walk_trace(_read_json(path), calls)
+            return _walk_trace(_read_json(path), calls, ignored_tools=ignored_tools)
     except (OSError, json.JSONDecodeError, HarborSuiteError):
         return 1
     return 0
@@ -107,7 +150,9 @@ _HARBOR_CONVENTION_SOURCE = "/logs/artifacts"
 _HARBOR_CONVENTION_DESTINATION = "artifacts/logs/artifacts"
 
 
-def _is_empty_harbor_convention(entry: dict[str, Any]) -> bool:
+def _is_empty_harbor_convention(
+    entry: dict[str, Any], configured_artifacts: set[tuple[str, str | None]]
+) -> bool:
     """Identify Harbor's implicit, optional agent artifact directory."""
 
     return (
@@ -116,6 +161,7 @@ def _is_empty_harbor_convention(entry: dict[str, Any]) -> bool:
         and entry.get("type") == "directory"
         and entry.get("status") == "empty"
         and entry.get("service") is None
+        and (_HARBOR_CONVENTION_SOURCE, None) not in configured_artifacts
     )
 
 
@@ -293,6 +339,7 @@ def _manifest_entry_artifacts(
     step_index: int,
     step_name: str | None,
     source_prefix: str | None = None,
+    configured_artifacts: set[tuple[str, str | None]] | None = None,
 ) -> tuple[list[dict[str, Any]], list[str]]:
     location = f"trial {trial_name} manifest[{index}]"
     failures = _validate_manifest_entry(entry, location=location)
@@ -301,7 +348,9 @@ def _manifest_entry_artifacts(
     status = entry.get("status")
     # Harbor 0.20 always injects its conventional publish directory. Agents do
     # not have to use it, so its exact `empty` record carries no failed claim.
-    if not failures and _is_empty_harbor_convention(entry):
+    if not failures and _is_empty_harbor_convention(
+        entry, configured_artifacts or set()
+    ):
         return [], []
     if status in _MANIFEST_STATUSES_NON_CONCLUSION:
         failures.append(
@@ -361,6 +410,7 @@ def _manifest_artifacts_for_dir(
     step_index: int,
     step_name: str | None,
     source_prefix: str | None = None,
+    configured_artifacts: set[tuple[str, str | None]] | None = None,
 ) -> tuple[list[dict[str, Any]], list[str]]:
     """Read one ``artifacts/manifest.json`` and bind every ``ok`` entry.
 
@@ -398,6 +448,24 @@ def _manifest_artifacts_for_dir(
     if not raw:
         failures.append(f"trial {trial_name}: artifact manifest is empty")
         return [], failures
+    configured = configured_artifacts or set()
+    observed = {
+        (
+            entry.get("source"),
+            None if entry.get("service") in {None, "main"} else entry.get("service"),
+        )
+        for entry in raw
+        if isinstance(entry, dict)
+        and isinstance(entry.get("source"), str)
+        and (entry.get("service") is None or isinstance(entry.get("service"), str))
+    }
+    for source, service in sorted(
+        configured - observed, key=lambda item: (item[0], item[1] or "")
+    ):
+        failures.append(
+            f"trial {trial_name}: configured artifact is missing from manifest "
+            f"(source={source!r}, service={service!r})"
+        )
     artifacts: list[dict[str, Any]] = []
     for index, entry in enumerate(raw):
         entry_artifacts, entry_failures = _manifest_entry_artifacts(
@@ -410,6 +478,7 @@ def _manifest_artifacts_for_dir(
             step_index=step_index,
             step_name=step_name,
             source_prefix=source_prefix,
+            configured_artifacts=configured_artifacts,
         )
         artifacts.extend(entry_artifacts)
         failures.extend(entry_failures)
@@ -467,6 +536,7 @@ def trial_artifacts(
     job_label: str,
     *,
     source_prefix: str | None = None,
+    configured_artifacts: set[tuple[str, str | None]] | None = None,
 ) -> tuple[list[dict[str, Any]], dict[str, int], int, list[str]]:
     """Collect manifest-driven artifacts for one trial.
 
@@ -501,6 +571,7 @@ def trial_artifacts(
                 step_index=step_index,
                 step_name=step_dir.name,
                 source_prefix=source_prefix,
+                configured_artifacts=configured_artifacts,
             )
             artifacts.extend(step_artifacts)
             failures.extend(step_failures)
@@ -513,6 +584,7 @@ def trial_artifacts(
             step_index=0,
             step_name=None,
             source_prefix=source_prefix,
+            configured_artifacts=configured_artifacts,
         )
         artifacts.extend(step_artifacts)
         failures.extend(step_failures)
@@ -520,15 +592,30 @@ def trial_artifacts(
     # source_path (which includes the artifacts/ or steps/<step>/artifacts/
     # prefix); it never introduces artifacts on its own.
     calls: Counter[str] = Counter()
-    trace_paths = [
+    runtime_logs = [
         _artifact_host_path(root, artifact)
         for artifact in artifacts
-        if any(
+        if artifact.get("service") == "jacobian"
+        and Path(artifact["artifact_path"]).suffix == ".log"
+    ]
+    agent_traces = [
+        _artifact_host_path(root, artifact)
+        for artifact in artifacts
+        if artifact.get("service") != "jacobian"
+        and any(
             marker in Path(artifact["artifact_path"]).name.lower()
             for marker in ("trajectory", "atif", "telemetry")
         )
     ]
-    errors = sum(_read_trace(path, calls) for path in trace_paths)
+    ignored_tools = (
+        frozenset({"math.find", "math.run", "reasoning.write"})
+        if runtime_logs
+        else frozenset()
+    )
+    errors = sum(
+        _read_trace(path, calls, ignored_tools=ignored_tools) for path in agent_traces
+    )
+    errors += sum(_read_trace(path, calls) for path in runtime_logs)
     return artifacts, dict(sorted(calls.items())), errors, failures
 
 

--- a/benchmarks/tooling/observation_artifacts.py
+++ b/benchmarks/tooling/observation_artifacts.py
@@ -21,12 +21,13 @@ from jacobian.eval.telemetry import parse_reasoning_protocol_trace
 
 _MCP_TOOL_CALL = re.compile(
     r"\bMCP tool call tool=(math\.(?:find|run)|reasoning\.write)\b"
-    r".{0,512}?\bstatus=(success|error)\b",
+    r".{0,512}?\bstatus=(success|error)\b"
+    r".{0,512}?\brequest_digest=([0-9a-f]{16}|none)\b",
     re.DOTALL,
 )
 _MCP_CAPABILITY_ATTEMPT = re.compile(
-    r"\bMCP capability attempt\b.{0,2048}?"
-    r"\bexecution_status=([A-Z_]+)\b",
+    r"\bMCP capability attempt request_digest=([0-9a-f]{16}|none)\b"
+    r".{0,2048}?\bexecution_status=([A-Z_]+)\b",
     re.DOTALL,
 )
 
@@ -43,30 +44,23 @@ def _canonical_tool_name(value: str) -> str:
 def _read_mcp_runtime_log(path: Path, calls: Counter[str]) -> int:
     """Count server-observed MCP calls and failed mathematical attempts."""
 
-    errors = 0
-    pending_run_failures = 0
     text = path.read_text(encoding="utf-8")
-    events = sorted(
-        [
-            (match.start(), "attempt", match)
-            for match in _MCP_CAPABILITY_ATTEMPT.finditer(text)
-        ]
-        + [(match.start(), "tool", match) for match in _MCP_TOOL_CALL.finditer(text)],
-        key=lambda item: item[0],
-    )
-    for _position, event_type, match in events:
-        if event_type == "attempt":
-            if match.group(1) != "COMPLETED":
-                pending_run_failures += 1
-            continue
-        tool, status = match.groups()
+    failed_attempts: Counter[str] = Counter()
+    transport_errors: Counter[str] = Counter()
+    for match in _MCP_CAPABILITY_ATTEMPT.finditer(text):
+        request_digest, execution_status = match.groups()
+        if execution_status != "COMPLETED":
+            failed_attempts[request_digest] += 1
+    for match in _MCP_TOOL_CALL.finditer(text):
+        tool, status, request_digest = match.groups()
         calls[tool] += 1
-        if tool == "math.run" and pending_run_failures:
-            errors += 1
-            pending_run_failures -= 1
-        elif status == "error":
-            errors += 1
-    return errors + pending_run_failures
+        if status == "error":
+            transport_errors[request_digest] += 1
+    request_digests = set(failed_attempts) | set(transport_errors)
+    return sum(
+        max(failed_attempts[digest], transport_errors[digest])
+        for digest in request_digests
+    )
 
 
 def _read_json(path: Path) -> Any:
@@ -123,9 +117,10 @@ def _read_trace(
     calls: Counter[str],
     *,
     ignored_tools: frozenset[str] = frozenset(),
+    mcp_runtime_log: bool = False,
 ) -> int:
     try:
-        if path.suffix == ".log":
+        if mcp_runtime_log:
             return _read_mcp_runtime_log(path, calls)
         if path.suffix == ".jsonl":
             return sum(
@@ -135,7 +130,7 @@ def _read_trace(
             )
         if path.suffix == ".json":
             return _walk_trace(_read_json(path), calls, ignored_tools=ignored_tools)
-    except (OSError, json.JSONDecodeError, HarborSuiteError):
+    except (OSError, UnicodeError, json.JSONDecodeError, HarborSuiteError):
         return 1
     return 0
 
@@ -549,7 +544,15 @@ def trial_artifacts(
     """
 
     if trial_path is None:
-        return [], {}, 0, []
+        inline_failures = [
+            f"trial {trial_name}: configured artifact is missing without a "
+            f"trial manifest (source={source!r}, service={service!r})"
+            for source, service in sorted(
+                configured_artifacts or set(),
+                key=lambda item: (item[0], item[1] or ""),
+            )
+        ]
+        return [], {}, 0, inline_failures
     root = trial_path.parent
     artifacts: list[dict[str, Any]] = []
     failures: list[str] = []
@@ -596,7 +599,7 @@ def trial_artifacts(
         _artifact_host_path(root, artifact)
         for artifact in artifacts
         if artifact.get("service") == "jacobian"
-        and Path(artifact["artifact_path"]).suffix == ".log"
+        and artifact.get("manifest_source") == "/logs/jacobian/mcp.log"
     ]
     agent_traces = [
         _artifact_host_path(root, artifact)
@@ -615,7 +618,9 @@ def trial_artifacts(
     errors = sum(
         _read_trace(path, calls, ignored_tools=ignored_tools) for path in agent_traces
     )
-    errors += sum(_read_trace(path, calls) for path in runtime_logs)
+    errors += sum(
+        _read_trace(path, calls, mcp_runtime_log=True) for path in runtime_logs
+    )
     return artifacts, dict(sorted(calls.items())), errors, failures
 
 

--- a/benchmarks/tooling/observation_results.py
+++ b/benchmarks/tooling/observation_results.py
@@ -143,6 +143,13 @@ def _comparison_job(job: dict[str, Any]) -> dict[str, Any]:
 
     normalized: dict[str, Any] = json.loads(json.dumps(job))
     normalized.pop("jobs_dir", None)
+    artifacts = normalized.get("artifacts")
+    if isinstance(artifacts, list):
+        normalized["artifacts"] = [
+            entry
+            for entry in artifacts
+            if not (isinstance(entry, dict) and entry.get("service") == "jacobian")
+        ]
     environment = normalized.get("environment")
     if isinstance(environment, dict):
         compose = environment.get("extra_docker_compose")
@@ -222,6 +229,7 @@ def _normalize_trial(
     job_label: str,
     runtime: dict[str, Any] | None,
     source_prefix: str | None = None,
+    configured_artifacts: set[tuple[str, str | None]] | None = None,
 ) -> tuple[dict[str, Any], list[str]]:
     agent_result = _object(trial.get("agent_result"))
     agent_info = _object(trial.get("agent_info"))
@@ -240,6 +248,7 @@ def _normalize_trial(
             str(trial.get("trial_name", "")),
             job_label,
             source_prefix=source_prefix,
+            configured_artifacts=configured_artifacts,
         )
     )
     reasoning_protocol = observation_artifacts.trial_reasoning_protocol(
@@ -332,6 +341,22 @@ def _artifact_source_prefix(runtime: dict[str, Any] | None) -> str | None:
     if isinstance(pair_id, str) and isinstance(condition_id, str):
         return f"{pair_id}/{condition_id}"
     return None
+
+
+def _configured_artifacts(job: dict[str, Any]) -> set[tuple[str, str | None]]:
+    configured: set[tuple[str, str | None]] = set()
+    artifacts = job.get("artifacts")
+    if not isinstance(artifacts, list):
+        return configured
+    for artifact in artifacts:
+        if isinstance(artifact, str):
+            configured.add((artifact, None))
+        elif isinstance(artifact, dict) and isinstance(artifact.get("source"), str):
+            service = artifact.get("service")
+            configured.add(
+                (artifact["source"], None if service in {None, "main"} else service)
+            )
+    return configured
 
 
 def _observation_failures(
@@ -560,6 +585,7 @@ def build_observation_evidence(
     artifact_failures: list[str] = []
     job_label = _display_path(job_path)
     source_prefix = _artifact_source_prefix(runtime_snapshot)
+    configured_artifacts = _configured_artifacts(job)
     for path, raw in raw_trials:
         task = _task_id(raw.get("task_name"))
         repetition = counters[task]
@@ -575,6 +601,7 @@ def build_observation_evidence(
             job_label=job_label,
             runtime=runtime_snapshot,
             source_prefix=source_prefix,
+            configured_artifacts=configured_artifacts,
         )
         artifact_failures.extend(trial_artifact_failures)
         trials.append(normalized)

--- a/benchmarks/tooling/observation_results.py
+++ b/benchmarks/tooling/observation_results.py
@@ -148,7 +148,7 @@ def _comparison_job(job: dict[str, Any]) -> dict[str, Any]:
         normalized["artifacts"] = [
             entry
             for entry in artifacts
-            if not (isinstance(entry, dict) and entry.get("service") == "jacobian")
+            if entry != {"source": "/logs/jacobian/mcp.log", "service": "jacobian"}
         ]
     environment = normalized.get("environment")
     if isinstance(environment, dict):

--- a/benchmarks/validation/test_harbor_task_workflow.py
+++ b/benchmarks/validation/test_harbor_task_workflow.py
@@ -211,3 +211,40 @@ def test_validate_fails_fast_after_static_failure(
         workflow.validate(selection)
 
     assert calls == ["static-quality"]
+
+
+def test_oracle_evidence_freshness_rejects_unchanged_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    selection = workflow.TaskSelection("dataset-one", ("task-a",), (tmp_path,), ())
+    evidence = (
+        tmp_path / "benchmarks/results/dataset-one-oracle/job/oracle-evidence.json"
+    )
+    evidence.parent.mkdir(parents=True)
+    evidence.write_text(
+        json.dumps(
+            {
+                "dataset": "dataset-one",
+                "tasks": [{"task": "task-a", "digest": "sha256:old"}],
+            }
+        )
+    )
+    monkeypatch.setattr(workflow, "ROOT", tmp_path)
+    previous = workflow._oracle_evidence_snapshot(selection)
+
+    with pytest.raises(workflow.TaskWorkflowError, match="no fresh evidence"):
+        workflow._fresh_oracle_evidence(selection, "task-a", previous=previous)
+
+    evidence.write_text(
+        json.dumps(
+            {
+                "dataset": "dataset-one",
+                "tasks": [{"task": "task-a", "digest": "sha256:new"}],
+            }
+        )
+    )
+
+    assert workflow._fresh_oracle_evidence(selection, "task-a", previous=previous) == (
+        "sha256:new",
+        "benchmarks/results/dataset-one-oracle/job/oracle-evidence.json",
+    )

--- a/benchmarks/validation/test_observation_comparison.py
+++ b/benchmarks/validation/test_observation_comparison.py
@@ -179,12 +179,17 @@ def test_reasoning_comparison_rejects_divergent_condition_invariants() -> None:
 
 def test_comparison_normalization_allows_only_frozen_jacobian_differences() -> None:
     control = {
+        "artifacts": ["/logs/agent/trajectory.json"],
         "environment": {
             "extra_docker_compose": ["benchmarks/config/agent-eval-proxy.compose.yaml"]
         },
         "agents": [{"name": "codex"}],
     }
     treatment = {
+        "artifacts": [
+            "/logs/agent/trajectory.json",
+            {"source": "/logs/jacobian/mcp.log", "service": "jacobian"},
+        ],
         "environment": {
             "extra_docker_compose": [
                 "benchmarks/config/agent-eval-proxy.compose.yaml",
@@ -207,7 +212,12 @@ def test_comparison_normalization_allows_only_frozen_jacobian_differences() -> N
 
     assert _comparison_job(control) == _comparison_job(treatment)
 
+    treatment["artifacts"].append({"source": "/state", "service": "jacobian"})
+    assert _comparison_job(control) != _comparison_job(treatment)
+    treatment["artifacts"].pop()
+
     heldout_treatment = {
+        "artifacts": ["/logs/agent/trajectory.json"],
         "environment": {
             "extra_docker_compose": [
                 "benchmarks/config/agent-eval-proxy.compose.yaml",

--- a/benchmarks/validation/test_observation_manifests.py
+++ b/benchmarks/validation/test_observation_manifests.py
@@ -252,6 +252,99 @@ def test_reasoning_protocol_is_extracted_without_summary_text(tmp_path: Path) ->
     assert "private" not in json.dumps(protocol)
 
 
+def test_atif_unified_exec_accounts_for_nested_jacobian_calls(
+    tmp_path: Path,
+) -> None:
+    trajectory = {
+        "schema_version": "ATIF-v1.7",
+        "steps": [
+            {
+                "tool_calls": [
+                    {
+                        "tool_call_id": "call-1",
+                        "function_name": "exec",
+                        "arguments": {
+                            "input": "\n".join(
+                                [
+                                    "const toolsText = 'math.run is available';",
+                                    "await tools.mcp__jacobian__math_find({});",
+                                    "await tools.mcp__jacobian__math_run({});",
+                                    "await tools.mcp__jacobian__math_run({});",
+                                ]
+                            )
+                        },
+                    }
+                ],
+                "observation": {"results": []},
+            }
+        ],
+    }
+    trial_dir = tmp_path / "job" / "attempt-0"
+    _write_trial_manifest(
+        trial_dir,
+        [
+            {
+                "source": "/logs/agent/trajectory.json",
+                "destination": "artifacts/logs/agent/trajectory.json",
+                "type": "file",
+                "status": "ok",
+                "service": None,
+                "_content": json.dumps(trajectory),
+            }
+        ],
+    )
+    result_path = trial_dir / "result.json"
+    result_path.write_text("{}", encoding="utf-8")
+
+    _artifacts, calls, errors, failures = _trial_artifacts(
+        result_path, "attempt-0", "job.json"
+    )
+
+    assert calls == {"exec": 1, "math.find": 1, "math.run": 2}
+    assert errors == 0
+    assert failures == []
+
+
+def test_codex_mcp_events_account_for_canonical_tool_names_and_errors(
+    tmp_path: Path,
+) -> None:
+    events = [
+        _tool_event("mcp__jacobian__math_find", {}, {"matches": []}),
+        {
+            "type": "item.completed",
+            "item": {
+                "type": "mcp_tool_call",
+                "tool": "mcp__jacobian__math_run",
+                "result": {"isError": True},
+            },
+        },
+    ]
+    trial_dir = tmp_path / "job" / "attempt-0"
+    _write_trial_manifest(
+        trial_dir,
+        [
+            {
+                "source": "/logs/agent/trajectory.jsonl",
+                "destination": "artifacts/logs/agent/trajectory.jsonl",
+                "type": "file",
+                "status": "ok",
+                "service": None,
+                "_content": "\n".join(json.dumps(event) for event in events) + "\n",
+            }
+        ],
+    )
+    result_path = trial_dir / "result.json"
+    result_path.write_text("{}", encoding="utf-8")
+
+    _artifacts, calls, errors, failures = _trial_artifacts(
+        result_path, "attempt-0", "job.json"
+    )
+
+    assert calls == {"math.find": 1, "math.run": 1}
+    assert errors == 1
+    assert failures == []
+
+
 def test_heldout_artifact_source_paths_include_pair_and_condition(
     tmp_path: Path,
 ) -> None:
@@ -475,6 +568,58 @@ def test_directory_manifest_empty_ok_is_failure(tmp_path: Path) -> None:
 
     assert artifacts == []
     assert any("unexpectedly empty" in f for f in failures)
+
+
+def test_implicit_empty_harbor_convention_is_not_a_failure(tmp_path: Path) -> None:
+    trial_dir = tmp_path / "trial-0"
+    trial_dir.mkdir()
+    artifacts_dir = trial_dir / "artifacts"
+    artifacts_dir.mkdir()
+    manifest = [
+        {
+            "source": "/logs/artifacts",
+            "destination": "artifacts/logs/artifacts",
+            "type": "directory",
+            "status": "empty",
+            "service": None,
+        }
+    ]
+    (artifacts_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    result_path = trial_dir / "result.json"
+    result_path.write_text("{}", encoding="utf-8")
+
+    artifacts, _calls, _errors, failures = _trial_artifacts(
+        result_path, "attempt-0", "job.json"
+    )
+
+    assert artifacts == []
+    assert failures == []
+
+
+def test_empty_non_convention_manifest_entry_is_a_failure(tmp_path: Path) -> None:
+    trial_dir = tmp_path / "trial-0"
+    trial_dir.mkdir()
+    _write_trial_manifest(
+        trial_dir,
+        [
+            {
+                "source": "/app/evidence",
+                "destination": "artifacts/app/evidence",
+                "type": "directory",
+                "status": "empty",
+                "service": None,
+            }
+        ],
+    )
+    result_path = trial_dir / "result.json"
+    result_path.write_text("{}", encoding="utf-8")
+
+    artifacts, _calls, _errors, failures = _trial_artifacts(
+        result_path, "attempt-0", "job.json"
+    )
+
+    assert artifacts == []
+    assert any("non-conclusion status" in failure for failure in failures)
 
 
 def test_directory_manifest_missing_dir_is_failure(tmp_path: Path) -> None:

--- a/benchmarks/validation/test_observation_manifests.py
+++ b/benchmarks/validation/test_observation_manifests.py
@@ -252,7 +252,7 @@ def test_reasoning_protocol_is_extracted_without_summary_text(tmp_path: Path) ->
     assert "private" not in json.dumps(protocol)
 
 
-def test_atif_unified_exec_accounts_for_nested_jacobian_calls(
+def test_server_runtime_log_accounts_for_nested_jacobian_calls(
     tmp_path: Path,
 ) -> None:
     trajectory = {
@@ -266,10 +266,9 @@ def test_atif_unified_exec_accounts_for_nested_jacobian_calls(
                         "arguments": {
                             "input": "\n".join(
                                 [
-                                    "const toolsText = 'math.run is available';",
-                                    "await tools.mcp__jacobian__math_find({});",
-                                    "await tools.mcp__jacobian__math_run({});",
-                                    "await tools.mcp__jacobian__math_run({});",
+                                    "if (false) await tools.mcp__jacobian__math_find({});",
+                                    "for (let i = 0; i < 3; i++)",
+                                    "  await tools.mcp__jacobian__math_run({});",
                                 ]
                             )
                         },
@@ -290,7 +289,25 @@ def test_atif_unified_exec_accounts_for_nested_jacobian_calls(
                 "status": "ok",
                 "service": None,
                 "_content": json.dumps(trajectory),
-            }
+            },
+            {
+                "source": "/logs/jacobian/mcp.log",
+                "destination": "artifacts/logs/jacobian/mcp.log",
+                "type": "file",
+                "status": "ok",
+                "service": "jacobian",
+                "_content": "\n".join(
+                    [
+                        "INFO MCP capability attempt execution_status=COMPLETED",
+                        "INFO MCP tool call tool=math.run          server.py:314",
+                        "     status=success duration_ms=1.0",
+                        "INFO MCP capability attempt execution_status=ERROR",
+                        "INFO MCP tool call tool=math.run status=success",
+                        "INFO MCP capability attempt execution_status=COMPLETED",
+                        "INFO MCP tool call tool=math.run status=success",
+                    ]
+                ),
+            },
         ],
     )
     result_path = trial_dir / "result.json"
@@ -300,8 +317,8 @@ def test_atif_unified_exec_accounts_for_nested_jacobian_calls(
         result_path, "attempt-0", "job.json"
     )
 
-    assert calls == {"exec": 1, "math.find": 1, "math.run": 2}
-    assert errors == 0
+    assert calls == {"exec": 1, "math.run": 3}
+    assert errors == 1
     assert failures == []
 
 
@@ -594,6 +611,70 @@ def test_implicit_empty_harbor_convention_is_not_a_failure(tmp_path: Path) -> No
 
     assert artifacts == []
     assert failures == []
+
+
+def test_explicit_empty_harbor_convention_is_a_failure(tmp_path: Path) -> None:
+    trial_dir = tmp_path / "trial-0"
+    trial_dir.mkdir()
+    artifacts_dir = trial_dir / "artifacts"
+    artifacts_dir.mkdir()
+    manifest = [
+        {
+            "source": "/logs/artifacts",
+            "destination": "artifacts/logs/artifacts",
+            "type": "directory",
+            "status": "empty",
+            "service": None,
+        }
+    ]
+    (artifacts_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    result_path = trial_dir / "result.json"
+    result_path.write_text("{}", encoding="utf-8")
+
+    artifacts, _calls, _errors, failures = _trial_artifacts(
+        result_path,
+        "attempt-0",
+        "job.json",
+        configured_artifacts={("/logs/artifacts", None)},
+    )
+
+    assert artifacts == []
+    assert any("non-conclusion status" in failure for failure in failures)
+
+
+def test_missing_configured_sidecar_artifact_is_a_failure(tmp_path: Path) -> None:
+    trial_dir = tmp_path / "trial-0"
+    trial_dir.mkdir()
+    _write_trial_manifest(
+        trial_dir,
+        [
+            {
+                "source": "/logs/agent/trajectory.json",
+                "destination": "artifacts/logs/agent/trajectory.json",
+                "type": "file",
+                "status": "ok",
+                "service": None,
+                "_content": '{"steps": []}',
+            }
+        ],
+    )
+    result_path = trial_dir / "result.json"
+    result_path.write_text("{}", encoding="utf-8")
+
+    _artifacts, _calls, _errors, failures = _trial_artifacts(
+        result_path,
+        "attempt-0",
+        "job.json",
+        configured_artifacts={
+            ("/logs/agent/trajectory.json", None),
+            ("/logs/jacobian/mcp.log", "jacobian"),
+        },
+    )
+
+    assert any(
+        "configured artifact is missing" in failure and "service='jacobian'" in failure
+        for failure in failures
+    )
 
 
 def test_empty_non_convention_manifest_entry_is_a_failure(tmp_path: Path) -> None:

--- a/benchmarks/validation/test_observation_manifests.py
+++ b/benchmarks/validation/test_observation_manifests.py
@@ -292,19 +292,22 @@ def test_server_runtime_log_accounts_for_nested_jacobian_calls(
             },
             {
                 "source": "/logs/jacobian/mcp.log",
-                "destination": "artifacts/logs/jacobian/mcp.log",
+                "destination": "artifacts/telemetry/runtime.txt",
                 "type": "file",
                 "status": "ok",
                 "service": "jacobian",
                 "_content": "\n".join(
                     [
-                        "INFO MCP capability attempt execution_status=COMPLETED",
+                        "INFO MCP capability attempt request_digest=aaaaaaaaaaaaaaaa",
+                        "     execution_status=ERROR",
+                        "INFO MCP tool call tool=math.run status=error",
+                        "     request_digest=bbbbbbbbbbbbbbbb",
+                        "INFO MCP capability attempt request_digest=cccccccccccccccc",
+                        "     execution_status=COMPLETED",
                         "INFO MCP tool call tool=math.run          server.py:314",
-                        "     status=success duration_ms=1.0",
-                        "INFO MCP capability attempt execution_status=ERROR",
+                        "     status=success request_digest=aaaaaaaaaaaaaaaa",
                         "INFO MCP tool call tool=math.run status=success",
-                        "INFO MCP capability attempt execution_status=COMPLETED",
-                        "INFO MCP tool call tool=math.run status=success",
+                        "     request_digest=cccccccccccccccc",
                     ]
                 ),
             },
@@ -318,7 +321,7 @@ def test_server_runtime_log_accounts_for_nested_jacobian_calls(
     )
 
     assert calls == {"exec": 1, "math.run": 3}
-    assert errors == 1
+    assert errors == 2
     assert failures == []
 
 
@@ -675,6 +678,54 @@ def test_missing_configured_sidecar_artifact_is_a_failure(tmp_path: Path) -> Non
         "configured artifact is missing" in failure and "service='jacobian'" in failure
         for failure in failures
     )
+
+
+def test_inline_trial_rejects_every_configured_artifact_as_missing() -> None:
+    artifacts, calls, errors, failures = _trial_artifacts(
+        None,
+        "attempt-0",
+        "job.json",
+        configured_artifacts={
+            ("/logs/agent/trajectory.json", None),
+            ("/logs/jacobian/mcp.log", "jacobian"),
+        },
+    )
+
+    assert artifacts == []
+    assert calls == {}
+    assert errors == 0
+    assert len(failures) == 2
+    assert all("missing without a trial manifest" in failure for failure in failures)
+
+
+def test_non_utf8_runtime_log_is_a_fail_closed_tool_error(tmp_path: Path) -> None:
+    trial_dir = tmp_path / "trial-0"
+    trial_dir.mkdir()
+    _write_trial_manifest(
+        trial_dir,
+        [
+            {
+                "source": "/logs/jacobian/mcp.log",
+                "destination": "artifacts/telemetry/runtime.bin",
+                "type": "file",
+                "status": "ok",
+                "service": "jacobian",
+                "_content": "placeholder",
+            }
+        ],
+    )
+    runtime_log = trial_dir / "artifacts" / "telemetry" / "runtime.bin"
+    runtime_log.write_bytes(b"MCP tool call \xff")
+    result_path = trial_dir / "result.json"
+    result_path.write_text("{}", encoding="utf-8")
+
+    _artifacts, calls, errors, failures = _trial_artifacts(
+        result_path, "attempt-0", "job.json"
+    )
+
+    assert calls == {}
+    assert errors == 1
+    assert failures == []
 
 
 def test_empty_non_convention_manifest_entry_is_a_failure(tmp_path: Path) -> None:

--- a/docs/how-to/run-agent-evaluations.md
+++ b/docs/how-to/run-agent-evaluations.md
@@ -79,14 +79,20 @@ Linux, the host proxy must accept connections from Docker's bridge interface;
 a proxy listening only on `127.0.0.1` is not reachable from the container.
 
 This proxy profile is optional host integration, not part of a task contract.
-It renders a private runtime configuration that chains Harbor's transparent
-egress controller through the upstream proxy, so Harbor's task allowlist stays
-in force. Codex and Jacobian share Harbor's controlled network namespace, and
-MCP uses its loopback interface, so local tool traffic never enters the
-upstream chain. All jobs also mount the host's standalone Codex executable to
-avoid a trial-time package install; override its resolved path with
-`JACOBIAN_EVAL_CODEX_BINARY`. Keep machine-specific Clash addresses in local
-environment variables rather than committed configuration.
+It renders a private runtime configuration with both Harbor's transparent
+egress listener and a loopback HTTP proxy chained to the upstream proxy, so
+Harbor's task allowlist stays in force and upstream DNS resolution works for
+proxy-aware clients. Codex uses the loopback listener. Codex and Jacobian share
+Harbor's controlled network namespace, and MCP uses its loopback interface, so
+local tool traffic never enters the upstream chain.
+
+Proxy jobs also mount the host's standalone Codex executable to avoid a
+trial-time package install. When `codex` is installed through npm, the runner
+automatically resolves the bundled native Linux executable instead of mounting
+the JavaScript launcher without Node. Set `JACOBIAN_EVAL_CODEX_BINARY` only to
+override that candidate; the resolved file must be an executable Linux ELF.
+Keep machine-specific Clash addresses in local environment variables rather
+than committed configuration.
 
 ## Run with Jacobian
 
@@ -222,6 +228,12 @@ For Jacobian treatment runs, inspect Harbor ATIF together with Jacobian
 telemetry. Check capability discovery and descriptions, invocation and
 parameter errors, artifact and verification-record flow, repeated or
 irrelevant calls, shell/file activity, tokens, time, and completion.
+The committed observation jobs explicitly collect Codex's ATIF trajectory from
+`/logs/agent/trajectory.json`, allowing the normalizer to measure tool adoption
+from manifest-bound evidence. Harbor 0.20 also records its implicit
+`/logs/artifacts` publish directory; `empty` is expected there when the agent
+publishes no optional files. Failures for explicitly configured artifacts
+remain non-conclusions.
 
 For a paired control/treatment run, normalize each condition and then compare
 them so task digests, prompts, models, budgets, and job configuration are
@@ -229,9 +241,10 @@ checked for drift:
 
 ```sh
 make agent-eval-validate RESULTS=benchmarks/results/mathematical-benchmarks-v1 \
-  JOB=<job-name> CONDITION=control OUTPUT=benchmarks/results/normalized-control.json
+  JOB=<job-config.json> CONDITION=control \
+  OUTPUT=benchmarks/results/normalized-control.json
 make agent-eval-validate RESULTS=benchmarks/results/mathematical-benchmarks-v1 \
-  JOB=<job-name> CONDITION=treatment \
+  JOB=<job-config.json> CONDITION=treatment \
   RUNTIME_SNAPSHOT="$RUNTIME_SNAPSHOT" \
   OUTPUT=benchmarks/results/normalized-treatment.json
 make agent-eval-compare \

--- a/src/jacobian/adapters/mcp/server.py
+++ b/src/jacobian/adapters/mcp/server.py
@@ -42,6 +42,8 @@ from jacobian.adapters.mcp.resources import (
 )
 from jacobian.adapters.mcp.tooling import (
     _argument_digest,
+    _request_id_digest,
+    _request_trace_digest,
     _response_size,
     _tool_annotations,
 )
@@ -228,6 +230,8 @@ class JacobianCoreExtension(Extension):
         started = time.monotonic()
         arguments = params.arguments or {}
         argument_digest = _argument_digest(arguments)
+        request_digest = _request_id_digest(ctx)
+        trace_digest, trace_source = _request_trace_digest(ctx)
         try:
             with ExitStack() as request_resources:
                 if self._tenant_router is not None:
@@ -263,7 +267,15 @@ class JacobianCoreExtension(Extension):
                     )
                 result = await call_next(ctx)
         except MCPError:
-            _log_tool_call(params.name, started, argument_digest, status="error")
+            _log_tool_call(
+                params.name,
+                started,
+                argument_digest,
+                request_digest=request_digest,
+                trace_digest=trace_digest,
+                trace_source=trace_source,
+                status="error",
+            )
             raise
         except Exception as exc:
             _LOGGER.warning("MCP tool %s failed", params.name, exc_info=exc)
@@ -271,6 +283,9 @@ class JacobianCoreExtension(Extension):
                 params.name,
                 started,
                 argument_digest,
+                request_digest=request_digest,
+                trace_digest=trace_digest,
+                trace_source=trace_source,
                 status="error",
             )
             raise ToolError(_public_tool_error(params.name, exc)) from exc
@@ -278,6 +293,9 @@ class JacobianCoreExtension(Extension):
             params.name,
             started,
             argument_digest,
+            request_digest=request_digest,
+            trace_digest=trace_digest,
+            trace_source=trace_source,
             status="success",
             result=result,
         )
@@ -308,14 +326,21 @@ def _log_tool_call(
     started: float,
     argument_digest: str,
     *,
+    request_digest: str,
+    trace_digest: str,
+    trace_source: str,
     status: str,
     result: Any | None = None,
 ) -> None:
     _LOGGER.info(
-        "MCP tool call tool=%s status=%s duration_ms=%.3f "
+        "MCP tool call tool=%s status=%s request_digest=%s "
+        "trace_digest=%s trace_source=%s duration_ms=%.3f "
         "response_bytes=%d argument_digest=%s",
         name,
         status,
+        request_digest,
+        trace_digest,
+        trace_source,
         (time.monotonic() - started) * 1000,
         0 if result is None else _response_size(result),
         argument_digest,

--- a/src/jacobian/adapters/mcp/tooling.py
+++ b/src/jacobian/adapters/mcp/tooling.py
@@ -111,6 +111,20 @@ def _request_trace_digest(ctx: Any | None) -> tuple[str, str]:
     return digest, "request_id"
 
 
+def _request_id_digest(ctx: Any | None) -> str:
+    """Return a bounded per-request correlation digest for telemetry joins."""
+
+    if ctx is None:
+        return "none"
+    try:
+        request_id = str(ctx.request_id)
+    except (AttributeError, TypeError, ValueError):
+        return "none"
+    if not request_id or len(request_id) > 256:
+        return "none"
+    return hashlib.sha256(request_id.encode("utf-8")).hexdigest()[:16]
+
+
 def _response_size(value: Any) -> int:
     try:
         if hasattr(value, "model_dump_json"):
@@ -133,6 +147,7 @@ def _log_capability_attempt(
     mode: CapabilityMode,
     started: float,
     argument_digest: str,
+    request_digest: str,
     trace_digest: str,
     trace_source: str,
     result: CapabilityResult | None = None,
@@ -153,11 +168,12 @@ def _log_capability_attempt(
         response_bytes = 0
     codes = ",".join(diagnostic_codes[:8]) or "none"
     _LOGGER.info(
-        "MCP capability attempt trace_digest=%s trace_source=%s "
+        "MCP capability attempt request_digest=%s trace_digest=%s trace_source=%s "
         "capability_id=%s capability_version=%s mode=%s "
         "execution_status=%s assurance=%s diagnostic_codes=%s "
         "attempt_duration_ms=%.3f operation_runtime_ms=%s "
         "response_bytes=%d argument_digest=%s",
+        request_digest,
         trace_digest,
         trace_source,
         capability_id,
@@ -264,6 +280,7 @@ async def _invoke_capability_attempt(
         }
     )
     trace_digest, trace_source = _request_trace_digest(ctx)
+    request_digest = _request_id_digest(ctx)
     cancellation_event = threading.Event()
     bound = _claim_reasoning_call(
         runtime,
@@ -306,6 +323,7 @@ async def _invoke_capability_attempt(
                 mode=mode,
                 started=started,
                 argument_digest=argument_digest,
+                request_digest=request_digest,
                 trace_digest=trace_digest,
                 trace_source=trace_source,
                 result=drained,
@@ -327,6 +345,7 @@ async def _invoke_capability_attempt(
                 mode=mode,
                 started=started,
                 argument_digest=argument_digest,
+                request_digest=request_digest,
                 trace_digest=trace_digest,
                 trace_source=trace_source,
                 execution_status="CANCELLED",
@@ -350,6 +369,7 @@ async def _invoke_capability_attempt(
             mode=mode,
             started=started,
             argument_digest=argument_digest,
+            request_digest=request_digest,
             trace_digest=trace_digest,
             trace_source=trace_source,
             execution_status="ERROR",
@@ -372,6 +392,7 @@ async def _invoke_capability_attempt(
         mode=mode,
         started=started,
         argument_digest=argument_digest,
+        request_digest=request_digest,
         trace_digest=trace_digest,
         trace_source=trace_source,
         result=result,

--- a/tests/boundary/mcp/test_mcp_operations.py
+++ b/tests/boundary/mcp/test_mcp_operations.py
@@ -15,7 +15,11 @@ import pytest
 
 from jacobian.adapters.mcp.context import _public_tool_error
 from jacobian.adapters.mcp.server import create_server
-from jacobian.adapters.mcp.tooling import _request_trace_digest, _run_blocking
+from jacobian.adapters.mcp.tooling import (
+    _request_id_digest,
+    _request_trace_digest,
+    _run_blocking,
+)
 
 MCP_TOOL_NAMES = {
     "math.find",
@@ -38,6 +42,8 @@ def test_mcp_trace_correlation_hashes_headers_without_retaining_them() -> None:
     assert source == "traceparent"
     assert traceparent not in digest
     assert "private-request-id" not in digest
+    request_digest = _request_id_digest(RequestContext())
+    assert request_digest == hashlib.sha256(b"private-request-id").hexdigest()[:16]
 
 
 def test_mcp_logs_bounded_tool_metrics_without_arguments(
@@ -77,6 +83,7 @@ def test_mcp_logs_bounded_tool_metrics_without_arguments(
     assert "duration_ms=" in metric
     assert "response_bytes=" in metric
     assert "argument_digest=sha256:" in metric
+    assert "request_digest=" in metric
     assert "private-query-marker" not in metric
     attempt = next(
         message
@@ -87,6 +94,17 @@ def test_mcp_logs_bounded_tool_metrics_without_arguments(
     assert "execution_status=ERROR" in attempt
     assert "diagnostic_codes=UNKNOWN_CAPABILITY" in attempt
     assert "trace_digest=" in attempt
+    assert "request_digest=" in attempt
+    run_metric = next(
+        message
+        for message in messages
+        if "MCP tool call tool=math.run status=success" in message
+    )
+    metric_request = metric.split("request_digest=", 1)[1].split(" ", 1)[0]
+    run_request = run_metric.split("request_digest=", 1)[1].split(" ", 1)[0]
+    attempt_request = attempt.split("request_digest=", 1)[1].split(" ", 1)[0]
+    assert metric_request != attempt_request
+    assert run_request == attempt_request
     assert "argument_digest=sha256:" in attempt
     assert "private-payload-marker" not in attempt
 

--- a/tests/unit/tooling/test_codex_binary.py
+++ b/tests/unit/tooling/test_codex_binary.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from benchmarks.tooling.codex_binary import resolve_codex_binary
+
+
+def _write_executable(path: Path, content: bytes) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    path.chmod(0o755)
+    return path
+
+
+def test_resolve_codex_binary_accepts_native_linux_executable(tmp_path: Path) -> None:
+    binary = _write_executable(tmp_path / "codex", b"\x7fELFfixture")
+
+    assert resolve_codex_binary(binary) == binary.resolve()
+
+
+def test_resolve_codex_binary_finds_native_payload_for_npm_launcher(
+    tmp_path: Path,
+) -> None:
+    package = tmp_path / "lib/node_modules/@openai/codex"
+    launcher = _write_executable(package / "bin/codex.js", b"#!/usr/bin/env node\n")
+    native = _write_executable(
+        package
+        / "node_modules/@openai/codex-linux-x64"
+        / "vendor/x86_64-unknown-linux-musl/bin/codex",
+        b"\x7fELFfixture",
+    )
+
+    assert resolve_codex_binary(launcher) == native.resolve()
+
+
+def test_resolve_codex_binary_rejects_launcher_without_native_payload(
+    tmp_path: Path,
+) -> None:
+    launcher = _write_executable(
+        tmp_path / "lib/node_modules/@openai/codex/bin/codex.js",
+        b"#!/usr/bin/env node\n",
+    )
+
+    with pytest.raises(ValueError, match="Linux standalone Codex binary"):
+        resolve_codex_binary(launcher)
+
+
+def test_resolve_codex_binary_requires_executable_file(tmp_path: Path) -> None:
+    binary = tmp_path / "codex"
+    binary.write_bytes(b"\x7fELFfixture")
+    binary.chmod(0o644)
+
+    with pytest.raises(ValueError, match="executable"):
+        resolve_codex_binary(binary)
+    assert not os.access(binary, os.X_OK)

--- a/tests/unit/tooling/test_harbor_egress.py
+++ b/tests/unit/tooling/test_harbor_egress.py
@@ -74,6 +74,7 @@ def test_agent_eval_forwards_web_search_setting_to_harbor() -> None:
         in makefile
     )
     assert "JACOBIAN_EVAL_CODEX_BINARY" in makefile
+    assert "benchmarks.tooling.codex_binary" in makefile
     assert "JACOBIAN_EVAL_UPSTREAM_PROXY" in makefile
     assert "benchmarks.tooling.harbor_proxy" in makefile
     assert 'if [ "$(JACOBIAN_EVAL_PROXY)" = "1" ]; then' in makefile
@@ -81,10 +82,17 @@ def test_agent_eval_forwards_web_search_setting_to_harbor() -> None:
     assert "mathematical-benchmarks-v1-control-proxy.json" in makefile
     assert "jacobian-observation-proxy.json" in makefile
     assert "jacobian-loopback.mcp.json" in makefile
+    validate_recipe = makefile.split("agent-eval-validate:", maxsplit=1)[1].split(
+        "\n\n", maxsplit=1
+    )[0]
+    assert "$(HARBOR_PROJECT_PYTHON) -m benchmarks.tooling.observation_results" in (
+        validate_recipe
+    )
 
 
 def test_proxy_observation_job_is_opt_in_and_preserves_local_mcp_access() -> None:
     proxy_job = _read_json(OBSERVATION_PROXY_JOB)
+    proxy_control = _read_json(CONTROL_PROXY_JOB)
     proxy_overlay = EGRESS_PROXY_COMPOSE.read_text(encoding="utf-8")
     codex_overlay = CODEX_COMPOSE.read_text(encoding="utf-8")
     assert proxy_job["environment"]["extra_docker_compose"] == [
@@ -98,9 +106,11 @@ def test_proxy_observation_job_is_opt_in_and_preserves_local_mcp_access() -> Non
     assert "host.docker.internal:host-gateway" in proxy_overlay
     assert "harbor-docker-egress-control-sidecar:" in proxy_overlay
     assert "JACOBIAN_EVAL_GOST_CONFIG" in proxy_overlay
-    assert 'HTTPS_PROXY: ""' in proxy_overlay
+    assert "http://127.0.0.1:12346" in proxy_overlay
     assert "JACOBIAN_EVAL_CODEX_BINARY" in codex_overlay
     assert "target: /usr/local/bin/codex" in codex_overlay
+    assert proxy_job["artifacts"] == ["/logs/agent/trajectory.json"]
+    assert proxy_control["artifacts"] == proxy_job["artifacts"]
 
 
 def test_jacobian_sidecar_keeps_its_project_network_under_egress_control() -> None:
@@ -155,8 +165,19 @@ def test_proxy_compose_overlay_declares_proxy_environment() -> None:
 
     assert "environment" in main
     env = main["environment"]
-    for key in ("HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"):
+    for key in (
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "NO_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "no_proxy",
+    ):
         assert key in env, f"proxy compose missing {key}"
+    assert env["HTTP_PROXY"] == "http://127.0.0.1:12346"
+    assert env["HTTPS_PROXY"] == "http://127.0.0.1:12346"
+    assert env["http_proxy"] == "http://127.0.0.1:12346"
+    assert env["https_proxy"] == "http://127.0.0.1:12346"
 
     sidecar = parsed["services"]["harbor-docker-egress-control-sidecar"]
     assert "host.docker.internal:host-gateway" in sidecar["extra_hosts"]

--- a/tests/unit/tooling/test_harbor_egress.py
+++ b/tests/unit/tooling/test_harbor_egress.py
@@ -109,8 +109,11 @@ def test_proxy_observation_job_is_opt_in_and_preserves_local_mcp_access() -> Non
     assert "http://127.0.0.1:12346" in proxy_overlay
     assert "JACOBIAN_EVAL_CODEX_BINARY" in codex_overlay
     assert "target: /usr/local/bin/codex" in codex_overlay
-    assert proxy_job["artifacts"] == ["/logs/agent/trajectory.json"]
-    assert proxy_control["artifacts"] == proxy_job["artifacts"]
+    assert proxy_job["artifacts"] == [
+        "/logs/agent/trajectory.json",
+        {"source": "/logs/jacobian/mcp.log", "service": "jacobian"},
+    ]
+    assert proxy_control["artifacts"] == ["/logs/agent/trajectory.json"]
 
 
 def test_jacobian_sidecar_keeps_its_project_network_under_egress_control() -> None:

--- a/tests/unit/tooling/test_harbor_jobs.py
+++ b/tests/unit/tooling/test_harbor_jobs.py
@@ -89,9 +89,12 @@ def test_paired_jobs_use_three_attempts_per_condition() -> None:
     assert control["n_attempts"] == 3
 
 
-def test_paired_jobs_collect_codex_atif_trajectory() -> None:
+def test_paired_jobs_collect_runtime_evidence_available_in_each_condition() -> None:
     treatment = _read_json(JOB)
     control = _read_json(CONTROL_JOB)
 
-    assert treatment["artifacts"] == ["/logs/agent/trajectory.json"]
-    assert control["artifacts"] == treatment["artifacts"]
+    assert treatment["artifacts"] == [
+        "/logs/agent/trajectory.json",
+        {"source": "/logs/jacobian/mcp.log", "service": "jacobian"},
+    ]
+    assert control["artifacts"] == ["/logs/agent/trajectory.json"]

--- a/tests/unit/tooling/test_harbor_jobs.py
+++ b/tests/unit/tooling/test_harbor_jobs.py
@@ -65,14 +65,17 @@ def test_validate_all_catches_a_malformed_proxy_control_job(
 
     def patched_read_json(path: Path) -> object:
         if path.name == "mathematical-benchmarks-v1-control-proxy.json":
-            return {"n_attempts": "not-an-integer"}
+            malformed = original_read_json(path)
+            assert isinstance(malformed, dict)
+            malformed["artifacts"] = ["logs/agent/trajectory.json"]
+            return malformed
         return original_read_json(path)
 
     monkeypatch.setattr(benchmark_contracts, "_read_json", patched_read_json)
 
     failures = validate_all()
 
-    assert any("control-proxy" in f for f in failures), (
+    assert any("control-proxy" in f and "artifacts" in f for f in failures), (
         f"expected a contract failure for the malformed proxy control job, "
         f"got: {failures}"
     )
@@ -84,3 +87,11 @@ def test_paired_jobs_use_three_attempts_per_condition() -> None:
 
     assert treatment["n_attempts"] == 3
     assert control["n_attempts"] == 3
+
+
+def test_paired_jobs_collect_codex_atif_trajectory() -> None:
+    treatment = _read_json(JOB)
+    control = _read_json(CONTROL_JOB)
+
+    assert treatment["artifacts"] == ["/logs/agent/trajectory.json"]
+    assert control["artifacts"] == treatment["artifacts"]

--- a/tests/unit/tooling/test_harbor_proxy.py
+++ b/tests/unit/tooling/test_harbor_proxy.py
@@ -17,6 +17,7 @@ def test_render_config_chains_transparent_egress_through_http_proxy() -> None:
     assert explicit_service == {
         "name": "explicit-egress",
         "addr": "127.0.0.1:12346",
+        "bypass": "allowlist",
         "handler": {"type": "http", "chain": "upstream-proxy"},
         "listener": {"type": "tcp"},
     }

--- a/tests/unit/tooling/test_harbor_proxy.py
+++ b/tests/unit/tooling/test_harbor_proxy.py
@@ -7,12 +7,19 @@ from benchmarks.tooling.harbor_proxy import render_config
 def test_render_config_chains_transparent_egress_through_http_proxy() -> None:
     config = render_config("http://docker-host:7890")
 
-    service = config["services"][0]
+    transparent_service = config["services"][0]
+    explicit_service = config["services"][1]
     hop = config["chains"][0]["hops"][0]
     node = hop["nodes"][0]
-    assert service["handler"]["chain"] == "upstream-proxy"
-    assert service["bypass"] == "allowlist"
-    assert service["sockopts"] == {"mark": 114514}
+    assert transparent_service["handler"]["chain"] == "upstream-proxy"
+    assert transparent_service["bypass"] == "allowlist"
+    assert transparent_service["sockopts"] == {"mark": 114514}
+    assert explicit_service == {
+        "name": "explicit-egress",
+        "addr": "127.0.0.1:12346",
+        "handler": {"type": "http", "chain": "upstream-proxy"},
+        "listener": {"type": "tcp"},
+    }
     assert hop["bypass"] == "direct-private"
     assert hop["sockopts"] == {"mark": 114514}
     assert node["addr"] == "docker-host:7890"

--- a/tools/harbor_task_workflow.py
+++ b/tools/harbor_task_workflow.py
@@ -23,6 +23,7 @@ if str(ROOT) not in sys.path:
 from benchmarks.tooling.command_runner import (  # noqa: E402
     ToolCommandRequest,
     ToolCommandStatus,
+    ToolResolver,
     operator_environment,
     run_tool_command,
 )
@@ -44,6 +45,7 @@ OPERATOR_ENVIRONMENT = (
     "XDG_CACHE_HOME",
     "XDG_CONFIG_HOME",
 )
+TOOL_RESOLVER = ToolResolver()
 
 
 class TaskWorkflowError(RuntimeError):
@@ -195,7 +197,7 @@ def _run_checked(
 
 
 def _uv_executable() -> str:
-    uv = shutil.which("uv")
+    uv = TOOL_RESOLVER.resolve("uv")
     if uv is None:
         raise TaskWorkflowError("uv is required to run repository validation")
     return uv
@@ -298,8 +300,26 @@ def prepare(selection: TaskSelection) -> tuple[str, ...]:
     return changed
 
 
+def _oracle_evidence_snapshot(
+    selection: TaskSelection,
+) -> dict[Path, tuple[int, int, str]]:
+    evidence_root = ROOT / "benchmarks" / "results" / f"{selection.dataset}-oracle"
+    snapshot: dict[Path, tuple[int, int, str]] = {}
+    for path in evidence_root.glob("*/oracle-evidence.json"):
+        try:
+            stat = path.stat()
+            digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        except OSError:
+            continue
+        snapshot[path] = (stat.st_mtime_ns, stat.st_size, digest)
+    return snapshot
+
+
 def _fresh_oracle_evidence(
-    selection: TaskSelection, task: str, *, started_ns: int
+    selection: TaskSelection,
+    task: str,
+    *,
+    previous: dict[Path, tuple[int, int, str]],
 ) -> tuple[str, str]:
     evidence_root = ROOT / "benchmarks" / "results" / f"{selection.dataset}-oracle"
     candidates = sorted(
@@ -308,11 +328,17 @@ def _fresh_oracle_evidence(
         reverse=True,
     )
     for path in candidates:
-        if path.stat().st_mtime_ns < started_ns:
+        try:
+            stat = path.stat()
+            raw = path.read_bytes()
+        except OSError:
+            continue
+        fingerprint = (stat.st_mtime_ns, stat.st_size, hashlib.sha256(raw).hexdigest())
+        if previous.get(path) == fingerprint:
             continue
         try:
-            payload: Any = json.loads(path.read_text())
-        except (OSError, json.JSONDecodeError):
+            payload: Any = json.loads(raw)
+        except (UnicodeDecodeError, json.JSONDecodeError):
             continue
         if not isinstance(payload, dict) or payload.get("dataset") != selection.dataset:
             continue
@@ -384,8 +410,8 @@ def validate(selection: TaskSelection) -> tuple[tuple[str, str, str], ...]:
                 executable=_uv_executable(),
             )
         for task in selection.tasks:
-            started_ns = time.time_ns()
-            make = shutil.which("make")
+            previous_evidence = _oracle_evidence_snapshot(selection)
+            make = TOOL_RESOLVER.resolve("make")
             if make is None:
                 raise TaskWorkflowError("make is required to run the exact Oracle")
             _run_checked(
@@ -401,7 +427,7 @@ def validate(selection: TaskSelection) -> tuple[tuple[str, str, str], ...]:
                 executable=make,
             )
             digest, evidence_path = _fresh_oracle_evidence(
-                selection, task, started_ns=started_ns
+                selection, task, previous=previous_evidence
             )
             oracle_evidence.append((task, digest, evidence_path))
     finally:


### PR DESCRIPTION
## Problem

Harbor Codex observations could fail before model execution because npm installs expose a JavaScript launcher, while the proxy job mounts it into a container without Node. Proxy-aware Codex traffic also lacked usable DNS routing, and completed Harbor 0.20 trials could not be normalized into tool-adoption evidence.

## Changes

- Resolve and validate the bundled native Linux Codex executable for proxy runs.
- Add a loopback HTTP listener chained through the existing allowlisted GOST egress path.
- Collect Harbor ATIF explicitly, accept only the implicit empty convention directory, and account for direct and unified-exec Jacobian calls.
- Run observation normalization in an environment containing both Harbor and Jacobian.
- Reuse the bounded tooling resolver and replace timestamp-based Oracle freshness checks in the selected-task workflow merged in #572.

## Validation

- `make harbor-execution-check` (contracts plus 59 tests)
- Focused Harbor/observation tests (47 passed)
- Selected-task workflow tests (5 passed)
- Planned lanes: unit 677, component 692, domain 153, composition 446 passed/2 skipped, storage 114, process 218, MCP 33, E2E 8 passed/1 skipped, npm 44
- `make security-audit`, `make duplicate-code`, and `make docs-linkcheck`
- Full `make check-static` on a tracked-tree copy, excluding ignored local benchmark evidence

A real proxied Harbor run completed with zero exceptions. Its manifest-bound ATIF normalized to `math.find: 1`, `math.run: 3`, and `tool_errors: 0`. The trial scored mathematical correctness 1; aggregate reward remained 0 because that model submission missed the task evidence-validity contract, independent of the harness fix.