### PR TITLE
fix(benchmarks): accept compact network_mode TOML assignments

### DIFF
--- a/benchmarks/datasets/conjecture-probes-v1/littlewood-certified-finite-search/task.toml
+++ b/benchmarks/datasets/conjecture-probes-v1/littlewood-certified-finite-search/task.toml
@@ -28,12 +28,12 @@ timeout_sec=600.0
 timeout_sec=120.0
 environment_mode="separate"
 [environment]
-network_mode="no-network"
+network_mode = "no-network"
 cpus=1
 memory_mb=1024
 storage_mb=4096
 [verifier.environment]
-network_mode="no-network"
+network_mode = "no-network"
 cpus=1
 memory_mb=1024
 storage_mb=4096

--- a/benchmarks/datasets/conjecture-probes-v1/yang-mills-gauge-invariance-certificate/task.toml
+++ b/benchmarks/datasets/conjecture-probes-v1/yang-mills-gauge-invariance-certificate/task.toml
@@ -28,12 +28,12 @@ timeout_sec=600.0
 timeout_sec=120.0
 environment_mode="separate"
 [environment]
-network_mode="no-network"
+network_mode = "no-network"
 cpus=1
 memory_mb=1024
 storage_mb=4096
 [verifier.environment]
-network_mode="no-network"
+network_mode = "no-network"
 cpus=1
 memory_mb=1024
 storage_mb=4096

--- a/benchmarks/validation/test_benchmark_environment_profiles.py
+++ b/benchmarks/validation/test_benchmark_environment_profiles.py
@@ -41,7 +41,7 @@ def test_network_policy_is_independent_of_image_profile() -> None:
     for suite in load_registry():
         for task in suite.tasks:
             task_toml = (task.path / "task.toml").read_text()
-            modes = set(re.findall(r'network_mode = "([^"]+)"', task_toml))
+            modes = set(re.findall(r'network_mode\s*=\s*"([^"]+)"', task_toml))
             assert modes  # every task pins both agent and verifier network modes
             assert modes <= NETWORK_MODES
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Full host verification failed with:

```text
FAILED test_network_policy_is_independent_of_image_profile - assert set()
```

Two recently merged conjecture tasks used compact TOML (`network_mode="no-network"`) while the inventory test only matched spaced form (`network_mode = "..."`).

## Changes
- Normalize `yang-mills-gauge-invariance-certificate` and `littlewood-certified-finite-search` `task.toml` network assignments to spaced form.
- Harden the regex to `network_mode\s*=\s*"..."`.

## Related
- https://github.com/morluto/jacobian/issues/667
- Unblocks host verification on open eval PRs such as #614 that exercise the full registry.

## Test plan
- [x] All `task.toml` files match the hardened network_mode regex
- [ ] CI host validation green

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-58365a07-3c97-411c-939a-5937dea1ddf4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-58365a07-3c97-411c-939a-5937dea1ddf4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

