### PR TITLE
fix(ci): restore static gates after benchmark additions

### DIFF
--- a/tools/c901-baseline.json
+++ b/tools/c901-baseline.json
@@ -165,7 +165,7 @@
     {
       "path": "benchmarks/datasets/provider-feasibility-v1/cgal/tests/verifier.py",
       "symbol": "_execution_bound",
-      "complexity": 11
+      "complexity": 13
     },
     {
       "path": "benchmarks/datasets/provider-feasibility-v1/gudhi/environment/spike.py",
@@ -175,12 +175,12 @@
     {
       "path": "benchmarks/datasets/provider-feasibility-v1/gudhi/tests/verifier.py",
       "symbol": "_execution_bound",
-      "complexity": 11
+      "complexity": 15
     },
     {
       "path": "benchmarks/datasets/provider-feasibility-v1/nauty/tests/verifier.py",
       "symbol": "_execution_bound",
-      "complexity": 11
+      "complexity": 17
     },
     {
       "path": "benchmarks/datasets/provider-feasibility-v1/regina/environment/spike.py",

--- a/tools/check_architecture.py
+++ b/tools/check_architecture.py
@@ -64,6 +64,7 @@ _SUBPROCESS_ALLOWED_EXACT: frozenset[PurePosixPath] = frozenset(
         PurePosixPath("tests/e2e/verified_results/test_reference_runtime.py"),
         # Process boundary tests directly exercise subprocess seams.
         PurePosixPath("tests/boundary/process/test_bounded_process.py"),
+        PurePosixPath("tests/boundary/process/test_cvc5_worker_command_profile.py"),
         PurePosixPath("tests/boundary/process/test_process_policy.py"),
         PurePosixPath("tests/boundary/process/test_rational_lp_worker_protocol.py"),
         PurePosixPath("tests/boundary/process/test_worker_error_protocol.py"),

--- a/tools/check_architecture.py
+++ b/tools/check_architecture.py
@@ -122,11 +122,52 @@ _SUBPROCESS_ALLOWED_EXACT: frozenset[PurePosixPath] = frozenset(
         PurePosixPath("tests/unit/tooling/test_architecture_harbor_contracts.py"),
         PurePosixPath("tests/unit/tooling/test_architecture_unsupported_surfaces.py"),
         PurePosixPath("tests/unit/tooling/test_architecture_diagnostics.py"),
-        # Repository-command integration tests deliberately invoke CLI entrypoints.
+        # Benchmark regressions spawn task-owned solution or Oracle entrypoints.
         PurePosixPath(
             "benchmarks/validation/mathematical_benchmarks_v1/"
             "test_multiplicative_grid_extremum.py"
         ),
+        PurePosixPath(
+            "benchmarks/validation/conjecture_probes_v1/"
+            "test_bsd_infinite_order_certificate.py"
+        ),
+        PurePosixPath(
+            "benchmarks/validation/conjecture_probes_v1/"
+            "test_hadamard_order12_construction.py"
+        ),
+        PurePosixPath(
+            "benchmarks/validation/conjecture_probes_v1/"
+            "test_hadwiger_triangle_free_minor_certificate.py"
+        ),
+        PurePosixPath(
+            "benchmarks/validation/conjecture_probes_v1/"
+            "test_happy_ending_convex_position.py"
+        ),
+        PurePosixPath(
+            "benchmarks/validation/conjecture_probes_v1/"
+            "test_hodge_blowup_divisor_certificate.py"
+        ),
+        PurePosixPath(
+            "benchmarks/validation/conjecture_probes_v1/"
+            "test_littlewood_certified_finite_search.py"
+        ),
+        PurePosixPath(
+            "benchmarks/validation/conjecture_probes_v1/"
+            "test_navier_stokes_polynomial_certificate.py"
+        ),
+        PurePosixPath(
+            "benchmarks/validation/conjecture_probes_v1/"
+            "test_perfect_cuboid_scope_audit.py"
+        ),
+        PurePosixPath(
+            "benchmarks/validation/conjecture_probes_v1/"
+            "test_reconstruction_deck_certificate.py"
+        ),
+        PurePosixPath(
+            "benchmarks/validation/conjecture_probes_v1/"
+            "test_yang_mills_gauge_invariance_certificate.py"
+        ),
+        # Repository-command integration tests deliberately invoke CLI entrypoints.
         PurePosixPath("benchmarks/validation/test_benchmark_plan_validation.py"),
         PurePosixPath("benchmarks/validation/test_benchmark_planner.py"),
     }
@@ -662,7 +703,9 @@ def _public_contract_drift_violations(root: Path) -> tuple[Violation, ...]:
             if not (task_dir / "task.toml").is_file():
                 continue
             contract_path = task_dir / "tests" / "public_contract.json"
-            contract_rel = str(PurePosixPath(contract_path.relative_to(root).as_posix()))
+            contract_rel = str(
+                PurePosixPath(contract_path.relative_to(root).as_posix())
+            )
             if not contract_path.is_file():
                 violations.append(
                     Violation(
@@ -682,7 +725,9 @@ def _public_contract_drift_violations(root: Path) -> tuple[Violation, ...]:
                 )
                 continue
             for drift in drifts:
-                violations.append(Violation(contract_rel, "public-contract-drift", drift))
+                violations.append(
+                    Violation(contract_rel, "public-contract-drift", drift)
+                )
     return tuple(violations)
 
 


### PR DESCRIPTION
## Problem

The benchmark additions merged in #683 left `main` failing two static gates:

- Ruff C901 now measures three provider-feasibility verifier functions at 13, 15, and 17, while their checked-in baseline still records 11.
- Ten conjecture-probe regression fixtures intentionally launch their task-owned `solution/solve.py`, but the subprocess architecture policy does not yet recognize those exact files.

As a result, the shared Lint & Format check fails before unrelated PRs can obtain a clean signal.

## Solution

Refresh only the three measured C901 entries and add only the ten benchmark regression paths to the existing exact-path subprocess allowlist. Each listed fixture invokes a checked-in task-owned solution entrypoint; same-directory siblings remain prohibited. No scanner logic, directory-wide exception, or benchmark execution policy changes.

The formatter also wraps two pre-existing long expressions in the touched architecture checker.

## Testing

On unchanged `main`, `make complexity-check` reported the three baseline mismatches and `make architecture` reported all ten `subprocess-confined` violations.

```sh
make complexity-check architecture
make check-static
make test-unit TESTS=tests/unit/tooling/test_architecture_process_policies.py PYTEST_ARGS='-n 0'
make test-unit
make test-component
make test-domain
make test-plan BASE=origin/main
make harbor-plan BASE=origin/main
```

Local results:

- complexity baseline matched all 146 known observations; architecture passed across 1,575 Python files;
- the complete static/build gate passed;
- focused architecture policy: 32 passed;
- unit: 721 passed; component: 706 passed; domain: 162 passed;
- Harbor plan: `mode=none`, with no host-validation or Oracle work.

The exact pushed commit also passed every selected GitHub check, including both composition shards, process, storage, MCP, e2e, unit, all domain shards, component, Lint & Format, build, package validation, security, coverage, duplicate detection, deployment tests, and the aggregate Python/Lean gates.

## Trust & Compatibility Impact

No product, checker, verifier, artifact, protocol, or public API behavior changes. This restores CI policy metadata to the benchmark code already present on `main`.

## Checklist

- [ ] Routine local validation passes (`make check`)
- [x] Relevant focused tests are listed above
- [x] CI-selected full validation passes