### PR TITLE
fix(tests): audit and clean up test anti-patterns

### DIFF
--- a/tests/boundary/process/tooling/test_topology_runner.py
+++ b/tests/boundary/process/tooling/test_topology_runner.py
@@ -10,6 +10,9 @@ from tools.test_topology import lane_environment, load_topology, main, pytest_co
 
 ROOT = Path(__file__).resolve().parents[4]
 
+_FAKE_HOME = "/tmp/jacobian-fake-home"
+_FAKE_ELAN = "/tmp/jacobian-fake-elan"
+
 
 def test_domain_lane_dry_run_is_explicit_and_topology_owned() -> None:
     result = subprocess.run(
@@ -268,22 +271,22 @@ def test_lane_environment_forwards_only_allowlisted_lean_variables(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     topology = load_topology(ROOT / "tests" / "topology.toml")
-    monkeypatch.setenv("HOME", "/tmp/jacobian-fake-home")
-    monkeypatch.setenv("ELAN_HOME", "/tmp/jacobian-fake-elan")
+    monkeypatch.setenv("HOME", _FAKE_HOME)
+    monkeypatch.setenv("ELAN_HOME", _FAKE_ELAN)
     monkeypatch.setenv("JACOBIAN_TOPOLOGY_LEAK", "secret")
 
     lean = lane_environment(topology.lane("lean"))
     assert lean["JACOBIAN_TEST_LANE"] == "lean"
     assert lean["PATH"] == os.environ["PATH"]
-    assert lean["HOME"] == "/tmp/jacobian-fake-home"
-    assert lean["ELAN_HOME"] == "/tmp/jacobian-fake-elan"
+    assert lean["HOME"] == _FAKE_HOME
+    assert lean["ELAN_HOME"] == _FAKE_ELAN
     assert "JACOBIAN_TOPOLOGY_LEAK" not in lean
 
     provider = lane_environment(topology.lane("provider"))
     assert provider["JACOBIAN_TEST_LANE"] == "provider"
     assert provider["PATH"] == os.environ["PATH"]
-    assert provider["HOME"] == "/tmp/jacobian-fake-home"
-    assert provider["ELAN_HOME"] == "/tmp/jacobian-fake-elan"
+    assert provider["HOME"] == _FAKE_HOME
+    assert provider["ELAN_HOME"] == _FAKE_ELAN
     assert "JACOBIAN_TOPOLOGY_LEAK" not in provider
 
     unit = lane_environment(topology.lane("unit"))
@@ -299,7 +302,7 @@ def test_lane_environment_never_forwards_unauthorized_host_variables(
 ) -> None:
     topology = load_topology(ROOT / "tests" / "topology.toml")
     monkeypatch.setenv("JACOBIAN_TOPOLOGY_LEAK", "secret")
-    monkeypatch.setenv("HOME", "/tmp/jacobian-fake-home")
+    monkeypatch.setenv("HOME", _FAKE_HOME)
 
     for lane_name in ("lean", "provider", "unit", "process", "storage"):
         environment = lane_environment(topology.lane(lane_name))

--- a/tests/component/checkers/test_finite_partition_checker.py
+++ b/tests/component/checkers/test_finite_partition_checker.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
+
 from jacobian_checkers.finite_partition import check_partition
 
 

--- a/tests/component/checkers/test_finite_partition_checker.py
+++ b/tests/component/checkers/test_finite_partition_checker.py
@@ -85,38 +85,42 @@ def test_finite_partition_checker_rejects_gap_and_overlap() -> None:
     assert "overlap" in overlap["detail"]
 
 
-def test_finite_partition_checker_rejects_unbound_relationship_metadata() -> None:
-    request = _request(
-        cases=[
-            {"case_id": "left", "members": ["a", "b"]},
-            {"case_id": "right", "members": ["c", "d"]},
-        ]
-    )
+_PARTITION_CASES = [
+    {"case_id": "left", "members": ["a", "b"]},
+    {"case_id": "right", "members": ["c", "d"]},
+]
+
+
+def _unbound_relationship_metadata(request: dict) -> None:
     request["certificate"]["payload"]["payload"]["obligation_uri"] = (
         "artifact://sha256/" + "9" * 64
     )
 
-    decision = check_partition(request)
 
-    assert decision["accepted"] is False
-    assert "relationship metadata" in decision["detail"]
-
-
-def test_finite_partition_checker_rejects_binding_substitution() -> None:
-    request = _request(
-        cases=[
-            {"case_id": "left", "members": ["a", "b"]},
-            {"case_id": "right", "members": ["c", "d"]},
-        ]
-    )
+def _rebound_bindings(request: dict) -> None:
     rebound = dict(request["certificate"]["payload"]["bindings"])
     rebound["scope_digest"] = "sha256:" + "9" * 64
     request["certificate"]["payload"]["bindings"] = rebound
 
+
+@pytest.mark.parametrize(
+    ("mutation", "expected_detail"),
+    [
+        (_unbound_relationship_metadata, "relationship metadata"),
+        (_rebound_bindings, "bindings"),
+    ],
+    ids=["unbound_relationship_metadata", "binding_substitution"],
+)
+def test_finite_partition_checker_rejects_corrupted_certificate(
+    mutation: Any, expected_detail: str
+) -> None:
+    request = _request(cases=_PARTITION_CASES)
+    mutation(request)
+
     decision = check_partition(request)
 
     assert decision["accepted"] is False
-    assert "bindings" in decision["detail"]
+    assert expected_detail in decision["detail"]
 
 
 def test_finite_partition_checker_rejects_unknown_format() -> None:

--- a/tests/component/checkers/test_rational_determinant_checker.py
+++ b/tests/component/checkers/test_rational_determinant_checker.py
@@ -115,20 +115,27 @@ def test_checker_accepts_exact_rational_determinant() -> None:
     assert decision["method"] == "DIRECT_WITNESS"
 
 
-def test_checker_rejects_mutated_determinant_with_refreshed_digest() -> None:
-    request = _request()
-    request["candidate"]["payload"]["determinant"] = _rational(1)
-    _refresh_payload_digest(request["candidate"])
-
-    decision = check_rational_determinant(request)
-
-    assert decision["accepted"] is False
-    assert decision["conclusion"] == "UNKNOWN"
+def _mutated_determinant(request: dict[str, Any]) -> None:
+    request["candidate"]["payload"]["determinant"].update(num="1")
 
 
-def test_checker_rejects_rebound_source_identity() -> None:
-    request = _request()
+def _rebound_source_identity(request: dict[str, Any]) -> None:
     request["candidate"]["payload"]["matrix_uri"] = _uri("9")
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        _mutated_determinant,
+        _rebound_source_identity,
+    ],
+    ids=["mutated_determinant", "rebound_source_identity"],
+)
+def test_checker_rejects_candidate_rebinding_with_refreshed_digest(
+    mutation: Any,
+) -> None:
+    request = _request()
+    mutation(request)
     _refresh_payload_digest(request["candidate"])
 
     decision = check_rational_determinant(request)

--- a/tests/component/datasets/test_conjecture_ingestion.py
+++ b/tests/component/datasets/test_conjecture_ingestion.py
@@ -204,11 +204,27 @@ def test_allowed_license_without_evidence_withholds_text(tmp_path: Path) -> None
 @pytest.mark.parametrize(
     ("field", "fake_digest", "expected_code"),
     [
-        ("expected_content_digest", "0" * 64, "EXTERNAL_CONJECTURE_CONTENT_DIGEST_MISMATCH"),
-        ("expected_record_digest", "f" * 64, "EXTERNAL_CONJECTURE_RECORD_DIGEST_MISMATCH"),
-        ("license_evidence_digest", "0" * 64, "EXTERNAL_CONJECTURE_LICENSE_DIGEST_MISMATCH"),
+        (
+            "expected_content_digest",
+            "0" * 64,
+            "EXTERNAL_CONJECTURE_CONTENT_DIGEST_MISMATCH",
+        ),
+        (
+            "expected_record_digest",
+            "f" * 64,
+            "EXTERNAL_CONJECTURE_RECORD_DIGEST_MISMATCH",
+        ),
+        (
+            "license_evidence_digest",
+            "0" * 64,
+            "EXTERNAL_CONJECTURE_LICENSE_DIGEST_MISMATCH",
+        ),
     ],
-    ids=["content_digest_mismatch", "record_digest_mismatch", "license_digest_mismatch"],
+    ids=[
+        "content_digest_mismatch",
+        "record_digest_mismatch",
+        "license_digest_mismatch",
+    ],
 )
 def test_digest_binding_mismatch_is_rejected(
     tmp_path: Path,

--- a/tests/component/datasets/test_conjecture_ingestion.py
+++ b/tests/component/datasets/test_conjecture_ingestion.py
@@ -201,10 +201,24 @@ def test_allowed_license_without_evidence_withholds_text(tmp_path: Path) -> None
     assert "lacks a URL-and-digest" in result.output["license_reason"]
 
 
-def test_changed_content_fails_expected_digest_binding(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    ("field", "fake_digest", "expected_code"),
+    [
+        ("expected_content_digest", "0" * 64, "EXTERNAL_CONJECTURE_CONTENT_DIGEST_MISMATCH"),
+        ("expected_record_digest", "f" * 64, "EXTERNAL_CONJECTURE_RECORD_DIGEST_MISMATCH"),
+        ("license_evidence_digest", "0" * 64, "EXTERNAL_CONJECTURE_LICENSE_DIGEST_MISMATCH"),
+    ],
+    ids=["content_digest_mismatch", "record_digest_mismatch", "license_digest_mismatch"],
+)
+def test_digest_binding_mismatch_is_rejected(
+    tmp_path: Path,
+    field: str,
+    fake_digest: str,
+    expected_code: str,
+) -> None:
     adapter = _adapter(tmp_path)
     payload = _request()
-    payload["expected_content_digest"] = "sha256:" + "0" * 64
+    payload[field] = "sha256:" + fake_digest
 
     with pytest.raises(CapabilityInvocationError) as exc_info:
         adapter.invoke(
@@ -214,45 +228,7 @@ def test_changed_content_fails_expected_digest_binding(tmp_path: Path) -> None:
             )
         )
 
-    assert (
-        exc_info.value.diagnostic.code == "EXTERNAL_CONJECTURE_CONTENT_DIGEST_MISMATCH"
-    )
-
-
-def test_tampered_record_fails_expected_digest_binding(tmp_path: Path) -> None:
-    adapter = _adapter(tmp_path)
-    payload = _request()
-    payload["expected_record_digest"] = "sha256:" + "f" * 64
-
-    with pytest.raises(CapabilityInvocationError) as exc_info:
-        adapter.invoke(
-            CapabilityRequest(
-                capability_id="dataset.conjecture.ingest",
-                input=payload,
-            )
-        )
-
-    assert (
-        exc_info.value.diagnostic.code == "EXTERNAL_CONJECTURE_RECORD_DIGEST_MISMATCH"
-    )
-
-
-def test_tampered_license_evidence_digest_is_rejected(tmp_path: Path) -> None:
-    adapter = _adapter(tmp_path)
-    payload = _request()
-    payload["license_evidence_digest"] = "sha256:" + "0" * 64
-
-    with pytest.raises(CapabilityInvocationError) as exc_info:
-        adapter.invoke(
-            CapabilityRequest(
-                capability_id="dataset.conjecture.ingest",
-                input=payload,
-            )
-        )
-
-    assert (
-        exc_info.value.diagnostic.code == "EXTERNAL_CONJECTURE_LICENSE_DIGEST_MISMATCH"
-    )
+    assert exc_info.value.diagnostic.code == expected_code
 
 
 def test_metadata_only_source_without_statement_is_retained(tmp_path: Path) -> None:

--- a/tests/component/providers/lean/test_lean_checker_errors.py
+++ b/tests/component/providers/lean/test_lean_checker_errors.py
@@ -181,7 +181,7 @@ def test_system_elan_uses_the_original_user_toolchain_home(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv("ELAN_HOME", raising=False)
-    monkeypatch.setenv("HOME", "/home/jacobian")
+    monkeypatch.setenv("HOME", "/tmp/jacobian-test-home")
 
     assert _elan_home(("/usr/bin/elan", "run", LEAN_TOOLCHAIN, "lean")) == (
         "/home/jacobian/.elan"

--- a/tests/component/providers/lean/test_lean_checker_errors.py
+++ b/tests/component/providers/lean/test_lean_checker_errors.py
@@ -184,7 +184,7 @@ def test_system_elan_uses_the_original_user_toolchain_home(
     monkeypatch.setenv("HOME", "/tmp/jacobian-test-home")
 
     assert _elan_home(("/usr/bin/elan", "run", LEAN_TOOLCHAIN, "lean")) == (
-        "/home/jacobian/.elan"
+        "/tmp/jacobian-test-home/.elan"
     )
 
 

--- a/tests/domain/graph/test_graph_invariant_domain.py
+++ b/tests/domain/graph/test_graph_invariant_domain.py
@@ -31,20 +31,18 @@ def _graph(
     return {"vertices": vertices, "edges": edges}
 
 
-def test_graph_invariant_family_boundaries_and_witnesses(domain_services) -> None:
-    triangle_tail = _graph(
-        ["a", "b", "c", "d"],
-        [["a", "b"], ["b", "c"], ["a", "c"], ["c", "d"]],
-    )
-    cases = (
-        (
-            "graph.invariant.girth.compute",
-            triangle_tail,
-            {"girth": 3, "has_cycle": True},
-        ),
+_TRIANGLE_TAIL = {
+    "vertices": ["a", "b", "c", "d"],
+    "edges": [["a", "b"], ["b", "c"], ["a", "c"], ["c", "d"]],
+}
+
+
+@pytest.mark.parametrize(
+    ("capability_id", "expected"),
+    [
+        ("graph.invariant.girth.compute", {"girth": 3, "has_cycle": True}),
         (
             "graph.invariant.diameter.compute",
-            triangle_tail,
             {
                 "status": "COMPUTED",
                 "diameter": 2,
@@ -53,34 +51,38 @@ def test_graph_invariant_family_boundaries_and_witnesses(domain_services) -> Non
                 "detail": None,
             },
         ),
-        (
-            "graph.invariant.edge_connectivity.compute",
-            triangle_tail,
-            {"edge_connectivity": 1},
-        ),
-        (
-            "graph.invariant.vertex_connectivity.compute",
-            triangle_tail,
-            {"vertex_connectivity": 1},
-        ),
-        (
-            "graph.invariant.is_eulerian.compute",
-            triangle_tail,
-            {"is_eulerian": False},
-        ),
-        (
-            "graph.invariant.spanning_tree_count.compute",
-            triangle_tail,
-            {"spanning_tree_count": 3, "connected": True},
-        ),
+        ("graph.invariant.edge_connectivity.compute", {"edge_connectivity": 1}),
+        ("graph.invariant.vertex_connectivity.compute", {"vertex_connectivity": 1}),
+        ("graph.invariant.is_eulerian.compute", {"is_eulerian": False}),
+        ("graph.invariant.spanning_tree_count.compute", {"spanning_tree_count": 3, "connected": True}),
+    ],
+    ids=[
+        "girth",
+        "diameter",
+        "edge_connectivity",
+        "vertex_connectivity",
+        "is_eulerian",
+        "spanning_tree_count",
+    ],
+)
+def test_graph_invariant_family_boundaries_and_witnesses(
+    domain_services,
+    capability_id: str,
+    expected: dict[str, object],
+) -> None:
+    result = domain_services.core.capabilities.invoke(
+        CapabilityRequest(capability_id=capability_id, input={"graph": _TRIANGLE_TAIL})
     )
-    for capability_id, graph, expected in cases:
-        result = domain_services.core.capabilities.invoke(
-            CapabilityRequest(capability_id=capability_id, input={"graph": graph})
-        )
-        assert result.execution.status is ExecutionStatus.COMPLETED
-        assert result.output["result"] == expected
-        assert result.artifact_uris == ()
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output["result"] == expected
+    assert result.artifact_uris == ()
+
+
+def test_maximum_matching_and_star_conventions(domain_services) -> None:
+    triangle_tail = _graph(
+        ["a", "b", "c", "d"],
+        [["a", "b"], ["b", "c"], ["a", "c"], ["c", "d"]],
+    )
 
     matching = domain_services.core.capabilities.invoke(
         CapabilityRequest(
@@ -193,36 +195,44 @@ def test_radius_uses_explicit_not_applicable_for_disconnected_graph(
     }
 
 
-def test_np_hard_invariants_are_budgeted_and_carry_obligations(
-    domain_services,
-) -> None:
-    cycle = _graph(
-        ["a", "b", "c", "d", "e"],
-        [["a", "b"], ["b", "c"], ["c", "d"], ["d", "e"], ["a", "e"]],
-    )
-    for capability_id, optimum in (
+_CYCLE_5 = {
+    "vertices": ["a", "b", "c", "d", "e"],
+    "edges": [["a", "b"], ["b", "c"], ["c", "d"], ["d", "e"], ["a", "e"]],
+}
+
+
+@pytest.mark.parametrize(
+    ("capability_id", "optimum"),
+    [
         ("graph.invariant.clique_number.compute", 2),
         ("graph.invariant.independence_number.compute", 2),
-    ):
-        result = domain_services.core.capabilities.invoke(
-            CapabilityRequest(
-                capability_id=capability_id,
-                input={
-                    "graph": cycle,
-                    "resource_budget": {
-                        "wall_seconds": 5,
-                        "max_solver_calls": 33,
-                        "max_order": 32,
-                    },
+    ],
+    ids=["clique_number", "independence_number"],
+)
+def test_np_hard_invariants_are_budgeted_and_carry_obligations(
+    domain_services,
+    capability_id: str,
+    optimum: int,
+) -> None:
+    result = domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id=capability_id,
+            input={
+                "graph": _CYCLE_5,
+                "resource_budget": {
+                    "wall_seconds": 5,
+                    "max_solver_calls": 33,
+                    "max_order": 32,
                 },
-            )
+            },
         )
-        assert result.execution.status is ExecutionStatus.COMPLETED
-        assert result.output["status"] == "EXACT"
-        assert result.output["optimum_value"] == optimum
-        assert len(result.output["witness_vertices"]) == optimum
-        assert len(result.artifact_uris) == 3
-        obligation = domain_services.core.store.get(
-            result.obligations[0].obligation_uri
-        )
-        assert obligation.payload["claimed_value"] == optimum
+    )
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output["status"] == "EXACT"
+    assert result.output["optimum_value"] == optimum
+    assert len(result.output["witness_vertices"]) == optimum
+    assert len(result.artifact_uris) == 3
+    obligation = domain_services.core.store.get(
+        result.obligations[0].obligation_uri
+    )
+    assert obligation.payload["claimed_value"] == optimum

--- a/tests/domain/graph/test_graph_invariant_domain.py
+++ b/tests/domain/graph/test_graph_invariant_domain.py
@@ -54,7 +54,10 @@ _TRIANGLE_TAIL = {
         ("graph.invariant.edge_connectivity.compute", {"edge_connectivity": 1}),
         ("graph.invariant.vertex_connectivity.compute", {"vertex_connectivity": 1}),
         ("graph.invariant.is_eulerian.compute", {"is_eulerian": False}),
-        ("graph.invariant.spanning_tree_count.compute", {"spanning_tree_count": 3, "connected": True}),
+        (
+            "graph.invariant.spanning_tree_count.compute",
+            {"spanning_tree_count": 3, "connected": True},
+        ),
     ],
     ids=[
         "girth",
@@ -232,7 +235,5 @@ def test_np_hard_invariants_are_budgeted_and_carry_obligations(
     assert result.output["optimum_value"] == optimum
     assert len(result.output["witness_vertices"]) == optimum
     assert len(result.artifact_uris) == 3
-    obligation = domain_services.core.store.get(
-        result.obligations[0].obligation_uri
-    )
+    obligation = domain_services.core.store.get(result.obligations[0].obligation_uri)
     assert obligation.payload["claimed_value"] == optimum


### PR DESCRIPTION
## Summary

Systematic audit of test fixtures for false greens, hardcoding, assertion debt, and other anti-patterns.

## Changes

### Hardcoded paths
- `/home/jacobian` → `/tmp/jacobian-test-home` in `test_lean_checker_errors.py`
- `/tmp/jacobian-fake-home` and `/tmp/jacobian-fake-elan` → module-level `_FAKE_HOME`/`_FAKE_ELAN` constants in `test_topology_runner.py` (prevents magic-string duplication across tests)

### Copy-paste tests parametrized
- **3 digest mismatch tests → 1 parametrized test** in `test_conjecture_ingestion.py`: `test_changed_content_fails_expected_digest_binding`, `test_tampered_record_fails_expected_digest_binding`, and `test_tampered_license_evidence_digest_is_rejected` were nearly identical — only the field name, digest, and expected error code differed. Consolidated into `test_digest_binding_mismatch_is_rejected` with explicit ids.
- **2 rejection tests → 1 parametrized test** in `test_finite_partition_checker.py`: `test_finite_partition_checker_rejects_unbound_relationship_metadata` and `test_finite_partition_checker_rejects_binding_substitution` shared identical setup and assertion structure. Consolidated into `test_finite_partition_checker_rejects_corrupted_certificate`.
- **2 rebinding tests → 1 parametrized test** in `test_rational_determinant_checker.py`: `test_checker_rejects_mutated_determinant_with_refreshed_digest` and `test_checker_rejects_rebound_source_identity` were identical except for the mutation. Consolidated into `test_checker_rejects_candidate_rebinding_with_refreshed_digest`.

### Loop-based test logic replaced with `@pytest.mark.parametrize`
- **6 graph invariant cases** in `test_graph_invariant_domain.py`: `test_graph_invariant_family_boundaries_and_witnesses` iterated over 6 (capability_id, graph, expected) tuples in a for-loop. Parametrized the invariant checks and split the matching/star assertions into a separate `test_maximum_matching_and_star_conventions` test.
- **2 NP-hard invariant cases** in `test_graph_invariant_domain.py`: `test_np_hard_invariants_are_budgeted_and_carry_obligations` iterated over 2 (capability_id, optimum) pairs in a for-loop. Parametrized the test.

## Patterns investigated but not changed (healthy)
- **Sleep-based sync**: All `time.sleep` calls are either in subprocess scripts or bounded polling loops — no anti-patterns.
- **Mock theatre**: No `Mock()`/`MagicMock()` usage; all test doubles use `monkeypatch`.
- **Skip/xfail debt**: No `@pytest.mark.skip` or unexplained `@pytest.mark.xfail`.
- **False greens**: All tests without explicit `assert` use `pytest.raises()` — valid exception-testing.
- **Shared mutable fixtures**: No module-level mutable state shared across tests.