### PR TITLE
fix(runtime): attempt every runtime teardown stage after close failures

### DIFF
--- a/src/jacobian/runtime/model.py
+++ b/src/jacobian/runtime/model.py
@@ -59,9 +59,18 @@ class JacobianRuntime:
 
         if self._closed:
             return
-        self.services.close()
-        self.portfolio.close()
-        self.core.close()
+        failures: list[Exception] = []
+        for close in (
+            self.services.close,
+            self.portfolio.close,
+            self.core.close,
+        ):
+            try:
+                close()
+            except Exception as exc:
+                failures.append(exc)
+        if failures:
+            raise ExceptionGroup("runtime resources failed to close", failures)
         self._closed = True
 
     def __enter__(self) -> JacobianRuntime:

--- a/tests/composition/runtime/test_runtime_lifecycle.py
+++ b/tests/composition/runtime/test_runtime_lifecycle.py
@@ -21,8 +21,10 @@ from pydantic import ValidationError
 from jacobian.contracts.discovery import ExperimentHandle
 from jacobian.contracts.search import ExperimentState
 from jacobian.experiments import ExperimentError, ExperimentService
+from jacobian.portfolio.result import PortfolioInstallation
 from jacobian.runtime import create_runtime
 from jacobian.runtime.model import RuntimeClosedError
+from jacobian.runtime.services import ApplicationServices, CoreServices
 from jacobian.search import SearchError, SearchService
 from jacobian.storage.errors import StorageClosedError
 
@@ -474,21 +476,26 @@ def test_close_failure_keeps_store_closable_on_retry(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     # Regression test: JacobianRuntime.close() must set its closed marker only
-    # after core.close() succeeds. If service close raises, the runtime
-    # must remain closable so a retry can still release the underlying store.
+    # after core.close() succeeds. If core close raises, the runtime must remain
+    # closable so a retry can still release the underlying store.
     runtime = create_runtime(tmp_path)
     store = runtime.core.store
 
     def failing_close(self: object) -> None:
-        raise RuntimeError("service close failed")
+        raise RuntimeError("core close failed")
 
     monkeypatch.setattr(
         "jacobian.runtime.services.CoreServices.close",
         failing_close,
     )
 
-    with pytest.raises(RuntimeError, match="service close failed"):
+    with pytest.raises(
+        ExceptionGroup, match="runtime resources failed to close"
+    ) as exc:
         runtime.close()
+    assert [str(failure) for failure in exc.value.exceptions] == [
+        "core close failed",
+    ]
 
     # The store was not closed by the failed runtime close. Retrying the
     # runtime close (with the real service close restored) must eventually
@@ -498,3 +505,52 @@ def test_close_failure_keeps_store_closable_on_retry(
 
     with pytest.raises(StorageClosedError), store.connection():
         pass
+
+
+def test_close_attempts_every_owner_before_raising_failures(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = create_runtime(tmp_path)
+    store = runtime.core.store
+    close_order: list[str] = []
+    services_close = ApplicationServices.close
+    portfolio_close = PortfolioInstallation.close
+    core_close = CoreServices.close
+
+    def fail_after_services_close(self: ApplicationServices) -> None:
+        close_order.append("services")
+        services_close(self)
+        raise RuntimeError("services close failed")
+
+    def fail_after_portfolio_close(self: PortfolioInstallation) -> None:
+        close_order.append("portfolio")
+        portfolio_close(self)
+        raise RuntimeError("portfolio close failed")
+
+    def fail_after_core_close(self: CoreServices) -> None:
+        close_order.append("core")
+        core_close(self)
+        raise RuntimeError("core close failed")
+
+    monkeypatch.setattr(ApplicationServices, "close", fail_after_services_close)
+    monkeypatch.setattr(PortfolioInstallation, "close", fail_after_portfolio_close)
+    monkeypatch.setattr(CoreServices, "close", fail_after_core_close)
+
+    with pytest.raises(
+        ExceptionGroup, match="runtime resources failed to close"
+    ) as exc:
+        runtime.close()
+
+    assert close_order == ["services", "portfolio", "core"]
+    assert [str(failure) for failure in exc.value.exceptions] == [
+        "services close failed",
+        "portfolio close failed",
+        "core close failed",
+    ]
+    with pytest.raises(StorageClosedError), store.connection():
+        pass
+
+    monkeypatch.undo()
+    runtime.close()
+    runtime.close()


### PR DESCRIPTION
Fixes #674.

## Problem

`JacobianRuntime.close()` stopped at the first owner that raised. A service-quiescence failure therefore skipped portfolio and core teardown, potentially leaving the artifact repository and its SQLite handles open.

The focused regression fails on `origin/main` at the first injected `RuntimeError("services close failed")`; neither portfolio nor core is reached.

## Solution

Runtime shutdown now attempts services, portfolio, and core independently in ownership order. It collects every failure and raises an ordered `ExceptionGroup("runtime resources failed to close", ...)` only after all three owners have been attempted.

The runtime closed marker remains unset when any owner fails, so callers can retry. The regression calls each real close method before injecting its failure, proves the core store is closed even when all three stages report errors, then verifies retry and double-close behavior.

## Testing

- Base regression: `make test-composition TESTS='tests/composition/runtime/test_runtime_lifecycle.py' PYTEST_ARGS='-n 0 -k attempts_every_owner'` — failed on `origin/main` with the first service error escaping before later owners ran.
- Final focused regression: the same command — 1 passed.
- Final lifecycle module: `make test-composition TESTS='tests/composition/runtime/test_runtime_lifecycle.py' PYTEST_ARGS='-n 0'` — 16 passed.
- Planner-selected Python lanes: `make test-unit test-component test-domain test-composition test-storage test-process test-mcp test-e2e` — 2,432 passed and 3 skipped because the pinned Lean/Mathlib runtime was unavailable.
- `make npm-test` — 45 passed; npm package dry-run succeeded.
- Ruff, mypy, deptry, vulture, test-architecture, package build, `pip-audit`, and duplicate-code checks passed.

`make check-static` remains blocked by two failures reproduced unchanged on `origin/main@41504be7a`: stale C901 baselines for three provider-feasibility verifiers and ten benchmark validation fixtures outside the subprocess allowlist. Neither failing area is changed here.

## Trust & Compatibility Impact

This does not change the verification kernel, checker authority, artifact formats, mathematical capabilities, or the supported `jacobian.math` API.

The shutdown error shape changes intentionally: one or more owner-close failures now surface as a runtime-level `ExceptionGroup` instead of exposing only the first owner exception. Successful shutdown and idempotent close behavior are unchanged.

## Checklist

- [ ] Routine local validation passes (`make check`) — blocked by the reproduced `origin/main` static baseline failures above.
- [x] Relevant focused tests are listed above