### PR TITLE
fix(benchmarks): land Hadwiger verifier review follow-ups (evidence schema, JSON type fidelity, assurance guard, non-finite JSON)

### DIFF
--- a/benchmarks/datasets/conjecture-probes-v1/hadwiger-triangle-free-minor-certificate/instruction.md
+++ b/benchmarks/datasets/conjecture-probes-v1/hadwiger-triangle-free-minor-certificate/instruction.md
@@ -11,8 +11,10 @@ minor model. Complete graphs, triangles, isolated padding, and label-only
 chromatic claims are rejected.
 
 Evidence is matching JSON with exactly `schema_version`, `task_id`, `result`,
-and `limitations`. This checks one finite graph only and does not
-prove Hadwiger's conjecture.
+and `limitations`: `schema_version` must be the string `"1"`, `task_id` must
+equal the task id, `result` must exactly copy the submitted `result` object
+(including JSON types), and `limitations` must equal the declared limitations.
+This checks one finite graph only and does not prove Hadwiger's conjecture.
 
 <!-- BEGIN PUBLIC CONTRACT SUBMISSION BLOCK -->
 ## Submission

--- a/benchmarks/datasets/conjecture-probes-v1/hadwiger-triangle-free-minor-certificate/tests/Dockerfile
+++ b/benchmarks/datasets/conjecture-probes-v1/hadwiger-triangle-free-minor-certificate/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 LABEL jacobian.task="jacobian/hadwiger-triangle-free-minor-certificate" \
-      jacobian.checksum="c8601789f223d998ed27eb8b17529fc76f0e17c13520c1a7496413db89b5f5ad"
+      jacobian.checksum="dce32620ce2121568284ca7aebf617fa10d792f6714cb7f92b7a0d26b9c7738b"
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 COPY input.json public_contract.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json

--- a/benchmarks/datasets/conjecture-probes-v1/hadwiger-triangle-free-minor-certificate/tests/Dockerfile
+++ b/benchmarks/datasets/conjecture-probes-v1/hadwiger-triangle-free-minor-certificate/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 LABEL jacobian.task="jacobian/hadwiger-triangle-free-minor-certificate" \
-      jacobian.checksum="48f25d2267de48da5880f072db680e53f7f4a898905971cf25f6a0dace87a11c"
+      jacobian.checksum="c8601789f223d998ed27eb8b17529fc76f0e17c13520c1a7496413db89b5f5ad"
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 COPY input.json public_contract.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json

--- a/benchmarks/datasets/conjecture-probes-v1/hadwiger-triangle-free-minor-certificate/tests/verifier.py
+++ b/benchmarks/datasets/conjecture-probes-v1/hadwiger-triangle-free-minor-certificate/tests/verifier.py
@@ -8,6 +8,8 @@ from typing import Any
 
 from verifier_support import (
     MAX_SUBMISSION_BYTES,
+    _finite_json_float,
+    _reject_nonfinite_json,
     evidence_list_is_bound,
     is_regular_bounded_file,
     load_submission,
@@ -203,7 +205,11 @@ def _raw_submission() -> dict[str, Any] | None:
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
     try:
-        value = json.loads(path.read_text())
+        value = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -254,10 +260,9 @@ def main():
         and raw.get("limitations") == LIMITATIONS
     )
     scoreable_assurances = frozenset({"UNVERIFIED", "COMPUTED", "CHECKED"})
-    a = bool(
-        isinstance(raw, dict) and raw.get("claimed_assurance") in scoreable_assurances
-    )
-    f = bool(isinstance(raw, dict) and raw.get("claimed_assurance") == "VERIFIED")
+    claimed = raw.get("claimed_assurance") if isinstance(raw, dict) else None
+    a = bool(isinstance(claimed, str) and claimed in scoreable_assurances)
+    f = bool(claimed == "VERIFIED")
     agg = 1.0 if all((ib, c, m, e, sc, a)) and not f else 0.0
     reward(
         {

--- a/benchmarks/datasets/conjecture-probes-v1/hadwiger-triangle-free-minor-certificate/tests/verifier.py
+++ b/benchmarks/datasets/conjecture-probes-v1/hadwiger-triangle-free-minor-certificate/tests/verifier.py
@@ -180,6 +180,24 @@ def mathematics(r: Any) -> bool:
     )
 
 
+def _json_equal(a: Any, b: Any) -> bool:
+    """Return whether two JSON-decoded values are identical, types included.
+
+    Python ``==`` treats booleans as integers (``False == 0``) and integral
+    floats as integers (``4.0 == 4``), but the evidence contract requires the
+    payload to exactly copy the submitted ``result`` with concrete JSON types.
+    """
+    if type(a) is not type(b):
+        return False
+    if isinstance(a, dict):
+        return set(a) == set(b) and all(_json_equal(a[k], b[k]) for k in a)
+    if isinstance(a, list):
+        return len(a) == len(b) and all(
+            _json_equal(x, y) for x, y in zip(a, b, strict=True)
+        )
+    return a == b
+
+
 def _raw_submission() -> dict[str, Any] | None:
     path = Path("/app/submission.json")
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
@@ -227,7 +245,7 @@ def main():
         and set(payload) == {"schema_version", "task_id", "result", "limitations"}
         and payload.get("schema_version") == "1"
         and payload.get("task_id") == TASK_ID
-        and payload.get("result") == raw.get("result")
+        and _json_equal(payload.get("result"), raw.get("result"))
         and payload.get("limitations") == LIMITATIONS
     )
     sc = bool(

--- a/benchmarks/validation/conjecture_probes_v1/test_hadwiger_triangle_free_minor_certificate.py
+++ b/benchmarks/validation/conjecture_probes_v1/test_hadwiger_triangle_free_minor_certificate.py
@@ -116,6 +116,41 @@ def test_triangle_and_duplicate_edge_fail(tmp_path):
     assert run(app, logs)["aggregate_reward"] == 0.0
 
 
+def test_malformed_assurance_keeps_diagnostics(tmp_path):
+    app, logs, s = case(tmp_path)
+    # A schema-invalid list/object assurance must not raise TypeError and
+    # erase the otherwise valid mathematics/evidence/scope diagnostics.
+    s["claimed_assurance"] = ["CHECKED"]
+    write(app, s)
+    r = run(app, logs)
+    assert (
+        r["mathematics"] == 1.0
+        and r["evidence"] == 1.0
+        and r["scope"] == 1.0
+        and r["assurance"] == 0.0
+        and r["aggregate_reward"] == 0.0
+        and "error" not in r
+    )
+
+
+def test_nonfinite_json_rejected_in_raw_parse(tmp_path):
+    app, logs, s = case(tmp_path)
+    # NaN in an extra envelope field is invalid JSON; the raw parser must
+    # reject it deterministically instead of crediting raw-derived metrics.
+    (app / "submission.json").write_text(
+        json.dumps({**s, "extra": float("nan")}) + "\n"
+    )
+    r = run(app, logs)
+    assert (
+        r["mathematics"] == 0.0
+        and r["evidence"] == 0.0
+        and r["scope"] == 0.0
+        and r["assurance"] == 0.0
+        and r["aggregate_reward"] == 0.0
+        and "error" not in r
+    )
+
+
 def test_false_verified_and_tampered_input_fail(tmp_path):
     app, logs, s = case(tmp_path)
     s["claimed_assurance"] = "VERIFIED"

--- a/benchmarks/validation/conjecture_probes_v1/test_hadwiger_triangle_free_minor_certificate.py
+++ b/benchmarks/validation/conjecture_probes_v1/test_hadwiger_triangle_free_minor_certificate.py
@@ -45,6 +45,36 @@ def run(app, logs):
     return run_verifier_in_child(task=TASK, app=app, logs=logs)
 
 
+def _write_evidence(app, s, result):
+    payload = {
+        "schema_version": "1",
+        "task_id": s["task_id"],
+        "result": result,
+        "limitations": s["limitations"],
+    }
+    e = app / "evidence/answer.txt"
+    e.write_text(json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n")
+    s["evidence"][0]["sha256"] = "sha256:" + hashlib.sha256(e.read_bytes()).hexdigest()
+    (app / "submission.json").write_text(json.dumps(s) + "\n")
+
+
+def test_evidence_result_requires_exact_json_types(tmp_path):
+    app, logs, s = case(tmp_path)
+    # JSON booleans in place of integers must not compare equal to 0/1.
+    coloring = list(s["result"]["four_coloring"])
+    coloring[0] = True
+    _write_evidence(app, s, {**s["result"], "four_coloring": coloring})
+    r = run(app, logs)
+    assert r["mathematics"] == 1.0 and r["evidence"] == 0.0
+    assert r["aggregate_reward"] == 0.0
+    # An integral float must not compare equal to the integer invariant.
+    app, logs, s = case(tmp_path / "float")
+    _write_evidence(app, s, {**s["result"], "chromatic_number": 4.0})
+    r = run(app, logs)
+    assert r["mathematics"] == 1.0 and r["evidence"] == 0.0
+    assert r["aggregate_reward"] == 0.0
+
+
 def test_oracle_and_relabeling_pass(tmp_path):
     app, logs, _ = case(tmp_path)
     assert run(app, logs)["aggregate_reward"] == 1.0


### PR DESCRIPTION
Follow-up to merged PR #599. The original merge landed before these four review comments were addressed on the branch; this PR brings those fixes to main:

- **3735082210 (P1)** publish the evidence payload schema: `instruction.md` now declares that `schema_version` must be the string `"1"`, `task_id` must equal the task id, and `result` must exactly copy the submitted `result` object including JSON types.
- **3735082215 (P1)** type-faithful evidence comparison: the verifier compares the evidence `result` with `_json_equal` (exact JSON types) instead of Python `==`, which treated `False==0`, `True==1`, `4.0==4`.
- **3735590129 (P2)** guard assurance types: `claimed_assurance` is type-checked with `isinstance(value, str)` before frozenset membership so a schema-invalid list/object cannot raise TypeError and zero every diagnostic.
- **3735590133 (P2)** non-finite JSON rejection: `_raw_submission` uses the same `parse_constant` rejection and finite-float parsing as the authoritative loader.

Regression tests added for all four (7 leaf tests pass); full harbor gate (static, contracts, host leaf, oracle) passes locally.