### PR TITLE
fix(discovery): improve discovery for partially ordered set terminology

### DIFF
--- a/src/jacobian/domains/posets/operations.py
+++ b/src/jacobian/domains/posets/operations.py
@@ -330,6 +330,7 @@ FINITE_POSET_CAPABILITIES: tuple[MaterializedOperation[Any, Any, Any], ...] = (
         tags=(
             "poset",
             "partial-order",
+            "partially-ordered-set",
             "hasse-diagram",
             "transitive-closure",
             "exact",

--- a/src/jacobian/domains/posets/operations.py
+++ b/src/jacobian/domains/posets/operations.py
@@ -356,6 +356,8 @@ FINITE_POSET_CAPABILITIES: tuple[MaterializedOperation[Any, Any, Any], ...] = (
         relation_id="poset.width.dilworth.relation",
         tags=(
             "poset",
+            "partial-order",
+            "partially-ordered-set",
             "width",
             "maximum-antichain",
             "minimum-chain-cover",

--- a/tests/composition/runtime/test_poset_capabilities.py
+++ b/tests/composition/runtime/test_poset_capabilities.py
@@ -85,6 +85,20 @@ def test_antichain_chain_decomposition_intent_finds_width(
     assert discovered.matches[0].lexical_fit == "STRONG_CANDIDATE"
 
 
+def test_partially_ordered_set_intent_finds_width(
+    fresh_complete_runtime,
+) -> None:
+    discovered = fresh_complete_runtime.core.capabilities.discover(
+        CapabilityDiscoveryRequest(
+            query="compute the width of a finite partially ordered set",
+            limit=5,
+        )
+    )
+
+    assert discovered.matches[0].capability_id == "poset.width.compute"
+    assert discovered.matches[0].lexical_fit == "STRONG_CANDIDATE"
+
+
 def test_materialization_is_canonical_complete_and_artifact_backed(
     fresh_complete_runtime,
 ) -> None:


### PR DESCRIPTION
## Summary

- add canonical `partial-order` and `partially-ordered-set` synonyms to the finite-poset width descriptor
- add a regression proving that “compute the width of a finite partially ordered set” selects `poset.width.compute` first

## Root cause

Capability discovery is intentionally deterministic and lexical. The width descriptor used only the abbreviation “poset,” while users commonly spell out “partially ordered set.” That canonical wording therefore ranked generic `finite_set.*` operations above the dedicated width operation.

## Audit evidence

A 12-query natural-language discovery audit covered matrix algebra, number theory, polynomial arithmetic, probability, optimization, SAT, posets, topology, and graph search. The dedicated operation was within the top five for every valid expected ID except this poset wording. Before the patch, `poset.width.compute` was absent from the top five; after adding canonical synonym tags, it ranks first with `STRONG_CANDIDATE` lexical fit.

The apparent optimization miss in the audit was an audit expectation typo: the installed ID is `optimization.linear.rational_optimum.compute`, and it ranked first. No repository change is needed there.

## Overlap review

- #604 addresses unknown domain filters, not canonical terminology in an installed descriptor.
- #605 changes agent routing guidance, not capability metadata.
- Searches across open and closed issues and PRs found no existing fix for partially ordered set discovery.

## Validation

- `tests/composition/runtime/test_poset_capabilities.py` — 16 passed
- focused Ruff lint — passed
- focused Ruff format check — passed
- `git diff --check` — passed
- rerun of the 12-query deterministic discovery sample places the poset width operation first

This is intentionally a draft PR. It changes discovery metadata only; mathematical behavior and assurance are unchanged.