### PR TITLE
fix(tests): audit and clean up false greens, assertion debt, and antipatterns

### DIFF
--- a/tests/boundary/process/tooling/test_ci_plan_validation.py
+++ b/tests/boundary/process/tooling/test_ci_plan_validation.py
@@ -30,6 +30,11 @@ def _encoded(plan: dict[str, str]) -> str:
 def test_ci_plan_output_is_internally_consistent(args: tuple[str, ...]) -> None:
     plan = run_ci_script("classify-ci-paths", *args, check=True).stdout
 
+    # The classifier must produce a non-empty plan with at least a
+    # classification line and runnable flags.
+    assert plan.strip(), "classifier produced empty plan"
+    assert "classification=" in plan, "plan missing classification line"
+
     run_ci_script("validate-ci-plan", input_text=plan, check=True)
 
 

--- a/tests/boundary/providers/external_sat/startup/test_carcara.py
+++ b/tests/boundary/providers/external_sat/startup/test_carcara.py
@@ -17,8 +17,6 @@ from jacobian.providers.external_solver_runtime import carcara_provider_runtime
 from jacobian.runtime import CheckerAuthorityMode, create_runtime
 from jacobian.runtime.model import JacobianRuntime
 
-pytestmark = []
-
 _FIXTURES = (
     Path(__file__).resolve().parents[5]
     / "tests"

--- a/tests/boundary/providers/external_sat/test_sat_unsat_proof_external_backend.py
+++ b/tests/boundary/providers/external_sat/test_sat_unsat_proof_external_backend.py
@@ -16,8 +16,6 @@ from jacobian.providers.external_solver_runtime import (
     drat_trim_provider_runtime,
 )
 
-pytestmark = []
-
 
 def test_cadical_text_proof_replays_in_pinned_drat_trim(
     authorized_complete_runtime,

--- a/tests/composition/portfolio/test_plugin_registry_snapshots.py
+++ b/tests/composition/portfolio/test_plugin_registry_snapshots.py
@@ -27,8 +27,6 @@ from jacobian.plugins.registry import PluginRegistryError
 from jacobian.runtime import create_runtime
 from jacobian.runtime.model import JacobianRuntime
 
-pytestmark = []
-
 
 @pytest.fixture
 def plugin_runtime(

--- a/tests/composition/runtime/test_graph_coloring_encoding.py
+++ b/tests/composition/runtime/test_graph_coloring_encoding.py
@@ -10,8 +10,6 @@ from jacobian.contracts.capabilities import (
 from jacobian.contracts.results import ExecutionStatus
 from jacobian.runtime.model import JacobianRuntime
 
-pytestmark = []
-
 
 def _encode(runtime: JacobianRuntime) -> CapabilityResult:
     return runtime.core.capabilities.invoke(

--- a/tests/composition/runtime/test_recurrence_series_capabilities.py
+++ b/tests/composition/runtime/test_recurrence_series_capabilities.py
@@ -20,24 +20,22 @@ _PUBLIC_TASKS = (
     / "datasets"
     / "public-reproductions-v1"
 )
-_OVERLAP_CASES = []
-for _slug in (
-    "recurrence-fibonacci",
-    "recurrence-linear-eval",
-    "recurrence-lucas",
-    "recurrence-rational-series",
-):
-    _task = _PUBLIC_TASKS / _slug
-    _OVERLAP_CASES.append(
-        {
-            "query": json.loads((_task / "environment" / "input.json").read_text())[
-                "query"
-            ],
-            "expected_first": json.loads(
-                (_task / "tests" / "expected.json").read_text()
-            )["expected_first"],
-        }
+_OVERLAP_CASES = [
+    {
+        "query": json.loads(
+            (_PUBLIC_TASKS / slug / "environment" / "input.json").read_text()
+        )["query"],
+        "expected_first": json.loads(
+            (_PUBLIC_TASKS / slug / "tests" / "expected.json").read_text()
+        )["expected_first"],
+    }
+    for slug in (
+        "recurrence-fibonacci",
+        "recurrence-linear-eval",
+        "recurrence-lucas",
+        "recurrence-rational-series",
     )
+]
 
 
 def _q(numerator: int, denominator: int = 1) -> dict[str, str]:

--- a/tests/composition/runtime/test_sat_lrat_verification.py
+++ b/tests/composition/runtime/test_sat_lrat_verification.py
@@ -12,8 +12,6 @@ from jacobian.contracts.capabilities import (
 from jacobian.contracts.results import ExecutionStatus
 from jacobian.runtime.model import JacobianRuntime
 
-pytestmark = []
-
 
 def _verify(runtime: JacobianRuntime, cnf_uri: str, proof: bytes, **extra: object):
     return runtime.core.capabilities.invoke(

--- a/tests/unit/contracts/test_enumeration_page_size_bounds.py
+++ b/tests/unit/contracts/test_enumeration_page_size_bounds.py
@@ -33,8 +33,8 @@ def _matrix_payload(page_size: int) -> dict:
     ],
 )
 def test_page_size_accepts_one_through_256(model, payload) -> None:
-    model.model_validate(payload(1))
-    model.model_validate(payload(256))
+    assert model.model_validate(payload(1)).page_size == 1
+    assert model.model_validate(payload(256)).page_size == 256
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/providers/test_provider_metadata.py
+++ b/tests/unit/providers/test_provider_metadata.py
@@ -21,17 +21,20 @@ class _Distribution:
         return f"1.0-{self.requested_name}"
 
 
-@pytest.fixture
-def isolated_metadata_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.fixture(autouse=True)
+def _isolated_metadata_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reset the version and summary caches before each test.
+
+    This fixture is autouse so every test in this module gets a clean cache
+    without each test needing to declare and then ``del`` the fixture.
+    """
     monkeypatch.setattr(provider_metadata, "_version_cache", {})
     monkeypatch.setattr(provider_metadata, "_summary_cache", {})
 
 
 def test_distribution_summary_computes_identical_identity_once(
-    isolated_metadata_cache: None,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    del isolated_metadata_cache
     requested: list[str] = []
 
     def lookup(name: str) -> _Distribution:
@@ -48,10 +51,8 @@ def test_distribution_summary_computes_identical_identity_once(
 
 
 def test_distribution_summary_keeps_distinct_inputs_distinct(
-    isolated_metadata_cache: None,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    del isolated_metadata_cache
     requested: list[str] = []
 
     def lookup(name: str) -> _Distribution:
@@ -68,10 +69,8 @@ def test_distribution_summary_keeps_distinct_inputs_distinct(
 
 
 def test_missing_distribution_is_not_cached(
-    isolated_metadata_cache: None,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    del isolated_metadata_cache
     calls = 0
 
     def lookup(name: str) -> _Distribution:
@@ -104,11 +103,9 @@ class _NamelessDistribution:
 
 @pytest.mark.parametrize("recorded", [None, ""])
 def test_distribution_summary_falls_back_to_requested_name_when_name_missing_or_empty(
-    isolated_metadata_cache: None,
     monkeypatch: pytest.MonkeyPatch,
     recorded: object,
 ) -> None:
-    del isolated_metadata_cache
     monkeypatch.setattr(
         provider_metadata,
         "distribution",
@@ -121,10 +118,8 @@ def test_distribution_summary_falls_back_to_requested_name_when_name_missing_or_
 
 
 def test_distribution_summary_falls_back_when_name_is_non_str(
-    isolated_metadata_cache: None,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    del isolated_metadata_cache
     monkeypatch.setattr(
         provider_metadata,
         "distribution",

--- a/tests/unit/tooling/test_audit_fixes.py
+++ b/tests/unit/tooling/test_audit_fixes.py
@@ -16,36 +16,32 @@ import pytest
 
 
 # Bug 1a: _observation_pair_failures should fail closed on non-dict JSON
-def test_observation_pair_failures_fails_closed_on_non_dict(tmp_path):
+def test_observation_pair_failures_fails_closed_on_non_dict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Formally prove that malformed observation JSON is not silently accepted."""
     from benchmarks.tooling import benchmark_contracts
 
-    # Mock _read_json to return non-dict values
-    original_read_json = benchmark_contracts._read_json
+    # Test: JSON array instead of object
+    def mock_read_json_array(path):
+        return []
 
-    try:
-        # Test: JSON array instead of object
-        def mock_read_json_array(path):
-            return []
+    monkeypatch.setattr(benchmark_contracts, "_read_json", mock_read_json_array)
+    failures = benchmark_contracts._observation_pair_failures()
+    assert len(failures) > 0, "Bug 1a: malformed JSON should not silently pass"
+    assert "malformed" in failures[0].lower()
 
-        benchmark_contracts._read_json = mock_read_json_array
-        failures = benchmark_contracts._observation_pair_failures()
-        assert len(failures) > 0, "Bug 1a: malformed JSON should not silently pass"
-        assert "malformed" in failures[0].lower()
+    # Test: JSON null
+    def mock_read_json_null(path):
+        return None
 
-        # Test: JSON null
-        def mock_read_json_null(path):
-            return None
-
-        benchmark_contracts._read_json = mock_read_json_null
-        failures = benchmark_contracts._observation_pair_failures()
-        assert len(failures) > 0, "Bug 1a: null JSON should not silently pass"
-    finally:
-        benchmark_contracts._read_json = original_read_json
+    monkeypatch.setattr(benchmark_contracts, "_read_json", mock_read_json_null)
+    failures = benchmark_contracts._observation_pair_failures()
+    assert len(failures) > 0, "Bug 1a: null JSON should not silently pass"
 
 
 # Bug 1b: _usage should reject non-dict stats
-def test_usage_rejects_non_dict_stats():
+def test_usage_rejects_non_dict_stats() -> None:
     """Formally prove that non-dict stats is rejected."""
     from benchmarks.tooling import heldout_runner
 
@@ -63,7 +59,7 @@ def test_usage_rejects_non_dict_stats():
 
 
 # Bug 3a: Registry cache should be invalidatable
-def test_registry_cache_invalidation():
+def test_registry_cache_invalidation() -> None:
     """Formally prove that cache invalidation works."""
     from benchmarks.tooling import harbor_suite
 
@@ -71,48 +67,37 @@ def test_registry_cache_invalidation():
         "invalidate_registry_cache should exist"
     )
     harbor_suite.invalidate_registry_cache()
-    assert harbor_suite._load_registry_cache == {}, (
+    assert not harbor_suite._load_registry_cache, (
         "Cache should be empty after invalidation"
     )
 
 
 # Bug TOCTOU: install_source_only_importer should purge sys.modules
-def test_source_only_importer_purges_sys_modules():
+def test_source_only_importer_purges_sys_modules(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Formally prove that pre-imported modules are purged."""
-    from jacobian.implementation import install_source_only_importer
+    from jacobian.implementation import _SourceOnlyFinder, install_source_only_importer
 
     # Create a fake module in sys.modules that looks like the target package
     fake_module = type(sys)("fake_test_package")
     fake_module.some_value = "stale"
-    sys.modules["fake_test_package"] = fake_module
-    sys.modules["fake_test_package.helper"] = type(sys)("fake_test_package.helper")
+    monkeypatch.setitem(sys.modules, "fake_test_package", fake_module)
+    monkeypatch.setitem(
+        sys.modules, "fake_test_package.helper", type(sys)("fake_test_package.helper")
+    )
 
-    try:
-        install_source_only_importer("fake_test_package:main")
-        assert "fake_test_package" not in sys.modules, (
-            "Pre-imported module should be purged"
-        )
-        assert "fake_test_package.helper" not in sys.modules, (
-            "Pre-imported submodule should be purged"
-        )
-    finally:
-        sys.modules.pop("fake_test_package", None)
-        sys.modules.pop("fake_test_package.helper", None)
-        # Clean up meta_path
-        from jacobian.implementation import _SourceOnlyFinder
+    install_source_only_importer("fake_test_package:main")
+    assert "fake_test_package" not in sys.modules, (
+        "Pre-imported module should be purged"
+    )
+    assert "fake_test_package.helper" not in sys.modules, (
+        "Pre-imported submodule should be purged"
+    )
 
-        sys.meta_path = [
-            f for f in sys.meta_path if not isinstance(f, _SourceOnlyFinder)
-        ]
-
-
-if __name__ == "__main__":
-    test_observation_pair_failures_fails_closed_on_non_dict(None)
-    print("Bug 1a test passed")
-    test_usage_rejects_non_dict_stats()
-    print("Bug 1b test passed")
-    test_registry_cache_invalidation()
-    print("Bug 3a test passed")
-    test_source_only_importer_purges_sys_modules()
-    print("TOCTOU test passed")
-    print("\nAll audit fix tests passed!")
+    # Clean up meta_path — monkeypatch does not manage this automatically
+    # since the importer appends to sys.meta_path after import.
+    monkeypatch.setattr(
+        sys, "meta_path",
+        [f for f in sys.meta_path if not isinstance(f, _SourceOnlyFinder)],
+    )

--- a/tests/unit/tooling/test_audit_fixes.py
+++ b/tests/unit/tooling/test_audit_fixes.py
@@ -77,7 +77,13 @@ def test_source_only_importer_purges_sys_modules(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Formally prove that pre-imported modules are purged."""
-    from jacobian.implementation import _SourceOnlyFinder, install_source_only_importer
+    from jacobian.implementation import install_source_only_importer
+
+    # Snapshot sys.meta_path *before* calling the installer so monkeypatch
+    # restores the clean list (without the finder) at fixture teardown.
+    # If we patched after the installer ran, monkeypatch would record the
+    # already-mutated list and leak the finder back in at teardown.
+    monkeypatch.setattr(sys, "meta_path", list(sys.meta_path))
 
     # Create a fake module in sys.modules that looks like the target package
     fake_module = type(sys)("fake_test_package")
@@ -93,11 +99,4 @@ def test_source_only_importer_purges_sys_modules(
     )
     assert "fake_test_package.helper" not in sys.modules, (
         "Pre-imported submodule should be purged"
-    )
-
-    # Clean up meta_path — monkeypatch does not manage this automatically
-    # since the importer appends to sys.meta_path after import.
-    monkeypatch.setattr(
-        sys, "meta_path",
-        [f for f in sys.meta_path if not isinstance(f, _SourceOnlyFinder)],
     )

--- a/tests/unit/tooling/test_audit_fixes_round2.py
+++ b/tests/unit/tooling/test_audit_fixes_round2.py
@@ -168,12 +168,17 @@ def test_compare_evidence_tolerates_missing_optional_metrics() -> None:
     assert report["metrics"]["evidence_validity"]["pair_count"] == 0
 
 
-def test_mkstemp_fd_closed_on_fdopen_failure() -> None:
-    """If os.fdopen fails after mkstemp, the fd must be closed."""
+def test_mkstemp_fd_closed_on_fdopen_failure_source_guard() -> None:
+    """Guardrail: statement.py must close the mkstemp fd if os.fdopen fails.
+
+    A full behavior test requires a Lean runtime to exercise the mkstemp path.
+    This source-level guardrail ensures the fd-close fix is not accidentally removed.
+    """
     statement_path = (
         Path(__file__).parents[3] / "src/jacobian/lean_frontend/statement.py"
     )
     source = statement_path.read_text(encoding="utf-8")
-    assert "os.close(fd)" in source, (
+    # The fix pattern: os.close(fd) in an except block after os.fdopen.
+    assert "except OSError:" in source and "os.close(fd)" in source, (
         "statement.py must close the mkstemp fd if os.fdopen fails"
     )

--- a/tests/unit/tooling/test_codex_visibility.py
+++ b/tests/unit/tooling/test_codex_visibility.py
@@ -184,10 +184,14 @@ def test_codex_skill_avoids_full_code_mode_tool_catalog_projection() -> None:
 
     assert "tools.mcp__jacobian__math_find" in skill
     assert "tools.mcp__jacobian__math_run" in skill
-    assert "Do not enumerate, filter, or\nprint `ALL_TOOLS`" in skill
+    # Check for key phrases that may span multiple lines in the SKILL.md.
+    # Normalize whitespace to avoid brittleness from line rewrapping.
+    import re
+    skill_flat = re.sub(r"\s+", " ", skill)
+    assert "Do not enumerate, filter, or print `ALL_TOOLS`" in skill_flat
     assert "text(r.structuredContent ?? r)" in skill
-    assert "never reconstruct or paraphrase such a\nrecord" in skill
-    assert "required task authorization and bindings are preserved" in skill
+    assert "never reconstruct or paraphrase such a record" in skill_flat
+    assert "required task authorization and bindings are preserved" in skill_flat
 
 
 def test_visibility_classification_records_adoption_without_grading_shell(

--- a/tests/unit/tooling/test_codex_visibility.py
+++ b/tests/unit/tooling/test_codex_visibility.py
@@ -187,6 +187,7 @@ def test_codex_skill_avoids_full_code_mode_tool_catalog_projection() -> None:
     # Check for key phrases that may span multiple lines in the SKILL.md.
     # Normalize whitespace to avoid brittleness from line rewrapping.
     import re
+
     skill_flat = re.sub(r"\s+", " ", skill)
     assert "Do not enumerate, filter, or print `ALL_TOOLS`" in skill_flat
     assert "text(r.structuredContent ?? r)" in skill

--- a/tests/unit/tooling/test_strict_boundaries.py
+++ b/tests/unit/tooling/test_strict_boundaries.py
@@ -99,7 +99,11 @@ def test_harbor_job_selection_rejects_non_str_path() -> None:
 
 
 def test_harbor_job_dataset_entry_accepts_valid_selection() -> None:
-    HarborJobDatasetEntry.model_validate({"path": "p", "task_names": ["a", "b"]})
+    entry = HarborJobDatasetEntry.model_validate(
+        {"path": "p", "task_names": ["a", "b"]}
+    )
+    assert entry.path == "p"
+    assert entry.task_names == ["a", "b"]
 
 
 def test_heldout_run_plan_rejects_invalid_condition() -> None:


### PR DESCRIPTION
## Summary

Systematic audit of all test fixtures, conftest files, support modules, benchmark verifiers, and test suites across `tests/` and `benchmarks/datasets/` for false greens, hardcoding, assertion debt, conflicts, hotspots, and antipatterns.

## Audit findings

**Audited:** 9 conftest.py files, 19 support modules, 219 benchmark verifier pairs, 16 solution files, 30+ validation harnesses, 94 unit test files, all component/composition/e2e/domain/boundary test suites.

**Verdict:** The test infrastructure is overwhelmingly healthy. No hardcoding of expected values (all hardcoded values are independent mathematical oracles), no false greens in benchmark verifiers, no swallowed exceptions, no dead tests. The benchmark verifier infrastructure has active guards against false greens (fail-closed reward ratchet, hard-gate correctness/evidence checks).

## Issues found and fixed

### False greens — tests with no assertions (3 tests)
- `test_harbor_job_dataset_entry_accepts_valid_selection` — called `model_validate` without asserting on the result
- `test_page_size_accepts_one_through_256` — called `model_validate` without asserting the `page_size` round-trips
- `test_ci_plan_output_is_internally_consistent` — used `check=True` subprocess calls but never inspected the classified plan's contents

**Fix:** Added explicit assertions on returned values and plan contents.

### Mutable shared state antipatterns (2 tests)
- `test_audit_fixes.py` used manual `try/finally` to restore module globals and `sys.modules` — if an assertion failed before `finally`, mutations leaked into subsequent tests
- Dead `__main__` block called test functions with a bogus `None` argument bypassing pytest fixtures

**Fix:** Replaced with `monkeypatch` fixture for guaranteed cleanup. Removed dead `__main__` block.

### Obscure fixture pattern (1 file, 5 tests)
- `test_provider_metadata.py` used an `isolated_metadata_cache` fixture that each test immediately `del`-eted to silence linters — fragile if someone removed the "unused" fixture

**Fix:** Converted to an `autouse=True` fixture so cache reset is automatic and invisible.

### Source-grep test masquerading as behavior test (1 test)
- `test_mkstemp_fd_closed_on_fdopen_failure` grepped source code for `os.close(fd)` but the name implied behavior testing

**Fix:** Renamed to `..._source_guard` to honestly reflect what it tests, and strengthened the assertion.

### Brittle multi-line substring assertions (1 test)
- `test_codex_visibility.py` asserted exact multi-line substrings against SKILL.md — any rewrapping would break them

**Fix:** Normalize whitespace before checking key phrases.

### Dead code (5 files)
- No-op `pytestmark = []` in 5 test files — likely leftovers from removed skip markers

**Fix:** Removed.

### Minor style (1 file)
- `_OVERLAP_CASES` built with imperative for-loop + `.append()` instead of list comprehension

**Fix:** Refactored to list comprehension.

## What was NOT found (explicitly verified)

- No hardcoded expected values that should be computed (all are independent mathematical oracles)
- No false greens in benchmark verifiers (all recompute results from frozen input)
- No try/except blocks that swallow verification failures (all are fail-closed)
- No dead tests of removed functionality
- No trivial `assert True` or pass-only test bodies
- No unjustified `pytest.skip` calls (all carry clear reason strings)
- No mutable shared state in component/composition/e2e/domain/boundary tests
- No broad exception catches that aren't legitimate concurrency-test patterns

## Test results

- 698 unit tests pass
- 189 boundary/tooling tests pass
- 34 composition/boundary tests pass
- All lint (ruff) checks pass