### PR TITLE
fix(benchmarks): pin deterministic pytest-randomly seed for host shards

### DIFF
--- a/benchmarks/tooling/host_validation.py
+++ b/benchmarks/tooling/host_validation.py
@@ -25,12 +25,23 @@ from benchmarks.tooling.validation_plan import (
 
 ROOT = Path(__file__).resolve().parents[2]
 TIMING_PATH = ROOT / ".ci" / "benchmark-test-durations.json"
+_CI_CONFIG = ROOT / ".github" / "ci-config.json"
 _DIGEST = re.compile(r"sha256:[0-9a-f]{64}\Z")
 _SHA = re.compile(r"[0-9a-f]{40,64}\Z")
 _HOST_NAME = re.compile(r"[A-Za-z0-9_.-]+\Z")
 _HOST_KEYWORD = re.compile(r"[A-Za-z0-9_.-]*\Z")
 _MAX_TIMING_BYTES = 5 * 1024 * 1024
 _MAX_TIMING_ENTRIES = 10_000
+
+
+def _shard_seed() -> int:
+    """Return the pinned pytest-randomly seed from ci-config.json."""
+
+    payload = json.loads(_CI_CONFIG.read_text(encoding="utf-8"))
+    seed = payload.get("pytest_randomly_shard_seed")
+    if not isinstance(seed, int) or isinstance(seed, bool) or seed < 0:
+        raise ValueError("pytest_randomly_shard_seed must be a nonnegative integer")
+    return seed
 
 
 @dataclass(frozen=True, slots=True)
@@ -295,6 +306,7 @@ def pytest_arguments(
     arguments = ["-n", str(workers), "--durations=10", entry.selector]
     if entry.keyword:
         arguments.extend(("-k", entry.keyword))
+    arguments.extend(("--randomly-seed", str(_shard_seed())))
     if entry.splits:
         arguments.extend(
             (

--- a/benchmarks/validation/test_host_validation.py
+++ b/benchmarks/validation/test_host_validation.py
@@ -75,6 +75,48 @@ def test_full_shard_uses_ci_timing_shape_and_least_duration(tmp_path: Path) -> N
     assert "--store-durations" not in arguments
 
 
+def test_all_shards_receive_same_deterministic_seed(tmp_path: Path) -> None:
+    """Every full-host shard must get the same pytest-randomly seed so that
+    pytest-split sees an identical collection order across CI runners."""
+
+    entries = full_host_validation()
+    seeds: set[str] = set()
+    for entry in entries:
+        arguments = pytest_arguments(
+            entry,
+            timing_path=tmp_path / "timings.json",
+            workers=2,
+            store_durations=False,
+        )
+        seed_index = arguments.index("--randomly-seed")
+        seeds.add(arguments[seed_index + 1])
+    assert len(seeds) == 1
+    assert seeds.pop() == "0"
+
+
+def test_keyword_filtered_entry_also_receives_deterministic_seed(
+    tmp_path: Path,
+) -> None:
+    from benchmarks.tooling.validation_plan import task_host_validation
+
+    entries = task_host_validation(
+        Path(__file__).resolve().parents[2],
+        "mathematical-benchmarks-v1",
+        "algebraic-independence-transfer-audit",
+    )
+    assert entries
+    for entry in entries:
+        arguments = pytest_arguments(
+            entry,
+            timing_path=tmp_path / "timings.json",
+            workers=1,
+            store_durations=False,
+        )
+        assert "--randomly-seed" in arguments
+        seed_index = arguments.index("--randomly-seed")
+        assert arguments[seed_index + 1] == "0"
+
+
 def test_local_full_run_uses_empty_timing_fallback_and_writes_bound_receipts(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- Benchmark host-validation shards ran without a pinned pytest-randomly seed, so each CI runner used a different random collection order. pytest-split's `LeastDurationAlgorithm` partitions differently ordered collections independently, assigning the same test to multiple groups and producing duplicate timing entries across shards (58 duplicates observed in PR #615's run 31158290052, where groups 1-4 used seeds 1460269416, 485794681, 4254704848, and 922742955).
- Wire the existing `pytest_randomly_shard_seed` from `.github/ci-config.json` (the same SSOT used by the CI workflow for domain/composition shards) through `pytest_arguments()` in `host_validation.py`, injecting `--randomly-seed` into every shard's pytest command vector. This ensures all shards see an identical collection order, so pytest-split produces disjoint groups.
- The defensive merge behavior from #624 remains intact as a second line of defense.

## Root cause

The CI workflow passes `--randomly-seed ${{ needs.plan.outputs.pytest-randomly-shard-seed }}` to domain and composition shards, but the benchmark workflow's `host_validation.py` never included `--randomly-seed` in its `pytest_arguments()` builder. With no seed pinned, pytest-randomly generated a different random seed per CI runner, producing different collection orders. pytest-split's `LeastDurationAlgorithm` then partitioned each shard's differently ordered collection independently, causing the same tests to appear in multiple groups.

## Fix

Added `_shard_seed()` to `host_validation.py` that reads `pytest_randomly_shard_seed` from `.github/ci-config.json` (same config, same validation as `manage-test-timings`). `pytest_arguments()` now injects `--randomly-seed <seed>` into every shard's command vector, mirroring the CI workflow's approach for domain/composition shards.

## Testing

```sh
uv run --locked python -m pytest benchmarks/validation/test_host_validation.py -v
uv run --locked python -m pytest benchmarks/validation/test_benchmark_validation.py benchmarks/validation/test_benchmark_planner.py benchmarks/validation/test_validation_plan.py -v
uv run --locked python -m pytest tests/boundary/process/tooling/test_ci_test_timings.py tests/boundary/process/tooling/test_topology_runner.py -v
make check-static
```

Results: 9 host validation tests passed, 60 benchmark validation/planner/plan tests passed, 27 process boundary/timing tests passed. Ruff, deptry, and complexity checks clean. Pre-existing mypy errors unchanged.

#### Test plan

- [x] `test_all_shards_receive_same_deterministic_seed` — all 4 full-host shards get the same `--randomly-seed 0`
- [x] `test_keyword_filtered_entry_also_receives_deterministic_seed` — task-specific entries also get the seed
- [x] `test_full_shard_uses_ci_timing_shape_and_least_duration` — existing argument shape test still passes
- [x] All existing host validation, benchmark validation, and timing merge tests pass
- [x] Static checks (ruff, deptry, complexity) pass

Generated with [Devin](https://devin.ai)