### PR TITLE
perf(discovery): improve Codex tool discovery efficiency

### DIFF
--- a/.agents/skills/jacobian-math/SKILL.md
+++ b/.agents/skills/jacobian-math/SKILL.md
@@ -7,6 +7,18 @@ description: Use Jacobian for specialized exact mathematics, including matrix de
 
 <!-- Managed by Jacobian's Codex integration. -->
 
+In Codex Code Mode, call the nested methods
+`tools.mcp__jacobian__math_find(...)` and
+`tools.mcp__jacobian__math_run(...)` directly. Do not enumerate, filter, or
+print `ALL_TOOLS` merely to locate them; that needlessly adds every matching
+tool description to the model context. Return only the typed projection when
+available, for example:
+
+```js
+const r = await tools.mcp__jacobian__math_find({query: "...", limit: 3});
+text(r.structuredContent ?? r);
+```
+
 Call `math.run` directly when the requested local outcome exactly matches one of
 these stable built-in contracts; replace the example values but preserve the
 shown JSON types:
@@ -37,5 +49,9 @@ searches, and missing witnesses as non-conclusions.
 
 When independent checking is requested, calculations or programs authored by
 the same model are not independent checker evidence. Use an installed `VERIFY`
-capability when available. Claim `VERIFIED` only when the result has assurance
-level `VERIFIED` and a local verification record.
+capability when available. An artifact URI or checker-result summary is not a
+task-local verification-record file: never reconstruct or paraphrase such a
+record from the returned fields. Claim `VERIFIED` only when the result has
+assurance level `VERIFIED`, the exact record bytes are available, and any
+required task authorization and bindings are preserved. Otherwise use a lower
+assurance permitted by the task.

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ endif
 # in pyproject.toml: direct pytest invocations must not silently inherit a
 # signal-based deadline that cannot interrupt a native solver.  Process and
 # provider lanes run risky work in killable children and set their own deadline.
-.PHONY: help help-all uv-version-check setup setup-agent container-image eval-image eval-image-pull eval-image-bind hooks fix lint complexity-check lint-full security-audit typecheck test-architecture architecture ci-plan test-plan test-changed check-changed test-unit test-component test-domain test-composition test-storage test-process test-mcp test-provider test-lean test-e2e test-affected test-all-ci test-compatibility test-stress test-ordering duplicate-code npm-test todo-check coverage build check precommit check-static harbor-plan harbor-prepare-task harbor-validate-task harbor-sync harbor-contracts harbor-execution-check harbor-adapter-checks harbor-validation-tests harbor-host-validation harbor-validate harbor-check harbor-check-task benchmark-inventory benchmark-snapshot benchmark-snapshot-validate benchmark-publish harbor-oracle harbor-oracle-task harbor-oracle-run harbor-oracle-all harbor-adapter-check heldout-validate heldout-render heldout-smoke agent-eval agent-eval-validate agent-eval-compare codex-visibility provider-eval clean docs-command-check docs-linkcheck deploy-check
+.PHONY: help help-all uv-version-check setup setup-agent container-image eval-image eval-image-pull eval-image-bind hooks fix lint complexity-check lint-full security-audit typecheck test-architecture architecture ci-plan test-plan test-changed check-changed test-unit test-component test-domain test-composition test-storage test-process test-mcp test-provider test-lean test-e2e test-affected test-all-ci test-compatibility test-stress test-ordering duplicate-code npm-test todo-check coverage build check precommit check-static harbor-plan harbor-prepare-task harbor-validate-task harbor-sync harbor-contracts harbor-execution-check harbor-adapter-checks harbor-validation-tests harbor-host-validation harbor-validate harbor-check harbor-check-task benchmark-inventory benchmark-snapshot benchmark-snapshot-validate benchmark-publish harbor-oracle harbor-oracle-task harbor-oracle-run harbor-oracle-all harbor-adapter-check heldout-validate heldout-render heldout-smoke agent-eval agent-eval-validate agent-eval-compare codex-visibility codex-tool-context provider-eval clean docs-command-check docs-linkcheck deploy-check
 
 help: ## Show available developer commands.
 	@awk -v public="$(PUBLIC_COMMANDS)" 'BEGIN {FS = ":.*## "; n = split(public, names, " "); for (i = 1; i <= n; i++) wanted[names[i]] = 1; printf "Jacobian common developer commands:\n\n"} /^[a-zA-Z_-]+:.*## / && ($$1 in wanted) {printf "  %-18s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -547,6 +547,7 @@ agent-eval-compare: ## Compare normalized observations (CONTROL=..., TREATMENT=.
 VISIBILITY_CASES ?= benchmarks/config/codex-visibility-v2.json
 VISIBILITY_REPETITIONS ?= 1
 VISIBILITY_REASONING_EFFORT ?= high
+VISIBILITY_TOOL_MODE ?= direct
 
 codex-visibility: ## Measure Codex adoption of Jacobian (VISIBILITY_EXECUTE=1, VISIBILITY_MCP_URL=..., VISIBILITY_MODEL=..., VISIBILITY_OUTPUT=...).
 	@set -e; \
@@ -561,9 +562,15 @@ codex-visibility: ## Measure Codex adoption of Jacobian (VISIBILITY_EXECUTE=1, V
 	$(UV_RUN) python -m benchmarks.tooling.codex_visibility \
 		--execute --cases "$(VISIBILITY_CASES)" --mcp-url "$(VISIBILITY_MCP_URL)" \
 		--model "$(VISIBILITY_MODEL)" --reasoning-effort "$(VISIBILITY_REASONING_EFFORT)" \
+		--tool-mode "$(VISIBILITY_TOOL_MODE)" \
 		--repetitions "$(VISIBILITY_REPETITIONS)" --output "$(VISIBILITY_OUTPUT)" \
 		$(foreach case,$(VISIBILITY_CASES_SELECTED),--case "$(case)") \
 		$(if $(VISIBILITY_SKILL),--skill "$(VISIBILITY_SKILL)",)
+
+codex-tool-context: ## Measure ALL_TOOLS projection cost in Codex ATIF traces (TRAJECTORIES="...").
+	@test -n "$(TRAJECTORIES)" || { echo "TRAJECTORIES is required" >&2; exit 2; }
+	$(UV_RUN) python -m benchmarks.tooling.codex_tool_context $(TRAJECTORIES) \
+		$(if $(LABEL),--label "$(LABEL)",) $(if $(OUTPUT),--output "$(OUTPUT)",)
 
 provider-eval: ## Run pinned provider feasibility jobs (PROVIDER=cddlib|cgal|gudhi|lean-repl|nauty|regina).
 	@test -n "$(PROVIDER)" || { echo "PROVIDER is required" >&2; exit 2; }

--- a/benchmarks/tooling/codex_tool_context.py
+++ b/benchmarks/tooling/codex_tool_context.py
@@ -1,0 +1,217 @@
+"""Measure model-visible tool-catalog cost in Codex ATIF trajectories."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import statistics
+from pathlib import Path
+from typing import Any
+
+from benchmarks.tooling.errors import HarborSuiteError
+
+_JACOBIAN_FIND = "tools.mcp__jacobian__math_find("
+_JACOBIAN_RUN = "tools.mcp__jacobian__math_run("
+
+
+def _read_trajectory(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise HarborSuiteError(f"unable to read ATIF trajectory {path}: {exc}") from exc
+    if not isinstance(value, dict) or not isinstance(value.get("steps"), list):
+        raise HarborSuiteError(
+            f"invalid ATIF trajectory {path}: steps must be an array"
+        )
+    return value
+
+
+def _visible_bytes(value: object) -> int:
+    if isinstance(value, str):
+        encoded = value.encode("utf-8")
+    else:
+        encoded = json.dumps(
+            value, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+        ).encode("utf-8")
+    return len(encoded)
+
+
+def _integer(value: object) -> int | None:
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _number(value: object) -> int | float | None:
+    return (
+        value
+        if isinstance(value, (int, float)) and not isinstance(value, bool)
+        else None
+    )
+
+
+def _visible_results(step: dict[str, Any]) -> dict[str, int]:
+    observation = step.get("observation")
+    results = observation.get("results", []) if isinstance(observation, dict) else []
+    visible_by_call: dict[str, int] = {}
+    if not isinstance(results, list):
+        return visible_by_call
+    for result in results:
+        if not isinstance(result, dict):
+            continue
+        source_call_id = result.get("source_call_id")
+        if isinstance(source_call_id, str) and "content" in result:
+            visible_by_call[source_call_id] = _visible_bytes(result["content"])
+    return visible_by_call
+
+
+def _analyze_step(step: object) -> tuple[int, int, int, int, int, int]:
+    if not isinstance(step, dict):
+        return (0, 0, 0, 0, 0, 0)
+    visible_by_call = _visible_results(step)
+    tool_calls = step.get("tool_calls", [])
+    if not isinstance(tool_calls, list):
+        return (0, 0, 0, 0, 0, 0)
+    scan_count = scan_bytes = unbound_scan_count = tool_output_bytes = 0
+    direct_find_references = direct_run_references = 0
+    for call in tool_calls:
+        if not isinstance(call, dict):
+            continue
+        call_id = call.get("tool_call_id")
+        visible = visible_by_call.get(call_id, 0) if isinstance(call_id, str) else 0
+        tool_output_bytes += visible
+        arguments = call.get("arguments")
+        source = arguments.get("input") if isinstance(arguments, dict) else None
+        if call.get("function_name") != "exec" or not isinstance(source, str):
+            continue
+        direct_find_references += source.count(_JACOBIAN_FIND)
+        direct_run_references += source.count(_JACOBIAN_RUN)
+        if "ALL_TOOLS" in source:
+            scan_count += 1
+            scan_bytes += visible
+            if not isinstance(call_id, str) or call_id not in visible_by_call:
+                unbound_scan_count += 1
+    return (
+        scan_count,
+        scan_bytes,
+        unbound_scan_count,
+        tool_output_bytes,
+        direct_find_references,
+        direct_run_references,
+    )
+
+
+def analyze_trajectory(path: Path) -> dict[str, Any]:
+    """Extract directory projection and token-cost facts from one ATIF trace."""
+
+    trajectory = _read_trajectory(path)
+    scan_count = 0
+    scan_bytes = 0
+    unbound_scan_count = 0
+    tool_output_bytes = 0
+    direct_find_references = 0
+    direct_run_references = 0
+
+    for step in trajectory["steps"]:
+        step_counts = _analyze_step(step)
+        scan_count += step_counts[0]
+        scan_bytes += step_counts[1]
+        unbound_scan_count += step_counts[2]
+        tool_output_bytes += step_counts[3]
+        direct_find_references += step_counts[4]
+        direct_run_references += step_counts[5]
+
+    metrics = trajectory.get("final_metrics")
+    metrics = metrics if isinstance(metrics, dict) else {}
+    prompt_tokens = _integer(metrics.get("total_prompt_tokens"))
+    cached_tokens = _integer(metrics.get("total_cached_tokens"))
+    uncached_tokens = (
+        max(0, prompt_tokens - cached_tokens)
+        if prompt_tokens is not None and cached_tokens is not None
+        else None
+    )
+    return {
+        "trajectory": str(path),
+        "trajectory_sha256": "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest(),
+        "agent": trajectory.get("agent"),
+        "all_tools_scan_count": scan_count,
+        "all_tools_model_visible_bytes": scan_bytes,
+        "all_tools_unbound_observation_count": unbound_scan_count,
+        "tool_model_visible_bytes": tool_output_bytes,
+        "direct_jacobian_find_references": direct_find_references,
+        "direct_jacobian_run_references": direct_run_references,
+        "prompt_tokens": prompt_tokens,
+        "cached_prompt_tokens": cached_tokens,
+        "uncached_prompt_tokens": uncached_tokens,
+        "completion_tokens": _integer(metrics.get("total_completion_tokens")),
+        "cost_usd": _number(metrics.get("total_cost_usd")),
+    }
+
+
+def _median(trials: list[dict[str, Any]], field: str) -> int | float | None:
+    values = [
+        trial[field] for trial in trials if isinstance(trial.get(field), (int, float))
+    ]
+    return statistics.median(values) if values else None
+
+
+def build_report(paths: list[Path], *, label: str) -> dict[str, Any]:
+    """Build one digest-bound observation report for a set of trajectories."""
+
+    if not paths:
+        raise HarborSuiteError("at least one ATIF trajectory is required")
+    trials = [analyze_trajectory(path) for path in paths]
+    return {
+        "schema_version": "1",
+        "label": label,
+        "trial_count": len(trials),
+        "summary": {
+            "all_tools_scan_trials": sum(
+                int(trial["all_tools_scan_count"] > 0) for trial in trials
+            ),
+            "all_tools_scan_count": sum(
+                int(trial["all_tools_scan_count"]) for trial in trials
+            ),
+            "all_tools_model_visible_bytes": sum(
+                int(trial["all_tools_model_visible_bytes"]) for trial in trials
+            ),
+            "all_tools_unbound_observation_count": sum(
+                int(trial["all_tools_unbound_observation_count"]) for trial in trials
+            ),
+            "median_prompt_tokens": _median(trials, "prompt_tokens"),
+            "median_cached_prompt_tokens": _median(trials, "cached_prompt_tokens"),
+            "median_uncached_prompt_tokens": _median(trials, "uncached_prompt_tokens"),
+            "median_completion_tokens": _median(trials, "completion_tokens"),
+            "median_cost_usd": _median(trials, "cost_usd"),
+        },
+        "trials": trials,
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("trajectories", nargs="+", type=Path)
+    parser.add_argument("--label", default="observation")
+    parser.add_argument("--output", type=Path)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    try:
+        report = build_report(args.trajectories, label=args.label)
+    except HarborSuiteError as exc:
+        raise SystemExit(str(exc)) from exc
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output is None:
+        print(rendered, end="")
+    else:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = ["analyze_trajectory", "build_report"]

--- a/benchmarks/tooling/codex_visibility.py
+++ b/benchmarks/tooling/codex_visibility.py
@@ -64,6 +64,13 @@ class AdoptionExpectation(StrEnum):
     ABSTAIN = "ABSTAIN"
 
 
+class ToolMode(StrEnum):
+    """How Codex receives and dispatches tools during one visibility run."""
+
+    DIRECT = "direct"
+    UNIFIED_EXEC = "unified_exec"
+
+
 class VisibilityCase(BaseModel):
     """One agent-visible prompt plus hidden trajectory expectations."""
 
@@ -323,6 +330,7 @@ def _codex_arguments(
     reasoning_effort: str,
     mcp_url: str,
     prompt: str,
+    tool_mode: ToolMode,
 ) -> tuple[str, ...]:
     arguments = [
         "-a",
@@ -343,6 +351,8 @@ def _codex_arguments(
         "-c",
         f"mcp_servers.jacobian.url={json.dumps(mcp_url)}",
     ]
+    if tool_mode is ToolMode.UNIFIED_EXEC:
+        arguments.extend(("--enable", "unified_exec"))
     if os.environ.get("JACOBIAN_MCP_BEARER_TOKEN"):
         arguments.extend(
             (
@@ -376,6 +386,7 @@ def _run_case(
     reasoning_effort: str,
     mcp_url: str,
     timeout_seconds: float,
+    tool_mode: ToolMode,
 ) -> dict[str, Any]:
     stem = f"{case.case_id}-r{repetition:02d}"
     transcript_path = output / f"{stem}.jsonl"
@@ -389,6 +400,7 @@ def _run_case(
             reasoning_effort=reasoning_effort,
             mcp_url=mcp_url,
             prompt=case.prompt,
+            tool_mode=tool_mode,
         ),
         cwd=workspace,
         timeout_seconds=timeout_seconds,
@@ -441,6 +453,13 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--mcp-url", required=True)
     parser.add_argument("--model", required=True)
     parser.add_argument("--reasoning-effort", default="high")
+    parser.add_argument(
+        "--tool-mode",
+        type=ToolMode,
+        choices=tuple(ToolMode),
+        default=ToolMode.DIRECT,
+        help="Codex tool dispatch mode; unified_exec matches Harbor Code Mode.",
+    )
     parser.add_argument("--repetitions", type=int, default=1)
     parser.add_argument(
         "--case",
@@ -518,6 +537,7 @@ def main() -> None:
                 reasoning_effort=args.reasoning_effort,
                 mcp_url=args.mcp_url,
                 timeout_seconds=args.timeout_seconds,
+                tool_mode=args.tool_mode,
             )
             for case in selected_cases
             for repetition in range(1, args.repetitions + 1)
@@ -549,6 +569,7 @@ def main() -> None:
             "codex_version": codex_version,
             "model": args.model,
             "reasoning_effort": args.reasoning_effort,
+            "tool_mode": args.tool_mode,
             "repetitions": args.repetitions,
             "repository_revision": git_head_sha(_ROOT),
         },

--- a/docs/how-to/run-codex-visibility-evaluation.md
+++ b/docs/how-to/run-codex-visibility-evaluation.md
@@ -24,6 +24,12 @@ make codex-visibility VISIBILITY_EXECUTE=1 \
   VISIBILITY_OUTPUT=benchmarks/results/visibility-skill
 ```
 
+Set `VISIBILITY_TOOL_MODE=unified_exec` to reproduce Codex Code Mode's nested
+tool dispatch, as used by the Harbor adapter. This matters for cost testing:
+Code Mode exposes nested methods through `tools`, and a model can otherwise
+print matching entries from `ALL_TOOLS` into its own context before calling
+them.
+
 The runner refuses to overwrite an existing output directory. Each output binds
 the prompt-suite digest, Git revision, Codex version, model, reasoning effort,
 skill digest, evaluator and telemetry-parser digests, MCP server metadata, tool
@@ -45,6 +51,23 @@ independent diagnostics rather than proxies for mathematical correctness. The
 cumulative Codex input-token count may grow much faster than MCP payload bytes
 because each later model turn includes earlier tool results; compare both
 dimensions rather than treating adoption alone as a win.
+
+For Harbor ATIF trajectories, measure that projection directly rather than
+inferring it from token totals:
+
+```sh
+make codex-tool-context \
+  TRAJECTORIES="benchmarks/results/<job>/<trial>/agent/trajectory.json" \
+  LABEL=skill-treatment \
+  OUTPUT=benchmarks/results/tool-context-treatment.json
+```
+
+The report counts `exec` source that references `ALL_TOOLS`, binds the matching
+observation bytes by tool-call ID, and reports cached and uncached prompt-token
+medians separately. Missing call-ID bindings are reported rather than silently
+treated as measured zero-byte projections. It is a client-behavior diagnostic,
+not a correctness score or proof that a prompt change caused the observed
+difference.
 
 For an A/B claim, hold the suite digest, Codex version, model, reasoning effort,
 MCP catalog, budgets, and repetition count fixed. Change only the visibility

--- a/npm/skills/jacobian-math/SKILL.md
+++ b/npm/skills/jacobian-math/SKILL.md
@@ -7,6 +7,18 @@ description: Use Jacobian for specialized exact mathematics, including matrix de
 
 <!-- Managed by Jacobian's Codex integration. -->
 
+In Codex Code Mode, call the nested methods
+`tools.mcp__jacobian__math_find(...)` and
+`tools.mcp__jacobian__math_run(...)` directly. Do not enumerate, filter, or
+print `ALL_TOOLS` merely to locate them; that needlessly adds every matching
+tool description to the model context. Return only the typed projection when
+available, for example:
+
+```js
+const r = await tools.mcp__jacobian__math_find({query: "...", limit: 3});
+text(r.structuredContent ?? r);
+```
+
 Call `math.run` directly when the requested local outcome exactly matches one of
 these stable built-in contracts; replace the example values but preserve the
 shown JSON types:
@@ -37,5 +49,9 @@ searches, and missing witnesses as non-conclusions.
 
 When independent checking is requested, calculations or programs authored by
 the same model are not independent checker evidence. Use an installed `VERIFY`
-capability when available. Claim `VERIFIED` only when the result has assurance
-level `VERIFIED` and a local verification record.
+capability when available. An artifact URI or checker-result summary is not a
+task-local verification-record file: never reconstruct or paraphrase such a
+record from the returned fields. Claim `VERIFIED` only when the result has
+assurance level `VERIFIED`, the exact record bytes are available, and any
+required task authorization and bindings are preserved. Otherwise use a lower
+assurance permitted by the task.

--- a/tests/unit/tooling/test_codex_tool_context.py
+++ b/tests/unit/tooling/test_codex_tool_context.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from benchmarks.tooling.codex_tool_context import analyze_trajectory, build_report
+from benchmarks.tooling.errors import HarborSuiteError
+
+
+def _write_trajectory(
+    path: Path,
+    *,
+    source: str,
+    content: object,
+    prompt_tokens: int = 100,
+    cached_tokens: int = 60,
+) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": "ATIF-v1.7",
+                "agent": {"name": "codex", "version": "test"},
+                "final_metrics": {
+                    "total_prompt_tokens": prompt_tokens,
+                    "total_cached_tokens": cached_tokens,
+                    "total_completion_tokens": 7,
+                    "total_cost_usd": 0.125,
+                },
+                "steps": [
+                    {
+                        "source": "agent",
+                        "tool_calls": [
+                            {
+                                "tool_call_id": "call-1",
+                                "function_name": "exec",
+                                "arguments": {"input": source},
+                            }
+                        ],
+                        "observation": {
+                            "results": [
+                                {"source_call_id": "call-1", "content": content},
+                                {"source_call_id": "other-call", "content": "ignored"},
+                            ]
+                        },
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_analyze_trajectory_measures_all_tools_projection(tmp_path: Path) -> None:
+    path = tmp_path / "trajectory.json"
+    _write_trajectory(
+        path,
+        source="const xs = ALL_TOOLS.filter(x => x.name.includes('jacobian')); text(xs);",
+        content="catalog output",
+    )
+
+    result = analyze_trajectory(path)
+
+    assert result["all_tools_scan_count"] == 1
+    assert result["all_tools_model_visible_bytes"] == len(b"catalog output")
+    assert result["all_tools_unbound_observation_count"] == 0
+    assert result["tool_model_visible_bytes"] == len(b"catalog output")
+    assert result["direct_jacobian_find_references"] == 0
+    assert result["uncached_prompt_tokens"] == 40
+
+
+def test_analyze_trajectory_counts_direct_nested_calls_without_scan(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "trajectory.json"
+    _write_trajectory(
+        path,
+        source=(
+            "const a = await tools.mcp__jacobian__math_find({query:'gcd'});"
+            "const b = await tools.mcp__jacobian__math_run({capability_id:'x'});"
+            "text(a.structuredContent ?? a); text(b.structuredContent ?? b);"
+        ),
+        content={"kind": "result"},
+    )
+
+    result = analyze_trajectory(path)
+
+    assert result["all_tools_scan_count"] == 0
+    assert result["all_tools_model_visible_bytes"] == 0
+    assert result["direct_jacobian_find_references"] == 1
+    assert result["direct_jacobian_run_references"] == 1
+
+
+def test_build_report_aggregates_trials_with_medians(tmp_path: Path) -> None:
+    first = tmp_path / "first.json"
+    second = tmp_path / "second.json"
+    _write_trajectory(first, source="text(ALL_TOOLS);", content="one", prompt_tokens=80)
+    _write_trajectory(
+        second, source="text('bounded');", content="two", prompt_tokens=120
+    )
+
+    report = build_report([first, second], label="paired-control")
+
+    assert report["label"] == "paired-control"
+    assert report["trial_count"] == 2
+    assert report["summary"] == {
+        "all_tools_scan_trials": 1,
+        "all_tools_scan_count": 1,
+        "all_tools_model_visible_bytes": 3,
+        "all_tools_unbound_observation_count": 0,
+        "median_prompt_tokens": 100,
+        "median_cached_prompt_tokens": 60,
+        "median_uncached_prompt_tokens": 40,
+        "median_completion_tokens": 7,
+        "median_cost_usd": 0.125,
+    }
+
+
+def test_build_report_rejects_empty_input() -> None:
+    with pytest.raises(HarborSuiteError, match="at least one"):
+        build_report([], label="empty")
+
+
+def test_analyze_trajectory_reports_unbound_scan_observation(tmp_path: Path) -> None:
+    path = tmp_path / "trajectory.json"
+    _write_trajectory(path, source="text(ALL_TOOLS);", content="catalog")
+    value = json.loads(path.read_text(encoding="utf-8"))
+    value["steps"][0]["observation"]["results"] = []
+    path.write_text(json.dumps(value), encoding="utf-8")
+
+    result = analyze_trajectory(path)
+
+    assert result["all_tools_scan_count"] == 1
+    assert result["all_tools_model_visible_bytes"] == 0
+    assert result["all_tools_unbound_observation_count"] == 1

--- a/tests/unit/tooling/test_codex_visibility.py
+++ b/tests/unit/tooling/test_codex_visibility.py
@@ -7,7 +7,9 @@ import pytest
 from benchmarks.tooling.codex_visibility import (
     AdoptionExpectation,
     CueLevel,
+    ToolMode,
     VisibilityCase,
+    _codex_arguments,
     classify_visibility,
     load_suite,
 )
@@ -127,6 +129,22 @@ def test_packaged_codex_skill_matches_repository_skill() -> None:
     assert packaged_skill.read_bytes() == repository_skill.read_bytes()
 
 
+def test_unified_exec_mode_is_opt_in(tmp_path: Path) -> None:
+    common = {
+        "workspace": tmp_path,
+        "model": "test-model",
+        "reasoning_effort": "high",
+        "mcp_url": "https://example.test/mcp",
+        "prompt": "Compute exactly.",
+    }
+
+    direct = _codex_arguments(**common, tool_mode=ToolMode.DIRECT)
+    unified = _codex_arguments(**common, tool_mode=ToolMode.UNIFIED_EXEC)
+
+    assert "unified_exec" not in direct
+    assert unified[-3:-1] == ("--enable", "unified_exec")
+
+
 def test_codex_skill_keeps_bounded_stable_direct_run_contracts() -> None:
     skill = (_ROOT / ".agents/skills/jacobian-math/SKILL.md").read_text(
         encoding="utf-8"
@@ -157,6 +175,19 @@ def test_codex_skill_keeps_bounded_stable_direct_run_contracts() -> None:
         {"left": polynomial_value, "right": polynomial_value}
     )
     assert len(skill.encode("utf-8")) <= 4 * 1024
+
+
+def test_codex_skill_avoids_full_code_mode_tool_catalog_projection() -> None:
+    skill = (_ROOT / ".agents/skills/jacobian-math/SKILL.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "tools.mcp__jacobian__math_find" in skill
+    assert "tools.mcp__jacobian__math_run" in skill
+    assert "Do not enumerate, filter, or\nprint `ALL_TOOLS`" in skill
+    assert "text(r.structuredContent ?? r)" in skill
+    assert "never reconstruct or paraphrase such a\nrecord" in skill
+    assert "required task authorization and bindings are preserved" in skill
 
 
 def test_visibility_classification_records_adoption_without_grading_shell(


### PR DESCRIPTION
## Problem

In Codex Code Mode, the model can search `ALL_TOOLS` to locate Jacobian's nested MCP methods. Printing that directory makes the matching tool metadata model-visible again on later turns, adding substantial prompt cost even though the callable methods are already available through `tools`.

## Changes

- Teach the Jacobian math skill to call `math.find` and `math.run` directly in Code Mode, avoid `ALL_TOOLS` projection, and return the typed `structuredContent` projection.
- Tighten independent-verification guidance so agents do not reconstruct verification records or overclaim `VERIFIED`.
- Add a unified-exec mode to the Codex visibility runner.
- Add a fail-closed ATIF diagnostic that binds exec calls to observations and reports `ALL_TOOLS` scans, model-visible bytes, direct Jacobian references, cached/uncached tokens, and cost.
- Document the Code Mode evaluation workflow and keep the packaged npm skill byte-identical to the repository skill.

## Evaluation

Controlled finite-magma runs with the same task/model changed `ALL_TOOLS` scans from 3/3 control trials to 0/3 treatment trials. Median cumulative input fell 44.1% (396,820 to 221,842) and median cost fell 23.5% ($0.520956 to $0.398702); all three treatment trials received full verifier reward.

Nine additional Harbor trajectories across graph, linear algebra, polynomial, SAT, matrix, and modular tasks had 0/9 `ALL_TOOLS` scans, complete observation bindings, and direct Jacobian use in every trajectory. Lightweight tasks typically used one `math.find` and one `math.run`, while agents remained free to derive candidates themselves. No discovery or dispatch regression was observed.

Some additional tasks exposed separate benchmark issues: stale frozen-input filenames, hidden checker-authorization drift, artifact handoff friction, or submission encoding mistakes. These affected task reward but not Jacobian discovery or direct invocation, so this PR does not claim the full nine-task set is verifier-green.

## Validation

- `make test-plan BASE=origin/main`
- `make check` (698 passed)
- `make npm-test` (45 passed plus package dry run)
- `make docs-linkcheck`
- `make harbor-execution-check` (59 passed)
- `git diff origin/main...HEAD --check`
