### PR TITLE
fix: verify accepted false conclusions

### DIFF
--- a/src/jacobian/verification/service.py
+++ b/src/jacobian/verification/service.py
@@ -400,11 +400,7 @@ class VerificationService:
                 arithmetic=decision.arithmetic,
                 method=decision.method,
                 coverage=decision.coverage,
-                verification=(
-                    Verification.VERIFIED
-                    if decision.conclusion == Conclusion.TRUE
-                    else Verification.UNVERIFIED
-                ),
+                verification=Verification.VERIFIED,
                 checker_id=checker.checker_id,
                 checker_digest=checker.executable_digest,
                 scope_uri=scope.artifact_uri if scope is not None else None,
@@ -692,11 +688,7 @@ class VerificationService:
                 arithmetic=decision.arithmetic,
                 method=decision.method,
                 coverage=decision.coverage,
-                verification=(
-                    Verification.VERIFIED
-                    if decision.conclusion == Conclusion.TRUE
-                    else Verification.UNVERIFIED
-                ),
+                verification=Verification.VERIFIED,
                 checker_id=checker.checker_id,
                 checker_digest=checker.executable_digest,
                 scope_uri=scope.artifact_uri if scope is not None else None,
@@ -915,11 +907,7 @@ class VerificationService:
                 arithmetic=decision.arithmetic,
                 method=decision.method,
                 coverage=decision.coverage,
-                verification=(
-                    Verification.VERIFIED
-                    if decision.conclusion == Conclusion.TRUE
-                    else Verification.UNVERIFIED
-                ),
+                verification=Verification.VERIFIED,
                 checker_id=checker.checker_id,
                 checker_digest=checker.executable_digest,
                 scope_uri=transformation_uri,
@@ -1125,11 +1113,7 @@ class VerificationService:
                 arithmetic=decision.arithmetic,
                 method=decision.method,
                 coverage=decision.coverage,
-                verification=(
-                    Verification.VERIFIED
-                    if decision.conclusion == Conclusion.TRUE
-                    else Verification.UNVERIFIED
-                ),
+                verification=Verification.VERIFIED,
                 checker_id=checker.checker_id,
                 checker_digest=checker.executable_digest,
             )

--- a/tests/component/checkers/test_fail_closed_verification_semantics.py
+++ b/tests/component/checkers/test_fail_closed_verification_semantics.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from jacobian.contracts.results import Conclusion, Verification
+from jacobian.contracts.results import Verification
 from jacobian.exact_domain_checkers import _checker_supports
 
 
@@ -19,21 +19,19 @@ def test_checker_supports_unknown_polynomial_operation_is_false() -> None:
 def test_checker_supports_known_univariate_gcd() -> None:
     payload = {
         "left": {"variables": ["x"], "terms": [{"coefficient": "1", "exponents": [1]}]},
-        "right": {"variables": ["x"], "terms": [{"coefficient": "1", "exponents": [0]}]},
+        "right": {
+            "variables": ["x"],
+            "terms": [{"coefficient": "1", "exponents": [0]}],
+        },
     }
     assert _checker_supports("polynomial.compute.gcd", payload) is True
 
 
-def test_verified_assurance_requires_true_conclusion_policy() -> None:
-    """Document the service policy: VERIFIED only when conclusion is TRUE."""
+def test_verified_assurance_requires_accepted_checker_decision() -> None:
+    """An accepted exact checker verifies either decisive conclusion."""
 
-    def verification_for(conclusion: Conclusion) -> Verification:
-        return (
-            Verification.VERIFIED
-            if conclusion == Conclusion.TRUE
-            else Verification.UNVERIFIED
-        )
+    def verification_for(*, accepted: bool) -> Verification:
+        return Verification.VERIFIED if accepted else Verification.UNVERIFIED
 
-    assert verification_for(Conclusion.TRUE) is Verification.VERIFIED
-    assert verification_for(Conclusion.FALSE) is Verification.UNVERIFIED
-    assert verification_for(Conclusion.UNKNOWN) is Verification.UNVERIFIED
+    assert verification_for(accepted=True) is Verification.VERIFIED
+    assert verification_for(accepted=False) is Verification.UNVERIFIED


### PR DESCRIPTION
## Problem

Accepted exact checkers that correctly refuted a claim returned `conclusion=FALSE`, but VerificationService labeled those results `UNVERIFIED` because it promoted only `TRUE` conclusions. This caused valid witness replays to lose verification records and made the shrinker reject valid preservation steps.

## Change

Use checker acceptance as the verification boundary for witness, certificate, transformation, and preservation verification. Rejected, malformed, timed-out, cancelled, and operationally failed checker runs remain `UNVERIFIED` and fail closed.

The policy regression now covers accepted versus rejected decisions rather than conflating verification assurance with the truth value of the mathematical conclusion.

## Validation

- Reference-runtime e2e regressions: all 3 previously failing tests pass.
- Complete owning verification/shrinking set: 35 passed.
- Ruff and mypy pass for changed files.

No public API or migration changes.