### PR TITLE
fix(verification): include metadata for supporting certificate artifacts

### DIFF
--- a/src/jacobian/verification/service.py
+++ b/src/jacobian/verification/service.py
@@ -626,7 +626,10 @@ class VerificationService:
             }
             if supporting_artifacts:
                 request["supporting_artifacts"] = [
-                    self._checker_artifact(artifact)
+                    self._checker_artifact(
+                        artifact,
+                        include_storage_metadata=include_artifact_metadata,
+                    )
                     for artifact in supporting_artifacts
                 ]
             request_digest = _digest_bytes(canonicalize_json(request))

--- a/tests/component/checkers/_fixture_checkers.py
+++ b/tests/component/checkers/_fixture_checkers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import os
 from typing import Any
 
@@ -100,5 +101,33 @@ def check_parameter_region_certificate(request: dict[str, Any]) -> dict[str, Any
             "certificate proves the exact parameter-region subject"
             if accepted
             else "certificate does not prove the bound parameter region"
+        ),
+    }
+
+
+def check_supporting_artifact_metadata(request: dict[str, Any]) -> dict[str, Any]:
+    supporting_artifacts = request.get("supporting_artifacts")
+    support = (
+        supporting_artifacts[0]
+        if isinstance(supporting_artifacts, list) and len(supporting_artifacts) == 1
+        else None
+    )
+    accepted = (
+        request.get("request_version") == "1"
+        and isinstance(support, dict)
+        and support.get("payload_digest")
+        == "sha256:" + hashlib.sha256(b'{"kind":"supporting-evidence"}').hexdigest()
+        and support.get("parents") == []
+    )
+    return {
+        "accepted": accepted,
+        "conclusion": "FALSE" if accepted else "UNKNOWN",
+        "arithmetic": "EXACT_INTEGER",
+        "method": "CHECKED_CERTIFICATE",
+        "coverage": "EXHAUSTIVE",
+        "detail": (
+            "supporting artifact includes its requested storage metadata"
+            if accepted
+            else "supporting artifact storage metadata is missing or incomplete"
         ),
     }

--- a/tests/component/checkers/test_certificate_verification.py
+++ b/tests/component/checkers/test_certificate_verification.py
@@ -14,6 +14,8 @@ from jacobian.verification import VerificationService
 
 def _certificate_case(
     tmp_path: Path,
+    *,
+    checker_entrypoint: str = "jacobian_checkers.graph_paths:check_path_enumeration",
 ) -> tuple[ArtifactRepository, VerificationService, str]:
     store = ArtifactRepository(tmp_path)
     claim_schema = store.register_descriptor(
@@ -113,7 +115,7 @@ def _certificate_case(
     registry = CheckerRegistry(store)
     registry.authorize(
         name="graph-path-enumeration-v1",
-        entrypoint="jacobian_checkers.graph_paths:check_path_enumeration",
+        entrypoint=checker_entrypoint,
         evidence_kind="CERTIFICATE",
         format_id="graph.path_enumeration",
         format_version="1",
@@ -137,6 +139,39 @@ def test_complete_path_enumeration_certificate_is_verified(tmp_path: Path) -> No
     assert result.conclusion is Conclusion.FALSE
     assert result.assurance.verification is Verification.VERIFIED
     assert result.assurance.coverage.value == "EXHAUSTIVE"
+
+
+def test_certificate_supporting_artifacts_include_requested_storage_metadata(
+    tmp_path: Path,
+) -> None:
+    store, service, certificate_uri = _certificate_case(
+        tmp_path,
+        checker_entrypoint=(
+            "tests.component.checkers._fixture_checkers:"
+            "check_supporting_artifact_metadata"
+        ),
+    )
+    certificate = store.get(certificate_uri)
+    supporting_schema = store.register_descriptor(
+        kind="schema",
+        name="graph.path-enumeration.supporting-evidence",
+        version="1",
+        definition={"type": "object"},
+    )
+    supporting_artifact = store.put(
+        schema_uri=supporting_schema,
+        semantics_uri=certificate.manifest.semantics_uri,
+        payload={"kind": "supporting-evidence"},
+    )
+
+    result = service.verify_certificate(
+        certificate_uri=certificate_uri,
+        supporting_artifact_uris=(supporting_artifact.artifact_uri,),
+        include_artifact_metadata=True,
+    )
+
+    assert result.conclusion is Conclusion.FALSE
+    assert result.assurance.verification is Verification.VERIFIED
 
 
 def test_certificate_binding_substitution_is_rejected(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #660.

## Problem

`verify_certificate(..., include_artifact_metadata=True)` included storage metadata for the certificate and other verifier inputs, but not for `supporting_artifacts`. Checkers that rely on `payload_digest` or `parents` therefore received an inconsistent request shape despite the caller explicitly enabling metadata.

## Change

Thread the existing metadata flag through supporting-artifact serialization. This keeps the current request format when metadata is disabled and makes every artifact in certificate verification honor the same option when it is enabled.

The regression uses an independently executed fixture checker that requires the supporting artifact's exact payload digest and parent list. That binds the test to the checker request contract rather than the serialization helper's implementation.

## Validation

- Base regression proof: the new checker case returned `UNKNOWN` on `25141d0e293ea0d8023273cea3ad20049ef47340` because supporting metadata was absent.
- Focused regression: 1 passed; complete certificate-verification module: 5 passed.
- Selected product lanes: unit 721 passed; component 707 passed; domain 162 passed; composition 457 passed / 2 expected Lean skips; storage 114 passed; process 227 passed; MCP 36 passed; end-to-end 8 passed / 1 expected Lean skip.
- Ruff lint and formatting, dependency analysis, vulture, mypy, test architecture, TODO checks, and package build passed.

## Current-main gate failures

The aggregate static target is not green on current main (`41504be7ac07cb6d9983a5ba81750c1c851b316c`). Both failures reproduce unchanged outside this branch:

- `complexity-check` reports stale baselines for three provider-feasibility verifier functions.
- `architecture` reports direct-subprocess violations in ten conjecture host-validation tests.

This branch does not touch those benchmark files or gate configuration.