### PR TITLE
fix: address post-merge MCP and observation review findings

### DIFF
--- a/benchmarks/tooling/observation_comparison.py
+++ b/benchmarks/tooling/observation_comparison.py
@@ -16,6 +16,7 @@ from benchmarks.tooling.errors import HarborSuiteError
 SCHEMA_PATH = (
     Path(__file__).resolve().parents[1] / "schemas" / "observation-evidence.schema.json"
 )
+CORE_METRICS = ("correctness", "false_certification")
 
 
 def _validate_contract(value: dict[str, Any]) -> None:
@@ -283,9 +284,9 @@ def compare_evidence(
         metric: _metric_report(metric, pairs, control_trials, treatment_trials)
         for metric in metric_names
     }
-    for metric in metric_names:
+    for metric in CORE_METRICS:
         if metrics[metric]["pair_count"] != len(pairs):
-            failures.append(f"metric is missing from a complete pair: {metric}")
+            failures.append(f"core metric is missing from a complete pair: {metric}")
     return {
         "schema_version": "1",
         "evidence_class": _derived_comparison_class(control, treatment),

--- a/benchmarks/tooling/observation_results.py
+++ b/benchmarks/tooling/observation_results.py
@@ -134,6 +134,39 @@ def _object(value: Any) -> dict[str, Any]:
     return value if isinstance(value, dict) else {}
 
 
+def _completed_job_stats(job_stats: dict[str, Any], observed_trial_count: int) -> bool:
+    if (
+        not isinstance(observed_trial_count, int)
+        or isinstance(observed_trial_count, bool)
+        or observed_trial_count <= 0
+    ):
+        return False
+    completed = job_stats.get("n_completed_trials")
+    total = job_stats.get("n_total_trials")
+    if (
+        not isinstance(completed, int)
+        or isinstance(completed, bool)
+        or completed <= 0
+        or not isinstance(total, int)
+        or isinstance(total, bool)
+        or total <= 0
+        or completed != total
+        or total != observed_trial_count
+    ):
+        return False
+    return all(
+        isinstance(job_stats.get(key), int)
+        and not isinstance(job_stats.get(key), bool)
+        and job_stats[key] == 0
+        for key in (
+            "n_errored_trials",
+            "n_running_trials",
+            "n_pending_trials",
+            "n_cancelled_trials",
+        )
+    )
+
+
 def _comparison_job(job: dict[str, Any]) -> dict[str, Any]:
     """Normalize only the frozen Jacobian treatment additions.
 
@@ -208,6 +241,7 @@ def _trial_status(
     exception: Any,
     *,
     job_stats: dict[str, Any] | None = None,
+    observed_trial_count: int | None = None,
 ) -> str:
     raw = trial.get("status")
     if exception is not None:
@@ -242,39 +276,21 @@ def _trial_status(
         "TIMEOUT",
         "CANCELLED",
     }:
+        if verifier_status == "COMPLETED" and (
+            job_stats is None
+            or observed_trial_count is None
+            or not _completed_job_stats(job_stats, observed_trial_count)
+        ):
+            return "ERROR"
         return verifier_status
     if verifier_status is not None:
         return "ERROR"
-    if job_stats is not None:
-        completed = job_stats.get("n_completed_trials")
-        total = job_stats.get("n_total_trials")
-        if (
-            isinstance(completed, int)
-            and not isinstance(completed, bool)
-            and isinstance(total, int)
-            and not isinstance(total, bool)
-            and completed == total
-            and all(
-                job_stats.get(key, 0) == 0
-                for key in (
-                    "n_errored_trials",
-                    "n_running_trials",
-                    "n_pending_trials",
-                    "n_cancelled_trials",
-                )
-            )
-        ):
-            return "COMPLETED"
-        if verifier_result and all(
-            job_stats.get(key, 0) == 0
-            for key in (
-                "n_errored_trials",
-                "n_running_trials",
-                "n_pending_trials",
-                "n_cancelled_trials",
-            )
-        ):
-            return "COMPLETED"
+    if (
+        job_stats is not None
+        and observed_trial_count is not None
+        and _completed_job_stats(job_stats, observed_trial_count)
+    ):
+        return "COMPLETED"
     return "ERROR"
 
 
@@ -288,6 +304,7 @@ def _normalize_trial(
     source_prefix: str | None = None,
     configured_artifacts: set[tuple[str, str | None]] | None = None,
     job_stats: dict[str, Any] | None = None,
+    observed_trial_count: int | None = None,
 ) -> tuple[dict[str, Any], list[str]]:
     agent_result = _object(trial.get("agent_result"))
     agent_info = _object(trial.get("agent_info"))
@@ -358,7 +375,12 @@ def _normalize_trial(
         "repetition": repetition,
         "trial_name": str(trial.get("trial_name", "")),
         "pair_id": None,
-        "status": _trial_status(trial, exception, job_stats=job_stats),
+        "status": _trial_status(
+            trial,
+            exception,
+            job_stats=job_stats,
+            observed_trial_count=observed_trial_count,
+        ),
         "exception_type": exception.get("exception_type")
         if isinstance(exception, dict)
         else None,
@@ -444,7 +466,13 @@ def _observation_failures(
         if expected_digests.get(trial["task"]) is not None
         and trial["task_digest"] != expected_digests[trial["task"]]
     )
-    stats = _object(payload.get("stats"))
+    stats = dict(_object(payload.get("stats")))
+    if "n_total_trials" not in stats:
+        stats["n_total_trials"] = payload.get("n_total_trials")
+    if not _completed_job_stats(stats, len(trials)):
+        failures.append(
+            "execution completion counts are missing, malformed, or disagree with observed trials"
+        )
     incomplete = any(
         stats.get(key, 0)
         for key in (
@@ -664,6 +692,7 @@ def build_observation_evidence(
             source_prefix=source_prefix,
             configured_artifacts=configured_artifacts,
             job_stats=job_stats,
+            observed_trial_count=len(raw_trials),
         )
         artifact_failures.extend(trial_artifact_failures)
         trials.append(normalized)

--- a/benchmarks/tooling/observation_results.py
+++ b/benchmarks/tooling/observation_results.py
@@ -203,9 +203,17 @@ def _timing_seconds(value: Any) -> float | None:
         return None
 
 
-def _trial_status(trial: dict[str, Any], exception: Any) -> str:
+def _trial_status(
+    trial: dict[str, Any],
+    exception: Any,
+    *,
+    job_stats: dict[str, Any] | None = None,
+) -> str:
     raw = trial.get("status")
+    if exception is not None:
+        return "ERROR"
     if isinstance(raw, str) and raw in {
+        "COMPLETED",
         "RUNNING",
         "PENDING",
         "FAILED",
@@ -214,11 +222,60 @@ def _trial_status(trial: dict[str, Any], exception: Any) -> str:
         "CANCELLED",
     }:
         return raw
-    if exception is not None:
+    if raw is not None:
         return "ERROR"
-    if not isinstance(raw, str) or raw != "COMPLETED":
+    verifier_result = _object(trial.get("verifier_result"))
+    verifier_status: Any = None
+    for key in ("status", "state"):
+        if key in verifier_result:
+            verifier_status = verifier_result[key]
+            if verifier_status is not None and not isinstance(verifier_status, str):
+                return "ERROR"
+            if verifier_status is not None:
+                break
+    if isinstance(verifier_status, str) and verifier_status in {
+        "COMPLETED",
+        "RUNNING",
+        "PENDING",
+        "FAILED",
+        "ERROR",
+        "TIMEOUT",
+        "CANCELLED",
+    }:
+        return verifier_status
+    if verifier_status is not None:
         return "ERROR"
-    return "COMPLETED"
+    if job_stats is not None:
+        completed = job_stats.get("n_completed_trials")
+        total = job_stats.get("n_total_trials")
+        if (
+            isinstance(completed, int)
+            and not isinstance(completed, bool)
+            and isinstance(total, int)
+            and not isinstance(total, bool)
+            and completed == total
+            and all(
+                job_stats.get(key, 0) == 0
+                for key in (
+                    "n_errored_trials",
+                    "n_running_trials",
+                    "n_pending_trials",
+                    "n_cancelled_trials",
+                )
+            )
+        ):
+            return "COMPLETED"
+        if verifier_result and all(
+            job_stats.get(key, 0) == 0
+            for key in (
+                "n_errored_trials",
+                "n_running_trials",
+                "n_pending_trials",
+                "n_cancelled_trials",
+            )
+        ):
+            return "COMPLETED"
+    return "ERROR"
 
 
 def _normalize_trial(
@@ -230,6 +287,7 @@ def _normalize_trial(
     runtime: dict[str, Any] | None,
     source_prefix: str | None = None,
     configured_artifacts: set[tuple[str, str | None]] | None = None,
+    job_stats: dict[str, Any] | None = None,
 ) -> tuple[dict[str, Any], list[str]]:
     agent_result = _object(trial.get("agent_result"))
     agent_info = _object(trial.get("agent_info"))
@@ -300,7 +358,7 @@ def _normalize_trial(
         "repetition": repetition,
         "trial_name": str(trial.get("trial_name", "")),
         "pair_id": None,
-        "status": _trial_status(trial, exception),
+        "status": _trial_status(trial, exception, job_stats=job_stats),
         "exception_type": exception.get("exception_type")
         if isinstance(exception, dict)
         else None,
@@ -574,6 +632,9 @@ def build_observation_evidence(
     )
 
     raw_trials = _trial_results(result_path, payload)
+    job_stats = dict(_object(payload.get("stats")))
+    if "n_total_trials" not in job_stats:
+        job_stats["n_total_trials"] = payload.get("n_total_trials")
     raw_trials.sort(
         key=lambda pair: (
             _task_id(pair[1].get("task_name")),
@@ -602,6 +663,7 @@ def build_observation_evidence(
             runtime=runtime_snapshot,
             source_prefix=source_prefix,
             configured_artifacts=configured_artifacts,
+            job_stats=job_stats,
         )
         artifact_failures.extend(trial_artifact_failures)
         trials.append(normalized)

--- a/benchmarks/validation/test_heldout_bundle.py
+++ b/benchmarks/validation/test_heldout_bundle.py
@@ -458,7 +458,9 @@ def test_complete_plan_collects_exact_pairs_and_derives_heldout_report(
         result_root = plan_path.parent / run["jobs_dir"] / "job"
         result_root.mkdir(parents=True)
         result = {
+            "n_total_trials": 1,
             "stats": {
+                "n_completed_trials": 1,
                 "n_errored_trials": 0,
                 "n_running_trials": 0,
                 "n_pending_trials": 0,

--- a/src/jacobian/adapters/mcp/remote.py
+++ b/src/jacobian/adapters/mcp/remote.py
@@ -159,6 +159,7 @@ class TenantRuntimeRouter:
         self._runtime_factory = runtime_factory
         self._runtimes: dict[str, _TenantRuntimeEntry] = {}
         self._creating: set[str] = set()
+        self._evicting: set[str] = set()
         self._evictions_in_flight = 0
         self._condition = threading.Condition()
         self._closing = False
@@ -235,6 +236,8 @@ class TenantRuntimeRouter:
 
     def _plan_acquisition(self, tenant_key: str) -> _AcquisitionPlan:
         now = self._clock()
+        if tenant_key in self._evicting:
+            return "WAIT"
         entry = self._runtimes.get(tenant_key)
         if entry is not None and not (
             entry.active_leases == 0
@@ -245,6 +248,7 @@ class TenantRuntimeRouter:
             return TenantRuntimeLease(self, tenant_key, entry.runtime)
         if entry is not None:
             eviction = (tenant_key, self._runtimes.pop(tenant_key))
+            self._evicting.add(tenant_key)
             self._evictions_in_flight += 1
             return eviction
         if tenant_key in self._creating:
@@ -266,6 +270,7 @@ class TenantRuntimeRouter:
             )
         eviction = min(inactive, key=lambda item: (item[1].last_used, item[0]))
         del self._runtimes[eviction[0]]
+        self._evicting.add(eviction[0])
         self._evictions_in_flight += 1
         return eviction
 
@@ -276,14 +281,13 @@ class TenantRuntimeRouter:
         except BaseException:
             with self._condition:
                 self._evictions_in_flight -= 1
-                # Guard against overwriting a runtime that was created
-                # concurrently while this eviction was in flight.
-                if tenant_key not in self._runtimes:
-                    self._runtimes[tenant_key] = entry
+                self._evicting.remove(tenant_key)
+                self._runtimes[tenant_key] = entry
                 self._condition.notify_all()
             raise
         with self._condition:
             self._evictions_in_flight -= 1
+            self._evicting.remove(tenant_key)
             self._condition.notify_all()
 
     def _release(self, tenant_key: str) -> None:
@@ -326,7 +330,6 @@ class TenantRuntimeRouter:
         if failures:
             with self._condition:
                 self._shutdown_in_flight = False
-                self._closing = False
                 self._condition.notify_all()
             raise ExceptionGroup(
                 "one or more tenant runtimes failed to close", failures

--- a/src/jacobian/adapters/mcp/tooling.py
+++ b/src/jacobian/adapters/mcp/tooling.py
@@ -47,13 +47,26 @@ async def _run_blocking[BlockingResultT](
         if on_cancel is not None:
             on_cancel()
         drained: BlockingResultT | None = None
-        try:
-            drained = await asyncio.shield(worker)
-        except BaseException:
-            _LOGGER.debug(
-                "blocking MCP worker failed while its cancelled request drained",
-                exc_info=True,
-            )
+        while not worker.done():
+            try:
+                drained = await asyncio.shield(worker)
+                break
+            except asyncio.CancelledError:
+                continue
+            except BaseException:
+                _LOGGER.debug(
+                    "blocking MCP worker failed while its cancelled request drained",
+                    exc_info=True,
+                )
+                break
+        if worker.done() and drained is None:
+            try:
+                drained = worker.result()
+            except BaseException:
+                _LOGGER.debug(
+                    "blocking MCP worker failed while its cancelled request drained",
+                    exc_info=True,
+                )
         exc.drained_result = drained  # type: ignore[attr-defined]
         raise
 

--- a/tests/boundary/mcp/test_mcp_operations.py
+++ b/tests/boundary/mcp/test_mcp_operations.py
@@ -271,3 +271,31 @@ def test_cancelled_mcp_blocking_work_drains_before_request_task_finishes() -> No
         assert finished.is_set()
 
     asyncio.run(scenario())
+
+
+def test_repeated_cancellation_keeps_draining_blocking_work() -> None:
+    started = threading.Event()
+    release = threading.Event()
+    finished = threading.Event()
+
+    def blocking_operation() -> str:
+        started.set()
+        release.wait(timeout=2)
+        finished.set()
+        return "finished"
+
+    async def scenario() -> None:
+        task = asyncio.create_task(_run_blocking(blocking_operation))
+        while not started.is_set():
+            await asyncio.sleep(0)
+        task.cancel()
+        await asyncio.sleep(0.05)
+        task.cancel()
+        await asyncio.sleep(0.05)
+        assert not task.done()
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert finished.is_set()
+
+    asyncio.run(scenario())

--- a/tests/boundary/mcp/test_remote_mcp_tenants.py
+++ b/tests/boundary/mcp/test_remote_mcp_tenants.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from jacobian.adapters.mcp.remote import (
+    TenantRuntimeLease,
     TenantRuntimeLimitError,
     TenantRuntimeRouter,
     TenantRuntimeRouterClosedError,
@@ -46,13 +47,26 @@ def test_tenant_router_isolates_artifact_stores(tmp_path: Path) -> None:
 
 
 class _FakeRuntime:
-    def __init__(self, identity: Path, *, fail_close: bool = False) -> None:
+    def __init__(
+        self,
+        identity: Path,
+        *,
+        fail_close: bool = False,
+        close_started: threading.Event | None = None,
+        close_release: threading.Event | None = None,
+    ) -> None:
         self.identity = identity
         self.fail_close = fail_close
+        self.close_started = close_started
+        self.close_release = close_release
         self.close_calls = 0
 
     def close(self) -> None:
         self.close_calls += 1
+        if self.close_started is not None:
+            self.close_started.set()
+        if self.close_release is not None:
+            self.close_release.wait(timeout=2)
         if self.fail_close:
             raise RuntimeError("injected close failure")
 
@@ -190,6 +204,56 @@ def test_tenant_router_restores_failed_eviction_and_shutdown_waits_for_leases(
     assert closed.is_set()
 
 
+def test_tenant_router_blocks_same_tenant_during_eviction_cleanup(
+    tmp_path: Path,
+) -> None:
+    close_started = threading.Event()
+    close_release = threading.Event()
+    first = _FakeRuntime(
+        tmp_path / "first",
+        fail_close=True,
+        close_started=close_started,
+        close_release=close_release,
+    )
+    router = TenantRuntimeRouter(
+        tmp_path,
+        max_tenant_runtimes=1,
+        runtime_factory=lambda _path, **_kwargs: first,  # type: ignore[arg-type]
+    )
+    router.runtime_for("alpha")
+
+    eviction_error: list[BaseException] = []
+
+    def evict() -> None:
+        try:
+            router.lease_for("beta")
+        except BaseException as exc:
+            eviction_error.append(exc)
+
+    evictor = threading.Thread(target=evict)
+    evictor.start()
+    assert close_started.wait(timeout=2)
+
+    acquired: list[TenantRuntimeLease] = []
+
+    def reacquire() -> None:
+        acquired.append(router.lease_for("alpha"))
+
+    reacquirer = threading.Thread(target=reacquire)
+    reacquirer.start()
+    reacquirer.join(timeout=0.1)
+    assert reacquirer.is_alive()
+
+    close_release.set()
+    evictor.join(timeout=2)
+    reacquirer.join(timeout=2)
+
+    assert len(eviction_error) == 1
+    assert len(acquired) == 1
+    assert acquired[0].runtime is first
+    acquired[0].release()
+
+
 def test_tenant_router_retries_only_failed_runtime_shutdowns(tmp_path: Path) -> None:
     created: list[_FakeRuntime] = []
 
@@ -209,6 +273,8 @@ def test_tenant_router_retries_only_failed_runtime_shutdowns(tmp_path: Path) -> 
     with pytest.raises(ExceptionGroup, match="tenant runtimes failed to close"):
         router.close()
     assert [runtime.close_calls for runtime in created] == [1, 1]
+    with pytest.raises(TenantRuntimeRouterClosedError, match="closing"):
+        router.lease_for("gamma")
 
     created[0].fail_close = False
     router.close()

--- a/tests/unit/tooling/test_audit_fixes_round2.py
+++ b/tests/unit/tooling/test_audit_fixes_round2.py
@@ -5,8 +5,8 @@ Validates six bugs identified during the audit:
 1. ``_close_evicted`` overwrites a concurrently-created runtime on close failure.
 2. ``close()`` leaves ``_closing=True`` on failure, permanently rejecting leases.
 3. ``_run_blocking`` orphans the worker thread on a second ``CancelledError``.
-4. ``_trial_status`` treated a missing ``status`` field as ``COMPLETED``.
-5. ``compare_evidence`` only checked core metrics for missing pairs.
+4. ``_trial_status`` required a non-standard top-level ``status`` field.
+5. ``compare_evidence`` treated optional metrics as required pair invariants.
 6. ``mkstemp`` fd was leaked if ``os.fdopen`` raised before the ``with`` block.
 """
 
@@ -25,6 +25,25 @@ def test_trial_status_missing_status_fails_closed() -> None:
     assert _trial_status({"status": "FAILED"}, None) == "FAILED"
     assert _trial_status({}, RuntimeError("boom")) == "ERROR"
     assert _trial_status({"status": "COMPLETED"}, RuntimeError("boom")) == "ERROR"
+    assert _trial_status({"verifier_result": {"status": 1}}, None) == "ERROR"
+    assert (
+        _trial_status({"verifier_result": {"status": "COMPLETED"}}, None) == "COMPLETED"
+    )
+    assert (
+        _trial_status(
+            {},
+            None,
+            job_stats={
+                "n_total_trials": 1,
+                "n_completed_trials": 1,
+                "n_errored_trials": 0,
+                "n_running_trials": 0,
+                "n_pending_trials": 0,
+                "n_cancelled_trials": 0,
+            },
+        )
+        == "COMPLETED"
+    )
 
 
 def test_trial_status_non_string_status_fails_closed() -> None:
@@ -32,7 +51,9 @@ def test_trial_status_non_string_status_fails_closed() -> None:
     from benchmarks.tooling.observation_results import _trial_status
 
     for bad in (None, 0, 1, True, False, [], {}):
-        assert _trial_status({"status": bad}, None) == "ERROR", f"{bad!r} should be ERROR"
+        assert _trial_status({"status": bad}, None) == "ERROR", (
+            f"{bad!r} should be ERROR"
+        )
 
 
 def test_metric_report_reports_missing_pairs_for_all_metrics() -> None:
@@ -62,17 +83,28 @@ def test_metric_report_reports_missing_pairs_for_all_metrics() -> None:
     )
 
 
-def test_compare_evidence_checks_all_metrics_for_missing_pairs() -> None:
-    """compare_evidence must iterate over all metric_names, not just 2."""
-    from benchmarks.tooling import observation_comparison
+def test_compare_evidence_tolerates_missing_optional_metrics() -> None:
+    """Optional accounting and reward dimensions do not invalidate a pair."""
+    from copy import deepcopy
 
-    source = inspect.getsource(observation_comparison.compare_evidence)
-    assert "metric_names" in source, (
-        "compare_evidence must iterate over all metric_names"
-    )
-    assert 'for metric in ("correctness", "false_certification")' not in source, (
-        "compare_evidence should no longer hard-code only 2 metrics"
-    )
+    from benchmarks.tooling.observation_comparison import compare_evidence
+    from benchmarks.validation.observation_results_support import _evidence
+
+    control = _evidence("control", [1.0])
+    treatment = deepcopy(_evidence("treatment", [1.0]))
+    for evidence in (control, treatment):
+        trial = evidence["trials"][0]
+        for key in ("evidence_validity", "scope_accuracy", "assurance_calibration"):
+            trial["rewards"].pop(key)
+        trial["tokens"]["input"] = None
+        trial["tokens"]["output"] = None
+        trial["cost_usd"] = None
+        trial["agent_seconds"] = None
+
+    report = compare_evidence(control, treatment)
+
+    assert report["status"] == "VALID"
+    assert report["metrics"]["evidence_validity"]["pair_count"] == 0
 
 
 def test_mkstemp_fd_closed_on_fdopen_failure() -> None:
@@ -82,35 +114,4 @@ def test_mkstemp_fd_closed_on_fdopen_failure() -> None:
     source = inspect.getsource(statement_module)
     assert "os.close(fd)" in source, (
         "statement.py must close the mkstemp fd if os.fdopen fails"
-    )
-
-
-def test_close_evicted_guards_concurrent_runtime_creation() -> None:
-    """_close_evicted must not overwrite a concurrently-created runtime."""
-    from jacobian.adapters.mcp import remote
-
-    source = inspect.getsource(remote.TenantRuntimeRouter._close_evicted)
-    assert "if tenant_key not in self._runtimes" in source, (
-        "_close_evicted must guard against overwriting a concurrent runtime"
-    )
-
-
-def test_close_resets_closing_flag_on_failure() -> None:
-    """close() must reset _closing on failure to avoid permanently rejecting leases."""
-    from jacobian.adapters.mcp import remote
-
-    source = inspect.getsource(remote.TenantRuntimeRouter.close)
-    assert "_closing = False" in source, (
-        "close() must reset _closing=False in the failure path"
-    )
-
-
-def test_run_blocking_catches_base_exception_for_drain() -> None:
-    """_run_blocking must catch BaseException (not just Exception) for the drain."""
-    from jacobian.adapters.mcp import tooling
-
-    source = inspect.getsource(tooling._run_blocking)
-    assert "except BaseException:" in source, (
-        "_run_blocking must catch BaseException for the drain so that a "
-        "second CancelledError does not orphan the worker thread"
     )

--- a/tests/unit/tooling/test_audit_fixes_round2.py
+++ b/tests/unit/tooling/test_audit_fixes_round2.py
@@ -26,12 +26,10 @@ def test_trial_status_missing_status_fails_closed() -> None:
     assert _trial_status({}, RuntimeError("boom")) == "ERROR"
     assert _trial_status({"status": "COMPLETED"}, RuntimeError("boom")) == "ERROR"
     assert _trial_status({"verifier_result": {"status": 1}}, None) == "ERROR"
-    assert (
-        _trial_status({"verifier_result": {"status": "COMPLETED"}}, None) == "COMPLETED"
-    )
+    assert _trial_status({"verifier_result": {"status": "COMPLETED"}}, None) == "ERROR"
     assert (
         _trial_status(
-            {},
+            {"verifier_result": {"rewards": {"correctness": 1.0}}},
             None,
             job_stats={
                 "n_total_trials": 1,
@@ -41,8 +39,34 @@ def test_trial_status_missing_status_fails_closed() -> None:
                 "n_pending_trials": 0,
                 "n_cancelled_trials": 0,
             },
+            observed_trial_count=1,
         )
         == "COMPLETED"
+    )
+    assert (
+        _trial_status(
+            {"verifier_result": {"status": "COMPLETED"}},
+            None,
+            job_stats={
+                "n_total_trials": 1,
+                "n_completed_trials": 1,
+                "n_errored_trials": 0,
+                "n_running_trials": 0,
+                "n_pending_trials": 0,
+                "n_cancelled_trials": 0,
+            },
+            observed_trial_count=1,
+        )
+        == "COMPLETED"
+    )
+    assert (
+        _trial_status(
+            {"verifier_result": {"rewards": {"correctness": 1.0}}},
+            None,
+            job_stats={"n_total_trials": 1},
+            observed_trial_count=1,
+        )
+        == "ERROR"
     )
 
 
@@ -54,6 +78,43 @@ def test_trial_status_non_string_status_fails_closed() -> None:
         assert _trial_status({"status": bad}, None) == "ERROR", (
             f"{bad!r} should be ERROR"
         )
+
+
+def test_observation_failures_require_authoritative_completion_counts() -> None:
+    from collections import Counter
+
+    from benchmarks.tooling.observation_results import _observation_failures
+
+    failures = _observation_failures(
+        counters=Counter({"case": 1}),
+        expected_tasks={"case"},
+        attempts=1,
+        expected_digests={},
+        trials=[
+            {
+                "task": "case",
+                "repetition": 0,
+                "task_digest": None,
+                "status": "COMPLETED",
+                "reasoning_protocol": {
+                    "mode": "OFF",
+                    "status": "NOT_REQUIRED",
+                    "requirement_status": "COMPLETE",
+                },
+            }
+        ],
+        payload={
+            "n_total_trials": 1,
+            "stats": {
+                "n_errored_trials": 0,
+                "n_running_trials": 0,
+                "n_pending_trials": 0,
+                "n_cancelled_trials": 0,
+            },
+        },
+    )
+
+    assert any("completion counts" in failure for failure in failures)
 
 
 def test_metric_report_reports_missing_pairs_for_all_metrics() -> None:


### PR DESCRIPTION
Follow-up to #586.

## Summary

Addresses all five actionable review findings raised after #586 merged:

- Derive Harbor trial completion from verifier results and authoritative job statistics, while keeping exceptions and malformed states fail-closed.
- Require complete pairs only for core comparison metrics; preserve optional accounting and reward dimensions without invalidating otherwise valid held-out evidence.
- Block same-tenant replacement while eviction cleanup is in flight, restore failed evictions for retry, and keep router admission closed after partial shutdown failure.
- Continue draining blocking MCP work across repeated request cancellation.
- Replace source-inspection regressions with behavioral coverage for the review scenarios.

## Review guidance

Suggested order:

1. observation_results.py and observation_comparison.py with their unit/validation regressions.
2. remote.py with the eviction and shutdown lifecycle tests.
3. tooling.py with the repeated-cancellation boundary test.

## Validation

Passing:

- Focused review regression and observation suite: 94 passed.
- Unit lane: 687 passed.
- MCP lane: 35 passed.
- npm test and package dry-run: 45 passed.
- mypy: 444 source files, no issues.
- Ruff check/format on all changed files.
- Architecture check and Python package build.

Repository-gate notes:

- The component lane currently reports three failures in unchanged checker/polynomial tests.
- The e2e lane currently reports three failures in unchanged reference-runtime tests; one optional Lean test is skipped because the pinned Lean runtime is unavailable.
- The planner-wide static gate is blocked by four existing Ruff violations in tests/unit/tooling/test_audit_fixes.py, outside this change.

No public API or migration changes.