### PR TITLE
fix(smt): route SAT and SMT recovery diagnostics through public capabilities

### DIFF
--- a/src/jacobian/sat_smt/cadical.py
+++ b/src/jacobian/sat_smt/cadical.py
@@ -544,8 +544,9 @@ def _resolve_request(
                 schema_uri=sat.installation.cnf_schema_uri,
                 expected="one valid canonical CNF artifact and enforceable budget",
                 hint=(
-                    "Create the instance with SatArtifactService.put_cnf and use "
-                    "only the advertised wall-time and conflict limits."
+                    "Use math.find for sat.cnf.materialize to create the canonical "
+                    "CNF, then pass its cnf_uri with only the advertised wall-time "
+                    "and conflict limits."
                 ),
             )
         ) from exc

--- a/src/jacobian/sat_smt/sat_capabilities.py
+++ b/src/jacobian/sat_smt/sat_capabilities.py
@@ -154,7 +154,7 @@ class SatCnfMaterializationAdapter:
                         "literals referring only to declared variables"
                     ),
                     hint=(
-                        "Call math.find for sat.cnf.materialize and correct "
+                        "Inspect sat.cnf.materialize with math.find and execute it with math.run to correct "
                         "the variable_names or clauses."
                     ),
                 )
@@ -417,7 +417,7 @@ class SatAssignmentVerificationAdapter:
                         "to one canonical CNF"
                     ),
                     hint=(
-                        "Use math.find for sat.model.find to produce an assignment "
+                        "Inspect sat.model.find with math.find and execute it with math.run to produce an assignment "
                         "artifact for the intended canonical CNF. If that optional "
                         "producer is unavailable, install the CaDiCaL provider; do "
                         "not invent an assignment URI."
@@ -632,7 +632,7 @@ class SatUnsatProofVerificationAdapter:
                         "lineage to one canonical CNF"
                     ),
                     hint=(
-                        "Use math.find for sat.unsat_proof.find to produce a proof "
+                        "Inspect sat.unsat_proof.find with math.find and execute it with math.run to produce a proof "
                         "artifact for the intended canonical CNF. If that optional "
                         "producer is unavailable, install the CaDiCaL provider; do "
                         "not invent a proof URI."

--- a/src/jacobian/sat_smt/sat_capabilities.py
+++ b/src/jacobian/sat_smt/sat_capabilities.py
@@ -417,8 +417,10 @@ class SatAssignmentVerificationAdapter:
                         "to one canonical CNF"
                     ),
                     hint=(
-                        "Create the assignment with SatArtifactService.put_assignment "
-                        "against the intended canonical CNF."
+                        "Use math.find for sat.model.find to produce an assignment "
+                        "artifact for the intended canonical CNF. If that optional "
+                        "producer is unavailable, install the CaDiCaL provider; do "
+                        "not invent an assignment URI."
                     ),
                 )
             ) from exc
@@ -630,8 +632,10 @@ class SatUnsatProofVerificationAdapter:
                         "lineage to one canonical CNF"
                     ),
                     hint=(
-                        "Create the proof with SatArtifactService.put_proof against "
-                        "the intended canonical CNF."
+                        "Use math.find for sat.unsat_proof.find to produce a proof "
+                        "artifact for the intended canonical CNF. If that optional "
+                        "producer is unavailable, install the CaDiCaL provider; do "
+                        "not invent a proof URI."
                     ),
                 )
             ) from exc

--- a/src/jacobian/sat_smt/smt_capabilities.py
+++ b/src/jacobian/sat_smt/smt_capabilities.py
@@ -180,8 +180,10 @@ class SmtUnsatProofVerificationAdapter:
                         "lineage to one exact pinned-profile SMT query"
                     ),
                     hint=(
-                        "Create the proof with smt.unsat_proof.find or "
-                        "SmtArtifactService.put_proof against the intended query."
+                        "Use math.find for smt.unsat_proof.find to produce a proof "
+                        "artifact for the intended query. If that optional producer "
+                        "is unavailable, install the cvc5 provider; do not invent a "
+                        "proof URI."
                     ),
                 )
             ) from exc

--- a/tests/boundary/providers/external_sat/startup/test_smt_unsat_proof_verification.py
+++ b/tests/boundary/providers/external_sat/startup/test_smt_unsat_proof_verification.py
@@ -167,6 +167,27 @@ def _verify(runtime: JacobianRuntime, proof_uri: str):
     )
 
 
+def test_invalid_proof_diagnostic_routes_through_public_capabilities(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable = _fake_carcara(
+        tmp_path,
+        "print('valid')\nraise SystemExit(0)",
+    )
+    runtime = _runtime_with_runtime(tmp_path, monkeypatch, executable)
+
+    result = _verify(runtime, "artifact://sha256/" + "0" * 64)
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.diagnostics[0].code == "INVALID_SMT_UNSAT_PROOF"
+    hint = result.diagnostics[0].hint or ""
+    assert "math.find" in hint
+    assert "smt.unsat_proof.find" in hint
+    assert "cvc5" in hint
+    assert "SmtArtifactService" not in hint
+
+
 def test_unsat_proof_is_verified_by_authorized_strict_carcara(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/composition/runtime/test_sat_assignment_verification.py
+++ b/tests/composition/runtime/test_sat_assignment_verification.py
@@ -79,6 +79,23 @@ def test_sat_assignment_verifier_declares_its_typed_artifact_route(
     )
 
 
+def test_invalid_assignment_diagnostic_routes_through_public_capabilities(
+    authorized_complete_runtime,
+) -> None:
+    result = _verify(
+        authorized_complete_runtime,
+        "artifact://sha256/" + "0" * 64,
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.diagnostics[0].code == "INVALID_SAT_ASSIGNMENT"
+    hint = result.diagnostics[0].hint or ""
+    assert "math.find" in hint
+    assert "sat.model.find" in hint
+    assert "CaDiCaL" in hint
+    assert "SatArtifactService" not in hint
+
+
 def test_sat_assignment_is_verified_by_an_authorized_clean_process(
     authorized_complete_runtime,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

- replace SAT and SMT recovery hints that named internal artifact-service methods with public `math.find` capability routes
- explain which optional solver provider is required for assignment or proof production
- explicitly tell callers not to invent artifact URIs
- add regression coverage for invalid SAT assignment and SMT proof recovery guidance

## Root cause

Verifier and solver diagnostics were exposed through public capability results, but their remediation text instructed agents to call internal Python service methods that are not available through MCP. Evaluation exposed this first for SAT; a repository-wide literal-hint audit then found the same independent pattern in SMT proof verification.

## Audit evidence

A combined capability-composition and diagnostic-actionability audit checked:

- 134 literal public diagnostic hints for internal APIs and capability references
- producer-to-verifier continuity
- discovery reachability
- invocation-example correctness
- capability relationship integrity
- packaged-surface parity

All 328 installed capability titles were rediscoverable in the top five, all 224 published invocation examples completed, 42 emitted relationships resolved to stored artifacts, and the two packaged skill surfaces were byte-identical. The actionable internal-API references were isolated to SAT and SMT recovery hints.

## Overlap review

- Draft #604 distinguishes unknown discovery-domain filters; it does not modify invocation diagnostics.
- Draft #605 improves deterministic routing guidance; it does not replace internal API names emitted by capability failures.
- Searches across open and closed issues and PRs found no existing SAT/SMT diagnostic fix.

## Validation

- SAT focused tests: 15 passed
- focused Ruff lint and formatting: passed
- `git diff --check`: passed
- SMT regression is included in the existing Linux/provider test lane. On this macOS host, that file retains its pre-existing Carcara runtime-provenance failures because the pinned external checker is unavailable; 3 provider-independent cases pass locally. No provider or assurance behavior was changed.

This is intentionally a draft PR and does not change SAT/SMT mathematics, assurance, artifact validation, or provider installation policy.