### PR TITLE
fix(ci): tolerate duplicate timing entries across benchmark shards

### DIFF
--- a/.github/scripts/manage-test-timings
+++ b/.github/scripts/manage-test-timings
@@ -300,10 +300,16 @@ def merge(
         payload = load_json_bytes(path.read_bytes(), str(path))
         durations = validate_durations(payload, str(path), suite)
         duplicates = merged.keys() & durations.keys()
-        if duplicates:
-            duplicate = min(duplicates)
-            raise ValueError(f"duplicate timing entry across shards: {duplicate}")
-        merged.update(durations)
+        for nodeid in sorted(duplicates):
+            previous = merged[nodeid]
+            incoming = durations[nodeid]
+            if incoming > previous:
+                merged[nodeid] = incoming
+            warning(
+                f"duplicate timing entry across shards for {nodeid}; "
+                f"keeping max({previous}, {incoming})"
+            )
+        merged.update({k: v for k, v in durations.items() if k not in duplicates})
 
     envelope = {
         "version": 1,

--- a/tests/boundary/process/tooling/test_ci_test_timings.py
+++ b/tests/boundary/process/tooling/test_ci_test_timings.py
@@ -192,7 +192,7 @@ def test_emit_plan_outputs_exposes_ci_config_ssot() -> None:
     )
 
 
-def test_merge_rejects_duplicate_node_ids(tmp_path: Path) -> None:
+def test_merge_keeps_max_duration_for_duplicate_node_ids(tmp_path: Path) -> None:
     count = shard_count()
     inputs: list[str] = []
     for shard in range(1, count + 1):
@@ -219,5 +219,54 @@ def test_merge_rejects_duplicate_node_ids(tmp_path: Path) -> None:
         pinned_pytest_split_version(),
     )
 
-    assert result.returncode != 0
-    assert "duplicate" in result.stderr.lower() or result.stderr
+    assert result.returncode == 0, result.stderr
+    assert "duplicate" in result.stderr.lower()
+    payload = json.loads((tmp_path / "output.json").read_text(encoding="utf-8"))
+    assert payload["durations"]["tests/domain/test_shared.py::test_case"] == float(
+        count
+    )
+
+
+def test_merge_handles_partial_overlap_across_shards(tmp_path: Path) -> None:
+    """Duplicate entries from pytest-split overlap should keep max duration."""
+    count = shard_count()
+    inputs: list[str] = []
+    shard_data: list[dict[str, float]] = [
+        {
+            "tests/domain/test_a.py::test_one": 1.0,
+            "tests/domain/test_b.py::test_two": 2.0,
+        },
+        {
+            "tests/domain/test_a.py::test_one": 3.0,
+            "tests/domain/test_c.py::test_three": 4.0,
+        },
+    ]
+    while len(shard_data) < count:
+        shard_data.append({"tests/domain/test_d.py::test_d": 0.5})
+    for shard, durations in enumerate(shard_data, start=1):
+        path = tmp_path / f"shard-{shard}.json"
+        path.write_text(json.dumps(durations), encoding="utf-8")
+        inputs.extend(["--input", str(path)])
+
+    result = run_ci_script(
+        "manage-test-timings",
+        "merge",
+        *inputs,
+        "--output",
+        str(tmp_path / "output.json"),
+        "--source-sha",
+        "a" * 40,
+        "--python-version",
+        "3.12",
+        "--suite",
+        "domain",
+        "--pytest-split-version",
+        pinned_pytest_split_version(),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "duplicate" in result.stderr.lower()
+    payload = json.loads((tmp_path / "output.json").read_text(encoding="utf-8"))
+    assert payload["durations"]["tests/domain/test_a.py::test_one"] == 3.0
+    assert payload["durations"]["tests/domain/test_b.py::test_two"] == 2.0
+    assert payload["durations"]["tests/domain/test_c.py::test_three"] == 4.0


### PR DESCRIPTION
## Summary

- pytest-split's `LeastDurationAlgorithm` can assign the same test to multiple groups when shards execute on separate CI runners with empty or identical timing files. The `manage-test-timings merge` step raised `ValueError` on any duplicate key, failing the "Publish Benchmark Timings" job even though all host-validation shards passed (observed on PR #615 where all 4 shards passed 847 tests each, but 58 tests appeared in multiple shard duration maps).
- Replace the hard failure with max-duration reconciliation: when a test appears in multiple shard duration maps, keep the largest measured duration and emit a GitHub Actions warning. This is the correct boundary because the merge is the only step that sees all shards together, and the pinned pytest-split version (0.11.0) cannot be fixed in-tree.
- Updated `test_merge_rejects_duplicate_node_ids` to `test_merge_keeps_max_duration_for_duplicate_node_ids` and added `test_merge_handles_partial_overlap_across_shards` to cover partial overlap with unique entries.

## Root cause evidence

Downloaded the 4 shard duration artifacts from the failing PR #615 run (31158290052). All 58 duplicate keys had positive durations in both shards — these tests genuinely ran in multiple groups, not deselected-with-zero artifacts. The total was 3388 entries across 3326 unique keys (847 per shard).

## Testing

```sh
uv run --locked python -m pytest tests/boundary/process/tooling/test_ci_test_timings.py -v
make test-process
make check-static
```

Results: 9 timing tests passed, 224 process boundary tests passed, ruff and deptry clean. The pre-existing mypy `no-any-return` on line 181 of `manage-test-timings` is unchanged.

#### Test plan

- [x] `test_merge_keeps_max_duration_for_duplicate_node_ids` — all shards report the same test; merge keeps max
- [x] `test_merge_handles_partial_overlap_across_shards` — partial overlap with unique entries; merge keeps max for duplicates
- [x] `test_merge_publishes_versioned_metadata_and_all_shards` — no duplicates; merge still works
- [x] Process boundary lane (224 tests) passes
- [x] Static checks (ruff, deptry, complexity) pass

Generated with [Devin](https://devin.ai)