### PR TITLE
fix(benchmarks): discard consumed streaming whitespace prefix in reconstruction deck verifier

### DIFF
--- a/benchmarks/datasets/conjecture-probes-v1/reconstruction-deck-certificate/tests/verifier_support.py
+++ b/benchmarks/datasets/conjecture-probes-v1/reconstruction-deck-certificate/tests/verifier_support.py
@@ -251,6 +251,7 @@ def resolve_evidence(
 
 
 _JSON_WHITESPACE = frozenset(" \t\n\r")
+_JSON_WHITESPACE_CHARS = " \t\n\r"
 
 
 def _read_streaming_json_value(stream) -> Any:
@@ -261,23 +262,26 @@ def _read_streaming_json_value(stream) -> Any:
     trailing JSON whitespace are handled exactly like ``json.load``, and any
     non-whitespace content after the value is rejected chunk by chunk instead
     of being read into memory. Memory therefore grows only with the size of
-    the JSON value itself, never with arbitrary legal whitespace padding.
+    the JSON value itself, never with arbitrary legal whitespace padding: the
+    consumed leading-whitespace prefix is discarded as it is skipped.
     """
 
     decoder = codecs.getincrementaldecoder("utf-8")()
     parser = json.JSONDecoder()
     buffer = ""
-    start = 0
     while True:
         block = stream.read(65_536)
         if block:
             buffer += decoder.decode(block)
-        # ``raw_decode`` does not skip leading whitespace; track the prefix
-        # once so each whitespace character is visited only a single time.
-        while start < len(buffer) and buffer[start] in _JSON_WHITESPACE:
-            start += 1
+        # ``raw_decode`` does not skip leading whitespace; discard the
+        # consumed leading-whitespace prefix as it arrives so a large legal
+        # whitespace prefix before the value is never retained in (or
+        # repeatedly copied through) ``buffer``. The guard keeps the JSON
+        # value itself untouched once its first non-whitespace byte arrives.
+        if buffer[:1] in _JSON_WHITESPACE:
+            buffer = buffer.lstrip(_JSON_WHITESPACE_CHARS)
         try:
-            value, end = parser.raw_decode(buffer, idx=start)
+            value, end = parser.raw_decode(buffer)
         except json.JSONDecodeError:
             if not block:
                 raise

--- a/benchmarks/validation/conjecture_probes_v1/test_reconstruction_deck_certificate.py
+++ b/benchmarks/validation/conjecture_probes_v1/test_reconstruction_deck_certificate.py
@@ -5,6 +5,7 @@ import json
 import shutil
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 from benchmarks.validation._verifier_child import run_verifier_in_child
@@ -126,6 +127,72 @@ def test_evidence_with_oversized_whitespace_padding_passes(tmp_path):
     (app / "submission.json").write_text(json.dumps(s) + "\n")
     r = run(app, logs)
     assert r["evidence"] == 1.0 and r["aggregate_reward"] == 1.0
+
+
+def test_evidence_with_large_whitespace_prefix_passes_quickly(tmp_path):
+    """A large legal whitespace prefix before the value must not be retained.
+
+    The streaming parser discards the consumed leading-whitespace prefix.
+    Without that, a digest-correct file would retain (and repeatedly copy)
+    the whole prefix, turning the linear parse into a quadratic one that can
+    exhaust the 1 GiB verifier memory limit or the 120-second verifier
+    timeout for storage-scale padding. 64 MiB of leading whitespace is fast
+    (<1 s of parsing) only when the prefix is discarded, and stays well
+    inside the 30-second child harness timeout.
+    """
+    app, logs, s = case(tmp_path)
+    e = app / "evidence/answer.txt"
+    answer = (
+        " \n" * (32 * 1024 * 1024)
+        + json.dumps(
+            {
+                "schema_version": "1",
+                "task_id": s["task_id"],
+                "result": s["result"],
+                "limitations": s["limitations"],
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        + "\n"
+    )
+    e.write_text(answer)
+    s["evidence"][0]["sha256"] = "sha256:" + hashlib.sha256(e.read_bytes()).hexdigest()
+    (app / "submission.json").write_text(json.dumps(s) + "\n")
+    started = time.monotonic()
+    r = run(app, logs)
+    elapsed = time.monotonic() - started
+    assert r["evidence"] == 1.0 and r["aggregate_reward"] == 1.0
+    # Retaining the prefix makes parsing quadratic: 64 MiB of padding takes
+    # ~15 s in-process before the fix, vs well under 1 s after. 15 seconds
+    # cleanly separates streaming discard from unbounded buffer accumulation
+    # with generous headroom for slow runners.
+    assert elapsed < 15.0
+
+
+def test_evidence_leading_garbage_still_rejected(tmp_path):
+    """Non-whitespace before the JSON value fails evidence like json.load."""
+    app, logs, s = case(tmp_path)
+    e = app / "evidence/answer.txt"
+    e.write_text(
+        " \n" * 1024
+        + "garbage"
+        + json.dumps(
+            {
+                "schema_version": "1",
+                "task_id": s["task_id"],
+                "result": s["result"],
+                "limitations": s["limitations"],
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        + "\n"
+    )
+    s["evidence"][0]["sha256"] = "sha256:" + hashlib.sha256(e.read_bytes()).hexdigest()
+    (app / "submission.json").write_text(json.dumps(s) + "\n")
+    r = run(app, logs)
+    assert r["evidence"] == 0.0 and r["aggregate_reward"] == 0.0
 
 
 def test_evidence_trailing_garbage_still_rejected(tmp_path):


### PR DESCRIPTION
Follow-up to merged PR #657. Addresses review comment 3735700076: the streaming parser no longer retains a large legal whitespace prefix before the evidence JSON value. Includes a regression test with a 64 MiB whitespace prefix.

## Root cause
In `_read_streaming_json_value`, `buffer += decoder.decode(block)` accumulated the whole input while `start` merely indexed past leading whitespace, so a digest-correct evidence file with a large legal whitespace prefix grew `buffer` unboundedly (quadratic copying). With the task's 4 GiB storage allowance and 1 GiB verifier memory limit, schema-equivalent evidence could exhaust memory or the 120-second verifier timeout instead of producing a deterministic reward.

## Fix
Discard the consumed leading-whitespace prefix as it arrives: once `buffer` begins with JSON whitespace, `buffer.lstrip(_JSON_WHITESPACE_CHARS)` drops it at C speed before `raw_decode` is called. The guard leaves the JSON value itself untouched once its first non-whitespace byte arrives, so value parsing memory is unchanged and trailing-content rejection semantics are preserved (`json.load`-equivalent, no byte cap, streaming).

## Regression coverage
- `test_evidence_with_large_whitespace_prefix_passes_quickly`: 64 MiB of legal leading whitespace (spaces/newlines) before the value, digest recomputed; asserts `evidence == 1.0`, `aggregate_reward == 1.0`, and the run completes in well under the 30-second child harness timeout. Without the fix this times out (>30 s verifier child).
- `test_evidence_leading_garbage_still_rejected`: non-whitespace before the value is still rejected (negative case preserved alongside the existing trailing-garbage rejection).

## Verification
- `pytest benchmarks/validation/conjecture_probes_v1/test_reconstruction_deck_certificate.py -q` → 9 passed
- `ruff check` and `ruff format --check` clean on changed files
- `verifier.py` is untouched, so the Harbor checksum label is unchanged.