### PR TITLE
fix(benchmarks): publish bound input for provider Oracle verifiers

### DIFF
--- a/benchmarks/datasets/provider-feasibility-v1/cddlib/environment/input.json
+++ b/benchmarks/datasets/provider-feasibility-v1/cddlib/environment/input.json
@@ -2,5 +2,5 @@
   "task_id": "jacobian/cddlib",
   "provider": "cddlib/pycddlib",
   "contract": "jacobian.cddlib-hv-spike/v1",
-  "pin_sha256": "sha256:0ee86d1ba1b82fd022f4396d0e23bc46fb3e96409dd8e8435cbc6c721297d382"
+  "pin_sha256": "sha256:15b0b5b4d608bc2f354dd484c44aa3da7441d615ab9650d6f7611c7e97af7871"
 }

--- a/benchmarks/datasets/provider-feasibility-v1/cddlib/environment/pin.json
+++ b/benchmarks/datasets/provider-feasibility-v1/cddlib/environment/pin.json
@@ -1,5 +1,5 @@
 {
-  "adapter_source_sha256": "sha256:860b037e097e38b4e0f44601c08eec1a153e6686625c08e844eb161ccaec3d85",
+  "adapter_source_sha256": "sha256:8a6f0c90929f3cf9582208844d4d9ce10258bc5721dbe8581171dbc180eb05cd",
   "contract": "jacobian.cddlib-hv-spike/v1",
   "provider": "cddlib/pycddlib",
   "reproduction": {

--- a/benchmarks/datasets/provider-feasibility-v1/cddlib/environment/spike.py
+++ b/benchmarks/datasets/provider-feasibility-v1/cddlib/environment/spike.py
@@ -22,7 +22,14 @@ from benchmarks.tooling.command_runner import (
 
 PIN_PATH = Path(__file__).with_name("pin.json")
 ADAPTER_SOURCE = Path(__file__)
-_ENVIRONMENT = {"LANG": "C", "LC_ALL": "C", "TZ": "UTC"}
+# Worker re-exec replaces the process environment; keep the image PYTHONPATH so
+# `benchmarks.tooling.command_runner` remains importable inside --worker mode.
+_ENVIRONMENT = {
+    "LANG": "C",
+    "LC_ALL": "C",
+    "TZ": "UTC",
+    "PYTHONPATH": "/opt",
+}
 _KIND_ORDER = {
     "EQUALITY": 0,
     "INEQUALITY": 1,

--- a/benchmarks/datasets/provider-feasibility-v1/cddlib/environment/submission_schema.json
+++ b/benchmarks/datasets/provider-feasibility-v1/cddlib/environment/submission_schema.json
@@ -14,7 +14,7 @@
         "provider": {"const": "cddlib/pycddlib"},
         "contract": {"const": "jacobian.cddlib-hv-spike/v1"},
         "status": {"enum": ["COMPLETED", "TIMEOUT", "CANCELLED", "ERROR", "REJECTED"]},
-        "pin_sha256": {"const": "sha256:0ee86d1ba1b82fd022f4396d0e23bc46fb3e96409dd8e8435cbc6c721297d382"}
+        "pin_sha256": {"const": "sha256:15b0b5b4d608bc2f354dd484c44aa3da7441d615ab9650d6f7611c7e97af7871"}
       }
     },
     "claimed_assurance": {"enum": ["UNVERIFIED","COMPUTED"]},

--- a/benchmarks/datasets/provider-feasibility-v1/cddlib/solution/solve.py
+++ b/benchmarks/datasets/provider-feasibility-v1/cddlib/solution/solve.py
@@ -9,7 +9,7 @@ REPORT = APP / "evidence" / "provider-report.json"
 TASK_ID = "jacobian/cddlib"
 PROVIDER = "cddlib/pycddlib"
 CONTRACT = "jacobian.cddlib-hv-spike/v1"
-PIN = "sha256:0ee86d1ba1b82fd022f4396d0e23bc46fb3e96409dd8e8435cbc6c721297d382"
+PIN = "sha256:15b0b5b4d608bc2f354dd484c44aa3da7441d615ab9650d6f7611c7e97af7871"
 
 report = json.loads(REPORT.read_text())
 status = report.get("status", "ERROR")

--- a/benchmarks/datasets/provider-feasibility-v1/cddlib/task.toml
+++ b/benchmarks/datasets/provider-feasibility-v1/cddlib/task.toml
@@ -1,5 +1,5 @@
 schema_version = "1.4"
-artifacts = ["/app/submission.json", "/app/evidence"]
+artifacts = ["/app/input.json", "/app/submission.json", "/app/evidence"]
 
 [task]
 name = "jacobian/cddlib"
@@ -19,7 +19,7 @@ field = "provider-integration"
 assurance_ceiling = "COMPUTED"
 answer_visibility = "public"
 provenance_class = "pinned-provider-spike"
-fixture_digest = "sha256:5318109cac828a3616dc770b3a37ca079022f2e49e1c8f610b9ba11d44f3866b"
+fixture_digest = "sha256:cae830638539783f53d716e6b381c833acd4d29b6504a3c35e9bdb5d4a99a00d"
 required_provider = "cddlib"
 
 [agent]

--- a/benchmarks/datasets/provider-feasibility-v1/cddlib/tests/expected.json
+++ b/benchmarks/datasets/provider-feasibility-v1/cddlib/tests/expected.json
@@ -2,7 +2,7 @@
   "task_id": "jacobian/cddlib",
   "provider": "cddlib/pycddlib",
   "contract": "jacobian.cddlib-hv-spike/v1",
-  "pin_sha256": "sha256:0ee86d1ba1b82fd022f4396d0e23bc46fb3e96409dd8e8435cbc6c721297d382",
+  "pin_sha256": "sha256:15b0b5b4d608bc2f354dd484c44aa3da7441d615ab9650d6f7611c7e97af7871",
   "report_conclusion": "SPIKE_PASSED_PRODUCTION_DEFERRED",
   "report_assurance": "OBSERVED_EXACT_PROVIDER_BEHAVIOR_WITH_SOUNDNESS_REPLAY"
 }

--- a/benchmarks/datasets/provider-feasibility-v1/cddlib/tests/input.json
+++ b/benchmarks/datasets/provider-feasibility-v1/cddlib/tests/input.json
@@ -2,5 +2,5 @@
   "task_id": "jacobian/cddlib",
   "provider": "cddlib/pycddlib",
   "contract": "jacobian.cddlib-hv-spike/v1",
-  "pin_sha256": "sha256:0ee86d1ba1b82fd022f4396d0e23bc46fb3e96409dd8e8435cbc6c721297d382"
+  "pin_sha256": "sha256:15b0b5b4d608bc2f354dd484c44aa3da7441d615ab9650d6f7611c7e97af7871"
 }

--- a/benchmarks/datasets/provider-feasibility-v1/cddlib/tests/public_contract.json
+++ b/benchmarks/datasets/provider-feasibility-v1/cddlib/tests/public_contract.json
@@ -57,7 +57,7 @@
             "const": "jacobian.cddlib-hv-spike/v1"
           },
           "pin_sha256": {
-            "const": "sha256:0ee86d1ba1b82fd022f4396d0e23bc46fb3e96409dd8e8435cbc6c721297d382"
+            "const": "sha256:15b0b5b4d608bc2f354dd484c44aa3da7441d615ab9650d6f7611c7e97af7871"
           },
           "provider": {
             "const": "cddlib/pycddlib"

--- a/benchmarks/datasets/provider-feasibility-v1/cgal/task.toml
+++ b/benchmarks/datasets/provider-feasibility-v1/cgal/task.toml
@@ -1,5 +1,5 @@
 schema_version = "1.4"
-artifacts = ["/app/submission.json", "/app/evidence"]
+artifacts = ["/app/input.json", "/app/submission.json", "/app/evidence"]
 
 [task]
 name = "jacobian/cgal"

--- a/benchmarks/datasets/provider-feasibility-v1/cgal/tests/Dockerfile
+++ b/benchmarks/datasets/provider-feasibility-v1/cgal/tests/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
-LABEL jacobian.checksum="b00795964e81bd8cbe49ec3e2a03da70a3c623991816c253aea18f81bdc911cd"
+LABEL jacobian.checksum="f08e09b4a258905124fa1c0869360a5d109d1f36ab83119c09e49f36f96a184f"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 RUN chmod +x /tests/test.sh

--- a/benchmarks/datasets/provider-feasibility-v1/cgal/tests/Dockerfile
+++ b/benchmarks/datasets/provider-feasibility-v1/cgal/tests/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
-LABEL jacobian.checksum="f08e09b4a258905124fa1c0869360a5d109d1f36ab83119c09e49f36f96a184f"
+LABEL jacobian.checksum="a7967326c7d097b0e603cf944e31cfc3ffbea183593383d386be6396835247d7"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 RUN chmod +x /tests/test.sh

--- a/benchmarks/datasets/provider-feasibility-v1/cgal/tests/expected.json
+++ b/benchmarks/datasets/provider-feasibility-v1/cgal/tests/expected.json
@@ -1,8 +1,24 @@
 {
-  "task_id": "jacobian/cgal",
-  "provider": "cgal",
   "contract": "jacobian.cgal-delaunay-spike/v1",
   "pin_sha256": "sha256:c60409201b0e97ec2814f810da92283f64b4d4342d7eac27a342e70469fc22f5",
+  "provider": "cgal",
+  "report_assurance": "OBSERVED_PROVIDER_BEHAVIOR",
   "report_conclusion": "SPIKE_PASSED_PRODUCTION_DEFERRED",
-  "report_assurance": "OBSERVED_PROVIDER_BEHAVIOR"
+  "reproductions": {
+    "cocircular": {
+      "command": [
+        "--cocircular"
+      ],
+      "expected_output": "contract jacobian.cgal-delaunay-spike/v1\ncgal_version 6.2\nkernel Exact_predicates_exact_constructions_kernel\nsemantics REQUIRE_UNIQUE\napplicable false\nreason COCIRCULAR\n",
+      "expected_output_sha256": "sha256:4260fdbc095751f5a880778590d0b0d5217f1042a61e14eb212320c390213372"
+    },
+    "unique": {
+      "command": [
+        "--unique"
+      ],
+      "expected_output": "contract jacobian.cgal-delaunay-spike/v1\ncgal_version 6.2\nkernel Exact_predicates_exact_constructions_kernel\nsemantics REQUIRE_UNIQUE\napplicable true\nvalid true\nsite_count 6\ntriangle 0 1 5\ntriangle 0 5 4\ntriangle 1 2 5\ntriangle 2 3 5\ntriangle 3 4 5\nedge 0 1\nedge 0 4\nedge 0 5\nedge 1 2\nedge 1 5\nedge 2 3\nedge 2 5\nedge 3 4\nedge 3 5\nedge 4 5\nhull_edge 0 1\nhull_edge 0 4\nhull_edge 1 2\nhull_edge 2 3\nhull_edge 3 4\n",
+      "expected_output_sha256": "sha256:a1cecc8c3781dfd8626e62da3d2ff4a4f974b31a3cb19c4baa23db0d11741ce9"
+    }
+  },
+  "task_id": "jacobian/cgal"
 }

--- a/benchmarks/datasets/provider-feasibility-v1/cgal/tests/verifier.py
+++ b/benchmarks/datasets/provider-feasibility-v1/cgal/tests/verifier.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 
@@ -20,16 +21,30 @@ def _digest_ok(value: object) -> bool:
     return isinstance(value, str) and value.startswith("sha256:") and len(value) == 71
 
 
-def _case_bound(case: object) -> bool:
-    if not isinstance(case, dict):
+def _sha256_text(value: str) -> str:
+    return "sha256:" + hashlib.sha256(value.encode("ascii")).hexdigest()
+
+
+def _case_bound(name: str, case: object) -> bool:
+    frozen = expected["reproductions"].get(name)
+    if not isinstance(frozen, dict) or not isinstance(case, dict):
         return False
-    if not isinstance(case.get("command"), list) or not case.get("command"):
+    if case.get("command") != frozen["command"]:
         return False
-    if not isinstance(case.get("expected_output"), str):
+    expected_output = case.get("expected_output")
+    if expected_output != frozen["expected_output"]:
         return False
-    return _digest_ok(case.get("expected_output_sha256")) and _digest_ok(
-        case.get("observed_output_sha256")
-    )
+    if not isinstance(expected_output, str):
+        return False
+    expected_digest = case.get("expected_output_sha256")
+    observed_digest = case.get("observed_output_sha256")
+    if expected_digest != frozen["expected_output_sha256"]:
+        return False
+    if not _digest_ok(expected_digest) or not _digest_ok(observed_digest):
+        return False
+    if _sha256_text(expected_output) != expected_digest:
+        return False
+    return observed_digest == expected_digest
 
 
 def _execution_bound(report: object) -> bool:
@@ -57,9 +72,9 @@ def _execution_bound(report: object) -> bool:
         return False
     if set(reproductions) != {"unique", "cocircular"}:
         return False
-    if not _case_bound(reproductions.get("unique")):
+    if not _case_bound("unique", reproductions.get("unique")):
         return False
-    if not _case_bound(reproductions.get("cocircular")):
+    if not _case_bound("cocircular", reproductions.get("cocircular")):
         return False
     limitations = report.get("limitations")
     if not isinstance(limitations, list) or not limitations:

--- a/benchmarks/datasets/provider-feasibility-v1/cgal/tests/verifier.py
+++ b/benchmarks/datasets/provider-feasibility-v1/cgal/tests/verifier.py
@@ -16,6 +16,22 @@ if isinstance(submission, dict) and isinstance(submission.get("evidence"), list)
 result = submission.get("result") if isinstance(submission, dict) else None
 
 
+def _digest_ok(value: object) -> bool:
+    return isinstance(value, str) and value.startswith("sha256:") and len(value) == 71
+
+
+def _case_bound(case: object) -> bool:
+    if not isinstance(case, dict):
+        return False
+    if not isinstance(case.get("command"), list) or not case.get("command"):
+        return False
+    if not isinstance(case.get("expected_output"), str):
+        return False
+    return _digest_ok(case.get("expected_output_sha256")) and _digest_ok(
+        case.get("observed_output_sha256")
+    )
+
+
 def _execution_bound(report: object) -> bool:
     """Reject reports that only restate public spike success literals."""
 
@@ -30,21 +46,20 @@ def _execution_bound(report: object) -> bool:
     if report.get("assurance") != expected["report_assurance"]:
         return False
     provider = report.get("provider")
-    reproduction = report.get("reproduction")
-    if not isinstance(provider, dict) or not isinstance(reproduction, dict):
+    reproductions = report.get("reproductions")
+    if not isinstance(provider, dict) or not isinstance(reproductions, dict):
         return False
-    runtime = provider.get("runtime")
-    if not isinstance(runtime, dict) or not runtime:
-        return False
-    cases = reproduction.get("cases")
-    if not isinstance(cases, list) or not cases:
-        return False
-    output_digest = reproduction.get("provider_output_sha256")
-    if not (
-        isinstance(output_digest, str)
-        and output_digest.startswith("sha256:")
-        and len(output_digest) == 71
+    if not isinstance(provider.get("executable"), str) or not provider.get(
+        "executable"
     ):
+        return False
+    if not _digest_ok(provider.get("executable_sha256")):
+        return False
+    if set(reproductions) != {"unique", "cocircular"}:
+        return False
+    if not _case_bound(reproductions.get("unique")):
+        return False
+    if not _case_bound(reproductions.get("cocircular")):
         return False
     limitations = report.get("limitations")
     if not isinstance(limitations, list) or not limitations:

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/environment/Dockerfile
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/environment/Dockerfile
@@ -1,11 +1,11 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /opt/provider && \
-    curl -fsSL https://files.pythonhosted.org/packages/02/fb/fad8db68c325617708b8033f196c09633fea0962c0878ccc73571ce889b2/gudhi-3.13.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl -o /opt/provider/gudhi.whl && \
+    curl -fsSL https://files.pythonhosted.org/packages/02/fb/fad8db68c325617708b8033f196c09633fea0962c0878ccc73571ce889b2/gudhi-3.13.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl -o /opt/provider/gudhi-3.13.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl && \
     curl -fsSL https://github.com/GUDHI/gudhi-devel/archive/refs/tags/tags/gudhi-release-3.13.0.tar.gz -o /opt/provider/gudhi-source.tar.gz && \
-    printf '%s  %s\n' d7ce52905d147a7e599607758843c7f37525c98e7aeaca87cbbbcbd3adb71598 /opt/provider/gudhi.whl | sha256sum -c - && \
+    printf '%s  %s\n' d7ce52905d147a7e599607758843c7f37525c98e7aeaca87cbbbcbd3adb71598 /opt/provider/gudhi-3.13.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl | sha256sum -c - && \
     printf '%s  %s\n' 7640d716d6a118b7787602826e4144bfa1ad5903a31f4a760a7f3a1e68cfdc02 /opt/provider/gudhi-source.tar.gz | sha256sum -c - && \
-    uv pip install --system /opt/provider/gudhi.whl numpy==2.5.1
+    uv pip install --system /opt/provider/gudhi-3.13.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl numpy==2.5.1
 WORKDIR /app
 COPY __init__.py /opt/benchmarks/__init__.py
 COPY tooling/__init__.py /opt/benchmarks/tooling/__init__.py

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/environment/input.json
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/environment/input.json
@@ -2,5 +2,5 @@
   "task_id": "jacobian/gudhi",
   "provider": "gudhi",
   "contract": "jacobian.gudhi-persistence-spike/v1",
-  "pin_sha256": "sha256:fa137d5d1f5ecf74352ecdae2b4fb1b8d6c3433e6e26707c32d898319e1cdc84"
+  "pin_sha256": "sha256:1463f2cc07f189d7e12daa010b2bebd838756a7ec90a791901a62bdec9bcd552"
 }

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/environment/pin.json
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/environment/pin.json
@@ -1,5 +1,5 @@
 {
-  "adapter_source_sha256": "sha256:529de59f14407df8515b3b698269dad4030e9aaca8812b1f328378ab6cfdfeee",
+  "adapter_source_sha256": "sha256:9faf64ddf467696fc15a1f6e7dbf9d19ad89070656046a4b95a7f69ee932159e",
   "contract": "jacobian.gudhi-persistence-spike/v1",
   "documentation_url": "https://gudhi.inria.fr/python/3.13.0/simplex_tree_ref.html",
   "licensing_url": "https://gudhi.inria.fr/licensing/",

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/environment/spike.py
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/environment/spike.py
@@ -32,7 +32,14 @@ _SOURCE_MEMBERS = {
         "Persistent_cohomology.h"
     ),
 }
-_ENVIRONMENT = {"LANG": "C", "LC_ALL": "C", "TZ": "UTC"}
+# Worker re-exec replaces the process environment; keep the image PYTHONPATH so
+# `benchmarks.tooling.command_runner` remains importable inside --worker mode.
+_ENVIRONMENT = {
+    "LANG": "C",
+    "LC_ALL": "C",
+    "TZ": "UTC",
+    "PYTHONPATH": "/opt",
+}
 ProcessRunner = Callable[..., ToolCommandResult]
 _WORKER_ERROR_PREFIX = b"JACOBIAN_SPIKE_ERROR "
 

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/environment/submission_schema.json
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/environment/submission_schema.json
@@ -14,7 +14,7 @@
         "provider": {"const": "gudhi"},
         "contract": {"const": "jacobian.gudhi-persistence-spike/v1"},
         "status": {"enum": ["COMPLETED", "TIMEOUT", "CANCELLED", "ERROR", "REJECTED"]},
-        "pin_sha256": {"const": "sha256:fa137d5d1f5ecf74352ecdae2b4fb1b8d6c3433e6e26707c32d898319e1cdc84"}
+        "pin_sha256": {"const": "sha256:1463f2cc07f189d7e12daa010b2bebd838756a7ec90a791901a62bdec9bcd552"}
       }
     },
     "claimed_assurance": {"enum": ["UNVERIFIED","COMPUTED"]},

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/solution/solve.py
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/solution/solve.py
@@ -9,7 +9,7 @@ REPORT = APP / "evidence" / "provider-report.json"
 TASK_ID = "jacobian/gudhi"
 PROVIDER = "gudhi"
 CONTRACT = "jacobian.gudhi-persistence-spike/v1"
-PIN = "sha256:fa137d5d1f5ecf74352ecdae2b4fb1b8d6c3433e6e26707c32d898319e1cdc84"
+PIN = "sha256:1463f2cc07f189d7e12daa010b2bebd838756a7ec90a791901a62bdec9bcd552"
 
 report = json.loads(REPORT.read_text())
 status = report.get("status", "ERROR")

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/solution/solve.sh
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/solution/solve.sh
@@ -3,7 +3,7 @@ set -eu
 mkdir -p /app/evidence
 python /app/spike.py \
   --python-executable /usr/local/bin/python \
-  --wheel /opt/provider/gudhi.whl \
+  --wheel /opt/provider/gudhi-3.13.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl \
   --source-archive /opt/provider/gudhi-source.tar.gz \
   --pin /app/pin.json \
   --output /app/evidence/provider-report.json

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/task.toml
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/task.toml
@@ -1,5 +1,5 @@
 schema_version = "1.4"
-artifacts = ["/app/submission.json", "/app/evidence"]
+artifacts = ["/app/input.json", "/app/submission.json", "/app/evidence"]
 
 [task]
 name = "jacobian/gudhi"
@@ -19,7 +19,7 @@ field = "provider-integration"
 assurance_ceiling = "COMPUTED"
 answer_visibility = "public"
 provenance_class = "pinned-provider-spike"
-fixture_digest = "sha256:d5c4eb2ebe0dcfb5512ee2ffe1f8d4186883158a36aadb9e115b55273400bc8b"
+fixture_digest = "sha256:98ef068d9ef62688c4a32da586515a76f132b8c938516adcfed074c7fbc10c2b"
 required_provider = "gudhi"
 
 [agent]

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/Dockerfile
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
-LABEL jacobian.checksum="f904a9a66f4d86f079a44567bab5375186c1ea4e2f815b1e1a65f35b6b1c60ed"
+LABEL jacobian.checksum="71914b032b097712cfe80745ad6efab90fe34aee9e210d6d92945b495911ed92"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 RUN chmod +x /tests/test.sh

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/Dockerfile
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
-LABEL jacobian.checksum="b00795964e81bd8cbe49ec3e2a03da70a3c623991816c253aea18f81bdc911cd"
+LABEL jacobian.checksum="f904a9a66f4d86f079a44567bab5375186c1ea4e2f815b1e1a65f35b6b1c60ed"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 RUN chmod +x /tests/test.sh

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/expected.json
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/expected.json
@@ -2,7 +2,7 @@
   "task_id": "jacobian/gudhi",
   "provider": "gudhi",
   "contract": "jacobian.gudhi-persistence-spike/v1",
-  "pin_sha256": "sha256:fa137d5d1f5ecf74352ecdae2b4fb1b8d6c3433e6e26707c32d898319e1cdc84",
+  "pin_sha256": "sha256:1463f2cc07f189d7e12daa010b2bebd838756a7ec90a791901a62bdec9bcd552",
   "report_conclusion": "SPIKE_PASSED_PRODUCTION_DEFERRED",
   "report_assurance": "OBSERVED_PROVIDER_BEHAVIOR_WITH_INDEPENDENT_REPLAY"
 }

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/expected.json
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/expected.json
@@ -1,8 +1,250 @@
 {
-  "task_id": "jacobian/gudhi",
-  "provider": "gudhi",
   "contract": "jacobian.gudhi-persistence-spike/v1",
   "pin_sha256": "sha256:1463f2cc07f189d7e12daa010b2bebd838756a7ec90a791901a62bdec9bcd552",
+  "provider": "gudhi",
+  "report_assurance": "OBSERVED_PROVIDER_BEHAVIOR_WITH_INDEPENDENT_REPLAY",
   "report_conclusion": "SPIKE_PASSED_PRODUCTION_DEFERRED",
-  "report_assurance": "OBSERVED_PROVIDER_BEHAVIOR_WITH_INDEPENDENT_REPLAY"
+  "reproduction": {
+    "expected_mathematical_output_sha256": "sha256:f57b4969027b4dd6ab6c6ff66b841d9dda3348f5eb00f04d200b38e6a02b17e9",
+    "filtration": [
+      {
+        "rank": 0,
+        "simplex_id": "v0"
+      },
+      {
+        "rank": 1,
+        "simplex_id": "v1"
+      },
+      {
+        "rank": 2,
+        "simplex_id": "v2"
+      },
+      {
+        "rank": 3,
+        "simplex_id": "v3"
+      },
+      {
+        "rank": 4,
+        "simplex_id": "e01"
+      },
+      {
+        "rank": 5,
+        "simplex_id": "e12"
+      },
+      {
+        "rank": 6,
+        "simplex_id": "e23"
+      },
+      {
+        "rank": 7,
+        "simplex_id": "e03"
+      },
+      {
+        "rank": 8,
+        "simplex_id": "e02"
+      },
+      {
+        "rank": 9,
+        "simplex_id": "t012"
+      },
+      {
+        "rank": 10,
+        "simplex_id": "t023"
+      }
+    ],
+    "mathematical_output": {
+      "contract": "jacobian.gudhi-persistence-spike/v1",
+      "filtration": [
+        {
+          "rank": 0,
+          "simplex_id": "v0"
+        },
+        {
+          "rank": 1,
+          "simplex_id": "v1"
+        },
+        {
+          "rank": 2,
+          "simplex_id": "v2"
+        },
+        {
+          "rank": 3,
+          "simplex_id": "v3"
+        },
+        {
+          "rank": 4,
+          "simplex_id": "e01"
+        },
+        {
+          "rank": 5,
+          "simplex_id": "e12"
+        },
+        {
+          "rank": 6,
+          "simplex_id": "e23"
+        },
+        {
+          "rank": 7,
+          "simplex_id": "e03"
+        },
+        {
+          "rank": 8,
+          "simplex_id": "e02"
+        },
+        {
+          "rank": 9,
+          "simplex_id": "t012"
+        },
+        {
+          "rank": 10,
+          "simplex_id": "t023"
+        }
+      ],
+      "pairs": [
+        {
+          "birth_exact_value": "-2/3",
+          "birth_rank": 0,
+          "birth_simplex_id": "v0",
+          "death": {
+            "kind": "INFINITE"
+          },
+          "dimension": 0
+        },
+        {
+          "birth_exact_value": "1/7",
+          "birth_rank": 1,
+          "birth_simplex_id": "v1",
+          "death": {
+            "exact_value": "5/11",
+            "kind": "FINITE",
+            "rank": 4,
+            "simplex_id": "e01"
+          },
+          "dimension": 0
+        },
+        {
+          "birth_exact_value": "2/7",
+          "birth_rank": 2,
+          "birth_simplex_id": "v2",
+          "death": {
+            "exact_value": "7/13",
+            "kind": "FINITE",
+            "rank": 5,
+            "simplex_id": "e12"
+          },
+          "dimension": 0
+        },
+        {
+          "birth_exact_value": "1/3",
+          "birth_rank": 3,
+          "birth_simplex_id": "v3",
+          "death": {
+            "exact_value": "3/5",
+            "kind": "FINITE",
+            "rank": 6,
+            "simplex_id": "e23"
+          },
+          "dimension": 0
+        },
+        {
+          "birth_exact_value": "2/3",
+          "birth_rank": 7,
+          "birth_simplex_id": "e03",
+          "death": {
+            "exact_value": "8/9",
+            "kind": "FINITE",
+            "rank": 10,
+            "simplex_id": "t023"
+          },
+          "dimension": 1
+        },
+        {
+          "birth_exact_value": "5/7",
+          "birth_rank": 8,
+          "birth_simplex_id": "e02",
+          "death": {
+            "exact_value": "11/13",
+            "kind": "FINITE",
+            "rank": 9,
+            "simplex_id": "t012"
+          },
+          "dimension": 1
+        }
+      ],
+      "provider": "gudhi",
+      "version": "3.13.0"
+    },
+    "pairs": [
+      {
+        "birth_exact_value": "-2/3",
+        "birth_rank": 0,
+        "birth_simplex_id": "v0",
+        "death": {
+          "kind": "INFINITE"
+        },
+        "dimension": 0
+      },
+      {
+        "birth_exact_value": "1/7",
+        "birth_rank": 1,
+        "birth_simplex_id": "v1",
+        "death": {
+          "exact_value": "5/11",
+          "kind": "FINITE",
+          "rank": 4,
+          "simplex_id": "e01"
+        },
+        "dimension": 0
+      },
+      {
+        "birth_exact_value": "2/7",
+        "birth_rank": 2,
+        "birth_simplex_id": "v2",
+        "death": {
+          "exact_value": "7/13",
+          "kind": "FINITE",
+          "rank": 5,
+          "simplex_id": "e12"
+        },
+        "dimension": 0
+      },
+      {
+        "birth_exact_value": "1/3",
+        "birth_rank": 3,
+        "birth_simplex_id": "v3",
+        "death": {
+          "exact_value": "3/5",
+          "kind": "FINITE",
+          "rank": 6,
+          "simplex_id": "e23"
+        },
+        "dimension": 0
+      },
+      {
+        "birth_exact_value": "2/3",
+        "birth_rank": 7,
+        "birth_simplex_id": "e03",
+        "death": {
+          "exact_value": "8/9",
+          "kind": "FINITE",
+          "rank": 10,
+          "simplex_id": "t023"
+        },
+        "dimension": 1
+      },
+      {
+        "birth_exact_value": "5/7",
+        "birth_rank": 8,
+        "birth_simplex_id": "e02",
+        "death": {
+          "exact_value": "11/13",
+          "kind": "FINITE",
+          "rank": 9,
+          "simplex_id": "t012"
+        },
+        "dimension": 1
+      }
+    ]
+  },
+  "task_id": "jacobian/gudhi"
 }

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/input.json
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/input.json
@@ -2,5 +2,5 @@
   "task_id": "jacobian/gudhi",
   "provider": "gudhi",
   "contract": "jacobian.gudhi-persistence-spike/v1",
-  "pin_sha256": "sha256:fa137d5d1f5ecf74352ecdae2b4fb1b8d6c3433e6e26707c32d898319e1cdc84"
+  "pin_sha256": "sha256:1463f2cc07f189d7e12daa010b2bebd838756a7ec90a791901a62bdec9bcd552"
 }

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/public_contract.json
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/public_contract.json
@@ -57,7 +57,7 @@
             "const": "jacobian.gudhi-persistence-spike/v1"
           },
           "pin_sha256": {
-            "const": "sha256:fa137d5d1f5ecf74352ecdae2b4fb1b8d6c3433e6e26707c32d898319e1cdc84"
+            "const": "sha256:1463f2cc07f189d7e12daa010b2bebd838756a7ec90a791901a62bdec9bcd552"
           },
           "provider": {
             "const": "gudhi"

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/verifier.py
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/verifier.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 
@@ -20,6 +21,17 @@ def _digest_ok(value: object) -> bool:
     return isinstance(value, str) and value.startswith("sha256:") and len(value) == 71
 
 
+def _canonical_json(payload: object) -> bytes:
+    return (
+        json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+        + "\n"
+    ).encode("ascii")
+
+
+def _sha256_bytes(payload: bytes) -> str:
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
 def _execution_bound(report: object) -> bool:
     """Reject reports that only restate public spike success literals."""
 
@@ -35,16 +47,31 @@ def _execution_bound(report: object) -> bool:
         return False
     provider = report.get("provider")
     reproduction = report.get("reproduction")
+    frozen = expected["reproduction"]
     if not isinstance(provider, dict) or not isinstance(reproduction, dict):
+        return False
+    if not isinstance(frozen, dict):
         return False
     runtime = provider.get("runtime")
     if not isinstance(runtime, dict) or not runtime:
         return False
     pairs = reproduction.get("pairs")
     filtration = reproduction.get("filtration")
-    if not isinstance(pairs, list) or not pairs:
+    if pairs != frozen["pairs"]:
         return False
-    if not isinstance(filtration, list) or not filtration:
+    if filtration != frozen["filtration"]:
+        return False
+    mathematical_output = {
+        "contract": expected["contract"],
+        "filtration": filtration,
+        "pairs": pairs,
+        "provider": expected["provider"],
+        "version": frozen["mathematical_output"]["version"],
+    }
+    if mathematical_output != frozen["mathematical_output"]:
+        return False
+    mathematical_digest = _sha256_bytes(_canonical_json(mathematical_output))
+    if mathematical_digest != frozen["expected_mathematical_output_sha256"]:
         return False
     if not _digest_ok(reproduction.get("provider_output_sha256")):
         return False

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/verifier.py
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/verifier.py
@@ -16,6 +16,10 @@ if isinstance(submission, dict) and isinstance(submission.get("evidence"), list)
 result = submission.get("result") if isinstance(submission, dict) else None
 
 
+def _digest_ok(value: object) -> bool:
+    return isinstance(value, str) and value.startswith("sha256:") and len(value) == 71
+
+
 def _execution_bound(report: object) -> bool:
     """Reject reports that only restate public spike success literals."""
 
@@ -36,15 +40,13 @@ def _execution_bound(report: object) -> bool:
     runtime = provider.get("runtime")
     if not isinstance(runtime, dict) or not runtime:
         return False
-    cases = reproduction.get("cases")
-    if not isinstance(cases, list) or not cases:
+    pairs = reproduction.get("pairs")
+    filtration = reproduction.get("filtration")
+    if not isinstance(pairs, list) or not pairs:
         return False
-    output_digest = reproduction.get("provider_output_sha256")
-    if not (
-        isinstance(output_digest, str)
-        and output_digest.startswith("sha256:")
-        and len(output_digest) == 71
-    ):
+    if not isinstance(filtration, list) or not filtration:
+        return False
+    if not _digest_ok(reproduction.get("provider_output_sha256")):
         return False
     limitations = report.get("limitations")
     if not isinstance(limitations, list) or not limitations:

--- a/benchmarks/datasets/provider-feasibility-v1/nauty/task.toml
+++ b/benchmarks/datasets/provider-feasibility-v1/nauty/task.toml
@@ -1,5 +1,5 @@
 schema_version = "1.4"
-artifacts = ["/app/submission.json", "/app/evidence"]
+artifacts = ["/app/input.json", "/app/submission.json", "/app/evidence"]
 
 [task]
 name = "jacobian/nauty"

--- a/benchmarks/datasets/provider-feasibility-v1/nauty/tests/Dockerfile
+++ b/benchmarks/datasets/provider-feasibility-v1/nauty/tests/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
-LABEL jacobian.checksum="b00795964e81bd8cbe49ec3e2a03da70a3c623991816c253aea18f81bdc911cd"
+LABEL jacobian.checksum="e99d9f96a2d5221594e505dfbdc2a5c2f127f3732f401820d21bad8e29a935de"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 RUN chmod +x /tests/test.sh

--- a/benchmarks/datasets/provider-feasibility-v1/nauty/tests/Dockerfile
+++ b/benchmarks/datasets/provider-feasibility-v1/nauty/tests/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
-LABEL jacobian.checksum="e99d9f96a2d5221594e505dfbdc2a5c2f127f3732f401820d21bad8e29a935de"
+LABEL jacobian.checksum="3a331050935a642b86803b26a9a7e128609c09e9d8812ca98bfb2d4aad053c78"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 RUN chmod +x /tests/test.sh

--- a/benchmarks/datasets/provider-feasibility-v1/nauty/tests/expected.json
+++ b/benchmarks/datasets/provider-feasibility-v1/nauty/tests/expected.json
@@ -1,8 +1,25 @@
 {
-  "task_id": "jacobian/nauty",
-  "provider": "nauty-traces",
   "contract": "jacobian.nauty-provider-spike/v1",
   "pin_sha256": "sha256:c2f070eb0e1a6fc3bf9af3a3360bc8f6ddf65611c9e7c51755a24cbc4dd08070",
+  "provider": "nauty-traces",
+  "report_assurance": "OBSERVED_PROVIDER_BEHAVIOR",
   "report_conclusion": "SPIKE_PASSED_PRODUCTION_DEFERRED",
-  "report_assurance": "OBSERVED_PROVIDER_BEHAVIOR"
+  "reproduction": {
+    "expected_graph6": [
+      "C?",
+      "CC",
+      "CE",
+      "CF",
+      "CQ",
+      "CU",
+      "CT",
+      "CV",
+      "C]",
+      "C^",
+      "C~"
+    ],
+    "expected_output_sha256": "sha256:b809c405cd3b8fb3cc836a9e7471658a8cf02cbc258029bddbecc9f2caf2ea32",
+    "observed_count": 11
+  },
+  "task_id": "jacobian/nauty"
 }

--- a/benchmarks/datasets/provider-feasibility-v1/nauty/tests/verifier.py
+++ b/benchmarks/datasets/provider-feasibility-v1/nauty/tests/verifier.py
@@ -35,19 +35,31 @@ def _execution_bound(report: object) -> bool:
         return False
     provider = report.get("provider")
     reproduction = report.get("reproduction")
+    frozen = expected["reproduction"]
     if not isinstance(provider, dict) or not isinstance(reproduction, dict):
+        return False
+    if not isinstance(frozen, dict):
         return False
     executables = provider.get("executables")
     if not isinstance(executables, dict) or not executables:
         return False
     expected_graph6 = reproduction.get("expected_graph6")
+    if expected_graph6 != frozen["expected_graph6"]:
+        return False
     if not isinstance(expected_graph6, list) or not expected_graph6:
         return False
-    if type(reproduction.get("observed_count")) is not int:
+    observed_count = reproduction.get("observed_count")
+    if type(observed_count) is not int or observed_count != frozen["observed_count"]:
         return False
-    if not _digest_ok(reproduction.get("observed_output_sha256")):
+    if observed_count != len(expected_graph6):
         return False
-    if not _digest_ok(reproduction.get("expected_output_sha256")):
+    expected_digest = reproduction.get("expected_output_sha256")
+    observed_digest = reproduction.get("observed_output_sha256")
+    if expected_digest != frozen["expected_output_sha256"]:
+        return False
+    if not _digest_ok(expected_digest) or not _digest_ok(observed_digest):
+        return False
+    if observed_digest != expected_digest:
         return False
     limitations = report.get("limitations")
     if not isinstance(limitations, list) or not limitations:

--- a/benchmarks/datasets/provider-feasibility-v1/nauty/tests/verifier.py
+++ b/benchmarks/datasets/provider-feasibility-v1/nauty/tests/verifier.py
@@ -16,6 +16,10 @@ if isinstance(submission, dict) and isinstance(submission.get("evidence"), list)
 result = submission.get("result") if isinstance(submission, dict) else None
 
 
+def _digest_ok(value: object) -> bool:
+    return isinstance(value, str) and value.startswith("sha256:") and len(value) == 71
+
+
 def _execution_bound(report: object) -> bool:
     """Reject reports that only restate public spike success literals."""
 
@@ -33,18 +37,17 @@ def _execution_bound(report: object) -> bool:
     reproduction = report.get("reproduction")
     if not isinstance(provider, dict) or not isinstance(reproduction, dict):
         return False
-    runtime = provider.get("runtime")
-    if not isinstance(runtime, dict) or not runtime:
+    executables = provider.get("executables")
+    if not isinstance(executables, dict) or not executables:
         return False
-    cases = reproduction.get("cases")
-    if not isinstance(cases, list) or not cases:
+    expected_graph6 = reproduction.get("expected_graph6")
+    if not isinstance(expected_graph6, list) or not expected_graph6:
         return False
-    output_digest = reproduction.get("provider_output_sha256")
-    if not (
-        isinstance(output_digest, str)
-        and output_digest.startswith("sha256:")
-        and len(output_digest) == 71
-    ):
+    if type(reproduction.get("observed_count")) is not int:
+        return False
+    if not _digest_ok(reproduction.get("observed_output_sha256")):
+        return False
+    if not _digest_ok(reproduction.get("expected_output_sha256")):
         return False
     limitations = report.get("limitations")
     if not isinstance(limitations, list) or not limitations:

--- a/benchmarks/datasets/provider-feasibility-v1/regina/environment/Dockerfile
+++ b/benchmarks/datasets/provider-feasibility-v1/regina/environment/Dockerfile
@@ -1,11 +1,11 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /opt/provider && \
-    curl -fsSL https://files.pythonhosted.org/packages/68/42/b4a994e393298c08c361342ee19bf240b7b16f155c492ce0631082c14e66/regina-7.4.1-cp312-cp312-manylinux_2_28_x86_64.whl -o /opt/provider/regina.whl && \
+    curl -fsSL https://files.pythonhosted.org/packages/68/42/b4a994e393298c08c361342ee19bf240b7b16f155c492ce0631082c14e66/regina-7.4.1-cp312-cp312-manylinux_2_28_x86_64.whl -o /opt/provider/regina-7.4.1-cp312-cp312-manylinux_2_28_x86_64.whl && \
     curl -fsSL https://github.com/regina-normal/regina/releases/download/regina-7.4.1/regina-7.4.1.tar.gz -o /opt/provider/regina-source.tar.gz && \
-    printf '%s  %s\n' d33ccc69697ec680a8dcf8f0c663428853da44f3578898ad9b908e4669e83c71 /opt/provider/regina.whl | sha256sum -c - && \
+    printf '%s  %s\n' d33ccc69697ec680a8dcf8f0c663428853da44f3578898ad9b908e4669e83c71 /opt/provider/regina-7.4.1-cp312-cp312-manylinux_2_28_x86_64.whl | sha256sum -c - && \
     printf '%s  %s\n' 74131014099b77083dd1d09004fd6bc972421c792d188cdf43f0fd11ca6cb2ed /opt/provider/regina-source.tar.gz | sha256sum -c - && \
-    uv pip install --system /opt/provider/regina.whl
+    uv pip install --system /opt/provider/regina-7.4.1-cp312-cp312-manylinux_2_28_x86_64.whl
 WORKDIR /app
 COPY __init__.py /opt/benchmarks/__init__.py
 COPY tooling/__init__.py /opt/benchmarks/tooling/__init__.py

--- a/benchmarks/datasets/provider-feasibility-v1/regina/environment/input.json
+++ b/benchmarks/datasets/provider-feasibility-v1/regina/environment/input.json
@@ -2,5 +2,5 @@
   "task_id": "jacobian/regina",
   "provider": "regina",
   "contract": "jacobian.regina-outcomes-spike/v1",
-  "pin_sha256": "sha256:b5736de228ddc8b4e6dbdf375736b78faafb68add6ae57c49facaafebf8fb7bc"
+  "pin_sha256": "sha256:188618c36f37e31609eb57158f6f8fba270f86c5c6520b816eda6b7634482563"
 }

--- a/benchmarks/datasets/provider-feasibility-v1/regina/environment/pin.json
+++ b/benchmarks/datasets/provider-feasibility-v1/regina/environment/pin.json
@@ -1,5 +1,5 @@
 {
-  "adapter_source_sha256": "sha256:dd8f48b0b3d473c17a813ef2002e790aa3de1f8f7e9273fae939c105faaceccb",
+  "adapter_source_sha256": "sha256:e017a6f203585eacf2e57551aba282af510635e45bade5e5d722e1fee724d005",
   "contract": "jacobian.regina-outcomes-spike/v1",
   "distribution_version": "7.4.1",
   "documentation_url": "https://regina-normal.github.io/engine-docs/",

--- a/benchmarks/datasets/provider-feasibility-v1/regina/environment/spike.py
+++ b/benchmarks/datasets/provider-feasibility-v1/regina/environment/spike.py
@@ -33,7 +33,14 @@ _SOURCE_MEMBERS = {
     "triangulation": (f"{_SOURCE_ROOT}/engine/triangulation/dim3/triangulation3.h"),
     "normal_surfaces": f"{_SOURCE_ROOT}/engine/surface/normalsurfaces.h",
 }
-_ENVIRONMENT = {"LANG": "C", "LC_ALL": "C", "TZ": "UTC"}
+# Worker re-exec replaces the process environment; keep the image PYTHONPATH so
+# `benchmarks.tooling.command_runner` remains importable inside --worker mode.
+_ENVIRONMENT = {
+    "LANG": "C",
+    "LC_ALL": "C",
+    "TZ": "UTC",
+    "PYTHONPATH": "/opt",
+}
 _INTEGER = re.compile(r"^(?:0|[1-9][0-9]*)$")
 ProcessRunner = Callable[..., ToolCommandResult]
 _WORKER_ERROR_PREFIX = b"JACOBIAN_SPIKE_ERROR "

--- a/benchmarks/datasets/provider-feasibility-v1/regina/environment/submission_schema.json
+++ b/benchmarks/datasets/provider-feasibility-v1/regina/environment/submission_schema.json
@@ -14,7 +14,7 @@
         "provider": {"const": "regina"},
         "contract": {"const": "jacobian.regina-outcomes-spike/v1"},
         "status": {"enum": ["COMPLETED", "TIMEOUT", "CANCELLED", "ERROR", "REJECTED"]},
-        "pin_sha256": {"const": "sha256:b5736de228ddc8b4e6dbdf375736b78faafb68add6ae57c49facaafebf8fb7bc"}
+        "pin_sha256": {"const": "sha256:188618c36f37e31609eb57158f6f8fba270f86c5c6520b816eda6b7634482563"}
       }
     },
     "claimed_assurance": {"enum": ["UNVERIFIED","COMPUTED"]},

--- a/benchmarks/datasets/provider-feasibility-v1/regina/solution/solve.py
+++ b/benchmarks/datasets/provider-feasibility-v1/regina/solution/solve.py
@@ -9,7 +9,7 @@ REPORT = APP / "evidence" / "provider-report.json"
 TASK_ID = "jacobian/regina"
 PROVIDER = "regina"
 CONTRACT = "jacobian.regina-outcomes-spike/v1"
-PIN = "sha256:b5736de228ddc8b4e6dbdf375736b78faafb68add6ae57c49facaafebf8fb7bc"
+PIN = "sha256:188618c36f37e31609eb57158f6f8fba270f86c5c6520b816eda6b7634482563"
 
 report = json.loads(REPORT.read_text())
 status = report.get("status", "ERROR")

--- a/benchmarks/datasets/provider-feasibility-v1/regina/solution/solve.sh
+++ b/benchmarks/datasets/provider-feasibility-v1/regina/solution/solve.sh
@@ -3,7 +3,7 @@ set -eu
 mkdir -p /app/evidence
 python /app/spike.py \
   --python-executable /usr/local/bin/python \
-  --wheel /opt/provider/regina.whl \
+  --wheel /opt/provider/regina-7.4.1-cp312-cp312-manylinux_2_28_x86_64.whl \
   --source-archive /opt/provider/regina-source.tar.gz \
   --pin /app/pin.json \
   --output /app/evidence/provider-report.json

--- a/benchmarks/datasets/provider-feasibility-v1/regina/task.toml
+++ b/benchmarks/datasets/provider-feasibility-v1/regina/task.toml
@@ -1,5 +1,5 @@
 schema_version = "1.4"
-artifacts = ["/app/submission.json", "/app/evidence"]
+artifacts = ["/app/input.json", "/app/submission.json", "/app/evidence"]
 
 [task]
 name = "jacobian/regina"
@@ -19,7 +19,7 @@ field = "provider-integration"
 assurance_ceiling = "COMPUTED"
 answer_visibility = "public"
 provenance_class = "pinned-provider-spike"
-fixture_digest = "sha256:b56b8741c6b1ec216bb0d510e12fe5eddc75c901c0ff067e84de887ffdf64a24"
+fixture_digest = "sha256:a20f6aab6523ac570f77fca5226ebe39d9ae951986ec0a933d323c9ce54ff1dc"
 required_provider = "regina"
 
 [agent]

--- a/benchmarks/datasets/provider-feasibility-v1/regina/tests/expected.json
+++ b/benchmarks/datasets/provider-feasibility-v1/regina/tests/expected.json
@@ -2,7 +2,7 @@
   "task_id": "jacobian/regina",
   "provider": "regina",
   "contract": "jacobian.regina-outcomes-spike/v1",
-  "pin_sha256": "sha256:b5736de228ddc8b4e6dbdf375736b78faafb68add6ae57c49facaafebf8fb7bc",
+  "pin_sha256": "sha256:188618c36f37e31609eb57158f6f8fba270f86c5c6520b816eda6b7634482563",
   "report_conclusion": "SPIKE_PASSED_PRODUCTION_DEFERRED",
   "report_assurance": "OBSERVED_PROVIDER_BEHAVIOR_WITH_PARTIAL_INDEPENDENT_REPLAY"
 }

--- a/benchmarks/datasets/provider-feasibility-v1/regina/tests/input.json
+++ b/benchmarks/datasets/provider-feasibility-v1/regina/tests/input.json
@@ -2,5 +2,5 @@
   "task_id": "jacobian/regina",
   "provider": "regina",
   "contract": "jacobian.regina-outcomes-spike/v1",
-  "pin_sha256": "sha256:b5736de228ddc8b4e6dbdf375736b78faafb68add6ae57c49facaafebf8fb7bc"
+  "pin_sha256": "sha256:188618c36f37e31609eb57158f6f8fba270f86c5c6520b816eda6b7634482563"
 }

--- a/benchmarks/datasets/provider-feasibility-v1/regina/tests/public_contract.json
+++ b/benchmarks/datasets/provider-feasibility-v1/regina/tests/public_contract.json
@@ -57,7 +57,7 @@
             "const": "jacobian.regina-outcomes-spike/v1"
           },
           "pin_sha256": {
-            "const": "sha256:b5736de228ddc8b4e6dbdf375736b78faafb68add6ae57c49facaafebf8fb7bc"
+            "const": "sha256:188618c36f37e31609eb57158f6f8fba270f86c5c6520b816eda6b7634482563"
           },
           "provider": {
             "const": "regina"

--- a/benchmarks/tooling/command_runner.py
+++ b/benchmarks/tooling/command_runner.py
@@ -672,6 +672,10 @@ class ToolInteractiveCommand:
                 raise RuntimeError("interactive process closed before responding")
             if not item.strip():
                 if lines:
+                    # Re-check stream bounds before accepting a completed frame.
+                    abort = self._check_read_abort(deadline)
+                    if abort is not None:
+                        raise abort
                     self._responses_read += 1
                     return "\n".join(lines)
                 continue

--- a/benchmarks/tooling/harbor_suite.py
+++ b/benchmarks/tooling/harbor_suite.py
@@ -706,7 +706,36 @@ def _task_manifest_failures(suite: Suite, task_dir: Path, rel: str) -> list[str]
         failures.append(f"{rel}/task.toml: task.name disagrees with suite manifest")
     failures.extend(_metadata_failures(suite, task_dir, rel, cfg.get("metadata", {})))
     failures.extend(_network_mode_failures(cfg, rel))
+    failures.extend(
+        _separate_verifier_input_artifact_failures(suite, task_dir, rel, cfg)
+    )
     return failures
+
+
+def _separate_verifier_input_artifact_failures(
+    suite: Suite, task_dir: Path, rel: str, cfg: dict[str, Any]
+) -> list[str]:
+    """Require bound input publication for separate-verifier provider tasks.
+
+    Harbor's separate verifier mode only mounts declared ``artifacts``. Provider
+    verifiers call ``load_submission`` with input binding, so omitting
+    ``/app/input.json`` makes every completed Oracle trial score zero.
+    """
+
+    if suite.id != "provider-feasibility-v1":
+        return []
+    verifier = cfg.get("verifier", {})
+    if not isinstance(verifier, dict) or verifier.get("environment_mode") != "separate":
+        return []
+    if not (task_dir / "tests" / "input.json").is_file():
+        return []
+    artifacts = cfg.get("artifacts")
+    if not isinstance(artifacts, list) or "/app/input.json" not in artifacts:
+        return [
+            f"{rel}/task.toml: separate verifier mode requires "
+            "/app/input.json in artifacts"
+        ]
+    return []
 
 
 def _agent_environment_failures(suite: Suite, task_dir: Path, rel: str) -> list[str]:

--- a/benchmarks/validation/test_tooling_interactive_command.py
+++ b/benchmarks/validation/test_tooling_interactive_command.py
@@ -5,6 +5,7 @@ import os
 import sys
 import textwrap
 import threading
+import time
 from pathlib import Path
 
 import pytest
@@ -206,6 +207,13 @@ def test_interactive_stderr_is_bounded(tmp_path: Path) -> None:
     command = ToolInteractiveCommand(request)
     command.start()
     try:
+        # The child flushes oversized stderr before reading stdin; wait until
+        # the drain thread observes it so read_response does not race ahead of
+        # the bound flag under parallel host-validation load.
+        deadline = time.monotonic() + 5.0
+        while not command.stderr_exceeded and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert command.stderr_exceeded is True
         command.send("ping")
         with pytest.raises(RuntimeError, match="stderr bounds"):
             command.read_response()

--- a/benchmarks/validation/test_verifier_security_regressions.py
+++ b/benchmarks/validation/test_verifier_security_regressions.py
@@ -318,3 +318,128 @@ def test_lean_repl_accepts_complete_distinct_task_traces(tmp_path: Path) -> None
     task, app, logs = _lean_case(tmp_path, tasks)
     accepted = support._run_verifier(task, app, logs)
     assert accepted["reward"] == pytest.approx(1.0)
+
+
+def _provider_report_case(tmp_path: Path, task_name: str, report: dict) -> tuple:
+    task = DATASETS / "provider-feasibility-v1" / task_name
+    app = tmp_path / task_name / "app"
+    logs = tmp_path / task_name / "logs"
+    (app / "evidence").mkdir(parents=True)
+    logs.mkdir(parents=True)
+    shutil.copy2(task / "environment" / "input.json", app / "input.json")
+    report_path = app / "evidence" / "provider-report.json"
+    _write_json(report_path, report)
+    expected = json.loads((task / "tests" / "expected.json").read_text())
+    submission = {
+        "task_id": expected["task_id"],
+        "conclusion": "FEASIBLE",
+        "result": {
+            "provider": expected["provider"],
+            "contract": expected["contract"],
+            "status": "COMPLETED",
+            "pin_sha256": expected["pin_sha256"],
+        },
+        "claimed_assurance": "COMPUTED",
+        "scope": "pinned bounded provider reproduction",
+        "completeness": "COMPLETE",
+        "evidence": [
+            {
+                "path": "evidence/provider-report.json",
+                "sha256": _digest(report_path),
+            }
+        ],
+        "limitations": [
+            "provider output is not an operator-authorized independent verification",
+        ],
+    }
+    _write_json(app / "submission.json", submission)
+    return task, app, logs
+
+
+def test_cgal_rejects_fabricated_reproduction_digests(tmp_path: Path) -> None:
+    expected = json.loads(
+        (
+            DATASETS / "provider-feasibility-v1" / "cgal" / "tests" / "expected.json"
+        ).read_text()
+    )
+    fake_digest = "sha256:" + ("0" * 64)
+    report = {
+        "contract": expected["contract"],
+        "status": "COMPLETED",
+        "conclusion": expected["report_conclusion"],
+        "assurance": expected["report_assurance"],
+        "provider": {
+            "executable": "/usr/local/bin/cgal-spike",
+            "executable_sha256": fake_digest,
+        },
+        "reproductions": {
+            name: {
+                **case,
+                "observed_output_sha256": fake_digest,
+                "expected_output_sha256": fake_digest,
+            }
+            for name, case in expected["reproductions"].items()
+        },
+        "limitations": ["fabricated"],
+        "extra": True,
+    }
+    task, app, logs = _provider_report_case(tmp_path, "cgal", report)
+    rejected = support._run_verifier(task, app, logs)
+    assert rejected["reward"] == 0.0
+
+
+def test_gudhi_rejects_fabricated_persistence_shape(tmp_path: Path) -> None:
+    expected = json.loads(
+        (
+            DATASETS / "provider-feasibility-v1" / "gudhi" / "tests" / "expected.json"
+        ).read_text()
+    )
+    fake_digest = "sha256:" + ("0" * 64)
+    report = {
+        "contract": expected["contract"],
+        "status": "COMPLETED",
+        "conclusion": expected["report_conclusion"],
+        "assurance": expected["report_assurance"],
+        "provider": {
+            "runtime": {"gudhi": "3.13.0", "python": "3.12.0", "numpy": "2.0"}
+        },
+        "reproduction": {
+            "pairs": [{}],
+            "filtration": [{}],
+            "provider_output_sha256": fake_digest,
+        },
+        "limitations": ["fabricated"],
+        "extra": True,
+    }
+    task, app, logs = _provider_report_case(tmp_path, "gudhi", report)
+    rejected = support._run_verifier(task, app, logs)
+    assert rejected["reward"] == 0.0
+
+
+def test_nauty_rejects_fabricated_count_and_digests(tmp_path: Path) -> None:
+    expected = json.loads(
+        (
+            DATASETS / "provider-feasibility-v1" / "nauty" / "tests" / "expected.json"
+        ).read_text()
+    )
+    fake_digest = "sha256:" + ("0" * 64)
+    report = {
+        "contract": expected["contract"],
+        "status": "COMPLETED",
+        "conclusion": expected["report_conclusion"],
+        "assurance": expected["report_assurance"],
+        "provider": {
+            "executables": {"geng": {"path": "/bin/geng", "sha256": fake_digest}}
+        },
+        "reproduction": {
+            "expected_graph6": ["ZZ"],
+            "observed_count": -1,
+            "observed_output_sha256": fake_digest,
+            "expected_output_sha256": fake_digest,
+        },
+        "limitations": ["fabricated"],
+        "extra": True,
+    }
+    task, app, logs = _provider_report_case(tmp_path, "nauty", report)
+    rejected = support._run_verifier(task, app, logs)
+    assert rejected["reward"] == 0.0

--- a/benchmarks/validation/test_verifier_security_regressions.py
+++ b/benchmarks/validation/test_verifier_security_regressions.py
@@ -45,6 +45,24 @@ def test_provider_verifier_images_include_bound_frozen_input(task_name: str) -> 
     )
 
 
+@pytest.mark.parametrize("task_name", PROVIDER_TASKS)
+def test_provider_separate_verifier_publishes_bound_input_artifact(
+    task_name: str,
+) -> None:
+    """Separate verifier mode only receives declared artifacts.
+
+    ``load_submission`` requires ``/app/input.json`` to match the frozen
+    verifier input, so provider tasks must publish that path or Oracle reward
+    collapses to zero after a successful spike.
+    """
+
+    task = DATASETS / "provider-feasibility-v1" / task_name
+    text = (task / "task.toml").read_text(encoding="utf-8")
+    assert 'environment_mode = "separate"' in text
+    assert '"/app/input.json"' in text
+    assert text.index('"/app/input.json"') < text.index('"/app/submission.json"')
+
+
 def test_reliability_recomputes_input_and_rejects_coerced_state_count(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Open eval/provider PRs were failing `provider-feasibility-v1` Oracle with `pin_fidelity` / `provider_outcome` = 0 even when spikes completed (and earlier with wheel/`ADAPTER_SOURCE_MISMATCH` failures).

**Root cause:** with `environment_mode = "separate"`, Harbor only mounts declared `artifacts` into the verifier. Provider verifiers call `load_submission()` which requires `/app/input.json` to match the frozen tests input. Five provider tasks omitted that artifact (lean-repl already published it).

**Also included:** the #648 wheel PEP 427 filename / adapter pin / PYTHONPATH worker fixes, plus binding CGAL/GUDHI/nauty rewards to frozen reproduction payloads so fabricated shape-only digests cannot earn full reward.

## Changes

- Publish `/app/input.json` as a verifier artifact on cddlib, cgal, gudhi, nauty, regina
- Align environment/tests `input.json` copies and verifier Dockerfiles
- Bind CGAL case digests, GUDHI pairs/filtration + mathematical digest, and nauty count/graph6/digests to pinned expected outputs
- Host regressions covering fabricated COMPLETED reports for those three providers

## Related

- Supersedes the remaining Oracle failure on #648 (wheel/PYTHONPATH fixes are included here)
- https://github.com/morluto/jacobian/issues/654

## Test plan

- [x] Focused fabricated-report host regressions
- [x] `make harbor-contracts`
- [x] Prior CI Oracle lanes green for cddlib/cgal/gudhi/nauty/regina
- [ ] CI re-run after frozen-reproduction binding
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a35b6f3-58eb-4fcb-82e0-271ce6978bf7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a35b6f3-58eb-4fcb-82e0-271ce6978bf7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

