### PR TITLE
docs: improve deterministic math routing guidance

### DIFF
--- a/.agents/skills/jacobian-math/SKILL.md
+++ b/.agents/skills/jacobian-math/SKILL.md
@@ -19,6 +19,14 @@ const r = await tools.mcp__jacobian__math_find({query: "...", limit: 3});
 text(r.structuredContent ?? r);
 ```
 
+For each requested exact mathematical outcome, use Jacobian even when the
+calculation is small or could be done mentally or in shell code. Route multiple
+requested outcomes separately. Prefer a capability matching the requested
+mathematical operation over a generic arithmetic substep that happens to produce
+the same scalar; use a supporting operation only after a dedicated search finds
+no direct capability. Do not call Jacobian for definitions, formatting, or other
+tasks needing no mathematical execution.
+
 Call `math.run` directly when the requested local outcome exactly matches one of
 these stable built-in contracts; replace the example values but preserve the
 shown JSON types:
@@ -42,6 +50,13 @@ because lower `limit` values reduce context. Inspect the `CONTRACT` view only
 when its typed schema is needed to construct the `math.run` payload. A discovery
 card's validated `invocation_example`, or its required top-level fields when no
 example is available, may already provide a sufficient payload shape.
+
+Do not add a discovery domain filter unless its exact installed spelling is
+known. If discovery reports an unknown domain, retry once without that filter.
+After invalid input, correct only the reported constraint and retry once. Stop
+after a second invalid request, no route, an unavailable provider, or a timeout.
+Accept only a completed result whose scope covers the supplied input, and carry
+forward the smallest decisive value, witness, status, and assurance.
 
 Keep representation, decomposition, composition, iteration, verification
 timing, and stopping decisions agent-owned. Treat timeouts, errors, incomplete

--- a/.agents/skills/jacobian-math/SKILL.md
+++ b/.agents/skills/jacobian-math/SKILL.md
@@ -23,9 +23,9 @@ For each requested exact mathematical outcome, use Jacobian even when the
 calculation is small or could be done mentally or in shell code. Route multiple
 requested outcomes separately. Prefer a capability matching the requested
 mathematical operation over a generic arithmetic substep that happens to produce
-the same scalar; use a supporting operation only after a dedicated search finds
-no direct capability. Do not call Jacobian for definitions, formatting, or other
-tasks needing no mathematical execution.
+the same scalar; composing already-known supporting operations remains allowed
+when that is the clearer route. Do not call Jacobian for definitions,
+formatting, or other tasks needing no mathematical execution.
 
 Call `math.run` directly when the requested local outcome exactly matches one of
 these stable built-in contracts; replace the example values but preserve the
@@ -52,11 +52,14 @@ card's validated `invocation_example`, or its required top-level fields when no
 example is available, may already provide a sufficient payload shape.
 
 Do not add a discovery domain filter unless its exact installed spelling is
-known. If discovery reports an unknown domain, retry once without that filter.
-After invalid input, correct only the reported constraint and retry once. Stop
-after a second invalid request, no route, an unavailable provider, or a timeout.
-Accept only a completed result whose scope covers the supplied input, and carry
-forward the smallest decisive value, witness, status, and assurance.
+known. When discovery exposes recovery paths, follow those fields—for example
+`remove_unknown_domain_filter`, `remove_filters`, or `reformulate_query`—before
+treating absence as final. After invalid input, correct the reported constraint
+and retry within the task resource bounds as further errors appear. If one
+provider is unavailable, continue with other installed routes that can produce
+the outcome. Treat timeouts as non-conclusions. Accept only a completed result
+whose scope covers the supplied input, and carry forward the smallest decisive
+value, witness, status, assurance, completeness, and open obligations.
 
 Keep representation, decomposition, composition, iteration, verification
 timing, and stopping decisions agent-owned. Treat timeouts, errors, incomplete

--- a/.agents/skills/jacobian-math/SKILL.md
+++ b/.agents/skills/jacobian-math/SKILL.md
@@ -59,7 +59,7 @@ and retry within the task resource bounds as further errors appear. If one
 provider is unavailable, continue with other installed routes that can produce
 the outcome. Treat timeouts as non-conclusions. Accept only a completed result
 whose scope covers the supplied input, and carry forward the smallest decisive
-value, witness, status, assurance, completeness, and open obligations.
+value, witness, status, assurance, completeness, open obligations, and first-class artifact references (including verification record URIs) so artifact-backed results remain evidence-bound.
 
 Keep representation, decomposition, composition, iteration, verification
 timing, and stopping decisions agent-owned. Treat timeouts, errors, incomplete

--- a/.agents/skills/jacobian-math/SKILL.md
+++ b/.agents/skills/jacobian-math/SKILL.md
@@ -10,26 +10,22 @@ description: Use Jacobian for specialized exact mathematics, including matrix de
 In Codex Code Mode, call the nested methods
 `tools.mcp__jacobian__math_find(...)` and
 `tools.mcp__jacobian__math_run(...)` directly. Do not enumerate, filter, or
-print `ALL_TOOLS` merely to locate them; that needlessly adds every matching
-tool description to the model context. Return only the typed projection when
-available, for example:
+print `ALL_TOOLS`; that loads matching tool descriptions into context. Return
+only the typed projection when available:
 
 ```js
 const r = await tools.mcp__jacobian__math_find({query: "...", limit: 3});
 text(r.structuredContent ?? r);
 ```
 
-For each requested exact mathematical outcome, use Jacobian even when the
-calculation is small or could be done mentally or in shell code. Route multiple
-requested outcomes separately. Prefer a capability matching the requested
-mathematical operation over a generic arithmetic substep that happens to produce
-the same scalar; composing already-known supporting operations remains allowed
-when that is the clearer route. Do not call Jacobian for definitions,
-formatting, or other tasks needing no mathematical execution.
+Use Jacobian for each requested exact mathematical outcome, even when small or
+shell-solvable. Route multiple requested outcomes separately. Prefer a
+capability matching the requested operation over a generic arithmetic substep
+that yields the same scalar; composing already-known supporting operations remains allowed when clearer.
+Do not call Jacobian for definitions, formatting, or non-execution tasks.
 
-Call `math.run` directly when the requested local outcome exactly matches one of
-these stable built-in contracts; replace the example values but preserve the
-shown JSON types:
+Call `math.run` directly when the requested local outcome exactly matches these
+stable built-in contracts; replace examples but preserve JSON types:
 
 - `integer.compute.gcd`, `integer.compute.lcm`, or
   `integer.compute.extended_gcd` in `EXPLORE` mode:
@@ -44,32 +40,31 @@ shown JSON types:
   `{"determinant_uri":"<determinant_uri from compute output>"}`.
 
 For other outcomes or unfamiliar payloads, use `math.find` with a specific
-plain-language outcome and any domain or mode already implied by the task; a
-capability ID is not required. Request only as many matches as are useful
-because lower `limit` values reduce context. Inspect the `CONTRACT` view only
-when its typed schema is needed to construct the `math.run` payload. A discovery
-card's validated `invocation_example`, or its required top-level fields when no
-example is available, may already provide a sufficient payload shape.
+plain-language outcome and implied domain or mode; no capability ID is required.
+Use low `limit` values. Inspect `CONTRACT` only when the typed schema is needed.
+A card's `invocation_example`, or required top-level fields, may be enough.
 
 Do not add a discovery domain filter unless its exact installed spelling is
-known. When discovery exposes recovery paths, follow those fields—for example
-`remove_unknown_domain_filter`, `remove_filters`, or `reformulate_query`—before
+known. When discovery exposes recovery paths, follow those fields (for example,
+`remove_unknown_domain_filter`, `remove_filters`, or `reformulate_query`) before
 treating absence as final. After invalid input, correct the reported constraint
 and retry within the task resource bounds as further errors appear. If one
 provider is unavailable, continue with other installed routes that can produce
 the outcome. Treat timeouts as non-conclusions. Accept only a completed result
-whose scope covers the supplied input, and carry forward the smallest decisive
-value, witness, status, assurance, completeness, open obligations, and first-class artifact references (including verification record URIs) so artifact-backed results remain evidence-bound.
+whose scope covers the input, and carry forward the smallest decisive value,
+witness, status, assurance, completeness, and open obligations; preserve artifact
+refs, including verification record URIs.
 
 Keep representation, decomposition, composition, iteration, verification
 timing, and stopping decisions agent-owned. Treat timeouts, errors, incomplete
 searches, and missing witnesses as non-conclusions.
 
-When independent checking is requested, calculations or programs authored by
-the same model are not independent checker evidence. Use an installed `VERIFY`
-capability when available. An artifact URI or checker-result summary is not a
-task-local verification-record file: never reconstruct or paraphrase such a
-record from the returned fields. Claim `VERIFIED` only when the result has
-assurance level `VERIFIED`, the exact record bytes are available, and any
-required task authorization and bindings are preserved. Otherwise use a lower
-assurance permitted by the task.
+When independent checking is requested, model-authored calculations or programs
+are not independent evidence. Use installed `VERIFY` when available. An artifact
+URI or checker summary is not a task-local verification-record file: never
+reconstruct or paraphrase such a record from returned fields. Claim `VERIFIED`
+only when the result has assurance level `VERIFIED`, exact record bytes, and
+required task authorization and bindings are preserved; otherwise use lower
+task-permitted assurance. Verification is bound to the exact checked claim: do
+not transfer `VERIFIED` from an input, premise, factorization, or related
+artifact to a model-derived conclusion, which needs its own checker-bound record.

--- a/npm/skills/jacobian-math/SKILL.md
+++ b/npm/skills/jacobian-math/SKILL.md
@@ -10,26 +10,22 @@ description: Use Jacobian for specialized exact mathematics, including matrix de
 In Codex Code Mode, call the nested methods
 `tools.mcp__jacobian__math_find(...)` and
 `tools.mcp__jacobian__math_run(...)` directly. Do not enumerate, filter, or
-print `ALL_TOOLS` merely to locate them; that needlessly adds every matching
-tool description to the model context. Return only the typed projection when
-available, for example:
+print `ALL_TOOLS`; that loads matching tool descriptions into context. Return
+only the typed projection when available:
 
 ```js
 const r = await tools.mcp__jacobian__math_find({query: "...", limit: 3});
 text(r.structuredContent ?? r);
 ```
 
-For each requested exact mathematical outcome, use Jacobian even when the
-calculation is small or could be done mentally or in shell code. Route multiple
-requested outcomes separately. Prefer a capability matching the requested
-mathematical operation over a generic arithmetic substep that happens to produce
-the same scalar; composing already-known supporting operations remains allowed
-when that is the clearer route. Do not call Jacobian for definitions,
-formatting, or other tasks needing no mathematical execution.
+Use Jacobian for each requested exact mathematical outcome, even when small or
+shell-solvable. Route multiple requested outcomes separately. Prefer a
+capability matching the requested operation over a generic arithmetic substep
+that yields the same scalar; composing already-known supporting operations remains allowed when clearer.
+Do not call Jacobian for definitions, formatting, or non-execution tasks.
 
-Call `math.run` directly when the requested local outcome exactly matches one of
-these stable built-in contracts; replace the example values but preserve the
-shown JSON types:
+Call `math.run` directly when the requested local outcome exactly matches these
+stable built-in contracts; replace examples but preserve JSON types:
 
 - `integer.compute.gcd`, `integer.compute.lcm`, or
   `integer.compute.extended_gcd` in `EXPLORE` mode:
@@ -44,32 +40,31 @@ shown JSON types:
   `{"determinant_uri":"<determinant_uri from compute output>"}`.
 
 For other outcomes or unfamiliar payloads, use `math.find` with a specific
-plain-language outcome and any domain or mode already implied by the task; a
-capability ID is not required. Request only as many matches as are useful
-because lower `limit` values reduce context. Inspect the `CONTRACT` view only
-when its typed schema is needed to construct the `math.run` payload. A discovery
-card's validated `invocation_example`, or its required top-level fields when no
-example is available, may already provide a sufficient payload shape.
+plain-language outcome and implied domain or mode; no capability ID is required.
+Use low `limit` values. Inspect `CONTRACT` only when the typed schema is needed.
+A card's `invocation_example`, or required top-level fields, may be enough.
 
 Do not add a discovery domain filter unless its exact installed spelling is
-known. When discovery exposes recovery paths, follow those fields—for example
-`remove_unknown_domain_filter`, `remove_filters`, or `reformulate_query`—before
+known. When discovery exposes recovery paths, follow those fields (for example,
+`remove_unknown_domain_filter`, `remove_filters`, or `reformulate_query`) before
 treating absence as final. After invalid input, correct the reported constraint
 and retry within the task resource bounds as further errors appear. If one
 provider is unavailable, continue with other installed routes that can produce
 the outcome. Treat timeouts as non-conclusions. Accept only a completed result
-whose scope covers the supplied input, and carry forward the smallest decisive
-value, witness, status, assurance, completeness, and open obligations.
+whose scope covers the input, and carry forward the smallest decisive value,
+witness, status, assurance, completeness, and open obligations; preserve artifact
+refs, including verification record URIs.
 
 Keep representation, decomposition, composition, iteration, verification
 timing, and stopping decisions agent-owned. Treat timeouts, errors, incomplete
 searches, and missing witnesses as non-conclusions.
 
-When independent checking is requested, calculations or programs authored by
-the same model are not independent checker evidence. Use an installed `VERIFY`
-capability when available. An artifact URI or checker-result summary is not a
-task-local verification-record file: never reconstruct or paraphrase such a
-record from the returned fields. Claim `VERIFIED` only when the result has
-assurance level `VERIFIED`, the exact record bytes are available, and any
-required task authorization and bindings are preserved. Otherwise use a lower
-assurance permitted by the task.
+When independent checking is requested, model-authored calculations or programs
+are not independent evidence. Use installed `VERIFY` when available. An artifact
+URI or checker summary is not a task-local verification-record file: never
+reconstruct or paraphrase such a record from returned fields. Claim `VERIFIED`
+only when the result has assurance level `VERIFIED`, exact record bytes, and
+required task authorization and bindings are preserved; otherwise use lower
+task-permitted assurance. Verification is bound to the exact checked claim: do
+not transfer `VERIFIED` from an input, premise, factorization, or related
+artifact to a model-derived conclusion, which needs its own checker-bound record.

--- a/npm/skills/jacobian-math/SKILL.md
+++ b/npm/skills/jacobian-math/SKILL.md
@@ -19,6 +19,14 @@ const r = await tools.mcp__jacobian__math_find({query: "...", limit: 3});
 text(r.structuredContent ?? r);
 ```
 
+For each requested exact mathematical outcome, use Jacobian even when the
+calculation is small or could be done mentally or in shell code. Route multiple
+requested outcomes separately. Prefer a capability matching the requested
+mathematical operation over a generic arithmetic substep that happens to produce
+the same scalar; use a supporting operation only after a dedicated search finds
+no direct capability. Do not call Jacobian for definitions, formatting, or other
+tasks needing no mathematical execution.
+
 Call `math.run` directly when the requested local outcome exactly matches one of
 these stable built-in contracts; replace the example values but preserve the
 shown JSON types:
@@ -42,6 +50,13 @@ because lower `limit` values reduce context. Inspect the `CONTRACT` view only
 when its typed schema is needed to construct the `math.run` payload. A discovery
 card's validated `invocation_example`, or its required top-level fields when no
 example is available, may already provide a sufficient payload shape.
+
+Do not add a discovery domain filter unless its exact installed spelling is
+known. If discovery reports an unknown domain, retry once without that filter.
+After invalid input, correct only the reported constraint and retry once. Stop
+after a second invalid request, no route, an unavailable provider, or a timeout.
+Accept only a completed result whose scope covers the supplied input, and carry
+forward the smallest decisive value, witness, status, and assurance.
 
 Keep representation, decomposition, composition, iteration, verification
 timing, and stopping decisions agent-owned. Treat timeouts, errors, incomplete

--- a/npm/skills/jacobian-math/SKILL.md
+++ b/npm/skills/jacobian-math/SKILL.md
@@ -23,9 +23,9 @@ For each requested exact mathematical outcome, use Jacobian even when the
 calculation is small or could be done mentally or in shell code. Route multiple
 requested outcomes separately. Prefer a capability matching the requested
 mathematical operation over a generic arithmetic substep that happens to produce
-the same scalar; use a supporting operation only after a dedicated search finds
-no direct capability. Do not call Jacobian for definitions, formatting, or other
-tasks needing no mathematical execution.
+the same scalar; composing already-known supporting operations remains allowed
+when that is the clearer route. Do not call Jacobian for definitions,
+formatting, or other tasks needing no mathematical execution.
 
 Call `math.run` directly when the requested local outcome exactly matches one of
 these stable built-in contracts; replace the example values but preserve the
@@ -52,11 +52,14 @@ card's validated `invocation_example`, or its required top-level fields when no
 example is available, may already provide a sufficient payload shape.
 
 Do not add a discovery domain filter unless its exact installed spelling is
-known. If discovery reports an unknown domain, retry once without that filter.
-After invalid input, correct only the reported constraint and retry once. Stop
-after a second invalid request, no route, an unavailable provider, or a timeout.
-Accept only a completed result whose scope covers the supplied input, and carry
-forward the smallest decisive value, witness, status, and assurance.
+known. When discovery exposes recovery paths, follow those fields—for example
+`remove_unknown_domain_filter`, `remove_filters`, or `reformulate_query`—before
+treating absence as final. After invalid input, correct the reported constraint
+and retry within the task resource bounds as further errors appear. If one
+provider is unavailable, continue with other installed routes that can produce
+the outcome. Treat timeouts as non-conclusions. Accept only a completed result
+whose scope covers the supplied input, and carry forward the smallest decisive
+value, witness, status, assurance, completeness, and open obligations.
 
 Keep representation, decomposition, composition, iteration, verification
 timing, and stopping decisions agent-owned. Treat timeouts, errors, incomplete

--- a/tests/unit/tooling/test_codex_visibility.py
+++ b/tests/unit/tooling/test_codex_visibility.py
@@ -195,9 +195,11 @@ def test_codex_skill_routes_exact_outcomes_without_catalog_projection() -> None:
     for guidance in (
         "requested outcomes separately.",
         "over a generic arithmetic substep",
-        "retry once without that filter",
-        "correct only the reported constraint and retry once",
-        "smallest decisive value, witness, status, and assurance",
+        "composing already-known supporting operations remains allowed",
+        "follow those fields",
+        "retry within the task resource bounds",
+        "continue with other installed routes",
+        "completeness, and open obligations",
     ):
         assert guidance in skill
 

--- a/tests/unit/tooling/test_codex_visibility.py
+++ b/tests/unit/tooling/test_codex_visibility.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -177,7 +178,7 @@ def test_codex_skill_keeps_bounded_stable_direct_run_contracts() -> None:
     assert len(skill.encode("utf-8")) <= 4 * 1024
 
 
-def test_codex_skill_avoids_full_code_mode_tool_catalog_projection() -> None:
+def test_codex_skill_routes_exact_outcomes_without_catalog_projection() -> None:
     skill = (_ROOT / ".agents/skills/jacobian-math/SKILL.md").read_text(
         encoding="utf-8"
     )
@@ -186,13 +187,19 @@ def test_codex_skill_avoids_full_code_mode_tool_catalog_projection() -> None:
     assert "tools.mcp__jacobian__math_run" in skill
     # Check for key phrases that may span multiple lines in the SKILL.md.
     # Normalize whitespace to avoid brittleness from line rewrapping.
-    import re
-
     skill_flat = re.sub(r"\s+", " ", skill)
     assert "Do not enumerate, filter, or print `ALL_TOOLS`" in skill_flat
     assert "text(r.structuredContent ?? r)" in skill
     assert "never reconstruct or paraphrase such a record" in skill_flat
     assert "required task authorization and bindings are preserved" in skill_flat
+    for guidance in (
+        "requested outcomes separately.",
+        "over a generic arithmetic substep",
+        "retry once without that filter",
+        "correct only the reported constraint and retry once",
+        "smallest decisive value, witness, status, and assurance",
+    ):
+        assert guidance in skill
 
 
 def test_visibility_classification_records_adoption_without_grading_shell(


### PR DESCRIPTION
## What changed

- Route each requested exact mathematical outcome through Jacobian, including small calculations.
- Route multiple requested outcomes independently.
- Prefer the capability that semantically matches the requested operation over a generic arithmetic substep.
- Add bounded recovery for unknown discovery domains and invalid payloads.
- Keep result handoff compact and scope-aware.
- Keep the repository and packaged Codex skills byte-identical, with focused regression coverage.

## Why

A controlled GPT-5.5 visibility experiment showed that the current skill sometimes solved positive tasks manually or substituted supporting arithmetic operations even when a direct installed capability existed. The misses appeared in independent probability, exact optimization, and multi-invariant cases.

The deterministic-first routing prototype was iterated against those failures and then rerun across the complete diverse treatment set.

## Evaluation evidence

Same model, task suite, execution budget, MCP surface, and three repetitions per case:

- current skill: **23/27** contracts satisfied
- proposed router: **27/27** contracts satisfied
- command failures: **0**
- independent verification requirements: **6/6**
- negative-task abstentions: **6/6**

The final treatment covered determinant computation and verification, factorization verification, polynomial resultants, finite probability, rational linear optimization, multiple integer invariants, and two non-math abstention cases.

Temporary evaluation configs and transcripts are intentionally not included in this production PR.

## Overlap review

- Merged #567 provides bounded direct-invocation contracts. This PR preserves those contracts and adds semantic routing for direct and discovered operations.
- Draft #604 adds structured unknown-domain diagnostics. This PR only gives the agent bounded guidance for consuming that recovery signal; it does not duplicate the diagnostic implementation.
- Searches of current open PRs found no implementation of multi-outcome or semantic-operation routing.

## Validation

- skill-creator `quick_validate.py`: pass
- `pytest -q tests/unit/tooling/test_codex_visibility.py`: **13 passed**
- focused Ruff check: pass
- packaged/repository skill byte parity: pass
- skill size: **3331 bytes**, below the existing 4 KiB limit
- full 27-run treatment: **27/27**, zero command failures

`make check-changed` reaches repository-wide lint but is currently blocked by ten unrelated errors already present on `main` in `tests/unit/support/test_copy_template.py` and `tests/unit/tooling/test_audit_fixes.py`; this branch does not modify those files.
