### PR TITLE
fix(mcp): report nested required constraints, keep capability selection agent-owned

### DIFF
--- a/.agents/skills/jacobian-math/SKILL.md
+++ b/.agents/skills/jacobian-math/SKILL.md
@@ -19,9 +19,8 @@ text(r.structuredContent ?? r);
 ```
 
 Use Jacobian for each requested exact mathematical outcome, even when small or
-shell-solvable. Route multiple requested outcomes separately. Prefer a
-capability matching the requested operation over a generic arithmetic substep
-that yields the same scalar; composing already-known supporting operations remains allowed when clearer.
+shell-solvable. Keep decomposition and routing decisions agent-owned;
+composing already-known supporting operations remains allowed when clearer.
 Do not call Jacobian for definitions, formatting, or non-execution tasks.
 
 Call `math.run` directly when the requested local outcome exactly matches these

--- a/npm/skills/jacobian-math/SKILL.md
+++ b/npm/skills/jacobian-math/SKILL.md
@@ -19,9 +19,8 @@ text(r.structuredContent ?? r);
 ```
 
 Use Jacobian for each requested exact mathematical outcome, even when small or
-shell-solvable. Route multiple requested outcomes separately. Prefer a
-capability matching the requested operation over a generic arithmetic substep
-that yields the same scalar; composing already-known supporting operations remains allowed when clearer.
+shell-solvable. Keep decomposition and routing decisions agent-owned;
+composing already-known supporting operations remains allowed when clearer.
 Do not call Jacobian for definitions, formatting, or non-execution tasks.
 
 Call `math.run` directly when the requested local outcome exactly matches these

--- a/src/jacobian/capability_validation.py
+++ b/src/jacobian/capability_validation.py
@@ -124,6 +124,7 @@ def schema_violation_details(error: JsonSchemaValidationError) -> dict[str, obje
 
     details: dict[str, object] = {"validator": str(error.validator)}
     if error.validator in {
+        "additionalProperties",
         "minimum",
         "exclusiveMinimum",
         "maximum",
@@ -134,6 +135,7 @@ def schema_violation_details(error: JsonSchemaValidationError) -> dict[str, obje
         "maxItems",
         "multipleOf",
         "pattern",
+        "required",
         "enum",
         "const",
         "type",

--- a/tests/unit/contracts/test_capability_validation_diagnostics.py
+++ b/tests/unit/contracts/test_capability_validation_diagnostics.py
@@ -107,3 +107,71 @@ def test_payload_validation_bounds_serialized_diagnostic_size() -> None:
     # failed_result serializes this diagnostic in both output.error and
     # diagnostics, so a bounded dump keeps the whole response bounded.
     assert len(diagnostic.model_dump_json()) <= 4096
+
+
+def test_payload_validation_reports_missing_nested_required_member() -> None:
+    """A nested object omitting a required member must name the missing key."""
+
+    with pytest.raises(PayloadValidationError) as error:
+        validate_payload(
+            {
+                "type": "object",
+                "properties": {
+                    "outer": {
+                        "type": "object",
+                        "properties": {"inner": {"type": "integer"}},
+                        "required": ["inner"],
+                    }
+                },
+                "required": ["outer"],
+                "additionalProperties": False,
+            },
+            {"outer": {}},
+        )
+
+    assert error.value.path == "outer"
+    assert error.value.details == {
+        "validator": "required",
+        "constraint": ["inner"],
+    }
+
+
+def test_payload_validation_reports_additional_properties_constraint() -> None:
+    """An unexpected key must surface the additionalProperties constraint."""
+
+    with pytest.raises(PayloadValidationError) as error:
+        validate_payload(
+            {
+                "type": "object",
+                "properties": {"known": {"type": "integer"}},
+                "required": ["known"],
+                "additionalProperties": False,
+            },
+            {"known": 1, "extra": "x"},
+        )
+
+    assert error.value.details == {
+        "validator": "additionalProperties",
+        "constraint": False,
+    }
+
+
+def test_payload_validation_bounds_large_required_constraint() -> None:
+    """A large required list must be summarized, not copied unbounded."""
+
+    required_keys = [f"key{i}" for i in range(2000)]
+    with pytest.raises(PayloadValidationError) as error:
+        validate_payload(
+            {
+                "type": "object",
+                "properties": {"key0": {"type": "integer"}},
+                "required": required_keys,
+            },
+            {"key0": 1},
+        )
+
+    assert error.value.details["validator"] == "required"
+    constraint = error.value.details["constraint"]
+    assert isinstance(constraint, str)
+    assert len(constraint) <= 1024
+    assert constraint.endswith("...")

--- a/tests/unit/tooling/test_codex_visibility.py
+++ b/tests/unit/tooling/test_codex_visibility.py
@@ -193,8 +193,7 @@ def test_codex_skill_routes_exact_outcomes_without_catalog_projection() -> None:
     assert "never reconstruct or paraphrase such a record" in skill_flat
     assert "required task authorization and bindings are preserved" in skill_flat
     for guidance in (
-        "requested outcomes separately.",
-        "over a generic arithmetic substep",
+        "Keep decomposition and routing decisions agent-owned",
         "composing already-known supporting operations remains allowed",
         "follow those fields",
         "retry within the task resource bounds",

--- a/tools/c901-baseline.json
+++ b/tools/c901-baseline.json
@@ -3,6 +3,11 @@
   "max_complexity": 10,
   "violations": [
     {
+      "path": "benchmarks/datasets/conjecture-probes-v1/reconstruction-deck-certificate/tests/verifier_support.py",
+      "symbol": "_read_streaming_json_value",
+      "complexity": 11
+    },
+    {
       "path": "benchmarks/datasets/conjecture-probes-v1/vizing-bounded-cartesian-products/tests/verifier.py",
       "symbol": "_frozen",
       "complexity": 11


### PR DESCRIPTION
Follow-up to merged PR #602. Addresses comments 3735680535 (nested required/additionalProperties constraints now included in bounded diagnostic details) and 3735641044 (skill no longer prescribes routing/decomposition policy).