### PR TITLE
fix(benchmarks): sort functools import for schema validator cache CI

### DIFF
--- a/benchmarks/tooling/benchmark_contracts.py
+++ b/benchmarks/tooling/benchmark_contracts.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 import json
 import tomllib
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
-
-from functools import lru_cache
 
 from jsonschema import Draft202012Validator
 from jsonschema.exceptions import SchemaError, ValidationError

--- a/benchmarks/tooling/benchmark_contracts.py
+++ b/benchmarks/tooling/benchmark_contracts.py
@@ -7,6 +7,8 @@ import tomllib
 from pathlib import Path
 from typing import Any
 
+from functools import lru_cache
+
 from jsonschema import Draft202012Validator
 from jsonschema.exceptions import SchemaError, ValidationError
 
@@ -48,6 +50,7 @@ def _read_toml(path: Path) -> dict[str, Any]:
     return value
 
 
+@lru_cache(maxsize=16)
 def _validator(schema_name: str) -> Draft202012Validator:
     path = SCHEMAS / schema_name
     schema = _read_json(path)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Caches benchmark schema validators (`lru_cache` on `_validator` in `benchmarks/tooling/benchmark_contracts.py`) and keeps the stdlib import sorted for ruff `I001`.

## CI root cause

1. **PR-introduced:** ruff `I001` from `functools.lru_cache` import placement — fixed by sorting the import.
2. **Remaining Host Verifiers / Benchmark Validation:** not caused by `lru_cache`. The branch lagged `main` before `#623` (legacy verifier diagnostics / `load_submission_raw`) and related main fixes. Rebased onto current `main`.

## Validation

- `ruff check benchmarks/tooling/benchmark_contracts.py` — pass
- Focused previously failing host tests — 143 passed
- Latest CI + Benchmarks runs — success (all four Host Verifiers shards + Benchmark Validation green)

PR: https://github.com/morluto/jacobian/pull/621
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-beca33d5-e5b8-43a7-a806-b061627051cb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-beca33d5-e5b8-43a7-a806-b061627051cb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

