### PR TITLE
fix(experiments): use available parent capacity on the first page

### DIFF
--- a/src/jacobian/experiments/service.py
+++ b/src/jacobian/experiments/service.py
@@ -627,11 +627,12 @@ class ExperimentService:
                     )
                     return
 
+                fixed_page_parents = 1 if not page_uris else 2
                 page_size = min(
                     request.budget.page_size,
                     remaining_candidates,
                     self.evaluation.max_batch_size,
-                    self.store.limits.max_parents - 2,
+                    self.store.limits.max_parents - fixed_page_parents,
                 )
                 execution = self.executor.run(
                     entrypoint=enumerator.descriptor.entrypoint,

--- a/tests/boundary/storage/recovery/test_enumeration_experiments.py
+++ b/tests/boundary/storage/recovery/test_enumeration_experiments.py
@@ -12,6 +12,7 @@ from jacobian.contracts.discovery import (
     SearchEnumerateRequest,
 )
 from jacobian.experiments import ExperimentError, ExperimentNotFoundError
+from jacobian.storage.models import StorageLimits
 
 
 def test_unknown_experiment_error_explains_recovery(
@@ -245,6 +246,53 @@ def test_enumeration_pages_respect_evaluator_batch_limit(
         snapshot.archive_page_uris[-1]
     )
     assert snapshot.archive_page_uris[0] in second_page.manifest.parents
+
+
+def test_enumeration_uses_available_parent_capacity_per_page(
+    authorized_complete_runtime,
+) -> None:
+    authorized_complete_runtime.core.store.limits = StorageLimits(max_parents=3)
+    claim_uri, plugin_id = _claim(
+        authorized_complete_runtime,
+        reference_name="matrices",
+        predicate="is_nonsingular",
+        parameters={},
+    )
+    handle = authorized_complete_runtime.services.experiments.start_enumeration(
+        SearchEnumerateRequest(
+            claim_uri=claim_uri,
+            plugin_id=plugin_id,
+            bounds={"rows": 1, "cols": 1, "entries": [0, 1, 2, 3]},
+            budget=EnumerationBudget(
+                candidates_max=4,
+                wall_seconds=30,
+                page_size=2,
+            ),
+        )
+    )
+
+    snapshot = authorized_complete_runtime.services.experiments.wait(
+        handle.experiment_uri, timeout_seconds=30
+    )
+
+    assert snapshot.state is ExperimentState.COMPLETED
+    assert snapshot.stop_reason is EnumerationStopReason.COMPLETE
+    first_page_uri = snapshot.archive_page_uris[0]
+    first_page = authorized_complete_runtime.core.store.get(first_page_uri)
+    assert len(first_page.payload["candidate_uris"]) == 2
+    assert set(first_page.manifest.parents) == {
+        first_page.payload["evaluation_uris"][0],
+        *first_page.payload["candidate_uris"],
+    }
+    assert len(snapshot.archive_page_uris) == 3
+    for index, page_uri in enumerate(snapshot.archive_page_uris[1:], start=1):
+        page = authorized_complete_runtime.core.store.get(page_uri)
+        assert len(page.payload["candidate_uris"]) == 1
+        assert set(page.manifest.parents) == {
+            page.payload["evaluation_uris"][0],
+            *page.payload["candidate_uris"],
+            snapshot.archive_page_uris[index - 1],
+        }
 
 
 def test_cancellation_never_becomes_an_exhaustive_conclusion(


### PR DESCRIPTION
## Problem

Enumeration reserves two fixed archive-parent slots on every page, even though page zero has no previous-page parent. With `max_parents=3`, that unnecessarily limits the first page to one candidate when it can safely carry two, creating an avoidable extra page under tight budgets.

Fixes #656.

## Solution

Calculate fixed parent overhead from page state: reserve one slot before any archive page exists, then reserve two for later pages that also link to their predecessor. The existing evaluator, request, and remaining-candidate caps are unchanged.

The regression uses `max_parents=3` and four candidates. It proves page zero carries two candidates plus its evaluation artifact, while both following pages still reserve their previous-page link and remain within the parent limit.

## Testing

The new regression failed on `main` because the first page contained one candidate instead of two.

```sh
uv run --locked pytest -q tests/boundary/storage/recovery/test_enumeration_experiments.py::test_enumeration_uses_available_parent_capacity_per_page tests/boundary/storage/recovery/test_enumeration_experiments.py::test_enumeration_pages_respect_evaluator_batch_limit
uv run --locked ruff check src/jacobian/experiments/service.py tests/boundary/storage/recovery/test_enumeration_experiments.py
uv run --locked ruff format --check src/jacobian/experiments/service.py tests/boundary/storage/recovery/test_enumeration_experiments.py
git diff --check origin/main
make test-plan BASE=origin/main
```

Result: 2 tests passed; Ruff, formatting, and diff checks passed. The planner conservatively selects the full product and static lanes because the service is transitively imported; those broader draft-PR checks are pending.

## Trust & Compatibility Impact

This changes only page packing. Artifact identity, parent completeness, archive chaining, execution status, evidence semantics, public contracts, and checker authorization are unchanged.

## Checklist

- [ ] Routine local validation passes (`make check`)
- [x] Relevant focused tests are listed above