### PR TITLE
fix(lean): resolve toolchain binary instead of elan proxy

### DIFF
--- a/.github/ci-impact.json
+++ b/.github/ci-impact.json
@@ -201,7 +201,8 @@
       "name": "lean-python-adapter",
       "patterns": [
         "src/jacobian/lean*.py",
-        "src/jacobian/**/*lean*.py"
+        "src/jacobian/**/*lean*.py",
+        "src/jacobian_checkers/lean4.py"
       ],
       "suites": [
         "unit",

--- a/src/jacobian_checkers/lean4.py
+++ b/src/jacobian_checkers/lean4.py
@@ -161,9 +161,27 @@ def _authorized_lean_runtime() -> Path:
     return path
 
 
+def _toolchain_sibling(name: str, lean_executable: Path) -> Path:
+    """Return ``name`` from the same toolchain bin directory as *lean_executable*."""
+
+    candidate = lean_executable.with_name(
+        f"{name}.exe" if lean_executable.suffix.lower() == ".exe" else name
+    )
+    if not candidate.is_file():
+        raise _LeanSetupError(
+            f"TOOLCHAIN_RESOLUTION: The pinned Lean {LEAN_VERSION} {name} "
+            "launcher is unavailable. Install "
+            f"it with `elan toolchain install {LEAN_TOOLCHAIN}`, then retry."
+        )
+    return candidate
+
+
 def _lean_command(name: str) -> tuple[str, ...]:
-    if name == "lean" and os.environ.get("JACOBIAN_CHECKER_EXECUTABLE") is not None:
-        return (str(_authorized_lean_runtime()),)
+    if os.environ.get("JACOBIAN_CHECKER_EXECUTABLE") is not None:
+        lean = _authorized_lean_runtime()
+        if name == "lean":
+            return (str(lean),)
+        return (str(_toolchain_sibling(name, lean)),)
     elan = shutil.which("elan")
     if elan is not None:
         return (elan, "run", LEAN_TOOLCHAIN, name)
@@ -373,6 +391,73 @@ def _mathlib_runtime() -> Path:
     return runtime
 
 
+def _resolve_elan_toolchain_executable(command: tuple[str, ...]) -> Path:
+    """Resolve the pinned toolchain ``lean`` binary, not the elan multi-call proxy.
+
+    ``elan run <toolchain> which lean`` can return ``$ELAN_HOME/bin/lean``, which is
+    the elan proxy. That proxy requires a default toolchain and breaks under the
+    isolated ``HOME`` used by CORE checkers and declaration/elaboration workers.
+    ``lean --print-prefix`` returns the toolchain root that contains the real
+    ``bin/lean`` launcher.
+    """
+
+    elan_home = _elan_home(command)
+    overrides: dict[str, str] = {"ELAN_TOOLCHAIN": LEAN_TOOLCHAIN}
+    if elan_home is not None:
+        overrides["ELAN_HOME"] = elan_home
+    environment = worker_environment(
+        extra_variables=("PATH", "HOME"),
+        overrides=overrides,
+    )
+    try:
+        prefix_result = execute_process(
+            ProcessRequest(
+                executable=command[0],
+                arguments=(*command[1:], "--print-prefix"),
+                environment=environment,
+                cwd=str(Path.cwd()),
+                timeout_seconds=5.0,
+                stdin_bytes=b"",
+                stdout_limit_bytes=4096,
+                stderr_limit_bytes=4096,
+            )
+        )
+    except OSError as exc:
+        raise _LeanSetupError(
+            f"The pinned Lean {LEAN_VERSION} executable could not be resolved."
+        ) from exc
+    if (
+        prefix_result.termination is not ProcessTermination.EXITED
+        or prefix_result.returncode != 0
+    ):
+        raise _LeanSetupError(
+            f"The pinned Lean {LEAN_VERSION} executable could not be resolved."
+        )
+    prefix = prefix_result.stdout.decode("utf-8", errors="replace").strip()
+    if not prefix or "\n" in prefix or "\x00" in prefix:
+        raise _LeanSetupError(
+            f"The pinned Lean {LEAN_VERSION} executable could not be resolved."
+        )
+    executable = Path(prefix) / "bin" / "lean"
+    if not executable.is_file():
+        raise _LeanSetupError(
+            f"The pinned Lean {LEAN_VERSION} executable is unavailable."
+        )
+    elan = shutil.which("elan")
+    if elan is not None:
+        try:
+            if executable.samefile(elan):
+                raise _LeanSetupError(
+                    f"The pinned Lean {LEAN_VERSION} executable resolved to the "
+                    "elan proxy rather than the toolchain binary."
+                )
+        except OSError as exc:
+            raise _LeanSetupError(
+                f"The pinned Lean {LEAN_VERSION} executable could not be resolved."
+            ) from exc
+    return executable
+
+
 def inspect_runtime(*, require_mathlib: bool) -> tuple[Path, Path | None]:
     """Validate the pinned runtime and return the exact executable and profile root."""
 
@@ -381,36 +466,7 @@ def inspect_runtime(*, require_mathlib: bool) -> tuple[Path, Path | None]:
     if len(command) == 1:
         executable = Path(command[0])
     else:
-        environment = worker_environment(
-            extra_variables=("PATH", "HOME", "ELAN_HOME"),
-            overrides={"ELAN_TOOLCHAIN": LEAN_TOOLCHAIN},
-        )
-        try:
-            which_result = execute_process(
-                ProcessRequest(
-                    executable=command[0],
-                    arguments=(*command[1:-1], "which", "lean"),
-                    environment=environment,
-                    cwd=str(Path.cwd()),
-                    timeout_seconds=5.0,
-                    stdin_bytes=b"",
-                    stdout_limit_bytes=4096,
-                    stderr_limit_bytes=4096,
-                )
-            )
-        except OSError as exc:
-            raise _LeanSetupError(
-                f"The pinned Lean {LEAN_VERSION} executable could not be resolved."
-            ) from exc
-        if (
-            which_result.termination is not ProcessTermination.EXITED
-            or which_result.returncode != 0
-        ):
-            raise _LeanSetupError(
-                f"The pinned Lean {LEAN_VERSION} executable could not be resolved."
-            )
-        resolved = which_result.stdout.decode("utf-8", errors="replace").strip()
-        executable = Path(resolved)
+        executable = _resolve_elan_toolchain_executable(command)
     if not executable.is_file():
         raise _LeanSetupError(
             f"The pinned Lean {LEAN_VERSION} executable is unavailable."

--- a/tests/component/providers/lean/test_lean_checker_errors.py
+++ b/tests/component/providers/lean/test_lean_checker_errors.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 from pathlib import Path
 
 import pytest
@@ -11,6 +12,7 @@ from jacobian_checkers.lean4 import (
     _lean_command,
     _lean_rejection,
     _LeanSetupError,
+    _resolve_elan_toolchain_executable,
     _run_lean,
     _source,
     _validate_lean,
@@ -75,6 +77,101 @@ def test_elan_command_selects_the_pinned_toolchain_without_a_default(
         LEAN_TOOLCHAIN,
         "lean",
     )
+
+
+def test_authorized_checker_resolves_lake_beside_the_lean_executable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    toolchain_bin = tmp_path / "toolchains" / "lean4" / "bin"
+    toolchain_bin.mkdir(parents=True)
+    lean = toolchain_bin / "lean"
+    lake = toolchain_bin / "lake"
+    lean_bytes = b"lean-bin"
+    lean.write_bytes(lean_bytes)
+    lake.write_bytes(b"lake-bin")
+    lean_path = str(lean.resolve())
+    digest = "sha256:" + hashlib.sha256(lean_bytes).hexdigest()
+    monkeypatch.setenv("JACOBIAN_CHECKER_EXECUTABLE", lean_path)
+    monkeypatch.setenv("JACOBIAN_CHECKER_RUNTIME_DIGEST", digest)
+
+    assert _lean_command("lean") == (lean_path,)
+    assert _lean_command("lake") == (str(lake.resolve()),)
+
+
+def test_elan_toolchain_resolution_uses_print_prefix_not_proxy_which(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    toolchain_bin = tmp_path / "toolchains" / "leanprover--lean4---v4.31.0" / "bin"
+    toolchain_bin.mkdir(parents=True)
+    lean = toolchain_bin / "lean"
+    lean.write_bytes(b"toolchain-lean")
+    elan_proxy = tmp_path / "elan" / "bin" / "lean"
+    elan_proxy.parent.mkdir(parents=True)
+    elan_proxy.write_bytes(b"elan-proxy")
+    seen: list[tuple[str, ...]] = []
+
+    def completed(request: ProcessRequest, **_kwargs: object) -> ProcessResult:
+        seen.append((request.executable, *request.arguments))
+        return ProcessResult(
+            termination=ProcessTermination.EXITED,
+            returncode=0,
+            stdout=f"{toolchain_bin.parent}\n".encode(),
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+        )
+
+    monkeypatch.setattr("jacobian_checkers.lean4.execute_process", completed)
+    monkeypatch.setattr(
+        "jacobian_checkers.lean4.shutil.which",
+        lambda name: str(elan_proxy) if name == "elan" else None,
+    )
+
+    resolved = _resolve_elan_toolchain_executable(
+        ("/opt/elan/bin/elan", "run", LEAN_TOOLCHAIN, "lean")
+    )
+
+    assert resolved == lean
+    assert seen == [
+        ("/opt/elan/bin/elan", "run", LEAN_TOOLCHAIN, "lean", "--print-prefix")
+    ]
+
+
+def test_elan_toolchain_resolution_rejects_elan_proxy_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    elan_proxy = tmp_path / "elan"
+    elan_proxy.write_bytes(b"elan-proxy")
+
+    def completed(request: ProcessRequest, **_kwargs: object) -> ProcessResult:
+        return ProcessResult(
+            termination=ProcessTermination.EXITED,
+            returncode=0,
+            stdout=f"{tmp_path}\n".encode(),
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+        )
+
+    (tmp_path / "bin").mkdir()
+    (tmp_path / "bin" / "lean").write_bytes(b"elan-proxy")
+    # Make bin/lean the same file as the elan proxy for samefile().
+    (tmp_path / "bin" / "lean").unlink()
+    (tmp_path / "bin" / "lean").hardlink_to(elan_proxy)
+
+    monkeypatch.setattr("jacobian_checkers.lean4.execute_process", completed)
+    monkeypatch.setattr(
+        "jacobian_checkers.lean4.shutil.which",
+        lambda name: str(elan_proxy) if name == "elan" else None,
+    )
+
+    with pytest.raises(_LeanSetupError, match="elan proxy"):
+        _resolve_elan_toolchain_executable(
+            ("/opt/elan/bin/elan", "run", LEAN_TOOLCHAIN, "lean")
+        )
 
 
 def test_system_elan_uses_the_original_user_toolchain_home(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Main CI `Lean Runtime` is failing because `inspect_runtime` resolved Lean to the **elan multi-call proxy** (`$ELAN_HOME/bin/lean`) via `elan run <toolchain> which lean`. That proxy requires a default toolchain and breaks under the isolated `HOME` used by CORE checkers, statement elaboration, and declaration discovery.

This showed up on main after #620/#615 because Lean Runtime runs exhaustively on main pushes. Recent “green” Lean Runtime jobs were false greens that skipped live Lean/Mathlib tests (`pinned ... runtime is unavailable`). When Lean became available, the proxy-path bug caused:

- `error: no default toolchain configured`
- `TOOLCHAIN_RESOLUTION: ... lake launcher is unavailable` (checker worker has no host `PATH`)
- cascading REPL memory failures

## Fix

- Resolve the pinned toolchain binary with `lean --print-prefix` + `bin/lean`
- Reject resolution to the elan proxy
- Derive `lake` from the authorized Lean sibling inside checker workers
- Map `src/jacobian_checkers/lean4.py` into the lean CI impact rule

## Validation

- Local: CORE statement tests that failed on main now pass
- Component tests for resolution/lake sibling added and passing
- **Please apply the `ci:lean` label** so PR CI runs Lean Runtime (lean is deferred on PRs unless forced). Without that label this fix will not be exercised until merge to main.

## Test plan

- [ ] Apply `ci:lean` and confirm Lean Runtime passes
- [ ] Confirm previously failing CORE/Mathlib Lean tests no longer report elan proxy / missing lake errors

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-22e6773a-443d-4497-a3c3-0dbddd793d22?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22e6773a-443d-4497-a3c3-0dbddd793d22&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

