### PR TITLE
fix(benchmarks): store provider wheels under pinned PEP 427 names

### DIFF
--- a/benchmarks/datasets/provider-feasibility-v1/cddlib/environment/pin.json
+++ b/benchmarks/datasets/provider-feasibility-v1/cddlib/environment/pin.json
@@ -1,5 +1,5 @@
 {
-  "adapter_source_sha256": "sha256:860b037e097e38b4e0f44601c08eec1a153e6686625c08e844eb161ccaec3d85",
+  "adapter_source_sha256": "sha256:8a6f0c90929f3cf9582208844d4d9ce10258bc5721dbe8581171dbc180eb05cd",
   "contract": "jacobian.cddlib-hv-spike/v1",
   "provider": "cddlib/pycddlib",
   "reproduction": {

--- a/benchmarks/datasets/provider-feasibility-v1/cddlib/environment/spike.py
+++ b/benchmarks/datasets/provider-feasibility-v1/cddlib/environment/spike.py
@@ -22,7 +22,14 @@ from benchmarks.tooling.command_runner import (
 
 PIN_PATH = Path(__file__).with_name("pin.json")
 ADAPTER_SOURCE = Path(__file__)
-_ENVIRONMENT = {"LANG": "C", "LC_ALL": "C", "TZ": "UTC"}
+# Worker re-exec replaces the process environment; keep the image PYTHONPATH so
+# `benchmarks.tooling.command_runner` remains importable inside --worker mode.
+_ENVIRONMENT = {
+    "LANG": "C",
+    "LC_ALL": "C",
+    "TZ": "UTC",
+    "PYTHONPATH": "/opt",
+}
 _KIND_ORDER = {
     "EQUALITY": 0,
     "INEQUALITY": 1,

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/environment/Dockerfile
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/environment/Dockerfile
@@ -1,11 +1,11 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /opt/provider && \
-    curl -fsSL https://files.pythonhosted.org/packages/02/fb/fad8db68c325617708b8033f196c09633fea0962c0878ccc73571ce889b2/gudhi-3.13.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl -o /opt/provider/gudhi.whl && \
+    curl -fsSL https://files.pythonhosted.org/packages/02/fb/fad8db68c325617708b8033f196c09633fea0962c0878ccc73571ce889b2/gudhi-3.13.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl -o /opt/provider/gudhi-3.13.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl && \
     curl -fsSL https://github.com/GUDHI/gudhi-devel/archive/refs/tags/tags/gudhi-release-3.13.0.tar.gz -o /opt/provider/gudhi-source.tar.gz && \
-    printf '%s  %s\n' d7ce52905d147a7e599607758843c7f37525c98e7aeaca87cbbbcbd3adb71598 /opt/provider/gudhi.whl | sha256sum -c - && \
+    printf '%s  %s\n' d7ce52905d147a7e599607758843c7f37525c98e7aeaca87cbbbcbd3adb71598 /opt/provider/gudhi-3.13.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl | sha256sum -c - && \
     printf '%s  %s\n' 7640d716d6a118b7787602826e4144bfa1ad5903a31f4a760a7f3a1e68cfdc02 /opt/provider/gudhi-source.tar.gz | sha256sum -c - && \
-    uv pip install --system /opt/provider/gudhi.whl numpy==2.5.1
+    uv pip install --system /opt/provider/gudhi-3.13.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl numpy==2.5.1
 WORKDIR /app
 COPY __init__.py /opt/benchmarks/__init__.py
 COPY tooling/__init__.py /opt/benchmarks/tooling/__init__.py

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/environment/pin.json
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/environment/pin.json
@@ -1,5 +1,5 @@
 {
-  "adapter_source_sha256": "sha256:77a3727f57d27f7d6becc8f749d407853419ca56ca8d44cc303c32ed2e2c4403",
+  "adapter_source_sha256": "sha256:9faf64ddf467696fc15a1f6e7dbf9d19ad89070656046a4b95a7f69ee932159e",
   "contract": "jacobian.gudhi-persistence-spike/v1",
   "documentation_url": "https://gudhi.inria.fr/python/3.13.0/simplex_tree_ref.html",
   "licensing_url": "https://gudhi.inria.fr/licensing/",

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/environment/pin.json
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/environment/pin.json
@@ -1,5 +1,5 @@
 {
-  "adapter_source_sha256": "sha256:529de59f14407df8515b3b698269dad4030e9aaca8812b1f328378ab6cfdfeee",
+  "adapter_source_sha256": "sha256:77a3727f57d27f7d6becc8f749d407853419ca56ca8d44cc303c32ed2e2c4403",
   "contract": "jacobian.gudhi-persistence-spike/v1",
   "documentation_url": "https://gudhi.inria.fr/python/3.13.0/simplex_tree_ref.html",
   "licensing_url": "https://gudhi.inria.fr/licensing/",

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/environment/spike.py
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/environment/spike.py
@@ -32,7 +32,14 @@ _SOURCE_MEMBERS = {
         "Persistent_cohomology.h"
     ),
 }
-_ENVIRONMENT = {"LANG": "C", "LC_ALL": "C", "TZ": "UTC"}
+# Worker re-exec replaces the process environment; keep the image PYTHONPATH so
+# `benchmarks.tooling.command_runner` remains importable inside --worker mode.
+_ENVIRONMENT = {
+    "LANG": "C",
+    "LC_ALL": "C",
+    "TZ": "UTC",
+    "PYTHONPATH": "/opt",
+}
 ProcessRunner = Callable[..., ToolCommandResult]
 _WORKER_ERROR_PREFIX = b"JACOBIAN_SPIKE_ERROR "
 

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/solution/solve.sh
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/solution/solve.sh
@@ -3,7 +3,7 @@ set -eu
 mkdir -p /app/evidence
 python /app/spike.py \
   --python-executable /usr/local/bin/python \
-  --wheel /opt/provider/gudhi.whl \
+  --wheel /opt/provider/gudhi-3.13.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl \
   --source-archive /opt/provider/gudhi-source.tar.gz \
   --pin /app/pin.json \
   --output /app/evidence/provider-report.json

--- a/benchmarks/datasets/provider-feasibility-v1/regina/environment/Dockerfile
+++ b/benchmarks/datasets/provider-feasibility-v1/regina/environment/Dockerfile
@@ -1,11 +1,11 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /opt/provider && \
-    curl -fsSL https://files.pythonhosted.org/packages/68/42/b4a994e393298c08c361342ee19bf240b7b16f155c492ce0631082c14e66/regina-7.4.1-cp312-cp312-manylinux_2_28_x86_64.whl -o /opt/provider/regina.whl && \
+    curl -fsSL https://files.pythonhosted.org/packages/68/42/b4a994e393298c08c361342ee19bf240b7b16f155c492ce0631082c14e66/regina-7.4.1-cp312-cp312-manylinux_2_28_x86_64.whl -o /opt/provider/regina-7.4.1-cp312-cp312-manylinux_2_28_x86_64.whl && \
     curl -fsSL https://github.com/regina-normal/regina/releases/download/regina-7.4.1/regina-7.4.1.tar.gz -o /opt/provider/regina-source.tar.gz && \
-    printf '%s  %s\n' d33ccc69697ec680a8dcf8f0c663428853da44f3578898ad9b908e4669e83c71 /opt/provider/regina.whl | sha256sum -c - && \
+    printf '%s  %s\n' d33ccc69697ec680a8dcf8f0c663428853da44f3578898ad9b908e4669e83c71 /opt/provider/regina-7.4.1-cp312-cp312-manylinux_2_28_x86_64.whl | sha256sum -c - && \
     printf '%s  %s\n' 74131014099b77083dd1d09004fd6bc972421c792d188cdf43f0fd11ca6cb2ed /opt/provider/regina-source.tar.gz | sha256sum -c - && \
-    uv pip install --system /opt/provider/regina.whl
+    uv pip install --system /opt/provider/regina-7.4.1-cp312-cp312-manylinux_2_28_x86_64.whl
 WORKDIR /app
 COPY __init__.py /opt/benchmarks/__init__.py
 COPY tooling/__init__.py /opt/benchmarks/tooling/__init__.py

--- a/benchmarks/datasets/provider-feasibility-v1/regina/environment/pin.json
+++ b/benchmarks/datasets/provider-feasibility-v1/regina/environment/pin.json
@@ -1,5 +1,5 @@
 {
-  "adapter_source_sha256": "sha256:efbfb51037f7976a43b0e56bd5a4b98ffb0fada9f0a9ab1db0b6fd5d3ffcd981",
+  "adapter_source_sha256": "sha256:e017a6f203585eacf2e57551aba282af510635e45bade5e5d722e1fee724d005",
   "contract": "jacobian.regina-outcomes-spike/v1",
   "distribution_version": "7.4.1",
   "documentation_url": "https://regina-normal.github.io/engine-docs/",

--- a/benchmarks/datasets/provider-feasibility-v1/regina/environment/pin.json
+++ b/benchmarks/datasets/provider-feasibility-v1/regina/environment/pin.json
@@ -1,5 +1,5 @@
 {
-  "adapter_source_sha256": "sha256:dd8f48b0b3d473c17a813ef2002e790aa3de1f8f7e9273fae939c105faaceccb",
+  "adapter_source_sha256": "sha256:efbfb51037f7976a43b0e56bd5a4b98ffb0fada9f0a9ab1db0b6fd5d3ffcd981",
   "contract": "jacobian.regina-outcomes-spike/v1",
   "distribution_version": "7.4.1",
   "documentation_url": "https://regina-normal.github.io/engine-docs/",

--- a/benchmarks/datasets/provider-feasibility-v1/regina/environment/spike.py
+++ b/benchmarks/datasets/provider-feasibility-v1/regina/environment/spike.py
@@ -33,7 +33,14 @@ _SOURCE_MEMBERS = {
     "triangulation": (f"{_SOURCE_ROOT}/engine/triangulation/dim3/triangulation3.h"),
     "normal_surfaces": f"{_SOURCE_ROOT}/engine/surface/normalsurfaces.h",
 }
-_ENVIRONMENT = {"LANG": "C", "LC_ALL": "C", "TZ": "UTC"}
+# Worker re-exec replaces the process environment; keep the image PYTHONPATH so
+# `benchmarks.tooling.command_runner` remains importable inside --worker mode.
+_ENVIRONMENT = {
+    "LANG": "C",
+    "LC_ALL": "C",
+    "TZ": "UTC",
+    "PYTHONPATH": "/opt",
+}
 _INTEGER = re.compile(r"^(?:0|[1-9][0-9]*)$")
 ProcessRunner = Callable[..., ToolCommandResult]
 _WORKER_ERROR_PREFIX = b"JACOBIAN_SPIKE_ERROR "

--- a/benchmarks/datasets/provider-feasibility-v1/regina/solution/solve.sh
+++ b/benchmarks/datasets/provider-feasibility-v1/regina/solution/solve.sh
@@ -3,7 +3,7 @@ set -eu
 mkdir -p /app/evidence
 python /app/spike.py \
   --python-executable /usr/local/bin/python \
-  --wheel /opt/provider/regina.whl \
+  --wheel /opt/provider/regina-7.4.1-cp312-cp312-manylinux_2_28_x86_64.whl \
   --source-archive /opt/provider/regina-source.tar.gz \
   --pin /app/pin.json \
   --output /app/evidence/provider-report.json


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Provider feasibility Oracle images failed because `uv` rejects short wheel paths like `gudhi.whl` / `regina.whl` (`Must have a version`). Dockerfiles and `solve.sh` now install/copy the pinned PEP 427 filenames.

Also fixes two follow-on Oracle blockers uncovered after install succeeded:

1. Refresh `adapter_source_sha256` in gudhi/regina(/cddlib) `pin.json` to match current `spike.py`.
2. Preserve `PYTHONPATH=/opt` in spike worker child environments so `--worker` re-exec can still import `benchmarks.tooling.command_runner` (was collapsing to opaque `PROVIDER_CRASH`).

## Related
- https://github.com/morluto/jacobian/issues/654 (wheel filenames)
- https://github.com/morluto/jacobian/issues/666 (worker PYTHONPATH strip)

## Test plan
- [x] Local gudhi `run_spike` completes with `COMPLETED` after PYTHONPATH fix
- [x] Pin digests match current spike adapters
- [ ] CI provider Oracle lanes (gudhi/regina) green on this branch

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-58365a07-3c97-411c-939a-5937dea1ddf4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-58365a07-3c97-411c-939a-5937dea1ddf4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

