### PR TITLE
fix(benchmarks): repair legacy verifier diagnostics under schema failures

### DIFF
--- a/benchmarks/datasets/public-reproductions-v1/closed-set-distance-strengthening-audit/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/closed-set-distance-strengthening-audit/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
-LABEL jacobian.checksum="b3ea4bc1a359b8258ec449dcdb08f3ff3dd2ffca9e7b560b7e66f1fe23801279"
+LABEL jacobian.checksum="4ed14f93b41b244877b06c09aa9364d509501469e734c25067a867ed064c7b04"
 LABEL jacobian.task="jacobian/closed-set-distance-strengthening-audit"
 COPY expected.json input.json public_contract.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json

--- a/benchmarks/datasets/public-reproductions-v1/closed-set-distance-strengthening-audit/tests/verifier.py
+++ b/benchmarks/datasets/public-reproductions-v1/closed-set-distance-strengthening-audit/tests/verifier.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from verifier_support import (
     false_verified_claim,
-    load_submission,
+    load_submission_raw,
     read_evidence_json,
     strict_submission_contract,
     valid_sha256_uri,
@@ -266,7 +266,7 @@ def _evidence_schema(value: object) -> bool:
 
 
 def main() -> None:
-    submission = load_submission()
+    submission = load_submission_raw(require_input_binding=False)
     data = submission if isinstance(submission, dict) else {}
     expected = json.loads((TESTS / "expected.json").read_text())
     contract = bool(

--- a/benchmarks/datasets/public-reproductions-v1/closed-set-distance-strengthening-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/closed-set-distance-strengthening-audit/tests/verifier_support.py
@@ -122,6 +122,28 @@ def load_submission(
     )
 
 
+def load_submission_raw(
+    path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
+) -> dict[str, Any] | None:
+    """Parse one bounded submission without applying its public schema."""
+
+    if require_input_binding and not workspace_input_is_bound():
+        return None
+    if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
+        return None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
 def _public_submission_is_valid(submission: object) -> bool:
     contract = _load_public_contract()
     if contract is None:
@@ -414,6 +436,7 @@ __all__ = [
     "false_verified_claim",
     "is_regular_bounded_file",
     "load_submission",
+    "load_submission_raw",
     "read_evidence_json",
     "resolve_evidence",
     "sha256_uri",

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-004/tests/Dockerfile
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-004/tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/jcb-postdoc-004" \
-      jacobian.checksum="b8cb51e98bb9748ab72ba71159a95f7e1886b624d30a3fc8e58c87ecf1ecdd98"
+      jacobian.checksum="20d37996de8a2051b7621594933721ea312f67af592e936b78f3ba411ef5798f"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-004/tests/verifier.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-004/tests/verifier.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from verifier_support import (
     false_verified_claim,
-    load_submission,
+    load_submission_raw,
     read_evidence_json,
     strict_submission_contract,
 )
@@ -203,7 +203,7 @@ def _evaluate(certificate, result):
 
 
 def main():
-    submission = load_submission()
+    submission = load_submission_raw()
     data = submission if isinstance(submission, dict) else {}
     expected = json.loads((TESTS / "expected.json").read_text())
     contract = bool(

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-004/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-004/tests/verifier_support.py
@@ -122,6 +122,28 @@ def load_submission(
     )
 
 
+def load_submission_raw(
+    path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
+) -> dict[str, Any] | None:
+    """Parse one bounded submission without applying its public schema."""
+
+    if require_input_binding and not workspace_input_is_bound():
+        return None
+    if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
+        return None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
 def _public_submission_is_valid(submission: object) -> bool:
     contract = _load_public_contract()
     if contract is None:
@@ -414,6 +436,7 @@ __all__ = [
     "false_verified_claim",
     "is_regular_bounded_file",
     "load_submission",
+    "load_submission_raw",
     "read_evidence_json",
     "resolve_evidence",
     "sha256_uri",

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-014/tests/Dockerfile
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-014/tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/jcb-postdoc-014" \
-      jacobian.checksum="251814d49ad768d3d10122293dd10f547bb81f9de1ee650f9cd921a31fb9eade"
+      jacobian.checksum="48a7d80251f9a2f84783a767a665d33ab69d4a968b0d2ba5dd27063539ac5774"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-014/tests/verifier.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-014/tests/verifier.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from verifier_support import (
     false_verified_claim,
-    load_submission,
+    load_submission_raw,
     read_evidence_json,
     strict_submission_contract,
 )
@@ -332,7 +332,7 @@ def _evaluate(input_data, certificate, result):
 
 
 def main():
-    submission = load_submission()
+    submission = load_submission_raw()
     data = submission if isinstance(submission, dict) else {}
     expected = json.loads((TESTS / "expected.json").read_text())
     input_data = _load_frozen_input()

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-014/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-014/tests/verifier_support.py
@@ -122,6 +122,28 @@ def load_submission(
     )
 
 
+def load_submission_raw(
+    path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
+) -> dict[str, Any] | None:
+    """Parse one bounded submission without applying its public schema."""
+
+    if require_input_binding and not workspace_input_is_bound():
+        return None
+    if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
+        return None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
 def _public_submission_is_valid(submission: object) -> bool:
     contract = _load_public_contract()
     if contract is None:
@@ -414,6 +436,7 @@ __all__ = [
     "false_verified_claim",
     "is_regular_bounded_file",
     "load_submission",
+    "load_submission_raw",
     "read_evidence_json",
     "resolve_evidence",
     "sha256_uri",

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-015/tests/Dockerfile
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-015/tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/jcb-postdoc-015" \
-      jacobian.checksum="6a214ffe909fbe457a8e8ee66fd806f8518f1a8981a6efaf3ceeadf944355e42"
+      jacobian.checksum="7f15d646552eec5208ddeb92a2c5e5c32be2d81303c45d76de353b4ec35e70de"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-015/tests/verifier.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-015/tests/verifier.py
@@ -5,7 +5,7 @@ import re
 from pathlib import Path
 
 from verifier_support import (
-    load_submission,
+    load_submission_raw,
     read_evidence_json,
     strict_submission_contract,
 )
@@ -212,7 +212,7 @@ def _safe_evidence(submission):
 
 
 def main():
-    submission = load_submission()
+    submission = load_submission_raw()
     frozen = json.loads((E / "input.json").read_text())
     expected = json.loads((E / "expected.json").read_text())
     contract = strict_submission_contract(

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-015/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-015/tests/verifier_support.py
@@ -122,6 +122,28 @@ def load_submission(
     )
 
 
+def load_submission_raw(
+    path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
+) -> dict[str, Any] | None:
+    """Parse one bounded submission without applying its public schema."""
+
+    if require_input_binding and not workspace_input_is_bound():
+        return None
+    if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
+        return None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
 def _public_submission_is_valid(submission: object) -> bool:
     contract = _load_public_contract()
     if contract is None:
@@ -414,6 +436,7 @@ __all__ = [
     "false_verified_claim",
     "is_regular_bounded_file",
     "load_submission",
+    "load_submission_raw",
     "read_evidence_json",
     "resolve_evidence",
     "sha256_uri",

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-016/tests/Dockerfile
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-016/tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/jcb-postdoc-016" \
-      jacobian.checksum="f61a04c56464461c9238033bd9922911e70bcaca015c545e495c6e1e7b2da8ee"
+      jacobian.checksum="7e067318fbe47939ad784ebf2799ac0d7a218793b332d8dee3c58022cc892c46"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-016/tests/verifier.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-016/tests/verifier.py
@@ -3,7 +3,7 @@ import re
 from pathlib import Path
 
 from verifier_support import (
-    load_submission,
+    load_submission_raw,
     read_evidence_json,
     strict_submission_contract,
 )
@@ -210,7 +210,7 @@ def _safe_evidence(submission):
 
 
 def main():
-    submission = load_submission()
+    submission = load_submission_raw()
     frozen = json.loads((E / "input.json").read_text())
     expected = json.loads((E / "expected.json").read_text())
     contract = strict_submission_contract(

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-016/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-016/tests/verifier_support.py
@@ -122,6 +122,28 @@ def load_submission(
     )
 
 
+def load_submission_raw(
+    path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
+) -> dict[str, Any] | None:
+    """Parse one bounded submission without applying its public schema."""
+
+    if require_input_binding and not workspace_input_is_bound():
+        return None
+    if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
+        return None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
 def _public_submission_is_valid(submission: object) -> bool:
     contract = _load_public_contract()
     if contract is None:
@@ -414,6 +436,7 @@ __all__ = [
     "false_verified_claim",
     "is_regular_bounded_file",
     "load_submission",
+    "load_submission_raw",
     "read_evidence_json",
     "resolve_evidence",
     "sha256_uri",

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-019/tests/Dockerfile
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-019/tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/jcb-postdoc-019" \
-      jacobian.checksum="ee57c229de55c9d4fd3ac77cf68aeb81cc3febb773d5ae4d85610e8d99a7852b"
+      jacobian.checksum="17b977d55deec1c194a3a7f85910c7c48619f33538b550eea2a6153db3219ea3"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-019/tests/verifier.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-019/tests/verifier.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from verifier_support import (
     false_verified_claim,
     is_regular_bounded_file,
-    load_submission,
+    load_submission_raw,
     resolve_evidence,
     strict_submission_contract,
 )
@@ -303,7 +303,7 @@ def _result_matches(value):
 
 
 def main():
-    submission = load_submission()
+    submission = load_submission_raw()
     data = submission if isinstance(submission, dict) else {}
     expected = json.loads((TESTS / "expected.json").read_text())
     protocol_compliance = bool(

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-019/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-019/tests/verifier_support.py
@@ -122,6 +122,28 @@ def load_submission(
     )
 
 
+def load_submission_raw(
+    path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
+) -> dict[str, Any] | None:
+    """Parse one bounded submission without applying its public schema."""
+
+    if require_input_binding and not workspace_input_is_bound():
+        return None
+    if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
+        return None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
 def _public_submission_is_valid(submission: object) -> bool:
     contract = _load_public_contract()
     if contract is None:
@@ -414,6 +436,7 @@ __all__ = [
     "false_verified_claim",
     "is_regular_bounded_file",
     "load_submission",
+    "load_submission_raw",
     "read_evidence_json",
     "resolve_evidence",
     "sha256_uri",

--- a/benchmarks/templates/task/tests/verifier_support.py
+++ b/benchmarks/templates/task/tests/verifier_support.py
@@ -122,6 +122,28 @@ def load_submission(
     )
 
 
+def load_submission_raw(
+    path: Path = WORKSPACE / "submission.json",
+    *,
+    require_input_binding: bool = True,
+) -> dict[str, Any] | None:
+    """Parse one bounded submission without applying its public schema."""
+
+    if require_input_binding and not workspace_input_is_bound():
+        return None
+    if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
+        return None
+    try:
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError, TypeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
 def _public_submission_is_valid(submission: object) -> bool:
     contract = _load_public_contract()
     if contract is None:
@@ -414,6 +436,7 @@ __all__ = [
     "false_verified_claim",
     "is_regular_bounded_file",
     "load_submission",
+    "load_submission_raw",
     "read_evidence_json",
     "resolve_evidence",
     "sha256_uri",

--- a/benchmarks/validation/test_benchmark_adapters.py
+++ b/benchmarks/validation/test_benchmark_adapters.py
@@ -12,13 +12,17 @@ def _sha256_text(value: str) -> str:
     return "sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()
 
 
+def _evidence_json(payload: dict[str, object]) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n"
+
+
 def test_adapter_lock_requires_disjoint_rows_and_pinned_outputs(tmp_path: Path) -> None:
     adapter = tmp_path / "source"
     adapter.mkdir()
     (adapter / "generate.py").write_text("", encoding="utf-8")
     (adapter / "check.sh").write_text("#!/bin/sh\n", encoding="utf-8")
-    oracle_evidence = "oracle evidence\n"
-    parity_evidence = "parity evidence\n"
+    oracle_evidence = _evidence_json({"kind": "oracle"})
+    parity_evidence = _evidence_json({"kind": "parity"})
     (adapter / "oracle-evidence.json").write_text(oracle_evidence, encoding="utf-8")
     (adapter / "parity-evidence.json").write_text(parity_evidence, encoding="utf-8")
     (adapter / "source.lock.json").write_text(
@@ -69,8 +73,8 @@ def test_adapter_output_digest_uses_the_pinned_harbor_task_model(
     (task / "task.toml").write_text("schema_version = '1.4'\n", encoding="utf-8")
     (adapter / "generate.py").write_text("", encoding="utf-8")
     (adapter / "check.sh").write_text("#!/bin/sh\n", encoding="utf-8")
-    oracle_evidence = "oracle evidence\n"
-    parity_evidence = "parity evidence\n"
+    oracle_evidence = _evidence_json({"kind": "oracle"})
+    parity_evidence = _evidence_json({"kind": "parity"})
     (adapter / "oracle-evidence.json").write_text(oracle_evidence, encoding="utf-8")
     (adapter / "parity-evidence.json").write_text(parity_evidence, encoding="utf-8")
     lock = {
@@ -115,8 +119,8 @@ def test_adapter_evidence_must_remain_present_and_digest_bound(
     (task / "task.toml").write_text("schema_version = '1.4'\n", encoding="utf-8")
     (adapter / "generate.py").write_text("", encoding="utf-8")
     (adapter / "check.sh").write_text("#!/bin/sh\n", encoding="utf-8")
-    oracle_evidence = "oracle evidence\n"
-    parity_evidence = "parity evidence\n"
+    oracle_evidence = _evidence_json({"kind": "oracle"})
+    parity_evidence = _evidence_json({"kind": "parity"})
     (adapter / "oracle-evidence.json").write_text(oracle_evidence, encoding="utf-8")
     (adapter / "parity-evidence.json").write_text(parity_evidence, encoding="utf-8")
     lock = {
@@ -149,7 +153,9 @@ def test_adapter_evidence_must_remain_present_and_digest_bound(
         "benchmarks.tooling.harbor_suite.task_digest", lambda _path: "b" * 64
     )
 
-    (adapter / "oracle-evidence.json").write_text("changed\n", encoding="utf-8")
+    (adapter / "oracle-evidence.json").write_text(
+        _evidence_json({"kind": "changed"}), encoding="utf-8"
+    )
     failures = _failures(adapter)
 
     assert any("oracle_evidence_digest mismatch" in failure for failure in failures)

--- a/benchmarks/validation/test_benchmark_contracts.py
+++ b/benchmarks/validation/test_benchmark_contracts.py
@@ -60,9 +60,16 @@ def test_visible_submission_contracts_match_evidence_and_assurance_limits() -> N
             assurance = properties["claimed_assurance"]
             contract_path = task.path / "tests" / "public_contract.json"
             if contract_path.is_file():
-                assert assurance.get("enum") == list(ASSURANCE_ORDER), task.path
                 public_contract = json.loads(contract_path.read_text())
-                advertised = public_contract["allowed_assurance"]
+                if "allowed_assurance" in public_contract:
+                    # Modern public contracts advertise the full assurance ladder
+                    # in the agent-visible schema and constrain the ceiling through
+                    # allowed_assurance.
+                    assert assurance.get("enum") == list(ASSURANCE_ORDER), task.path
+                    advertised = public_contract["allowed_assurance"]
+                else:
+                    # Legacy contracts only mirror the submission schema.
+                    advertised = assurance.get("enum", [assurance.get("const")])
             else:
                 advertised = assurance.get("enum", [assurance.get("const")])
             ceiling_index = ASSURANCE_ORDER.index(ceiling)


### PR DESCRIPTION
## Problem

Legacy benchmark verifiers parsed submissions through the strict public-schema loader before computing independent diagnostic scores. A schema-invalid envelope therefore became `None`, collapsing correctness and scope diagnostics and hiding false-certification behavior. This surfaced as 20 host-validation failures on current `main`.

## What changed

- add the established bounded raw-submission parser to the verifier template and six remaining legacy tasks
- use raw parsing only for independent diagnostic evaluation while retaining `strict_submission_contract()` for schema, protocol, and reward gating
- preserve the closed-set task's separate input-binding diagnostic when visible input metadata is malformed
- refresh the affected verifier-support checksums
- update two validation fixtures whose assumptions no longer matched valid evidence JSON and legacy public contracts

The strict `load_submission()` contract is intentionally unchanged.

## Validation

- `make harbor-validation-tests TESTS='benchmarks/validation/public_reproductions_v1/test_closed_set_distance_strengthening_audit.py benchmarks/validation/research_diagnostics_v1/test_structured_verifiers.py benchmarks/validation/test_benchmark_adapters.py benchmarks/validation/test_benchmark_contracts.py benchmarks/validation/test_verifier_support_schema.py'` (`162 passed`)
- `make harbor-oracle-task DATASET=public-reproductions-v1 TASKS='closed-set-distance-strengthening-audit'` (full reward)
- `make harbor-oracle-task DATASET=research-diagnostics-v1 TASKS='jcb-postdoc-004 jcb-postdoc-014 jcb-postdoc-015 jcb-postdoc-016 jcb-postdoc-019'` (full reward for all five tasks)
- `make lint-full`
- `make harbor-plan BASE=origin/main`
