### PR TITLE
fix(matrix): reject non-string FLINT worker protocols as invalid input

### DIFF
--- a/src/jacobian/matrices/flint_linear_worker.py
+++ b/src/jacobian/matrices/flint_linear_worker.py
@@ -175,12 +175,11 @@ def _solve(
 
 def _run(request: dict[str, Any]) -> dict[str, object]:
     protocol = request.get("protocol")
-    if protocol not in {
+    if not isinstance(protocol, str) or protocol not in {
         FLINT_LINEAR_WORKER_PROTOCOL,
         FLINT_LINEAR_INCONSISTENCY_WORKER_PROTOCOL,
     }:
         raise FlintLinearWorkerError("FLINT_LINEAR_INPUT_INVALID")
-    assert isinstance(protocol, str)
     coefficients, rhs = _validate_system(request, protocol=protocol)
     try:
         flint: Any = importlib.import_module("flint")

--- a/tests/boundary/process/test_worker_error_protocol.py
+++ b/tests/boundary/process/test_worker_error_protocol.py
@@ -128,6 +128,28 @@ def test_checker_worker_classifies_malformed_provider_runtime() -> None:
     assert response == {"error_code": "MALFORMED_RUNTIME"}
 
 
+def test_flint_linear_worker_classifies_non_string_protocol_as_invalid_input() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-m",
+            "jacobian.matrices.flint_linear_worker",
+        ],
+        input=canonicalize_json({"protocol": [], "system": {}}),
+        capture_output=True,
+        check=False,
+        timeout=10,
+    )
+
+    assert completed.returncode == 2
+    assert completed.stderr == b""
+    assert loads_strict_json(completed.stdout) == {
+        "protocol": "jacobian.flint-linear-worker/v1",
+        "error_code": "FLINT_LINEAR_INPUT_INVALID",
+    }
+
+
 def _lean_runtime_encoded(
     lean: Path,
     lake: Path | None,


### PR DESCRIPTION
## Problem

The Python-FLINT linear worker performs set membership on `request["protocol"]` before checking its type. A JSON array is therefore unhashable and falls into the execution-failure bucket, reporting `FLINT_LINEAR_EXECUTION_FAILED` for malformed input.

Fixes #636.

## Solution

Type-check the protocol before membership and remove the now-redundant assertion. Invalid protocol shapes follow the existing `FLINT_LINEAR_INPUT_INVALID` path; valid linear-solution and inconsistency protocols are unchanged.

A real isolated worker subprocess regression sends a canonical JSON array for `protocol` and checks the exit code, empty stderr, and exact error envelope.

## Testing

On `main`, the regression returned `FLINT_LINEAR_EXECUTION_FAILED`. On this branch:

```sh
uv run --locked pytest -q tests/boundary/process/test_worker_error_protocol.py
uv run --locked ruff check src/jacobian/matrices/flint_linear_worker.py tests/boundary/process/test_worker_error_protocol.py
uv run --locked ruff format --check src/jacobian/matrices/flint_linear_worker.py tests/boundary/process/test_worker_error_protocol.py
git diff --check origin/main
make test-plan BASE=origin/main
```

Result: 9 tests passed; Ruff, formatting, and diff checks passed. The planner conservatively selects broader product lanes because the worker is transitively imported; those draft-PR checks are pending.

## Trust & Compatibility Impact

Malformed input receives a more accurate fail-closed error code. Worker protocols, supported request shapes, assurance, artifacts, checker authorization, and the public API remain unchanged.

## Checklist

- [ ] Routine local validation passes (`make check`)
- [x] Relevant focused tests are listed above