### PR TITLE
perf(benchmarks): cache schema validators with lru_cache

### DIFF
--- a/benchmarks/tooling/benchmark_contracts.py
+++ b/benchmarks/tooling/benchmark_contracts.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 import json
 import tomllib
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
-
-from functools import lru_cache
 
 from jsonschema import Draft202012Validator
 from jsonschema.exceptions import SchemaError, ValidationError

--- a/benchmarks/tooling/benchmark_contracts.py
+++ b/benchmarks/tooling/benchmark_contracts.py
@@ -7,6 +7,8 @@ import tomllib
 from pathlib import Path
 from typing import Any
 
+from functools import lru_cache
+
 from jsonschema import Draft202012Validator
 from jsonschema.exceptions import SchemaError, ValidationError
 
@@ -48,6 +50,7 @@ def _read_toml(path: Path) -> dict[str, Any]:
     return value
 
 
+@lru_cache(maxsize=16)
 def _validator(schema_name: str) -> Draft202012Validator:
     path = SCHEMAS / schema_name
     schema = _read_json(path)


### PR DESCRIPTION
## Summary

The `_validator` function in `benchmarks/tooling/benchmark_contracts.py` re-reads and re-checks the schema file on every call. With 219 task.toml files and multiple schema validations per task, this causes unnecessary I/O and computation.

## Fix

Add `lru_cache(maxsize=16)` to `_validator`. There are only a handful of schemas, so the cache hit rate is near 100% after the first call.

## Validation

- `tests/unit/tooling/` benchmark tests: 9 passed, 278 deselected