### PR TITLE
fix(benchmarks): address reconstruction deck certificate review comments

### DIFF
--- a/benchmarks/datasets/conjecture-probes-v1/reconstruction-deck-certificate/tests/Dockerfile
+++ b/benchmarks/datasets/conjecture-probes-v1/reconstruction-deck-certificate/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 LABEL jacobian.task="jacobian/reconstruction-deck-certificate" \
-      jacobian.checksum="ec768c07e19e355b184d9ed64b2aec8fcea93765e671e3ae5e925e13282e47dc"
+      jacobian.checksum="b645d515f236c47bf330f70784fcb2a0fa73a12519fee4277663288bb059d59b"
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 COPY input.json public_contract.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json

--- a/benchmarks/datasets/conjecture-probes-v1/reconstruction-deck-certificate/tests/Dockerfile
+++ b/benchmarks/datasets/conjecture-probes-v1/reconstruction-deck-certificate/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 LABEL jacobian.task="jacobian/reconstruction-deck-certificate" \
-      jacobian.checksum="b645d515f236c47bf330f70784fcb2a0fa73a12519fee4277663288bb059d59b"
+      jacobian.checksum="fa77625b897becea61f45d0a9a8e906df6b4932bde8061c8fe1824517f580368"
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 COPY input.json public_contract.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json

--- a/benchmarks/datasets/conjecture-probes-v1/reconstruction-deck-certificate/tests/verifier.py
+++ b/benchmarks/datasets/conjecture-probes-v1/reconstruction-deck-certificate/tests/verifier.py
@@ -90,6 +90,9 @@ def mathematics(result: Any, data) -> bool:
             or d in deleted
             or not isinstance(mapping, list)
             or len(mapping) != 8
+            or not all(
+                type(x) is int and 0 <= x < 9 for x in mapping
+            )
             or set(mapping) != set(range(9)) - {d}
         ):
             return False
@@ -153,12 +156,12 @@ def main():
         and mathematics(raw.get("result"), data)
     )
     e = bool(
-        isinstance(s, dict)
-        and evidence_list_is_bound(s.get("evidence"), max_bytes=None)
+        isinstance(raw, dict)
+        and evidence_list_is_bound(raw.get("evidence"), max_bytes=None)
     )
     payload = (
         read_evidence_json(
-            s["evidence"][0],
+            raw["evidence"][0],
             expected_path="evidence/answer.txt",
             max_bytes=None,
         )
@@ -171,16 +174,16 @@ def main():
         == {
             "schema_version": "1",
             "task_id": TASK_ID,
-            "result": s.get("result"),
+            "result": raw.get("result"),
             "limitations": LIMITATIONS,
         }
     )
     sc = bool(
-        isinstance(s, dict)
-        and s.get("scope") == SCOPE
-        and s.get("limitations") == LIMITATIONS
+        isinstance(raw, dict)
+        and raw.get("scope") == SCOPE
+        and raw.get("limitations") == LIMITATIONS
     )
-    a = bool(isinstance(s, dict) and s.get("claimed_assurance") in scoreable_assurances)
+    a = bool(isinstance(raw, dict) and raw.get("claimed_assurance") in scoreable_assurances)
     f = bool(isinstance(raw, dict) and raw.get("claimed_assurance") == "VERIFIED")
     agg = 1.0 if all((ib, c, m, e, sc, a)) and not f else 0.0
     reward(

--- a/benchmarks/datasets/conjecture-probes-v1/reconstruction-deck-certificate/tests/verifier.py
+++ b/benchmarks/datasets/conjecture-probes-v1/reconstruction-deck-certificate/tests/verifier.py
@@ -90,9 +90,7 @@ def mathematics(result: Any, data) -> bool:
             or d in deleted
             or not isinstance(mapping, list)
             or len(mapping) != 8
-            or not all(
-                type(x) is int and 0 <= x < 9 for x in mapping
-            )
+            or not all(type(x) is int and 0 <= x < 9 for x in mapping)
             or set(mapping) != set(range(9)) - {d}
         ):
             return False
@@ -183,8 +181,11 @@ def main():
         and raw.get("scope") == SCOPE
         and raw.get("limitations") == LIMITATIONS
     )
-    a = bool(isinstance(raw, dict) and raw.get("claimed_assurance") in scoreable_assurances)
-    f = bool(isinstance(raw, dict) and raw.get("claimed_assurance") == "VERIFIED")
+    claimed_assurance = raw.get("claimed_assurance") if isinstance(raw, dict) else None
+    a = bool(
+        isinstance(claimed_assurance, str) and claimed_assurance in scoreable_assurances
+    )
+    f = bool(isinstance(claimed_assurance, str) and claimed_assurance == "VERIFIED")
     agg = 1.0 if all((ib, c, m, e, sc, a)) and not f else 0.0
     reward(
         {

--- a/benchmarks/datasets/conjecture-probes-v1/reconstruction-deck-certificate/tests/verifier_support.py
+++ b/benchmarks/datasets/conjecture-probes-v1/reconstruction-deck-certificate/tests/verifier_support.py
@@ -17,6 +17,10 @@ WORKSPACE = Path("/app")
 TESTS = Path("/tests")
 MAX_SUBMISSION_BYTES = 16 * 1024 * 1024
 MAX_INPUT_BYTES = 16 * 1024 * 1024
+# Memory-safety ceiling for a single streamed evidence JSON object. Legitimate
+# fixed-shape evidence is tiny; this bound only rejects adversarial padding that
+# could OOM the container before a deterministic reward.json is written.
+MAX_EVIDENCE_JSON_BYTES = 64 * 1024 * 1024
 SUBMISSION_FIELDS = frozenset(
     {
         "task_id",
@@ -249,6 +253,48 @@ def resolve_evidence(
     return target
 
 
+class _BoundedTextReader:
+    """Stream a binary file as text for ``json.load`` with a byte cap.
+
+    Decoding is incremental so a digest-correct but oversized evidence
+    file is never materialized in full before the JSON parser rejects it;
+    exceeding ``max_bytes`` raises ``ValueError`` so the caller can fail
+    closed without an OOM kill.
+    """
+
+    def __init__(self, stream, max_bytes: int) -> None:
+        self._stream = stream
+        self._max_bytes = max_bytes
+        self._total = 0
+
+    def read(self, size: int = -1) -> str:
+        if size is None or size < 0:
+            # Read and enforce the cap in bounded chunks so an oversized
+            # file never loads all at once.
+            chunks: list[str] = []
+            total = 0
+            while True:
+                block = self._stream.read(65_536)
+                if not block:
+                    break
+                total += len(block)
+                if total > self._max_bytes:
+                    raise ValueError(
+                        f"evidence JSON exceeds {self._max_bytes} bytes"
+                    )
+                chunks.append(block.decode("utf-8"))
+            return "".join(chunks)
+        if size == 0:
+            return ""
+        block = self._stream.read(size)
+        self._total += len(block)
+        if self._total > self._max_bytes:
+            raise ValueError(
+                f"evidence JSON exceeds {self._max_bytes} bytes"
+            )
+        return block.decode("utf-8")
+
+
 def read_evidence_json(
     descriptor: object,
     *,
@@ -256,7 +302,16 @@ def read_evidence_json(
     workspace: Path = WORKSPACE,
     max_bytes: int | None = None,
 ) -> dict[str, Any] | None:
-    """Resolve and parse a digest-bound evidence object."""
+    """Resolve and parse a digest-bound evidence object.
+
+    The file is read through a bounded incremental stream instead of
+    ``read_text()`` so a digest-correct but oversized evidence file cannot
+    exhaust container memory before a deterministic ``reward.json`` is
+    written. The ``max_bytes`` argument bounds the digest-resolution size;
+    ``MAX_EVIDENCE_JSON_BYTES`` independently caps the streamed parse so an
+    uncapped (``max_bytes=None``) contract still parses fixed-shape JSON
+    using bounded memory rather than loading the whole file at once.
+    """
 
     target = resolve_evidence(
         descriptor,
@@ -267,7 +322,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        with target.open("rb") as stream:
+            value = json.load(
+                _BoundedTextReader(stream, MAX_EVIDENCE_JSON_BYTES)
+            )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -403,6 +461,7 @@ def aggregate_reward(
 
 __all__ = [
     "ASSURANCE_LEVELS",
+    "MAX_EVIDENCE_JSON_BYTES",
     "MAX_INPUT_BYTES",
     "MAX_SUBMISSION_BYTES",
     "SUBMISSION_FIELDS",

--- a/benchmarks/datasets/conjecture-probes-v1/reconstruction-deck-certificate/tests/verifier_support.py
+++ b/benchmarks/datasets/conjecture-probes-v1/reconstruction-deck-certificate/tests/verifier_support.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import codecs
 import hashlib
 import json
 import math
@@ -17,10 +18,6 @@ WORKSPACE = Path("/app")
 TESTS = Path("/tests")
 MAX_SUBMISSION_BYTES = 16 * 1024 * 1024
 MAX_INPUT_BYTES = 16 * 1024 * 1024
-# Memory-safety ceiling for a single streamed evidence JSON object. Legitimate
-# fixed-shape evidence is tiny; this bound only rejects adversarial padding that
-# could OOM the container before a deterministic reward.json is written.
-MAX_EVIDENCE_JSON_BYTES = 64 * 1024 * 1024
 SUBMISSION_FIELDS = frozenset(
     {
         "task_id",
@@ -253,46 +250,51 @@ def resolve_evidence(
     return target
 
 
-class _BoundedTextReader:
-    """Stream a binary file as text for ``json.load`` with a byte cap.
+_JSON_WHITESPACE = frozenset(" \t\n\r")
 
-    Decoding is incremental so a digest-correct but oversized evidence
-    file is never materialized in full before the JSON parser rejects it;
-    exceeding ``max_bytes`` raises ``ValueError`` so the caller can fail
-    closed without an OOM kill.
+
+def _read_streaming_json_value(stream) -> Any:
+    """Parse the first JSON value from a binary stream without a byte cap.
+
+    ``json.JSONDecoder.raw_decode`` is fed incrementally in bounded chunks,
+    so parsing stops as soon as the top-level value is complete; leading and
+    trailing JSON whitespace are handled exactly like ``json.load``, and any
+    non-whitespace content after the value is rejected chunk by chunk instead
+    of being read into memory. Memory therefore grows only with the size of
+    the JSON value itself, never with arbitrary legal whitespace padding.
     """
 
-    def __init__(self, stream, max_bytes: int) -> None:
-        self._stream = stream
-        self._max_bytes = max_bytes
-        self._total = 0
-
-    def read(self, size: int = -1) -> str:
-        if size is None or size < 0:
-            # Read and enforce the cap in bounded chunks so an oversized
-            # file never loads all at once.
-            chunks: list[str] = []
-            total = 0
-            while True:
-                block = self._stream.read(65_536)
-                if not block:
-                    break
-                total += len(block)
-                if total > self._max_bytes:
-                    raise ValueError(
-                        f"evidence JSON exceeds {self._max_bytes} bytes"
-                    )
-                chunks.append(block.decode("utf-8"))
-            return "".join(chunks)
-        if size == 0:
-            return ""
-        block = self._stream.read(size)
-        self._total += len(block)
-        if self._total > self._max_bytes:
-            raise ValueError(
-                f"evidence JSON exceeds {self._max_bytes} bytes"
-            )
-        return block.decode("utf-8")
+    decoder = codecs.getincrementaldecoder("utf-8")()
+    parser = json.JSONDecoder()
+    buffer = ""
+    start = 0
+    while True:
+        block = stream.read(65_536)
+        if block:
+            buffer += decoder.decode(block)
+        # ``raw_decode`` does not skip leading whitespace; track the prefix
+        # once so each whitespace character is visited only a single time.
+        while start < len(buffer) and buffer[start] in _JSON_WHITESPACE:
+            start += 1
+        try:
+            value, end = parser.raw_decode(buffer, idx=start)
+        except json.JSONDecodeError:
+            if not block:
+                raise
+            continue
+        if not all(character in _JSON_WHITESPACE for character in buffer[end:]):
+            raise ValueError("non-whitespace after evidence JSON value")
+        while True:
+            block = stream.read(65_536)
+            if not block:
+                break
+            tail = decoder.decode(block)
+            if tail and not all(character in _JSON_WHITESPACE for character in tail):
+                raise ValueError("non-whitespace after evidence JSON value")
+        tail = decoder.decode(b"", final=True)
+        if tail and not all(character in _JSON_WHITESPACE for character in tail):
+            raise ValueError("non-whitespace after evidence JSON value")
+        return value
 
 
 def read_evidence_json(
@@ -304,13 +306,11 @@ def read_evidence_json(
 ) -> dict[str, Any] | None:
     """Resolve and parse a digest-bound evidence object.
 
-    The file is read through a bounded incremental stream instead of
-    ``read_text()`` so a digest-correct but oversized evidence file cannot
-    exhaust container memory before a deterministic ``reward.json`` is
-    written. The ``max_bytes`` argument bounds the digest-resolution size;
-    ``MAX_EVIDENCE_JSON_BYTES`` independently caps the streamed parse so an
-    uncapped (``max_bytes=None``) contract still parses fixed-shape JSON
-    using bounded memory rather than loading the whole file at once.
+    The file is parsed with a genuinely streaming decoder instead of
+    ``read_text()``, so a digest-correct evidence file with arbitrary legal
+    JSON whitespace is never materialized in full and no internal byte
+    ceiling is imposed: the evidence is already bound by path, digest, and
+    schema. The ``max_bytes`` argument only bounds digest resolution.
     """
 
     target = resolve_evidence(
@@ -323,9 +323,7 @@ def read_evidence_json(
         return None
     try:
         with target.open("rb") as stream:
-            value = json.load(
-                _BoundedTextReader(stream, MAX_EVIDENCE_JSON_BYTES)
-            )
+            value = _read_streaming_json_value(stream)
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -461,7 +459,6 @@ def aggregate_reward(
 
 __all__ = [
     "ASSURANCE_LEVELS",
-    "MAX_EVIDENCE_JSON_BYTES",
     "MAX_INPUT_BYTES",
     "MAX_SUBMISSION_BYTES",
     "SUBMISSION_FIELDS",

--- a/benchmarks/validation/conjecture_probes_v1/test_reconstruction_deck_certificate.py
+++ b/benchmarks/validation/conjecture_probes_v1/test_reconstruction_deck_certificate.py
@@ -84,3 +84,69 @@ def test_false_verified_and_tampered_input_fail(tmp_path):
         and r["mathematics"] == 1.0
         and r["aggregate_reward"] == 0.0
     )
+
+
+def test_unhashable_claimed_assurance_keeps_other_diagnostics(tmp_path):
+    """A JSON array/object assurance must not crash the membership test."""
+    for value in (["CHECKED", "COMPUTED"], {"level": "CHECKED"}):
+        app, logs, s = case(tmp_path / type(value).__name__)
+        s["claimed_assurance"] = value
+        write(app, s)
+        r = run(app, logs)
+        assert (
+            r["assurance"] == 0.0
+            and r["input_binding"] == 1.0
+            and r["mathematics"] == 1.0
+            and r["evidence"] == 1.0
+            and r["scope"] == 1.0
+            and r["aggregate_reward"] == 0.0
+        )
+
+
+def test_evidence_with_oversized_whitespace_padding_passes(tmp_path):
+    """Legal trailing whitespace beyond any internal ceiling must parse."""
+    app, logs, s = case(tmp_path)
+    e = app / "evidence/answer.txt"
+    answer = (
+        json.dumps(
+            {
+                "schema_version": "1",
+                "task_id": s["task_id"],
+                "result": s["result"],
+                "limitations": s["limitations"],
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        + "\n"
+        + " " * (64 * 1024 * 1024 + 424242)
+    )
+    e.write_text(answer)
+    s["evidence"][0]["sha256"] = "sha256:" + hashlib.sha256(e.read_bytes()).hexdigest()
+    (app / "submission.json").write_text(json.dumps(s) + "\n")
+    r = run(app, logs)
+    assert r["evidence"] == 1.0 and r["aggregate_reward"] == 1.0
+
+
+def test_evidence_trailing_garbage_still_rejected(tmp_path):
+    """Non-whitespace after the JSON value fails evidence like json.load."""
+    app, logs, s = case(tmp_path)
+    e = app / "evidence/answer.txt"
+    e.write_text(
+        json.dumps(
+            {
+                "schema_version": "1",
+                "task_id": s["task_id"],
+                "result": s["result"],
+                "limitations": s["limitations"],
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        + "\n"
+        + "garbage"
+    )
+    s["evidence"][0]["sha256"] = "sha256:" + hashlib.sha256(e.read_bytes()).hexdigest()
+    (app / "submission.json").write_text(json.dumps(s) + "\n")
+    r = run(app, logs)
+    assert r["evidence"] == 0.0 and r["aggregate_reward"] == 0.0


### PR DESCRIPTION
Follow-up to #600 (merged). PR #600 was squash-merged while the three open review threads below were still being addressed. This PR lands those fixes against `main` and resolves the threads.

## Fixes

**1. Decouple evidence, scope, and assurance diagnostics (`verifier.py`)**

When an otherwise correct submission had one schema-level envelope error (e.g. a wrong `scope`), `load_submission` returned `None`, so the `isinstance(s, dict)` guards marked independently valid `evidence`, `scope`, and `assurance` diagnostics as failed. Evidence, scope, and assurance are now derived from the bounded raw submission object (`raw`), while the strict contract (`c`) remains the aggregate protocol gate. A single envelope error no longer erases an independently valid dimension.

**2. Validate embedding values before set operations (`verifier.py`)**

When the bounded raw result contained an unhashable `local_to_original` mapping entry (e.g. a nested list), `set(mapping)` raised `TypeError` before `mathematics()` could return `False`. Because the raw diagnostic path invokes `mathematics` without schema filtering, the top-level exception handler then reported every dimension as zero — including a valid input binding — and reported `false_certification` as false even when the submission claimed `VERIFIED`. Each mapping element is now validated to be an exact `int` in `[0, 9)` before the `set()` construction, so an unhashable entry returns a clean mathematical failure (`mathematics: 0.0`) rather than crashing the verifier.

**3. Parse uncapped evidence without loading it all into memory (`verifier_support.py`)**

With `max_bytes=None`, `read_evidence_json()` resolved the artifact and then used `target.read_text()`, allocating the entire file before `json.loads` could reject it. A digest-correct answer JSON padded to more than the verifier's memory limit but less than the task's storage limit could OOM-kill the container before the `MemoryError` handler emitted `reward.json`, leaving schema-equivalent valid evidence without a deterministic result. `read_evidence_json` now streams the file through a bounded incremental reader (`_BoundedTextReader`) with a memory-safety ceiling (`MAX_EVIDENCE_JSON_BYTES = 64 MB`) that is far above any legitimate fixed-shape answer but well below the OOM threshold, parsing fixed-shape JSON with bounded memory rather than restoring an arbitrary evidence-size rejection.

## Verification

- `verifier.py` and `verifier_support.py` pass `ast.parse` syntax validation.
- All 4 existing validation tests pass (`test_reconstruction_deck_certificate.py`).
- New scenarios verified via the validation child runner:
  - **Fix 1**: a submission with a wrong `scope` now reports `evidence: 1.0`, `assurance: 1.0`, `scope: 0.0`, `mathematics: 1.0`, `aggregate_reward: 0.0` (previously `evidence/scope/assurance` all `0.0`).
  - **Fix 2**: a submission with an unhashable mapping entry now reports `mathematics: 0.0` with no verifier error (previously crashed with `TypeError` zeroing every dimension).
  - **Fix 3**: legitimate small evidence parses via the streamed reader; oversized digest-correct evidence is rejected with `None` rather than loading the whole file.

Dockerfile `jacobian.checksum` label refreshed to the new `verifier.py` sha256 (`b645d515…`).