### PR TITLE
fix(runtime): preserve bootstrap failures when cleanup fails

### DIFF
--- a/src/jacobian/runtime/bootstrap.py
+++ b/src/jacobian/runtime/bootstrap.py
@@ -68,6 +68,9 @@ def bootstrap_services(root: str | Path, options: RuntimeOptions) -> CoreService
             capabilities=capabilities,
             reasoning_log=reasoning_log,
         )
-    except BaseException:
-        store.close()
+    except BaseException as exc:
+        try:
+            store.close()
+        except BaseException as cleanup_exc:
+            exc.add_note(f"service bootstrap cleanup also failed: {cleanup_exc}")
         raise

--- a/tests/composition/runtime/test_runtime_lifecycle.py
+++ b/tests/composition/runtime/test_runtime_lifecycle.py
@@ -469,6 +469,35 @@ def test_partial_bootstrap_failure_releases_owned_store(
     reopened.close()
 
 
+def test_bootstrap_cleanup_failure_preserves_primary_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from jacobian.storage.repository import ArtifactRepository
+
+    def failing_install(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("bootstrap failure")
+
+    original_close = ArtifactRepository.close
+
+    def close_then_fail(store: ArtifactRepository) -> None:
+        original_close(store)
+        raise OSError("store close failure")
+
+    monkeypatch.setattr(
+        "jacobian.runtime.bootstrap.install_sat_artifacts",
+        failing_install,
+    )
+    monkeypatch.setattr(ArtifactRepository, "close", close_then_fail)
+
+    with pytest.raises(RuntimeError, match="bootstrap failure") as caught:
+        create_runtime(tmp_path)
+
+    assert caught.value.__notes__ == [
+        "service bootstrap cleanup also failed: store close failure"
+    ]
+
+
 def test_close_failure_keeps_store_closable_on_retry(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Problem

If runtime bootstrap fails after opening its artifact store and `ArtifactRepository.close()` also raises, the cleanup exception replaces the original construction error. Users then see a secondary teardown fault instead of the startup root cause.

Fixes #676.

## Solution

Keep cleanup best-effort inside the existing bootstrap exception path. When closing the store also fails, attach that secondary failure as an exception note and re-raise the original exception unchanged.

The regression closes a real store before injecting the cleanup error, so it proves both resource release and exception precedence rather than bypassing cleanup.

## Testing

The regression failed on `main` by raising `OSError: store close failure` instead of the injected primary `RuntimeError`.

```sh
uv run --locked pytest -q tests/composition/runtime/test_runtime_lifecycle.py::test_bootstrap_cleanup_failure_preserves_primary_failure
uv run --locked ruff check src/jacobian/runtime/bootstrap.py tests/composition/runtime/test_runtime_lifecycle.py
uv run --locked ruff format --check src/jacobian/runtime/bootstrap.py tests/composition/runtime/test_runtime_lifecycle.py
git diff --check origin/main
make test-plan BASE=origin/main
```

Result: the regression passed and preserved the cleanup error in `__notes__`; Ruff, formatting, and diff checks passed. The planner conservatively selects broader product lanes for the transitively imported bootstrap path; those draft-PR checks are pending.

## Trust & Compatibility Impact

No verification, checker authorization, artifact, protocol, or public API contract changes. Only dual-failure exception reporting changes; a cleanup-only failure is still raised normally.

## Checklist

- [ ] Routine local validation passes (`make check`)
- [x] Relevant focused tests are listed above