### PR TITLE
ci(benchmarks): stream and shard validation with bound receipts

### DIFF
--- a/.github/scripts/emit-plan-receipt
+++ b/.github/scripts/emit-plan-receipt
@@ -4,13 +4,18 @@
 from __future__ import annotations
 
 import argparse
-import hashlib
 import json
 import re
+import sys
 from pathlib import Path, PurePosixPath
 from typing import Any
 
 ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from benchmarks.tooling.receipts import canonical_json, digest_bytes  # noqa: E402
+
 EVENTS = {"pull_request", "merge_group", "push", "schedule", "workflow_dispatch"}
 SHA = re.compile(r"[0-9a-f]{40,64}\Z")
 MAX_PATHS = 10_000
@@ -22,13 +27,7 @@ def fail(message: str) -> None:
 
 
 def _sha256(payload: bytes) -> str:
-    return "sha256:" + hashlib.sha256(payload).hexdigest()
-
-
-def _canonical_json(value: Any) -> bytes:
-    return (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode(
-        "utf-8"
-    )
+    return digest_bytes(payload)
 
 
 def _relative_path(value: str, label: str) -> str:
@@ -131,7 +130,7 @@ def build_receipt(
         ),
         "plan": plan,
     }
-    receipt["receipt_digest"] = _sha256(_canonical_json(receipt))
+    receipt["receipt_digest"] = _sha256(canonical_json(receipt))
     return receipt
 
 

--- a/.github/scripts/manage-test-timings
+++ b/.github/scripts/manage-test-timings
@@ -18,7 +18,8 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[2]
 CONFIG = ROOT / ".github" / "ci-config.json"
-SHARDED_SUITES = ("domain", "composition")
+CI_SHARDED_SUITES = ("domain", "composition")
+TIMING_SUITES = (*CI_SHARDED_SUITES, "benchmark")
 MAX_BYTES = 5 * 1024 * 1024
 MAX_ENTRIES = 10_000
 MAX_CANDIDATES = 5
@@ -58,8 +59,10 @@ class CrossOriginRedirectHandler(urllib.request.HTTPRedirectHandler):
 
 
 def shard_count(suite: str) -> int:
-    if suite not in SHARDED_SUITES:
+    if suite not in TIMING_SUITES:
         raise ValueError(f"unsupported timing suite: {suite}")
+    if suite == "benchmark":
+        return 4
     return int(ci_config()[f"{suite}_shard_count"])
 
 
@@ -75,7 +78,7 @@ def ci_config() -> dict[str, Any]:
     payload = json.loads(CONFIG.read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
         raise ValueError("ci-config.json must contain a JSON object")
-    for suite in SHARDED_SUITES:
+    for suite in CI_SHARDED_SUITES:
         count = payload.get(f"{suite}_shard_count")
         if not isinstance(count, int) or isinstance(count, bool) or count < 1:
             raise ValueError(f"{suite}_shard_count must be a positive integer")
@@ -111,7 +114,7 @@ def emit_plan_outputs() -> None:
     """Print GitHub Actions outputs for shard, Node, and pytest-split pins."""
 
     config = ci_config()
-    for suite in SHARDED_SUITES:
+    for suite in CI_SHARDED_SUITES:
         count = int(config[f"{suite}_shard_count"])
         print(f"{suite}-shard-count={count}")
         print(f"{suite}-shards={json.dumps(list(range(1, count + 1)))}")
@@ -138,8 +141,9 @@ def validate_durations(value: Any, source: str, suite: str) -> dict[str, float]:
         raise ValueError(f"{source} exceeds {MAX_ENTRIES} timing entries")
 
     durations: dict[str, float] = {}
+    prefix = "benchmarks/validation/" if suite == "benchmark" else f"tests/{suite}/"
     for nodeid, duration in value.items():
-        if not isinstance(nodeid, str) or not nodeid.startswith(f"tests/{suite}/"):
+        if not isinstance(nodeid, str) or not nodeid.startswith(prefix):
             raise ValueError(f"{source} contains an invalid test node id: {nodeid!r}")
         if isinstance(duration, bool) or not isinstance(duration, (int, float)):
             raise ValueError(f"{source} contains a non-numeric duration for {nodeid}")
@@ -321,14 +325,14 @@ def main() -> None:
 
     prepare_parser = subparsers.add_parser("prepare")
     prepare_parser.add_argument("--output", type=Path, required=True)
-    prepare_parser.add_argument("--suite", choices=SHARDED_SUITES, required=True)
+    prepare_parser.add_argument("--suite", choices=TIMING_SUITES, required=True)
 
     merge_parser = subparsers.add_parser("merge")
     merge_parser.add_argument("--input", action="append", type=Path, required=True)
     merge_parser.add_argument("--output", type=Path, required=True)
     merge_parser.add_argument("--source-sha", required=True)
     merge_parser.add_argument("--python-version", required=True)
-    merge_parser.add_argument("--suite", choices=SHARDED_SUITES, required=True)
+    merge_parser.add_argument("--suite", choices=TIMING_SUITES, required=True)
     merge_parser.add_argument(
         "--pytest-split-version",
         default=None,

--- a/.github/scripts/plan-benchmarks
+++ b/.github/scripts/plan-benchmarks
@@ -39,6 +39,10 @@ _SCRIPTS_DIR = str(Path(__file__).resolve().parent)
 if _SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, _SCRIPTS_DIR)
 from _ci_paths import normalize_paths, path_values  # noqa: E402
+from benchmarks.tooling.validation_plan import (  # noqa: E402
+    full_host_validation,
+    host_validation_plan,
+)
 
 PLAN_VERSION = "2"
 EVENTS = ("pull_request", "merge_group", "push", "schedule", "workflow_dispatch")
@@ -55,21 +59,27 @@ _ORACLE_SCOPE_RANK = {
 BENCHMARK_CONTROL_PATHS = frozenset(
     {
         ".github/scripts/_ci_paths.py",
+        ".github/scripts/emit-plan-receipt",
         ".github/scripts/plan-benchmarks",
+        ".github/scripts/manage-test-timings",
         ".github/scripts/validate-benchmark-plan",
         ".github/workflows/benchmarks.yml",
         ".github/workflows/heldout-benchmarks.yml",
         "Makefile",
         "tools/check_benchmark_adapters.py",
+        "tools/benchmark_pr_status.py",
         "tools/check_benchmark_contracts.py",
         "tools/check_benchmark_static.py",
         "tools/check_harbor_dataset.py",
         "tools/harbor_task_workflow.py",
+        "tools/pytest_lifecycle.py",
+        "benchmarks/tooling/validation_plan.py",
         "tools/sync_harbor_verifier_support.py",
     }
 )
 BENCHMARK_EXECUTION_CONTROL_PATHS = frozenset(
     {
+        ".github/scripts/manage-test-timings",
         "tools/check_benchmark_adapters.py",
         "tools/check_benchmark_contracts.py",
         "tools/check_harbor_dataset.py",
@@ -77,23 +87,6 @@ BENCHMARK_EXECUTION_CONTROL_PATHS = frozenset(
     }
 )
 BENCHMARK_CONFIG_PREFIX = "benchmarks/config/"
-HOST_VALIDATION_ROOT = "benchmarks/validation"
-HOST_VALIDATION_FULL_SHARDS = 4
-HOST_VALIDATION_DATASET_FILES = {
-    "conjecture-probes-v1": (
-        "benchmarks/validation/conjecture_probes_v1/"
-        "test_vizing_bounded_cartesian_products.py",
-    ),
-    "symbolic-coordination-v1": (
-        "benchmarks/validation/symbolic_coordination_v1/test_pilot_contract.py",
-    ),
-    "research-diagnostics-v1": (
-        "benchmarks/validation/research_diagnostics_v1/test_structured_verifiers.py",
-    ),
-    "provider-feasibility-v1": (
-        "benchmarks/validation/test_provider_download_integrity.py",
-    ),
-}
 
 
 def _json(value: object) -> str:
@@ -113,6 +106,7 @@ def _planner_digest() -> str:
     sources = (
         Path(__file__),
         ROOT / ".github" / "scripts" / "_ci_paths.py",
+        ROOT / "benchmarks" / "tooling" / "validation_plan.py",
     )
     payload = "\n".join(
         f"{path.relative_to(ROOT).as_posix()}\t{path.read_bytes().hex()}"
@@ -171,12 +165,21 @@ def _membership() -> tuple[dict[str, list[tuple[str, Path]]], dict[str, Any]]:
     return by_task, suites
 
 
-def _exact_entry(dataset: str, task: str, path: Path) -> dict[str, Any]:
+def _exact_entry(
+    dataset: str,
+    task: str,
+    path: Path,
+    *,
+    timings: dict[str, float] | None = None,
+) -> dict[str, Any]:
     return {
         "dataset": dataset,
         "shard": task,
         "tasks": [task],
         "task_digests": [{"task": task, "digest": _digest(path)}],
+        "predicted_seconds": round(
+            float((timings or {}).get(f"{dataset}/{task}", 1.0)), 6
+        ),
     }
 
 
@@ -211,7 +214,7 @@ def _shard_entries(
                 weight + timings.get(f"{suite.id}/{ref.path.name}", 1.0),
                 assigned,
             )
-        for index, (_weight, assigned) in enumerate(bins, start=1):
+        for index, (weight, assigned) in enumerate(bins, start=1):
             ordered = sorted(assigned, key=lambda ref: ref.path.name)
             matrix.append(
                 {
@@ -222,6 +225,7 @@ def _shard_entries(
                         {"task": ref.path.name, "digest": _digest(ref.path)}
                         for ref in ordered
                     ],
+                    "predicted_seconds": round(weight, 6),
                 }
             )
     return matrix
@@ -266,146 +270,6 @@ def _emit(
     }
 
 
-def _host_entry(
-    *,
-    name: str,
-    selector: str,
-    keyword: str = "",
-    splits: int = 0,
-    group: int = 0,
-) -> dict[str, Any]:
-    return {
-        "name": name,
-        "selector": selector,
-        "keyword": keyword,
-        "splits": splits,
-        "group": group,
-    }
-
-
-def _full_host_validation() -> list[dict[str, Any]]:
-    return [
-        _host_entry(
-            name=f"full-{group}-of-{HOST_VALIDATION_FULL_SHARDS}",
-            selector=HOST_VALIDATION_ROOT,
-            splits=HOST_VALIDATION_FULL_SHARDS,
-            group=group,
-        )
-        for group in range(1, HOST_VALIDATION_FULL_SHARDS + 1)
-    ]
-
-
-def _dataset_host_validation(dataset: str) -> list[dict[str, Any]]:
-    return [
-        _host_entry(name=f"{dataset}-{index}", selector=selector)
-        for index, selector in enumerate(
-            HOST_VALIDATION_DATASET_FILES.get(dataset, ()), start=1
-        )
-    ]
-
-
-def _task_host_validation(dataset: str, task: str) -> list[dict[str, Any]]:
-    if dataset == "mathematical-benchmarks-v1":
-        dedicated = (
-            ROOT
-            / "benchmarks"
-            / "validation"
-            / "mathematical_benchmarks_v1"
-            / f"test_{task.replace('-', '_')}.py"
-        )
-        entries: list[dict[str, Any]] = []
-        if dedicated.is_file():
-            entries.append(
-                _host_entry(
-                    name=f"{task}-specific",
-                    selector=dedicated.relative_to(ROOT).as_posix(),
-                )
-            )
-        entries.append(
-            _host_entry(
-                name=f"{task}-generic",
-                selector=(
-                    "benchmarks/validation/mathematical_benchmarks_v1/"
-                    "test_generic_verifier_contracts.py"
-                ),
-                keyword=task,
-            )
-        )
-        return entries
-    if dataset == "public-reproductions-v1" and task == "sat-erdos-schur-f4":
-        return [
-            _host_entry(
-                name=task,
-                selector="benchmarks/validation/test_sat_erdos_schur_f4.py",
-            )
-        ]
-    return _dataset_host_validation(dataset)
-
-
-def _host_validation_plan(
-    benchmark_paths: list[str], suites_by_id: dict[str, Any]
-) -> list[dict[str, Any]]:
-    entries: list[dict[str, Any]] = []
-    full = False
-    for path in benchmark_paths:
-        if path.startswith("benchmarks/validation/"):
-            candidate = ROOT / path
-            if candidate.is_file() and candidate.name.startswith("test_"):
-                entries.append(_host_entry(name=candidate.stem, selector=path))
-            elif candidate.suffix == ".py":
-                parent = candidate.parent.relative_to(ROOT).as_posix()
-                entries.append(_host_entry(name=candidate.parent.name, selector=parent))
-            else:
-                full = True
-            continue
-        parts = Path(path).parts
-        if len(parts) >= 4 and parts[:2] == ("benchmarks", "datasets"):
-            dataset = parts[2]
-            suite = suites_by_id.get(dataset)
-            task_ids = {ref.path.name for ref in suite.tasks} if suite else set()
-            relative = parts[3:]
-            task = relative[0] if len(relative) >= 2 else None
-            if task in task_ids:
-                if relative[1:] != ("README.md",):
-                    entries.extend(_task_host_validation(dataset, task))
-                continue
-            if relative[:1] == ("members",) and len(relative) == 2:
-                member = Path(relative[1]).stem
-                if member in task_ids:
-                    entries.extend(_task_host_validation(dataset, member))
-                    continue
-            if relative[:1] in {("README.md",), ("dataset.toml",)}:
-                continue
-            dataset_entries = _dataset_host_validation(dataset)
-            if dataset_entries:
-                entries.extend(dataset_entries)
-            else:
-                full = True
-            continue
-        if path in {
-            "benchmarks/README.md",
-            "benchmarks/__init__.py",
-        } or path.startswith("benchmarks/templates/"):
-            continue
-        if path == "benchmarks/adapters/README.md":
-            continue
-        if path.startswith("benchmarks/adapters/"):
-            entries.append(
-                _host_entry(
-                    name="benchmark-adapters",
-                    selector="benchmarks/validation/test_benchmark_adapters.py",
-                )
-            )
-            continue
-        full = True
-    if full:
-        return _full_host_validation()
-    unique = {(entry["selector"], entry["keyword"]): entry for entry in entries}
-    return sorted(
-        unique.values(), key=lambda entry: (entry["selector"], entry["keyword"])
-    )
-
-
 def _oracle_matrix(
     *,
     scope: str,
@@ -423,7 +287,7 @@ def _oracle_matrix(
             timings=timings,
         )
     return [
-        _exact_entry(dataset, task_id, path)
+        _exact_entry(dataset, task_id, path, timings=timings)
         for task_id in sorted(oracle_tasks)
         for dataset, path in by_task[task_id]
     ]
@@ -702,7 +566,10 @@ def plan(
             record_schema=True,
             prospective_digest=True,
             inventory=True,
-            host_validation=_full_host_validation(),
+            host_validation=[
+                entry.as_matrix_entry()
+                for entry in full_host_validation(timings=timings)
+            ],
             run_oracle=True,
             scope="all",
             matrix=matrix,
@@ -749,10 +616,13 @@ def plan(
     classification = _classify_benchmark_paths(
         benchmark_paths, suites_by_id, integration=integration
     )
-    host_validation = _host_validation_plan(benchmark_paths, suites_by_id)
+    host_plan = host_validation_plan(
+        ROOT, benchmark_paths, suites_by_id, timings=timings
+    )
+    host_validation = [entry.as_matrix_entry() for entry in host_plan.entries]
     oracle_tasks = classification.oracle_tasks
     affected_datasets = classification.affected_datasets
-    reasons = classification.reasons
+    reasons = [*classification.reasons, *host_plan.reasons]
     run_oracle = classification.run_oracle
     scope = classification.scope
     unknown = classification.unknown

--- a/.github/scripts/validate-benchmark-plan
+++ b/.github/scripts/validate-benchmark-plan
@@ -85,12 +85,14 @@ def _validate_matrix(matrix: list[Any]) -> None:
             "shard",
             "tasks",
             "task_digests",
+            "predicted_seconds",
         }:
             fail(f"benchmark Oracle matrix entry {index} has an invalid shape")
         dataset = entry["dataset"]
         shard = entry["shard"]
         tasks = entry["tasks"]
         digests = entry["task_digests"]
+        predicted = entry["predicted_seconds"]
         if not isinstance(dataset, str) or not dataset:
             fail(f"benchmark Oracle matrix entry {index} has an invalid dataset")
         if not isinstance(shard, str) or not shard:
@@ -104,6 +106,12 @@ def _validate_matrix(matrix: list[Any]) -> None:
             fail(f"benchmark Oracle matrix entry {index} has invalid tasks")
         if not isinstance(digests, list) or len(digests) != len(tasks):
             fail(f"benchmark Oracle matrix entry {index} has invalid task digests")
+        if (
+            not isinstance(predicted, (int, float))
+            or isinstance(predicted, bool)
+            or predicted <= 0
+        ):
+            fail(f"benchmark Oracle matrix entry {index} has invalid prediction")
         digest_tasks: set[str] = set()
         for item in digests:
             if not isinstance(item, dict) or set(item) != {"task", "digest"}:
@@ -141,6 +149,7 @@ def _validate_host_matrix(matrix: list[Any]) -> None:
             "keyword",
             "splits",
             "group",
+            "predicted_seconds",
         }:
             fail(f"benchmark host validation matrix entry {index} has an invalid shape")
         name = entry["name"]
@@ -148,7 +157,12 @@ def _validate_host_matrix(matrix: list[Any]) -> None:
         keyword = entry["keyword"]
         splits = entry["splits"]
         group = entry["group"]
-        if not isinstance(name, str) or HOST_NAME.fullmatch(name) is None:
+        predicted = entry["predicted_seconds"]
+        if (
+            not isinstance(name, str)
+            or name in {".", ".."}
+            or HOST_NAME.fullmatch(name) is None
+        ):
             fail(f"benchmark host validation matrix entry {index} has an invalid name")
         if name in names:
             fail(f"duplicate benchmark host validation matrix name: {name}")
@@ -176,6 +190,12 @@ def _validate_host_matrix(matrix: list[Any]) -> None:
             or splits > MAX_MATRIX_JOBS
         ):
             fail(f"benchmark host validation matrix entry {index} has invalid sharding")
+        if (
+            not isinstance(predicted, (int, float))
+            or isinstance(predicted, bool)
+            or predicted <= 0
+        ):
+            fail(f"benchmark host validation matrix entry {index} has invalid prediction")
         key = (selector, keyword)
         expected_splits, groups = shard_groups.setdefault(key, (splits, set()))
         if expected_splits != splits:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -17,6 +17,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
+  actions: read
   contents: read
 
 jobs:
@@ -112,6 +113,7 @@ jobs:
             --head "$HEAD_SHA" \
             --planner .github/scripts/plan-benchmarks \
             --config .github/scripts/_ci_paths.py \
+            --config .github/scripts/manage-test-timings \
             --config .github/scripts/validate-benchmark-plan \
             --config benchmarks/registry.toml \
             --config benchmarks/environment-profiles.toml \
@@ -120,8 +122,12 @@ jobs:
             --config tools/check_benchmark_adapters.py \
             --config tools/check_benchmark_contracts.py \
             --config tools/check_benchmark_static.py \
+            --config tools/pytest_lifecycle.py \
             --config tools/check_harbor_dataset.py \
             --config tools/sync_harbor_verifier_support.py \
+            --config benchmarks/tooling/benchmark_validation.py \
+            --config benchmarks/tooling/host_validation.py \
+            --config benchmarks/tooling/validation_plan.py \
             --plan-file "$plan_dir/plan.txt" \
             --paths-file "$plan_dir/changed-paths.txt" \
             --output "$plan_dir/plan-receipt.json"
@@ -140,6 +146,22 @@ jobs:
           name: benchmark-plan-receipt
           path: ${{ runner.temp }}/jacobian-benchmark-plan/plan-receipt.json
           retention-days: 14
+      - name: Prepare benchmark pytest timing hint
+        if: steps.plan.outputs.run-benchmark-host-validation == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          .github/scripts/manage-test-timings prepare \
+            --suite benchmark \
+            --output .ci/benchmark-test-durations.json
+      - name: Upload benchmark pytest timing hint
+        if: steps.plan.outputs.run-benchmark-host-validation == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: benchmark-test-durations-input
+          path: .ci/benchmark-test-durations.json
+          include-hidden-files: true
+          retention-days: 1
 
   static:
     name: Benchmark Static Quality
@@ -194,22 +216,45 @@ jobs:
         with:
           python-version: "3.12"
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - name: Download benchmark timing hint
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: benchmark-test-durations-input
+          path: .ci
+      - name: Download benchmark plan receipt
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: benchmark-plan-receipt
+          path: ${{ runner.temp }}/benchmark-plan
       - name: Run selected host-side verifier regressions
         env:
-          SELECTOR: ${{ matrix.selector }}
-          KEYWORD: ${{ matrix.keyword }}
-          SPLITS: ${{ matrix.splits }}
-          GROUP: ${{ matrix.group }}
+          HOST_ENTRY: ${{ toJSON(matrix) }}
         run: |
-          set -eu
-          pytest_args=()
-          if [ -n "$KEYWORD" ]; then
-            pytest_args=(-k "$KEYWORD")
-          fi
-          if [ "$SPLITS" -gt 0 ]; then
-            pytest_args+=(--splits "$SPLITS" --group "$GROUP")
-          fi
-          make harbor-validation-tests TESTS="$SELECTOR" PYTEST_ARGS="${pytest_args[*]}"
+          uv run --locked python -m benchmarks.tooling.host_validation run-entry \
+            --entry-json "$HOST_ENTRY" \
+            --plan-receipt "${{ runner.temp }}/benchmark-plan/plan-receipt.json" \
+            --execution-sha "${{ github.sha }}" \
+            --timings .ci/benchmark-test-durations.json \
+            --durations-output "${{ runner.temp }}/benchmark-host-timing/durations/benchmark-test-durations.json" \
+            --receipt-dir "${{ runner.temp }}/benchmark-host-timing" \
+            --total-workers 8 --max-parallel 4 --store-durations
+      - name: Upload host timing receipt
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: benchmark-host-timing-${{ matrix.name }}
+          path: ${{ runner.temp }}/benchmark-host-timing/**/pytest-receipt.json
+          if-no-files-found: error
+          retention-days: 90
+      - name: Upload benchmark shard durations
+        if: matrix.splits > 0 && !cancelled()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        continue-on-error: true
+        with:
+          name: benchmark-duration-shard-${{ matrix.group }}
+          path: ${{ runner.temp }}/benchmark-host-timing/durations/benchmark-test-durations.json
+          include-hidden-files: true
+          retention-days: 1
 
   inventory:
     name: Benchmark Inventory Validation
@@ -276,6 +321,33 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - name: Download benchmark plan receipt
+        if: needs.plan.result == 'success'
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: benchmark-plan-receipt
+          path: ${{ runner.temp }}/benchmark-validation/plan
+      - name: Download host shard receipts
+        if: needs.plan.outputs.run-benchmark-host-validation == 'true'
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: benchmark-host-timing-*
+          path: ${{ runner.temp }}/benchmark-validation/host
+      - name: Download host timing input
+        if: needs.plan.outputs.run-benchmark-host-validation == 'true'
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: benchmark-test-durations-input
+          path: ${{ runner.temp }}/benchmark-validation/timing
       - name: Require planned benchmark validation
         env:
           PLAN_RESULT: ${{ needs.plan.result }}
@@ -291,64 +363,28 @@ jobs:
           INVENTORY_RESULT: ${{ needs.inventory.result }}
           ORACLE_RESULT: ${{ needs.oracle.result }}
         run: |
-          set -eu
-          # The planner itself must always succeed; a missing plan is a hard
-          # failure rather than an unselected lane.
-          test "$PLAN_RESULT" = success
-          # A selected lane (flag=true) must report success.  Any other result
-          # (failure, cancelled, timeout, or an unexpected skip) is a failure:
-          # an unselected lane is the only acceptable non-success outcome, and
-          # it is handled by the flag=false branch below.  This keeps unselected
-          # lanes distinct from failures, cancellations, timeouts, and skips
-          # that occur despite a lane being selected.
-          check_lane() {
-            local flag="$1" result="$2" name="$3"
-            case "$flag" in
-              true)
-                if [ "$result" != "success" ]; then
-                  echo "benchmark lane $name was selected but did not succeed (result=$result)" >&2
-                  return 1
-                fi
-                ;;
-              false)
-                if [ "$result" != "skipped" ]; then
-                  echo "benchmark lane $name was unselected but result=$result (expected skipped)" >&2
-                  return 1
-                fi
-                ;;
-              *)
-                echo "invalid $name plan flag: $flag" >&2
-                return 1
-                ;;
-            esac
-          }
-          # Record/schema and prospective-digest are evidence roles owned by
-          # one deterministic contracts job.  They must not create duplicate
-          # checkouts and duplicate Harbor validation runs.
-          case "$RECORD_SCHEMA_FLAG" in
-            true) test "$CONTRACTS_RESULT" = "success" ;;
-            false) test "$CONTRACTS_RESULT" = "skipped" ;;
-            *) echo "invalid record-schema plan flag: $RECORD_SCHEMA_FLAG" >&2; exit 1 ;;
-          esac
-          check_lane "$PLAN_CHECK" "$STATIC_RESULT" "static"
-          check_lane "$HOST_VALIDATION_FLAG" "$HOST_VALIDATION_RESULT" "host-validation"
-          check_lane "$INVENTORY_FLAG" "$INVENTORY_RESULT" "inventory"
-          check_lane "$ORACLE_FLAG" "$ORACLE_RESULT" "oracle"
-          case "$PLAN_CHECK" in
-            true) ;;
-            false)
-              test "$CONTRACTS_RESULT" = skipped
-              test "$HOST_VALIDATION_RESULT" = skipped
-              test "$INVENTORY_RESULT" = skipped
-              test "$ORACLE_RESULT" = skipped
-              ;;
-            *) echo "invalid run-benchmark-check flag: $PLAN_CHECK" >&2; exit 1 ;;
-          esac
+          python -m benchmarks.tooling.benchmark_validation \
+            --plan-result "$PLAN_RESULT" \
+            --plan-receipt "${{ runner.temp }}/benchmark-validation/plan/plan-receipt.json" \
+            --execution-sha "${{ github.sha }}" \
+            --receipt-root "${{ runner.temp }}/benchmark-validation/host" \
+            --timings "${{ runner.temp }}/benchmark-validation/timing/benchmark-test-durations.json" \
+            --lane "static:$PLAN_CHECK:$STATIC_RESULT" \
+            --lane "contracts:$RECORD_SCHEMA_FLAG:$CONTRACTS_RESULT" \
+            --lane "host-validation:$HOST_VALIDATION_FLAG:$HOST_VALIDATION_RESULT" \
+            --lane "inventory:$INVENTORY_FLAG:$INVENTORY_RESULT" \
+            --lane "oracle:$ORACLE_FLAG:$ORACLE_RESULT"
 
   timings:
     name: Publish Benchmark Timings
-    needs: [plan, oracle]
-    if: needs.plan.outputs.run-benchmark-oracle == 'true' && needs.oracle.result == 'success'
+    needs: [plan, host_validation, oracle, validation]
+    if: >-
+      ${{ always() &&
+      needs.plan.outputs.run-benchmark-host-validation == 'true' &&
+      needs.host_validation.result == 'success' &&
+      needs.validation.result == 'success' &&
+      (needs.plan.outputs.run-benchmark-oracle != 'true' ||
+       needs.oracle.result == 'success') }}
     runs-on: ubuntu-latest
     timeout-minutes: 8
     steps:
@@ -359,23 +395,78 @@ jobs:
         with:
           python-version: "3.12"
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - name: Restore previous timing history
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: .benchmark-timings.json
+          key: benchmark-timings-unmatched
+          restore-keys: benchmark-timings-
+      - name: Download host timing receipts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: benchmark-host-timing-*
+          path: timing-artifacts
+      - name: Download benchmark shard durations
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        continue-on-error: true
+        with:
+          pattern: benchmark-duration-shard-*
+          path: .ci/shards
       - name: Download Oracle artifacts
+        if: needs.plan.outputs.run-benchmark-oracle == 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: benchmark-oracle-*
-          path: oracle-artifacts
-      - name: Collect per-task timings
+          path: timing-artifacts
+      - name: Collect and compare shard timings
+        env:
+          ORACLE_MATRIX: ${{ needs.plan.outputs.benchmark-oracle-matrix }}
+          HOST_MATRIX: ${{ needs.plan.outputs.benchmark-host-validation-matrix }}
         run: |
           uv run --locked python -m benchmarks.tooling.benchmark_timings \
-            --root oracle-artifacts --output .benchmark-timings.json
-      - name: Stage timing evidence for upload
-        run: cp .benchmark-timings.json benchmark-timings.json
+            --root timing-artifacts \
+            --output .benchmark-timings.json \
+            --previous .benchmark-timings.json \
+            --oracle-matrix-json "$ORACLE_MATRIX" \
+            --host-matrix-json "$HOST_MATRIX" \
+            --report-output benchmark-timing-report.json \
+            --summary-output "$GITHUB_STEP_SUMMARY"
+      - id: benchmark-durations
+        name: Merge complete full-suite pytest timings
+        run: |
+          set -eu
+          inputs=()
+          for shard in 1 2 3 4; do
+            path=".ci/shards/benchmark-duration-shard-${shard}/benchmark-test-durations.json"
+            if [ ! -f "$path" ]; then
+              echo "complete=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            inputs+=(--input "$path")
+          done
+          .github/scripts/manage-test-timings merge \
+            --suite benchmark \
+            "${inputs[@]}" \
+            --output .ci/benchmark-test-durations.json \
+            --source-sha "${{ github.sha }}" \
+            --python-version "3.12"
+          echo "complete=true" >> "$GITHUB_OUTPUT"
       - name: Upload timing evidence
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: benchmark-timings-${{ github.sha }}
-          path: benchmark-timings.json
+          path: |
+            .benchmark-timings.json
+            benchmark-timing-report.json
           if-no-files-found: error
+          retention-days: 90
+      - name: Publish benchmark pytest timing hint
+        if: steps.benchmark-durations.outputs.complete == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: benchmark-test-durations
+          path: .ci/benchmark-test-durations.json
+          include-hidden-files: true
           retention-days: 90
       - name: Save timing history for future main-branch plans
         if: github.ref == 'refs/heads/main'

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ HARBOR_PROJECT_PYTHON ?= uv run --locked --with harbor==$(HARBOR_VERSION) --with
 # Validation pytest is process-isolated under xdist; Path monkeypatches stay
 # worker-local. Oracle/adapter Make targets remain serial.
 HARBOR_VALIDATION_WORKERS ?= 2
+HARBOR_VALIDATION_TOTAL_WORKERS ?= 4
 PYTEST_ARGS ?=
 TESTS ?=
 EVAL_ARGS ?=
@@ -16,6 +17,7 @@ ORDERING_DEFAULT_SEED := --randomly-seed=17
 PYTEST_DIAGNOSTIC_ARGS ?= --durations=10
 RUFF_PATHS := src tests benchmarks
 TOPOLOGY_RUNNER := $(UV_RUN) python tools/test_topology.py
+PYTEST_RUNNER := $(UV_RUN) python tools/pytest_lifecycle.py
 PUBLIC_COMMANDS := help setup check check-changed ci-plan test-plan test-changed test-unit test-component test-domain test-composition test-storage test-process test-mcp test-provider test-lean test-e2e docs-command-check docs-linkcheck harbor-plan harbor-prepare-task harbor-validate-task harbor-execution-check harbor-check-task harbor-oracle-task npm-test test-all-ci check-static deploy-check
 
 ifneq ($(strip $(PATHS)),)
@@ -27,7 +29,7 @@ endif
 # in pyproject.toml: direct pytest invocations must not silently inherit a
 # signal-based deadline that cannot interrupt a native solver.  Process and
 # provider lanes run risky work in killable children and set their own deadline.
-.PHONY: help help-all uv-version-check setup setup-agent container-image eval-image eval-image-pull eval-image-bind hooks fix lint complexity-check lint-full security-audit typecheck test-architecture architecture ci-plan test-plan test-changed check-changed test-unit test-component test-domain test-composition test-storage test-process test-mcp test-provider test-lean test-e2e test-affected test-all-ci test-compatibility test-stress test-ordering duplicate-code npm-test todo-check coverage build check precommit check-static harbor-plan harbor-prepare-task harbor-validate-task harbor-sync harbor-contracts harbor-execution-check harbor-adapter-checks harbor-validation-tests harbor-validate harbor-check harbor-check-task benchmark-inventory benchmark-snapshot benchmark-snapshot-validate benchmark-publish harbor-oracle harbor-oracle-task harbor-oracle-run harbor-oracle-all harbor-adapter-check heldout-validate heldout-render heldout-smoke agent-eval agent-eval-validate agent-eval-compare codex-visibility provider-eval clean docs-command-check docs-linkcheck deploy-check
+.PHONY: help help-all uv-version-check setup setup-agent container-image eval-image eval-image-pull eval-image-bind hooks fix lint complexity-check lint-full security-audit typecheck test-architecture architecture ci-plan test-plan test-changed check-changed test-unit test-component test-domain test-composition test-storage test-process test-mcp test-provider test-lean test-e2e test-affected test-all-ci test-compatibility test-stress test-ordering duplicate-code npm-test todo-check coverage build check precommit check-static harbor-plan harbor-prepare-task harbor-validate-task harbor-sync harbor-contracts harbor-execution-check harbor-adapter-checks harbor-validation-tests harbor-host-validation harbor-validate harbor-check harbor-check-task benchmark-inventory benchmark-snapshot benchmark-snapshot-validate benchmark-publish harbor-oracle harbor-oracle-task harbor-oracle-run harbor-oracle-all harbor-adapter-check heldout-validate heldout-render heldout-smoke agent-eval agent-eval-validate agent-eval-compare codex-visibility provider-eval clean docs-command-check docs-linkcheck deploy-check
 
 help: ## Show available developer commands.
 	@awk -v public="$(PUBLIC_COMMANDS)" 'BEGIN {FS = ":.*## "; n = split(public, names, " "); for (i = 1; i <= n; i++) wanted[names[i]] = 1; printf "Jacobian common developer commands:\n\n"} /^[a-zA-Z_-]+:.*## / && ($$1 in wanted) {printf "  %-18s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -66,7 +68,7 @@ eval-image-bind: ## Bind image identity into RUNTIME_SNAPSHOT (JACOBIAN_IMAGE=..
 
 deploy-check: ## Validate the clone-to-systemd deployment entrypoint.
 	bash -n deploy/install.sh
-	$(UV_RUN) pytest -n 0 tests/boundary/process/tooling/test_deploy_installer.py
+	$(PYTEST_RUNNER) --name deploy-check -- -n 0 tests/boundary/process/tooling/test_deploy_installer.py
 
 hooks: setup ## Install pre-commit hooks.
 	$(UV_RUN) pre-commit install --install-hooks
@@ -197,7 +199,7 @@ test-e2e: ## Run complete user-visible CLI/workflow scenarios serially.
 	$(call run_topology_lane,e2e)
 
 test-compatibility: ## Run the small supported-version import/API compatibility smoke suite.
-	$(UV_RUN) pytest -n 0 --timeout=30 --timeout-method=thread tests/unit/tooling/test_ci_compatibility.py $(PYTEST_DIAGNOSTIC_ARGS) $(PYTEST_ARGS)
+	$(PYTEST_RUNNER) --name compatibility -- -n 0 --timeout=30 --timeout-method=thread tests/unit/tooling/test_ci_compatibility.py $(PYTEST_DIAGNOSTIC_ARGS) $(PYTEST_ARGS)
 
 test-affected: test-changed ## Compatibility alias for the changed-path planner.
 
@@ -214,7 +216,7 @@ test-all-ci: ## Explicitly run every semantic lane locally (exceptional).
 	$(MAKE) test-e2e
 
 test-stress: ## Repeat explicitly marked property tests on the scheduled lane.
-	$(UV_RUN) pytest -n 0 --timeout=120 --timeout-method=thread -m property --count=$(STRESS_COUNT) \
+	$(PYTEST_RUNNER) --name stress -- -n 0 --timeout=120 --timeout-method=thread -m property --count=$(STRESS_COUNT) \
 		$(if $(TESTS),$(TESTS),tests) $(PYTEST_DIAGNOSTIC_ARGS) $(PYTEST_ARGS)
 
 test-ordering: ## Reproduce scheduled ordering (default seed 17; override with PYTEST_ARGS).
@@ -329,7 +331,7 @@ harbor-contracts: ## Check Harbor sync, task topology, schemas, and generated re
 	$(HARBOR_PYTHON) tools/check_benchmark_contracts.py
 
 harbor-execution-check: harbor-contracts ## Check Harbor jobs, MCP config, Compose, and execution helpers.
-	$(UV_RUN) pytest -n 0 tests/unit/tooling/test_harbor*.py \
+	$(PYTEST_RUNNER) --name harbor-execution -- -n 0 tests/unit/tooling/test_harbor*.py \
 		$(PYTEST_DIAGNOSTIC_ARGS) $(PYTEST_ARGS)
 
 harbor-adapter-checks: ## Check every repository-owned Harbor adapter.
@@ -340,10 +342,14 @@ harbor-adapter-checks: ## Check every repository-owned Harbor adapter.
 	done
 
 harbor-validation-tests: ## Run Harbor's host-side validation test suite.
-	$(UV_RUN) pytest -n $(HARBOR_VALIDATION_WORKERS) \
+	$(PYTEST_RUNNER) --name "$(or $(PYTEST_RUN_NAME),harbor-validation)" -- -n $(HARBOR_VALIDATION_WORKERS) \
 		$(PYTEST_DIAGNOSTIC_ARGS) $(if $(TESTS),$(TESTS),benchmarks/validation) $(PYTEST_ARGS)
 
-harbor-validate: harbor-contracts harbor-adapter-checks harbor-validation-tests ## Run all repository-owned Harbor checks under the pinned Harbor runtime.
+harbor-host-validation: ## Run the full host suite in timing-balanced local shards.
+	$(UV_RUN) python -m benchmarks.tooling.host_validation run-full \
+		--total-workers $(HARBOR_VALIDATION_TOTAL_WORKERS) --max-parallel 4
+
+harbor-validate: harbor-contracts harbor-adapter-checks harbor-host-validation ## Run all repository-owned Harbor checks under the pinned Harbor runtime.
 
 harbor-check: harbor-validate ## Run Harbor topology, digest, provenance, and host-side validation checks.
 

--- a/benchmarks/tooling/benchmark_timings.py
+++ b/benchmarks/tooling/benchmark_timings.py
@@ -1,10 +1,11 @@
-"""Collect per-task Harbor Oracle wall times for future deterministic sharding."""
+"""Collect benchmark timings and compare planned with observed shard cost."""
 
 from __future__ import annotations
 
 import argparse
 import json
 import statistics
+from collections.abc import Iterable
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -26,10 +27,21 @@ def _seconds(started: Any, finished: Any) -> float | None:
 
 
 def collect(root: Path) -> dict[str, float]:
+    samples: dict[str, list[float]] = {}
+    _collect_oracle_timings(root, samples)
+    _collect_host_timings(root, samples)
+    if not samples:
+        raise HarborSuiteError(f"no completed Harbor trial timings found below {root}")
+    return {
+        key: round(statistics.median(values), 6)
+        for key, values in sorted(samples.items())
+    }
+
+
+def _collect_oracle_timings(root: Path, samples: dict[str, list[float]]) -> None:
     owners = {
         ref.path.name: suite.id for suite in load_registry() for ref in suite.tasks
     }
-    samples: dict[str, list[float]] = {}
     for path in sorted(root.rglob("result.json")):
         try:
             payload = json.loads(path.read_text(encoding="utf-8"))
@@ -43,26 +55,182 @@ def collect(root: Path) -> dict[str, float]:
         if dataset is None or elapsed is None:
             continue
         samples.setdefault(f"{dataset}/{task}", []).append(elapsed)
-    if not samples:
-        raise HarborSuiteError(f"no completed Harbor trial timings found below {root}")
+
+
+def _collect_host_timings(root: Path, samples: dict[str, list[float]]) -> None:
+    for path in sorted(root.rglob("pytest-receipt.json")):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(payload, dict) or payload.get("exit_code") != 0:
+            continue
+        entry = payload.get("entry")
+        name = payload.get("name")
+        if name is None and isinstance(entry, dict):
+            name = entry.get("name")
+        elapsed = payload.get("actual_seconds")
+        if (
+            not isinstance(name, str)
+            or not name
+            or not isinstance(elapsed, (int, float))
+            or isinstance(elapsed, bool)
+            or elapsed <= 0
+        ):
+            continue
+        key = name if name.startswith("host-validation/") else f"host-validation/{name}"
+        samples.setdefault(key, []).append(float(elapsed))
+
+
+def _load_matrix(value: str | None) -> list[dict[str, Any]]:
+    if not value:
+        return []
+    try:
+        matrix = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise HarborSuiteError(f"invalid timing matrix JSON: {exc}") from exc
+    if not isinstance(matrix, list) or not all(
+        isinstance(item, dict) for item in matrix
+    ):
+        raise HarborSuiteError("timing matrix must be an array of objects")
+    return matrix
+
+
+def comparison_report(
+    timings: dict[str, float],
+    *,
+    oracle_matrix: Iterable[dict[str, Any]] = (),
+    host_matrix: Iterable[dict[str, Any]] = (),
+) -> dict[str, Any]:
+    """Bind planner predictions to the durations observed for each matrix job."""
+    shards: list[dict[str, Any]] = []
+    for entry in oracle_matrix:
+        dataset = entry.get("dataset")
+        shard = entry.get("shard")
+        tasks = entry.get("tasks")
+        predicted = entry.get("predicted_seconds")
+        if (
+            not isinstance(dataset, str)
+            or not isinstance(shard, str)
+            or not isinstance(tasks, list)
+        ):
+            raise HarborSuiteError("Oracle timing matrix entry is malformed")
+        observed = [timings.get(f"{dataset}/{task}") for task in tasks]
+        oracle_actual = sum(value for value in observed if value is not None)
+        missing = [
+            task for task, value in zip(tasks, observed, strict=True) if value is None
+        ]
+        shards.append(
+            _comparison_entry(
+                kind="oracle",
+                name=f"{dataset}/{shard}",
+                predicted=predicted,
+                actual=oracle_actual if not missing else None,
+                missing=missing,
+            )
+        )
+    for entry in host_matrix:
+        name = entry.get("name")
+        if not isinstance(name, str):
+            raise HarborSuiteError("host timing matrix entry is malformed")
+        host_actual = timings.get(f"host-validation/{name}")
+        shards.append(
+            _comparison_entry(
+                kind="host",
+                name=name,
+                predicted=entry.get("predicted_seconds"),
+                actual=host_actual,
+                missing=[] if host_actual is not None else [name],
+            )
+        )
+    return {"schema_version": 1, "shards": shards}
+
+
+def _comparison_entry(
+    *, kind: str, name: str, predicted: Any, actual: float | None, missing: list[str]
+) -> dict[str, Any]:
+    if (
+        not isinstance(predicted, (int, float))
+        or isinstance(predicted, bool)
+        or predicted <= 0
+    ):
+        raise HarborSuiteError(f"timing prediction for {name} must be positive")
+    predicted_value = round(float(predicted), 6)
+    actual_value = round(actual, 6) if actual is not None else None
     return {
-        key: round(statistics.median(values), 6)
-        for key, values in sorted(samples.items())
+        "kind": kind,
+        "name": name,
+        "predicted_seconds": predicted_value,
+        "actual_seconds": actual_value,
+        "delta_seconds": (
+            round(actual_value - predicted_value, 6)
+            if actual_value is not None
+            else None
+        ),
+        "actual_to_predicted": (
+            round(actual_value / predicted_value, 6)
+            if actual_value is not None
+            else None
+        ),
+        "missing": missing,
     }
+
+
+def _markdown(report: dict[str, Any]) -> str:
+    lines = [
+        "## Benchmark shard timing",
+        "",
+        "| Kind | Shard | Predicted | Actual | Ratio |",
+        "| --- | --- | ---: | ---: | ---: |",
+    ]
+    for shard in report["shards"]:
+        actual = shard["actual_seconds"]
+        ratio = shard["actual_to_predicted"]
+        lines.append(
+            f"| {shard['kind']} | `{shard['name']}` | "
+            f"{shard['predicted_seconds']:.1f}s | "
+            f"{actual:.1f}s | {ratio:.2f}x |"
+            if actual is not None
+            else f"| {shard['kind']} | `{shard['name']}` | "
+            f"{shard['predicted_seconds']:.1f}s | unavailable | unavailable |"
+        )
+    return "\n".join(lines) + "\n"
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--root", type=Path, required=True)
     parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--previous", type=Path)
+    parser.add_argument("--oracle-matrix-json")
+    parser.add_argument("--host-matrix-json")
+    parser.add_argument("--report-output", type=Path)
+    parser.add_argument("--summary-output", type=Path)
     args = parser.parse_args()
     try:
         timings = collect(args.root)
+        if args.previous is not None and args.previous.is_file():
+            previous = json.loads(args.previous.read_text(encoding="utf-8"))
+            if not isinstance(previous, dict):
+                raise HarborSuiteError("previous timing history must be an object")
+            timings = {**previous, **timings}
+        report = comparison_report(
+            timings,
+            oracle_matrix=_load_matrix(args.oracle_matrix_json),
+            host_matrix=_load_matrix(args.host_matrix_json),
+        )
     except HarborSuiteError as exc:
         parser.error(str(exc))
     args.output.write_text(
         json.dumps(timings, indent=2, sort_keys=True) + "\n", encoding="utf-8"
     )
+    if args.report_output is not None:
+        args.report_output.write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+    if args.summary_output is not None:
+        with args.summary_output.open("a", encoding="utf-8") as stream:
+            stream.write(_markdown(report))
     print(args.output)
     return 0
 
@@ -71,4 +239,4 @@ if __name__ == "__main__":
     raise SystemExit(main())
 
 
-__all__ = ["collect"]
+__all__ = ["collect", "comparison_report"]

--- a/benchmarks/tooling/benchmark_validation.py
+++ b/benchmarks/tooling/benchmark_validation.py
@@ -1,0 +1,118 @@
+"""Stable fail-closed aggregate validation for the benchmark workflow."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from benchmarks.tooling.errors import HarborSuiteError
+from benchmarks.tooling.host_validation import (
+    load_plan_receipt,
+    timing_digest,
+    validate_receipts,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class LaneResult:
+    """Planner selection and observed GitHub job result for one evidence lane."""
+
+    selected: bool
+    result: str
+
+
+def _validate_lane(name: str, lane: LaneResult) -> None:
+    expected = "success" if lane.selected else "skipped"
+    if lane.result != expected:
+        raise HarborSuiteError(
+            f"benchmark lane {name} expected {expected}, observed {lane.result}"
+        )
+
+
+def validate_aggregate(
+    *,
+    plan_result: str,
+    plan_receipt: Path,
+    execution_sha: str,
+    lanes: dict[str, LaneResult],
+    receipt_root: Path | None,
+    timing_path: Path | None,
+) -> None:
+    """Validate stable lane results and exact host-shard execution evidence."""
+
+    if plan_result != "success":
+        raise HarborSuiteError(f"benchmark planner did not succeed: {plan_result}")
+    provenance, host_entries = load_plan_receipt(
+        plan_receipt, execution_sha=execution_sha
+    )
+    receipt = json.loads(plan_receipt.read_text(encoding="utf-8"))
+    plan = receipt["plan"]
+    expected_flags = {
+        "static": plan["run-benchmark-check"] == "true",
+        "contracts": plan["run-benchmark-record-schema"] == "true",
+        "host-validation": plan["run-benchmark-host-validation"] == "true",
+        "inventory": plan["run-benchmark-inventory"] == "true",
+        "oracle": plan["run-benchmark-oracle"] == "true",
+    }
+    if set(lanes) != set(expected_flags):
+        raise HarborSuiteError("benchmark aggregate lane set is incomplete")
+    for name, selected in expected_flags.items():
+        lane = lanes[name]
+        if lane.selected != selected:
+            raise HarborSuiteError(
+                f"benchmark aggregate selection disagrees for {name}"
+            )
+        _validate_lane(name, lane)
+    if expected_flags["host-validation"]:
+        if receipt_root is None or timing_path is None:
+            raise HarborSuiteError("selected host validation has no receipt evidence")
+        validate_receipts(
+            receipt_root,
+            expected=host_entries,
+            provenance=provenance,
+            timing_digest=timing_digest(timing_path),
+        )
+    elif host_entries:
+        raise HarborSuiteError("unselected host validation has a non-empty matrix")
+
+
+def _lane(value: str) -> tuple[str, LaneResult]:
+    parts = value.split(":", 2)
+    if len(parts) != 3 or parts[1] not in {"true", "false"}:
+        raise argparse.ArgumentTypeError("lanes must use name:true|false:result")
+    return parts[0], LaneResult(selected=parts[1] == "true", result=parts[2])
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--plan-result", required=True)
+    parser.add_argument("--plan-receipt", type=Path, required=True)
+    parser.add_argument("--execution-sha", required=True)
+    parser.add_argument("--lane", action="append", type=_lane, required=True)
+    parser.add_argument("--receipt-root", type=Path)
+    parser.add_argument("--timings", type=Path)
+    args = parser.parse_args(argv)
+    try:
+        lanes = dict(args.lane)
+        if len(lanes) != len(args.lane):
+            raise HarborSuiteError("benchmark aggregate lanes must be unique")
+        validate_aggregate(
+            plan_result=args.plan_result,
+            plan_receipt=args.plan_receipt,
+            execution_sha=args.execution_sha,
+            lanes=lanes,
+            receipt_root=args.receipt_root,
+            timing_path=args.timings,
+        )
+    except (HarborSuiteError, OSError, json.JSONDecodeError) as exc:
+        parser.error(str(exc))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = ["LaneResult", "validate_aggregate"]

--- a/benchmarks/tooling/command_runner.py
+++ b/benchmarks/tooling/command_runner.py
@@ -16,7 +16,7 @@ import signal
 import subprocess
 import threading
 import time
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from contextlib import suppress
 from dataclasses import dataclass, field
 from enum import StrEnum
@@ -46,6 +46,7 @@ class ToolCommandStatus(StrEnum):
     TIMED_OUT = "TIMED_OUT"
     CANCELLED = "CANCELLED"
     OUTPUT_LIMIT_EXCEEDED = "OUTPUT_LIMIT_EXCEEDED"
+    STREAM_FAILED = "STREAM_FAILED"
     START_FAILED = "START_FAILED"
 
 
@@ -62,6 +63,12 @@ class ToolCommandRequest:
     stdout_limit_bytes: int = 0
     stderr_limit_bytes: int = 0
     cancellation_event: threading.Event | None = None
+    stdout_sink: Callable[[bytes], None] | None = field(
+        default=None, compare=False, repr=False
+    )
+    stderr_sink: Callable[[bytes], None] | None = field(
+        default=None, compare=False, repr=False
+    )
 
     def __post_init__(self) -> None:
         self._validate_command()
@@ -96,6 +103,10 @@ class ToolCommandRequest:
             self.cancellation_event, threading.Event
         ):
             raise TypeError("cancellation_event must be a threading.Event or None")
+        for name in ("stdout_sink", "stderr_sink"):
+            sink = getattr(self, name)
+            if sink is not None and not callable(sink):
+                raise TypeError(f"{name} must be callable or None")
 
 
 @dataclass(frozen=True, slots=True)
@@ -198,14 +209,29 @@ def operator_environment(
 
 
 def _read_stream(
-    stream: object, target: bytearray, limit: int, exceeded: threading.Event
+    stream: object,
+    target: bytearray,
+    limit: int,
+    exceeded: threading.Event,
+    sink: Callable[[bytes], None] | None,
+    sink_name: str,
+    sink_failure: queue.Queue[tuple[str, str]],
 ) -> None:
+    read = getattr(stream, "read1", None) or stream.read  # type: ignore[attr-defined]
     while True:
-        block = stream.read(65_536)  # type: ignore[attr-defined]
+        block = read(65_536)
         if not block:
             return
         remaining = max(0, limit - len(target))
-        target.extend(block[:remaining])
+        accepted = block[:remaining]
+        target.extend(accepted)
+        if accepted and sink is not None:
+            try:
+                sink(bytes(accepted))
+            except Exception as exc:
+                with suppress(queue.Full):
+                    sink_failure.put_nowait((sink_name, type(exc).__name__))
+                return
         if len(block) > remaining:
             exceeded.set()
             return
@@ -257,6 +283,7 @@ def _poll_tool_status(
     request: ToolCommandRequest,
     stdout_overflow: threading.Event,
     stderr_overflow: threading.Event,
+    sink_failure: queue.Queue[tuple[str, str]],
     deadline: float,
 ) -> ToolCommandStatus:
     while process.poll() is None:
@@ -267,6 +294,8 @@ def _poll_tool_status(
             return ToolCommandStatus.CANCELLED
         if stdout_overflow.is_set() or stderr_overflow.is_set():
             return ToolCommandStatus.OUTPUT_LIMIT_EXCEEDED
+        if not sink_failure.empty():
+            return ToolCommandStatus.STREAM_FAILED
         if time.monotonic() >= deadline:
             return ToolCommandStatus.TIMED_OUT
         time.sleep(0.01)
@@ -287,10 +316,44 @@ def run_tool_command(
             stderr=b"",
             diagnostic=process[1],
         )
-    stdout = bytearray()
-    stderr = bytearray()
-    stdout_overflow = threading.Event()
-    stderr_overflow = threading.Event()
+    stdout, stderr, stdout_overflow, stderr_overflow, sink_failure, readers = (
+        _start_stream_readers(process, request)
+    )
+    _start_input_writer(process, request.stdin_bytes)
+    deadline = time.monotonic() + request.timeout_seconds
+    status = _poll_tool_status(
+        process,
+        request,
+        stdout_overflow,
+        stderr_overflow,
+        sink_failure,
+        deadline,
+    )
+    return _finish_tool_process(
+        process,
+        status=status,
+        readers=readers,
+        stdout=stdout,
+        stderr=stderr,
+        stdout_overflow=stdout_overflow,
+        stderr_overflow=stderr_overflow,
+        sink_failure=sink_failure,
+    )
+
+
+def _start_stream_readers(
+    process: subprocess.Popen[bytes], request: ToolCommandRequest
+) -> tuple[
+    bytearray,
+    bytearray,
+    threading.Event,
+    threading.Event,
+    queue.Queue[tuple[str, str]],
+    tuple[threading.Thread, threading.Thread],
+]:
+    stdout, stderr = bytearray(), bytearray()
+    stdout_overflow, stderr_overflow = threading.Event(), threading.Event()
+    sink_failure: queue.Queue[tuple[str, str]] = queue.Queue(maxsize=1)
     readers = (
         threading.Thread(
             target=_read_stream,
@@ -299,6 +362,9 @@ def run_tool_command(
                 stdout,
                 request.stdout_limit_bytes,
                 stdout_overflow,
+                request.stdout_sink,
+                "stdout",
+                sink_failure,
             ),
             daemon=True,
         ),
@@ -309,26 +375,41 @@ def run_tool_command(
                 stderr,
                 request.stderr_limit_bytes,
                 stderr_overflow,
+                request.stderr_sink,
+                "stderr",
+                sink_failure,
             ),
             daemon=True,
         ),
     )
     for reader in readers:
         reader.start()
+    return stdout, stderr, stdout_overflow, stderr_overflow, sink_failure, readers
 
+
+def _start_input_writer(process: subprocess.Popen[bytes], stdin_bytes: bytes) -> None:
     def write_input() -> None:
         try:
             assert process.stdin is not None
-            process.stdin.write(request.stdin_bytes)
+            process.stdin.write(stdin_bytes)
             process.stdin.close()
         except (BrokenPipeError, OSError):
             pass
 
     threading.Thread(target=write_input, daemon=True).start()
-    deadline = time.monotonic() + request.timeout_seconds
-    status = _poll_tool_status(
-        process, request, stdout_overflow, stderr_overflow, deadline
-    )
+
+
+def _finish_tool_process(
+    process: subprocess.Popen[bytes],
+    *,
+    status: ToolCommandStatus,
+    readers: tuple[threading.Thread, threading.Thread],
+    stdout: bytearray,
+    stderr: bytearray,
+    stdout_overflow: threading.Event,
+    stderr_overflow: threading.Event,
+    sink_failure: queue.Queue[tuple[str, str]],
+) -> ToolCommandResult:
     if status is not ToolCommandStatus.EXITED:
         _kill_tool_process_tree(process)
     try:
@@ -349,10 +430,15 @@ def run_tool_command(
             )
     for reader in readers:
         reader.join(timeout=1.0)
-    if status is ToolCommandStatus.EXITED and (
-        stdout_overflow.is_set() or stderr_overflow.is_set()
-    ):
-        status = ToolCommandStatus.OUTPUT_LIMIT_EXCEEDED
+    if status is ToolCommandStatus.EXITED:
+        if stdout_overflow.is_set() or stderr_overflow.is_set():
+            status = ToolCommandStatus.OUTPUT_LIMIT_EXCEEDED
+        elif not sink_failure.empty():
+            status = ToolCommandStatus.STREAM_FAILED
+    diagnostic = None
+    if status is ToolCommandStatus.STREAM_FAILED:
+        sink_name, exception_name = sink_failure.get_nowait()
+        diagnostic = f"{sink_name} sink failed: {exception_name}"
     return ToolCommandResult(
         status=status,
         exit_code=process.returncode if status is ToolCommandStatus.EXITED else None,
@@ -360,6 +446,7 @@ def run_tool_command(
         stderr=bytes(stderr),
         stdout_exceeded=stdout_overflow.is_set(),
         stderr_exceeded=stderr_overflow.is_set(),
+        diagnostic=diagnostic,
     )
 
 

--- a/benchmarks/tooling/host_validation.py
+++ b/benchmarks/tooling/host_validation.py
@@ -1,0 +1,754 @@
+"""Timing-aware orchestration and receipts for benchmark host validation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import re
+import shutil
+import uuid
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from contextlib import contextmanager, suppress
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from benchmarks.tooling.errors import HarborSuiteError
+from benchmarks.tooling.receipts import canonical_json, digest_bytes, receipt_digest
+from benchmarks.tooling.validation_plan import (
+    HostValidation,
+    full_host_validation,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+TIMING_PATH = ROOT / ".ci" / "benchmark-test-durations.json"
+_DIGEST = re.compile(r"sha256:[0-9a-f]{64}\Z")
+_SHA = re.compile(r"[0-9a-f]{40,64}\Z")
+_HOST_NAME = re.compile(r"[A-Za-z0-9_.-]+\Z")
+_HOST_KEYWORD = re.compile(r"[A-Za-z0-9_.-]*\Z")
+_MAX_TIMING_BYTES = 5 * 1024 * 1024
+_MAX_TIMING_ENTRIES = 10_000
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionProvenance:
+    """Immutable identities shared by every shard in one host-validation run."""
+
+    plan_head_sha: str
+    execution_sha: str
+    planner_digest: str
+    topology_digest: str
+    plan_digest: str
+    plan_receipt_digest: str
+
+
+@dataclass(frozen=True, slots=True)
+class ShardResult:
+    """Normalized result returned by the pytest lifecycle boundary."""
+
+    status: str
+    exit_code: int
+    actual_seconds: float
+
+
+ShardRunner = Callable[[HostValidation, tuple[str, ...], int], ShardResult]
+
+
+def _canonical(value: object) -> bytes:
+    return canonical_json(value)
+
+
+def _digest_bytes(value: bytes) -> str:
+    return digest_bytes(value)
+
+
+def _require_digest(value: object, label: str) -> str:
+    if not isinstance(value, str) or _DIGEST.fullmatch(value) is None:
+        raise HarborSuiteError(f"{label} must be a sha256 digest")
+    return value
+
+
+def _require_sha(value: object, label: str) -> str:
+    if not isinstance(value, str) or _SHA.fullmatch(value) is None:
+        raise HarborSuiteError(f"{label} must be a Git revision")
+    return value
+
+
+def _read_json_object(path: Path, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise HarborSuiteError(f"{label} is unavailable or invalid: {path}") from exc
+    if not isinstance(value, dict):
+        raise HarborSuiteError(f"{label} must contain a JSON object")
+    return value
+
+
+def _entry(value: object) -> HostValidation:
+    if not isinstance(value, Mapping) or set(value) != {
+        "name",
+        "selector",
+        "keyword",
+        "splits",
+        "group",
+        "predicted_seconds",
+    }:
+        raise HarborSuiteError("host-validation entry has an invalid shape")
+    name = value["name"]
+    selector = value["selector"]
+    keyword = value["keyword"]
+    splits = value["splits"]
+    group = value["group"]
+    predicted = value["predicted_seconds"]
+    if (
+        not isinstance(name, str)
+        or not isinstance(selector, str)
+        or not isinstance(keyword, str)
+        or not isinstance(splits, int)
+        or isinstance(splits, bool)
+        or not isinstance(group, int)
+        or isinstance(group, bool)
+        or not isinstance(predicted, (int, float))
+        or isinstance(predicted, bool)
+        or not math.isfinite(float(predicted))
+    ):
+        raise HarborSuiteError("host-validation entry has invalid values")
+    entry = HostValidation(
+        name=name,
+        selector=selector,
+        keyword=keyword,
+        splits=splits,
+        group=group,
+        predicted_seconds=float(predicted),
+    )
+    if (
+        not entry.name
+        or entry.name in {".", ".."}
+        or Path(entry.name).name != entry.name
+        or _HOST_NAME.fullmatch(entry.name) is None
+        or (
+            entry.selector != "benchmarks/validation"
+            and not entry.selector.startswith("benchmarks/validation/")
+        )
+        or ".." in Path(entry.selector).parts
+        or _HOST_KEYWORD.fullmatch(entry.keyword) is None
+        or entry.predicted_seconds <= 0
+        or (entry.splits == 0 and entry.group != 0)
+        or (entry.splits > 0 and not 1 <= entry.group <= entry.splits)
+        or entry.splits < 0
+    ):
+        raise HarborSuiteError("host-validation entry is incoherent")
+    return entry
+
+
+def load_plan_receipt(
+    path: Path, *, execution_sha: str
+) -> tuple[ExecutionProvenance, tuple[HostValidation, ...]]:
+    """Validate a plan receipt and return its host matrix and provenance."""
+
+    receipt = _read_json_object(path, "benchmark plan receipt")
+    declared = _require_digest(receipt.get("receipt_digest"), "plan receipt digest")
+    unsigned = {key: value for key, value in receipt.items() if key != "receipt_digest"}
+    if receipt_digest(unsigned) != declared:
+        raise HarborSuiteError(
+            "benchmark plan receipt digest does not match its content"
+        )
+    if receipt.get("receipt_version") != "1" or receipt.get("plan_kind") != "benchmark":
+        raise HarborSuiteError("benchmark plan receipt has an unsupported identity")
+    plan = receipt.get("plan")
+    if not isinstance(plan, dict) or not all(
+        isinstance(key, str) and isinstance(value, str) for key, value in plan.items()
+    ):
+        raise HarborSuiteError("benchmark plan receipt has an invalid plan")
+    plan_payload = "".join(f"{key}={plan[key]}\n" for key in sorted(plan)).encode()
+    plan_digest = _require_digest(receipt.get("plan_digest"), "plan digest")
+    if _digest_bytes(plan_payload) != plan_digest:
+        raise HarborSuiteError("benchmark plan digest does not match its plan")
+    plan_head_sha = _require_sha(plan.get("benchmark-plan-head-sha"), "plan head SHA")
+    if receipt.get("head_sha") != plan_head_sha:
+        raise HarborSuiteError("benchmark plan receipt and plan head SHA disagree")
+    try:
+        matrix = json.loads(plan["benchmark-host-validation-matrix"])
+    except (KeyError, json.JSONDecodeError) as exc:
+        raise HarborSuiteError("benchmark plan host matrix is invalid") from exc
+    if not isinstance(matrix, list):
+        raise HarborSuiteError("benchmark plan host matrix must be a list")
+    entries = tuple(_entry(value) for value in matrix)
+    return (
+        ExecutionProvenance(
+            plan_head_sha=plan_head_sha,
+            execution_sha=_require_sha(execution_sha, "execution SHA"),
+            planner_digest=_require_digest(
+                plan.get("benchmark-planner-digest"), "planner digest"
+            ),
+            topology_digest=_topology_digest(plan, entries),
+            plan_digest=plan_digest,
+            plan_receipt_digest=declared,
+        ),
+        entries,
+    )
+
+
+def _topology_digest(plan: Mapping[str, str], entries: Sequence[HostValidation]) -> str:
+    value = plan.get("benchmark-topology-digest")
+    selected = any(
+        plan.get(name) == "true"
+        for name in (
+            "run-benchmark-check",
+            "run-benchmark-record-schema",
+            "run-benchmark-host-validation",
+            "run-benchmark-inventory",
+            "run-benchmark-oracle",
+        )
+    )
+    if value == "" and not selected and not entries:
+        return ""
+    return _require_digest(value, "topology digest")
+
+
+def local_provenance(
+    root: Path, entries: Sequence[HostValidation]
+) -> ExecutionProvenance:
+    """Bind a local run to HEAD, planner sources, and the selected matrix."""
+
+    from benchmarks.tooling.command_runner import git_head_sha
+
+    execution_sha = git_head_sha(root)
+    if execution_sha is None:
+        raise HarborSuiteError("cannot resolve the local source revision")
+    planner_sources = (
+        root / ".github/scripts/plan-benchmarks",
+        root / "benchmarks/tooling/validation_plan.py",
+    )
+    planner_digest = _digest_bytes(
+        b"\n".join(path.read_bytes() for path in planner_sources)
+    )
+    matrix = [entry.as_matrix_entry() for entry in entries]
+    plan_digest = _digest_bytes(_canonical(matrix))
+    identity = {
+        "execution_sha": execution_sha,
+        "planner_digest": planner_digest,
+        "plan_digest": plan_digest,
+    }
+    return ExecutionProvenance(
+        plan_head_sha=execution_sha,
+        execution_sha=execution_sha,
+        planner_digest=planner_digest,
+        topology_digest=plan_digest,
+        plan_digest=plan_digest,
+        plan_receipt_digest=receipt_digest(identity),
+    )
+
+
+def verify_execution_sha(root: Path, expected: str) -> str:
+    """Require the checked-out tree to match the workflow execution identity."""
+
+    expected = _require_sha(expected, "execution SHA")
+    from benchmarks.tooling.command_runner import git_head_sha
+
+    if git_head_sha(root) != expected:
+        raise HarborSuiteError(
+            "checked-out Git revision does not match --execution-sha"
+        )
+    return expected
+
+
+def worker_allocation(
+    *, entry_count: int, total_worker_budget: int, max_parallel: int
+) -> tuple[int, int]:
+    """Return concurrent shard processes and xdist workers per process.
+
+    ``max_parallel`` reserves the process slots that may run concurrently,
+    including slots executed by separate CI matrix jobs. Dividing the total
+    budget by those slots prevents each under-filled invocation from consuming
+    the complete budget as nested xdist workers.
+    """
+
+    if entry_count < 1:
+        raise ValueError("entry_count must be positive")
+    if total_worker_budget < 1:
+        raise ValueError("total_worker_budget must be positive")
+    if max_parallel < 1:
+        raise ValueError("max_parallel must be positive")
+    budgeted_slots = min(total_worker_budget, max_parallel)
+    parallel = min(entry_count, budgeted_slots)
+    workers = max(1, total_worker_budget // budgeted_slots)
+    if budgeted_slots * workers > total_worker_budget:
+        raise AssertionError("worker allocation exceeded its declared budget")
+    return parallel, workers
+
+
+def pytest_arguments(
+    entry: HostValidation,
+    *,
+    timing_path: Path,
+    workers: int,
+    store_durations: bool,
+) -> tuple[str, ...]:
+    """Build one structured pytest argument vector from a validated entry."""
+
+    if workers < 1:
+        raise ValueError("workers must be positive")
+    arguments = ["-n", str(workers), "--durations=10", entry.selector]
+    if entry.keyword:
+        arguments.extend(("-k", entry.keyword))
+    if entry.splits:
+        arguments.extend(
+            (
+                "--splits",
+                str(entry.splits),
+                "--group",
+                str(entry.group),
+                "--splitting-algorithm",
+                "least_duration",
+                "--durations-path",
+                str(timing_path),
+            )
+        )
+        if store_durations:
+            arguments.extend(("--store-durations", "--clean-durations"))
+    return tuple(arguments)
+
+
+def _command_digest(
+    entry: HostValidation, *, workers: int, store_durations: bool
+) -> str:
+    arguments = pytest_arguments(
+        entry,
+        timing_path=Path("<timing-input>"),
+        workers=workers,
+        store_durations=store_durations,
+    )
+    return receipt_digest({"arguments": arguments})
+
+
+def timing_digest(path: Path) -> str:
+    try:
+        payload = path.read_bytes()
+    except OSError as exc:
+        raise HarborSuiteError(f"timing input is unavailable: {path}") from exc
+    if len(payload) > _MAX_TIMING_BYTES:
+        raise HarborSuiteError("timing input exceeds its byte limit")
+    try:
+        value = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise HarborSuiteError("timing input is not valid JSON") from exc
+    if not isinstance(value, dict) or len(value) > _MAX_TIMING_ENTRIES:
+        raise HarborSuiteError("timing input has an invalid shape")
+    for nodeid, duration in value.items():
+        if (
+            not isinstance(nodeid, str)
+            or not nodeid.startswith("benchmarks/validation/")
+            or isinstance(duration, bool)
+            or not isinstance(duration, (int, float))
+            or not math.isfinite(float(duration))
+            or duration < 0
+        ):
+            raise HarborSuiteError("timing input contains an invalid entry")
+    return _digest_bytes(payload)
+
+
+@contextmanager
+def timing_input(root: Path, requested: Path) -> Iterator[tuple[Path, str]]:
+    """Yield a validated timing file, using a worktree-local empty fallback."""
+
+    run_root: Path | None = None
+    path = requested
+    try:
+        requested_digest = timing_digest(requested)
+    except HarborSuiteError as exc:
+        run_root = root / ".pytest_cache" / "benchmark-host" / uuid.uuid4().hex
+        run_root.mkdir(parents=True)
+        path = run_root / "benchmark-test-durations.json"
+        path.write_text("{}\n", encoding="utf-8")
+        requested_digest = timing_digest(path)
+        print(
+            json.dumps(
+                {
+                    "event": "benchmark-host-timing-fallback",
+                    "reason": str(exc),
+                    "requested": str(requested),
+                },
+                sort_keys=True,
+            ),
+            flush=True,
+        )
+    try:
+        yield path, requested_digest
+    finally:
+        if run_root is not None:
+            shutil.rmtree(run_root, ignore_errors=True)
+            with suppress(OSError):
+                run_root.parent.rmdir()
+
+
+def build_receipt(
+    *,
+    entry: HostValidation,
+    result: ShardResult,
+    provenance: ExecutionProvenance,
+    timing_digest: str,
+    workers: int,
+    total_worker_budget: int,
+    max_parallel: int,
+    store_durations: bool = False,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "schema_version": 1,
+        "kind": "benchmark-host-validation-shard",
+        **asdict(provenance),
+        "timing_digest": timing_digest,
+        "entry": entry.as_matrix_entry(),
+        "workers": workers,
+        "total_worker_budget": total_worker_budget,
+        "max_parallel": max_parallel,
+        "store_durations": store_durations,
+        "command_digest": _command_digest(
+            entry, workers=workers, store_durations=store_durations
+        ),
+        "status": result.status,
+        "exit_code": result.exit_code,
+        "actual_seconds": round(result.actual_seconds, 6),
+    }
+    payload["receipt_digest"] = receipt_digest(payload)
+    return payload
+
+
+def _write_receipt(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def _default_runner(root: Path, environment: Mapping[str, str]) -> ShardRunner:
+    def run(
+        entry: HostValidation, arguments: tuple[str, ...], _workers: int
+    ) -> ShardResult:
+        from tools.pytest_lifecycle import run_pytest
+
+        result = run_pytest(
+            arguments,
+            root=root,
+            name=f"host-validation/{entry.name}",
+            environment=environment,
+            predicted_seconds=entry.predicted_seconds,
+        )
+        return ShardResult(
+            status=result.status,
+            exit_code=result.exit_code,
+            actual_seconds=result.actual_seconds,
+        )
+
+    return run
+
+
+def execute(
+    entries: Sequence[HostValidation],
+    *,
+    root: Path,
+    timing_path: Path,
+    receipt_dir: Path,
+    provenance: ExecutionProvenance,
+    total_worker_budget: int,
+    max_parallel: int,
+    store_durations: bool = False,
+    duration_output: Path | None = None,
+    runner: ShardRunner | None = None,
+) -> int:
+    """Execute selected entries under one explicit worker budget."""
+
+    if not entries:
+        raise ValueError("at least one host-validation entry is required")
+    if store_durations and len(entries) != 1:
+        raise ValueError("duration updates require one isolated shard process")
+    if store_durations and duration_output is None:
+        raise ValueError("duration updates require a separate output path")
+    budgeted_slots = min(total_worker_budget, max_parallel)
+    parallel, workers = worker_allocation(
+        entry_count=len(entries),
+        total_worker_budget=total_worker_budget,
+        max_parallel=max_parallel,
+    )
+    run = runner or _default_runner(root, dict(os.environ))
+    with timing_input(root, timing_path) as (resolved_timing, input_timing_digest):
+        timing_run_root: Path | None = None
+        execution_timing = resolved_timing
+        if store_durations:
+            timing_run_root = (
+                root / ".pytest_cache" / "benchmark-host-timing" / uuid.uuid4().hex
+            )
+            timing_run_root.mkdir(parents=True)
+            execution_timing = timing_run_root / "benchmark-test-durations.json"
+            shutil.copyfile(resolved_timing, execution_timing)
+
+        def run_one(entry: HostValidation) -> tuple[HostValidation, ShardResult]:
+            print(
+                json.dumps(
+                    {
+                        "event": "benchmark-host-shard-start",
+                        "name": entry.name,
+                        "workers": workers,
+                    },
+                    sort_keys=True,
+                ),
+                flush=True,
+            )
+            result = run(
+                entry,
+                pytest_arguments(
+                    entry,
+                    timing_path=execution_timing,
+                    workers=workers,
+                    store_durations=store_durations,
+                ),
+                workers,
+            )
+            payload = build_receipt(
+                entry=entry,
+                result=result,
+                provenance=provenance,
+                timing_digest=input_timing_digest,
+                workers=workers,
+                total_worker_budget=total_worker_budget,
+                max_parallel=budgeted_slots,
+                store_durations=store_durations,
+            )
+            _write_receipt(receipt_dir / entry.name / "pytest-receipt.json", payload)
+            print(
+                json.dumps(
+                    {
+                        "event": "benchmark-host-shard-complete",
+                        "name": entry.name,
+                        "status": result.status,
+                        "exit_code": result.exit_code,
+                        "actual_seconds": round(result.actual_seconds, 3),
+                    },
+                    sort_keys=True,
+                ),
+                flush=True,
+            )
+            return entry, result
+
+        outcomes: list[tuple[HostValidation, ShardResult]] = []
+        try:
+            with ThreadPoolExecutor(max_workers=parallel) as pool:
+                futures = [pool.submit(run_one, entry) for entry in entries]
+                for future in as_completed(futures):
+                    outcomes.append(future.result())
+            if (
+                store_durations
+                and all(result.exit_code == 0 for _, result in outcomes)
+                and duration_output is not None
+            ):
+                duration_output.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copyfile(execution_timing, duration_output)
+        finally:
+            if timing_run_root is not None:
+                shutil.rmtree(timing_run_root, ignore_errors=True)
+                with suppress(OSError):
+                    timing_run_root.parent.rmdir()
+    return 0 if all(result.exit_code == 0 for _, result in outcomes) else 1
+
+
+def validate_receipts(
+    root: Path,
+    *,
+    expected: Sequence[HostValidation],
+    provenance: ExecutionProvenance,
+    timing_digest: str,
+    total_worker_budget: int = 8,
+    max_parallel: int = 4,
+) -> None:
+    """Fail closed unless exactly one successful bound receipt exists per entry."""
+
+    paths = sorted(root.rglob("pytest-receipt.json")) if root.is_dir() else []
+    if len(paths) != len(expected):
+        raise HarborSuiteError(
+            f"expected {len(expected)} host receipts, found {len(paths)}"
+        )
+    expected_by_name = {entry.name: entry for entry in expected}
+    seen: set[str] = set()
+    for path in paths:
+        entry = _validate_receipt(
+            path,
+            provenance=provenance,
+            timing_digest=timing_digest,
+            total_worker_budget=total_worker_budget,
+            max_parallel=max_parallel,
+        )
+        if entry.name in seen or expected_by_name.get(entry.name) != entry:
+            raise HarborSuiteError(
+                f"unexpected or duplicate host-validation receipt: {entry.name}"
+            )
+        seen.add(entry.name)
+    if seen != set(expected_by_name):
+        raise HarborSuiteError(
+            "host-validation receipts do not cover the planned matrix"
+        )
+
+
+def _validate_receipt(
+    path: Path,
+    *,
+    provenance: ExecutionProvenance,
+    timing_digest: str,
+    total_worker_budget: int,
+    max_parallel: int,
+) -> HostValidation:
+    payload = _read_json_object(path, "host-validation receipt")
+    declared = _require_digest(payload.get("receipt_digest"), "shard receipt digest")
+    unsigned = {key: value for key, value in payload.items() if key != "receipt_digest"}
+    if receipt_digest(unsigned) != declared:
+        raise HarborSuiteError(f"host-validation receipt digest mismatch: {path}")
+    if payload.get("schema_version") != 1 or payload.get("kind") != (
+        "benchmark-host-validation-shard"
+    ):
+        raise HarborSuiteError(f"unsupported host-validation receipt: {path}")
+    for field, value in asdict(provenance).items():
+        if payload.get(field) != value:
+            raise HarborSuiteError(f"host-validation receipt {field} mismatch: {path}")
+    if payload.get("timing_digest") != timing_digest:
+        raise HarborSuiteError(f"host-validation receipt timing mismatch: {path}")
+    entry = _entry(payload.get("entry"))
+    workers = payload.get("workers")
+    total = payload.get("total_worker_budget")
+    parallel = payload.get("max_parallel")
+    store_durations = payload.get("store_durations")
+    valid_budget = (
+        isinstance(workers, int)
+        and not isinstance(workers, bool)
+        and isinstance(total, int)
+        and not isinstance(total, bool)
+        and isinstance(parallel, int)
+        and not isinstance(parallel, bool)
+        and workers >= 1
+        and parallel >= 1
+        and workers * parallel <= total
+        and total == total_worker_budget
+        and parallel == min(total_worker_budget, max_parallel)
+        and store_durations is True
+    )
+    if not valid_budget:
+        raise HarborSuiteError(f"host-validation receipt exceeds worker budget: {path}")
+    if payload.get("command_digest") != _command_digest(
+        entry, workers=workers, store_durations=store_durations
+    ):
+        raise HarborSuiteError(f"host-validation receipt command mismatch: {path}")
+    actual_seconds = payload.get("actual_seconds")
+    if (
+        isinstance(actual_seconds, bool)
+        or not isinstance(actual_seconds, (int, float))
+        or not math.isfinite(float(actual_seconds))
+        or actual_seconds < 0
+    ):
+        raise HarborSuiteError(f"host-validation receipt duration is invalid: {path}")
+    if payload.get("status") != "EXITED" or payload.get("exit_code") != 0:
+        raise HarborSuiteError(f"host-validation shard did not succeed: {entry.name}")
+    return entry
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be positive")
+    return parsed
+
+
+def _resolve_plan(
+    args: argparse.Namespace,
+) -> tuple[ExecutionProvenance, tuple[HostValidation, ...]]:
+    if args.plan_receipt is None:
+        if args.execution_sha is not None:
+            raise HarborSuiteError("--execution-sha requires --plan-receipt")
+        planned = full_host_validation()
+        return local_provenance(ROOT, planned), planned
+    if args.execution_sha is None:
+        raise HarborSuiteError("--execution-sha is required with --plan-receipt")
+    execution_sha = verify_execution_sha(ROOT, args.execution_sha)
+    return load_plan_receipt(args.plan_receipt, execution_sha=execution_sha)
+
+
+def _selected_entries(
+    args: argparse.Namespace, planned: tuple[HostValidation, ...]
+) -> tuple[HostValidation, ...]:
+    if args.command == "run-entry":
+        entry = _entry(json.loads(args.entry_json))
+        if entry not in planned:
+            raise HarborSuiteError(
+                "requested host entry is absent from the plan receipt"
+            )
+        return (entry,)
+    entries = full_host_validation()
+    if args.plan_receipt is not None and tuple(planned) != entries:
+        raise HarborSuiteError("run-full requires the complete full-host matrix")
+    return entries
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    for command in ("run-full", "run-entry"):
+        child = subparsers.add_parser(command)
+        child.add_argument("--timings", type=Path, default=TIMING_PATH)
+        child.add_argument("--receipt-dir", type=Path)
+        child.add_argument("--total-workers", type=_positive_int, required=True)
+        child.add_argument("--max-parallel", type=_positive_int, default=4)
+        child.add_argument("--plan-receipt", type=Path)
+        child.add_argument("--execution-sha")
+        child.add_argument("--store-durations", action="store_true")
+        child.add_argument("--durations-output", type=Path)
+    entry_parser = subparsers.choices["run-entry"]
+    entry_parser.add_argument("--entry-json", required=True)
+    args = parser.parse_args(argv)
+    try:
+        provenance, planned = _resolve_plan(args)
+        entries = _selected_entries(args, planned)
+        local_receipt_root: Path | None = None
+        receipt_dir = args.receipt_dir
+        if receipt_dir is None:
+            local_receipt_root = (
+                ROOT / ".pytest_cache" / "benchmark-host-receipts" / uuid.uuid4().hex
+            )
+            receipt_dir = local_receipt_root
+        try:
+            return execute(
+                entries,
+                root=ROOT,
+                timing_path=args.timings,
+                receipt_dir=receipt_dir,
+                provenance=provenance,
+                total_worker_budget=args.total_workers,
+                max_parallel=args.max_parallel,
+                store_durations=args.store_durations,
+                duration_output=args.durations_output,
+            )
+        finally:
+            if local_receipt_root is not None:
+                shutil.rmtree(local_receipt_root, ignore_errors=True)
+    except (HarborSuiteError, json.JSONDecodeError, ValueError) as exc:
+        parser.error(str(exc))
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "ExecutionProvenance",
+    "ShardResult",
+    "build_receipt",
+    "execute",
+    "load_plan_receipt",
+    "local_provenance",
+    "pytest_arguments",
+    "timing_digest",
+    "timing_input",
+    "validate_receipts",
+    "verify_execution_sha",
+    "worker_allocation",
+]

--- a/benchmarks/tooling/receipts.py
+++ b/benchmarks/tooling/receipts.py
@@ -1,0 +1,27 @@
+"""Canonical serialization helpers for provenance-bound benchmark receipts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+
+def canonical_json(value: object) -> bytes:
+    """Serialize receipt content exactly once for producers and consumers."""
+
+    return (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode()
+
+
+def digest_bytes(value: bytes) -> str:
+    """Return the repository's tagged SHA-256 representation."""
+
+    return "sha256:" + hashlib.sha256(value).hexdigest()
+
+
+def receipt_digest(value: object) -> str:
+    """Digest canonical receipt content."""
+
+    return digest_bytes(canonical_json(value))
+
+
+__all__ = ["canonical_json", "digest_bytes", "receipt_digest"]

--- a/benchmarks/tooling/validation_plan.py
+++ b/benchmarks/tooling/validation_plan.py
@@ -1,0 +1,330 @@
+"""Stable host-side validation planning for Harbor benchmark changes."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+HOST_VALIDATION_ROOT = "benchmarks/validation"
+HOST_VALIDATION_FULL_SHARDS = 4
+HOST_VALIDATION_DATASET_FILES = {
+    "conjecture-probes-v1": (
+        "benchmarks/validation/conjecture_probes_v1/"
+        "test_vizing_bounded_cartesian_products.py",
+    ),
+    "symbolic-coordination-v1": (
+        "benchmarks/validation/symbolic_coordination_v1/test_pilot_contract.py",
+    ),
+    "research-diagnostics-v1": (
+        "benchmarks/validation/research_diagnostics_v1/test_structured_verifiers.py",
+    ),
+    "provider-feasibility-v1": (
+        "benchmarks/validation/test_provider_download_integrity.py",
+    ),
+}
+CONTROL_PLANE_HOST_TESTS = {
+    ".github/scripts/emit-plan-receipt": (),
+    ".github/scripts/manage-test-timings": (),
+    ".github/scripts/plan-benchmarks": (
+        "benchmarks/validation/test_benchmark_planner.py",
+        "benchmarks/validation/test_benchmark_plan_validation.py",
+    ),
+    ".github/scripts/validate-benchmark-plan": (
+        "benchmarks/validation/test_benchmark_plan_validation.py",
+    ),
+    ".github/workflows/benchmarks.yml": (
+        "benchmarks/validation/test_benchmark_planner.py",
+        "benchmarks/validation/test_benchmark_validation.py",
+    ),
+    ".github/workflows/heldout-benchmarks.yml": (
+        "benchmarks/validation/test_heldout_bundle.py",
+        "benchmarks/validation/test_heldout_runner.py",
+    ),
+    "benchmarks/tooling/benchmark_timings.py": (
+        "benchmarks/validation/test_benchmark_timings.py",
+    ),
+    "benchmarks/tooling/benchmark_validation.py": (
+        "benchmarks/validation/test_benchmark_validation.py",
+    ),
+    "benchmarks/tooling/host_validation.py": (
+        "benchmarks/validation/test_host_validation.py",
+    ),
+    "benchmarks/tooling/validation_plan.py": (
+        "benchmarks/validation/test_validation_plan.py",
+        "benchmarks/validation/test_benchmark_planner.py",
+    ),
+    "tools/benchmark_pr_status.py": (
+        "benchmarks/validation/test_benchmark_pr_status.py",
+    ),
+    "tools/check_benchmark_adapters.py": (
+        "benchmarks/validation/test_benchmark_adapters.py",
+    ),
+    "tools/check_benchmark_contracts.py": (
+        "benchmarks/validation/test_benchmark_contracts.py",
+    ),
+    "tools/check_benchmark_static.py": (
+        "benchmarks/validation/test_benchmark_static.py",
+    ),
+    "tools/harbor_task_workflow.py": (
+        "benchmarks/validation/test_harbor_task_workflow.py",
+    ),
+    "tools/check_harbor_dataset.py": (
+        "benchmarks/validation/test_mathematical_benchmarks_v1.py",
+    ),
+    "tools/sync_harbor_verifier_support.py": (
+        "benchmarks/validation/test_public_contract.py",
+    ),
+    "benchmarks/environment-profiles.toml": (
+        "benchmarks/validation/test_benchmark_environment_profiles.py",
+    ),
+}
+SHARED_HOST_HARNESS_PATHS = {
+    "Makefile",
+    "tools/pytest_lifecycle.py",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class HostValidation:
+    """One bounded pytest selector in the host-validation matrix."""
+
+    name: str
+    selector: str
+    keyword: str = ""
+    splits: int = 0
+    group: int = 0
+    predicted_seconds: float = 1.0
+
+    def as_matrix_entry(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class HostValidationPlan:
+    """Selected host checks plus human-readable escalation reasons."""
+
+    entries: tuple[HostValidation, ...]
+    reasons: tuple[str, ...]
+
+
+def _prediction(name: str, timings: Mapping[str, float] | None) -> float:
+    value = (timings or {}).get(f"host-validation/{name}", 1.0)
+    return round(float(value), 6)
+
+
+def _entry(
+    *,
+    name: str,
+    selector: str,
+    timings: Mapping[str, float] | None,
+    keyword: str = "",
+    splits: int = 0,
+    group: int = 0,
+) -> HostValidation:
+    return HostValidation(
+        name=name,
+        selector=selector,
+        keyword=keyword,
+        splits=splits,
+        group=group,
+        predicted_seconds=_prediction(name, timings),
+    )
+
+
+def full_host_validation(
+    *, timings: Mapping[str, float] | None = None
+) -> tuple[HostValidation, ...]:
+    return tuple(
+        _entry(
+            name=f"full-{group}-of-{HOST_VALIDATION_FULL_SHARDS}",
+            selector=HOST_VALIDATION_ROOT,
+            splits=HOST_VALIDATION_FULL_SHARDS,
+            group=group,
+            timings=timings,
+        )
+        for group in range(1, HOST_VALIDATION_FULL_SHARDS + 1)
+    )
+
+
+def dataset_host_validation(
+    dataset: str, *, timings: Mapping[str, float] | None = None
+) -> tuple[HostValidation, ...]:
+    return tuple(
+        _entry(name=f"{dataset}-{index}", selector=selector, timings=timings)
+        for index, selector in enumerate(
+            HOST_VALIDATION_DATASET_FILES.get(dataset, ()), start=1
+        )
+    )
+
+
+def task_host_validation(
+    root: Path,
+    dataset: str,
+    task: str,
+    *,
+    timings: Mapping[str, float] | None = None,
+) -> tuple[HostValidation, ...]:
+    """Select the leaf and task-filtered generic contracts for one task."""
+    if dataset == "mathematical-benchmarks-v1":
+        dedicated = (
+            root
+            / "benchmarks"
+            / "validation"
+            / "mathematical_benchmarks_v1"
+            / f"test_{task.replace('-', '_')}.py"
+        )
+        entries: list[HostValidation] = []
+        if dedicated.is_file():
+            entries.append(
+                _entry(
+                    name=f"{task}-specific",
+                    selector=dedicated.relative_to(root).as_posix(),
+                    timings=timings,
+                )
+            )
+        entries.append(
+            _entry(
+                name=f"{task}-generic",
+                selector=(
+                    "benchmarks/validation/mathematical_benchmarks_v1/"
+                    "test_generic_verifier_contracts.py"
+                ),
+                keyword=task,
+                timings=timings,
+            )
+        )
+        return tuple(entries)
+    if dataset == "public-reproductions-v1" and task == "sat-erdos-schur-f4":
+        return (
+            _entry(
+                name=task,
+                selector="benchmarks/validation/test_sat_erdos_schur_f4.py",
+                timings=timings,
+            ),
+        )
+    return dataset_host_validation(dataset, timings=timings)
+
+
+def _validation_path_plan(
+    root: Path, path: str, timings: Mapping[str, float] | None
+) -> tuple[tuple[HostValidation, ...], str | None]:
+    candidate = root / path
+    if candidate.is_file() and candidate.name.startswith("test_"):
+        return (_entry(name=candidate.stem, selector=path, timings=timings),), None
+    if candidate.suffix == ".py":
+        return (), f"shared verifier harness requires full host validation: {path}"
+    return (), f"unclassified validation path requires full host validation: {path}"
+
+
+def _dataset_path_plan(
+    root: Path,
+    path: str,
+    suites_by_id: Mapping[str, Any],
+    timings: Mapping[str, float] | None,
+) -> tuple[tuple[HostValidation, ...], str | None]:
+    parts = Path(path).parts
+    dataset = parts[2]
+    suite = suites_by_id.get(dataset)
+    task_ids = {ref.path.name for ref in suite.tasks} if suite else set()
+    relative = parts[3:]
+    task = relative[0] if len(relative) >= 2 else None
+    if task is not None and task in task_ids:
+        entries = (
+            ()
+            if relative[1:] == ("README.md",)
+            else task_host_validation(root, dataset, task, timings=timings)
+        )
+        return entries, None
+    if relative[:1] == ("members",) and len(relative) == 2:
+        member = Path(relative[1]).stem
+        if member in task_ids:
+            return task_host_validation(root, dataset, member, timings=timings), None
+    if relative[:1] in {("README.md",), ("dataset.toml",)}:
+        return (), None
+    entries = dataset_host_validation(dataset, timings=timings)
+    if entries:
+        return entries, None
+    return (), f"dataset-wide change requires full host validation: {path}"
+
+
+def _shared_path_plan(
+    path: str, timings: Mapping[str, float] | None
+) -> tuple[tuple[HostValidation, ...], str | None]:
+    owned = CONTROL_PLANE_HOST_TESTS.get(path)
+    if owned is not None:
+        return tuple(
+            _entry(
+                name=f"control-{Path(selector).stem}",
+                selector=selector,
+                timings=timings,
+            )
+            for selector in owned
+        ), None
+    if path in SHARED_HOST_HARNESS_PATHS:
+        return (
+            (),
+            f"shared verifier execution harness requires full host validation: {path}",
+        )
+    if path in {"benchmarks/README.md", "benchmarks/__init__.py"} or path.startswith(
+        "benchmarks/templates/"
+    ):
+        return (), None
+    if path == "benchmarks/adapters/README.md":
+        return (), None
+    if path.startswith("benchmarks/adapters/"):
+        return (
+            _entry(
+                name="benchmark-adapters",
+                selector="benchmarks/validation/test_benchmark_adapters.py",
+                timings=timings,
+            ),
+        ), None
+    return (), f"shared benchmark tooling requires full host validation: {path}"
+
+
+def host_validation_plan(
+    root: Path,
+    benchmark_paths: Sequence[str],
+    suites_by_id: Mapping[str, Any],
+    *,
+    timings: Mapping[str, float] | None = None,
+) -> HostValidationPlan:
+    """Plan host regressions, escalating only paths with portfolio-wide reach."""
+    entries: list[HostValidation] = []
+    full_reasons: list[str] = []
+    for path in benchmark_paths:
+        if path.startswith("benchmarks/validation/"):
+            selected, reason = _validation_path_plan(root, path, timings)
+        elif len(Path(path).parts) >= 4 and Path(path).parts[:2] == (
+            "benchmarks",
+            "datasets",
+        ):
+            selected, reason = _dataset_path_plan(root, path, suites_by_id, timings)
+        else:
+            selected, reason = _shared_path_plan(path, timings)
+        entries.extend(selected)
+        if reason is not None:
+            full_reasons.append(reason)
+    if full_reasons:
+        return HostValidationPlan(
+            full_host_validation(timings=timings), tuple(dict.fromkeys(full_reasons))
+        )
+    unique = {(entry.selector, entry.keyword): entry for entry in entries}
+    ordered = tuple(
+        sorted(unique.values(), key=lambda entry: (entry.selector, entry.keyword))
+    )
+    reasons = tuple(f"focused host validation: {entry.name}" for entry in ordered)
+    return HostValidationPlan(ordered, reasons)
+
+
+__all__ = [
+    "CONTROL_PLANE_HOST_TESTS",
+    "HostValidation",
+    "HostValidationPlan",
+    "dataset_host_validation",
+    "full_host_validation",
+    "host_validation_plan",
+    "task_host_validation",
+]

--- a/benchmarks/validation/test_benchmark_plan_validation.py
+++ b/benchmarks/validation/test_benchmark_plan_validation.py
@@ -47,6 +47,7 @@ def _plan() -> dict[str, str]:
                     "keyword": "",
                     "splits": 0,
                     "group": 0,
+                    "predicted_seconds": 5.0,
                 }
             ]
         ),
@@ -59,6 +60,7 @@ def _plan() -> dict[str, str]:
                     "shard": "task",
                     "tasks": ["task"],
                     "task_digests": [{"task": "task", "digest": DIGEST}],
+                    "predicted_seconds": 30.0,
                 }
             ]
         ),

--- a/benchmarks/validation/test_benchmark_planner.py
+++ b/benchmarks/validation/test_benchmark_planner.py
@@ -16,6 +16,7 @@ import pytest
 ROOT = Path(__file__).resolve().parents[2]
 PLANNER_PATH = ROOT / ".github" / "scripts" / "plan-benchmarks"
 PATH_POLICY_PATH = ROOT / ".github" / "scripts" / "_ci_paths.py"
+VALIDATION_PLAN_PATH = ROOT / "benchmarks" / "tooling" / "validation_plan.py"
 VALIDATOR_PATH = ROOT / ".github" / "scripts" / "validate-benchmark-plan"
 _SPEC = importlib.util.spec_from_loader(
     "benchmark_planner", SourceFileLoader("benchmark_planner", str(PLANNER_PATH))
@@ -46,6 +47,14 @@ def _matrix_tasks(result: dict[str, str]) -> set[str]:
 
 
 def _host_matrix(result: dict[str, str]) -> list[dict[str, object]]:
+    matrix = json.loads(result["benchmark-host-validation-matrix"])
+    return [
+        {key: value for key, value in entry.items() if key != "predicted_seconds"}
+        for entry in matrix
+    ]
+
+
+def _raw_host_matrix(result: dict[str, str]) -> list[dict[str, object]]:
     return json.loads(result["benchmark-host-validation-matrix"])
 
 
@@ -109,7 +118,7 @@ def test_plan_is_versioned_and_bound_to_event_base_head_sha() -> None:
 def test_planner_digest_binds_to_planner_and_path_policy_sources() -> None:
     payload = "\n".join(
         f"{path.relative_to(ROOT).as_posix()}\t{path.read_bytes().hex()}"
-        for path in (PLANNER_PATH, PATH_POLICY_PATH)
+        for path in (PLANNER_PATH, PATH_POLICY_PATH, VALIDATION_PLAN_PATH)
     ).encode()
     expected = "sha256:" + hashlib.sha256(payload).hexdigest()
     result = planner.plan(
@@ -144,6 +153,21 @@ def test_benchmark_control_plane_changes_run_contract_checks(path: str) -> None:
     assert result["benchmark-oracle-scope"] == "none"
     assert result["benchmark-plan-mode"] == "changed"
     assert _matrix(result) == []
+    _assert_plan_valid(result)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [".github/scripts/manage-test-timings", ".github/scripts/emit-plan-receipt"],
+)
+def test_non_host_control_utilities_do_not_select_full_verifier_corpus(
+    path: str,
+) -> None:
+    result = planner.plan([path], event="pull_request")
+
+    assert result["run-benchmark-check"] == "true"
+    assert result["run-benchmark-host-validation"] == "false"
+    assert _host_matrix(result) == []
     _assert_plan_valid(result)
 
 
@@ -270,6 +294,29 @@ def test_executable_task_change_selects_exact_task_without_version_bump() -> Non
     _assert_plan_valid(result)
 
 
+def test_host_and_oracle_matrices_record_predictions() -> None:
+    task = "parameterized-sharp-bound-audit"
+    result = planner.plan(
+        [f"benchmarks/datasets/mathematical-benchmarks-v1/{task}/tests/verifier.py"],
+        event="pull_request",
+        timings={
+            f"mathematical-benchmarks-v1/{task}": 73.5,
+            f"host-validation/{task}-specific": 8.25,
+            f"host-validation/{task}-generic": 3.5,
+        },
+    )
+
+    assert _matrix(result)[0]["predicted_seconds"] == 73.5
+    predictions = {
+        entry["name"]: entry["predicted_seconds"] for entry in _raw_host_matrix(result)
+    }
+    assert predictions == {
+        f"{task}-generic": 3.5,
+        f"{task}-specific": 8.25,
+    }
+    _assert_plan_valid(result)
+
+
 def test_dataset_owned_task_selects_shared_host_regression() -> None:
     result = planner.plan(
         [
@@ -344,6 +391,22 @@ def test_shared_benchmark_support_falls_back_to_full_host_validation() -> None:
             "group": group,
         }
         for group in range(1, 5)
+    ]
+    assert any(
+        "shared benchmark tooling requires full host validation" in reason
+        for reason in json.loads(result["benchmark-plan-reasons"])
+    )
+    _assert_plan_valid(result)
+
+
+def test_shared_verifier_harness_states_full_suite_reason() -> None:
+    path = "benchmarks/validation/mathematical_benchmarks_v1/support.py"
+    result = planner.plan([path], event="pull_request")
+
+    assert len(_host_matrix(result)) == 4
+    assert json.loads(result["benchmark-plan-reasons"]) == [
+        "benchmark validation or documentation change",
+        f"shared verifier harness requires full host validation: {path}",
     ]
     _assert_plan_valid(result)
 

--- a/benchmarks/validation/test_benchmark_pr_status.py
+++ b/benchmarks/validation/test_benchmark_pr_status.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from collections.abc import Sequence
+
+from benchmarks.tooling.command_runner import (
+    ToolCommandResult,
+    ToolCommandStatus,
+    operator_environment,
+)
+from tools import benchmark_pr_status
+from tools.benchmark_pr_status import GitHubReader, build_status, render_human
+
+
+def _zip_receipt(digest: str = "sha256:abc") -> bytes:
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, "w") as bundle:
+        bundle.writestr("plan-receipt.json", json.dumps({"receipt_digest": digest}))
+    return output.getvalue()
+
+
+class FakeRunner:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, ...]] = []
+
+    def __call__(self, arguments: Sequence[str]) -> bytes:
+        call = tuple(arguments)
+        self.calls.append(call)
+        if call[:2] == ("api", "graphql"):
+            return json.dumps(
+                {
+                    "data": {
+                        "repository": {
+                            "pullRequest": {
+                                "reviewThreads": {
+                                    "nodes": [
+                                        {"isResolved": False},
+                                        {"isResolved": True},
+                                    ],
+                                    "pageInfo": {
+                                        "hasNextPage": False,
+                                        "endCursor": None,
+                                    },
+                                }
+                            }
+                        }
+                    }
+                }
+            ).encode()
+        if call[-1].endswith("/artifacts"):
+            return json.dumps(
+                {
+                    "artifacts": [
+                        {
+                            "id": 77,
+                            "name": "benchmark-plan-receipt",
+                            "expired": False,
+                        }
+                    ]
+                }
+            ).encode()
+        if call[-1].endswith("/zip"):
+            return _zip_receipt()
+        raise AssertionError(call)
+
+
+def _payload(*, validation: str = "SUCCESS") -> dict[str, object]:
+    checks = [
+        {"name": name, "conclusion": "SUCCESS", "detailsUrl": ""}
+        for name in (
+            "Benchmark Static Quality",
+            "Benchmark Contracts, Adapters, Records & Digests",
+        )
+    ]
+    checks.append(
+        {
+            "name": "Benchmark Validation",
+            "conclusion": validation,
+            "detailsUrl": "https://github.com/o/r/actions/runs/123/job/456",
+        }
+    )
+    return {
+        "number": 42,
+        "title": "benchmarks: add task",
+        "url": "https://github.com/o/r/pull/42",
+        "state": "OPEN",
+        "isDraft": False,
+        "mergeable": "MERGEABLE",
+        "mergeStateStatus": "CLEAN",
+        "files": [
+            {
+                "path": "benchmarks/datasets/mathematical-benchmarks-v1/"
+                "task-a/tests/verifier.py"
+            }
+        ],
+        "statusCheckRollup": checks,
+    }
+
+
+def test_batch_status_binds_actual_plan_receipt_and_reports_blocker() -> None:
+    runner = FakeRunner()
+    reader = GitHubReader("o/r", runner=runner)
+
+    status = build_status(reader, 42, _payload())
+
+    assert status.tasks == ("mathematical-benchmarks-v1/task-a",)
+    assert status.unresolved_threads == 1
+    assert status.preparation == "confirmed"
+    assert status.receipt_digest == "sha256:abc"
+    assert status.ci == "passed"
+    assert status.merge_ready is False
+    assert status.blockers == ("unresolved-threads=1",)
+    assert "#42 blocked" in render_human([status])
+
+
+def test_failed_validation_is_ci_failure_even_when_receipt_exists() -> None:
+    runner = FakeRunner()
+    status = build_status(
+        GitHubReader("o/r", runner=runner), 42, _payload(validation="FAILURE")
+    )
+
+    assert status.ci == "failed"
+    assert "ci=failed" in status.blockers
+
+
+def test_missing_receipt_artifact_is_fail_closed() -> None:
+    class MissingReceipt(FakeRunner):
+        def __call__(self, arguments: Sequence[str]) -> bytes:
+            if tuple(arguments)[-1].endswith("/artifacts"):
+                return b'{"artifacts":[]}'
+            return super().__call__(arguments)
+
+    runner = MissingReceipt()
+    status = build_status(GitHubReader("o/r", runner=runner), 42, _payload())
+
+    assert status.receipt_digest is None
+    assert "validation-receipt=missing" in status.blockers
+
+
+def test_skipped_preparation_check_is_not_confirmed() -> None:
+    payload = _payload()
+    checks = payload["statusCheckRollup"]
+    assert isinstance(checks, list)
+    checks[0]["conclusion"] = "SKIPPED"
+    runner = FakeRunner()
+
+    status = build_status(GitHubReader("o/r", runner=runner), 42, payload)
+
+    assert status.preparation == "failed"
+    assert "preparation=failed" in status.blockers
+
+
+def test_unstable_merge_state_is_blocked() -> None:
+    payload = _payload()
+    payload["mergeStateStatus"] = "UNSTABLE"
+    runner = FakeRunner()
+
+    status = build_status(GitHubReader("o/r", runner=runner), 42, payload)
+
+    assert "merge-state=UNSTABLE" in status.blockers
+
+
+def test_gh_receives_only_explicit_auth_and_process_environment(
+    monkeypatch,
+) -> None:
+    forwarded: dict[str, str] = {}
+
+    for name, value in {
+        "PATH": "/operator/bin",
+        "HOME": "/operator/home",
+        "XDG_CONFIG_HOME": "/operator/config",
+        "GH_CONFIG_DIR": "/operator/gh",
+        "GH_TOKEN": "gh-token",
+        "GITHUB_TOKEN": "github-token",
+        "UNRELATED_SECRET": "must-not-be-forwarded",
+    }.items():
+        monkeypatch.setenv(name, value)
+    expected = dict(
+        operator_environment(
+            include=(
+                "PATH",
+                "HOME",
+                "XDG_CONFIG_HOME",
+                "GH_CONFIG_DIR",
+                "GH_TOKEN",
+                "GITHUB_TOKEN",
+            )
+        )
+    )
+
+    def fake_run_operator_command(*args, **kwargs):
+        forwarded.update(kwargs["environment"])
+        return ToolCommandResult(
+            status=ToolCommandStatus.EXITED,
+            exit_code=0,
+            stdout=b"authenticated",
+            stderr=b"",
+        )
+
+    monkeypatch.setattr(
+        benchmark_pr_status,
+        "run_operator_command",
+        fake_run_operator_command,
+    )
+
+    assert benchmark_pr_status._gh(("auth", "status")) == b"authenticated"
+    assert forwarded == expected
+    assert "UNRELATED_SECRET" not in forwarded

--- a/benchmarks/validation/test_benchmark_timings.py
+++ b/benchmarks/validation/test_benchmark_timings.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 
 import pytest
-from benchmarks.tooling.benchmark_timings import collect
+from benchmarks.tooling.benchmark_timings import collect, comparison_report
 from benchmarks.tooling.errors import HarborSuiteError
 from benchmarks.tooling.harbor_suite import get_suite
 
@@ -33,3 +33,71 @@ def test_timing_collector_uses_median_completed_trial_duration(tmp_path: Path) -
 def test_timing_collector_fails_closed_without_trials(tmp_path: Path) -> None:
     with pytest.raises(HarborSuiteError, match="no completed"):
         collect(tmp_path)
+
+
+def test_timing_collector_includes_successful_pytest_receipt(tmp_path: Path) -> None:
+    receipt = tmp_path / "host" / "pytest-receipt.json"
+    receipt.parent.mkdir()
+    receipt.write_text(
+        json.dumps({"name": "full-1-of-4", "actual_seconds": 171.25, "exit_code": 0}),
+        encoding="utf-8",
+    )
+
+    assert collect(tmp_path)["host-validation/full-1-of-4"] == 171.25
+
+
+def test_timing_collector_reads_provenance_receipt_entry_name(tmp_path: Path) -> None:
+    receipt = tmp_path / "host" / "pytest-receipt.json"
+    receipt.parent.mkdir()
+    receipt.write_text(
+        json.dumps(
+            {
+                "entry": {"name": "full-2-of-4"},
+                "actual_seconds": 173.0,
+                "exit_code": 0,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert collect(tmp_path)["host-validation/full-2-of-4"] == 173.0
+
+
+def test_comparison_report_records_predicted_and_actual_shards() -> None:
+    report = comparison_report(
+        {
+            "dataset/task-a": 10.0,
+            "dataset/task-b": 15.0,
+            "host-validation/full-1-of-4": 171.0,
+        },
+        oracle_matrix=[
+            {
+                "dataset": "dataset",
+                "shard": "01-of-01",
+                "tasks": ["task-a", "task-b"],
+                "predicted_seconds": 20.0,
+            }
+        ],
+        host_matrix=[{"name": "full-1-of-4", "predicted_seconds": 180.0}],
+    )
+
+    assert report["shards"] == [
+        {
+            "kind": "oracle",
+            "name": "dataset/01-of-01",
+            "predicted_seconds": 20.0,
+            "actual_seconds": 25.0,
+            "delta_seconds": 5.0,
+            "actual_to_predicted": 1.25,
+            "missing": [],
+        },
+        {
+            "kind": "host",
+            "name": "full-1-of-4",
+            "predicted_seconds": 180.0,
+            "actual_seconds": 171.0,
+            "delta_seconds": -9.0,
+            "actual_to_predicted": 0.95,
+            "missing": [],
+        },
+    ]

--- a/benchmarks/validation/test_benchmark_validation.py
+++ b/benchmarks/validation/test_benchmark_validation.py
@@ -1,0 +1,240 @@
+"""Fail-closed tests for the stable benchmark result aggregator."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from benchmarks.tooling.benchmark_validation import LaneResult, validate_aggregate
+from benchmarks.tooling.errors import HarborSuiteError
+from benchmarks.tooling.host_validation import (
+    ExecutionProvenance,
+    ShardResult,
+    build_receipt,
+    load_plan_receipt,
+)
+from benchmarks.tooling.receipts import digest_bytes, receipt_digest
+from benchmarks.tooling.validation_plan import full_host_validation
+from tests.boundary.process.tooling.ci import run_ci_script
+
+DIGEST = "sha256:" + "a" * 64
+SHA = "1" * 40
+EXECUTION_SHA = "2" * 40
+
+
+def _digest(value: object) -> str:
+    return receipt_digest(value)
+
+
+def _plan_digest(plan: dict[str, str]) -> str:
+    payload = "".join(f"{key}={plan[key]}\n" for key in sorted(plan)).encode()
+    return digest_bytes(payload)
+
+
+def _plan_receipt(tmp_path: Path) -> tuple[Path, ExecutionProvenance]:
+    entries = full_host_validation()
+    plan = {
+        "benchmark-plan-head-sha": SHA,
+        "benchmark-planner-digest": DIGEST,
+        "benchmark-topology-digest": DIGEST,
+        "benchmark-host-validation-matrix": json.dumps(
+            [entry.as_matrix_entry() for entry in entries]
+        ),
+        "run-benchmark-check": "true",
+        "run-benchmark-record-schema": "true",
+        "run-benchmark-host-validation": "true",
+        "run-benchmark-inventory": "false",
+        "run-benchmark-oracle": "false",
+    }
+    receipt = {
+        "receipt_version": "1",
+        "plan_kind": "benchmark",
+        "head_sha": SHA,
+        "plan_digest": _plan_digest(plan),
+        "plan": plan,
+    }
+    receipt["receipt_digest"] = _digest(receipt)
+    path = tmp_path / "plan-receipt.json"
+    path.write_text(json.dumps(receipt), encoding="utf-8")
+    provenance = ExecutionProvenance(
+        plan_head_sha=SHA,
+        execution_sha=EXECUTION_SHA,
+        planner_digest=DIGEST,
+        topology_digest=DIGEST,
+        plan_digest=receipt["plan_digest"],
+        plan_receipt_digest=receipt["receipt_digest"],
+    )
+    return path, provenance
+
+
+def _evidence(tmp_path: Path) -> tuple[Path, Path, Path]:
+    plan_path, provenance = _plan_receipt(tmp_path)
+    timings = tmp_path / "benchmark-test-durations.json"
+    timings.write_text("{}\n", encoding="utf-8")
+    timing_digest = digest_bytes(b"{}\n")
+    receipt_root = tmp_path / "receipts"
+    for entry in full_host_validation():
+        payload = build_receipt(
+            entry=entry,
+            result=ShardResult(status="EXITED", exit_code=0, actual_seconds=3.0),
+            provenance=provenance,
+            timing_digest=timing_digest,
+            workers=2,
+            total_worker_budget=8,
+            max_parallel=4,
+            store_durations=True,
+        )
+        path = receipt_root / entry.name / "pytest-receipt.json"
+        path.parent.mkdir(parents=True)
+        path.write_text(json.dumps(payload), encoding="utf-8")
+    return plan_path, receipt_root, timings
+
+
+def _lanes() -> dict[str, LaneResult]:
+    return {
+        "static": LaneResult(True, "success"),
+        "contracts": LaneResult(True, "success"),
+        "host-validation": LaneResult(True, "success"),
+        "inventory": LaneResult(False, "skipped"),
+        "oracle": LaneResult(False, "skipped"),
+    }
+
+
+def test_aggregate_accepts_exact_successful_shard_receipts(tmp_path: Path) -> None:
+    plan, receipts, timings = _evidence(tmp_path)
+
+    validate_aggregate(
+        plan_result="success",
+        plan_receipt=plan,
+        execution_sha=EXECUTION_SHA,
+        lanes=_lanes(),
+        receipt_root=receipts,
+        timing_path=timings,
+    )
+
+
+def test_real_plan_receipt_round_trips_through_consumer(tmp_path: Path) -> None:
+    entries = full_host_validation()
+    plan = {
+        "benchmark-plan-head-sha": SHA,
+        "benchmark-planner-digest": DIGEST,
+        "benchmark-topology-digest": DIGEST,
+        "benchmark-host-validation-matrix": json.dumps(
+            [entry.as_matrix_entry() for entry in entries]
+        ),
+        "run-benchmark-check": "true",
+        "run-benchmark-record-schema": "true",
+        "run-benchmark-host-validation": "true",
+        "run-benchmark-inventory": "false",
+        "run-benchmark-oracle": "false",
+    }
+    plan_file = tmp_path / "plan.txt"
+    plan_file.write_text(
+        "".join(f"{key}={plan[key]}\n" for key in sorted(plan)), encoding="utf-8"
+    )
+    paths_file = tmp_path / "paths.txt"
+    paths_file.write_text("README.md\n", encoding="utf-8")
+    output = tmp_path / "receipt.json"
+
+    run_ci_script(
+        "emit-plan-receipt",
+        "--kind",
+        "benchmark",
+        "--event",
+        "pull_request",
+        "--head",
+        SHA,
+        "--planner",
+        ".github/scripts/plan-benchmarks",
+        "--plan-file",
+        plan_file,
+        "--paths-file",
+        paths_file,
+        "--output",
+        output,
+        check=True,
+    )
+
+    provenance, observed = load_plan_receipt(output, execution_sha=EXECUTION_SHA)
+    assert observed == entries
+    assert provenance.plan_head_sha == SHA
+
+
+def test_aggregate_accepts_consistent_empty_plan(tmp_path: Path) -> None:
+    plan = {
+        "benchmark-plan-head-sha": SHA,
+        "benchmark-planner-digest": DIGEST,
+        "benchmark-topology-digest": "",
+        "benchmark-host-validation-matrix": "[]",
+        "run-benchmark-check": "false",
+        "run-benchmark-record-schema": "false",
+        "run-benchmark-host-validation": "false",
+        "run-benchmark-inventory": "false",
+        "run-benchmark-oracle": "false",
+    }
+    receipt = {
+        "receipt_version": "1",
+        "plan_kind": "benchmark",
+        "head_sha": SHA,
+        "plan_digest": _plan_digest(plan),
+        "plan": plan,
+    }
+    receipt["receipt_digest"] = receipt_digest(receipt)
+    path = tmp_path / "plan-receipt.json"
+    path.write_text(json.dumps(receipt), encoding="utf-8")
+    lanes = {name: LaneResult(False, "skipped") for name in _lanes()}
+
+    validate_aggregate(
+        plan_result="success",
+        plan_receipt=path,
+        execution_sha=EXECUTION_SHA,
+        lanes=lanes,
+        receipt_root=None,
+        timing_path=None,
+    )
+
+
+@pytest.mark.parametrize("failure", ["missing", "stale", "failed"])
+def test_aggregate_rejects_invalid_host_evidence(tmp_path: Path, failure: str) -> None:
+    plan, receipts, timings = _evidence(tmp_path)
+    first = next(receipts.rglob("pytest-receipt.json"))
+    if failure == "missing":
+        first.unlink()
+    else:
+        payload = json.loads(first.read_text(encoding="utf-8"))
+        if failure == "stale":
+            payload["execution_sha"] = "3" * 40
+        else:
+            payload["exit_code"] = 1
+        unsigned = {
+            key: value for key, value in payload.items() if key != "receipt_digest"
+        }
+        payload["receipt_digest"] = _digest(unsigned)
+        first.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(HarborSuiteError):
+        validate_aggregate(
+            plan_result="success",
+            plan_receipt=plan,
+            execution_sha=EXECUTION_SHA,
+            lanes=_lanes(),
+            receipt_root=receipts,
+            timing_path=timings,
+        )
+
+
+def test_aggregate_rejects_selected_lane_that_was_skipped(tmp_path: Path) -> None:
+    plan, receipts, timings = _evidence(tmp_path)
+    lanes = _lanes()
+    lanes["static"] = LaneResult(True, "skipped")
+
+    with pytest.raises(HarborSuiteError, match="static expected success"):
+        validate_aggregate(
+            plan_result="success",
+            plan_receipt=plan,
+            execution_sha=EXECUTION_SHA,
+            lanes=lanes,
+            receipt_root=receipts,
+            timing_path=timings,
+        )

--- a/benchmarks/validation/test_harbor_task_workflow.py
+++ b/benchmarks/validation/test_harbor_task_workflow.py
@@ -22,13 +22,7 @@ sys.modules[_SPEC.name] = workflow
 _SPEC.loader.exec_module(workflow)
 
 
-def test_resolve_selection_uses_planner_owned_host_matrix(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    planner = workflow._load_planner()
-    monkeypatch.setattr(planner, "_digest", lambda path: f"sha256:{path.name}")
-    monkeypatch.setattr(workflow, "_load_planner", lambda: planner)
-
+def test_resolve_selection_uses_planner_owned_host_matrix() -> None:
     selection = workflow.resolve_selection(
         "mathematical-benchmarks-v1", ("parameterized-sharp-bound-audit",)
     )
@@ -45,6 +39,20 @@ def test_resolve_selection_uses_planner_owned_host_matrix(
             "test_parameterized_sharp_bound_audit.py",
             "",
         ),
+    ]
+
+
+def test_resolve_selection_deduplicates_shared_dataset_validation() -> None:
+    selection = workflow.resolve_selection(
+        "symbolic-coordination-v1",
+        (
+            "symbolic-coordination-collision-found-01",
+            "symbolic-coordination-collision-found-02",
+        ),
+    )
+
+    assert [item.selector for item in selection.host_validations] == [
+        "benchmarks/validation/symbolic_coordination_v1/test_pilot_contract.py"
     ]
 
 

--- a/benchmarks/validation/test_host_validation.py
+++ b/benchmarks/validation/test_host_validation.py
@@ -1,0 +1,199 @@
+"""Behavioral tests for timing-aware host-validation orchestration."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from benchmarks.tooling import command_runner
+from benchmarks.tooling.errors import HarborSuiteError
+from benchmarks.tooling.host_validation import (
+    ExecutionProvenance,
+    ShardResult,
+    execute,
+    pytest_arguments,
+    verify_execution_sha,
+    worker_allocation,
+)
+from benchmarks.tooling.validation_plan import full_host_validation
+
+DIGEST = "sha256:" + "a" * 64
+PROVENANCE = ExecutionProvenance(
+    plan_head_sha="1" * 40,
+    execution_sha="2" * 40,
+    planner_digest=DIGEST,
+    topology_digest=DIGEST,
+    plan_digest=DIGEST,
+    plan_receipt_digest=DIGEST,
+)
+
+
+def test_worker_allocation_caps_nested_parallelism() -> None:
+    assert worker_allocation(entry_count=4, total_worker_budget=4, max_parallel=4) == (
+        4,
+        1,
+    )
+    assert worker_allocation(entry_count=1, total_worker_budget=8, max_parallel=4) == (
+        1,
+        2,
+    )
+    assert worker_allocation(entry_count=2, total_worker_budget=8, max_parallel=4) == (
+        2,
+        2,
+    )
+    assert worker_allocation(entry_count=4, total_worker_budget=2, max_parallel=4) == (
+        2,
+        1,
+    )
+
+
+def test_execution_sha_must_match_checked_out_merge_tree(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(command_runner, "git_head_sha", lambda _root: "2" * 40)
+
+    assert verify_execution_sha(tmp_path, "2" * 40) == "2" * 40
+    with pytest.raises(HarborSuiteError, match="checked-out Git revision"):
+        verify_execution_sha(tmp_path, "3" * 40)
+
+
+def test_full_shard_uses_ci_timing_shape_and_least_duration(tmp_path: Path) -> None:
+    entry = full_host_validation()[1]
+
+    arguments = pytest_arguments(
+        entry,
+        timing_path=tmp_path / "benchmark-test-durations.json",
+        workers=2,
+        store_durations=False,
+    )
+
+    assert arguments[:4] == ("-n", "2", "--durations=10", "benchmarks/validation")
+    assert arguments[arguments.index("--splits") + 1] == "4"
+    assert arguments[arguments.index("--group") + 1] == "2"
+    assert arguments[arguments.index("--splitting-algorithm") + 1] == "least_duration"
+    assert "--store-durations" not in arguments
+
+
+def test_local_full_run_uses_empty_timing_fallback_and_writes_bound_receipts(
+    tmp_path: Path,
+) -> None:
+    entries = full_host_validation()
+    observed: list[tuple[str, tuple[str, ...], int]] = []
+
+    def fake_runner(entry, arguments, workers):
+        observed.append((entry.name, arguments, workers))
+        return ShardResult(status="EXITED", exit_code=0, actual_seconds=2.5)
+
+    result = execute(
+        entries,
+        root=tmp_path,
+        timing_path=tmp_path / ".ci/benchmark-test-durations.json",
+        receipt_dir=tmp_path / "receipts",
+        provenance=PROVENANCE,
+        total_worker_budget=4,
+        max_parallel=4,
+        runner=fake_runner,
+    )
+
+    assert result == 0
+    assert {name for name, _, _ in observed} == {entry.name for entry in entries}
+    assert {workers for _, _, workers in observed} == {1}
+    receipts = sorted((tmp_path / "receipts").rglob("pytest-receipt.json"))
+    assert len(receipts) == 4
+    payload = json.loads(receipts[0].read_text(encoding="utf-8"))
+    assert payload["plan_head_sha"] == PROVENANCE.plan_head_sha
+    assert payload["execution_sha"] == PROVENANCE.execution_sha
+    assert payload["timing_digest"].startswith("sha256:")
+    assert payload["total_worker_budget"] == 4
+    assert payload["max_parallel"] == 4
+    assert not (tmp_path / ".pytest_cache/benchmark-host").exists()
+
+
+def test_failed_shard_fails_the_aggregate_exit_code(tmp_path: Path) -> None:
+    entries = full_host_validation()[:2]
+
+    def fake_runner(entry, _arguments, _workers):
+        return ShardResult(
+            status="EXITED",
+            exit_code=1 if entry == entries[0] else 0,
+            actual_seconds=1.0,
+        )
+
+    result = execute(
+        entries,
+        root=tmp_path,
+        timing_path=tmp_path / "missing.json",
+        receipt_dir=tmp_path / "receipts",
+        provenance=PROVENANCE,
+        total_worker_budget=2,
+        max_parallel=2,
+        runner=fake_runner,
+    )
+
+    assert result == 1
+
+
+def test_invalid_timing_history_falls_back_without_mutating_input(
+    tmp_path: Path,
+) -> None:
+    entry = full_host_validation()[0]
+    timing_path = tmp_path / "durations.json"
+    timing_path.write_text('{"bad": "duration"}\n', encoding="utf-8")
+    observed: list[tuple[str, ...]] = []
+
+    def fake_runner(_entry, arguments, _workers):
+        observed.append(arguments)
+        return ShardResult(status="EXITED", exit_code=0, actual_seconds=1.0)
+
+    assert (
+        execute(
+            (entry,),
+            root=tmp_path,
+            timing_path=timing_path,
+            receipt_dir=tmp_path / "receipts",
+            provenance=PROVENANCE,
+            total_worker_budget=1,
+            max_parallel=1,
+            runner=fake_runner,
+        )
+        == 0
+    )
+    assert timing_path.read_text(encoding="utf-8") == '{"bad": "duration"}\n'
+    assert not (tmp_path / ".pytest_cache/benchmark-host").exists()
+    assert observed
+
+
+def test_duration_collection_writes_separate_output(tmp_path: Path) -> None:
+    entry = full_host_validation()[0]
+    timing_path = tmp_path / "input.json"
+    timing_path.write_text("{}\n", encoding="utf-8")
+    output = tmp_path / "output.json"
+
+    def fake_runner(_entry, arguments, _workers):
+        duration_path = Path(arguments[arguments.index("--durations-path") + 1])
+        assert duration_path != timing_path
+        duration_path.write_text(
+            '{"benchmarks/validation/test_example.py::test_it": 1.0}\n',
+            encoding="utf-8",
+        )
+        return ShardResult(status="EXITED", exit_code=0, actual_seconds=1.0)
+
+    assert (
+        execute(
+            (entry,),
+            root=tmp_path,
+            timing_path=timing_path,
+            receipt_dir=tmp_path / "receipts",
+            provenance=PROVENANCE,
+            total_worker_budget=4,
+            max_parallel=4,
+            store_durations=True,
+            duration_output=output,
+            runner=fake_runner,
+        )
+        == 0
+    )
+    assert timing_path.read_text(encoding="utf-8") == "{}\n"
+    assert "test_example.py::test_it" in output.read_text(encoding="utf-8")
+    assert not (tmp_path / ".pytest_cache/benchmark-host-timing").exists()

--- a/benchmarks/validation/test_tooling_command_runner.py
+++ b/benchmarks/validation/test_tooling_command_runner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import sys
+import threading
 from pathlib import Path
 
 import pytest
@@ -13,6 +14,7 @@ from benchmarks.tooling.command_runner import (
     git_head_sha,
     operator_environment,
     run_operator_command,
+    run_tool_command,
 )
 
 
@@ -88,3 +90,104 @@ def test_operator_command_has_bounded_output(tmp_path: Path) -> None:
     )
     assert result.status is ToolCommandStatus.OUTPUT_LIMIT_EXCEEDED
     assert len(result.stdout) <= 32
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX executable path fixture")
+def test_tool_command_streams_stdout_and_stderr_before_exit(tmp_path: Path) -> None:
+    stdout = bytearray()
+    stderr = bytearray()
+    delivered = threading.Event()
+
+    def receive_stdout(block: bytes) -> None:
+        stdout.extend(block)
+        delivered.set()
+
+    request = ToolCommandRequest(
+        executable=sys.executable,
+        arguments=(
+            "-c",
+            "import sys,time; print('live', flush=True); "
+            "print('warning', file=sys.stderr, flush=True); time.sleep(0.5)",
+        ),
+        cwd=str(tmp_path),
+        timeout_seconds=5.0,
+        stdout_limit_bytes=128,
+        stderr_limit_bytes=128,
+        stdout_sink=receive_stdout,
+        stderr_sink=stderr.extend,
+    )
+    result_box: list[ToolCommandResult] = []
+    runner = threading.Thread(
+        target=lambda: result_box.append(run_tool_command(request))
+    )
+
+    runner.start()
+    assert delivered.wait(timeout=2.0)
+    assert runner.is_alive()
+    runner.join(timeout=5.0)
+
+    assert not runner.is_alive()
+    assert result_box[0].status is ToolCommandStatus.EXITED
+    assert stdout == b"live\n"
+    assert stderr == b"warning\n"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX executable path fixture")
+def test_streamed_output_remains_bounded(tmp_path: Path) -> None:
+    streamed = bytearray()
+    result = run_tool_command(
+        ToolCommandRequest(
+            executable=sys.executable,
+            arguments=("-c", "print('x' * 10000, flush=True)"),
+            cwd=str(tmp_path),
+            timeout_seconds=5.0,
+            stdout_limit_bytes=32,
+            stderr_limit_bytes=32,
+            stdout_sink=streamed.extend,
+        )
+    )
+
+    assert result.status is ToolCommandStatus.OUTPUT_LIMIT_EXCEEDED
+    assert streamed == result.stdout
+    assert len(streamed) == 32
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX executable path fixture")
+def test_tool_command_timeout_is_preserved_with_streaming(tmp_path: Path) -> None:
+    streamed = bytearray()
+    result = run_tool_command(
+        ToolCommandRequest(
+            executable=sys.executable,
+            arguments=("-c", "import time; print('ready', flush=True); time.sleep(5)"),
+            cwd=str(tmp_path),
+            timeout_seconds=0.5,
+            stdout_limit_bytes=128,
+            stderr_limit_bytes=128,
+            stdout_sink=streamed.extend,
+        )
+    )
+
+    assert result.status is ToolCommandStatus.TIMED_OUT
+    assert streamed == b"ready\n"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX executable path fixture")
+def test_sink_failure_stops_the_tool_process(tmp_path: Path) -> None:
+    def reject_output(_block: bytes) -> None:
+        raise RuntimeError("sink unavailable")
+
+    result = run_tool_command(
+        ToolCommandRequest(
+            executable=sys.executable,
+            arguments=("-c", "import time; print('ready', flush=True); time.sleep(5)"),
+            cwd=str(tmp_path),
+            timeout_seconds=4.0,
+            stdout_limit_bytes=128,
+            stderr_limit_bytes=128,
+            stdout_sink=reject_output,
+        )
+    )
+
+    assert result.status is ToolCommandStatus.STREAM_FAILED
+    assert result.exit_code is None
+    assert result.diagnostic == "stdout sink failed: RuntimeError"

--- a/benchmarks/validation/test_validation_plan.py
+++ b/benchmarks/validation/test_validation_plan.py
@@ -1,0 +1,113 @@
+"""Tests for the importable benchmark host-validation planner."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from benchmarks.tooling.validation_plan import host_validation_plan
+
+
+def test_task_change_selects_only_leaf_and_filtered_generic(tmp_path: Path) -> None:
+    task = "task-a"
+    leaf = tmp_path / "benchmarks/validation/mathematical_benchmarks_v1/test_task_a.py"
+    leaf.parent.mkdir(parents=True)
+    leaf.write_text("", encoding="utf-8")
+    suite = SimpleNamespace(tasks=(SimpleNamespace(path=Path(task)),))
+
+    plan = host_validation_plan(
+        tmp_path,
+        [f"benchmarks/datasets/mathematical-benchmarks-v1/{task}/tests/verifier.py"],
+        {"mathematical-benchmarks-v1": suite},
+    )
+
+    assert [(entry.selector, entry.keyword) for entry in plan.entries] == [
+        (
+            "benchmarks/validation/mathematical_benchmarks_v1/"
+            "test_generic_verifier_contracts.py",
+            task,
+        ),
+        (
+            "benchmarks/validation/mathematical_benchmarks_v1/test_task_a.py",
+            "",
+        ),
+    ]
+    assert all(reason.startswith("focused host validation:") for reason in plan.reasons)
+
+
+def test_shared_harness_change_explains_full_validation(tmp_path: Path) -> None:
+    support = tmp_path / "benchmarks/validation/mathematical_benchmarks_v1/support.py"
+    support.parent.mkdir(parents=True)
+    support.write_text("", encoding="utf-8")
+
+    plan = host_validation_plan(
+        tmp_path, [support.relative_to(tmp_path).as_posix()], {}
+    )
+
+    assert len(plan.entries) == 4
+    assert plan.reasons == (
+        "shared verifier harness requires full host validation: "
+        "benchmarks/validation/mathematical_benchmarks_v1/support.py",
+    )
+
+
+def test_control_plane_change_selects_its_exact_contract_tests(tmp_path: Path) -> None:
+    plan = host_validation_plan(
+        tmp_path, ["benchmarks/tooling/benchmark_validation.py"], {}
+    )
+
+    assert [entry.selector for entry in plan.entries] == [
+        "benchmarks/validation/test_benchmark_validation.py"
+    ]
+    assert plan.reasons == (
+        "focused host validation: control-test_benchmark_validation",
+    )
+
+
+def test_workflow_change_selects_each_owned_contract_without_full_fallback(
+    tmp_path: Path,
+) -> None:
+    plan = host_validation_plan(tmp_path, [".github/workflows/benchmarks.yml"], {})
+
+    assert {entry.selector for entry in plan.entries} == {
+        "benchmarks/validation/test_benchmark_planner.py",
+        "benchmarks/validation/test_benchmark_validation.py",
+    }
+    assert len(plan.entries) == 2
+
+
+def test_non_host_control_utility_has_an_explicit_empty_host_selection(
+    tmp_path: Path,
+) -> None:
+    plan = host_validation_plan(tmp_path, [".github/scripts/manage-test-timings"], {})
+
+    assert plan.entries == ()
+    assert plan.reasons == ()
+
+
+def test_shared_path_policy_remains_conservative(tmp_path: Path) -> None:
+    plan = host_validation_plan(tmp_path, [".github/scripts/_ci_paths.py"], {})
+
+    assert len(plan.entries) == 4
+    assert "full host validation" in plan.reasons[0]
+
+
+def test_unknown_tooling_still_falls_back_to_full_validation(tmp_path: Path) -> None:
+    path = "benchmarks/tooling/new_shared_harness.py"
+    plan = host_validation_plan(tmp_path, [path], {})
+
+    assert len(plan.entries) == 4
+    assert plan.reasons == (
+        f"shared benchmark tooling requires full host validation: {path}",
+    )
+
+
+def test_makefile_change_remains_fail_closed_without_hunk_ownership(
+    tmp_path: Path,
+) -> None:
+    plan = host_validation_plan(tmp_path, ["Makefile"], {})
+
+    assert len(plan.entries) == 4
+    assert plan.reasons == (
+        "shared verifier execution harness requires full host validation: Makefile",
+    )

--- a/tests/boundary/process/tooling/test_ci_test_timings.py
+++ b/tests/boundary/process/tooling/test_ci_test_timings.py
@@ -76,6 +76,8 @@ def plan_outputs() -> dict[str, str]:
 
 
 def shard_count(suite: str = "domain") -> int:
+    if suite == "benchmark":
+        return 4
     return int(plan_outputs()[f"{suite}-shard-count"])
 
 
@@ -106,7 +108,7 @@ def test_prepare_falls_back_to_equal_weighting_without_github_context(
     assert "equal weighting" in result.stderr
 
 
-@pytest.mark.parametrize("suite", ["domain", "composition"])
+@pytest.mark.parametrize("suite", ["domain", "composition", "benchmark"])
 def test_merge_publishes_versioned_metadata_and_all_shards(
     tmp_path: Path, suite: str
 ) -> None:
@@ -114,8 +116,9 @@ def test_merge_publishes_versioned_metadata_and_all_shards(
     inputs: list[str] = []
     for shard in range(1, count + 1):
         path = tmp_path / f"shard-{shard}.json"
+        prefix = "benchmarks/validation" if suite == "benchmark" else f"tests/{suite}"
         path.write_text(
-            json.dumps({f"tests/{suite}/test_{shard}.py::test_case": shard}),
+            json.dumps({f"{prefix}/test_{shard}.py::test_case": shard}),
             encoding="utf-8",
         )
         inputs.extend(["--input", str(path)])

--- a/tests/boundary/process/tooling/test_plan_receipt.py
+++ b/tests/boundary/process/tooling/test_plan_receipt.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from benchmarks.tooling.receipts import receipt_digest
 from tests.boundary.process.tooling.ci import run_ci_script
 
 
@@ -68,6 +69,8 @@ def test_plan_receipt_binds_plan_paths_source_and_configuration(tmp_path: Path) 
     }
     assert str(receipt["plan_digest"]).startswith("sha256:")
     assert str(receipt["receipt_digest"]).startswith("sha256:")
+    unsigned = {key: value for key, value in receipt.items() if key != "receipt_digest"}
+    assert receipt["receipt_digest"] == receipt_digest(unsigned)
 
 
 def test_plan_receipt_changes_when_changed_paths_change(tmp_path: Path) -> None:

--- a/tests/boundary/process/tooling/test_pytest_lifecycle.py
+++ b/tests/boundary/process/tooling/test_pytest_lifecycle.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from benchmarks.tooling.command_runner import (
+    ToolCommandRequest,
+    ToolCommandResult,
+    ToolCommandStatus,
+)
+from tools import pytest_lifecycle
+
+
+def _tool_result(exit_code: int) -> ToolCommandResult:
+    return ToolCommandResult(
+        status=ToolCommandStatus.EXITED,
+        exit_code=exit_code,
+        stdout=b"",
+        stderr=b"",
+    )
+
+
+def test_success_uses_unique_worktree_basetemp_and_cleans_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    observed: list[tuple[str, ...]] = []
+
+    def run(request: object) -> ToolCommandResult:
+        observed.append(request.arguments)  # type: ignore[attr-defined]
+        basetemp_argument = next(
+            argument
+            for argument in request.arguments  # type: ignore[attr-defined]
+            if argument.startswith("--basetemp=")
+        )
+        basetemp = Path(basetemp_argument.split("=", 1)[1])
+        (basetemp.parent / "session-template").mkdir()
+        return _tool_result(0)
+
+    monkeypatch.setattr(pytest_lifecycle, "run_tool_command", run)
+
+    first = pytest_lifecycle.run_pytest(
+        ["tests/unit/test_one.py"],
+        root=tmp_path,
+        name="unit",
+        environment={},
+    )
+    second = pytest_lifecycle.run_pytest(
+        ["tests/unit/test_one.py"],
+        root=tmp_path,
+        name="unit",
+        environment={},
+    )
+
+    assert first.basetemp != second.basetemp
+    assert first.basetemp.is_relative_to(tmp_path / ".pytest_cache" / "basetemp")
+    assert first.basetemp.name == "pytest"
+    assert not first.basetemp.exists()
+    assert not first.basetemp.parent.exists()
+    assert not second.basetemp.exists()
+    assert any(argument.startswith("--basetemp=") for argument in observed[0])
+
+
+def test_failure_cleanup_is_default_and_retention_is_opt_in(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        pytest_lifecycle, "run_tool_command", lambda request: _tool_result(1)
+    )
+
+    cleaned = pytest_lifecycle.run_pytest(
+        ["test_bad.py"], root=tmp_path, name="clean", environment={}
+    )
+    retained = pytest_lifecycle.run_pytest(
+        ["test_bad.py"],
+        root=tmp_path,
+        name="retain",
+        environment={},
+        retain_on_failure=True,
+    )
+
+    assert not cleaned.basetemp.exists()
+    assert retained.retained is True
+    assert retained.basetemp.is_dir()
+
+
+def test_receipt_records_prediction_and_actual_result(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        pytest_lifecycle, "run_tool_command", lambda request: _tool_result(0)
+    )
+    receipt = tmp_path / "evidence" / "pytest-receipt.json"
+
+    pytest_lifecycle.run_pytest(
+        ["test_ok.py"],
+        root=tmp_path,
+        name="host-validation/full-1-of-4",
+        environment={},
+        receipt=receipt,
+        predicted_seconds=180.0,
+    )
+
+    payload = json.loads(receipt.read_text(encoding="utf-8"))
+    assert payload["name"] == "host-validation/full-1-of-4"
+    assert payload["predicted_seconds"] == 180.0
+    assert payload["actual_seconds"] >= 0
+    assert payload["exit_code"] == 0
+
+
+def test_explicit_basetemp_is_rejected(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="owned"):
+        pytest_lifecycle.run_pytest(
+            ["--basetemp=/tmp/shared"],
+            root=tmp_path,
+            name="unsafe",
+            environment={},
+        )
+
+
+def test_run_streams_output_once_and_emits_lifecycle_events(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    def run(request: ToolCommandRequest) -> ToolCommandResult:
+        assert request.stdout_sink is not None
+        assert request.stderr_sink is not None
+        request.stdout_sink(b"live output\n")
+        request.stderr_sink(b"live warning\n")
+        return ToolCommandResult(
+            status=ToolCommandStatus.EXITED,
+            exit_code=0,
+            stdout=b"live output\n",
+            stderr=b"live warning\n",
+        )
+
+    monkeypatch.setattr(pytest_lifecycle, "run_tool_command", run)
+
+    pytest_lifecycle.run_pytest(
+        ["test_ok.py"],
+        root=tmp_path,
+        name="process/shard-1",
+        environment={},
+        predicted_seconds=12.0,
+    )
+
+    captured = capfd.readouterr()
+    assert captured.out == "live output\n"
+    assert captured.err.count("live warning") == 1
+    events = [
+        json.loads(line.removeprefix("[pytest-lifecycle] "))
+        for line in captured.err.splitlines()
+        if line.startswith("[pytest-lifecycle] ")
+    ]
+    assert events[0] == {
+        "event": "pytest.run.started",
+        "name": "process/shard-1",
+        "predicted_seconds": 12.0,
+        "timeout_seconds": 3600.0,
+    }
+    assert events[1]["event"] == "pytest.run.completed"
+    assert events[1]["name"] == "process/shard-1"
+    assert events[1]["status"] == "EXITED"
+    assert events[1]["exit_code"] == 0
+    assert events[1]["actual_seconds"] >= 0

--- a/tests/boundary/process/tooling/test_topology_runner.py
+++ b/tests/boundary/process/tooling/test_topology_runner.py
@@ -67,32 +67,21 @@ def test_make_semantic_lane_forwards_pytest_arguments() -> None:
 
 
 def test_topology_runner_executes_pytest_via_command_runner(monkeypatch) -> None:
-    from benchmarks.tooling.command_runner import ToolCommandStatus
+    from types import SimpleNamespace
+
     from tools import test_topology
 
     topology = test_topology.load_topology()
     observed: dict[str, object] = {}
 
-    class FakeResult:
-        status = ToolCommandStatus.EXITED
-        exit_code = 0
-        stdout = b"all tests passed\n"
-        stderr = b""
-
-    def fake_run_tool_command(request: object) -> FakeResult:
-        observed.update(
-            executable=request.executable,  # type: ignore[attr-defined]
-            arguments=request.arguments,  # type: ignore[attr-defined]
-            cwd=request.cwd,  # type: ignore[attr-defined]
-            environment=request.environment,  # type: ignore[attr-defined]
-            timeout_seconds=request.timeout_seconds,  # type: ignore[attr-defined]
-        )
-        return FakeResult()
+    def fake_run_pytest(arguments: object, **kwargs: object) -> object:
+        observed.update(arguments=arguments, **kwargs)
+        return SimpleNamespace(exit_code=0)
 
     monkeypatch.setattr(
         test_topology,
-        "run_tool_command",
-        fake_run_tool_command,
+        "run_pytest",
+        fake_run_pytest,
     )
 
     rc = test_topology.run_lane(
@@ -103,74 +92,34 @@ def test_topology_runner_executes_pytest_via_command_runner(monkeypatch) -> None
     )
 
     assert rc == 0
-    # Must use the active interpreter verbatim, not resolved (which loses the venv).
-    assert observed["executable"] == sys.executable
-    assert observed["arguments"] == (
-        "-m",
-        "pytest",
+    assert observed["arguments"] == [
         "tests/unit/tooling/test_fixture_architecture.py",
         "-q",
         "--timeout",
         "10",
-    )
+    ]
     environment = observed["environment"]
     assert environment is not None
     assert environment["JACOBIAN_TEST_LANE"] == "unit"
     assert observed["timeout_seconds"] == 3600.0
 
 
-def test_topology_runner_forwards_child_stdout_and_stderr(monkeypatch, capfd) -> None:
-    from benchmarks.tooling.command_runner import ToolCommandStatus
+def test_topology_runner_returns_pytest_failure(monkeypatch) -> None:
+    from types import SimpleNamespace
+
     from tools import test_topology
 
     topology = test_topology.load_topology()
 
-    class FakeResult:
-        status = ToolCommandStatus.EXITED
-        exit_code = 1
-        stdout = b"FAILED tests/unit/test_bad.py\n"
-        stderr = b"Error: assertion failed\n"
-
     monkeypatch.setattr(
         test_topology,
-        "run_tool_command",
-        lambda request: FakeResult(),
+        "run_pytest",
+        lambda *args, **kwargs: SimpleNamespace(exit_code=1),
     )
 
     rc = test_topology.run_lane(topology, "unit", ["tests/unit/test_bad.py"], [])
 
     assert rc == 1
-    captured = capfd.readouterr()
-    assert "FAILED tests/unit/test_bad.py" in captured.out
-    assert "Error: assertion failed" in captured.err
-
-
-def test_topology_runner_emits_diagnostic_on_timeout(monkeypatch, capfd) -> None:
-    from benchmarks.tooling.command_runner import ToolCommandStatus
-    from tools import test_topology
-
-    topology = test_topology.load_topology()
-
-    class FakeResult:
-        status = ToolCommandStatus.TIMED_OUT
-        exit_code = None
-        stdout = b""
-        stderr = b""
-        diagnostic = "deadline exceeded"
-        stdout_exceeded = False
-        stderr_exceeded = False
-
-    monkeypatch.setattr(
-        test_topology,
-        "run_tool_command",
-        lambda request: FakeResult(),
-    )
-
-    rc = test_topology.run_lane(topology, "unit", [], [])
-
-    assert rc == 1
-    captured = capfd.readouterr()
-    assert "deadline exceeded" in captured.err
 
 
 def test_focused_selector_does_not_start_configured_workers() -> None:

--- a/tests/unit/tooling/harbor_suite_support.py
+++ b/tests/unit/tooling/harbor_suite_support.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 import tomli_w
+from benchmarks.tooling.command_runner import ToolCommandStatus, run_operator_command
 from benchmarks.tooling.harbor_suite import (
     TASK_SCHEMA_VERSION,
     EnvironmentProfile,
@@ -22,6 +23,11 @@ def patch_harbor_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
     import benchmarks.tooling.harbor_suite as hs
 
     monkeypatch.setattr(hs, "ROOT", tmp_path)
+    # Worktree-local pytest basetemps remain inside the outer repository and
+    # inherit its ignore rules unless the synthetic Harbor root owns a Git
+    # boundary. Keep cache-policy tests independent of their temp location.
+    git = run_operator_command("git", ("init", "--quiet"), cwd=tmp_path)
+    assert git.status is ToolCommandStatus.EXITED and git.exit_code == 0
     profile = EnvironmentProfile(
         name="test-profile",
         agent_image="python:3.12-slim",

--- a/tests/unit/tooling/test_ci_execution_policy.py
+++ b/tests/unit/tooling/test_ci_execution_policy.py
@@ -144,11 +144,25 @@ def test_benchmark_contracts_run_once_for_record_and_digest_evidence() -> None:
     assert workflow.count("run: make harbor-contracts harbor-adapter-checks") == 1
     assert "  contracts:" in workflow
     assert "  host_validation:" in workflow
-    assert "make harbor-validation-tests TESTS=" in workflow
-    assert 'pytest_args+=(--splits "$SPLITS" --group "$GROUP")' in workflow
+    assert "benchmarks.tooling.host_validation run-entry" in workflow
+    assert '--entry-json "$HOST_ENTRY"' in workflow
+    assert "--total-workers 8 --max-parallel 4" in workflow
+    assert '--execution-sha "${{ github.sha }}"' in workflow
     assert "  prospective-digest:" not in workflow
     assert "python .github/scripts/emit-plan-receipt" in workflow
     assert "benchmark-plan-receipt" in workflow
+
+
+def test_benchmark_stable_gate_validates_provenance_receipts_in_python() -> None:
+    workflow = (ROOT / ".github/workflows/benchmarks.yml").read_text(encoding="utf-8")
+    validation = workflow.split("  validation:", 1)[1].split("  timings:", 1)[0]
+
+    assert "benchmarks.tooling.benchmark_validation" in validation
+    assert "benchmark-plan-receipt" in validation
+    assert "benchmark-host-timing-*" in validation
+    assert "benchmark-test-durations-input" in validation
+    assert '--execution-sha "${{ github.sha }}"' in validation
+    assert "check_lane()" not in validation
 
 
 def test_product_ci_publishes_a_provenance_bound_plan_receipt() -> None:

--- a/tools/benchmark_pr_status.py
+++ b/tools/benchmark_pr_status.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""Report merge readiness for one or more benchmark pull requests."""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import re
+import sys
+import zipfile
+from collections.abc import Callable, Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from benchmarks.tooling.command_runner import (  # noqa: E402
+    ToolCommandStatus,
+    operator_environment,
+    run_operator_command,
+)
+
+_TASK_PATH = re.compile(r"^benchmarks/datasets/([^/]+)/([^/]+)/")
+_RUN_ID = re.compile(r"/actions/runs/(\d+)(?:/|$)")
+_PREPARATION_CHECKS = (
+    "Benchmark Static Quality",
+    "Benchmark Contracts, Adapters, Records & Digests",
+)
+_VALIDATION_CHECK = "Benchmark Validation"
+_GH_ENVIRONMENT = (
+    "PATH",
+    "HOME",
+    "XDG_CONFIG_HOME",
+    "GH_CONFIG_DIR",
+    "GH_TOKEN",
+    "GITHUB_TOKEN",
+)
+
+
+class StatusError(RuntimeError):
+    """Live GitHub state could not be read or validated."""
+
+
+@dataclass(frozen=True, slots=True)
+class Check:
+    name: str
+    state: str
+    link: str
+
+
+@dataclass(frozen=True, slots=True)
+class PullRequestStatus:
+    number: int
+    title: str
+    url: str
+    tasks: tuple[str, ...]
+    unresolved_threads: int
+    preparation: str
+    receipt_digest: str | None
+    ci: str
+    merge_ready: bool
+    blockers: tuple[str, ...]
+
+
+Runner = Callable[[Sequence[str]], bytes]
+
+
+def _gh(arguments: Sequence[str]) -> bytes:
+    result = run_operator_command(
+        "gh",
+        arguments,
+        cwd=ROOT,
+        timeout_seconds=120.0,
+        stdout_limit_bytes=16 * 1024 * 1024,
+        stderr_limit_bytes=4 * 1024 * 1024,
+        environment=operator_environment(include=_GH_ENVIRONMENT),
+    )
+    if result.status is not ToolCommandStatus.EXITED or result.exit_code != 0:
+        detail = result.diagnostic or result.stderr.decode(errors="replace").strip()
+        raise StatusError(detail or "gh command failed")
+    return bytes(result.stdout)
+
+
+def _json(payload: bytes, context: str) -> Any:
+    try:
+        return json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise StatusError(f"invalid {context} JSON: {exc}") from exc
+
+
+class GitHubReader:
+    """Small read-only adapter around the authenticated gh CLI."""
+
+    def __init__(self, repository: str, *, runner: Runner = _gh) -> None:
+        if repository.count("/") != 1:
+            raise StatusError(f"invalid repository slug: {repository}")
+        self.repository = repository
+        self.runner = runner
+
+    def pull_request(self, number: int) -> dict[str, Any]:
+        fields = (
+            "number,title,url,state,isDraft,mergeable,mergeStateStatus,"
+            "headRefOid,files,statusCheckRollup"
+        )
+        payload = _json(
+            self.runner(
+                ("-R", self.repository, "pr", "view", str(number), "--json", fields)
+            ),
+            f"PR {number}",
+        )
+        if not isinstance(payload, dict):
+            raise StatusError(f"PR {number} response must be an object")
+        return payload
+
+    def unresolved_threads(self, number: int) -> int:
+        owner, repository = self.repository.split("/", 1)
+        query = (
+            "query($owner:String!,$repo:String!,$number:Int!,$after:String){"
+            "repository(owner:$owner,name:$repo){pullRequest(number:$number){"
+            "reviewThreads(first:100,after:$after){nodes{isResolved}"
+            "pageInfo{hasNextPage endCursor}}}}}"
+        )
+        after: str | None = None
+        unresolved = 0
+        while True:
+            arguments = [
+                "api",
+                "graphql",
+                "-f",
+                f"query={query}",
+                "-F",
+                f"owner={owner}",
+                "-F",
+                f"repo={repository}",
+                "-F",
+                f"number={number}",
+            ]
+            if after is not None:
+                arguments.extend(("-F", f"after={after}"))
+            payload = _json(self.runner(arguments), f"PR {number} review threads")
+            try:
+                threads = payload["data"]["repository"]["pullRequest"]["reviewThreads"]
+                unresolved += sum(not node["isResolved"] for node in threads["nodes"])
+                page = threads["pageInfo"]
+            except (KeyError, TypeError) as exc:
+                raise StatusError(
+                    f"PR {number} review-thread response is malformed"
+                ) from exc
+            if not page["hasNextPage"]:
+                return unresolved
+            after = page["endCursor"]
+            if not isinstance(after, str) or not after:
+                raise StatusError(f"PR {number} review-thread pagination is malformed")
+
+    def plan_receipt(self, run_id: int) -> str | None:
+        payload = _json(
+            self.runner(
+                ("api", f"repos/{self.repository}/actions/runs/{run_id}/artifacts")
+            ),
+            f"Actions run {run_id} artifacts",
+        )
+        artifacts = payload.get("artifacts", []) if isinstance(payload, dict) else []
+        artifact = next(
+            (
+                item
+                for item in artifacts
+                if item.get("name") == "benchmark-plan-receipt"
+                and not item.get("expired", False)
+            ),
+            None,
+        )
+        if artifact is None:
+            return None
+        archive = self.runner(
+            (
+                "api",
+                f"repos/{self.repository}/actions/artifacts/{artifact['id']}/zip",
+            )
+        )
+        try:
+            with zipfile.ZipFile(io.BytesIO(archive)) as bundle:
+                members = [
+                    name
+                    for name in bundle.namelist()
+                    if name.endswith("plan-receipt.json")
+                ]
+                if len(members) != 1:
+                    raise StatusError(
+                        "benchmark plan receipt archive has an invalid shape"
+                    )
+                receipt = json.loads(bundle.read(members[0]))
+        except (KeyError, json.JSONDecodeError, zipfile.BadZipFile) as exc:
+            raise StatusError("benchmark plan receipt artifact is invalid") from exc
+        digest = receipt.get("receipt_digest") if isinstance(receipt, dict) else None
+        if not isinstance(digest, str) or not digest.startswith("sha256:"):
+            raise StatusError("benchmark plan receipt has no valid receipt_digest")
+        return digest
+
+
+def _checks(payload: dict[str, Any]) -> tuple[Check, ...]:
+    checks: list[Check] = []
+    for item in payload.get("statusCheckRollup", []):
+        if not isinstance(item, dict):
+            continue
+        name = item.get("name") or item.get("context")
+        state = item.get("conclusion") or item.get("state") or item.get("status")
+        if isinstance(name, str) and isinstance(state, str):
+            checks.append(
+                Check(
+                    name,
+                    state.upper(),
+                    str(item.get("detailsUrl") or item.get("targetUrl") or ""),
+                )
+            )
+    return tuple(checks)
+
+
+def _tasks(payload: dict[str, Any]) -> tuple[str, ...]:
+    identities = {
+        f"{match.group(1)}/{match.group(2)}"
+        for item in payload.get("files", [])
+        if isinstance(item, dict)
+        and isinstance(item.get("path"), str)
+        and (match := _TASK_PATH.match(item["path"])) is not None
+    }
+    return tuple(sorted(identities))
+
+
+def _check_state(checks: Sequence[Check], names: Sequence[str]) -> str:
+    if not names:
+        return "missing"
+    selected = [check for check in checks if check.name in names]
+    if len(selected) != len(names):
+        return "missing"
+    if any(
+        check.state in {"PENDING", "IN_PROGRESS", "QUEUED", "WAITING", "REQUESTED"}
+        for check in selected
+    ):
+        return "pending"
+    return "passed" if all(check.state == "SUCCESS" for check in selected) else "failed"
+
+
+def build_status(
+    reader: GitHubReader, number: int, payload: dict[str, Any]
+) -> PullRequestStatus:
+    checks = _checks(payload)
+    tasks = _tasks(payload)
+    unresolved = reader.unresolved_threads(number)
+    preparation_checks = _check_state(checks, _PREPARATION_CHECKS)
+    preparation = "confirmed" if preparation_checks == "passed" else preparation_checks
+    validation = next(
+        (check for check in checks if check.name == _VALIDATION_CHECK), None
+    )
+    receipt_digest: str | None = None
+    if validation is not None:
+        match = _RUN_ID.search(validation.link)
+        if match is not None:
+            receipt_digest = reader.plan_receipt(int(match.group(1)))
+    ci = _check_state(checks, tuple(check.name for check in checks))
+
+    blockers = _merge_blockers(
+        payload,
+        unresolved=unresolved,
+        preparation=preparation,
+        ci=ci,
+        receipt_digest=receipt_digest,
+    )
+
+    return PullRequestStatus(
+        number=number,
+        title=str(payload.get("title", "")),
+        url=str(payload.get("url", "")),
+        tasks=tasks,
+        unresolved_threads=unresolved,
+        preparation=preparation,
+        receipt_digest=receipt_digest,
+        ci=ci,
+        merge_ready=not blockers,
+        blockers=blockers,
+    )
+
+
+def _merge_blockers(
+    payload: dict[str, Any],
+    *,
+    unresolved: int,
+    preparation: str,
+    ci: str,
+    receipt_digest: str | None,
+) -> tuple[str, ...]:
+    blockers: list[str] = []
+    if payload.get("state") != "OPEN":
+        blockers.append(f"state={payload.get('state', 'UNKNOWN')}")
+    if payload.get("isDraft"):
+        blockers.append("draft")
+    if payload.get("mergeable") != "MERGEABLE":
+        blockers.append(f"mergeable={payload.get('mergeable', 'UNKNOWN')}")
+    if payload.get("mergeStateStatus") != "CLEAN":
+        blockers.append(f"merge-state={payload.get('mergeStateStatus', 'UNKNOWN')}")
+    if unresolved:
+        blockers.append(f"unresolved-threads={unresolved}")
+    if preparation != "confirmed":
+        blockers.append(f"preparation={preparation}")
+    if ci != "passed":
+        blockers.append(f"ci={ci}")
+    if receipt_digest is None:
+        blockers.append("validation-receipt=missing")
+
+    return tuple(blockers)
+
+
+def render_human(statuses: Sequence[PullRequestStatus]) -> str:
+    lines: list[str] = []
+    for status in statuses:
+        readiness = "ready" if status.merge_ready else "blocked"
+        lines.append(f"#{status.number} {readiness} — {status.title}")
+        lines.append(f"  tasks: {', '.join(status.tasks) or 'none'}")
+        lines.append(
+            f"  threads={status.unresolved_threads} preparation={status.preparation} "
+            f"ci={status.ci} receipt={status.receipt_digest or 'missing'}"
+        )
+        if status.blockers:
+            lines.append(f"  blockers: {', '.join(status.blockers)}")
+    return "\n".join(lines) + "\n"
+
+
+def _repository(value: str | None, runner: Runner) -> str:
+    if value is not None:
+        return value
+    payload = _json(runner(("repo", "view", "--json", "nameWithOwner")), "repository")
+    repository = payload.get("nameWithOwner") if isinstance(payload, dict) else None
+    if not isinstance(repository, str):
+        raise StatusError("could not resolve repository; pass --repo owner/name")
+    return repository
+
+
+def main(argv: Sequence[str] | None = None, *, runner: Runner = _gh) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("pull_requests", nargs="+", type=int, metavar="PR")
+    parser.add_argument("--repo", help="owner/name; defaults to the current gh repo")
+    parser.add_argument("--json", action="store_true", help="emit structured JSON")
+    args = parser.parse_args(argv)
+    try:
+        reader = GitHubReader(_repository(args.repo, runner), runner=runner)
+        statuses = [
+            build_status(reader, number, reader.pull_request(number))
+            for number in args.pull_requests
+        ]
+    except StatusError as exc:
+        parser.error(str(exc))
+    if args.json:
+        print(json.dumps([asdict(status) for status in statuses], indent=2))
+    else:
+        sys.stdout.write(render_human(statuses))
+    return 0 if all(status.merge_ready for status in statuses) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "Check",
+    "GitHubReader",
+    "PullRequestStatus",
+    "StatusError",
+    "build_status",
+    "main",
+    "render_human",
+]

--- a/tools/check_benchmark_static.py
+++ b/tools/check_benchmark_static.py
@@ -26,14 +26,22 @@ from benchmarks.tooling.command_runner import (  # noqa: E402
 
 RUFF_TARGETS = (
     "benchmarks",
+    "tools/benchmark_pr_status.py",
     "tools/check_benchmark_static.py",
     "tools/harbor_task_workflow.py",
+    "tools/pytest_lifecycle.py",
 )
 MYPY_TARGETS = (
+    "benchmarks/tooling/benchmark_timings.py",
+    "benchmarks/tooling/benchmark_validation.py",
+    "benchmarks/tooling/host_validation.py",
+    "benchmarks/tooling/validation_plan.py",
+    "tools/benchmark_pr_status.py",
     "tools/check_benchmark_adapters.py",
     "tools/check_benchmark_contracts.py",
     "tools/check_benchmark_static.py",
     "tools/harbor_task_workflow.py",
+    "tools/pytest_lifecycle.py",
 )
 
 

--- a/tools/harbor_task_workflow.py
+++ b/tools/harbor_task_workflow.py
@@ -5,15 +5,12 @@ from __future__ import annotations
 
 import argparse
 import hashlib
-import importlib.util
 import json
 import shutil
 import sys
 import time
 from dataclasses import dataclass
-from importlib.machinery import SourceFileLoader
 from pathlib import Path
-from types import ModuleType
 from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -32,8 +29,11 @@ from benchmarks.tooling.harbor_suite import (  # noqa: E402
     get_suite,
     select_task_refs,
 )
+from benchmarks.tooling.validation_plan import (  # noqa: E402
+    HostValidation,
+    task_host_validation,
+)
 
-PLANNER_PATH = ROOT / ".github" / "scripts" / "plan-benchmarks"
 PYTEST_ROOT = ROOT / ".pytest_cache" / "harbor-validation"
 OUTPUT_LIMIT = 8 * 1024 * 1024
 OPERATOR_ENVIRONMENT = (
@@ -50,15 +50,6 @@ TOOL_RESOLVER = ToolResolver()
 
 class TaskWorkflowError(RuntimeError):
     """A selected-task workflow contract was invalid or a stage failed."""
-
-
-@dataclass(frozen=True, slots=True)
-class HostValidation:
-    """One planner-owned host validation selector."""
-
-    name: str
-    selector: str
-    keyword: str
 
 
 @dataclass(frozen=True, slots=True)
@@ -79,55 +70,6 @@ class StageTiming:
     seconds: float
 
 
-def _load_planner() -> ModuleType:
-    spec = importlib.util.spec_from_loader(
-        "harbor_task_workflow_planner",
-        SourceFileLoader("harbor_task_workflow_planner", str(PLANNER_PATH)),
-    )
-    if spec is None or spec.loader is None:
-        raise TaskWorkflowError(f"could not load benchmark planner: {PLANNER_PATH}")
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[spec.name] = module
-    spec.loader.exec_module(module)
-    return module
-
-
-def _parse_host_validations(raw: str) -> tuple[HostValidation, ...]:
-    try:
-        entries = json.loads(raw)
-    except json.JSONDecodeError as exc:
-        raise TaskWorkflowError(
-            "benchmark planner returned invalid host matrix JSON"
-        ) from exc
-    if not isinstance(entries, list) or not entries:
-        raise TaskWorkflowError("benchmark planner selected no host validation")
-
-    result: list[HostValidation] = []
-    for entry in entries:
-        if not isinstance(entry, dict):
-            raise TaskWorkflowError("benchmark host matrix entries must be objects")
-        name = entry.get("name")
-        selector = entry.get("selector")
-        keyword = entry.get("keyword", "")
-        splits = entry.get("splits", 0)
-        group = entry.get("group", 0)
-        if (
-            not isinstance(name, str)
-            or not isinstance(selector, str)
-            or not isinstance(keyword, str)
-        ):
-            raise TaskWorkflowError("benchmark host matrix strings are malformed")
-        if splits != 0 or group != 0:
-            raise TaskWorkflowError(
-                "selected-task validation may not use sharded selectors"
-            )
-        selector_path = Path(selector)
-        if selector_path.is_absolute() or ".." in selector_path.parts:
-            raise TaskWorkflowError(f"unsafe benchmark host selector: {selector}")
-        result.append(HostValidation(name=name, selector=selector, keyword=keyword))
-    return tuple(result)
-
-
 def resolve_selection(dataset: str, tasks: tuple[str, ...]) -> TaskSelection:
     """Resolve task membership and host selectors once through canonical owners."""
     if not dataset:
@@ -138,28 +80,25 @@ def resolve_selection(dataset: str, tasks: tuple[str, ...]) -> TaskSelection:
     except HarborSuiteError as exc:
         raise TaskWorkflowError(str(exc)) from exc
 
-    changed_paths = []
-    for ref in refs:
-        verifier = ref.path / "tests" / "verifier.py"
-        source = verifier if verifier.is_file() else ref.path / "task.toml"
-        changed_paths.append(source.relative_to(ROOT).as_posix())
-
-    planner = _load_planner()
-    plan_function = getattr(planner, "plan", None)
-    if not callable(plan_function):
-        raise TaskWorkflowError("benchmark planner does not expose plan()")
-    plan = plan_function(changed_paths, event="pull_request")
-    if not isinstance(plan, dict):
-        raise TaskWorkflowError("benchmark planner returned a malformed plan")
-    raw_host_matrix = plan.get("benchmark-host-validation-matrix")
-    if not isinstance(raw_host_matrix, str):
-        raise TaskWorkflowError("benchmark planner omitted the host validation matrix")
+    host_validations_by_selector = {
+        (validation.selector, validation.keyword): validation
+        for ref in refs
+        for validation in task_host_validation(ROOT, suite.id, ref.path.name)
+    }
+    host_validations = tuple(
+        sorted(
+            host_validations_by_selector.values(),
+            key=lambda item: (item.selector, item.keyword),
+        )
+    )
+    if not host_validations:
+        raise TaskWorkflowError("selected tasks have no owned host validation")
 
     return TaskSelection(
         dataset=suite.id,
         tasks=tuple(ref.path.name for ref in refs),
         task_paths=tuple(ref.path for ref in refs),
-        host_validations=_parse_host_validations(raw_host_matrix),
+        host_validations=host_validations,
     )
 
 
@@ -196,11 +135,11 @@ def _run_checked(
     timings.append(StageTiming(label=label, seconds=elapsed))
 
 
-def _uv_executable() -> str:
-    uv = TOOL_RESOLVER.resolve("uv")
-    if uv is None:
-        raise TaskWorkflowError("uv is required to run repository validation")
-    return uv
+def _required_tool(name: str) -> str:
+    executable = TOOL_RESOLVER.resolve(name)
+    if executable is None:
+        raise TaskWorkflowError(f"{name} is required to run repository validation")
+    return str(executable)
 
 
 def _task_tree_files(selection: TaskSelection, *, root: Path) -> tuple[Path, ...]:
@@ -257,7 +196,7 @@ def prepare(selection: TaskSelection) -> tuple[str, ...]:
             ("run", "--locked", "ruff", "format", *python_paths),
             timings=timings,
             timeout_seconds=120.0,
-            executable=_uv_executable(),
+            executable=_required_tool("uv"),
         )
     after_format = _snapshot(_task_tree_files(selection, root=ROOT), root=ROOT)
     formatted = _changed_paths(before, after_format)
@@ -375,7 +314,7 @@ def validate(selection: TaskSelection) -> tuple[tuple[str, str, str], ...]:
             ("run", "--locked", "python", "tools/check_benchmark_static.py"),
             timings=timings,
             timeout_seconds=360.0,
-            executable=_uv_executable(),
+            executable=_required_tool("uv"),
         )
         _run_checked(
             "contracts",
@@ -407,13 +346,10 @@ def validate(selection: TaskSelection) -> tuple[tuple[str, str, str], ...]:
                 arguments,
                 timings=timings,
                 timeout_seconds=600.0,
-                executable=_uv_executable(),
+                executable=_required_tool("uv"),
             )
         for task in selection.tasks:
             previous_evidence = _oracle_evidence_snapshot(selection)
-            make = TOOL_RESOLVER.resolve("make")
-            if make is None:
-                raise TaskWorkflowError("make is required to run the exact Oracle")
             _run_checked(
                 f"oracle:{task}",
                 (
@@ -424,7 +360,7 @@ def validate(selection: TaskSelection) -> tuple[tuple[str, str, str], ...]:
                 ),
                 timings=timings,
                 timeout_seconds=1800.0,
-                executable=make,
+                executable=_required_tool("make"),
             )
             digest, evidence_path = _fresh_oracle_evidence(
                 selection, task, previous=previous_evidence

--- a/tools/pytest_lifecycle.py
+++ b/tools/pytest_lifecycle.py
@@ -1,0 +1,232 @@
+"""Run pytest with a unique worktree-local temporary tree."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import sys
+import time
+import uuid
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from benchmarks.tooling.command_runner import (  # noqa: E402
+    ToolCommandRequest,
+    ToolCommandStatus,
+    run_tool_command,
+)
+
+BASETEMP_ROOT = ROOT / ".pytest_cache" / "basetemp"
+_OUTPUT_LIMIT = 16 * 1024 * 1024
+_SAFE_LABEL = re.compile(r"[^A-Za-z0-9_.-]+")
+
+
+@dataclass(frozen=True, slots=True)
+class PytestResult:
+    """Normalized outcome and lifecycle evidence for one pytest process."""
+
+    exit_code: int
+    status: str
+    actual_seconds: float
+    basetemp: Path
+    retained: bool
+
+
+def _has_basetemp(arguments: Sequence[str]) -> bool:
+    return any(
+        argument == "--basetemp" or argument.startswith("--basetemp=")
+        for argument in arguments
+    )
+
+
+def _unique_basetemp(root: Path, name: str) -> Path:
+    label = _SAFE_LABEL.sub("-", name).strip("-") or "pytest"
+    run_root = root / ".pytest_cache" / "basetemp" / f"{label}-{uuid.uuid4().hex}"
+    return run_root / "pytest"
+
+
+def _stream_stdout(block: bytes) -> None:
+    sys.stdout.buffer.write(block)
+    sys.stdout.buffer.flush()
+
+
+def _stream_stderr(block: bytes) -> None:
+    sys.stderr.buffer.write(block)
+    sys.stderr.buffer.flush()
+
+
+def _emit_lifecycle_event(event: str, **fields: object) -> None:
+    payload = {"event": event, **fields}
+    print(
+        f"[pytest-lifecycle] {json.dumps(payload, sort_keys=True)}",
+        file=sys.stderr,
+        flush=True,
+    )
+
+
+def _write_receipt(
+    path: Path,
+    *,
+    name: str,
+    predicted_seconds: float,
+    result: PytestResult,
+) -> None:
+    payload = {
+        "schema_version": 1,
+        "name": name,
+        "predicted_seconds": round(predicted_seconds, 6),
+        "actual_seconds": round(result.actual_seconds, 6),
+        "status": result.status,
+        "exit_code": result.exit_code,
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def run_pytest(
+    arguments: Sequence[str],
+    *,
+    root: Path,
+    name: str,
+    environment: Mapping[str, str],
+    timeout_seconds: float = 3600.0,
+    retain_on_failure: bool = False,
+    receipt: Path | None = None,
+    predicted_seconds: float = 1.0,
+) -> PytestResult:
+    """Execute pytest and clean its unique temp tree unless retention is requested."""
+    if _has_basetemp(arguments):
+        raise ValueError("pytest basetemp is owned by tools.pytest_lifecycle")
+    if predicted_seconds <= 0:
+        raise ValueError("predicted_seconds must be positive")
+
+    basetemp = _unique_basetemp(root.resolve(), name)
+    basetemp.mkdir(parents=True)
+    run_root = basetemp.parent
+    result: PytestResult | None = None
+    try:
+        _emit_lifecycle_event(
+            "pytest.run.started",
+            name=name,
+            predicted_seconds=predicted_seconds,
+            timeout_seconds=timeout_seconds,
+        )
+        started = time.monotonic()
+        tool_result = run_tool_command(
+            ToolCommandRequest(
+                executable=sys.executable,
+                arguments=("-m", "pytest", *arguments, f"--basetemp={basetemp}"),
+                environment=environment,
+                cwd=str(root.resolve()),
+                timeout_seconds=timeout_seconds,
+                stdout_limit_bytes=_OUTPUT_LIMIT,
+                stderr_limit_bytes=_OUTPUT_LIMIT,
+                stdout_sink=_stream_stdout,
+                stderr_sink=_stream_stderr,
+            )
+        )
+        elapsed = time.monotonic() - started
+        exited = tool_result.status is ToolCommandStatus.EXITED
+        exit_code = (
+            int(tool_result.exit_code)
+            if exited and tool_result.exit_code is not None
+            else 1
+        )
+        if not exited:
+            diagnostic = tool_result.diagnostic or tool_result.status.value
+            print(f"[{name}] {diagnostic}", file=sys.stderr)
+        retained = bool(exit_code and retain_on_failure)
+        result = PytestResult(
+            exit_code=exit_code,
+            status=tool_result.status.value,
+            actual_seconds=elapsed,
+            basetemp=basetemp,
+            retained=retained,
+        )
+        _emit_lifecycle_event(
+            "pytest.run.completed",
+            name=name,
+            status=result.status,
+            exit_code=result.exit_code,
+            actual_seconds=round(result.actual_seconds, 6),
+        )
+        if receipt is not None:
+            _write_receipt(
+                receipt,
+                name=name,
+                predicted_seconds=predicted_seconds,
+                result=result,
+            )
+    finally:
+        if result is not None and result.retained:
+            print(f"[{name}] retained failed pytest tree: {run_root}", file=sys.stderr)
+        else:
+            shutil.rmtree(run_root, ignore_errors=True)
+    assert result is not None
+    return result
+
+
+def _positive_float(value: str) -> float:
+    parsed = float(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be positive")
+    return parsed
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--name", default=os.environ.get("PYTEST_RUN_NAME", "pytest"))
+    parser.add_argument(
+        "--receipt",
+        type=Path,
+        default=(Path(value) if (value := os.environ.get("PYTEST_RECEIPT")) else None),
+    )
+    parser.add_argument(
+        "--predicted-seconds",
+        type=_positive_float,
+        default=_positive_float(os.environ.get("PYTEST_PREDICTED_SECONDS", "1")),
+    )
+    parser.add_argument(
+        "--retain-on-failure",
+        action="store_true",
+        default=os.environ.get("PYTEST_RETAIN_ON_FAILURE") == "1",
+    )
+    parser.add_argument("--timeout-seconds", type=_positive_float, default=3600.0)
+    parser.add_argument("pytest_arguments", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+    arguments = args.pytest_arguments
+    if arguments[:1] == ["--"]:
+        arguments = arguments[1:]
+    if not arguments:
+        parser.error("pytest arguments are required after --")
+    try:
+        result = run_pytest(
+            arguments,
+            root=ROOT,
+            name=args.name,
+            environment=dict(os.environ),
+            timeout_seconds=args.timeout_seconds,
+            retain_on_failure=args.retain_on_failure,
+            receipt=args.receipt,
+            predicted_seconds=args.predicted_seconds,
+        )
+    except ValueError as exc:
+        parser.error(str(exc))
+    return result.exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = ["PytestResult", "main", "run_pytest"]

--- a/tools/test_topology.py
+++ b/tools/test_topology.py
@@ -22,12 +22,12 @@ if str(_ROOT) not in sys.path:
     sys.path.insert(0, str(_ROOT))
 
 from benchmarks.tooling.command_runner import (  # noqa: E402
-    ToolCommandRequest,
     ToolCommandStatus,
     operator_environment,
     run_operator_command,
-    run_tool_command,
 )
+
+from tools.pytest_lifecycle import run_pytest  # noqa: E402
 
 DEFAULT_MANIFEST = _ROOT / "tests" / "topology.toml"
 _DISTRIBUTIONS = {"none", "load", "loadscope", "loadfile", "loadgroup", "worksteal"}
@@ -366,42 +366,16 @@ def run_lane(
     to stderr before returning a non-zero exit code.
     """
     command = pytest_command(topology, lane_name, selectors, extra_args)
-    arguments = tuple(command[1:])
+    arguments = command[3:]
     environment = lane_environment(topology.lane(lane_name))
-    request = ToolCommandRequest(
-        executable=sys.executable,
-        arguments=arguments,
+    result = run_pytest(
+        arguments,
+        root=topology.root,
+        name=f"topology-{lane_name}",
         environment=environment,
-        cwd=str(topology.root.resolve()),
         timeout_seconds=3600.0,
-        stdout_limit_bytes=16 * 1024 * 1024,
-        stderr_limit_bytes=4 * 1024 * 1024,
     )
-    result = run_tool_command(request)
-
-    # Forward bounded child output to parent streams.
-    if result.stdout:
-        sys.stdout.buffer.write(result.stdout)
-        sys.stdout.buffer.flush()
-    if result.stderr:
-        sys.stderr.buffer.write(result.stderr)
-        sys.stderr.buffer.flush()
-
-    if result.status is ToolCommandStatus.EXITED and result.exit_code is not None:
-        return result.exit_code
-
-    # Non-EXITED: emit a safe diagnostic so the failure is not silent.
-    diagnostic = result.diagnostic or result.status.value
-    overflow_note = ""
-    if result.stdout_exceeded:
-        overflow_note += " (stdout truncated)"
-    if result.stderr_exceeded:
-        overflow_note += " (stderr truncated)"
-    print(
-        f"lane '{lane_name}': {diagnostic}{overflow_note}",
-        file=sys.stderr,
-    )
-    return 1
+    return result.exit_code
 
 
 def _print_dry_run(


### PR DESCRIPTION
Closes #575.

## Problem

Local exhaustive benchmark validation ran the 3,335-test host corpus in one two-worker pytest pool, while CI used four shards. Bounded subprocess output was only visible after completion, planning logic was coupled to a CI script, and validation evidence was spread across lane results and ad hoc files.

## Change

- stream bounded pytest stdout/stderr while retaining timeout, cancellation, output-limit, process-tree cleanup, and unique worktree-local basetemps
- move host-test ownership into the importable `benchmarks.tooling.validation_plan` module, with explicit reasons for focused versus full-corpus selection
- run local Harbor host validation as four timing-aware shards under one total worker budget
- keep timing input immutable, publish per-shard timing output separately, and record predicted versus actual duration
- add a stable benchmark aggregate that validates canonical plan and shard receipts against plan head, tested revision, topology, timing input, worker budget, and command contract
- add a maintainer batch-status command reporting task identity, unresolved threads, preparation state, receipt state, CI, and merge readiness
- keep storage validation serial; the existing runtime-template publication is already immutable/quiesced with private mutable copies

## Results

On this host, the full local Harbor host corpus completed in 4m58s using four one-worker shards (3,366 tests collected), compared with the previously measured 9m28s single-pool run. Equal-weight fallback shards finished in 291–298 seconds.

The planner intentionally selects every semantic lane and the full host corpus for this cross-cutting control-plane change. The final tree passed:

- `make test-changed BASE=origin/main` — 2,342 passed, 3 expected Lean skips; static/type/architecture/build passed
- `make harbor-check` — all four host shards passed, 3,366 tests total
- focused rebased control-plane suite — 177 passed
- `make check-static` — passed
- exact branch-diff review — no actionable findings

## Review order

1. process streaming and lifecycle boundary
2. benchmark ownership, sharding, and receipt aggregation
3. maintainer batch-status reporting

The three commits follow that order.