### PR TITLE
fix(tests): avoid sharing template blob inodes

### DIFF
--- a/tests/support/state.py
+++ b/tests/support/state.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import shutil
 import tempfile
 from collections.abc import Callable
@@ -100,9 +99,9 @@ def publish_template(
 def copy_template(template: Path, destination: Path) -> Path:
     """Copy an immutable template into a new mutable per-test directory.
 
-    Blobs under ``blobs/`` are content-addressed and immutable, so they are
-    hardlinked instead of copied.  This avoids copying ~7 MB of blob data per
-    test across 80+ composition tests — a significant I/O reduction.
+    Every runtime receives independent file inodes.  In particular, blob
+    files must not be hardlinked because storage integrity checks inspect
+    inode metadata while another xdist worker may be copying the template.
     """
 
     template = Path(template)
@@ -111,33 +110,6 @@ def copy_template(template: Path, destination: Path) -> Path:
         raise FileNotFoundError(f"template directory does not exist: {template}")
     if destination.exists():
         raise FileExistsError(f"mutable test state already exists: {destination}")
-    destination.mkdir(parents=True, exist_ok=True)
-
-    # Copy everything except the blobs directory with a normal recursive copy,
-    # then hardlink the content-addressed blobs.
-    for entry in os.scandir(template):
-        src = Path(entry.path)
-        dst = destination / entry.name
-        if entry.name == "blobs":
-            _hardlink_tree(src, dst)
-        elif entry.is_dir():
-            shutil.copytree(src, dst)
-        else:
-            shutil.copy2(src, dst)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(template, destination)
     return destination
-
-
-def _hardlink_tree(src: Path, dst: Path) -> None:
-    """Recursively hardlink all files from *src* into *dst*."""
-
-    dst.mkdir(parents=True, exist_ok=True)
-    for entry in os.scandir(src):
-        s = Path(entry.path)
-        d = dst / entry.name
-        if entry.is_dir(follow_symlinks=False):
-            _hardlink_tree(s, d)
-        elif entry.is_file(follow_symlinks=False):
-            os.link(s, d)
-        else:
-            # Fallback for any unusual file types.
-            shutil.copy2(s, d)

--- a/tests/unit/support/test_copy_template.py
+++ b/tests/unit/support/test_copy_template.py
@@ -1,12 +1,12 @@
-"""Tests for copy_template hardlink optimization."""
+"""Tests for copy_template isolation."""
 import os
 from pathlib import Path
 
 from tests.support.state import copy_template
 
 
-def test_copy_template_hardlinks_blobs(tmp_path: Path) -> None:
-    """Blobs should be hardlinked (not copied) for I/O efficiency."""
+def test_copy_template_copies_blobs_without_sharing_inodes(tmp_path: Path) -> None:
+    """Blob copies must not share inodes with the immutable template."""
     template = tmp_path / "template"
     template.mkdir()
     blob = template / "blobs" / "sha256" / "00" / "abc123"
@@ -20,7 +20,10 @@ def test_copy_template_hardlinks_blobs(tmp_path: Path) -> None:
     assert (dest / "blobs" / "sha256" / "00" / "abc123").read_bytes() == b"blob content"
     template_inode = os.stat(blob).st_ino
     dest_inode = os.stat(dest / "blobs" / "sha256" / "00" / "abc123").st_ino
-    assert template_inode == dest_inode, "blob should be hardlinked"
+    assert template_inode != dest_inode, "blob should be copied, not hardlinked"
+
+    (dest / "blobs" / "sha256" / "00" / "abc123").write_bytes(b"changed")
+    assert blob.read_bytes() == b"blob content"
 
     template_meta = os.stat(template / "metadata.sqlite3").st_ino
     dest_meta = os.stat(dest / "metadata.sqlite3").st_ino


### PR DESCRIPTION
Follow-up to #580.

## Problem

Template blob files were hardlinked into each xdist runtime. A concurrent copy or artifact write could therefore change the shared inode's ctime while storage integrity checks were reading the same digest, producing a false ArtifactIntegrityError.

## Change

- Copy the complete template with independent destination inodes instead of hardlinking the content-addressed blob tree.
- Update the regression to verify blob inode separation and that mutating a destination blob cannot modify the template.

## Validation

- Focused state/storage tests: 18 passed.
- Ruff check, formatting, and diff validation passed for the changed files.
- Composition lane: 441 passed, 2 skipped because Lean is unavailable, and 5 unrelated existing verification/capability tests failed.

No public API or migration changes.