### PR TITLE
chore: ratchet streaming evidence parser complexity baseline

### DIFF
--- a/tools/c901-baseline.json
+++ b/tools/c901-baseline.json
@@ -3,6 +3,11 @@
   "max_complexity": 10,
   "violations": [
     {
+      "path": "benchmarks/datasets/conjecture-probes-v1/reconstruction-deck-certificate/tests/verifier_support.py",
+      "symbol": "_read_streaming_json_value",
+      "complexity": 11
+    },
+    {
       "path": "benchmarks/datasets/conjecture-probes-v1/vizing-bounded-cartesian-products/tests/verifier.py",
       "symbol": "_frozen",
       "complexity": 11


### PR DESCRIPTION
Merged PR #657 added `_read_streaming_json_value` (complexity 11) to the reconstruction-deck evidence parser without updating the C901 baseline, so `make lint-full` fails on main and on follow-up PRs. This records the function in the checked-in baseline (generated via `tools/check_complexity.py --update`).