### PR TITLE
fix(benchmarks): bind cddlib/regina and tighten provider Oracle evidence

### DIFF
--- a/benchmarks/datasets/provider-feasibility-v1/cddlib/tests/Dockerfile
+++ b/benchmarks/datasets/provider-feasibility-v1/cddlib/tests/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
-LABEL jacobian.checksum="b00795964e81bd8cbe49ec3e2a03da70a3c623991816c253aea18f81bdc911cd"
+LABEL jacobian.checksum="1585fef67c7beb04d830498e9c9db28f62eb4564446806875a426bcd0d30154e"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 RUN chmod +x /tests/test.sh

--- a/benchmarks/datasets/provider-feasibility-v1/cddlib/tests/expected.json
+++ b/benchmarks/datasets/provider-feasibility-v1/cddlib/tests/expected.json
@@ -4,5 +4,752 @@
   "contract": "jacobian.cddlib-hv-spike/v1",
   "pin_sha256": "sha256:15b0b5b4d608bc2f354dd484c44aa3da7441d615ab9650d6f7611c7e97af7871",
   "report_conclusion": "SPIKE_PASSED_PRODUCTION_DEFERRED",
-  "report_assurance": "OBSERVED_EXACT_PROVIDER_BEHAVIOR_WITH_SOUNDNESS_REPLAY"
+  "report_assurance": "OBSERVED_EXACT_PROVIDER_BEHAVIOR_WITH_SOUNDNESS_REPLAY",
+  "reproduction": {
+    "scope": {
+      "ambient_dimension": 2,
+      "case_count": 4,
+      "covers": [
+        "H_TO_V",
+        "V_TO_H",
+        "AFFINE_DIMENSION",
+        "EQUALITY",
+        "INEQUALITY",
+        "VERTEX",
+        "RAY",
+        "LINEALITY",
+        "HOMOGENEOUS_NORMALIZATION"
+      ],
+      "exact_input": "fractions.Fraction through cdd.gmp",
+      "max_homogeneous_rows_per_case": 3
+    },
+    "cases": [
+      {
+        "ambient_dimension": 2,
+        "case_id": "h_to_v_affine_ray",
+        "expected_output": {
+          "homogeneous_rows": [
+            [
+              "0",
+              "1",
+              "0"
+            ],
+            [
+              "1",
+              "1/2",
+              "1/3"
+            ]
+          ],
+          "linearity_rows": [],
+          "representation": "V"
+        },
+        "input": {
+          "homogeneous_rows": [
+            [
+              "-1/2",
+              "1",
+              "0"
+            ],
+            [
+              "-1/3",
+              "0",
+              "1"
+            ]
+          ],
+          "linearity_rows": [
+            1
+          ],
+          "representation": "H"
+        }
+      },
+      {
+        "ambient_dimension": 2,
+        "case_id": "h_to_v_strip_lineality",
+        "expected_output": {
+          "homogeneous_rows": [
+            [
+              "0",
+              "0",
+              "1"
+            ],
+            [
+              "1",
+              "0",
+              "0"
+            ],
+            [
+              "1",
+              "3/2",
+              "0"
+            ]
+          ],
+          "linearity_rows": [
+            0
+          ],
+          "representation": "V"
+        },
+        "input": {
+          "homogeneous_rows": [
+            [
+              "0",
+              "1",
+              "0"
+            ],
+            [
+              "3/2",
+              "-1",
+              "0"
+            ]
+          ],
+          "linearity_rows": [],
+          "representation": "H"
+        }
+      },
+      {
+        "ambient_dimension": 2,
+        "case_id": "v_to_h_affine_ray",
+        "expected_output": {
+          "homogeneous_rows": [
+            [
+              "-1/3",
+              "0",
+              "1"
+            ],
+            [
+              "-1",
+              "2",
+              "0"
+            ]
+          ],
+          "linearity_rows": [
+            0
+          ],
+          "representation": "H"
+        },
+        "input": {
+          "homogeneous_rows": [
+            [
+              "1",
+              "1/2",
+              "1/3"
+            ],
+            [
+              "0",
+              "1",
+              "0"
+            ]
+          ],
+          "linearity_rows": [],
+          "representation": "V"
+        }
+      },
+      {
+        "ambient_dimension": 2,
+        "case_id": "v_to_h_strip_lineality",
+        "expected_output": {
+          "homogeneous_rows": [
+            [
+              "3/2",
+              "-1",
+              "0"
+            ],
+            [
+              "0",
+              "1",
+              "0"
+            ]
+          ],
+          "linearity_rows": [],
+          "representation": "H"
+        },
+        "input": {
+          "homogeneous_rows": [
+            [
+              "1",
+              "0",
+              "0"
+            ],
+            [
+              "1",
+              "3/2",
+              "0"
+            ],
+            [
+              "0",
+              "0",
+              "1"
+            ]
+          ],
+          "linearity_rows": [
+            2
+          ],
+          "representation": "V"
+        }
+      }
+    ],
+    "exact_arithmetic_probe": "1208925819614629174706177/2288818359375",
+    "expected_mathematical_output_sha256": "sha256:46bc8c4f78c39fe5ddecd1731f6a1effc3351042e96f1a9d85f7fa97fae8acb4",
+    "mathematical_output": {
+      "contract": "jacobian.cddlib-hv-spike/v1",
+      "provider": "cddlib/pycddlib",
+      "versions": {
+        "cddlib": "0.94n",
+        "pycddlib": "3.0.2"
+      },
+      "exact_arithmetic": {
+        "module": "cdd.gmp",
+        "number_type": "fractions.Fraction",
+        "large_fraction_input": "1208925819614629174706177/2288818359375",
+        "large_fraction_output": "1208925819614629174706177/2288818359375",
+        "roundtrip_exact": true
+      },
+      "cases": [
+        {
+          "case_id": "h_to_v_affine_ray",
+          "conversion": "H_TO_V",
+          "input": {
+            "representation": "H",
+            "ambient_dimension": 2,
+            "affine_dimension": 1,
+            "homogeneous_convention": "H:[b,a] means b+a*x>=0; H linearity means equality; V:[1,x] vertex; V:[0,d] ray; V linearity means span(d)",
+            "homogeneous_rows": [
+              {
+                "kind": "EQUALITY",
+                "row": [
+                  "1",
+                  "0",
+                  "-3"
+                ]
+              },
+              {
+                "kind": "INEQUALITY",
+                "row": [
+                  "-1",
+                  "2",
+                  "0"
+                ]
+              }
+            ],
+            "equalities": [
+              [
+                "1",
+                "0",
+                "-3"
+              ]
+            ],
+            "inequalities": [
+              [
+                "-1",
+                "2",
+                "0"
+              ]
+            ],
+            "vertices": [],
+            "rays": [],
+            "lineality": []
+          },
+          "output": {
+            "representation": "V",
+            "ambient_dimension": 2,
+            "affine_dimension": 1,
+            "homogeneous_convention": "H:[b,a] means b+a*x>=0; H linearity means equality; V:[1,x] vertex; V:[0,d] ray; V linearity means span(d)",
+            "homogeneous_rows": [
+              {
+                "kind": "VERTEX",
+                "row": [
+                  "1",
+                  "1/2",
+                  "1/3"
+                ]
+              },
+              {
+                "kind": "RAY",
+                "row": [
+                  "0",
+                  "1",
+                  "0"
+                ]
+              }
+            ],
+            "equalities": [],
+            "inequalities": [],
+            "vertices": [
+              [
+                "1/2",
+                "1/3"
+              ]
+            ],
+            "rays": [
+              [
+                "1",
+                "0"
+              ]
+            ],
+            "lineality": []
+          },
+          "same_provider_roundtrip": {
+            "status": "MATCH",
+            "result": {
+              "representation": "H",
+              "ambient_dimension": 2,
+              "affine_dimension": 1,
+              "homogeneous_convention": "H:[b,a] means b+a*x>=0; H linearity means equality; V:[1,x] vertex; V:[0,d] ray; V linearity means span(d)",
+              "homogeneous_rows": [
+                {
+                  "kind": "EQUALITY",
+                  "row": [
+                    "1",
+                    "0",
+                    "-3"
+                  ]
+                },
+                {
+                  "kind": "INEQUALITY",
+                  "row": [
+                    "-1",
+                    "2",
+                    "0"
+                  ]
+                }
+              ],
+              "equalities": [
+                [
+                  "1",
+                  "0",
+                  "-3"
+                ]
+              ],
+              "inequalities": [
+                [
+                  "-1",
+                  "2",
+                  "0"
+                ]
+              ],
+              "vertices": [],
+              "rays": [],
+              "lineality": []
+            },
+            "independent": false
+          }
+        },
+        {
+          "case_id": "h_to_v_strip_lineality",
+          "conversion": "H_TO_V",
+          "input": {
+            "representation": "H",
+            "ambient_dimension": 2,
+            "affine_dimension": 2,
+            "homogeneous_convention": "H:[b,a] means b+a*x>=0; H linearity means equality; V:[1,x] vertex; V:[0,d] ray; V linearity means span(d)",
+            "homogeneous_rows": [
+              {
+                "kind": "INEQUALITY",
+                "row": [
+                  "0",
+                  "1",
+                  "0"
+                ]
+              },
+              {
+                "kind": "INEQUALITY",
+                "row": [
+                  "3",
+                  "-2",
+                  "0"
+                ]
+              }
+            ],
+            "equalities": [],
+            "inequalities": [
+              [
+                "0",
+                "1",
+                "0"
+              ],
+              [
+                "3",
+                "-2",
+                "0"
+              ]
+            ],
+            "vertices": [],
+            "rays": [],
+            "lineality": []
+          },
+          "output": {
+            "representation": "V",
+            "ambient_dimension": 2,
+            "affine_dimension": 2,
+            "homogeneous_convention": "H:[b,a] means b+a*x>=0; H linearity means equality; V:[1,x] vertex; V:[0,d] ray; V linearity means span(d)",
+            "homogeneous_rows": [
+              {
+                "kind": "VERTEX",
+                "row": [
+                  "1",
+                  "0",
+                  "0"
+                ]
+              },
+              {
+                "kind": "VERTEX",
+                "row": [
+                  "1",
+                  "3/2",
+                  "0"
+                ]
+              },
+              {
+                "kind": "LINEALITY",
+                "row": [
+                  "0",
+                  "0",
+                  "1"
+                ]
+              }
+            ],
+            "equalities": [],
+            "inequalities": [],
+            "vertices": [
+              [
+                "0",
+                "0"
+              ],
+              [
+                "3/2",
+                "0"
+              ]
+            ],
+            "rays": [],
+            "lineality": [
+              [
+                "0",
+                "1"
+              ]
+            ]
+          },
+          "same_provider_roundtrip": {
+            "status": "MATCH",
+            "result": {
+              "representation": "H",
+              "ambient_dimension": 2,
+              "affine_dimension": 2,
+              "homogeneous_convention": "H:[b,a] means b+a*x>=0; H linearity means equality; V:[1,x] vertex; V:[0,d] ray; V linearity means span(d)",
+              "homogeneous_rows": [
+                {
+                  "kind": "INEQUALITY",
+                  "row": [
+                    "0",
+                    "1",
+                    "0"
+                  ]
+                },
+                {
+                  "kind": "INEQUALITY",
+                  "row": [
+                    "3",
+                    "-2",
+                    "0"
+                  ]
+                }
+              ],
+              "equalities": [],
+              "inequalities": [
+                [
+                  "0",
+                  "1",
+                  "0"
+                ],
+                [
+                  "3",
+                  "-2",
+                  "0"
+                ]
+              ],
+              "vertices": [],
+              "rays": [],
+              "lineality": []
+            },
+            "independent": false
+          }
+        },
+        {
+          "case_id": "v_to_h_affine_ray",
+          "conversion": "V_TO_H",
+          "input": {
+            "representation": "V",
+            "ambient_dimension": 2,
+            "affine_dimension": 1,
+            "homogeneous_convention": "H:[b,a] means b+a*x>=0; H linearity means equality; V:[1,x] vertex; V:[0,d] ray; V linearity means span(d)",
+            "homogeneous_rows": [
+              {
+                "kind": "VERTEX",
+                "row": [
+                  "1",
+                  "1/2",
+                  "1/3"
+                ]
+              },
+              {
+                "kind": "RAY",
+                "row": [
+                  "0",
+                  "1",
+                  "0"
+                ]
+              }
+            ],
+            "equalities": [],
+            "inequalities": [],
+            "vertices": [
+              [
+                "1/2",
+                "1/3"
+              ]
+            ],
+            "rays": [
+              [
+                "1",
+                "0"
+              ]
+            ],
+            "lineality": []
+          },
+          "output": {
+            "representation": "H",
+            "ambient_dimension": 2,
+            "affine_dimension": 1,
+            "homogeneous_convention": "H:[b,a] means b+a*x>=0; H linearity means equality; V:[1,x] vertex; V:[0,d] ray; V linearity means span(d)",
+            "homogeneous_rows": [
+              {
+                "kind": "EQUALITY",
+                "row": [
+                  "1",
+                  "0",
+                  "-3"
+                ]
+              },
+              {
+                "kind": "INEQUALITY",
+                "row": [
+                  "-1",
+                  "2",
+                  "0"
+                ]
+              }
+            ],
+            "equalities": [
+              [
+                "1",
+                "0",
+                "-3"
+              ]
+            ],
+            "inequalities": [
+              [
+                "-1",
+                "2",
+                "0"
+              ]
+            ],
+            "vertices": [],
+            "rays": [],
+            "lineality": []
+          },
+          "same_provider_roundtrip": {
+            "status": "MATCH",
+            "result": {
+              "representation": "V",
+              "ambient_dimension": 2,
+              "affine_dimension": 1,
+              "homogeneous_convention": "H:[b,a] means b+a*x>=0; H linearity means equality; V:[1,x] vertex; V:[0,d] ray; V linearity means span(d)",
+              "homogeneous_rows": [
+                {
+                  "kind": "VERTEX",
+                  "row": [
+                    "1",
+                    "1/2",
+                    "1/3"
+                  ]
+                },
+                {
+                  "kind": "RAY",
+                  "row": [
+                    "0",
+                    "1",
+                    "0"
+                  ]
+                }
+              ],
+              "equalities": [],
+              "inequalities": [],
+              "vertices": [
+                [
+                  "1/2",
+                  "1/3"
+                ]
+              ],
+              "rays": [
+                [
+                  "1",
+                  "0"
+                ]
+              ],
+              "lineality": []
+            },
+            "independent": false
+          }
+        },
+        {
+          "case_id": "v_to_h_strip_lineality",
+          "conversion": "V_TO_H",
+          "input": {
+            "representation": "V",
+            "ambient_dimension": 2,
+            "affine_dimension": 2,
+            "homogeneous_convention": "H:[b,a] means b+a*x>=0; H linearity means equality; V:[1,x] vertex; V:[0,d] ray; V linearity means span(d)",
+            "homogeneous_rows": [
+              {
+                "kind": "VERTEX",
+                "row": [
+                  "1",
+                  "0",
+                  "0"
+                ]
+              },
+              {
+                "kind": "VERTEX",
+                "row": [
+                  "1",
+                  "3/2",
+                  "0"
+                ]
+              },
+              {
+                "kind": "LINEALITY",
+                "row": [
+                  "0",
+                  "0",
+                  "1"
+                ]
+              }
+            ],
+            "equalities": [],
+            "inequalities": [],
+            "vertices": [
+              [
+                "0",
+                "0"
+              ],
+              [
+                "3/2",
+                "0"
+              ]
+            ],
+            "rays": [],
+            "lineality": [
+              [
+                "0",
+                "1"
+              ]
+            ]
+          },
+          "output": {
+            "representation": "H",
+            "ambient_dimension": 2,
+            "affine_dimension": 2,
+            "homogeneous_convention": "H:[b,a] means b+a*x>=0; H linearity means equality; V:[1,x] vertex; V:[0,d] ray; V linearity means span(d)",
+            "homogeneous_rows": [
+              {
+                "kind": "INEQUALITY",
+                "row": [
+                  "0",
+                  "1",
+                  "0"
+                ]
+              },
+              {
+                "kind": "INEQUALITY",
+                "row": [
+                  "3",
+                  "-2",
+                  "0"
+                ]
+              }
+            ],
+            "equalities": [],
+            "inequalities": [
+              [
+                "0",
+                "1",
+                "0"
+              ],
+              [
+                "3",
+                "-2",
+                "0"
+              ]
+            ],
+            "vertices": [],
+            "rays": [],
+            "lineality": []
+          },
+          "same_provider_roundtrip": {
+            "status": "MATCH",
+            "result": {
+              "representation": "V",
+              "ambient_dimension": 2,
+              "affine_dimension": 2,
+              "homogeneous_convention": "H:[b,a] means b+a*x>=0; H linearity means equality; V:[1,x] vertex; V:[0,d] ray; V linearity means span(d)",
+              "homogeneous_rows": [
+                {
+                  "kind": "VERTEX",
+                  "row": [
+                    "1",
+                    "0",
+                    "0"
+                  ]
+                },
+                {
+                  "kind": "VERTEX",
+                  "row": [
+                    "1",
+                    "3/2",
+                    "0"
+                  ]
+                },
+                {
+                  "kind": "LINEALITY",
+                  "row": [
+                    "0",
+                    "0",
+                    "1"
+                  ]
+                }
+              ],
+              "equalities": [],
+              "inequalities": [],
+              "vertices": [
+                [
+                  "0",
+                  "0"
+                ],
+                [
+                  "3/2",
+                  "0"
+                ]
+              ],
+              "rays": [],
+              "lineality": [
+                [
+                  "0",
+                  "1"
+                ]
+              ]
+            },
+            "independent": false
+          }
+        }
+      ]
+    }
+  }
 }

--- a/benchmarks/datasets/provider-feasibility-v1/cddlib/tests/verifier.py
+++ b/benchmarks/datasets/provider-feasibility-v1/cddlib/tests/verifier.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 
@@ -14,6 +15,17 @@ if isinstance(submission, dict) and isinstance(submission.get("evidence"), list)
         expected_path="evidence/provider-report.json",
     )
 result = submission.get("result") if isinstance(submission, dict) else None
+
+
+def _canonical_json(payload: object) -> bytes:
+    return (
+        json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+        + "\n"
+    ).encode("ascii")
+
+
+def _sha256_bytes(payload: bytes) -> str:
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
 
 
 def _execution_bound(report: object) -> bool:
@@ -31,20 +43,45 @@ def _execution_bound(report: object) -> bool:
         return False
     provider = report.get("provider")
     reproduction = report.get("reproduction")
+    frozen = expected["reproduction"]
     if not isinstance(provider, dict) or not isinstance(reproduction, dict):
         return False
+    if not isinstance(frozen, dict):
+        return False
+    if reproduction.get("scope") != frozen["scope"]:
+        return False
     runtime = provider.get("runtime")
-    if not isinstance(runtime, dict) or not runtime:
+    versions = provider.get("versions")
+    if (
+        not isinstance(runtime, dict)
+        or not runtime
+        or versions != frozen["mathematical_output"]["versions"]
+    ):
+        return False
+    exact_arithmetic = reproduction.get("exact_arithmetic")
+    if not isinstance(exact_arithmetic, dict):
+        return False
+    if exact_arithmetic.get("large_fraction_input") != frozen["exact_arithmetic_probe"]:
+        return False
+    if (
+        exact_arithmetic.get("large_fraction_output")
+        != frozen["exact_arithmetic_probe"]
+    ):
         return False
     cases = reproduction.get("cases")
-    if not isinstance(cases, list) or not cases:
+    if cases != frozen["mathematical_output"]["cases"]:
         return False
-    output_digest = reproduction.get("provider_output_sha256")
-    if not (
-        isinstance(output_digest, str)
-        and output_digest.startswith("sha256:")
-        and len(output_digest) == 71
-    ):
+    mathematical_output = {
+        "contract": expected["contract"],
+        "provider": expected["provider"],
+        "versions": versions,
+        "exact_arithmetic": exact_arithmetic,
+        "cases": cases,
+    }
+    if mathematical_output != frozen["mathematical_output"]:
+        return False
+    mathematical_digest = _sha256_bytes(_canonical_json(mathematical_output))
+    if mathematical_digest != frozen["expected_mathematical_output_sha256"]:
         return False
     limitations = report.get("limitations")
     if not isinstance(limitations, list) or not limitations:

--- a/benchmarks/datasets/provider-feasibility-v1/cgal/tests/Dockerfile
+++ b/benchmarks/datasets/provider-feasibility-v1/cgal/tests/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
-LABEL jacobian.checksum="a7967326c7d097b0e603cf944e31cfc3ffbea183593383d386be6396835247d7"
+LABEL jacobian.checksum="5ad96c74b9ba96d5891d4e1d5de6bc95b50fb7d7d7b7cfb829bcd1d54c009244"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 RUN chmod +x /tests/test.sh

--- a/benchmarks/datasets/provider-feasibility-v1/cgal/tests/expected.json
+++ b/benchmarks/datasets/provider-feasibility-v1/cgal/tests/expected.json
@@ -20,5 +20,7 @@
       "expected_output_sha256": "sha256:a1cecc8c3781dfd8626e62da3d2ff4a4f974b31a3cb19c4baa23db0d11741ce9"
     }
   },
-  "task_id": "jacobian/cgal"
+  "task_id": "jacobian/cgal",
+  "adapter_source_sha256": "sha256:22c836bb7030f8f51fc20ec38b8ea0f8560f7546e703d17655a7f6f0c74c6768",
+  "archive_sha256": "sha256:f75d2b2486842fb47222c780c7241c262d392802d0811143c4e9b539972ee55b"
 }

--- a/benchmarks/datasets/provider-feasibility-v1/cgal/tests/verifier.py
+++ b/benchmarks/datasets/provider-feasibility-v1/cgal/tests/verifier.py
@@ -70,6 +70,13 @@ def _execution_bound(report: object) -> bool:
         return False
     if not _digest_ok(provider.get("executable_sha256")):
         return False
+    if provider.get("adapter_source_sha256") != expected["adapter_source_sha256"]:
+        return False
+    source = provider.get("source")
+    if not isinstance(source, dict):
+        return False
+    if source.get("archive_sha256") != expected["archive_sha256"]:
+        return False
     if set(reproductions) != {"unique", "cocircular"}:
         return False
     if not _case_bound("unique", reproductions.get("unique")):

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/environment/input.json
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/environment/input.json
@@ -2,5 +2,5 @@
   "task_id": "jacobian/gudhi",
   "provider": "gudhi",
   "contract": "jacobian.gudhi-persistence-spike/v1",
-  "pin_sha256": "sha256:1463f2cc07f189d7e12daa010b2bebd838756a7ec90a791901a62bdec9bcd552"
+  "pin_sha256": "sha256:329e57f50ad88ddbf2f6a3fe7cbbb0b5121be7c92a01d3a0b57db9241b1e6813"
 }

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/environment/pin.json
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/environment/pin.json
@@ -1,5 +1,5 @@
 {
-  "adapter_source_sha256": "sha256:9faf64ddf467696fc15a1f6e7dbf9d19ad89070656046a4b95a7f69ee932159e",
+  "adapter_source_sha256": "sha256:a6a8f83a0e6ebf6d4783506171e4f8f2be1c185a0a9032a7ff7ba3d2c4855131",
   "contract": "jacobian.gudhi-persistence-spike/v1",
   "documentation_url": "https://gudhi.inria.fr/python/3.13.0/simplex_tree_ref.html",
   "licensing_url": "https://gudhi.inria.fr/licensing/",

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/environment/spike.py
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/environment/spike.py
@@ -607,6 +607,10 @@ def run_spike(
             timeout_seconds=timeout_seconds,
         )
         provider_output = _parse_provider_output(output, pin)
+        mathematical_output = {
+            key: value for key, value in provider_output.items() if key != "runtime"
+        }
+        mathematical_digest = _sha256_bytes(_canonical_json(mathematical_output))
         prime = pin["reproduction"]["coefficient_prime"]
         independent = _independent_reduction(simplices, prime)
         if independent["pairs"] != provider_output["pairs"]:
@@ -638,6 +642,7 @@ def run_spike(
                 "rank_transport": "UNIQUE_INTEGER_RANKS_NOT_EXACT_VALUES",
                 "exact_value_source": "FROZEN_CANONICAL_INPUT",
                 "provider_output_sha256": _sha256_bytes(output),
+                "mathematical_output_sha256": mathematical_digest,
                 "pairs": provider_output["pairs"],
                 "filtration": provider_output["filtration"],
             },

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/environment/submission_schema.json
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/environment/submission_schema.json
@@ -14,7 +14,7 @@
         "provider": {"const": "gudhi"},
         "contract": {"const": "jacobian.gudhi-persistence-spike/v1"},
         "status": {"enum": ["COMPLETED", "TIMEOUT", "CANCELLED", "ERROR", "REJECTED"]},
-        "pin_sha256": {"const": "sha256:1463f2cc07f189d7e12daa010b2bebd838756a7ec90a791901a62bdec9bcd552"}
+        "pin_sha256": {"const": "sha256:329e57f50ad88ddbf2f6a3fe7cbbb0b5121be7c92a01d3a0b57db9241b1e6813"}
       }
     },
     "claimed_assurance": {"enum": ["UNVERIFIED","COMPUTED"]},

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/solution/solve.py
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/solution/solve.py
@@ -9,7 +9,7 @@ REPORT = APP / "evidence" / "provider-report.json"
 TASK_ID = "jacobian/gudhi"
 PROVIDER = "gudhi"
 CONTRACT = "jacobian.gudhi-persistence-spike/v1"
-PIN = "sha256:1463f2cc07f189d7e12daa010b2bebd838756a7ec90a791901a62bdec9bcd552"
+PIN = "sha256:329e57f50ad88ddbf2f6a3fe7cbbb0b5121be7c92a01d3a0b57db9241b1e6813"
 
 report = json.loads(REPORT.read_text())
 status = report.get("status", "ERROR")

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/Dockerfile
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
-LABEL jacobian.checksum="71914b032b097712cfe80745ad6efab90fe34aee9e210d6d92945b495911ed92"
+LABEL jacobian.checksum="fdcee93619002c2cf6afbb8a404473174db3c5b4612250abf7562b0448e5ba8f"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 RUN chmod +x /tests/test.sh

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/expected.json
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/expected.json
@@ -1,6 +1,6 @@
 {
   "contract": "jacobian.gudhi-persistence-spike/v1",
-  "pin_sha256": "sha256:1463f2cc07f189d7e12daa010b2bebd838756a7ec90a791901a62bdec9bcd552",
+  "pin_sha256": "sha256:329e57f50ad88ddbf2f6a3fe7cbbb0b5121be7c92a01d3a0b57db9241b1e6813",
   "provider": "gudhi",
   "report_assurance": "OBSERVED_PROVIDER_BEHAVIOR_WITH_INDEPENDENT_REPLAY",
   "report_conclusion": "SPIKE_PASSED_PRODUCTION_DEFERRED",

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/input.json
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/input.json
@@ -2,5 +2,5 @@
   "task_id": "jacobian/gudhi",
   "provider": "gudhi",
   "contract": "jacobian.gudhi-persistence-spike/v1",
-  "pin_sha256": "sha256:1463f2cc07f189d7e12daa010b2bebd838756a7ec90a791901a62bdec9bcd552"
+  "pin_sha256": "sha256:329e57f50ad88ddbf2f6a3fe7cbbb0b5121be7c92a01d3a0b57db9241b1e6813"
 }

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/public_contract.json
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/public_contract.json
@@ -57,7 +57,7 @@
             "const": "jacobian.gudhi-persistence-spike/v1"
           },
           "pin_sha256": {
-            "const": "sha256:1463f2cc07f189d7e12daa010b2bebd838756a7ec90a791901a62bdec9bcd552"
+            "const": "sha256:329e57f50ad88ddbf2f6a3fe7cbbb0b5121be7c92a01d3a0b57db9241b1e6813"
           },
           "provider": {
             "const": "gudhi"

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/verifier.py
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/verifier.py
@@ -73,6 +73,8 @@ def _execution_bound(report: object) -> bool:
     mathematical_digest = _sha256_bytes(_canonical_json(mathematical_output))
     if mathematical_digest != frozen["expected_mathematical_output_sha256"]:
         return False
+    if reproduction.get("mathematical_output_sha256") != mathematical_digest:
+        return False
     if not _digest_ok(reproduction.get("provider_output_sha256")):
         return False
     limitations = report.get("limitations")

--- a/benchmarks/datasets/provider-feasibility-v1/nauty/tests/Dockerfile
+++ b/benchmarks/datasets/provider-feasibility-v1/nauty/tests/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
-LABEL jacobian.checksum="3a331050935a642b86803b26a9a7e128609c09e9d8812ca98bfb2d4aad053c78"
+LABEL jacobian.checksum="a30b75b039561a6ed0c6d6bb5de70583a5f05b88b4d7fbcb3836d5197ced44ce"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 RUN chmod +x /tests/test.sh

--- a/benchmarks/datasets/provider-feasibility-v1/nauty/tests/expected.json
+++ b/benchmarks/datasets/provider-feasibility-v1/nauty/tests/expected.json
@@ -21,5 +21,20 @@
     "expected_output_sha256": "sha256:b809c405cd3b8fb3cc836a9e7471658a8cf02cbc258029bddbecc9f2caf2ea32",
     "observed_count": 11
   },
-  "task_id": "jacobian/nauty"
+  "task_id": "jacobian/nauty",
+  "canonicalization": {
+    "command": [
+      "labelg",
+      "-q"
+    ],
+    "expected_output_graph6": [
+      "CR",
+      "CR"
+    ],
+    "expected_output_sha256": "sha256:817bc1213291c8fbe5bd1c0301c12caca9388bbe1c8c65e1cdd519114e3c0a55",
+    "input_graph6": [
+      "Ch",
+      "CU"
+    ]
+  }
 }

--- a/benchmarks/datasets/provider-feasibility-v1/nauty/tests/verifier.py
+++ b/benchmarks/datasets/provider-feasibility-v1/nauty/tests/verifier.py
@@ -61,6 +61,30 @@ def _execution_bound(report: object) -> bool:
         return False
     if observed_digest != expected_digest:
         return False
+    canonicalization = report.get("canonicalization")
+    frozen_canonicalization = expected["canonicalization"]
+    if not isinstance(canonicalization, dict) or not isinstance(
+        frozen_canonicalization, dict
+    ):
+        return False
+    if canonicalization.get("command") != frozen_canonicalization["command"]:
+        return False
+    if (
+        canonicalization.get("expected_output_graph6")
+        != frozen_canonicalization["expected_output_graph6"]
+    ):
+        return False
+    if canonicalization.get("input_graph6") != frozen_canonicalization["input_graph6"]:
+        return False
+    canonical_digest = canonicalization.get("expected_output_sha256")
+    if canonical_digest != frozen_canonicalization["expected_output_sha256"]:
+        return False
+    if not _digest_ok(canonical_digest):
+        return False
+    if canonicalization.get("observed_output_sha256") != canonical_digest:
+        return False
+    if canonicalization.get("isomorphic_inputs_converged") is not True:
+        return False
     limitations = report.get("limitations")
     if not isinstance(limitations, list) or not limitations:
         return False

--- a/benchmarks/datasets/provider-feasibility-v1/regina/tests/Dockerfile
+++ b/benchmarks/datasets/provider-feasibility-v1/regina/tests/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
-LABEL jacobian.checksum="b00795964e81bd8cbe49ec3e2a03da70a3c623991816c253aea18f81bdc911cd"
+LABEL jacobian.checksum="c44df98d027b82cb8090d493159217aca21bfdc66c3a5c65f5e4a02899e427f5"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 RUN chmod +x /tests/test.sh

--- a/benchmarks/datasets/provider-feasibility-v1/regina/tests/expected.json
+++ b/benchmarks/datasets/provider-feasibility-v1/regina/tests/expected.json
@@ -4,5 +4,504 @@
   "contract": "jacobian.regina-outcomes-spike/v1",
   "pin_sha256": "sha256:188618c36f37e31609eb57158f6f8fba270f86c5c6520b816eda6b7634482563",
   "report_conclusion": "SPIKE_PASSED_PRODUCTION_DEFERRED",
-  "report_assurance": "OBSERVED_PROVIDER_BEHAVIOR_WITH_PARTIAL_INDEPENDENT_REPLAY"
+  "report_assurance": "OBSERVED_PROVIDER_BEHAVIOR_WITH_PARTIAL_INDEPENDENT_REPLAY",
+  "reproduction": {
+    "scope": "four answer-visible valid orientable 3-dimensional triangulations of at most two tetrahedra, plus standard-coordinate embedded vertex normal surfaces for L(2,1)",
+    "cases": [
+      {
+        "case_id": "three_sphere",
+        "iso_sig": "cPcbbbaaa",
+        "maximum_tetrahedra": 2
+      },
+      {
+        "case_id": "lens_l2_1",
+        "iso_sig": "cMcabbgqw",
+        "maximum_tetrahedra": 2
+      },
+      {
+        "case_id": "s2_cross_s1",
+        "iso_sig": "cMcabbjaj",
+        "maximum_tetrahedra": 2
+      },
+      {
+        "case_id": "three_ball",
+        "iso_sig": "baa",
+        "maximum_tetrahedra": 1
+      }
+    ],
+    "normal_surface_case_id": "lens_l2_1",
+    "expected_provider_output": {
+      "cases": [
+        {
+          "canonical_iso_sig": "cPcbbbaaa",
+          "case_id": "three_sphere",
+          "closed": true,
+          "connected": true,
+          "f_vector": [
+            4,
+            6,
+            4,
+            2
+          ],
+          "facet_gluings": [
+            [
+              {
+                "facet": 0,
+                "permutation": [
+                  0,
+                  1,
+                  2,
+                  3
+                ],
+                "tetrahedron": 1
+              },
+              {
+                "facet": 1,
+                "permutation": [
+                  0,
+                  1,
+                  2,
+                  3
+                ],
+                "tetrahedron": 1
+              },
+              {
+                "facet": 2,
+                "permutation": [
+                  0,
+                  1,
+                  2,
+                  3
+                ],
+                "tetrahedron": 1
+              },
+              {
+                "facet": 3,
+                "permutation": [
+                  0,
+                  1,
+                  2,
+                  3
+                ],
+                "tetrahedron": 1
+              }
+            ],
+            [
+              {
+                "facet": 0,
+                "permutation": [
+                  0,
+                  1,
+                  2,
+                  3
+                ],
+                "tetrahedron": 0
+              },
+              {
+                "facet": 1,
+                "permutation": [
+                  0,
+                  1,
+                  2,
+                  3
+                ],
+                "tetrahedron": 0
+              },
+              {
+                "facet": 2,
+                "permutation": [
+                  0,
+                  1,
+                  2,
+                  3
+                ],
+                "tetrahedron": 0
+              },
+              {
+                "facet": 3,
+                "permutation": [
+                  0,
+                  1,
+                  2,
+                  3
+                ],
+                "tetrahedron": 0
+              }
+            ]
+          ],
+          "homology_1": {
+            "free_rank": 0,
+            "torsion_invariant_factors": []
+          },
+          "input_iso_sig": "cPcbbbaaa",
+          "orientable": true,
+          "recognition": {
+            "is_three_ball": false,
+            "is_three_sphere": true
+          },
+          "tetrahedra": 2,
+          "valid": true
+        },
+        {
+          "canonical_iso_sig": "cMcabbgqw",
+          "case_id": "lens_l2_1",
+          "closed": true,
+          "connected": true,
+          "f_vector": [
+            1,
+            3,
+            4,
+            2
+          ],
+          "facet_gluings": [
+            [
+              {
+                "facet": 1,
+                "permutation": [
+                  1,
+                  0,
+                  2,
+                  3
+                ],
+                "tetrahedron": 0
+              },
+              {
+                "facet": 0,
+                "permutation": [
+                  1,
+                  0,
+                  2,
+                  3
+                ],
+                "tetrahedron": 0
+              },
+              {
+                "facet": 2,
+                "permutation": [
+                  0,
+                  1,
+                  2,
+                  3
+                ],
+                "tetrahedron": 1
+              },
+              {
+                "facet": 1,
+                "permutation": [
+                  2,
+                  3,
+                  0,
+                  1
+                ],
+                "tetrahedron": 1
+              }
+            ],
+            [
+              {
+                "facet": 3,
+                "permutation": [
+                  3,
+                  2,
+                  0,
+                  1
+                ],
+                "tetrahedron": 1
+              },
+              {
+                "facet": 3,
+                "permutation": [
+                  2,
+                  3,
+                  0,
+                  1
+                ],
+                "tetrahedron": 0
+              },
+              {
+                "facet": 2,
+                "permutation": [
+                  0,
+                  1,
+                  2,
+                  3
+                ],
+                "tetrahedron": 0
+              },
+              {
+                "facet": 0,
+                "permutation": [
+                  2,
+                  3,
+                  1,
+                  0
+                ],
+                "tetrahedron": 1
+              }
+            ]
+          ],
+          "homology_1": {
+            "free_rank": 0,
+            "torsion_invariant_factors": [
+              "2"
+            ]
+          },
+          "input_iso_sig": "cMcabbgqw",
+          "orientable": true,
+          "recognition": {
+            "is_three_ball": false,
+            "is_three_sphere": false
+          },
+          "tetrahedra": 2,
+          "valid": true
+        },
+        {
+          "canonical_iso_sig": "cMcabbjaj",
+          "case_id": "s2_cross_s1",
+          "closed": true,
+          "connected": true,
+          "f_vector": [
+            1,
+            3,
+            4,
+            2
+          ],
+          "facet_gluings": [
+            [
+              {
+                "facet": 1,
+                "permutation": [
+                  1,
+                  2,
+                  3,
+                  0
+                ],
+                "tetrahedron": 0
+              },
+              {
+                "facet": 0,
+                "permutation": [
+                  3,
+                  0,
+                  1,
+                  2
+                ],
+                "tetrahedron": 0
+              },
+              {
+                "facet": 2,
+                "permutation": [
+                  0,
+                  1,
+                  2,
+                  3
+                ],
+                "tetrahedron": 1
+              },
+              {
+                "facet": 3,
+                "permutation": [
+                  0,
+                  1,
+                  2,
+                  3
+                ],
+                "tetrahedron": 1
+              }
+            ],
+            [
+              {
+                "facet": 1,
+                "permutation": [
+                  1,
+                  2,
+                  3,
+                  0
+                ],
+                "tetrahedron": 1
+              },
+              {
+                "facet": 0,
+                "permutation": [
+                  3,
+                  0,
+                  1,
+                  2
+                ],
+                "tetrahedron": 1
+              },
+              {
+                "facet": 2,
+                "permutation": [
+                  0,
+                  1,
+                  2,
+                  3
+                ],
+                "tetrahedron": 0
+              },
+              {
+                "facet": 3,
+                "permutation": [
+                  0,
+                  1,
+                  2,
+                  3
+                ],
+                "tetrahedron": 0
+              }
+            ]
+          ],
+          "homology_1": {
+            "free_rank": 1,
+            "torsion_invariant_factors": []
+          },
+          "input_iso_sig": "cMcabbjaj",
+          "orientable": true,
+          "recognition": {
+            "is_three_ball": false,
+            "is_three_sphere": false
+          },
+          "tetrahedra": 2,
+          "valid": true
+        },
+        {
+          "canonical_iso_sig": "baa",
+          "case_id": "three_ball",
+          "closed": false,
+          "connected": true,
+          "f_vector": [
+            4,
+            6,
+            4,
+            1
+          ],
+          "facet_gluings": [
+            [
+              null,
+              null,
+              null,
+              null
+            ]
+          ],
+          "homology_1": {
+            "free_rank": 0,
+            "torsion_invariant_factors": []
+          },
+          "input_iso_sig": "baa",
+          "orientable": true,
+          "recognition": {
+            "is_three_ball": true,
+            "is_three_sphere": false
+          },
+          "tetrahedra": 1,
+          "valid": true
+        }
+      ],
+      "contract": "jacobian.regina-outcomes-spike/v1",
+      "distribution_version": "7.4.1",
+      "normal_surfaces": {
+        "coordinate_system": "STANDARD_7N",
+        "list_kind": "VERTEX_EMBEDDED_ONLY",
+        "observed_algorithm_flags": "0x0011",
+        "surface_count": 4,
+        "surfaces": [
+          {
+            "compact": true,
+            "connected": true,
+            "coordinates": [
+              "0",
+              "0",
+              "0",
+              "0",
+              "1",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "1",
+              "0",
+              "0"
+            ],
+            "euler_characteristic": -1,
+            "has_real_boundary": false,
+            "orientable": false
+          },
+          {
+            "compact": true,
+            "connected": true,
+            "coordinates": [
+              "0",
+              "0",
+              "1",
+              "1",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "0",
+              "1",
+              "0",
+              "0"
+            ],
+            "euler_characteristic": 1,
+            "has_real_boundary": false,
+            "orientable": false
+          },
+          {
+            "compact": true,
+            "connected": true,
+            "coordinates": [
+              "1",
+              "1",
+              "0",
+              "0",
+              "1",
+              "0",
+              "0",
+              "1",
+              "1",
+              "1",
+              "1",
+              "0",
+              "0",
+              "0"
+            ],
+            "euler_characteristic": 0,
+            "has_real_boundary": false,
+            "orientable": true
+          },
+          {
+            "compact": true,
+            "connected": true,
+            "coordinates": [
+              "1",
+              "1",
+              "1",
+              "1",
+              "0",
+              "0",
+              "0",
+              "1",
+              "1",
+              "1",
+              "1",
+              "0",
+              "0",
+              "0"
+            ],
+            "euler_characteristic": 2,
+            "has_real_boundary": false,
+            "orientable": true
+          }
+        ],
+        "triangulation_case_id": "lens_l2_1"
+      },
+      "provider": "regina"
+    },
+    "expected_mathematical_output_sha256": "sha256:5937e30dcc04370a2d7201ada568f8fdaac46906d4234d75d580fc80a68cc2a8"
+  }
 }

--- a/benchmarks/datasets/provider-feasibility-v1/regina/tests/verifier.py
+++ b/benchmarks/datasets/provider-feasibility-v1/regina/tests/verifier.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 
@@ -14,6 +15,17 @@ if isinstance(submission, dict) and isinstance(submission.get("evidence"), list)
         expected_path="evidence/provider-report.json",
     )
 result = submission.get("result") if isinstance(submission, dict) else None
+
+
+def _canonical_json(payload: object) -> bytes:
+    return (
+        json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+        + "\n"
+    ).encode("ascii")
+
+
+def _sha256_bytes(payload: bytes) -> str:
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
 
 
 def _execution_bound(report: object) -> bool:
@@ -31,20 +43,35 @@ def _execution_bound(report: object) -> bool:
         return False
     provider = report.get("provider")
     reproduction = report.get("reproduction")
+    frozen = expected["reproduction"]
     if not isinstance(provider, dict) or not isinstance(reproduction, dict):
         return False
+    if not isinstance(frozen, dict):
+        return False
+    if reproduction.get("scope") != frozen["scope"]:
+        return False
     runtime = provider.get("runtime")
+    distribution_version = provider.get("distribution_version")
     if not isinstance(runtime, dict) or not runtime:
         return False
     cases = reproduction.get("cases")
-    if not isinstance(cases, list) or not cases:
+    normal_surfaces = reproduction.get("normal_surfaces")
+    expected_output = frozen["expected_provider_output"]
+    if cases != expected_output["cases"]:
         return False
-    output_digest = reproduction.get("provider_output_sha256")
-    if not (
-        isinstance(output_digest, str)
-        and output_digest.startswith("sha256:")
-        and len(output_digest) == 71
-    ):
+    if normal_surfaces != expected_output["normal_surfaces"]:
+        return False
+    mathematical_output = {
+        "contract": expected["contract"],
+        "provider": expected["provider"],
+        "distribution_version": distribution_version,
+        "cases": cases,
+        "normal_surfaces": normal_surfaces,
+    }
+    if mathematical_output != expected_output:
+        return False
+    mathematical_digest = _sha256_bytes(_canonical_json(mathematical_output))
+    if mathematical_digest != frozen["expected_mathematical_output_sha256"]:
         return False
     limitations = report.get("limitations")
     if not isinstance(limitations, list) or not limitations:

--- a/benchmarks/validation/test_verifier_security_regressions.py
+++ b/benchmarks/validation/test_verifier_security_regressions.py
@@ -356,6 +356,69 @@ def _provider_report_case(tmp_path: Path, task_name: str, report: dict) -> tuple
     return task, app, logs
 
 
+def test_cddlib_rejects_fabricated_nonempty_cases(tmp_path: Path) -> None:
+    expected = json.loads(
+        (
+            DATASETS / "provider-feasibility-v1" / "cddlib" / "tests" / "expected.json"
+        ).read_text()
+    )
+    frozen = expected["reproduction"]
+    fake_digest = "sha256:" + ("0" * 64)
+    report = {
+        "contract": expected["contract"],
+        "status": "COMPLETED",
+        "conclusion": expected["report_conclusion"],
+        "assurance": expected["report_assurance"],
+        "provider": {
+            "runtime": {"python": "3.12.0"},
+            "versions": frozen["mathematical_output"]["versions"],
+        },
+        "reproduction": {
+            "scope": frozen["scope"],
+            "provider_output_sha256": fake_digest,
+            "cases": [{"case_id": "fabricated"}],
+        },
+        "limitations": ["fabricated"],
+        "extra": True,
+    }
+    task, app, logs = _provider_report_case(tmp_path, "cddlib", report)
+    rejected = support._run_verifier(task, app, logs)
+    assert rejected["reward"] == 0.0
+
+
+def test_regina_rejects_fabricated_nonempty_cases(tmp_path: Path) -> None:
+    expected = json.loads(
+        (
+            DATASETS / "provider-feasibility-v1" / "regina" / "tests" / "expected.json"
+        ).read_text()
+    )
+    frozen = expected["reproduction"]
+    fake_digest = "sha256:" + ("0" * 64)
+    report = {
+        "contract": expected["contract"],
+        "status": "COMPLETED",
+        "conclusion": expected["report_conclusion"],
+        "assurance": expected["report_assurance"],
+        "provider": {
+            "runtime": {"python": "3.12.0"},
+            "distribution_version": frozen["expected_provider_output"][
+                "distribution_version"
+            ],
+        },
+        "reproduction": {
+            "scope": frozen["scope"],
+            "provider_output_sha256": fake_digest,
+            "cases": [{"case_id": "fabricated"}],
+            "normal_surfaces": {"surface_count": 0, "surfaces": []},
+        },
+        "limitations": ["fabricated"],
+        "extra": True,
+    }
+    task, app, logs = _provider_report_case(tmp_path, "regina", report)
+    rejected = support._run_verifier(task, app, logs)
+    assert rejected["reward"] == 0.0
+
+
 def test_cgal_rejects_fabricated_reproduction_digests(tmp_path: Path) -> None:
     expected = json.loads(
         (
@@ -377,6 +440,39 @@ def test_cgal_rejects_fabricated_reproduction_digests(tmp_path: Path) -> None:
                 **case,
                 "observed_output_sha256": fake_digest,
                 "expected_output_sha256": fake_digest,
+            }
+            for name, case in expected["reproductions"].items()
+        },
+        "limitations": ["fabricated"],
+        "extra": True,
+    }
+    task, app, logs = _provider_report_case(tmp_path, "cgal", report)
+    rejected = support._run_verifier(task, app, logs)
+    assert rejected["reward"] == 0.0
+
+
+def test_cgal_rejects_unbound_source_and_adapter_identity(tmp_path: Path) -> None:
+    expected = json.loads(
+        (
+            DATASETS / "provider-feasibility-v1" / "cgal" / "tests" / "expected.json"
+        ).read_text()
+    )
+    fake_digest = "sha256:" + ("0" * 64)
+    report = {
+        "contract": expected["contract"],
+        "status": "COMPLETED",
+        "conclusion": expected["report_conclusion"],
+        "assurance": expected["report_assurance"],
+        "provider": {
+            "executable": "/usr/local/bin/cgal-spike",
+            "executable_sha256": fake_digest,
+            "adapter_source_sha256": fake_digest,
+            "source": {"archive_sha256": fake_digest},
+        },
+        "reproductions": {
+            name: {
+                **case,
+                "observed_output_sha256": case["expected_output_sha256"],
             }
             for name, case in expected["reproductions"].items()
         },
@@ -416,6 +512,34 @@ def test_gudhi_rejects_fabricated_persistence_shape(tmp_path: Path) -> None:
     assert rejected["reward"] == 0.0
 
 
+def test_gudhi_rejects_missing_mathematical_output_digest(tmp_path: Path) -> None:
+    expected = json.loads(
+        (
+            DATASETS / "provider-feasibility-v1" / "gudhi" / "tests" / "expected.json"
+        ).read_text()
+    )
+    fake_digest = "sha256:" + ("0" * 64)
+    report = {
+        "contract": expected["contract"],
+        "status": "COMPLETED",
+        "conclusion": expected["report_conclusion"],
+        "assurance": expected["report_assurance"],
+        "provider": {
+            "runtime": {"gudhi": "3.13.0", "python": "3.12.0", "numpy": "2.0"}
+        },
+        "reproduction": {
+            "pairs": expected["reproduction"]["pairs"],
+            "filtration": expected["reproduction"]["filtration"],
+            "provider_output_sha256": fake_digest,
+        },
+        "limitations": ["fabricated"],
+        "extra": True,
+    }
+    task, app, logs = _provider_report_case(tmp_path, "gudhi", report)
+    rejected = support._run_verifier(task, app, logs)
+    assert rejected["reward"] == 0.0
+
+
 def test_nauty_rejects_fabricated_count_and_digests(tmp_path: Path) -> None:
     expected = json.loads(
         (
@@ -437,6 +561,40 @@ def test_nauty_rejects_fabricated_count_and_digests(tmp_path: Path) -> None:
             "observed_output_sha256": fake_digest,
             "expected_output_sha256": fake_digest,
         },
+        "limitations": ["fabricated"],
+        "extra": True,
+    }
+    task, app, logs = _provider_report_case(tmp_path, "nauty", report)
+    rejected = support._run_verifier(task, app, logs)
+    assert rejected["reward"] == 0.0
+
+
+def test_nauty_rejects_unbound_canonicalization(tmp_path: Path) -> None:
+    expected = json.loads(
+        (
+            DATASETS / "provider-feasibility-v1" / "nauty" / "tests" / "expected.json"
+        ).read_text()
+    )
+    fake_digest = "sha256:" + ("0" * 64)
+    reproduction = expected["reproduction"]
+    canonicalization = {
+        **expected["canonicalization"],
+        "observed_output_sha256": fake_digest,
+        "isomorphic_inputs_converged": True,
+    }
+    report = {
+        "contract": expected["contract"],
+        "status": "COMPLETED",
+        "conclusion": expected["report_conclusion"],
+        "assurance": expected["report_assurance"],
+        "provider": {
+            "executables": {"geng": {"path": "/bin/geng", "sha256": fake_digest}}
+        },
+        "reproduction": {
+            **reproduction,
+            "observed_output_sha256": reproduction["expected_output_sha256"],
+        },
+        "canonicalization": canonicalization,
         "limitations": ["fabricated"],
         "extra": True,
     }

--- a/tools/c901-baseline.json
+++ b/tools/c901-baseline.json
@@ -165,11 +165,7 @@
     {
       "path": "benchmarks/datasets/provider-feasibility-v1/cgal/tests/verifier.py",
       "symbol": "_execution_bound",
-<<<<<<< HEAD
-      "complexity": 11
-=======
       "complexity": 16
->>>>>>> c1d1fab9 (Bind provider verifier evidence to frozen outputs)
     },
     {
       "path": "benchmarks/datasets/provider-feasibility-v1/gudhi/environment/spike.py",
@@ -179,20 +175,12 @@
     {
       "path": "benchmarks/datasets/provider-feasibility-v1/gudhi/tests/verifier.py",
       "symbol": "_execution_bound",
-<<<<<<< HEAD
-      "complexity": 11
-=======
       "complexity": 16
->>>>>>> c1d1fab9 (Bind provider verifier evidence to frozen outputs)
     },
     {
       "path": "benchmarks/datasets/provider-feasibility-v1/nauty/tests/verifier.py",
       "symbol": "_execution_bound",
-<<<<<<< HEAD
-      "complexity": 11
-=======
       "complexity": 25
->>>>>>> c1d1fab9 (Bind provider verifier evidence to frozen outputs)
     },
     {
       "path": "benchmarks/datasets/provider-feasibility-v1/regina/environment/spike.py",

--- a/tools/c901-baseline.json
+++ b/tools/c901-baseline.json
@@ -160,12 +160,16 @@
     {
       "path": "benchmarks/datasets/provider-feasibility-v1/cddlib/tests/verifier.py",
       "symbol": "_execution_bound",
-      "complexity": 11
+      "complexity": 17
     },
     {
       "path": "benchmarks/datasets/provider-feasibility-v1/cgal/tests/verifier.py",
       "symbol": "_execution_bound",
+<<<<<<< HEAD
       "complexity": 11
+=======
+      "complexity": 16
+>>>>>>> c1d1fab9 (Bind provider verifier evidence to frozen outputs)
     },
     {
       "path": "benchmarks/datasets/provider-feasibility-v1/gudhi/environment/spike.py",
@@ -175,12 +179,20 @@
     {
       "path": "benchmarks/datasets/provider-feasibility-v1/gudhi/tests/verifier.py",
       "symbol": "_execution_bound",
+<<<<<<< HEAD
       "complexity": 11
+=======
+      "complexity": 16
+>>>>>>> c1d1fab9 (Bind provider verifier evidence to frozen outputs)
     },
     {
       "path": "benchmarks/datasets/provider-feasibility-v1/nauty/tests/verifier.py",
       "symbol": "_execution_bound",
+<<<<<<< HEAD
       "complexity": 11
+=======
+      "complexity": 25
+>>>>>>> c1d1fab9 (Bind provider verifier evidence to frozen outputs)
     },
     {
       "path": "benchmarks/datasets/provider-feasibility-v1/regina/environment/spike.py",
@@ -190,7 +202,7 @@
     {
       "path": "benchmarks/datasets/provider-feasibility-v1/regina/tests/verifier.py",
       "symbol": "_execution_bound",
-      "complexity": 11
+      "complexity": 15
     },
     {
       "path": "benchmarks/datasets/public-reproductions-v1/superposition-proof-replay/tests/verifier.py",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to merged #683. That merge published `/app/input.json` and bound CGAL/GUDHI/nauty reproductions, but review still found weak acceptance paths on cddlib/regina and incomplete digests/canonicalization/adapter identity checks.

This PR:

- Binds cddlib and Regina verifier rewards to frozen reproduction cases and mathematical digests
- Requires GUDHI `mathematical_output_sha256` to match the recomputed frozen digest
- Binds Nauty `canonicalization` evidence alongside `geng` reproduction
- Binds CGAL adapter/source archive identity from the frozen pin
- Extends fabricated-report host regressions and refreshes verifier Dockerfile checksums / C901 baseline

## Test plan

- [x] `make harbor-validation-tests TESTS=benchmarks/validation/test_verifier_security_regressions.py`
- [x] `make complexity-check`
- [ ] CI provider Oracle + host verifier lanes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4659d0d-120b-4b4b-91ab-2d6695b69e52?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4659d0d-120b-4b4b-91ab-2d6695b69e52&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

