### PR TITLE
fix(eval): ignore malformed telemetry status and tool fields

### DIFF
--- a/src/jacobian/eval/telemetry.py
+++ b/src/jacobian/eval/telemetry.py
@@ -213,7 +213,9 @@ def _mcp_resource_link_uris(item: Mapping[str, Any]) -> tuple[str, ...]:
 def _mcp_resource_read_uri(item: Mapping[str, Any]) -> str | None:
     item_type = item.get("type")
     tool = item.get("tool")
-    if item_type != "mcp_resource_read" and tool not in _RESOURCE_READ_TOOL_NAMES:
+    if item_type != "mcp_resource_read" and (
+        not isinstance(tool, str) or tool not in _RESOURCE_READ_TOOL_NAMES
+    ):
         return None
     for key in ("arguments", "params", "input"):
         value = item.get(key)

--- a/src/jacobian/eval/telemetry.py
+++ b/src/jacobian/eval/telemetry.py
@@ -227,8 +227,12 @@ def _mcp_resource_read_uri(item: Mapping[str, Any]) -> str | None:
 
 def _mcp_resource_read_failed(item: Mapping[str, Any]) -> bool:
     result = item.get("result")
+    status = item.get("status")
     return bool(
-        item.get("status") in {"error", "failed", "CANCELLED", "ERROR", "TIMEOUT"}
+        (
+            isinstance(status, str)
+            and status in {"error", "failed", "CANCELLED", "ERROR", "TIMEOUT"}
+        )
         or item.get("error")
         or (
             isinstance(result, Mapping)
@@ -539,8 +543,9 @@ def parse_agent_transcript(path: Path) -> dict[str, Any]:
                 capability_attempt_ids.append(arguments["capability_id"])
             result = item.get("result")
             response = structured_response or text_response
+            status = item.get("status")
             failed = bool(
-                item.get("status") in {"error", "failed"}
+                (isinstance(status, str) and status in {"error", "failed"})
                 or item.get("error")
                 or (
                     isinstance(result, Mapping)

--- a/tests/unit/tooling/test_eval_telemetry.py
+++ b/tests/unit/tooling/test_eval_telemetry.py
@@ -149,6 +149,29 @@ def test_agent_telemetry_counts_response_bytes_and_repeated_calls(
     assert telemetry["mcp_logical_payload_observed_calls"] == 3
 
 
+def test_agent_telemetry_ignores_non_string_mcp_status(tmp_path: Path) -> None:
+    uri = "artifact://sha256/" + ("a" * 64)
+    event = {
+        "type": "item.completed",
+        "item": {
+            "type": "mcp_tool_call",
+            "tool": "resources/read",
+            "arguments": {"uri": uri},
+            "status": [],
+            "result": {},
+        },
+    }
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text(json.dumps(event) + "\n", encoding="utf-8")
+
+    telemetry = parse_agent_transcript(transcript)
+
+    assert telemetry["tool_error_count"] == 0
+    assert telemetry["successful_tool_calls"] == ["resources/read"]
+    assert telemetry["mcp_resource_read_attempts"] == 1
+    assert telemetry["mcp_resource_read_successes"] == 1
+
+
 def test_agent_telemetry_reports_reasoning_protocol_without_summary_text(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/tooling/test_eval_telemetry.py
+++ b/tests/unit/tooling/test_eval_telemetry.py
@@ -172,6 +172,24 @@ def test_agent_telemetry_ignores_non_string_mcp_status(tmp_path: Path) -> None:
     assert telemetry["mcp_resource_read_successes"] == 1
 
 
+def test_agent_telemetry_ignores_non_string_mcp_tool(tmp_path: Path) -> None:
+    event = {
+        "type": "item.completed",
+        "item": {
+            "type": "not_resource_read",
+            "tool": [],
+            "arguments": {"uri": "artifact://sha256/" + ("a" * 64)},
+        },
+    }
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text(json.dumps(event) + "\n", encoding="utf-8")
+
+    telemetry = parse_agent_transcript(transcript)
+
+    assert telemetry["mcp_calls"] == []
+    assert telemetry["mcp_resource_read_attempts"] == 0
+
+
 def test_agent_telemetry_reports_reasoning_protocol_without_summary_text(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Fixes #639.
Fixes #712.

## Problem

Agent transcripts are external telemetry input. Two malformed but valid JSON shapes could abort the complete summary:

- an MCP call with an array-valued `status` reached two direct set-membership checks;
- any completed item with an array-valued `tool` reached resource-read classification.

Both raised `TypeError: unhashable type: 'list'` instead of being treated as unrecognized telemetry.

## Change

Require `status` and `tool` to be strings before comparing them with the existing recognized values. Non-string fields are ignored; the accepted failure statuses, resource-read tool names, and all other error signals are unchanged.

The regressions write real JSONL transcripts for both malformed shapes. They verify parsing completes, valid accounting remains intact, and the malformed item is not invented as a tool call or resource read.

## Validation

- Base proof for #639: the status fixture failed on `41504be7ac07cb6d9983a5ba81750c1c851b316c` at both membership sites with `TypeError`.
- Base proof for #712: the tool fixture failed on the same base in `_mcp_resource_read_uri` with `TypeError`.
- Complete telemetry module: 8 passed.
- Exact planner-selected unit scope: 22 passed.
- Changed-file Ruff lint and formatting passed.
- `git diff --check` passed.