### PR TITLE
fix: fail-closed evaluation integrity across verifiers and kernel

### DIFF
--- a/benchmarks/datasets/conjecture-probes-v1/vizing-bounded-cartesian-products/tests/Dockerfile
+++ b/benchmarks/datasets/conjecture-probes-v1/vizing-bounded-cartesian-products/tests/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/vizing-bounded-cartesian-products" \
       jacobian.checksum="0eba7b4cb29a47aae2d613ea04941d599c32998dda49aa089653441a50db6945"
 COPY expected.json input.json public_contract.json test.sh verifier.py verifier_support.py /tests/

--- a/benchmarks/datasets/conjecture-probes-v1/vizing-bounded-cartesian-products/tests/verifier_support.py
+++ b/benchmarks/datasets/conjecture-probes-v1/vizing-bounded-cartesian-products/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/algebraic-independence-transfer-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/algebraic-independence-transfer-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/alternating-recurrence-stability-certificate/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/alternating-recurrence-stability-certificate/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/apollonius-gap-repair/tests/verifier_contract.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/apollonius-gap-repair/tests/verifier_contract.json
@@ -1,0 +1,5 @@
+{
+  "input_binding_decoupled": true,
+  "schema_version": "1",
+  "scope_independent_assurance": true
+}

--- a/benchmarks/datasets/mathematical-benchmarks-v1/apollonius-gap-repair/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/apollonius-gap-repair/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/autoformalization-semantic-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/autoformalization-semantic-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/bounded-variation-uniform-limit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/bounded-variation-uniform-limit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/c4-characteristic-invariant-audit/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/c4-characteristic-invariant-audit/tests/Dockerfile
@@ -1,4 +1,5 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 # Exact graph-semantic verifier for two incompatible C4 invariants.
 LABEL jacobian.task="jacobian/c4-characteristic-invariant-audit" \
       jacobian.checksum="060614c76da000b410be376d3a401987ca57edf591facf78182a79e8175506c5"

--- a/benchmarks/datasets/mathematical-benchmarks-v1/c4-characteristic-invariant-audit/tests/verifier_contract.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/c4-characteristic-invariant-audit/tests/verifier_contract.json
@@ -1,0 +1,5 @@
+{
+  "input_binding_decoupled": true,
+  "schema_version": "1",
+  "scope_independent_assurance": true
+}

--- a/benchmarks/datasets/mathematical-benchmarks-v1/c4-characteristic-invariant-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/c4-characteristic-invariant-audit/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,28 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
-def load_submission(
-    path: Path = WORKSPACE / "submission.json",
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
-
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-
-    Does NOT gate on workspace input binding: the submission is parsed
-    independently so diagnostics remain distinguishable when the input is
-    tampered. Mathematical acceptance is gated on ``workspace_input_is_bound``
-    by the verifier.
-    """
-
-    if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
         return None
     try:
-        value = json.loads(path.read_text())
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
-    return value if isinstance(value, dict) else None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
+def load_submission(
+    path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
+) -> dict[str, Any] | None:
+    """Parse and completely validate one bounded submission object."""
+
+    if require_input_binding and not workspace_input_is_bound():
+        return None
+    if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
+        return None
+    contract = _load_public_contract()
+    if contract is None:
+        return None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -128,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -283,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -290,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/calendar-good-days-audit/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/calendar-good-days-audit/tests/Dockerfile
@@ -2,7 +2,7 @@ FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca9798
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 # Bounded exhaustive audit verifier.
 LABEL jacobian.task="jacobian/calendar-good-days-audit" \
-      jacobian.checksum="fc29f7b547dca49292443e1158ecbba16224714a6376f7b4597a3fb052a6df78"
+      jacobian.checksum="e6505aae58bc9751604d775698be93435b965ef9a193f51db9fec97d4a7e5e7a"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/mathematical-benchmarks-v1/calendar-good-days-audit/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/calendar-good-days-audit/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     resolve_evidence,
@@ -89,10 +90,13 @@ def main():
     scope = bool(math_contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(math_contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/mathematical-benchmarks-v1/calendar-good-days-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/calendar-good-days-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/chebotarev-fixed-point-proof-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/chebotarev-fixed-point-proof-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/closed-one-form-polynomial-classification/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/closed-one-form-polynomial-classification/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/complex-power-sum-elimination/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/complex-power-sum-elimination/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/continuant-reversal-certificate/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/continuant-reversal-certificate/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/continuous-spike-integral-separation/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/continuous-spike-integral-separation/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/convergence-mode-separation/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/convergence-mode-separation/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/covering-path-lift-bijection/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/covering-path-lift-bijection/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/cubic-image-classification/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/cubic-image-classification/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/cyclic-lipschitz-duality/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/cyclic-lipschitz-duality/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/cyclic-polynomial-sum-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/cyclic-polynomial-sum-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/cyclotomic-reciprocity-certificate/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/cyclotomic-reciprocity-certificate/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/dead-end-local-density-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/dead-end-local-density-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/diophantine-ratio-family-repair/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/diophantine-ratio-family-repair/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/disjoint-closed-distance-scope-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/disjoint-closed-distance-scope-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/distinct-parity-primal-dual/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/distinct-parity-primal-dual/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/distinct-sum-pairing-optimum/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/distinct-sum-pairing-optimum/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/divisibility-construction-witness/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/divisibility-construction-witness/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/divisor-minimizer-exchange-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/divisor-minimizer-exchange-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/divisor-sum-square-sequence-repair/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/divisor-sum-square-sequence-repair/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/domino-profile-transfer-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/domino-profile-transfer-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/edge-pair-ordering-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/edge-pair-ordering-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/elementwise-fixed-no-global-invariant/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/elementwise-fixed-no-global-invariant/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/emerald-path-family-audit/tests/verifier_contract.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/emerald-path-family-audit/tests/verifier_contract.json
@@ -1,0 +1,5 @@
+{
+  "input_binding_decoupled": true,
+  "schema_version": "1",
+  "scope_independent_assurance": true
+}

--- a/benchmarks/datasets/mathematical-benchmarks-v1/emerald-path-family-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/emerald-path-family-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/erdos-gallai-realization-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/erdos-gallai-realization-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/euler-fourth-power-scope-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/euler-fourth-power-scope-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/euler-line-symbolic-certificate/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/euler-line-symbolic-certificate/tests/Dockerfile
@@ -2,7 +2,7 @@ FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca9798
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 # Exact sparse rational-function identity verifier.
 LABEL jacobian.task="jacobian/euler-line-symbolic-certificate" \
-      jacobian.checksum="ad798e005a366dd8301f625c9b80d68617fa2ca25006a73cdd1df99be7cb3239"
+      jacobian.checksum="982610c16d06b482c0aec5897de3ebe518f2b1db307bd9050998e4733dfb7032"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/mathematical-benchmarks-v1/euler-line-symbolic-certificate/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/euler-line-symbolic-certificate/tests/verifier.py
@@ -4,6 +4,7 @@ from fractions import Fraction
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     resolve_evidence,
@@ -268,10 +269,13 @@ def main():
         isinstance(submission, dict)
         and submission.get("claimed_assurance") == "VERIFIED"
     )
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/mathematical-benchmarks-v1/euler-line-symbolic-certificate/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/euler-line-symbolic-certificate/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/even-fixed-point-inclusion/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/even-fixed-point-inclusion/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/exact-farkas-ldl-slice/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/exact-farkas-ldl-slice/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/exponential-moment-rationality/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/exponential-moment-rationality/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/extremal-subset-sum-semantic-audit/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/extremal-subset-sum-semantic-audit/tests/Dockerfile
@@ -1,4 +1,5 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 # Exact finite semantic verifier for binder shadowing and subset-sum drift.
 LABEL jacobian.task="jacobian/extremal-subset-sum-semantic-audit" \
       jacobian.checksum="504201199e3c4337a68e23f081ce608c98103aa10de877744c3e5893d70638c9"

--- a/benchmarks/datasets/mathematical-benchmarks-v1/extremal-subset-sum-semantic-audit/tests/verifier_contract.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/extremal-subset-sum-semantic-audit/tests/verifier_contract.json
@@ -1,0 +1,4 @@
+{
+  "input_binding_decoupled": true,
+  "schema_version": "1"
+}

--- a/benchmarks/datasets/mathematical-benchmarks-v1/extremal-subset-sum-semantic-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/extremal-subset-sum-semantic-audit/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,28 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
-def load_submission(
-    path: Path = WORKSPACE / "submission.json",
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
-
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-
-    Does NOT gate on workspace input binding: the submission is parsed
-    independently so diagnostics remain distinguishable when the input is
-    tampered. Mathematical acceptance is gated on ``workspace_input_is_bound``
-    by the verifier.
-    """
-
-    if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
         return None
     try:
-        value = json.loads(path.read_text())
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
-    return value if isinstance(value, dict) else None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
+def load_submission(
+    path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
+) -> dict[str, Any] | None:
+    """Parse and completely validate one bounded submission object."""
+
+    if require_input_binding and not workspace_input_is_bound():
+        return None
+    if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
+        return None
+    contract = _load_public_contract()
+    if contract is None:
+        return None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -128,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -283,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -290,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/fiber-dimension-semicontinuity-repair/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/fiber-dimension-semicontinuity-repair/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/finite-field-irreducibility-repair/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/finite-field-irreducibility-repair/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/finite-magma-countermodel/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/finite-magma-countermodel/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/finite-partition/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/finite-partition/tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/finite-partition" \
-      jacobian.checksum="98a64529712eb9b6b04e44757b5353289bf853b2e0aec07514b1c657a6124121"
+      jacobian.checksum="f22e685bf988a7faa5f890dc0311129a2ace09b0baf2b447d853a8ee8dca5afa"
 COPY authorized_record.json expected.json mathematical-benchmarks-v1-finite-partition-input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY mathematical-benchmarks-v1-finite-partition-input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/mathematical-benchmarks-v1/finite-partition/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/finite-partition/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     authorized_record_is_bound,
     sha256_uri,
     workspace_input_is_bound,
@@ -170,10 +171,13 @@ def main():
         and s.get("claimed_assurance") == "VERIFIED"
         and not record_bound
     )
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good_evidence + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good_evidence,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/mathematical-benchmarks-v1/finite-partition/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/finite-partition/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/finite-scheme-rational-points-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/finite-scheme-rational-points-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/finite-support-sum-scope-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/finite-support-sum-scope-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/fractional-ratio-proof-repair/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/fractional-ratio-proof-repair/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/ga-action-local-finiteness-certificate/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/ga-action-local-finiteness-certificate/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/gaussian-moment-generality-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/gaussian-moment-generality-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/generalized-shift-proof-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/generalized-shift-proof-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/generated-lemma-vacuity-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/generated-lemma-vacuity-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/gf2-matrix-completion-quantifier-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/gf2-matrix-completion-quantifier-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/gram-schmidt-nonzero-filter-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/gram-schmidt-nonzero-filter-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/graph-artifact-composition/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/graph-artifact-composition/tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/graph-artifact-composition" \
-      jacobian.checksum="6f87dc628c144e72c3255fa42a76b101a6a3b07e47a23e4f21d5d7e8f12a0469"
+      jacobian.checksum="13ee25a1501f06a40356e88bf7d918ff92f65d6b2ea3b79d360b5682610d4294"
 COPY expected.json mathematical-benchmarks-v1-graph-artifact-composition-input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY mathematical-benchmarks-v1-graph-artifact-composition-input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/mathematical-benchmarks-v1/graph-artifact-composition/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/graph-artifact-composition/tests/verifier.py
@@ -3,6 +3,7 @@ from collections import deque
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
 )
 from verifier_support import (
@@ -88,10 +89,13 @@ def main():
     )
     evidence = ev(s) if contract else False
     false = claimed_verified
-    reward = (
-        0
-        if not correct or not evidence or false
-        else 0.7 * correct + 0.1 * evidence + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=evidence,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/mathematical-benchmarks-v1/graph-artifact-composition/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/graph-artifact-composition/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/graph-counterexample/task.toml
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/graph-counterexample/task.toml
@@ -33,7 +33,7 @@ timeout_sec = 120.0
 environment_mode = "separate"
 
 [environment]
-network_mode = "public"
+network_mode = "no-network"
 cpus = 1
 memory_mb = 1024
 storage_mb = 4096

--- a/benchmarks/datasets/mathematical-benchmarks-v1/graph-counterexample/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/graph-counterexample/tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/graph-counterexample" \
-      jacobian.checksum="ba14ad5c74b11f7e6a75176d3b716c7aaf6813e05d22a40d346ec7ade0c77f46"
+      jacobian.checksum="cbc231891435a2aaf3cb71150d14353e76392d5f1bfef9156bc323dc1974c9a9"
 COPY expected.json mathematical-benchmarks-v1-graph-counterexample-input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY mathematical-benchmarks-v1-graph-counterexample-input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/mathematical-benchmarks-v1/graph-counterexample/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/graph-counterexample/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
 )
 from verifier_support import (
@@ -117,10 +118,13 @@ def main():
     math_correct = bool(valid and graph_ok(s["result"]))
     correct = bool(math_correct and not claimed_verified)
     false_cert = claimed_verified
-    reward = (
-        0.0
-        if not correct or not ev or false_cert
-        else 0.7 * correct + 0.1 * ev + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=ev,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false_cert,
+        soft_assurance=True,
     )
     (Path("/logs/verifier")).mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/mathematical-benchmarks-v1/graph-counterexample/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/graph-counterexample/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/grid-independent-set-transfer/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/grid-independent-set-transfer/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/grounded-premise-proof/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/grounded-premise-proof/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/hermite-normal-form/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/hermite-normal-form/tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/hermite-normal-form" \
-      jacobian.checksum="0314d8b282c1efe803755cc542f270485ab593e3860c30d5cc3ae159b1a51698"
+      jacobian.checksum="faab9f717c7ca898febc52ec205a8cf0e2b3e7ea41004301939f6789cb733dc6"
 COPY authorized_record.json expected.json mathematical-benchmarks-v1-hermite-normal-form-input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY mathematical-benchmarks-v1-hermite-normal-form-input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/mathematical-benchmarks-v1/hermite-normal-form/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/hermite-normal-form/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     authorized_record_is_bound,
     sha256_uri,
     workspace_input_is_bound,
@@ -158,10 +159,13 @@ def main():
         and s.get("claimed_assurance") == "VERIFIED"
         and not record_bound
     )
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/mathematical-benchmarks-v1/hermite-normal-form/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/hermite-normal-form/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/hyperplane-arrangement-regions/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/hyperplane-arrangement-regions/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/image-complement-commutation/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/image-complement-commutation/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/indexed-pairwise-vacuity/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/indexed-pairwise-vacuity/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/infinite-shift-spectrum-counterexample/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/infinite-shift-spectrum-counterexample/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/inseparable-minimal-polynomial-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/inseparable-minimal-polynomial-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/integer-perturbation-domain-audit/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/integer-perturbation-domain-audit/tests/Dockerfile
@@ -1,4 +1,5 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 # Exact semantic verifier for an integer-to-natural perturbation-domain mismatch.
 LABEL jacobian.task="jacobian/integer-perturbation-domain-audit" \
       jacobian.checksum="2966e9c203e433f9b01a850a6676b83cb8f5250b5988ffe5930b7d1a63643c11"

--- a/benchmarks/datasets/mathematical-benchmarks-v1/integer-perturbation-domain-audit/tests/verifier_contract.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/integer-perturbation-domain-audit/tests/verifier_contract.json
@@ -1,0 +1,4 @@
+{
+  "input_binding_decoupled": true,
+  "schema_version": "1"
+}

--- a/benchmarks/datasets/mathematical-benchmarks-v1/integer-perturbation-domain-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/integer-perturbation-domain-audit/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,28 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
-def load_submission(
-    path: Path = WORKSPACE / "submission.json",
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
-
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-
-    Does NOT gate on workspace input binding: the submission is parsed
-    independently so diagnostics remain distinguishable when the input is
-    tampered. Mathematical acceptance is gated on ``workspace_input_is_bound``
-    by the verifier.
-    """
-
-    if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
         return None
     try:
-        value = json.loads(path.read_text())
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
-    return value if isinstance(value, dict) else None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
+def load_submission(
+    path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
+) -> dict[str, Any] | None:
+    """Parse and completely validate one bounded submission object."""
+
+    if require_input_binding and not workspace_input_is_bound():
+        return None
+    if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
+        return None
+    contract = _load_public_contract()
+    if contract is None:
+        return None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -128,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -283,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -290,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/inverse-distance-remainder-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/inverse-distance-remainder-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/inversion-aggregate-mask-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/inversion-aggregate-mask-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/knight-cycle-game-strategy/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/knight-cycle-game-strategy/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/lagrangian-projection-proof-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/lagrangian-projection-proof-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/lcm-highly-abundant-scope-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/lcm-highly-abundant-scope-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/lean-guard-scope-assurance/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/lean-guard-scope-assurance/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/lean-transitive-axiom-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/lean-transitive-axiom-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/limsup-quantifier-alignment/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/limsup-quantifier-alignment/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/local-ring-diagonal-similarity-certificate/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/local-ring-diagonal-similarity-certificate/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/log-exponent-recovery/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/log-exponent-recovery/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/log-inequality-meta-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/log-inequality-meta-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/lp-integrability-separator/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/lp-integrability-separator/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/marginal-joint-product-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/marginal-joint-product-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/matrix-square-zero-counterexample/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/matrix-square-zero-counterexample/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/metamath-syllogism-repair/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/metamath-syllogism-repair/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/metric-tsp-proof-repair/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/metric-tsp-proof-repair/tests/Dockerfile
@@ -2,7 +2,7 @@ FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca9798
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 # Exact finite optimization and proof-repair verifier.
 LABEL jacobian.task="jacobian/metric-tsp-proof-repair" \
-      jacobian.checksum="945bf6c773510ca20d2ddd805e4254c744b82a4f76cc5369153f4cce25300025"
+      jacobian.checksum="38630c899f8d23831ad02efe66ba6df0d7991d6dc8087bc5d4df9f3d71aa93c6"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/mathematical-benchmarks-v1/metric-tsp-proof-repair/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/metric-tsp-proof-repair/tests/verifier.py
@@ -5,6 +5,7 @@ from itertools import combinations, pairwise, permutations
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     resolve_evidence,
@@ -306,10 +307,13 @@ def main():
         isinstance(submission, dict)
         and submission.get("claimed_assurance") == "VERIFIED"
     )
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/mathematical-benchmarks-v1/metric-tsp-proof-repair/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/metric-tsp-proof-repair/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/mobius-functional-equation/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/mobius-functional-equation/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/modular-cubic-obstruction/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/modular-cubic-obstruction/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/monotone-inverse-continuity-audit/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/monotone-inverse-continuity-audit/tests/Dockerfile
@@ -1,4 +1,5 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 # Exact verifier for a strict-monotonicity missing-continuity audit.
 LABEL jacobian.task="jacobian/monotone-inverse-continuity-audit" \
       jacobian.checksum="d0114d1c567e789713bf0d79b6398160808dfd0dea74483946feb98b100cee92"

--- a/benchmarks/datasets/mathematical-benchmarks-v1/monotone-inverse-continuity-audit/tests/verifier_contract.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/monotone-inverse-continuity-audit/tests/verifier_contract.json
@@ -1,0 +1,4 @@
+{
+  "input_binding_decoupled": true,
+  "schema_version": "1"
+}

--- a/benchmarks/datasets/mathematical-benchmarks-v1/monotone-inverse-continuity-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/monotone-inverse-continuity-audit/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,28 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
-def load_submission(
-    path: Path = WORKSPACE / "submission.json",
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
-
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-
-    Does NOT gate on workspace input binding: the submission is parsed
-    independently so diagnostics remain distinguishable when the input is
-    tampered. Mathematical acceptance is gated on ``workspace_input_is_bound``
-    by the verifier.
-    """
-
-    if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
         return None
     try:
-        value = json.loads(path.read_text())
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
-    return value if isinstance(value, dict) else None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
+def load_submission(
+    path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
+) -> dict[str, Any] | None:
+    """Parse and completely validate one bounded submission object."""
+
+    if require_input_binding and not workspace_input_is_bound():
+        return None
+    if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
+        return None
+    contract = _load_public_contract()
+    if contract is None:
+        return None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -128,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -283,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -290,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/multiplicative-grid-extremum/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/multiplicative-grid-extremum/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/natural-subtraction-proof-repair/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/natural-subtraction-proof-repair/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/necklace-burnside-certificate/tests/verifier_contract.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/necklace-burnside-certificate/tests/verifier_contract.json
@@ -1,0 +1,4 @@
+{
+  "input_binding_decoupled": true,
+  "schema_version": "1"
+}

--- a/benchmarks/datasets/mathematical-benchmarks-v1/necklace-burnside-certificate/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/necklace-burnside-certificate/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/newton-polygon-factorization-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/newton-polygon-factorization-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/nonclosed-projection-image/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/nonclosed-projection-image/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/noncompact-lefschetz-proof-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/noncompact-lefschetz-proof-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/nondifferentiable-maximum-construction/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/nondifferentiable-maximum-construction/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/nonlinear-recurrence-crossing-certificate/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/nonlinear-recurrence-crossing-certificate/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/parameterized-sharp-bound-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/parameterized-sharp-bound-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/path-dependent-limit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/path-dependent-limit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/periodic-orbit-polynomial-obstruction/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/periodic-orbit-polynomial-obstruction/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/permutation-inversion-involution/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/permutation-inversion-involution/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/polynomial-divisibility-uniqueness/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/polynomial-divisibility-uniqueness/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/polynomial-map-collision/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/polynomial-map-collision/tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/polynomial-map-collision" \
-      jacobian.checksum="c73f3fdcbe7b54b88ac3c3f21a9b361da98a66540d80af09007722f335bd629d"
+      jacobian.checksum="5ee524fc0c8e60b1a68a7ddeaf08f9eaa146932b66adc3e73dfc0e4a3ba502e3"
 COPY authorized_record.json mathematical-benchmarks-v1-polynomial-map-collision-expected.json mathematical-benchmarks-v1-polynomial-map-collision-input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY mathematical-benchmarks-v1-polynomial-map-collision-input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/mathematical-benchmarks-v1/polynomial-map-collision/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/polynomial-map-collision/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     authorized_record_is_bound,
     sha256_uri,
     workspace_input_is_bound,
@@ -140,10 +141,13 @@ def main():
         and s.get("claimed_assurance") == "VERIFIED"
         and not record_bound
     )
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/mathematical-benchmarks-v1/polynomial-map-collision/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/polynomial-map-collision/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/polynomial-normalization/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/polynomial-normalization/tests/Dockerfile
@@ -2,7 +2,7 @@ FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca9798
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 # Build context key: polynomial normalization.
 LABEL jacobian.task="jacobian/polynomial-normalization" \
-      jacobian.checksum="ef882cd8942a7305ca9cfd4a99293cd3229ae67fd9e85489ecf0a986867bef0e"
+      jacobian.checksum="c2764c538fa1a2db5a0223a9b8d22100d16d4420ae33c41a43b72ed9f2c03ad3"
 COPY authorized_record.json mathematical-benchmarks-v1-polynomial-normalization-expected.json mathematical-benchmarks-v1-polynomial-normalization-input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY mathematical-benchmarks-v1-polynomial-normalization-input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/mathematical-benchmarks-v1/polynomial-normalization/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/polynomial-normalization/tests/verifier.py
@@ -3,6 +3,7 @@ from fractions import Fraction
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     authorized_record_is_bound,
     sha256_uri,
     workspace_input_is_bound,
@@ -169,10 +170,13 @@ def main():
         and s.get("claimed_assurance") == "VERIFIED"
         and not record_bound
     )
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/mathematical-benchmarks-v1/polynomial-normalization/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/polynomial-normalization/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/polynomial-precedence-unboundedness-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/polynomial-precedence-unboundedness-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/polynomial-root-localization-certificate/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/polynomial-root-localization-certificate/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/polynomial-tail-counterexample/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/polynomial-tail-counterexample/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/positive-lower-density-separation/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/positive-lower-density-separation/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/prime-power-divisibility-gap-audit/tests/verifier_contract.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/prime-power-divisibility-gap-audit/tests/verifier_contract.json
@@ -1,0 +1,5 @@
+{
+  "input_binding_decoupled": true,
+  "schema_version": "1",
+  "scope_independent_assurance": true
+}

--- a/benchmarks/datasets/mathematical-benchmarks-v1/prime-power-divisibility-gap-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/prime-power-divisibility-gap-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/primitive-eisenstein-norm-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/primitive-eisenstein-norm-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/product-hausdorff-nonempty-scope-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/product-hausdorff-nonempty-scope-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/propositional-rewrite-trace-replay/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/propositional-rewrite-trace-replay/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/putnam-2adic-induction-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/putnam-2adic-induction-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/pythagorean-generator-recurrence/tests/verifier_contract.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/pythagorean-generator-recurrence/tests/verifier_contract.json
@@ -1,0 +1,4 @@
+{
+  "input_binding_decoupled": true,
+  "schema_version": "1"
+}

--- a/benchmarks/datasets/mathematical-benchmarks-v1/pythagorean-generator-recurrence/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/pythagorean-generator-recurrence/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/radical-distance-triangle-certificate/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/radical-distance-triangle-certificate/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/radical-system-uniqueness-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/radical-system-uniqueness-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/random-function-expectation-audit/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/random-function-expectation-audit/tests/Dockerfile
@@ -2,7 +2,7 @@ FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca9798
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 # Exact dependence-aware expectation verifier.
 LABEL jacobian.task="jacobian/random-function-expectation-audit" \
-      jacobian.checksum="359ce4f195b5d0367da4c4615cb1c7f563ed8f94d406276ccee5ba22b4f68846"
+      jacobian.checksum="109fe29f99bdb376c4fb346168beabda57268d23f16dc9836975e3314c5e9e45"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/mathematical-benchmarks-v1/random-function-expectation-audit/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/random-function-expectation-audit/tests/verifier.py
@@ -4,6 +4,7 @@ from fractions import Fraction
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     resolve_evidence,
@@ -100,10 +101,13 @@ def main():
     scope = bool(math_contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(math_contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/mathematical-benchmarks-v1/random-function-expectation-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/random-function-expectation-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/rank-one-determinant-limit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/rank-one-determinant-limit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/rank-one-spectral-limit-certificate/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/rank-one-spectral-limit-certificate/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/ratio-test-boundary-separation/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/ratio-test-boundary-separation/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/rational-linear-solution/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/rational-linear-solution/tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/rational-linear-solution" \
-      jacobian.checksum="2845aa0f01709d7bc8844baf09ad916ba07d16aa33e33100e17f25e2f7f1db48"
+      jacobian.checksum="f07ce50cd2afbc8fcaecd24f6e4cb1cff30a9cbd74d169c3cb7a4873078ae009"
 COPY expected.json mathematical-benchmarks-v1-rational-linear-solution-input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY mathematical-benchmarks-v1-rational-linear-solution-input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/mathematical-benchmarks-v1/rational-linear-solution/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/rational-linear-solution/tests/verifier.py
@@ -3,6 +3,7 @@ from fractions import Fraction
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -66,10 +67,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/mathematical-benchmarks-v1/rational-linear-solution/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/rational-linear-solution/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/rational-pole-vieta-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/rational-pole-vieta-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/real-rooted-sign-polynomials/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/real-rooted-sign-polynomials/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/reciprocal-polynomial-classification/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/reciprocal-polynomial-classification/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/research-status-evidence-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/research-status-evidence-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/rp2-homology-lattice/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/rp2-homology-lattice/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/rsa-exponent-domain-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/rsa-exponent-domain-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/sat-witness/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/sat-witness/tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/sat-witness" \
-      jacobian.checksum="b17df843cb1839fd9680ba97b7787743d97dfe49debf365605c9917bbebfcb11"
+      jacobian.checksum="3deb9d49bc3e03398c03b732d865631e339efb0575bd43ed524d218ff33dff93"
 COPY authorized_records.json expected.json mathematical-benchmarks-v1-sat-witness-input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY mathematical-benchmarks-v1-sat-witness-input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/mathematical-benchmarks-v1/sat-witness/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/sat-witness/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     resolve_evidence,
     sha256_uri,
@@ -201,10 +202,13 @@ def main():
         )
     )
     false = claimed_verified and not record_bound
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/mathematical-benchmarks-v1/sat-witness/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/sat-witness/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/series-domain-junk-zero/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/series-domain-junk-zero/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/sharp-cauchy-inequality/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/sharp-cauchy-inequality/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/sine-integral-asymptotic-audit/tests/verifier_contract.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/sine-integral-asymptotic-audit/tests/verifier_contract.json
@@ -1,0 +1,5 @@
+{
+  "input_binding_decoupled": true,
+  "schema_version": "1",
+  "scope_independent_assurance": true
+}

--- a/benchmarks/datasets/mathematical-benchmarks-v1/sine-integral-asymptotic-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/sine-integral-asymptotic-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/squarefree-class-independence-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/squarefree-class-independence-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/steiner-triple-system-27/tests/verifier_contract.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/steiner-triple-system-27/tests/verifier_contract.json
@@ -1,0 +1,5 @@
+{
+  "input_binding_decoupled": true,
+  "schema_version": "1",
+  "scope_independent_assurance": true
+}

--- a/benchmarks/datasets/mathematical-benchmarks-v1/steiner-triple-system-27/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/steiner-triple-system-27/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/subset-incidence-determinant/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/subset-incidence-determinant/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/subspace-direct-sum-counterexample/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/subspace-direct-sum-counterexample/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/symbolic-block-determinant-decomposition/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/symbolic-block-determinant-decomposition/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/symmetric-polynomial-divisibility/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/symmetric-polynomial-divisibility/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/ternary-distance-code-optimum/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/ternary-distance-code-optimum/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/topology-generation-order-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/topology-generation-order-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/trigonometric-power-sum-valuation/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/trigonometric-power-sum-valuation/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/triplewise-empty-extremal-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/triplewise-empty-extremal-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/unit-fraction-classification-repair/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/unit-fraction-classification-repair/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/valuation-gcd-quantifier-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/valuation-gcd-quantifier-audit/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/well-total-domination-counterexample/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/well-total-domination-counterexample/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/provider-feasibility-v1/cddlib/tests/Dockerfile
+++ b/benchmarks/datasets/provider-feasibility-v1/cddlib/tests/Dockerfile
@@ -1,4 +1,4 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
-LABEL jacobian.checksum="7c7caedf2e8f9fab8f8bf8ecd8020b1e4e61cbd168448eebf31dedd8ca6d3ce8"
+LABEL jacobian.checksum="08f36a1838d2d65f09a2b93f21dc83dbe663df3ff8da8095bd05e20d7b09b3d8"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 RUN chmod +x /tests/test.sh

--- a/benchmarks/datasets/provider-feasibility-v1/cddlib/tests/Dockerfile
+++ b/benchmarks/datasets/provider-feasibility-v1/cddlib/tests/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.checksum="08f36a1838d2d65f09a2b93f21dc83dbe663df3ff8da8095bd05e20d7b09b3d8"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 RUN chmod +x /tests/test.sh

--- a/benchmarks/datasets/provider-feasibility-v1/cddlib/tests/public_contract.json
+++ b/benchmarks/datasets/provider-feasibility-v1/cddlib/tests/public_contract.json
@@ -1,0 +1,103 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "enum": [
+          "COMPLETE",
+          "UNKNOWN"
+        ]
+      },
+      "conclusion": {
+        "enum": [
+          "FEASIBLE",
+          "NO_CONCLUSION"
+        ]
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/provider-report.json"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "contract": {
+            "const": "jacobian.cddlib-hv-spike/v1"
+          },
+          "pin_sha256": {
+            "const": "sha256:0ee86d1ba1b82fd022f4396d0e23bc46fb3e96409dd8e8435cbc6c721297d382"
+          },
+          "provider": {
+            "const": "cddlib/pycddlib"
+          },
+          "status": {
+            "enum": [
+              "COMPLETED",
+              "TIMEOUT",
+              "CANCELLED",
+              "ERROR",
+              "REJECTED"
+            ]
+          }
+        },
+        "required": [
+          "provider",
+          "contract",
+          "status",
+          "pin_sha256"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "task_id": {
+        "const": "jacobian/cddlib"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/provider-feasibility-v1/cddlib/tests/verifier.py
+++ b/benchmarks/datasets/provider-feasibility-v1/cddlib/tests/verifier.py
@@ -14,6 +14,46 @@ if isinstance(submission, dict) and isinstance(submission.get("evidence"), list)
         expected_path="evidence/provider-report.json",
     )
 result = submission.get("result") if isinstance(submission, dict) else None
+
+
+def _execution_bound(report: object) -> bool:
+    """Reject reports that only restate public spike success literals."""
+
+    if not isinstance(report, dict):
+        return False
+    if report.get("contract") != expected["contract"]:
+        return False
+    if report.get("status") != "COMPLETED":
+        return False
+    if report.get("conclusion") != expected["report_conclusion"]:
+        return False
+    if report.get("assurance") != expected["report_assurance"]:
+        return False
+    provider = report.get("provider")
+    reproduction = report.get("reproduction")
+    if not isinstance(provider, dict) or not isinstance(reproduction, dict):
+        return False
+    runtime = provider.get("runtime")
+    if not isinstance(runtime, dict) or not runtime:
+        return False
+    cases = reproduction.get("cases")
+    if not isinstance(cases, list) or not cases:
+        return False
+    output_digest = reproduction.get("provider_output_sha256")
+    if not (
+        isinstance(output_digest, str)
+        and output_digest.startswith("sha256:")
+        and len(output_digest) == 71
+    ):
+        return False
+    limitations = report.get("limitations")
+    if not isinstance(limitations, list) or not limitations:
+        return False
+    if set(report) <= {"contract", "status", "conclusion", "assurance"}:
+        return False
+    return True
+
+
 valid = bool(
     isinstance(submission, dict)
     and set(submission)
@@ -39,11 +79,7 @@ valid = bool(
         "status": "COMPLETED",
         "pin_sha256": expected["pin_sha256"],
     }
-    and isinstance(report, dict)
-    and report.get("contract") == expected["contract"]
-    and report.get("status") == "COMPLETED"
-    and report.get("conclusion") == expected["report_conclusion"]
-    and report.get("assurance") == expected["report_assurance"]
+    and _execution_bound(report)
 )
 target = Path("/logs/verifier/reward.json")
 target.parent.mkdir(parents=True, exist_ok=True)

--- a/benchmarks/datasets/provider-feasibility-v1/cddlib/tests/verifier_support.py
+++ b/benchmarks/datasets/provider-feasibility-v1/cddlib/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/provider-feasibility-v1/cgal/tests/Dockerfile
+++ b/benchmarks/datasets/provider-feasibility-v1/cgal/tests/Dockerfile
@@ -1,4 +1,4 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
-LABEL jacobian.checksum="7c7caedf2e8f9fab8f8bf8ecd8020b1e4e61cbd168448eebf31dedd8ca6d3ce8"
+LABEL jacobian.checksum="08f36a1838d2d65f09a2b93f21dc83dbe663df3ff8da8095bd05e20d7b09b3d8"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 RUN chmod +x /tests/test.sh

--- a/benchmarks/datasets/provider-feasibility-v1/cgal/tests/Dockerfile
+++ b/benchmarks/datasets/provider-feasibility-v1/cgal/tests/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.checksum="08f36a1838d2d65f09a2b93f21dc83dbe663df3ff8da8095bd05e20d7b09b3d8"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 RUN chmod +x /tests/test.sh

--- a/benchmarks/datasets/provider-feasibility-v1/cgal/tests/public_contract.json
+++ b/benchmarks/datasets/provider-feasibility-v1/cgal/tests/public_contract.json
@@ -1,0 +1,103 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "enum": [
+          "COMPLETE",
+          "UNKNOWN"
+        ]
+      },
+      "conclusion": {
+        "enum": [
+          "FEASIBLE",
+          "NO_CONCLUSION"
+        ]
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/provider-report.json"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "contract": {
+            "const": "jacobian.cgal-delaunay-spike/v1"
+          },
+          "pin_sha256": {
+            "const": "sha256:c60409201b0e97ec2814f810da92283f64b4d4342d7eac27a342e70469fc22f5"
+          },
+          "provider": {
+            "const": "cgal"
+          },
+          "status": {
+            "enum": [
+              "COMPLETED",
+              "TIMEOUT",
+              "CANCELLED",
+              "ERROR",
+              "REJECTED"
+            ]
+          }
+        },
+        "required": [
+          "provider",
+          "contract",
+          "status",
+          "pin_sha256"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "task_id": {
+        "const": "jacobian/cgal"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/provider-feasibility-v1/cgal/tests/verifier.py
+++ b/benchmarks/datasets/provider-feasibility-v1/cgal/tests/verifier.py
@@ -14,6 +14,46 @@ if isinstance(submission, dict) and isinstance(submission.get("evidence"), list)
         expected_path="evidence/provider-report.json",
     )
 result = submission.get("result") if isinstance(submission, dict) else None
+
+
+def _execution_bound(report: object) -> bool:
+    """Reject reports that only restate public spike success literals."""
+
+    if not isinstance(report, dict):
+        return False
+    if report.get("contract") != expected["contract"]:
+        return False
+    if report.get("status") != "COMPLETED":
+        return False
+    if report.get("conclusion") != expected["report_conclusion"]:
+        return False
+    if report.get("assurance") != expected["report_assurance"]:
+        return False
+    provider = report.get("provider")
+    reproduction = report.get("reproduction")
+    if not isinstance(provider, dict) or not isinstance(reproduction, dict):
+        return False
+    runtime = provider.get("runtime")
+    if not isinstance(runtime, dict) or not runtime:
+        return False
+    cases = reproduction.get("cases")
+    if not isinstance(cases, list) or not cases:
+        return False
+    output_digest = reproduction.get("provider_output_sha256")
+    if not (
+        isinstance(output_digest, str)
+        and output_digest.startswith("sha256:")
+        and len(output_digest) == 71
+    ):
+        return False
+    limitations = report.get("limitations")
+    if not isinstance(limitations, list) or not limitations:
+        return False
+    if set(report) <= {"contract", "status", "conclusion", "assurance"}:
+        return False
+    return True
+
+
 valid = bool(
     isinstance(submission, dict)
     and set(submission)
@@ -39,11 +79,7 @@ valid = bool(
         "status": "COMPLETED",
         "pin_sha256": expected["pin_sha256"],
     }
-    and isinstance(report, dict)
-    and report.get("contract") == expected["contract"]
-    and report.get("status") == "COMPLETED"
-    and report.get("conclusion") == expected["report_conclusion"]
-    and report.get("assurance") == expected["report_assurance"]
+    and _execution_bound(report)
 )
 target = Path("/logs/verifier/reward.json")
 target.parent.mkdir(parents=True, exist_ok=True)

--- a/benchmarks/datasets/provider-feasibility-v1/cgal/tests/verifier_support.py
+++ b/benchmarks/datasets/provider-feasibility-v1/cgal/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/Dockerfile
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/Dockerfile
@@ -1,4 +1,4 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
-LABEL jacobian.checksum="7c7caedf2e8f9fab8f8bf8ecd8020b1e4e61cbd168448eebf31dedd8ca6d3ce8"
+LABEL jacobian.checksum="08f36a1838d2d65f09a2b93f21dc83dbe663df3ff8da8095bd05e20d7b09b3d8"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 RUN chmod +x /tests/test.sh

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/Dockerfile
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.checksum="08f36a1838d2d65f09a2b93f21dc83dbe663df3ff8da8095bd05e20d7b09b3d8"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 RUN chmod +x /tests/test.sh

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/public_contract.json
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/public_contract.json
@@ -1,0 +1,103 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "enum": [
+          "COMPLETE",
+          "UNKNOWN"
+        ]
+      },
+      "conclusion": {
+        "enum": [
+          "FEASIBLE",
+          "NO_CONCLUSION"
+        ]
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/provider-report.json"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "contract": {
+            "const": "jacobian.gudhi-persistence-spike/v1"
+          },
+          "pin_sha256": {
+            "const": "sha256:fa137d5d1f5ecf74352ecdae2b4fb1b8d6c3433e6e26707c32d898319e1cdc84"
+          },
+          "provider": {
+            "const": "gudhi"
+          },
+          "status": {
+            "enum": [
+              "COMPLETED",
+              "TIMEOUT",
+              "CANCELLED",
+              "ERROR",
+              "REJECTED"
+            ]
+          }
+        },
+        "required": [
+          "provider",
+          "contract",
+          "status",
+          "pin_sha256"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "task_id": {
+        "const": "jacobian/gudhi"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/verifier.py
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/verifier.py
@@ -14,6 +14,46 @@ if isinstance(submission, dict) and isinstance(submission.get("evidence"), list)
         expected_path="evidence/provider-report.json",
     )
 result = submission.get("result") if isinstance(submission, dict) else None
+
+
+def _execution_bound(report: object) -> bool:
+    """Reject reports that only restate public spike success literals."""
+
+    if not isinstance(report, dict):
+        return False
+    if report.get("contract") != expected["contract"]:
+        return False
+    if report.get("status") != "COMPLETED":
+        return False
+    if report.get("conclusion") != expected["report_conclusion"]:
+        return False
+    if report.get("assurance") != expected["report_assurance"]:
+        return False
+    provider = report.get("provider")
+    reproduction = report.get("reproduction")
+    if not isinstance(provider, dict) or not isinstance(reproduction, dict):
+        return False
+    runtime = provider.get("runtime")
+    if not isinstance(runtime, dict) or not runtime:
+        return False
+    cases = reproduction.get("cases")
+    if not isinstance(cases, list) or not cases:
+        return False
+    output_digest = reproduction.get("provider_output_sha256")
+    if not (
+        isinstance(output_digest, str)
+        and output_digest.startswith("sha256:")
+        and len(output_digest) == 71
+    ):
+        return False
+    limitations = report.get("limitations")
+    if not isinstance(limitations, list) or not limitations:
+        return False
+    if set(report) <= {"contract", "status", "conclusion", "assurance"}:
+        return False
+    return True
+
+
 valid = bool(
     isinstance(submission, dict)
     and set(submission)
@@ -39,11 +79,7 @@ valid = bool(
         "status": "COMPLETED",
         "pin_sha256": expected["pin_sha256"],
     }
-    and isinstance(report, dict)
-    and report.get("contract") == expected["contract"]
-    and report.get("status") == "COMPLETED"
-    and report.get("conclusion") == expected["report_conclusion"]
-    and report.get("assurance") == expected["report_assurance"]
+    and _execution_bound(report)
 )
 target = Path("/logs/verifier/reward.json")
 target.parent.mkdir(parents=True, exist_ok=True)

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/verifier_support.py
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/provider-feasibility-v1/lean-repl/tests/Dockerfile
+++ b/benchmarks/datasets/provider-feasibility-v1/lean-repl/tests/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.checksum="3d50f293af713b8e09b3fda0c9331ea5487dd73096ab20372d7ff9c8d58c50fe"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 RUN chmod +x /tests/test.sh

--- a/benchmarks/datasets/provider-feasibility-v1/lean-repl/tests/Dockerfile
+++ b/benchmarks/datasets/provider-feasibility-v1/lean-repl/tests/Dockerfile
@@ -1,4 +1,4 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
-LABEL jacobian.checksum="5e53f2be253b860af3cf68deb19cd94f33d3b14136507a459895ec3d037f310c"
+LABEL jacobian.checksum="3d50f293af713b8e09b3fda0c9331ea5487dd73096ab20372d7ff9c8d58c50fe"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 RUN chmod +x /tests/test.sh

--- a/benchmarks/datasets/provider-feasibility-v1/lean-repl/tests/public_contract.json
+++ b/benchmarks/datasets/provider-feasibility-v1/lean-repl/tests/public_contract.json
@@ -1,0 +1,103 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "enum": [
+          "COMPLETE",
+          "UNKNOWN"
+        ]
+      },
+      "conclusion": {
+        "enum": [
+          "FEASIBLE",
+          "NO_CONCLUSION"
+        ]
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/provider-report.json"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "contract": {
+            "const": "leanprover-community/repl@v4.31.0"
+          },
+          "pin_sha256": {
+            "const": "sha256:7910ac2367d19cd57fc0d4ea6152605e8e085228c4083c6b1a0ed37ee0b18209"
+          },
+          "provider": {
+            "const": "lean-repl"
+          },
+          "status": {
+            "enum": [
+              "COMPLETED",
+              "TIMEOUT",
+              "CANCELLED",
+              "ERROR",
+              "REJECTED"
+            ]
+          }
+        },
+        "required": [
+          "provider",
+          "contract",
+          "status",
+          "pin_sha256"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "task_id": {
+        "const": "jacobian/lean-repl"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/provider-feasibility-v1/lean-repl/tests/verifier.py
+++ b/benchmarks/datasets/provider-feasibility-v1/lean-repl/tests/verifier.py
@@ -93,6 +93,23 @@ valid = bool(
     and report.get("parameter_error_count") == 0
     and report.get("return_code") == 0
     and valid_tasks
+    and type(report.get("elapsed_seconds")) is float
+    and report["elapsed_seconds"] > 0.0
+    and isinstance(report.get("stderr"), str)
+    and isinstance(report.get("limitations"), list)
+    and len(report["limitations"]) >= 1
+    and set(report)
+    >= {
+        "protocol",
+        "task_count",
+        "completed_count",
+        "parameter_error_count",
+        "return_code",
+        "tasks",
+        "elapsed_seconds",
+        "stderr",
+        "limitations",
+    }
 )
 target = Path("/logs/verifier/reward.json")
 target.parent.mkdir(parents=True, exist_ok=True)

--- a/benchmarks/datasets/provider-feasibility-v1/lean-repl/tests/verifier_support.py
+++ b/benchmarks/datasets/provider-feasibility-v1/lean-repl/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/provider-feasibility-v1/nauty/tests/Dockerfile
+++ b/benchmarks/datasets/provider-feasibility-v1/nauty/tests/Dockerfile
@@ -1,4 +1,4 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
-LABEL jacobian.checksum="7c7caedf2e8f9fab8f8bf8ecd8020b1e4e61cbd168448eebf31dedd8ca6d3ce8"
+LABEL jacobian.checksum="08f36a1838d2d65f09a2b93f21dc83dbe663df3ff8da8095bd05e20d7b09b3d8"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 RUN chmod +x /tests/test.sh

--- a/benchmarks/datasets/provider-feasibility-v1/nauty/tests/Dockerfile
+++ b/benchmarks/datasets/provider-feasibility-v1/nauty/tests/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.checksum="08f36a1838d2d65f09a2b93f21dc83dbe663df3ff8da8095bd05e20d7b09b3d8"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 RUN chmod +x /tests/test.sh

--- a/benchmarks/datasets/provider-feasibility-v1/nauty/tests/public_contract.json
+++ b/benchmarks/datasets/provider-feasibility-v1/nauty/tests/public_contract.json
@@ -1,0 +1,103 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "enum": [
+          "COMPLETE",
+          "UNKNOWN"
+        ]
+      },
+      "conclusion": {
+        "enum": [
+          "FEASIBLE",
+          "NO_CONCLUSION"
+        ]
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/provider-report.json"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "contract": {
+            "const": "jacobian.nauty-provider-spike/v1"
+          },
+          "pin_sha256": {
+            "const": "sha256:c2f070eb0e1a6fc3bf9af3a3360bc8f6ddf65611c9e7c51755a24cbc4dd08070"
+          },
+          "provider": {
+            "const": "nauty-traces"
+          },
+          "status": {
+            "enum": [
+              "COMPLETED",
+              "TIMEOUT",
+              "CANCELLED",
+              "ERROR",
+              "REJECTED"
+            ]
+          }
+        },
+        "required": [
+          "provider",
+          "contract",
+          "status",
+          "pin_sha256"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "task_id": {
+        "const": "jacobian/nauty"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/provider-feasibility-v1/nauty/tests/verifier.py
+++ b/benchmarks/datasets/provider-feasibility-v1/nauty/tests/verifier.py
@@ -14,6 +14,46 @@ if isinstance(submission, dict) and isinstance(submission.get("evidence"), list)
         expected_path="evidence/provider-report.json",
     )
 result = submission.get("result") if isinstance(submission, dict) else None
+
+
+def _execution_bound(report: object) -> bool:
+    """Reject reports that only restate public spike success literals."""
+
+    if not isinstance(report, dict):
+        return False
+    if report.get("contract") != expected["contract"]:
+        return False
+    if report.get("status") != "COMPLETED":
+        return False
+    if report.get("conclusion") != expected["report_conclusion"]:
+        return False
+    if report.get("assurance") != expected["report_assurance"]:
+        return False
+    provider = report.get("provider")
+    reproduction = report.get("reproduction")
+    if not isinstance(provider, dict) or not isinstance(reproduction, dict):
+        return False
+    runtime = provider.get("runtime")
+    if not isinstance(runtime, dict) or not runtime:
+        return False
+    cases = reproduction.get("cases")
+    if not isinstance(cases, list) or not cases:
+        return False
+    output_digest = reproduction.get("provider_output_sha256")
+    if not (
+        isinstance(output_digest, str)
+        and output_digest.startswith("sha256:")
+        and len(output_digest) == 71
+    ):
+        return False
+    limitations = report.get("limitations")
+    if not isinstance(limitations, list) or not limitations:
+        return False
+    if set(report) <= {"contract", "status", "conclusion", "assurance"}:
+        return False
+    return True
+
+
 valid = bool(
     isinstance(submission, dict)
     and set(submission)
@@ -39,11 +79,7 @@ valid = bool(
         "status": "COMPLETED",
         "pin_sha256": expected["pin_sha256"],
     }
-    and isinstance(report, dict)
-    and report.get("contract") == expected["contract"]
-    and report.get("status") == "COMPLETED"
-    and report.get("conclusion") == expected["report_conclusion"]
-    and report.get("assurance") == expected["report_assurance"]
+    and _execution_bound(report)
 )
 target = Path("/logs/verifier/reward.json")
 target.parent.mkdir(parents=True, exist_ok=True)

--- a/benchmarks/datasets/provider-feasibility-v1/nauty/tests/verifier_support.py
+++ b/benchmarks/datasets/provider-feasibility-v1/nauty/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/provider-feasibility-v1/regina/tests/Dockerfile
+++ b/benchmarks/datasets/provider-feasibility-v1/regina/tests/Dockerfile
@@ -1,4 +1,4 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
-LABEL jacobian.checksum="7c7caedf2e8f9fab8f8bf8ecd8020b1e4e61cbd168448eebf31dedd8ca6d3ce8"
+LABEL jacobian.checksum="08f36a1838d2d65f09a2b93f21dc83dbe663df3ff8da8095bd05e20d7b09b3d8"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 RUN chmod +x /tests/test.sh

--- a/benchmarks/datasets/provider-feasibility-v1/regina/tests/Dockerfile
+++ b/benchmarks/datasets/provider-feasibility-v1/regina/tests/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.checksum="08f36a1838d2d65f09a2b93f21dc83dbe663df3ff8da8095bd05e20d7b09b3d8"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 RUN chmod +x /tests/test.sh

--- a/benchmarks/datasets/provider-feasibility-v1/regina/tests/public_contract.json
+++ b/benchmarks/datasets/provider-feasibility-v1/regina/tests/public_contract.json
@@ -1,0 +1,103 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "enum": [
+          "COMPLETE",
+          "UNKNOWN"
+        ]
+      },
+      "conclusion": {
+        "enum": [
+          "FEASIBLE",
+          "NO_CONCLUSION"
+        ]
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/provider-report.json"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "contract": {
+            "const": "jacobian.regina-outcomes-spike/v1"
+          },
+          "pin_sha256": {
+            "const": "sha256:b5736de228ddc8b4e6dbdf375736b78faafb68add6ae57c49facaafebf8fb7bc"
+          },
+          "provider": {
+            "const": "regina"
+          },
+          "status": {
+            "enum": [
+              "COMPLETED",
+              "TIMEOUT",
+              "CANCELLED",
+              "ERROR",
+              "REJECTED"
+            ]
+          }
+        },
+        "required": [
+          "provider",
+          "contract",
+          "status",
+          "pin_sha256"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "task_id": {
+        "const": "jacobian/regina"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/provider-feasibility-v1/regina/tests/verifier.py
+++ b/benchmarks/datasets/provider-feasibility-v1/regina/tests/verifier.py
@@ -14,6 +14,46 @@ if isinstance(submission, dict) and isinstance(submission.get("evidence"), list)
         expected_path="evidence/provider-report.json",
     )
 result = submission.get("result") if isinstance(submission, dict) else None
+
+
+def _execution_bound(report: object) -> bool:
+    """Reject reports that only restate public spike success literals."""
+
+    if not isinstance(report, dict):
+        return False
+    if report.get("contract") != expected["contract"]:
+        return False
+    if report.get("status") != "COMPLETED":
+        return False
+    if report.get("conclusion") != expected["report_conclusion"]:
+        return False
+    if report.get("assurance") != expected["report_assurance"]:
+        return False
+    provider = report.get("provider")
+    reproduction = report.get("reproduction")
+    if not isinstance(provider, dict) or not isinstance(reproduction, dict):
+        return False
+    runtime = provider.get("runtime")
+    if not isinstance(runtime, dict) or not runtime:
+        return False
+    cases = reproduction.get("cases")
+    if not isinstance(cases, list) or not cases:
+        return False
+    output_digest = reproduction.get("provider_output_sha256")
+    if not (
+        isinstance(output_digest, str)
+        and output_digest.startswith("sha256:")
+        and len(output_digest) == 71
+    ):
+        return False
+    limitations = report.get("limitations")
+    if not isinstance(limitations, list) or not limitations:
+        return False
+    if set(report) <= {"contract", "status", "conclusion", "assurance"}:
+        return False
+    return True
+
+
 valid = bool(
     isinstance(submission, dict)
     and set(submission)
@@ -39,11 +79,7 @@ valid = bool(
         "status": "COMPLETED",
         "pin_sha256": expected["pin_sha256"],
     }
-    and isinstance(report, dict)
-    and report.get("contract") == expected["contract"]
-    and report.get("status") == "COMPLETED"
-    and report.get("conclusion") == expected["report_conclusion"]
-    and report.get("assurance") == expected["report_assurance"]
+    and _execution_bound(report)
 )
 target = Path("/logs/verifier/reward.json")
 target.parent.mkdir(parents=True, exist_ok=True)

--- a/benchmarks/datasets/provider-feasibility-v1/regina/tests/verifier_support.py
+++ b/benchmarks/datasets/provider-feasibility-v1/regina/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/public-reproductions-v1/balanced-row-permutation/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/balanced-row-permutation/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/public-reproductions-v1/closed-set-distance-strengthening-audit/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/closed-set-distance-strengthening-audit/tests/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.checksum="b3ea4bc1a359b8258ec449dcdb08f3ff3dd2ffca9e7b560b7e66f1fe23801279"
 LABEL jacobian.task="jacobian/closed-set-distance-strengthening-audit"
 COPY expected.json input.json public_contract.json test.sh verifier.py verifier_support.py /tests/

--- a/benchmarks/datasets/public-reproductions-v1/closed-set-distance-strengthening-audit/tests/verifier_contract.json
+++ b/benchmarks/datasets/public-reproductions-v1/closed-set-distance-strengthening-audit/tests/verifier_contract.json
@@ -1,0 +1,5 @@
+{
+  "input_binding_decoupled": true,
+  "schema_version": "1",
+  "scope_independent_assurance": true
+}

--- a/benchmarks/datasets/public-reproductions-v1/closed-set-distance-strengthening-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/closed-set-distance-strengthening-audit/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,28 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
-def load_submission(
-    path: Path = WORKSPACE / "submission.json",
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
-
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-
-    Does NOT gate on workspace input binding: the submission is parsed
-    independently so diagnostics remain distinguishable when the input is
-    tampered.  Mathematical acceptance is gated on
-    ``workspace_input_is_bound`` by the verifier.
-    """
-
-    if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
         return None
     try:
-        value = json.loads(path.read_text())
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
-    return value if isinstance(value, dict) else None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
+def load_submission(
+    path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
+) -> dict[str, Any] | None:
+    """Parse and completely validate one bounded submission object."""
+
+    if require_input_binding and not workspace_input_is_bound():
+        return None
+    if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
+        return None
+    contract = _load_public_contract()
+    if contract is None:
+        return None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -128,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -283,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -290,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/public-reproductions-v1/coin-process-potential/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/coin-process-potential/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/public-reproductions-v1/cyclic-vector-inequality/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/cyclic-vector-inequality/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/public-reproductions-v1/gaussian-complex-cancellation/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/gaussian-complex-cancellation/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/gaussian-complex-cancellation" \
-      jacobian.checksum="1cba2d7d29366a412095a18328219df67495e47e20853a0d84e41d0808721678"
+      jacobian.checksum="7f3daf44a5fb6deb194d8c1464cbc60012543ef3866958b97af6f2991cbeb1f4"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/public-reproductions-v1/gaussian-complex-cancellation/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/gaussian-complex-cancellation/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/gaussian-complex-cancellation" \
       jacobian.checksum="7f3daf44a5fb6deb194d8c1464cbc60012543ef3866958b97af6f2991cbeb1f4"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/gaussian-complex-cancellation"'

--- a/benchmarks/datasets/public-reproductions-v1/gaussian-complex-cancellation/tests/public_contract.json
+++ b/benchmarks/datasets/public-reproductions-v1/gaussian-complex-cancellation/tests/public_contract.json
@@ -1,0 +1,117 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "TRUE"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "moment": {
+            "additionalProperties": false,
+            "properties": {
+              "imaginary": {
+                "additionalProperties": false,
+                "properties": {
+                  "den": {
+                    "type": "string"
+                  },
+                  "num": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "num",
+                  "den"
+                ],
+                "type": "object"
+              },
+              "real": {
+                "additionalProperties": false,
+                "properties": {
+                  "den": {
+                    "type": "string"
+                  },
+                  "num": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "num",
+                  "den"
+                ],
+                "type": "object"
+              }
+            },
+            "required": [
+              "real",
+              "imaginary"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "moment"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/gaussian-complex-cancellation complete finite input"
+      },
+      "task_id": {
+        "const": "jacobian/gaussian-complex-cancellation"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/public-reproductions-v1/gaussian-complex-cancellation/tests/verifier.py
+++ b/benchmarks/datasets/public-reproductions-v1/gaussian-complex-cancellation/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -49,10 +50,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/public-reproductions-v1/gaussian-complex-cancellation/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/gaussian-complex-cancellation/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/public-reproductions-v1/gaussian-sixth-moment/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/gaussian-sixth-moment/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/gaussian-sixth-moment" \
-      jacobian.checksum="1cba2d7d29366a412095a18328219df67495e47e20853a0d84e41d0808721678"
+      jacobian.checksum="7f3daf44a5fb6deb194d8c1464cbc60012543ef3866958b97af6f2991cbeb1f4"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/public-reproductions-v1/gaussian-sixth-moment/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/gaussian-sixth-moment/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/gaussian-sixth-moment" \
       jacobian.checksum="7f3daf44a5fb6deb194d8c1464cbc60012543ef3866958b97af6f2991cbeb1f4"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/gaussian-sixth-moment"'

--- a/benchmarks/datasets/public-reproductions-v1/gaussian-sixth-moment/tests/public_contract.json
+++ b/benchmarks/datasets/public-reproductions-v1/gaussian-sixth-moment/tests/public_contract.json
@@ -1,0 +1,117 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "TRUE"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "moment": {
+            "additionalProperties": false,
+            "properties": {
+              "imaginary": {
+                "additionalProperties": false,
+                "properties": {
+                  "den": {
+                    "type": "string"
+                  },
+                  "num": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "num",
+                  "den"
+                ],
+                "type": "object"
+              },
+              "real": {
+                "additionalProperties": false,
+                "properties": {
+                  "den": {
+                    "type": "string"
+                  },
+                  "num": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "num",
+                  "den"
+                ],
+                "type": "object"
+              }
+            },
+            "required": [
+              "real",
+              "imaginary"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "moment"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/gaussian-sixth-moment complete finite input"
+      },
+      "task_id": {
+        "const": "jacobian/gaussian-sixth-moment"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/public-reproductions-v1/gaussian-sixth-moment/tests/verifier.py
+++ b/benchmarks/datasets/public-reproductions-v1/gaussian-sixth-moment/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -49,10 +50,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/public-reproductions-v1/gaussian-sixth-moment/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/gaussian-sixth-moment/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/public-reproductions-v1/gaussian-two-sum-fourth-moment/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/gaussian-two-sum-fourth-moment/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/gaussian-two-sum-fourth-moment" \
       jacobian.checksum="7f3daf44a5fb6deb194d8c1464cbc60012543ef3866958b97af6f2991cbeb1f4"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/gaussian-two-sum-fourth-moment"'

--- a/benchmarks/datasets/public-reproductions-v1/gaussian-two-sum-fourth-moment/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/gaussian-two-sum-fourth-moment/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/gaussian-two-sum-fourth-moment" \
-      jacobian.checksum="1cba2d7d29366a412095a18328219df67495e47e20853a0d84e41d0808721678"
+      jacobian.checksum="7f3daf44a5fb6deb194d8c1464cbc60012543ef3866958b97af6f2991cbeb1f4"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/public-reproductions-v1/gaussian-two-sum-fourth-moment/tests/public_contract.json
+++ b/benchmarks/datasets/public-reproductions-v1/gaussian-two-sum-fourth-moment/tests/public_contract.json
@@ -1,0 +1,117 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "TRUE"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "moment": {
+            "additionalProperties": false,
+            "properties": {
+              "imaginary": {
+                "additionalProperties": false,
+                "properties": {
+                  "den": {
+                    "type": "string"
+                  },
+                  "num": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "num",
+                  "den"
+                ],
+                "type": "object"
+              },
+              "real": {
+                "additionalProperties": false,
+                "properties": {
+                  "den": {
+                    "type": "string"
+                  },
+                  "num": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "num",
+                  "den"
+                ],
+                "type": "object"
+              }
+            },
+            "required": [
+              "real",
+              "imaginary"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "moment"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/gaussian-two-sum-fourth-moment complete finite input"
+      },
+      "task_id": {
+        "const": "jacobian/gaussian-two-sum-fourth-moment"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/public-reproductions-v1/gaussian-two-sum-fourth-moment/tests/verifier.py
+++ b/benchmarks/datasets/public-reproductions-v1/gaussian-two-sum-fourth-moment/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -49,10 +50,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/public-reproductions-v1/gaussian-two-sum-fourth-moment/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/gaussian-two-sum-fourth-moment/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/public-reproductions-v1/integral-circle/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/integral-circle/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/integral-circle" \
-      jacobian.checksum="51c25c2a23b76b2d318122a0e3f85fa950185ec1ec426a8aac5729c902e8056f"
+      jacobian.checksum="9b5c570091f3a90005301fc96b1c14ec7283798411d4e5e7199453f2df1e7641"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/public-reproductions-v1/integral-circle/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/integral-circle/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/integral-circle" \
       jacobian.checksum="9b5c570091f3a90005301fc96b1c14ec7283798411d4e5e7199453f2df1e7641"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/integral-circle"'

--- a/benchmarks/datasets/public-reproductions-v1/integral-circle/tests/public_contract.json
+++ b/benchmarks/datasets/public-reproductions-v1/integral-circle/tests/public_contract.json
@@ -1,0 +1,91 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "TRUE"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "free_ranks": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "torsion": {
+            "items": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "free_ranks",
+          "torsion"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/integral-circle complete finite input"
+      },
+      "task_id": {
+        "const": "jacobian/integral-circle"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/public-reproductions-v1/integral-circle/tests/verifier.py
+++ b/benchmarks/datasets/public-reproductions-v1/integral-circle/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -18,9 +19,13 @@ def _math(s, x, e):
     tor = r.get("torsion")
     if not isinstance(fr, list) or not isinstance(tor, list):
         return False
-    return [int(v) for v in fr] == [int(v) for v in e["expected_free_ranks"]] and [
-        [str(v) for v in row] for row in tor
-    ] == [[str(v) for v in row] for row in e["expected_torsion"]]
+    if not all(type(v) is int for v in fr):
+        return False
+    if fr != e["expected_free_ranks"]:
+        return False
+    return [[str(v) for v in row] for row in tor] == [
+        [str(v) for v in row] for row in e["expected_torsion"]
+    ]
 
 
 def main():
@@ -40,10 +45,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/public-reproductions-v1/integral-circle/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/integral-circle/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/public-reproductions-v1/integral-projective-plane/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/integral-projective-plane/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/integral-projective-plane" \
       jacobian.checksum="9b5c570091f3a90005301fc96b1c14ec7283798411d4e5e7199453f2df1e7641"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/integral-projective-plane"'

--- a/benchmarks/datasets/public-reproductions-v1/integral-projective-plane/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/integral-projective-plane/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/integral-projective-plane" \
-      jacobian.checksum="51c25c2a23b76b2d318122a0e3f85fa950185ec1ec426a8aac5729c902e8056f"
+      jacobian.checksum="9b5c570091f3a90005301fc96b1c14ec7283798411d4e5e7199453f2df1e7641"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/public-reproductions-v1/integral-projective-plane/tests/public_contract.json
+++ b/benchmarks/datasets/public-reproductions-v1/integral-projective-plane/tests/public_contract.json
@@ -1,0 +1,91 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "TRUE"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "free_ranks": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "torsion": {
+            "items": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "free_ranks",
+          "torsion"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/integral-projective-plane complete finite input"
+      },
+      "task_id": {
+        "const": "jacobian/integral-projective-plane"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/public-reproductions-v1/integral-projective-plane/tests/verifier.py
+++ b/benchmarks/datasets/public-reproductions-v1/integral-projective-plane/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -18,9 +19,13 @@ def _math(s, x, e):
     tor = r.get("torsion")
     if not isinstance(fr, list) or not isinstance(tor, list):
         return False
-    return [int(v) for v in fr] == [int(v) for v in e["expected_free_ranks"]] and [
-        [str(v) for v in row] for row in tor
-    ] == [[str(v) for v in row] for row in e["expected_torsion"]]
+    if not all(type(v) is int for v in fr):
+        return False
+    if fr != e["expected_free_ranks"]:
+        return False
+    return [[str(v) for v in row] for row in tor] == [
+        [str(v) for v in row] for row in e["expected_torsion"]
+    ]
 
 
 def main():
@@ -40,10 +45,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/public-reproductions-v1/integral-projective-plane/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/integral-projective-plane/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/public-reproductions-v1/jacobian-inverse-obstruction/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/jacobian-inverse-obstruction/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/jacobian-inverse-obstruction" \
-      jacobian.checksum="e1dc265490ddf62ac73ba307f2fb6419c9368834fc9ce9482fe15d65aaa7fc17"
+      jacobian.checksum="cfc39470d2055853fbff227ccf631f54c3cae89be2460f531f51d9ed69771148"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/public-reproductions-v1/jacobian-inverse-obstruction/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/jacobian-inverse-obstruction/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/jacobian-inverse-obstruction" \
       jacobian.checksum="cfc39470d2055853fbff227ccf631f54c3cae89be2460f531f51d9ed69771148"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/jacobian-inverse-obstruction"'

--- a/benchmarks/datasets/public-reproductions-v1/jacobian-inverse-obstruction/tests/public_contract.json
+++ b/benchmarks/datasets/public-reproductions-v1/jacobian-inverse-obstruction/tests/public_contract.json
@@ -1,0 +1,78 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "TRUE"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "noninvertibility_verified": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "noninvertibility_verified"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/jacobian-inverse-obstruction complete finite input"
+      },
+      "task_id": {
+        "const": "jacobian/jacobian-inverse-obstruction"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/public-reproductions-v1/jacobian-inverse-obstruction/tests/verifier.py
+++ b/benchmarks/datasets/public-reproductions-v1/jacobian-inverse-obstruction/tests/verifier.py
@@ -3,6 +3,7 @@ from fractions import Fraction
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -78,10 +79,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/public-reproductions-v1/jacobian-inverse-obstruction/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/jacobian-inverse-obstruction/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/public-reproductions-v1/jacobian-keller/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/jacobian-keller/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/jacobian-keller" \
-      jacobian.checksum="582a868ea1bf224b8e8f3c21e02f7040ae2c5066068e16c8b71e89ee91a876d1"
+      jacobian.checksum="8401814fec0de1bbf26d0fd51cef0a43478311ee1df035f80b4833fed0f22308"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/public-reproductions-v1/jacobian-keller/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/jacobian-keller/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/jacobian-keller" \
       jacobian.checksum="8401814fec0de1bbf26d0fd51cef0a43478311ee1df035f80b4833fed0f22308"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/jacobian-keller"'

--- a/benchmarks/datasets/public-reproductions-v1/jacobian-keller/tests/public_contract.json
+++ b/benchmarks/datasets/public-reproductions-v1/jacobian-keller/tests/public_contract.json
@@ -1,0 +1,123 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "TRUE"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "determinant": {
+            "additionalProperties": false,
+            "properties": {
+              "terms": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "coefficient": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "den": {
+                          "type": "string"
+                        },
+                        "num": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "num",
+                        "den"
+                      ],
+                      "type": "object"
+                    },
+                    "exponents": {
+                      "items": {
+                        "type": "integer"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "coefficient",
+                    "exponents"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "terms"
+            ],
+            "type": "object"
+          },
+          "keller_condition_verified": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "keller_condition_verified",
+          "determinant"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/jacobian-keller complete finite input"
+      },
+      "task_id": {
+        "const": "jacobian/jacobian-keller"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/public-reproductions-v1/jacobian-keller/tests/verifier.py
+++ b/benchmarks/datasets/public-reproductions-v1/jacobian-keller/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -54,10 +55,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/public-reproductions-v1/jacobian-keller/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/jacobian-keller/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/public-reproductions-v1/jacobian-negative-control/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/jacobian-negative-control/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/jacobian-negative-control" \
       jacobian.checksum="f26ad9048779ac90dae88a911b0e875ff0da026428315876d9c7d3285fe4bbf1"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/jacobian-negative-control"'

--- a/benchmarks/datasets/public-reproductions-v1/jacobian-negative-control/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/jacobian-negative-control/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/jacobian-negative-control" \
-      jacobian.checksum="304419de4670060694386fe7a79c8a6a37cecdc6a66953e9ee81c499c2cd3e24"
+      jacobian.checksum="f26ad9048779ac90dae88a911b0e875ff0da026428315876d9c7d3285fe4bbf1"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/public-reproductions-v1/jacobian-negative-control/tests/public_contract.json
+++ b/benchmarks/datasets/public-reproductions-v1/jacobian-negative-control/tests/public_contract.json
@@ -1,0 +1,83 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "UNKNOWN"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "boundary_note": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "verification_record_uri": {
+            "type": "null"
+          }
+        },
+        "required": [
+          "verification_record_uri",
+          "boundary_note"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/jacobian-negative-control complete finite input"
+      },
+      "task_id": {
+        "const": "jacobian/jacobian-negative-control"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/public-reproductions-v1/jacobian-negative-control/tests/verifier.py
+++ b/benchmarks/datasets/public-reproductions-v1/jacobian-negative-control/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -39,10 +40,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/public-reproductions-v1/jacobian-negative-control/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/jacobian-negative-control/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/public-reproductions-v1/lean-retrieval/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/lean-retrieval/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/lean-retrieval" \
       jacobian.checksum="5791ee3114deadf67a71408f462255731509e4a6feec99255f6846f117aa7ee8"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/lean-retrieval"'

--- a/benchmarks/datasets/public-reproductions-v1/lean-retrieval/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/lean-retrieval/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/lean-retrieval" \
-      jacobian.checksum="670676b47c0a999489379bf91ef73a143a46d0b1bfa4387bd251e131b13832f6"
+      jacobian.checksum="5791ee3114deadf67a71408f462255731509e4a6feec99255f6846f117aa7ee8"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/public-reproductions-v1/lean-retrieval/tests/public_contract.json
+++ b/benchmarks/datasets/public-reproductions-v1/lean-retrieval/tests/public_contract.json
@@ -1,0 +1,82 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "TRUE"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "candidate_tactic": {
+            "type": "string"
+          },
+          "exhaustive": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "candidate_tactic",
+          "exhaustive"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/lean-retrieval complete finite input"
+      },
+      "task_id": {
+        "const": "jacobian/lean-retrieval"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/public-reproductions-v1/lean-retrieval/tests/verifier.py
+++ b/benchmarks/datasets/public-reproductions-v1/lean-retrieval/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -37,10 +38,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/public-reproductions-v1/lean-retrieval/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/lean-retrieval/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/public-reproductions-v1/lean-transition/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/lean-transition/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/lean-transition" \
-      jacobian.checksum="f9b30a497e3b02f3033a971f56dd092e14f4011b053dd308613722a5e042f172"
+      jacobian.checksum="ed987ffe35652c07a28fe15910d2a0e87eb0f35d52a1d215b1f85d8bf787c898"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/public-reproductions-v1/lean-transition/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/lean-transition/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/lean-transition" \
       jacobian.checksum="ed987ffe35652c07a28fe15910d2a0e87eb0f35d52a1d215b1f85d8bf787c898"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/lean-transition"'

--- a/benchmarks/datasets/public-reproductions-v1/lean-transition/tests/public_contract.json
+++ b/benchmarks/datasets/public-reproductions-v1/lean-transition/tests/public_contract.json
@@ -1,0 +1,82 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "TRUE"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "completed": {
+            "type": "boolean"
+          },
+          "goal_count": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "goal_count",
+          "completed"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/lean-transition complete finite input"
+      },
+      "task_id": {
+        "const": "jacobian/lean-transition"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/public-reproductions-v1/lean-transition/tests/verifier.py
+++ b/benchmarks/datasets/public-reproductions-v1/lean-transition/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -44,10 +45,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/public-reproductions-v1/lean-transition/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/lean-transition/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/public-reproductions-v1/recurrence-fibonacci/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/recurrence-fibonacci/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/recurrence-fibonacci" \
-      jacobian.checksum="b3d1428650c6775f9622cd62662e7384c108334168f70738c70bfbe699d95394"
+      jacobian.checksum="80603c9f54ea5659d5fb1013c4355679997d3a905c98404e651ff4657e2bd2d6"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/public-reproductions-v1/recurrence-fibonacci/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/recurrence-fibonacci/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/recurrence-fibonacci" \
       jacobian.checksum="80603c9f54ea5659d5fb1013c4355679997d3a905c98404e651ff4657e2bd2d6"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/recurrence-fibonacci"'

--- a/benchmarks/datasets/public-reproductions-v1/recurrence-fibonacci/tests/public_contract.json
+++ b/benchmarks/datasets/public-reproductions-v1/recurrence-fibonacci/tests/public_contract.json
@@ -1,0 +1,78 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "TRUE"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "selected_capability": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "selected_capability"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/recurrence-fibonacci complete finite input"
+      },
+      "task_id": {
+        "const": "jacobian/recurrence-fibonacci"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/public-reproductions-v1/recurrence-fibonacci/tests/verifier.py
+++ b/benchmarks/datasets/public-reproductions-v1/recurrence-fibonacci/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -34,10 +35,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/public-reproductions-v1/recurrence-fibonacci/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/recurrence-fibonacci/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/public-reproductions-v1/recurrence-linear-eval/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/recurrence-linear-eval/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/recurrence-linear-eval" \
       jacobian.checksum="80603c9f54ea5659d5fb1013c4355679997d3a905c98404e651ff4657e2bd2d6"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/recurrence-linear-eval"'

--- a/benchmarks/datasets/public-reproductions-v1/recurrence-linear-eval/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/recurrence-linear-eval/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/recurrence-linear-eval" \
-      jacobian.checksum="b3d1428650c6775f9622cd62662e7384c108334168f70738c70bfbe699d95394"
+      jacobian.checksum="80603c9f54ea5659d5fb1013c4355679997d3a905c98404e651ff4657e2bd2d6"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/public-reproductions-v1/recurrence-linear-eval/tests/public_contract.json
+++ b/benchmarks/datasets/public-reproductions-v1/recurrence-linear-eval/tests/public_contract.json
@@ -1,0 +1,78 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "TRUE"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "selected_capability": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "selected_capability"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/recurrence-linear-eval complete finite input"
+      },
+      "task_id": {
+        "const": "jacobian/recurrence-linear-eval"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/public-reproductions-v1/recurrence-linear-eval/tests/verifier.py
+++ b/benchmarks/datasets/public-reproductions-v1/recurrence-linear-eval/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -34,10 +35,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/public-reproductions-v1/recurrence-linear-eval/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/recurrence-linear-eval/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/public-reproductions-v1/recurrence-lucas/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/recurrence-lucas/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/recurrence-lucas" \
       jacobian.checksum="80603c9f54ea5659d5fb1013c4355679997d3a905c98404e651ff4657e2bd2d6"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/recurrence-lucas"'

--- a/benchmarks/datasets/public-reproductions-v1/recurrence-lucas/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/recurrence-lucas/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/recurrence-lucas" \
-      jacobian.checksum="b3d1428650c6775f9622cd62662e7384c108334168f70738c70bfbe699d95394"
+      jacobian.checksum="80603c9f54ea5659d5fb1013c4355679997d3a905c98404e651ff4657e2bd2d6"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/public-reproductions-v1/recurrence-lucas/tests/public_contract.json
+++ b/benchmarks/datasets/public-reproductions-v1/recurrence-lucas/tests/public_contract.json
@@ -1,0 +1,78 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "TRUE"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "selected_capability": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "selected_capability"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/recurrence-lucas complete finite input"
+      },
+      "task_id": {
+        "const": "jacobian/recurrence-lucas"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/public-reproductions-v1/recurrence-lucas/tests/verifier.py
+++ b/benchmarks/datasets/public-reproductions-v1/recurrence-lucas/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -34,10 +35,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/public-reproductions-v1/recurrence-lucas/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/recurrence-lucas/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/public-reproductions-v1/recurrence-rational-series/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/recurrence-rational-series/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/recurrence-rational-series" \
       jacobian.checksum="80603c9f54ea5659d5fb1013c4355679997d3a905c98404e651ff4657e2bd2d6"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/recurrence-rational-series"'

--- a/benchmarks/datasets/public-reproductions-v1/recurrence-rational-series/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/recurrence-rational-series/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/recurrence-rational-series" \
-      jacobian.checksum="b3d1428650c6775f9622cd62662e7384c108334168f70738c70bfbe699d95394"
+      jacobian.checksum="80603c9f54ea5659d5fb1013c4355679997d3a905c98404e651ff4657e2bd2d6"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/public-reproductions-v1/recurrence-rational-series/tests/public_contract.json
+++ b/benchmarks/datasets/public-reproductions-v1/recurrence-rational-series/tests/public_contract.json
@@ -1,0 +1,78 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "TRUE"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "selected_capability": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "selected_capability"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/recurrence-rational-series complete finite input"
+      },
+      "task_id": {
+        "const": "jacobian/recurrence-rational-series"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/public-reproductions-v1/recurrence-rational-series/tests/verifier.py
+++ b/benchmarks/datasets/public-reproductions-v1/recurrence-rational-series/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -34,10 +35,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/public-reproductions-v1/recurrence-rational-series/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/recurrence-rational-series/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/public-reproductions-v1/reduced-point/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/reduced-point/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/reduced-point" \
-      jacobian.checksum="51c25c2a23b76b2d318122a0e3f85fa950185ec1ec426a8aac5729c902e8056f"
+      jacobian.checksum="9b5c570091f3a90005301fc96b1c14ec7283798411d4e5e7199453f2df1e7641"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/public-reproductions-v1/reduced-point/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/reduced-point/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/reduced-point" \
       jacobian.checksum="9b5c570091f3a90005301fc96b1c14ec7283798411d4e5e7199453f2df1e7641"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/reduced-point"'

--- a/benchmarks/datasets/public-reproductions-v1/reduced-point/tests/public_contract.json
+++ b/benchmarks/datasets/public-reproductions-v1/reduced-point/tests/public_contract.json
@@ -1,0 +1,91 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "TRUE"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "free_ranks": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "torsion": {
+            "items": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "free_ranks",
+          "torsion"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/reduced-point complete finite input"
+      },
+      "task_id": {
+        "const": "jacobian/reduced-point"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/public-reproductions-v1/reduced-point/tests/verifier.py
+++ b/benchmarks/datasets/public-reproductions-v1/reduced-point/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -18,9 +19,13 @@ def _math(s, x, e):
     tor = r.get("torsion")
     if not isinstance(fr, list) or not isinstance(tor, list):
         return False
-    return [int(v) for v in fr] == [int(v) for v in e["expected_free_ranks"]] and [
-        [str(v) for v in row] for row in tor
-    ] == [[str(v) for v in row] for row in e["expected_torsion"]]
+    if not all(type(v) is int for v in fr):
+        return False
+    if fr != e["expected_free_ranks"]:
+        return False
+    return [[str(v) for v in row] for row in tor] == [
+        [str(v) for v in row] for row in e["expected_torsion"]
+    ]
 
 
 def main():
@@ -40,10 +45,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/public-reproductions-v1/reduced-point/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/reduced-point/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/public-reproductions-v1/reliability-series-path/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/reliability-series-path/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/reliability-series-path" \
       jacobian.checksum="fa251bc1ee598db6f9549f6d1ac60c8f1fc72137ea31afa7da2e9c2b33005f0a"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/reliability-series-path"'

--- a/benchmarks/datasets/public-reproductions-v1/reliability-series-path/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/reliability-series-path/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/reliability-series-path" \
-      jacobian.checksum="3ee4d9fb98720445d7d07eb44b7ea76deb80cba64e6a0586de06bbc98dd7eced"
+      jacobian.checksum="fa251bc1ee598db6f9549f6d1ac60c8f1fc72137ea31afa7da2e9c2b33005f0a"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/public-reproductions-v1/reliability-series-path/tests/public_contract.json
+++ b/benchmarks/datasets/public-reproductions-v1/reliability-series-path/tests/public_contract.json
@@ -1,0 +1,95 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "TRUE"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "probability": {
+            "additionalProperties": false,
+            "properties": {
+              "den": {
+                "type": "string"
+              },
+              "num": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "num",
+              "den"
+            ],
+            "type": "object"
+          },
+          "states": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "probability",
+          "states"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/reliability-series-path complete finite input"
+      },
+      "task_id": {
+        "const": "jacobian/reliability-series-path"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/public-reproductions-v1/reliability-series-path/tests/verifier.py
+++ b/benchmarks/datasets/public-reproductions-v1/reliability-series-path/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -23,13 +24,12 @@ def _frac(v):
 
 def _math(s, x, e):
     r = s.get("result", {})
-    try:
-        states = int(r.get("states"))
-    except (TypeError, ValueError):
+    states = r.get("states")
+    if type(states) is not int:
         return False
     return _frac(r.get("probability")) == _frac(
         e["expected_probability"]
-    ) and states == int(e["expected_states"])
+    ) and states == e["expected_states"]
 
 
 def main():
@@ -49,10 +49,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/public-reproductions-v1/reliability-series-path/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/reliability-series-path/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/public-reproductions-v1/reliability-single-edge/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/reliability-single-edge/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/reliability-single-edge" \
       jacobian.checksum="fa251bc1ee598db6f9549f6d1ac60c8f1fc72137ea31afa7da2e9c2b33005f0a"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/reliability-single-edge"'

--- a/benchmarks/datasets/public-reproductions-v1/reliability-single-edge/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/reliability-single-edge/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/reliability-single-edge" \
-      jacobian.checksum="3ee4d9fb98720445d7d07eb44b7ea76deb80cba64e6a0586de06bbc98dd7eced"
+      jacobian.checksum="fa251bc1ee598db6f9549f6d1ac60c8f1fc72137ea31afa7da2e9c2b33005f0a"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/public-reproductions-v1/reliability-single-edge/tests/public_contract.json
+++ b/benchmarks/datasets/public-reproductions-v1/reliability-single-edge/tests/public_contract.json
@@ -1,0 +1,95 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "TRUE"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "probability": {
+            "additionalProperties": false,
+            "properties": {
+              "den": {
+                "type": "string"
+              },
+              "num": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "num",
+              "den"
+            ],
+            "type": "object"
+          },
+          "states": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "probability",
+          "states"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/reliability-single-edge complete finite input"
+      },
+      "task_id": {
+        "const": "jacobian/reliability-single-edge"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/public-reproductions-v1/reliability-single-edge/tests/verifier.py
+++ b/benchmarks/datasets/public-reproductions-v1/reliability-single-edge/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -23,13 +24,12 @@ def _frac(v):
 
 def _math(s, x, e):
     r = s.get("result", {})
-    try:
-        states = int(r.get("states"))
-    except (TypeError, ValueError):
+    states = r.get("states")
+    if type(states) is not int:
         return False
     return _frac(r.get("probability")) == _frac(
         e["expected_probability"]
-    ) and states == int(e["expected_states"])
+    ) and states == e["expected_states"]
 
 
 def main():
@@ -49,10 +49,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/public-reproductions-v1/reliability-single-edge/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/reliability-single-edge/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/public-reproductions-v1/reliability-triangle-fair/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/reliability-triangle-fair/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/reliability-triangle-fair" \
-      jacobian.checksum="df026af4633cbea6bfd0c2fef250472028be44729cd5a0166150315ec17b2b60"
+      jacobian.checksum="12b5c0d8a273225a6de23a4c9acb9d010b9230aa318cc467ee7e4d74aa94a06c"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/public-reproductions-v1/reliability-triangle-fair/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/reliability-triangle-fair/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/reliability-triangle-fair" \
       jacobian.checksum="12b5c0d8a273225a6de23a4c9acb9d010b9230aa318cc467ee7e4d74aa94a06c"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/reliability-triangle-fair"'

--- a/benchmarks/datasets/public-reproductions-v1/reliability-triangle-fair/tests/public_contract.json
+++ b/benchmarks/datasets/public-reproductions-v1/reliability-triangle-fair/tests/public_contract.json
@@ -1,0 +1,95 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "TRUE"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "probability": {
+            "additionalProperties": false,
+            "properties": {
+              "den": {
+                "type": "string"
+              },
+              "num": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "num",
+              "den"
+            ],
+            "type": "object"
+          },
+          "states": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "probability",
+          "states"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/reliability-triangle-fair complete finite input"
+      },
+      "task_id": {
+        "const": "jacobian/reliability-triangle-fair"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/public-reproductions-v1/reliability-triangle-fair/tests/verifier.py
+++ b/benchmarks/datasets/public-reproductions-v1/reliability-triangle-fair/tests/verifier.py
@@ -4,6 +4,7 @@ from itertools import product
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -141,10 +142,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/public-reproductions-v1/reliability-triangle-fair/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/reliability-triangle-fair/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/public-reproductions-v1/sat-bool-mus/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/sat-bool-mus/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/sat-bool-mus" \
-      jacobian.checksum="c285051ab516ef9e85d3dee2c5482eb01a0d30ff12d1dba510e2405d1277387a"
+      jacobian.checksum="f8e6f1bd8d9d19446c2bc81a1a349dc6a3c9fa446456b6fa020785fb07eb00de"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/public-reproductions-v1/sat-bool-mus/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/sat-bool-mus/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/sat-bool-mus" \
       jacobian.checksum="f8e6f1bd8d9d19446c2bc81a1a349dc6a3c9fa446456b6fa020785fb07eb00de"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/sat-bool-mus"'

--- a/benchmarks/datasets/public-reproductions-v1/sat-bool-mus/tests/public_contract.json
+++ b/benchmarks/datasets/public-reproductions-v1/sat-bool-mus/tests/public_contract.json
@@ -1,0 +1,97 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "UNSATISFIABLE"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "assignment": {
+            "additionalProperties": true,
+            "properties": {
+              "x": {
+                "type": "boolean"
+              },
+              "y": {
+                "type": "boolean"
+              },
+              "z": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "status": {
+            "enum": [
+              "SATISFIABLE",
+              "UNSATISFIABLE"
+            ]
+          }
+        },
+        "required": [
+          "status",
+          "assignment"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/sat-bool-mus complete finite input"
+      },
+      "task_id": {
+        "const": "jacobian/sat-bool-mus"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/public-reproductions-v1/sat-bool-mus/tests/verifier.py
+++ b/benchmarks/datasets/public-reproductions-v1/sat-bool-mus/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -68,10 +69,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/public-reproductions-v1/sat-bool-mus/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/sat-bool-mus/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/public-reproductions-v1/sat-erdos-schur-f4/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/sat-erdos-schur-f4/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/sat-erdos-schur-f4" \
-      jacobian.checksum="292e904c21defea54001ee2094d33883e09f98930867c1d5e5151e6c3c9a7018"
+      jacobian.checksum="67ce7a8c8edd96ab1fac17fbc64ab3020cd54a8ae56da4d01e3220beb900d387"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/public-reproductions-v1/sat-erdos-schur-f4/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/sat-erdos-schur-f4/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/sat-erdos-schur-f4" \
       jacobian.checksum="67ce7a8c8edd96ab1fac17fbc64ab3020cd54a8ae56da4d01e3220beb900d387"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/sat-erdos-schur-f4"'

--- a/benchmarks/datasets/public-reproductions-v1/sat-erdos-schur-f4/tests/public_contract.json
+++ b/benchmarks/datasets/public-reproductions-v1/sat-erdos-schur-f4/tests/public_contract.json
@@ -1,0 +1,98 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "TRUE"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "f_value": {
+            "type": "integer"
+          },
+          "lower_bound_partition": {
+            "items": {
+              "items": {
+                "maximum": 44,
+                "minimum": 1,
+                "type": "integer"
+              },
+              "minItems": 1,
+              "type": "array",
+              "uniqueItems": true
+            },
+            "maxItems": 4,
+            "minItems": 4,
+            "type": "array"
+          },
+          "upper_bound_method": {
+            "const": "INDEPENDENT_EXHAUSTIVE_CSP"
+          }
+        },
+        "required": [
+          "f_value",
+          "lower_bound_partition",
+          "upper_bound_method"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/sat-erdos-schur-f4 complete finite input"
+      },
+      "task_id": {
+        "const": "jacobian/sat-erdos-schur-f4"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/public-reproductions-v1/sat-erdos-schur-f4/tests/verifier.py
+++ b/benchmarks/datasets/public-reproductions-v1/sat-erdos-schur-f4/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -230,10 +231,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/public-reproductions-v1/sat-erdos-schur-f4/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/sat-erdos-schur-f4/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/public-reproductions-v1/sat-pigeonhole/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/sat-pigeonhole/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/sat-pigeonhole" \
       jacobian.checksum="f8e6f1bd8d9d19446c2bc81a1a349dc6a3c9fa446456b6fa020785fb07eb00de"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/sat-pigeonhole"'

--- a/benchmarks/datasets/public-reproductions-v1/sat-pigeonhole/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/sat-pigeonhole/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/sat-pigeonhole" \
-      jacobian.checksum="c285051ab516ef9e85d3dee2c5482eb01a0d30ff12d1dba510e2405d1277387a"
+      jacobian.checksum="f8e6f1bd8d9d19446c2bc81a1a349dc6a3c9fa446456b6fa020785fb07eb00de"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/public-reproductions-v1/sat-pigeonhole/tests/public_contract.json
+++ b/benchmarks/datasets/public-reproductions-v1/sat-pigeonhole/tests/public_contract.json
@@ -1,0 +1,106 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "UNSATISFIABLE"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "assignment": {
+            "additionalProperties": true,
+            "properties": {
+              "p1h1": {
+                "type": "boolean"
+              },
+              "p1h2": {
+                "type": "boolean"
+              },
+              "p2h1": {
+                "type": "boolean"
+              },
+              "p2h2": {
+                "type": "boolean"
+              },
+              "p3h1": {
+                "type": "boolean"
+              },
+              "p3h2": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "status": {
+            "enum": [
+              "SATISFIABLE",
+              "UNSATISFIABLE"
+            ]
+          }
+        },
+        "required": [
+          "status",
+          "assignment"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/sat-pigeonhole complete finite input"
+      },
+      "task_id": {
+        "const": "jacobian/sat-pigeonhole"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/public-reproductions-v1/sat-pigeonhole/tests/verifier.py
+++ b/benchmarks/datasets/public-reproductions-v1/sat-pigeonhole/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -68,10 +69,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/public-reproductions-v1/sat-pigeonhole/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/sat-pigeonhole/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/public-reproductions-v1/sat-small/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/sat-small/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/sat-small" \
-      jacobian.checksum="c285051ab516ef9e85d3dee2c5482eb01a0d30ff12d1dba510e2405d1277387a"
+      jacobian.checksum="f8e6f1bd8d9d19446c2bc81a1a349dc6a3c9fa446456b6fa020785fb07eb00de"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/public-reproductions-v1/sat-small/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/sat-small/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/sat-small" \
       jacobian.checksum="f8e6f1bd8d9d19446c2bc81a1a349dc6a3c9fa446456b6fa020785fb07eb00de"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/sat-small"'

--- a/benchmarks/datasets/public-reproductions-v1/sat-small/tests/public_contract.json
+++ b/benchmarks/datasets/public-reproductions-v1/sat-small/tests/public_contract.json
@@ -1,0 +1,102 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "SATISFIABLE"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "assignment": {
+            "additionalProperties": false,
+            "properties": {
+              "a": {
+                "type": "boolean"
+              },
+              "b": {
+                "type": "boolean"
+              },
+              "c": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "a",
+              "b",
+              "c"
+            ],
+            "type": "object"
+          },
+          "status": {
+            "enum": [
+              "SATISFIABLE",
+              "UNSATISFIABLE"
+            ]
+          }
+        },
+        "required": [
+          "status",
+          "assignment"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/sat-small complete finite input"
+      },
+      "task_id": {
+        "const": "jacobian/sat-small"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/public-reproductions-v1/sat-small/tests/verifier.py
+++ b/benchmarks/datasets/public-reproductions-v1/sat-small/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -68,10 +69,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/public-reproductions-v1/sat-small/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/sat-small/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/public-reproductions-v1/smith-rank-deficient/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/smith-rank-deficient/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/smith-rank-deficient" \
       jacobian.checksum="e444996859778f0bff329351071e066259f6634a8a9cb381fc80471bb2d5162f"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/smith-rank-deficient"'

--- a/benchmarks/datasets/public-reproductions-v1/smith-rank-deficient/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/smith-rank-deficient/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/smith-rank-deficient" \
-      jacobian.checksum="669ed95b67d7057c6de194c9f0d385b2cca084d7f618e785d0f03b70754ee351"
+      jacobian.checksum="e444996859778f0bff329351071e066259f6634a8a9cb381fc80471bb2d5162f"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/public-reproductions-v1/smith-rank-deficient/tests/public_contract.json
+++ b/benchmarks/datasets/public-reproductions-v1/smith-rank-deficient/tests/public_contract.json
@@ -1,0 +1,85 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "TRUE"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "invariant_factors": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "rank": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "rank",
+          "invariant_factors"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/smith-rank-deficient complete finite input"
+      },
+      "task_id": {
+        "const": "jacobian/smith-rank-deficient"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/public-reproductions-v1/smith-rank-deficient/tests/verifier.py
+++ b/benchmarks/datasets/public-reproductions-v1/smith-rank-deficient/tests/verifier.py
@@ -3,6 +3,7 @@ import math
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -77,10 +78,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/public-reproductions-v1/smith-rank-deficient/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/smith-rank-deficient/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/public-reproductions-v1/smith-rectangular/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/smith-rectangular/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/smith-rectangular" \
       jacobian.checksum="469bf05653b8a2d0399a19aead84889d6a101642d099a126b9ac870bfe748441"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/smith-rectangular"'

--- a/benchmarks/datasets/public-reproductions-v1/smith-rectangular/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/smith-rectangular/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/smith-rectangular" \
-      jacobian.checksum="f7cd94c2e1600edc63b69f3b5da9c69ab4b68e0d86e7f54ecb750b76b2316c51"
+      jacobian.checksum="469bf05653b8a2d0399a19aead84889d6a101642d099a126b9ac870bfe748441"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/public-reproductions-v1/smith-rectangular/tests/public_contract.json
+++ b/benchmarks/datasets/public-reproductions-v1/smith-rectangular/tests/public_contract.json
@@ -1,0 +1,85 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "TRUE"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "invariant_factors": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "rank": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "rank",
+          "invariant_factors"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/smith-rectangular complete finite input"
+      },
+      "task_id": {
+        "const": "jacobian/smith-rectangular"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/public-reproductions-v1/smith-rectangular/tests/verifier.py
+++ b/benchmarks/datasets/public-reproductions-v1/smith-rectangular/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -14,9 +15,8 @@ ALLOWED = frozenset({"UNVERIFIED", "COMPUTED", "CHECKED"})
 
 def _math(s, x, e):
     r = s.get("result", {})
-    try:
-        rank = int(r.get("rank"))
-    except (TypeError, ValueError):
+    rank = r.get("rank")
+    if type(rank) is not int:
         return False
     ifs = r.get("invariant_factors")
     return (
@@ -43,10 +43,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/public-reproductions-v1/smith-rectangular/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/smith-rectangular/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/public-reproductions-v1/superposition-proof-replay/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/superposition-proof-replay/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/public-reproductions-v1/symmetry-colored-reflection/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/symmetry-colored-reflection/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/symmetry-colored-reflection" \
-      jacobian.checksum="d6c1bb9a7a21b79cbd3f6f51dbe1f63664e2589fa512199e0de1965b27400031"
+      jacobian.checksum="dd05dad47b7a7aba1bd0e704df082754ed1ed96d892d58173834d27c2dab0a0d"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/public-reproductions-v1/symmetry-colored-reflection/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/symmetry-colored-reflection/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/symmetry-colored-reflection" \
       jacobian.checksum="dd05dad47b7a7aba1bd0e704df082754ed1ed96d892d58173834d27c2dab0a0d"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/symmetry-colored-reflection"'

--- a/benchmarks/datasets/public-reproductions-v1/symmetry-colored-reflection/tests/public_contract.json
+++ b/benchmarks/datasets/public-reproductions-v1/symmetry-colored-reflection/tests/public_contract.json
@@ -1,0 +1,97 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "TRUE"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "edge_orbits": {
+            "items": {
+              "items": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "type": "array"
+          },
+          "vertex_orbits": {
+            "items": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "vertex_orbits",
+          "edge_orbits"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/symmetry-colored-reflection complete finite input"
+      },
+      "task_id": {
+        "const": "jacobian/symmetry-colored-reflection"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/public-reproductions-v1/symmetry-colored-reflection/tests/verifier.py
+++ b/benchmarks/datasets/public-reproductions-v1/symmetry-colored-reflection/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -140,10 +141,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/public-reproductions-v1/symmetry-colored-reflection/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/symmetry-colored-reflection/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/public-reproductions-v1/symmetry-cycle-rotation/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/symmetry-cycle-rotation/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/symmetry-cycle-rotation" \
       jacobian.checksum="f6c168c638944c20a4294ba01a34bc92fea9e0e759401dd81d7b3ded3b82738b"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/symmetry-cycle-rotation"'

--- a/benchmarks/datasets/public-reproductions-v1/symmetry-cycle-rotation/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/symmetry-cycle-rotation/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/symmetry-cycle-rotation" \
-      jacobian.checksum="9f6730a573f8f7f014fc669cfb227e4f4010233d22bc9519226417709dc6fe01"
+      jacobian.checksum="f6c168c638944c20a4294ba01a34bc92fea9e0e759401dd81d7b3ded3b82738b"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/public-reproductions-v1/symmetry-cycle-rotation/tests/public_contract.json
+++ b/benchmarks/datasets/public-reproductions-v1/symmetry-cycle-rotation/tests/public_contract.json
@@ -1,0 +1,97 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "TRUE"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "edge_orbits": {
+            "items": {
+              "items": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "type": "array"
+          },
+          "vertex_orbits": {
+            "items": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "vertex_orbits",
+          "edge_orbits"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/symmetry-cycle-rotation complete finite input"
+      },
+      "task_id": {
+        "const": "jacobian/symmetry-cycle-rotation"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/public-reproductions-v1/symmetry-cycle-rotation/tests/verifier.py
+++ b/benchmarks/datasets/public-reproductions-v1/symmetry-cycle-rotation/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -51,10 +52,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/public-reproductions-v1/symmetry-cycle-rotation/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/symmetry-cycle-rotation/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/public-reproductions-v1/symmetry-identity-subgroup/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/symmetry-identity-subgroup/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/symmetry-identity-subgroup" \
-      jacobian.checksum="9f6730a573f8f7f014fc669cfb227e4f4010233d22bc9519226417709dc6fe01"
+      jacobian.checksum="f6c168c638944c20a4294ba01a34bc92fea9e0e759401dd81d7b3ded3b82738b"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/public-reproductions-v1/symmetry-identity-subgroup/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/symmetry-identity-subgroup/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/symmetry-identity-subgroup" \
       jacobian.checksum="f6c168c638944c20a4294ba01a34bc92fea9e0e759401dd81d7b3ded3b82738b"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/symmetry-identity-subgroup"'

--- a/benchmarks/datasets/public-reproductions-v1/symmetry-identity-subgroup/tests/public_contract.json
+++ b/benchmarks/datasets/public-reproductions-v1/symmetry-identity-subgroup/tests/public_contract.json
@@ -1,0 +1,97 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "TRUE"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "edge_orbits": {
+            "items": {
+              "items": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "type": "array"
+          },
+          "vertex_orbits": {
+            "items": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "vertex_orbits",
+          "edge_orbits"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/symmetry-identity-subgroup complete finite input"
+      },
+      "task_id": {
+        "const": "jacobian/symmetry-identity-subgroup"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/public-reproductions-v1/symmetry-identity-subgroup/tests/verifier.py
+++ b/benchmarks/datasets/public-reproductions-v1/symmetry-identity-subgroup/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -51,10 +52,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/public-reproductions-v1/symmetry-identity-subgroup/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/symmetry-identity-subgroup/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-001/tests/Dockerfile
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-001/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/jcb-postdoc-001" \
       jacobian.checksum="d5ded0b4a38d4d9a0c946db0efce8604978caa0e5257be873040f1a9cfcb14ba"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/jcb-postdoc-001"'

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-001/tests/Dockerfile
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-001/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/jcb-postdoc-001" \
-      jacobian.checksum="036916f67f2869783afe5e91109a14b7c64d387880355e484f15f90ecad561fc"
+      jacobian.checksum="d5ded0b4a38d4d9a0c946db0efce8604978caa0e5257be873040f1a9cfcb14ba"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-001/tests/public_contract.json
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-001/tests/public_contract.json
@@ -1,0 +1,98 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "DISPROVED"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "answer_visible_summary": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "boundary_statement": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "expected_conclusion": {
+            "enum": [
+              "PROVED",
+              "DISPROVED",
+              "COUNTEREXAMPLE_EXISTS",
+              "EXACT_IDENTITY",
+              "NO_GLOBAL_CONCLUSION"
+            ]
+          },
+          "key_facts": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "expected_conclusion",
+          "answer_visible_summary",
+          "boundary_statement",
+          "key_facts"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/jcb-postdoc-001 answer-visible diagnostic"
+      },
+      "task_id": {
+        "const": "jacobian/jcb-postdoc-001"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-001/tests/verifier.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-001/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -9,7 +10,7 @@ from verifier_support import (
 
 W = Path("/app")
 E = Path("/tests")
-ALLOWED = frozenset({"UNVERIFIED", "COMPUTED", "CHECKED"})
+ALLOWED = frozenset({"UNVERIFIED", "COMPUTED"})
 
 
 def _math(s, x, e):
@@ -48,10 +49,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-001/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-001/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-002/tests/Dockerfile
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-002/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/jcb-postdoc-002" \
       jacobian.checksum="d5ded0b4a38d4d9a0c946db0efce8604978caa0e5257be873040f1a9cfcb14ba"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/jcb-postdoc-002"'

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-002/tests/Dockerfile
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-002/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/jcb-postdoc-002" \
-      jacobian.checksum="036916f67f2869783afe5e91109a14b7c64d387880355e484f15f90ecad561fc"
+      jacobian.checksum="d5ded0b4a38d4d9a0c946db0efce8604978caa0e5257be873040f1a9cfcb14ba"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-002/tests/public_contract.json
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-002/tests/public_contract.json
@@ -1,0 +1,98 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "COUNTEREXAMPLE_EXISTS"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "answer_visible_summary": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "boundary_statement": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "expected_conclusion": {
+            "enum": [
+              "PROVED",
+              "DISPROVED",
+              "COUNTEREXAMPLE_EXISTS",
+              "EXACT_IDENTITY",
+              "NO_GLOBAL_CONCLUSION"
+            ]
+          },
+          "key_facts": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "expected_conclusion",
+          "answer_visible_summary",
+          "boundary_statement",
+          "key_facts"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/jcb-postdoc-002 answer-visible diagnostic"
+      },
+      "task_id": {
+        "const": "jacobian/jcb-postdoc-002"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-002/tests/verifier.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-002/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -9,7 +10,7 @@ from verifier_support import (
 
 W = Path("/app")
 E = Path("/tests")
-ALLOWED = frozenset({"UNVERIFIED", "COMPUTED", "CHECKED"})
+ALLOWED = frozenset({"UNVERIFIED", "COMPUTED"})
 
 
 def _math(s, x, e):
@@ -48,10 +49,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-002/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-002/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-003/tests/Dockerfile
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-003/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/jcb-postdoc-003" \
-      jacobian.checksum="036916f67f2869783afe5e91109a14b7c64d387880355e484f15f90ecad561fc"
+      jacobian.checksum="d5ded0b4a38d4d9a0c946db0efce8604978caa0e5257be873040f1a9cfcb14ba"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-003/tests/Dockerfile
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-003/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/jcb-postdoc-003" \
       jacobian.checksum="d5ded0b4a38d4d9a0c946db0efce8604978caa0e5257be873040f1a9cfcb14ba"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/jcb-postdoc-003"'

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-003/tests/public_contract.json
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-003/tests/public_contract.json
@@ -1,0 +1,98 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "DISPROVED"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "answer_visible_summary": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "boundary_statement": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "expected_conclusion": {
+            "enum": [
+              "PROVED",
+              "DISPROVED",
+              "COUNTEREXAMPLE_EXISTS",
+              "EXACT_IDENTITY",
+              "NO_GLOBAL_CONCLUSION"
+            ]
+          },
+          "key_facts": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "expected_conclusion",
+          "answer_visible_summary",
+          "boundary_statement",
+          "key_facts"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/jcb-postdoc-003 answer-visible diagnostic"
+      },
+      "task_id": {
+        "const": "jacobian/jcb-postdoc-003"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-003/tests/verifier.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-003/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -9,7 +10,7 @@ from verifier_support import (
 
 W = Path("/app")
 E = Path("/tests")
-ALLOWED = frozenset({"UNVERIFIED", "COMPUTED", "CHECKED"})
+ALLOWED = frozenset({"UNVERIFIED", "COMPUTED"})
 
 
 def _math(s, x, e):
@@ -48,10 +49,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-003/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-003/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-004/tests/Dockerfile
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-004/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/jcb-postdoc-004" \
       jacobian.checksum="b8cb51e98bb9748ab72ba71159a95f7e1886b624d30a3fc8e58c87ecf1ecdd98"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/jcb-postdoc-004"'

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-004/tests/public_contract.json
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-004/tests/public_contract.json
@@ -1,0 +1,112 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "const": "COMPUTED"
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "COUNTEREXAMPLE_EXISTS"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/counterexample.json"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "const": [
+          "PUBLIC_ANSWER_VISIBLE",
+          "BENCHMARK_VERIFIER_NOT_PRODUCT_AUTHORITY"
+        ]
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "certificate_path": {
+            "const": "evidence/counterexample.json"
+          },
+          "hamiltonian_path_exists": {
+            "const": false
+          },
+          "independence_number": {
+            "maximum": 20,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "local_average": {
+            "additionalProperties": false,
+            "properties": {
+              "denominator": {
+                "maximum": 20,
+                "minimum": 1,
+                "type": "integer"
+              },
+              "numerator": {
+                "maximum": 400,
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "numerator",
+              "denominator"
+            ],
+            "type": "object"
+          },
+          "vertex_count": {
+            "maximum": 20,
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "certificate_path",
+          "vertex_count",
+          "independence_number",
+          "local_average",
+          "hamiltonian_path_exists"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/jcb-postdoc-004 public answer-visible witness with at most 20 vertices"
+      },
+      "task_id": {
+        "const": "jacobian/jcb-postdoc-004"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-004/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-004/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-005/tests/Dockerfile
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-005/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/jcb-postdoc-005" \
-      jacobian.checksum="036916f67f2869783afe5e91109a14b7c64d387880355e484f15f90ecad561fc"
+      jacobian.checksum="d5ded0b4a38d4d9a0c946db0efce8604978caa0e5257be873040f1a9cfcb14ba"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-005/tests/Dockerfile
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-005/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/jcb-postdoc-005" \
       jacobian.checksum="d5ded0b4a38d4d9a0c946db0efce8604978caa0e5257be873040f1a9cfcb14ba"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/jcb-postdoc-005"'

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-005/tests/public_contract.json
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-005/tests/public_contract.json
@@ -1,0 +1,98 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "EXACT_IDENTITY"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "answer_visible_summary": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "boundary_statement": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "expected_conclusion": {
+            "enum": [
+              "PROVED",
+              "DISPROVED",
+              "COUNTEREXAMPLE_EXISTS",
+              "EXACT_IDENTITY",
+              "NO_GLOBAL_CONCLUSION"
+            ]
+          },
+          "key_facts": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "expected_conclusion",
+          "answer_visible_summary",
+          "boundary_statement",
+          "key_facts"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/jcb-postdoc-005 answer-visible diagnostic"
+      },
+      "task_id": {
+        "const": "jacobian/jcb-postdoc-005"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-005/tests/verifier.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-005/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -9,7 +10,7 @@ from verifier_support import (
 
 W = Path("/app")
 E = Path("/tests")
-ALLOWED = frozenset({"UNVERIFIED", "COMPUTED", "CHECKED"})
+ALLOWED = frozenset({"UNVERIFIED", "COMPUTED"})
 
 
 def _math(s, x, e):
@@ -48,10 +49,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-005/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-005/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-006/tests/Dockerfile
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-006/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/jcb-postdoc-006" \
       jacobian.checksum="d5ded0b4a38d4d9a0c946db0efce8604978caa0e5257be873040f1a9cfcb14ba"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/jcb-postdoc-006"'

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-006/tests/Dockerfile
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-006/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/jcb-postdoc-006" \
-      jacobian.checksum="036916f67f2869783afe5e91109a14b7c64d387880355e484f15f90ecad561fc"
+      jacobian.checksum="d5ded0b4a38d4d9a0c946db0efce8604978caa0e5257be873040f1a9cfcb14ba"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-006/tests/public_contract.json
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-006/tests/public_contract.json
@@ -1,0 +1,98 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "COUNTEREXAMPLE_EXISTS"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "answer_visible_summary": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "boundary_statement": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "expected_conclusion": {
+            "enum": [
+              "PROVED",
+              "DISPROVED",
+              "COUNTEREXAMPLE_EXISTS",
+              "EXACT_IDENTITY",
+              "NO_GLOBAL_CONCLUSION"
+            ]
+          },
+          "key_facts": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "expected_conclusion",
+          "answer_visible_summary",
+          "boundary_statement",
+          "key_facts"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/jcb-postdoc-006 answer-visible diagnostic"
+      },
+      "task_id": {
+        "const": "jacobian/jcb-postdoc-006"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-006/tests/verifier.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-006/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -9,7 +10,7 @@ from verifier_support import (
 
 W = Path("/app")
 E = Path("/tests")
-ALLOWED = frozenset({"UNVERIFIED", "COMPUTED", "CHECKED"})
+ALLOWED = frozenset({"UNVERIFIED", "COMPUTED"})
 
 
 def _math(s, x, e):
@@ -48,10 +49,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-006/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-006/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-007/tests/Dockerfile
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-007/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/jcb-postdoc-007" \
-      jacobian.checksum="036916f67f2869783afe5e91109a14b7c64d387880355e484f15f90ecad561fc"
+      jacobian.checksum="d5ded0b4a38d4d9a0c946db0efce8604978caa0e5257be873040f1a9cfcb14ba"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-007/tests/Dockerfile
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-007/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/jcb-postdoc-007" \
       jacobian.checksum="d5ded0b4a38d4d9a0c946db0efce8604978caa0e5257be873040f1a9cfcb14ba"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/jcb-postdoc-007"'

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-007/tests/public_contract.json
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-007/tests/public_contract.json
@@ -1,0 +1,98 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "DISPROVED"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "answer_visible_summary": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "boundary_statement": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "expected_conclusion": {
+            "enum": [
+              "PROVED",
+              "DISPROVED",
+              "COUNTEREXAMPLE_EXISTS",
+              "EXACT_IDENTITY",
+              "NO_GLOBAL_CONCLUSION"
+            ]
+          },
+          "key_facts": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "expected_conclusion",
+          "answer_visible_summary",
+          "boundary_statement",
+          "key_facts"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/jcb-postdoc-007 answer-visible diagnostic"
+      },
+      "task_id": {
+        "const": "jacobian/jcb-postdoc-007"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-007/tests/verifier.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-007/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -9,7 +10,7 @@ from verifier_support import (
 
 W = Path("/app")
 E = Path("/tests")
-ALLOWED = frozenset({"UNVERIFIED", "COMPUTED", "CHECKED"})
+ALLOWED = frozenset({"UNVERIFIED", "COMPUTED"})
 
 
 def _math(s, x, e):
@@ -48,10 +49,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-007/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-007/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-008/tests/Dockerfile
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-008/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/jcb-postdoc-008" \
       jacobian.checksum="d5ded0b4a38d4d9a0c946db0efce8604978caa0e5257be873040f1a9cfcb14ba"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/jcb-postdoc-008"'

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-008/tests/Dockerfile
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-008/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/jcb-postdoc-008" \
-      jacobian.checksum="036916f67f2869783afe5e91109a14b7c64d387880355e484f15f90ecad561fc"
+      jacobian.checksum="d5ded0b4a38d4d9a0c946db0efce8604978caa0e5257be873040f1a9cfcb14ba"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-008/tests/public_contract.json
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-008/tests/public_contract.json
@@ -1,0 +1,98 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "EXACT_IDENTITY"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "answer_visible_summary": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "boundary_statement": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "expected_conclusion": {
+            "enum": [
+              "PROVED",
+              "DISPROVED",
+              "COUNTEREXAMPLE_EXISTS",
+              "EXACT_IDENTITY",
+              "NO_GLOBAL_CONCLUSION"
+            ]
+          },
+          "key_facts": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "expected_conclusion",
+          "answer_visible_summary",
+          "boundary_statement",
+          "key_facts"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/jcb-postdoc-008 answer-visible diagnostic"
+      },
+      "task_id": {
+        "const": "jacobian/jcb-postdoc-008"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-008/tests/verifier.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-008/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -9,7 +10,7 @@ from verifier_support import (
 
 W = Path("/app")
 E = Path("/tests")
-ALLOWED = frozenset({"UNVERIFIED", "COMPUTED", "CHECKED"})
+ALLOWED = frozenset({"UNVERIFIED", "COMPUTED"})
 
 
 def _math(s, x, e):
@@ -48,10 +49,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-008/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-008/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-009/tests/Dockerfile
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-009/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/jcb-postdoc-009" \
-      jacobian.checksum="036916f67f2869783afe5e91109a14b7c64d387880355e484f15f90ecad561fc"
+      jacobian.checksum="d5ded0b4a38d4d9a0c946db0efce8604978caa0e5257be873040f1a9cfcb14ba"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-009/tests/Dockerfile
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-009/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/jcb-postdoc-009" \
       jacobian.checksum="d5ded0b4a38d4d9a0c946db0efce8604978caa0e5257be873040f1a9cfcb14ba"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/jcb-postdoc-009"'

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-009/tests/public_contract.json
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-009/tests/public_contract.json
@@ -1,0 +1,98 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "PROVED"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "answer_visible_summary": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "boundary_statement": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "expected_conclusion": {
+            "enum": [
+              "PROVED",
+              "DISPROVED",
+              "COUNTEREXAMPLE_EXISTS",
+              "EXACT_IDENTITY",
+              "NO_GLOBAL_CONCLUSION"
+            ]
+          },
+          "key_facts": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "expected_conclusion",
+          "answer_visible_summary",
+          "boundary_statement",
+          "key_facts"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/jcb-postdoc-009 answer-visible diagnostic"
+      },
+      "task_id": {
+        "const": "jacobian/jcb-postdoc-009"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-009/tests/verifier.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-009/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -9,7 +10,7 @@ from verifier_support import (
 
 W = Path("/app")
 E = Path("/tests")
-ALLOWED = frozenset({"UNVERIFIED", "COMPUTED", "CHECKED"})
+ALLOWED = frozenset({"UNVERIFIED", "COMPUTED"})
 
 
 def _math(s, x, e):
@@ -48,10 +49,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-009/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-009/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-010/tests/Dockerfile
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-010/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/jcb-postdoc-010" \
-      jacobian.checksum="036916f67f2869783afe5e91109a14b7c64d387880355e484f15f90ecad561fc"
+      jacobian.checksum="d5ded0b4a38d4d9a0c946db0efce8604978caa0e5257be873040f1a9cfcb14ba"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-010/tests/Dockerfile
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-010/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/jcb-postdoc-010" \
       jacobian.checksum="d5ded0b4a38d4d9a0c946db0efce8604978caa0e5257be873040f1a9cfcb14ba"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/jcb-postdoc-010"'

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-010/tests/public_contract.json
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-010/tests/public_contract.json
@@ -1,0 +1,98 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "DISPROVED"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "answer_visible_summary": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "boundary_statement": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "expected_conclusion": {
+            "enum": [
+              "PROVED",
+              "DISPROVED",
+              "COUNTEREXAMPLE_EXISTS",
+              "EXACT_IDENTITY",
+              "NO_GLOBAL_CONCLUSION"
+            ]
+          },
+          "key_facts": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "expected_conclusion",
+          "answer_visible_summary",
+          "boundary_statement",
+          "key_facts"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/jcb-postdoc-010 answer-visible diagnostic"
+      },
+      "task_id": {
+        "const": "jacobian/jcb-postdoc-010"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-010/tests/verifier.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-010/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -9,7 +10,7 @@ from verifier_support import (
 
 W = Path("/app")
 E = Path("/tests")
-ALLOWED = frozenset({"UNVERIFIED", "COMPUTED", "CHECKED"})
+ALLOWED = frozenset({"UNVERIFIED", "COMPUTED"})
 
 
 def _math(s, x, e):
@@ -48,10 +49,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-010/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-010/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-011/tests/Dockerfile
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-011/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/jcb-postdoc-011" \
-      jacobian.checksum="036916f67f2869783afe5e91109a14b7c64d387880355e484f15f90ecad561fc"
+      jacobian.checksum="d5ded0b4a38d4d9a0c946db0efce8604978caa0e5257be873040f1a9cfcb14ba"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-011/tests/Dockerfile
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-011/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/jcb-postdoc-011" \
       jacobian.checksum="d5ded0b4a38d4d9a0c946db0efce8604978caa0e5257be873040f1a9cfcb14ba"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/jcb-postdoc-011"'

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-011/tests/public_contract.json
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-011/tests/public_contract.json
@@ -1,0 +1,98 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "DISPROVED"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "answer_visible_summary": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "boundary_statement": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "expected_conclusion": {
+            "enum": [
+              "PROVED",
+              "DISPROVED",
+              "COUNTEREXAMPLE_EXISTS",
+              "EXACT_IDENTITY",
+              "NO_GLOBAL_CONCLUSION"
+            ]
+          },
+          "key_facts": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "expected_conclusion",
+          "answer_visible_summary",
+          "boundary_statement",
+          "key_facts"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/jcb-postdoc-011 answer-visible diagnostic"
+      },
+      "task_id": {
+        "const": "jacobian/jcb-postdoc-011"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-011/tests/verifier.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-011/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -9,7 +10,7 @@ from verifier_support import (
 
 W = Path("/app")
 E = Path("/tests")
-ALLOWED = frozenset({"UNVERIFIED", "COMPUTED", "CHECKED"})
+ALLOWED = frozenset({"UNVERIFIED", "COMPUTED"})
 
 
 def _math(s, x, e):
@@ -48,10 +49,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-011/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-011/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-012/tests/Dockerfile
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-012/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/jcb-postdoc-012" \
-      jacobian.checksum="036916f67f2869783afe5e91109a14b7c64d387880355e484f15f90ecad561fc"
+      jacobian.checksum="d5ded0b4a38d4d9a0c946db0efce8604978caa0e5257be873040f1a9cfcb14ba"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-012/tests/Dockerfile
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-012/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/jcb-postdoc-012" \
       jacobian.checksum="d5ded0b4a38d4d9a0c946db0efce8604978caa0e5257be873040f1a9cfcb14ba"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/jcb-postdoc-012"'

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-012/tests/public_contract.json
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-012/tests/public_contract.json
@@ -1,0 +1,98 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "COUNTEREXAMPLE_EXISTS"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "answer_visible_summary": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "boundary_statement": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "expected_conclusion": {
+            "enum": [
+              "PROVED",
+              "DISPROVED",
+              "COUNTEREXAMPLE_EXISTS",
+              "EXACT_IDENTITY",
+              "NO_GLOBAL_CONCLUSION"
+            ]
+          },
+          "key_facts": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "expected_conclusion",
+          "answer_visible_summary",
+          "boundary_statement",
+          "key_facts"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/jcb-postdoc-012 answer-visible diagnostic"
+      },
+      "task_id": {
+        "const": "jacobian/jcb-postdoc-012"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-012/tests/verifier.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-012/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -9,7 +10,7 @@ from verifier_support import (
 
 W = Path("/app")
 E = Path("/tests")
-ALLOWED = frozenset({"UNVERIFIED", "COMPUTED", "CHECKED"})
+ALLOWED = frozenset({"UNVERIFIED", "COMPUTED"})
 
 
 def _math(s, x, e):
@@ -48,10 +49,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-012/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-012/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-013/tests/Dockerfile
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-013/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/jcb-postdoc-013" \
-      jacobian.checksum="036916f67f2869783afe5e91109a14b7c64d387880355e484f15f90ecad561fc"
+      jacobian.checksum="d5ded0b4a38d4d9a0c946db0efce8604978caa0e5257be873040f1a9cfcb14ba"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-013/tests/Dockerfile
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-013/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/jcb-postdoc-013" \
       jacobian.checksum="d5ded0b4a38d4d9a0c946db0efce8604978caa0e5257be873040f1a9cfcb14ba"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/jcb-postdoc-013"'

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-013/tests/public_contract.json
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-013/tests/public_contract.json
@@ -1,0 +1,98 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "DISPROVED"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "answer_visible_summary": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "boundary_statement": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "expected_conclusion": {
+            "enum": [
+              "PROVED",
+              "DISPROVED",
+              "COUNTEREXAMPLE_EXISTS",
+              "EXACT_IDENTITY",
+              "NO_GLOBAL_CONCLUSION"
+            ]
+          },
+          "key_facts": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "expected_conclusion",
+          "answer_visible_summary",
+          "boundary_statement",
+          "key_facts"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/jcb-postdoc-013 answer-visible diagnostic"
+      },
+      "task_id": {
+        "const": "jacobian/jcb-postdoc-013"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-013/tests/verifier.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-013/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -9,7 +10,7 @@ from verifier_support import (
 
 W = Path("/app")
 E = Path("/tests")
-ALLOWED = frozenset({"UNVERIFIED", "COMPUTED", "CHECKED"})
+ALLOWED = frozenset({"UNVERIFIED", "COMPUTED"})
 
 
 def _math(s, x, e):
@@ -48,10 +49,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-013/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-013/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-014/tests/Dockerfile
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-014/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/jcb-postdoc-014" \
       jacobian.checksum="251814d49ad768d3d10122293dd10f547bb81f9de1ee650f9cd921a31fb9eade"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/jcb-postdoc-014"'

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-014/tests/public_contract.json
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-014/tests/public_contract.json
@@ -1,0 +1,96 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "const": "COMPUTED"
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "DISPROVED"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/syzygy-certificate.json"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "const": [
+          "PUBLIC_ANSWER_VISIBLE",
+          "BENCHMARK_VERIFIER_NOT_PRODUCT_AUTHORITY"
+        ]
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "certificate_path": {
+            "const": "evidence/syzygy-certificate.json"
+          },
+          "mdr": {
+            "additionalProperties": false,
+            "properties": {
+              "f": {
+                "const": 4
+              },
+              "g": {
+                "const": 5
+              }
+            },
+            "required": [
+              "f",
+              "g"
+            ],
+            "type": "object"
+          },
+          "same_non_double_flats": {
+            "const": true
+          }
+        },
+        "required": [
+          "certificate_path",
+          "same_non_double_flats",
+          "mdr"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/jcb-postdoc-014 public answer-visible exact graded relation diagnostic"
+      },
+      "task_id": {
+        "const": "jacobian/jcb-postdoc-014"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-014/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-014/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-015/tests/Dockerfile
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-015/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/jcb-postdoc-015" \
       jacobian.checksum="6a214ffe909fbe457a8e8ee66fd806f8518f1a8981a6efaf3ceeadf944355e42"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/jcb-postdoc-015"'

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-015/tests/public_contract.json
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-015/tests/public_contract.json
@@ -1,0 +1,95 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "const": "COMPUTED"
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "DISPROVED"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/finite-core.json"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "const": [
+          "PUBLIC_UNIVERSAL_OBSTRUCTION_NOT_REPLAYED",
+          "FINITE_ORDERS_DO_NOT_PROVE_UNIVERSAL_RESULT"
+        ]
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "evidence_path": {
+            "const": "evidence/finite-core.json"
+          },
+          "fixed_orders_checked": {
+            "const": [
+              5,
+              6,
+              7
+            ]
+          },
+          "public_universal_result": {
+            "const": "A_IS_NOT_CONTAINED_IN_ANY_FINITE_PERFECT_DIFFERENCE_SET"
+          },
+          "sidon": {
+            "const": true
+          },
+          "universal_obstruction_replayed": {
+            "const": false
+          }
+        },
+        "required": [
+          "evidence_path",
+          "sidon",
+          "fixed_orders_checked",
+          "public_universal_result",
+          "universal_obstruction_replayed"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/jcb-postdoc-015 exact finite core for orders 5,6,7 plus public answer-visible universal result"
+      },
+      "task_id": {
+        "const": "jacobian/jcb-postdoc-015"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-015/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-015/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-016/tests/Dockerfile
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-016/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/jcb-postdoc-016" \
       jacobian.checksum="f61a04c56464461c9238033bd9922911e70bcaca015c545e495c6e1e7b2da8ee"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/jcb-postdoc-016"'

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-016/tests/public_contract.json
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-016/tests/public_contract.json
@@ -1,0 +1,109 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "const": "COMPUTED"
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "NO_GLOBAL_CONCLUSION"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/powerful-window.json"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "const": [
+          "PUBLIC_10E14_ARTIFACT_NOT_REPLAYED",
+          "FINITE_WINDOW_DOES_NOT_PROVE_UNBOUNDED_CONJECTURE"
+        ]
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "bounded_reference_replayed": {
+            "const": false
+          },
+          "checked_triple_starts": {
+            "const": [
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14"
+            ]
+          },
+          "checked_values": {
+            "const": [
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16"
+            ]
+          },
+          "evidence_path": {
+            "const": "evidence/powerful-window.json"
+          },
+          "global_conjecture_status": {
+            "const": "OPEN"
+          }
+        },
+        "required": [
+          "evidence_path",
+          "checked_values",
+          "checked_triple_starts",
+          "bounded_reference_replayed",
+          "global_conjecture_status"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/jcb-postdoc-016 exact values 8 through 16 and seven consecutive triples; public 10^14 reference not replayed"
+      },
+      "task_id": {
+        "const": "jacobian/jcb-postdoc-016"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-016/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-016/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-017/tests/Dockerfile
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-017/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/jcb-postdoc-017" \
-      jacobian.checksum="036916f67f2869783afe5e91109a14b7c64d387880355e484f15f90ecad561fc"
+      jacobian.checksum="d5ded0b4a38d4d9a0c946db0efce8604978caa0e5257be873040f1a9cfcb14ba"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-017/tests/Dockerfile
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-017/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/jcb-postdoc-017" \
       jacobian.checksum="d5ded0b4a38d4d9a0c946db0efce8604978caa0e5257be873040f1a9cfcb14ba"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/jcb-postdoc-017"'

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-017/tests/public_contract.json
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-017/tests/public_contract.json
@@ -1,0 +1,98 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "DISPROVED"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "answer_visible_summary": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "boundary_statement": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "expected_conclusion": {
+            "enum": [
+              "PROVED",
+              "DISPROVED",
+              "COUNTEREXAMPLE_EXISTS",
+              "EXACT_IDENTITY",
+              "NO_GLOBAL_CONCLUSION"
+            ]
+          },
+          "key_facts": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "expected_conclusion",
+          "answer_visible_summary",
+          "boundary_statement",
+          "key_facts"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/jcb-postdoc-017 answer-visible diagnostic"
+      },
+      "task_id": {
+        "const": "jacobian/jcb-postdoc-017"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-017/tests/verifier.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-017/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -9,7 +10,7 @@ from verifier_support import (
 
 W = Path("/app")
 E = Path("/tests")
-ALLOWED = frozenset({"UNVERIFIED", "COMPUTED", "CHECKED"})
+ALLOWED = frozenset({"UNVERIFIED", "COMPUTED"})
 
 
 def _math(s, x, e):
@@ -48,10 +49,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-017/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-017/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-018/tests/Dockerfile
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-018/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 LABEL jacobian.task="jacobian/jcb-postdoc-018" \
-      jacobian.checksum="036916f67f2869783afe5e91109a14b7c64d387880355e484f15f90ecad561fc"
+      jacobian.checksum="d5ded0b4a38d4d9a0c946db0efce8604978caa0e5257be873040f1a9cfcb14ba"
 COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-018/tests/Dockerfile
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-018/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/jcb-postdoc-018" \
       jacobian.checksum="d5ded0b4a38d4d9a0c946db0efce8604978caa0e5257be873040f1a9cfcb14ba"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/jcb-postdoc-018"'

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-018/tests/public_contract.json
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-018/tests/public_contract.json
@@ -1,0 +1,98 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "enum": [
+          "UNVERIFIED",
+          "COMPUTED"
+        ]
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "DISPROVED"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/answer.txt"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "answer_visible_summary": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "boundary_statement": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "expected_conclusion": {
+            "enum": [
+              "PROVED",
+              "DISPROVED",
+              "COUNTEREXAMPLE_EXISTS",
+              "EXACT_IDENTITY",
+              "NO_GLOBAL_CONCLUSION"
+            ]
+          },
+          "key_facts": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "expected_conclusion",
+          "answer_visible_summary",
+          "boundary_statement",
+          "key_facts"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/jcb-postdoc-018 answer-visible diagnostic"
+      },
+      "task_id": {
+        "const": "jacobian/jcb-postdoc-018"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-018/tests/verifier.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-018/tests/verifier.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    aggregate_reward,
     evidence_list_is_bound,
     load_submission,
     strict_submission_contract,
@@ -9,7 +10,7 @@ from verifier_support import (
 
 W = Path("/app")
 E = Path("/tests")
-ALLOWED = frozenset({"UNVERIFIED", "COMPUTED", "CHECKED"})
+ALLOWED = frozenset({"UNVERIFIED", "COMPUTED"})
 
 
 def _math(s, x, e):
@@ -48,10 +49,13 @@ def main():
     scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
     assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
-    reward = (
-        0
-        if not correct or false
-        else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+    reward = aggregate_reward(
+        correctness=correct,
+        evidence_validity=good,
+        scope_accuracy=scope,
+        assurance_calibration=assurance,
+        false_certification=false,
+        soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-018/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-018/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-019/tests/Dockerfile
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-019/tests/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/jcb-postdoc-019" \
       jacobian.checksum="ee57c229de55c9d4fd3ac77cf68aeb81cc3febb773d5ae4d85610e8d99a7852b"
-COPY expected.json input.json test.sh verifier.py verifier_support.py /tests/
+COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \
     python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/jcb-postdoc-019"'

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-019/tests/public_contract.json
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-019/tests/public_contract.json
@@ -1,0 +1,83 @@
+{
+  "schema_version": "1",
+  "submission_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "claimed_assurance": {
+        "const": "COMPUTED"
+      },
+      "completeness": {
+        "const": "COMPLETE"
+      },
+      "conclusion": {
+        "const": "INFEASIBLE"
+      },
+      "evidence": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "const": "evidence/nullstellensatz-certificate.json"
+            },
+            "sha256": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "type": "object"
+        },
+        "maxItems": 1,
+        "minItems": 1,
+        "type": "array"
+      },
+      "limitations": {
+        "const": [
+          "PUBLIC_ANSWER_VISIBLE",
+          "BENCHMARK_VERIFIER_NOT_PRODUCT_AUTHORITY"
+        ]
+      },
+      "result": {
+        "additionalProperties": false,
+        "properties": {
+          "certificate_path": {
+            "const": "evidence/nullstellensatz-certificate.json"
+          },
+          "chart_count": {
+            "const": 12
+          },
+          "identity": {
+            "const": "sum(h_i*f_i)=1"
+          }
+        },
+        "required": [
+          "certificate_path",
+          "chart_count",
+          "identity"
+        ],
+        "type": "object"
+      },
+      "scope": {
+        "const": "jacobian/jcb-postdoc-019 complete 12-chart normalized QQ degree-(2,3) slice"
+      },
+      "task_id": {
+        "const": "jacobian/jcb-postdoc-019"
+      }
+    },
+    "required": [
+      "task_id",
+      "conclusion",
+      "result",
+      "claimed_assurance",
+      "scope",
+      "completeness",
+      "evidence",
+      "limitations"
+    ],
+    "type": "object"
+  }
+}

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-019/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-019/tests/verifier_support.py
@@ -1,17 +1,17 @@
-"""Canonical fail-closed protocol helpers vendored into Harbor verifiers.
-
-This module uses only the Python standard library. Each task receives an
-identical copy in its hidden ``tests`` directory so the verifier remains
-self-contained and independent from production Jacobian code.
-"""
+"""Fail-closed protocol helpers for one self-contained Harbor verifier."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import stat
 from pathlib import Path
 from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from referencing.exceptions import Unresolvable
 
 WORKSPACE = Path("/app")
 TESTS = Path("/tests")
@@ -54,25 +54,90 @@ def sha256_uri(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
+MAX_PUBLIC_CONTRACT_BYTES = 4 * 1024 * 1024
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _load_public_contract(
+    path: Path = TESTS / "public_contract.json",
+) -> dict[str, Any] | None:
+    if not is_regular_bounded_file(path, max_bytes=MAX_PUBLIC_CONTRACT_BYTES):
+        return None
+    try:
+        contract = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return None
+    if not isinstance(contract, dict) or contract.get("schema_version") != "1":
+        return None
+    schema = contract.get("submission_schema")
+    if not isinstance(schema, dict):
+        return None
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError:
+        return None
+    return contract
+
+
 def load_submission(
     path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
 ) -> dict[str, Any] | None:
-    """Parse a submission as one JSON object, rejecting malformed input.
+    """Parse and completely validate one bounded submission object."""
 
-    Rejects symlinks, non-regular files, and oversized submissions before
-    reading so a malformed or hostile submission cannot OOM or block the
-    bounded verifier; such input yields a deterministic ``None`` (zero reward).
-    """
-
-    if not workspace_input_is_bound():
+    if require_input_binding and not workspace_input_is_bound():
         return None
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
-    try:
-        value = json.loads(path.read_text())
-    except (OSError, ValueError, RecursionError, MemoryError):
+    contract = _load_public_contract()
+    if contract is None:
         return None
-    return value if isinstance(value, dict) else None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return (
+        value
+        if isinstance(value, dict) and _public_submission_is_valid(value)
+        else None
+    )
+
+
+def _public_submission_is_valid(submission: object) -> bool:
+    contract = _load_public_contract()
+    if contract is None:
+        return False
+    schema = contract["submission_schema"]
+    try:
+        return Draft202012Validator(schema).is_valid(submission)
+    except (
+        SchemaError,
+        Unresolvable,
+        ValueError,
+        RecursionError,
+        MemoryError,
+        TypeError,
+    ):
+        return False
 
 
 def workspace_input_is_bound(
@@ -125,7 +190,8 @@ def strict_submission_contract(
         expected_fields.add(frozenset(SUBMISSION_FIELDS | {"verification_record_uri"}))
     limitations = submission.get("limitations", [])
     return bool(
-        frozenset(submission) in expected_fields
+        _public_submission_is_valid(submission)
+        and frozenset(submission) in expected_fields
         and submission.get("task_id") == task_id
         and submission.get("conclusion") == conclusion
         and submission.get("completeness") == completeness
@@ -280,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -287,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-collision-found-01/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-collision-found-01/tests/verifier_support.py
@@ -374,7 +374,62 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
 __all__ = [
+    "aggregate_reward",
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
     "MAX_SUBMISSION_BYTES",

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-collision-found-02/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-collision-found-02/tests/verifier_support.py
@@ -374,7 +374,62 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
 __all__ = [
+    "aggregate_reward",
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
     "MAX_SUBMISSION_BYTES",

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-grid-exhausted-01/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-grid-exhausted-01/tests/verifier_support.py
@@ -374,7 +374,62 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
 __all__ = [
+    "aggregate_reward",
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
     "MAX_SUBMISSION_BYTES",

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-grid-exhausted-02/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-grid-exhausted-02/tests/verifier_support.py
@@ -374,7 +374,62 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
 __all__ = [
+    "aggregate_reward",
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
     "MAX_SUBMISSION_BYTES",

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-keller-only-01/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-keller-only-01/tests/verifier_support.py
@@ -374,7 +374,62 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
 __all__ = [
+    "aggregate_reward",
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
     "MAX_SUBMISSION_BYTES",

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-keller-only-02/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-keller-only-02/tests/verifier_support.py
@@ -374,7 +374,62 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
 __all__ = [
+    "aggregate_reward",
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
     "MAX_SUBMISSION_BYTES",

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-keller-only-03/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-keller-only-03/tests/verifier_support.py
@@ -374,7 +374,62 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
 __all__ = [
+    "aggregate_reward",
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
     "MAX_SUBMISSION_BYTES",

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-keller-only-04/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-keller-only-04/tests/verifier_support.py
@@ -374,7 +374,62 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
 __all__ = [
+    "aggregate_reward",
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
     "MAX_SUBMISSION_BYTES",

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-near-miss-01/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-near-miss-01/tests/verifier_support.py
@@ -374,7 +374,62 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
 __all__ = [
+    "aggregate_reward",
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
     "MAX_SUBMISSION_BYTES",

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-near-miss-02/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-near-miss-02/tests/verifier_support.py
@@ -374,7 +374,62 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
 __all__ = [
+    "aggregate_reward",
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
     "MAX_SUBMISSION_BYTES",

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-near-miss-03/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-near-miss-03/tests/verifier_support.py
@@ -374,7 +374,62 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
 __all__ = [
+    "aggregate_reward",
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
     "MAX_SUBMISSION_BYTES",

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-near-miss-04/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-near-miss-04/tests/verifier_support.py
@@ -374,7 +374,62 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
 __all__ = [
+    "aggregate_reward",
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
     "MAX_SUBMISSION_BYTES",

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-one-direction-01/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-one-direction-01/tests/verifier_support.py
@@ -374,7 +374,62 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
 __all__ = [
+    "aggregate_reward",
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
     "MAX_SUBMISSION_BYTES",

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-one-direction-02/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-one-direction-02/tests/verifier_support.py
@@ -374,7 +374,62 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
 __all__ = [
+    "aggregate_reward",
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
     "MAX_SUBMISSION_BYTES",

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-one-direction-03/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-one-direction-03/tests/verifier_support.py
@@ -374,7 +374,62 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
 __all__ = [
+    "aggregate_reward",
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
     "MAX_SUBMISSION_BYTES",

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-search-incomplete-01/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-search-incomplete-01/tests/verifier_support.py
@@ -374,7 +374,62 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
 __all__ = [
+    "aggregate_reward",
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
     "MAX_SUBMISSION_BYTES",

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-search-timeout-01/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-search-timeout-01/tests/verifier_support.py
@@ -374,7 +374,62 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
 __all__ = [
+    "aggregate_reward",
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
     "MAX_SUBMISSION_BYTES",

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-semantic-equivalence-01/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-semantic-equivalence-01/tests/verifier_support.py
@@ -374,7 +374,62 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
 __all__ = [
+    "aggregate_reward",
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
     "MAX_SUBMISSION_BYTES",

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-semantic-equivalence-02/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-semantic-equivalence-02/tests/verifier_support.py
@@ -374,7 +374,62 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
 __all__ = [
+    "aggregate_reward",
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
     "MAX_SUBMISSION_BYTES",

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-semantic-equivalence-03/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-semantic-equivalence-03/tests/verifier_support.py
@@ -374,7 +374,62 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
 __all__ = [
+    "aggregate_reward",
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
     "MAX_SUBMISSION_BYTES",

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-semantic-equivalence-04/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-semantic-equivalence-04/tests/verifier_support.py
@@ -374,7 +374,62 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
 __all__ = [
+    "aggregate_reward",
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
     "MAX_SUBMISSION_BYTES",

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-valid-inverse-01/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-valid-inverse-01/tests/verifier_support.py
@@ -374,7 +374,62 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
 __all__ = [
+    "aggregate_reward",
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
     "MAX_SUBMISSION_BYTES",

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-valid-inverse-02/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-valid-inverse-02/tests/verifier_support.py
@@ -374,7 +374,62 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
 __all__ = [
+    "aggregate_reward",
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
     "MAX_SUBMISSION_BYTES",

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-valid-inverse-03/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-valid-inverse-03/tests/verifier_support.py
@@ -374,7 +374,62 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
 __all__ = [
+    "aggregate_reward",
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
     "MAX_SUBMISSION_BYTES",

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-valid-inverse-04/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-valid-inverse-04/tests/verifier_support.py
@@ -374,7 +374,62 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
 __all__ = [
+    "aggregate_reward",
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
     "MAX_SUBMISSION_BYTES",

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-valid-inverse-05/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-valid-inverse-05/tests/verifier_support.py
@@ -374,7 +374,62 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
 __all__ = [
+    "aggregate_reward",
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
     "MAX_SUBMISSION_BYTES",

--- a/benchmarks/templates/task/tests/verifier_support.py
+++ b/benchmarks/templates/task/tests/verifier_support.py
@@ -346,6 +346,61 @@ def false_verified_claim(
     )
 
 
+def _as_unit_score(value: float | bool | int) -> float:
+    """Normalize a diagnostic to a unit interval score."""
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    score = float(value)
+    if score < 0.0 or score > 1.0 or score != score:  # NaN check
+        raise ValueError(f"diagnostic score out of unit interval: {value!r}")
+    return score
+
+
+def aggregate_reward(
+    *,
+    correctness: float | bool,
+    evidence_validity: float | bool,
+    scope_accuracy: float | bool = 1.0,
+    assurance_calibration: float | bool = 1.0,
+    false_certification: bool = False,
+    protocol_ok: bool = True,
+    require_scope: bool = True,
+    soft_assurance: bool = False,
+    soft_assurance_base: float = 0.9,
+    soft_assurance_weight: float = 0.1,
+) -> float:
+    """Compute fail-closed aggregate reward from independent diagnostics.
+
+    Mandatory hard gates (protocol, correctness, evidence, and required scope)
+    always force ``0.0`` when they fail, as does ``false_certification``.
+    When ``soft_assurance`` is false, assurance is also a hard gate and the
+    successful aggregate is ``1.0``. When ``soft_assurance`` is true and every
+    hard gate passes, the aggregate is
+    ``soft_assurance_base + soft_assurance_weight * assurance`` so under-
+    claimed assurance can receive documented partial credit without diluting
+    evidence or protocol failures.
+    """
+
+    if false_certification or not protocol_ok:
+        return 0.0
+    correctness_score = _as_unit_score(correctness)
+    evidence_score = _as_unit_score(evidence_validity)
+    scope_score = _as_unit_score(scope_accuracy)
+    assurance_score = _as_unit_score(assurance_calibration)
+    if correctness_score < 1.0 or evidence_score < 1.0:
+        return 0.0
+    if require_scope and scope_score < 1.0:
+        return 0.0
+    if not soft_assurance:
+        return 1.0 if assurance_score >= 1.0 else 0.0
+    if soft_assurance_base < 0.0 or soft_assurance_weight < 0.0:
+        raise ValueError("soft assurance weights must be non-negative")
+    if soft_assurance_base + soft_assurance_weight > 1.0 + 1e-12:
+        raise ValueError("soft assurance weights must not exceed 1.0 in total")
+    return soft_assurance_base + soft_assurance_weight * assurance_score
+
+
 __all__ = [
     "ASSURANCE_LEVELS",
     "MAX_INPUT_BYTES",
@@ -353,6 +408,7 @@ __all__ = [
     "SUBMISSION_FIELDS",
     "TESTS",
     "WORKSPACE",
+    "aggregate_reward",
     "authorized_record_is_bound",
     "evidence_list_is_bound",
     "false_verified_claim",

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_generic_verifier_contracts.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_generic_verifier_contracts.py
@@ -7,12 +7,15 @@ import pytest
 from benchmarks.validation.mathematical_benchmarks_v1 import support
 
 
-def test_decoupled_input_binding_registrations_are_preserved() -> None:
+def test_decoupled_input_binding_contract_metadata_is_preserved() -> None:
     expected = {
         "extremal-subset-sum-semantic-audit",
     }
     assert expected <= set(support.VERIFIER_TASKS)
-    assert expected <= set(support.INPUT_BINDING_DECOUPLED_TASKS)
+    for task_name in expected:
+        assert support.is_input_binding_decoupled(task_name) is True
+        metadata = support.load_task_contract_metadata(task_name)
+        assert metadata.get("input_binding_decoupled") is True
 
 
 def test_verifier_execution_does_not_mutate_task_bundles(tmp_path: Path) -> None:

--- a/benchmarks/validation/public_reproductions_v1/support.py
+++ b/benchmarks/validation/public_reproductions_v1/support.py
@@ -94,6 +94,53 @@ SINGLE_EVIDENCE_TASKS = tuple(
     == 1
 )
 
+_TASK_CONTRACT_KEYS = frozenset(
+    {"schema_version", "input_binding_decoupled", "scope_independent_assurance"}
+)
+
+
+def load_task_contract_metadata(task_name: str) -> dict[str, object]:
+    """Load task-local verifier contract metadata from the task's tests/ dir."""
+
+    path = TASKS / task_name / "tests" / "verifier_contract.json"
+    if not path.is_file():
+        return {}
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise ValueError(f"{task_name}: invalid verifier_contract.json: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ValueError(f"{task_name}: verifier_contract.json must be an object")
+    unknown = set(value) - _TASK_CONTRACT_KEYS
+    if unknown:
+        raise ValueError(
+            f"{task_name}: unknown verifier contract fields: {sorted(unknown)}"
+        )
+    if value.get("schema_version") != "1":
+        raise ValueError(f"{task_name}: verifier contract schema_version must be '1'")
+    for field in ("input_binding_decoupled", "scope_independent_assurance"):
+        if field in value and type(value[field]) is not bool:
+            raise ValueError(f"{task_name}: {field} must be a boolean")
+    return value
+
+
+def is_input_binding_decoupled(task_name: str) -> bool:
+    """Whether correctness is reported independently of workspace input binding."""
+
+    metadata = load_task_contract_metadata(task_name)
+    if "input_binding_decoupled" in metadata:
+        return metadata["input_binding_decoupled"] is True
+    return task_name in INPUT_BINDING_DECOUPLED_TASKS
+
+
+def is_scope_independent_assurance(task_name: str) -> bool:
+    """Whether scope is reported independently of assurance typing."""
+
+    metadata = load_task_contract_metadata(task_name)
+    if "scope_independent_assurance" in metadata:
+        return metadata["scope_independent_assurance"] is True
+    return task_name in SCOPE_INDEPENDENT_ASSURANCE_TASKS
+
 
 def _task_tree_snapshot() -> dict[str, str]:
     return {

--- a/benchmarks/validation/public_reproductions_v1/test_fail_closed_evidence_gate.py
+++ b/benchmarks/validation/public_reproductions_v1/test_fail_closed_evidence_gate.py
@@ -1,0 +1,52 @@
+"""Golden fail-closed tasks: invalid evidence digests must zero aggregate reward.
+
+These tasks already use min-gate / hard evidence policy. They prove the
+two-layer scoring contract before the Phase 1 leaky-template migration.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from benchmarks.validation.public_reproductions_v1 import support
+
+# Tasks that hard-gate evidence into aggregate reward (pre-existing min-gate or
+# Phase 1 aggregate_reward migration).
+_GOLDEN_FAIL_CLOSED = (
+    "balanced-row-permutation",
+    "coin-process-potential",
+    "closed-set-distance-strengthening-audit",
+    "reduced-point",
+    "gaussian-complex-cancellation",
+    "reliability-triangle-fair",
+    "smith-rectangular",
+)
+
+
+@pytest.mark.parametrize("task_name", _GOLDEN_FAIL_CLOSED)
+def test_wrong_evidence_digest_zeros_reward_with_visible_diagnostics(
+    tmp_path: Path,
+    task_name: str,
+) -> None:
+    task, app, logs = support._prepare_case(tmp_path, task_name, "computed")
+    accepted = support._run_verifier(task, app, logs)
+    assert accepted["reward"] == pytest.approx(1.0)
+    assert accepted.get("evidence_validity", accepted.get("evidence", 1.0)) == pytest.approx(
+        1.0
+    )
+
+    submission_path = app / "submission.json"
+    submission = json.loads(submission_path.read_text(encoding="utf-8"))
+    assert isinstance(submission.get("evidence"), list) and submission["evidence"]
+    submission["evidence"][0]["sha256"] = "sha256:" + ("0" * 64)
+    support._write_json(submission_path, submission)
+
+    rejected = support._run_verifier(task, app, logs)
+    evidence = rejected.get("evidence_validity", rejected.get("evidence"))
+    assert evidence == pytest.approx(0.0)
+    assert rejected["reward"] == pytest.approx(0.0)
+    # Correct mathematics may remain visible; aggregate must still fail closed.
+    if "correctness" in rejected:
+        assert rejected["correctness"] in {0.0, 1.0}

--- a/benchmarks/validation/test_fail_closed_reward_ratchet.py
+++ b/benchmarks/validation/test_fail_closed_reward_ratchet.py
@@ -1,0 +1,89 @@
+"""Inventory ratchet: leaky weighted-reward formulas must not grow.
+
+The historical leaky template soft-weights evidence (and other mandatory
+dimensions) into aggregate reward so invalid digests still score ~0.9. Phase 1
+migrations shrink this inventory; this module fails if any *new* task reintroduces
+the pattern outside the frozen known set.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+DATASETS = ROOT / "benchmarks" / "datasets"
+TEMPLATE_SUPPORT = (
+    ROOT / "benchmarks" / "templates" / "task" / "tests" / "verifier_support.py"
+)
+TEMPLATE_VERIFIER = ROOT / "benchmarks" / "templates" / "task" / "tests" / "verifier.py"
+
+# Soft-weighted aggregate that does not hard-gate evidence (RC1 / A1).
+_LEAKY_WEIGHTED = re.compile(
+    r"0\.7\s*\*\s*(?:correct|math_correct|float\(\s*correct)"
+    r".{0,120}?"
+    r"0\.1\s*\*\s*(?:good|evidence)",
+    re.DOTALL,
+)
+_LEAKY_WEIGHTED_ALT = re.compile(
+    r"0\.7\s*\*\s*(?:correct|math_correct).{0,200}?0\.1\s*\*\s*(?:good|evidence_ok|evidence_valid)",
+    re.DOTALL,
+)
+
+# Frozen inventory at the start of the fail-closed reward migration.
+# Remove entries only when the task migrates to aggregate_reward / min-gate.
+# Do not add entries without an explicit migration exception review.
+# Empty after Phase 1 migration: no verifier may reintroduce the leaky pattern.
+KNOWN_LEAKY_REWARD_VERIFIERS: frozenset[str] = frozenset()
+
+_REQUIRED_TEMPLATE_EXPORTS = frozenset(
+    {
+        "aggregate_reward",
+        "evidence_list_is_bound",
+        "load_submission",
+        "strict_submission_contract",
+    }
+)
+
+
+def _is_leaky(text: str) -> bool:
+    return bool(_LEAKY_WEIGHTED.search(text) or _LEAKY_WEIGHTED_ALT.search(text))
+
+
+def _leaky_task_ids() -> set[str]:
+    found: set[str] = set()
+    for path in sorted(DATASETS.rglob("tests/verifier.py")):
+        relative = path.relative_to(DATASETS)
+        # datasets/<dataset>/<task>/tests/verifier.py
+        if len(relative.parts) < 4:
+            continue
+        task_id = f"{relative.parts[0]}/{relative.parts[1]}"
+        if _is_leaky(path.read_text(encoding="utf-8", errors="replace")):
+            found.add(task_id)
+    return found
+
+
+def test_template_support_exports_fail_closed_aggregate_helper() -> None:
+    text = TEMPLATE_SUPPORT.read_text(encoding="utf-8")
+    assert "def aggregate_reward(" in text
+    assert not _is_leaky(text)
+    for name in _REQUIRED_TEMPLATE_EXPORTS:
+        assert f'"{name}"' in text or f"'{name}'" in text
+    # Template verifier remains a stub; it must not ship the leaky formula.
+    assert not _is_leaky(TEMPLATE_VERIFIER.read_text(encoding="utf-8"))
+
+
+def test_leaky_reward_inventory_does_not_grow() -> None:
+    found = _leaky_task_ids()
+    unexpected = sorted(found - KNOWN_LEAKY_REWARD_VERIFIERS)
+    missing = sorted(KNOWN_LEAKY_REWARD_VERIFIERS - found)
+    assert not unexpected, (
+        "New leaky 0.7/0.1 reward formulas appeared; migrate them to "
+        f"aggregate_reward or get an explicit review exception: {unexpected}"
+    )
+    # Allow inventory shrinkage as tasks migrate; fail only if the frozen list
+    # still claims a task that no longer matches (stale inventory).
+    assert not missing, (
+        "Known leaky inventory is stale (tasks already migrated). Remove them "
+        f"from KNOWN_LEAKY_REWARD_VERIFIERS: {missing}"
+    )

--- a/benchmarks/validation/test_verifier_security_regressions.py
+++ b/benchmarks/validation/test_verifier_security_regressions.py
@@ -159,6 +159,11 @@ def _lean_case(tmp_path: Path, tasks: list[dict]):
         "parameter_error_count": 0,
         "return_code": 0,
         "tasks": tasks,
+        "elapsed_seconds": 0.042,
+        "stderr": "",
+        "limitations": [
+            "completed tactic states cannot be replayed into the originating command",
+        ],
     }
     report_path = app / "evidence" / "provider-report.json"
     _write_json(report_path, report)

--- a/benchmarks/validation/test_verifier_support_schema.py
+++ b/benchmarks/validation/test_verifier_support_schema.py
@@ -132,3 +132,41 @@ def test_load_submission_enforces_the_complete_public_schema(
     monkeypatch.setattr(_VS, "_load_public_contract", lambda: contract)
 
     assert _VS.load_submission(submission, require_input_binding=False) is None
+
+
+def test_aggregate_reward_full_credit_when_hard_gates_pass() -> None:
+    assert (
+        _VS.aggregate_reward(
+            correctness=1.0,
+            evidence_validity=True,
+            scope_accuracy=1,
+            assurance_calibration=1.0,
+        )
+        == 1.0
+    )
+
+
+def test_aggregate_reward_zeros_on_invalid_evidence_even_when_math_passes() -> None:
+    assert (
+        _VS.aggregate_reward(
+            correctness=1.0,
+            evidence_validity=0.0,
+            scope_accuracy=1.0,
+            assurance_calibration=1.0,
+        )
+        == 0.0
+    )
+
+
+def test_aggregate_reward_soft_assurance_partial_after_hard_gates() -> None:
+    assert _VS.aggregate_reward(
+        correctness=1.0,
+        evidence_validity=1.0,
+        scope_accuracy=1.0,
+        assurance_calibration=0.0,
+        soft_assurance=True,
+    ) == pytest.approx(0.9)
+
+
+def test_template_exports_aggregate_reward() -> None:
+    assert "aggregate_reward" in _VS.__all__

--- a/docs/explanation/lean-proof-state-inspection-direction.md
+++ b/docs/explanation/lean-proof-state-inspection-direction.md
@@ -1,0 +1,36 @@
+# Lean proof-state and trust inspection (issue #95)
+
+Status: design track for durable Lean intermediate inspection contracts.
+
+## Missing outcomes
+
+Durable, independently callable proof-state and trust inspection beyond:
+
+- `lean.statement.propose` (elaboration status),
+- `lean.proof_state.apply_tactic` (replay-source tactic steps),
+- `lean.check` (complete proof verification).
+
+## Contract decisions
+
+- Environment, source revision, and import digests bound into state identity.
+- Durable proof-state identity, expiry, and stale-state rejection on drift.
+- Normalized goals, local context, metavariables, and local instances.
+- Term-application diagnostics distinct from tactic syntax failures.
+- Dependency closure, axioms, package manifests, and sorry/admit reporting.
+- Session workers vs replayable immutable state artifacts (prefer immutable
+  artifacts for independent inspection).
+
+## Verification boundary
+
+Proof-state transitions and inspections are `COMPUTED` operational evidence.
+Only a complete clean replay through operator-pinned `lean.check` may return
+`VERIFIED`. Trust inspection reports dependencies; it does not set trust policy.
+
+## Non-goals
+
+- Replacing Lean as the proof kernel.
+- Letting inspection APIs authorize `VERIFIED`.
+- Prescribing a proof strategy through discovery rankings.
+
+This note does not ship new capabilities; it freezes the acceptance boundary for
+implementation after overlapping Lean contract work lands.

--- a/docs/explanation/persistence-policy-direction.md
+++ b/docs/explanation/persistence-policy-direction.md
@@ -1,0 +1,39 @@
+# Persistence policy direction (issue #386)
+
+Status: design track for hybrid mathematical intermediate retention.
+
+## Decision needed
+
+Define when Jacobian returns an inline value, a durable mathematical artifact, an
+evidence artifact, a verification record, or an execution episode—without
+materializing every leaf computation.
+
+## Direction
+
+| Role | Persist when |
+| --- | --- |
+| Inline mathematical value | Small, one-shot, no downstream binding or replay contract |
+| Mathematical artifact | Reuse, composition, exact identity, or later capability binding |
+| Evidence artifact | Certificate, witness, search ledger, open obligation |
+| Verification record | Authorized checker decision bound to exact claim and evidence |
+| Execution episode | Durable “what happened” distinct from the mathematical object |
+
+## Constraints
+
+- Do not weaken checker authorization or content-addressed evidence binding.
+- Do not turn computed or search output into `VERIFIED`.
+- Do not force a research workflow through persistence policy.
+- Prefer domain-owned artifact production over generic `artifact.put` in the
+  default agent-facing catalog.
+- Measure storage, response size, and task success before removing dual
+  representations.
+
+## Next implementation steps
+
+1. Add an explicit persistence intent to capability/operation contracts.
+2. Default deterministic leaf ops to inline-only with explicit replay status.
+3. Keep durable artifacts for verifier-bound and resumable producers.
+4. Evaluation: storage writes, URI reuse, verification correctness before/after.
+
+This note does not change runtime behavior; it records the accepted design
+direction for a follow-up implementation PR.

--- a/docs/how-to/run-agent-evaluations.md
+++ b/docs/how-to/run-agent-evaluations.md
@@ -7,6 +7,17 @@ paired Jacobian control/treatment runs. Model execution is not a routine
 development or pull-request gate. The evaluation roles, assurance rules, and
 interpretation boundaries are in the [reference page](../reference/evaluations/evaluation-methods.md).
 
+## Platform note: offline Oracle on macOS Docker Desktop
+
+Authoritative Docker Oracle validation runs on **Linux** (GitHub Actions and
+Linux Docker hosts). Harbor tasks use `network_mode = "no-network"` for offline
+isolation. Docker Desktop on macOS may reject that policy when the LinuxKit VM
+lacks the nftables features Harbor's egress control requires; the trial fails
+during environment validation before any container starts and must not be
+treated as a task pass or fail. Prefer a Linux runner for Oracle and selective
+backfills. Do not weaken task `no-network` settings merely to green local macOS
+execution.
+
 ## Validate the dataset
 
 Preview the benchmark plan before spending Docker or model time:

--- a/docs/reference/evaluations/benchmark-contracts.md
+++ b/docs/reference/evaluations/benchmark-contracts.md
@@ -81,6 +81,41 @@ contract authorizes. Wrong mathematical answers, malformed or escaped evidence,
 incomplete scope, and false certification receive zero reward. An Oracle answer
 does not authorize `VERIFIED`.
 
+### Diagnostics versus aggregate reward
+
+Harbor reads multi-key `reward.json` and treats named floats as independent
+metrics. Jacobian verifiers therefore use a **two-layer** scoring contract:
+
+1. **Diagnostics** — report independent 0/1 scores such as `correctness`,
+   `evidence_validity`, `scope_accuracy`, `assurance_calibration`, and
+   `false_certification`. A zero aggregate must not erase which dimensions
+   passed: invalid evidence with correct mathematics still reports
+   `correctness = 1.0` and `evidence_validity = 0.0`.
+2. **Aggregate `reward`** — the primary pass signal. Mandatory protocol
+   dimensions are **non-compensable hard gates**. Soft weighted sums that still
+   award most of the reward when a mandatory dimension fails are forbidden for
+   evidence-bound tasks.
+
+Mandatory hard gates for standard digest-bound tasks: protocol/envelope,
+mathematical correctness, evidence binding, required scope, and false
+certification. Assurance may be a hard gate or a documented soft partial
+(`soft_assurance=True` in template `aggregate_reward`) only after every hard
+gate passes.
+
+**Forbidden leaky template:**
+
+```python
+# FORBIDDEN: evidence failure still yields reward ≈ 0.9
+reward = (
+    0 if not correct or false
+    else 0.7 * correct + 0.1 * good + 0.1 * scope + 0.1 * assurance
+)
+```
+
+Use template `aggregate_reward` (or an equivalent min-gate of mandatory
+dimensions). Shared validation keeps an inventory ratchet so the leaky pattern
+cannot reappear.
+
 Each separate verifier owns its local `tests/verifier_support.py`; Harbor's
 whole-task digest binds that copy, so validation does not synchronize it with a
 global runtime helper. New tasks inherit the template copy, while shared fixes
@@ -89,7 +124,8 @@ command only after such a deliberate update. Evidence has no arbitrary byte
 cap, but its schema, digest, path, and workspace binding remain mandatory.
 Verifier regression fixtures should also prove that malformed submissions do
 not crash: exercise booleans where integers are expected, non-finite JSON
-numbers, unhashable nested values, wrong-shaped input, and assurance or
+numbers, unhashable nested values, wrong-shaped input, wrong evidence digests
+(aggregate reward zero while diagnostics stay independent), and assurance or
 protocol failures whose independent diagnostics remain visible. A full Oracle
 reward does not replace these negative-path checks.
 

--- a/src/jacobian/exact_domain_checkers.py
+++ b/src/jacobian/exact_domain_checkers.py
@@ -818,7 +818,9 @@ def _checker_supports(operation_id: str, payload: object) -> bool:
         "polynomial.compute.resultant": ("left", "right"),
         "polynomial.compute.discriminant": ("polynomial",),
         "polynomial.compute.square_free_decomposition": ("polynomial",),
-    }[operation_id]
+    }.get(operation_id)
+    if polynomial_fields is None:
+        return False
     return all(
         isinstance(payload.get(field), dict)
         and payload[field].get("variables")

--- a/src/jacobian/verification/service.py
+++ b/src/jacobian/verification/service.py
@@ -400,7 +400,11 @@ class VerificationService:
                 arithmetic=decision.arithmetic,
                 method=decision.method,
                 coverage=decision.coverage,
-                verification=Verification.VERIFIED,
+                verification=(
+                    Verification.VERIFIED
+                    if decision.conclusion == Conclusion.TRUE
+                    else Verification.UNVERIFIED
+                ),
                 checker_id=checker.checker_id,
                 checker_digest=checker.executable_digest,
                 scope_uri=scope.artifact_uri if scope is not None else None,
@@ -688,7 +692,11 @@ class VerificationService:
                 arithmetic=decision.arithmetic,
                 method=decision.method,
                 coverage=decision.coverage,
-                verification=Verification.VERIFIED,
+                verification=(
+                    Verification.VERIFIED
+                    if decision.conclusion == Conclusion.TRUE
+                    else Verification.UNVERIFIED
+                ),
                 checker_id=checker.checker_id,
                 checker_digest=checker.executable_digest,
                 scope_uri=scope.artifact_uri if scope is not None else None,
@@ -907,7 +915,11 @@ class VerificationService:
                 arithmetic=decision.arithmetic,
                 method=decision.method,
                 coverage=decision.coverage,
-                verification=Verification.VERIFIED,
+                verification=(
+                    Verification.VERIFIED
+                    if decision.conclusion == Conclusion.TRUE
+                    else Verification.UNVERIFIED
+                ),
                 checker_id=checker.checker_id,
                 checker_digest=checker.executable_digest,
                 scope_uri=transformation_uri,
@@ -1113,7 +1125,11 @@ class VerificationService:
                 arithmetic=decision.arithmetic,
                 method=decision.method,
                 coverage=decision.coverage,
-                verification=Verification.VERIFIED,
+                verification=(
+                    Verification.VERIFIED
+                    if decision.conclusion == Conclusion.TRUE
+                    else Verification.UNVERIFIED
+                ),
                 checker_id=checker.checker_id,
                 checker_digest=checker.executable_digest,
             )

--- a/tests/component/checkers/test_fail_closed_verification_semantics.py
+++ b/tests/component/checkers/test_fail_closed_verification_semantics.py
@@ -1,0 +1,39 @@
+"""Fail-closed verification semantics for checker support and VERIFIED gates."""
+
+from __future__ import annotations
+
+from jacobian.contracts.results import Conclusion, Verification
+from jacobian.exact_domain_checkers import _checker_supports
+
+
+def test_checker_supports_unknown_polynomial_operation_is_false() -> None:
+    assert (
+        _checker_supports(
+            "polynomial.compute.hypothetical_new_op",
+            {"left": {"variables": ["x"], "terms": []}},
+        )
+        is False
+    )
+
+
+def test_checker_supports_known_univariate_gcd() -> None:
+    payload = {
+        "left": {"variables": ["x"], "terms": [{"coefficient": "1", "exponents": [1]}]},
+        "right": {"variables": ["x"], "terms": [{"coefficient": "1", "exponents": [0]}]},
+    }
+    assert _checker_supports("polynomial.compute.gcd", payload) is True
+
+
+def test_verified_assurance_requires_true_conclusion_policy() -> None:
+    """Document the service policy: VERIFIED only when conclusion is TRUE."""
+
+    def verification_for(conclusion: Conclusion) -> Verification:
+        return (
+            Verification.VERIFIED
+            if conclusion == Conclusion.TRUE
+            else Verification.UNVERIFIED
+        )
+
+    assert verification_for(Conclusion.TRUE) is Verification.VERIFIED
+    assert verification_for(Conclusion.FALSE) is Verification.UNVERIFIED
+    assert verification_for(Conclusion.UNKNOWN) is Verification.UNVERIFIED

--- a/tools/check_benchmark_adapters.py
+++ b/tools/check_benchmark_adapters.py
@@ -75,6 +75,55 @@ def _evidence_failures(
             failures.append(
                 f"{_display(lock_path)}: {field} mismatch for {_display(evidence_path)}"
             )
+            continue
+        try:
+            payload = json.loads(evidence_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            failures.append(
+                f"{_display(lock_path)}: {_display(evidence_path)} is not JSON: {exc}"
+            )
+            continue
+        if not isinstance(payload, dict):
+            failures.append(
+                f"{_display(lock_path)}: {_display(evidence_path)} must be a JSON object"
+            )
+            continue
+        # Semantic provenance: digests inside evidence must match the lock's
+        # current output task digest, not only the evidence file hash.
+        expected_digest = output.get("task_digest")
+        declared = (
+            payload.get("task_digest")
+            or payload.get("output_task_digest")
+            or payload.get("source_task_digest")
+        )
+        if (
+            declared is not None
+            and expected_digest is not None
+            and declared != expected_digest
+        ):
+            failures.append(
+                f"{_display(lock_path)}: {_display(evidence_path)} task_digest "
+                f"{declared!r} does not match lock output task_digest "
+                f"{expected_digest!r}"
+            )
+        if filename == "parity-evidence.json":
+            if payload.get("task_digest_matches") is False:
+                failures.append(
+                    f"{_display(lock_path)}: {_display(evidence_path)} reports "
+                    "task_digest_matches=false"
+                )
+            for key in ("source_task_digest", "generated_task_digest", "task_digest"):
+                value = payload.get(key)
+                if (
+                    value is not None
+                    and expected_digest is not None
+                    and value != expected_digest
+                ):
+                    failures.append(
+                        f"{_display(lock_path)}: {_display(evidence_path)} {key} "
+                        f"{value!r} does not match lock output task_digest "
+                        f"{expected_digest!r}"
+                    )
     return failures
 
 


### PR DESCRIPTION
## Summary

Closes the systemic fail-closed evaluation gaps tracked across the open verifier/kernel issues: leaky aggregate reward formulas, fragmented verifier support, forgeable provider feasibility reports, and verification-service trust semantics.

### Kernel
- `Verification.VERIFIED` only when checker `conclusion == TRUE` (refutations stay decisive without claiming claim-truth).
- `_checker_supports` returns `False` for unknown polynomial operations instead of `KeyError`.

### Benchmark evaluation integrity
- Template `aggregate_reward` hard-gates protocol, math, evidence, and required scope; optional soft assurance only after hard gates.
- Migrated all leaky `0.7 * correct + 0.1 * evidence + …` verifiers to `aggregate_reward`.
- Unified task-local `verifier_support` with the full template helper (schema + non-finite rejection + aggregate helper).
- Generated missing `public_contract.json` and fixed verifier Dockerfiles (`jsonschema` install + contract copy).
- Provider-feasibility verifiers require execution observations beyond public spike literals.
- Integer type exactness for free ranks / Smith rank / reliability states; research diagnostics no longer free-score `CHECKED`.
- `graph-counterexample` agent network set to `no-network`.
- Adapter checker validates evidence document digests against lock outputs.
- Task-local `verifier_contract.json` for input-binding / scope-assurance exceptions (#500 groundwork).

### Docs
- Two-layer diagnostics vs aggregate reward policy.
- macOS Docker Desktop offline Oracle platform note.
- Design direction notes for persistence (#386) and Lean proof-state (#95).

## Related issues

Primary clusters: #534–#539, #545, #548, #561 (leaky reward); #527–#533, #536, #559–#560 (support/types/crash); #530 (CHECKED); #540, #546 (provider forge); #557, #558 (kernel); #547 (network); #494 (adapter semantics); #500 (contract ownership); #372 (docs). Design tracks documented only: #386, #95.

## Test plan

- [x] `uv run pytest` focused suite: fail-closed ratchet, evidence-gate goldens, security regressions, support schema, kernel semantics
- [x] `make harbor-check-task` for sample migrated tasks (`reduced-point`, `smith-rectangular`, `sat-witness`, `hermite-normal-form`, `graph-counterexample`)
- [x] `make harbor-oracle-task DATASET=public-reproductions-v1 TASKS="reduced-point"` → reward 1.0
- [x] `make harbor-oracle-task DATASET=public-reproductions-v1 TASKS="smith-rectangular gaussian-complex-cancellation"` → reward 1.0
- [ ] Broader Oracle matrix for remaining migrated public/research/mathematical tasks (follow-up in this PR or merge queue)
- [ ] Confirm CI Harbor validation on the full changed digest set