### PR TITLE
perf(benchmarks): cache schema validators with lru_cache

### DIFF
--- a/benchmarks/tooling/benchmark_contracts.py
+++ b/benchmarks/tooling/benchmark_contracts.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 import json
 import tomllib
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
-
-from functools import lru_cache
 
 from jsonschema import Draft202012Validator
 from jsonschema.exceptions import SchemaError, ValidationError

--- a/benchmarks/tooling/benchmark_contracts.py
+++ b/benchmarks/tooling/benchmark_contracts.py
@@ -7,6 +7,8 @@ import tomllib
 from pathlib import Path
 from typing import Any
 
+from functools import lru_cache
+
 from jsonschema import Draft202012Validator
 from jsonschema.exceptions import SchemaError, ValidationError
 
@@ -48,6 +50,7 @@ def _read_toml(path: Path) -> dict[str, Any]:
     return value
 
 
+@lru_cache(maxsize=16)
 def _validator(schema_name: str) -> Draft202012Validator:
     path = SCHEMAS / schema_name
     schema = _read_json(path)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Same change as #591, rebased onto current `main` after Host Verifiers CI failed on the outdated branch tip.

Cache JSON Schema validators in `benchmarks/tooling/benchmark_contracts.py` with `lru_cache(maxsize=16)`.

## CI root cause

Host Verifiers failures on #591 were caused by the branch being behind `main`, not by validator caching. The failing host tests reproduce on the old tip without `lru_cache` and pass after rebase.

#591's head was force-updated with this history; Host Verifiers and Benchmark Validation are green there.

## Validation

- Previously failing host tests: passed locally
- Related unit tooling tests: passed
- Ruff check/format on touched file: passed
- #591 CI after rebase: Host Verifiers + Benchmark Validation green
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cdd2c3fb-33c8-43a0-adb2-5f61434de77b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cdd2c3fb-33c8-43a0-adb2-5f61434de77b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

