### PR TITLE
fix(smt): reject non-string cvc5 worker statuses

### DIFF
--- a/src/jacobian/sat_smt/cvc5.py
+++ b/src/jacobian/sat_smt/cvc5.py
@@ -9,7 +9,7 @@ import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal
+from typing import Literal, cast
 
 from pydantic import ValidationError
 
@@ -537,7 +537,7 @@ def _parse_worker_output(
         or hole_count > 1_000_000
     ):
         raise ValueError("invalid Alethe hole count")
-    return status, proof_written, hole_count
+    return cast(_SolverStatus, status), proof_written, hole_count
 
 
 def _read_proof_file(path: Path) -> bytes:

--- a/src/jacobian/sat_smt/cvc5.py
+++ b/src/jacobian/sat_smt/cvc5.py
@@ -9,7 +9,7 @@ import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, cast
+from typing import Literal
 
 from pydantic import ValidationError
 
@@ -522,11 +522,14 @@ def _parse_worker_output(
     status = payload["solver_status"]
     proof_written = payload["proof_written"]
     hole_count = payload["alethe_hole_count"]
-    if not isinstance(status, str) or status not in {
-        "SATISFIABLE",
-        "UNSATISFIABLE",
-        "UNKNOWN",
-    }:
+    solver_status: _SolverStatus | None = None
+    if status == "SATISFIABLE":
+        solver_status = "SATISFIABLE"
+    elif status == "UNSATISFIABLE":
+        solver_status = "UNSATISFIABLE"
+    elif status == "UNKNOWN":
+        solver_status = "UNKNOWN"
+    if solver_status is None:
         raise ValueError("invalid worker status")
     if not isinstance(proof_written, bool):
         raise ValueError("invalid proof-written flag")
@@ -537,7 +540,7 @@ def _parse_worker_output(
         or hole_count > 1_000_000
     ):
         raise ValueError("invalid Alethe hole count")
-    return cast(_SolverStatus, status), proof_written, hole_count
+    return solver_status, proof_written, hole_count
 
 
 def _read_proof_file(path: Path) -> bytes:

--- a/src/jacobian/sat_smt/cvc5.py
+++ b/src/jacobian/sat_smt/cvc5.py
@@ -522,7 +522,11 @@ def _parse_worker_output(
     status = payload["solver_status"]
     proof_written = payload["proof_written"]
     hole_count = payload["alethe_hole_count"]
-    if status not in {"SATISFIABLE", "UNSATISFIABLE", "UNKNOWN"}:
+    if not isinstance(status, str) or status not in {
+        "SATISFIABLE",
+        "UNSATISFIABLE",
+        "UNKNOWN",
+    }:
         raise ValueError("invalid worker status")
     if not isinstance(proof_written, bool):
         raise ValueError("invalid proof-written flag")

--- a/tests/boundary/process/test_cvc5_worker_result_protocol.py
+++ b/tests/boundary/process/test_cvc5_worker_result_protocol.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import pytest
+
+from jacobian.canonical import canonicalize_json
+from jacobian.sat_smt.cvc5 import _parse_worker_output
+from jacobian.sat_smt.cvc5_worker import CVC5_WORKER_PROTOCOL
+
+
+def test_cvc5_worker_result_rejects_non_string_solver_status() -> None:
+    stdout = canonicalize_json(
+        {
+            "protocol": CVC5_WORKER_PROTOCOL,
+            "solver_status": [],
+            "proof_written": False,
+            "alethe_hole_count": 0,
+        }
+    )
+
+    with pytest.raises(ValueError, match="invalid worker status"):
+        _parse_worker_output(stdout)


### PR DESCRIPTION
## Problem

The cvc5 result parser performs set membership on `solver_status` before checking its type. A malformed JSON array or object is unhashable, so worker-output validation raises `TypeError` and bypasses the backend's controlled invalid-output handling.

Fixes #638.

## Solution

Require a string before checking the three supported solver statuses. Malformed external-process output now raises the parser's existing `ValueError("invalid worker status")`, which the backend translates into its typed `INVALID_CVC5_WORKER_OUTPUT` path.

The regression uses a canonical worker envelope with an array status and exercises the actual result parser boundary.

## Testing

The regression raised `TypeError: unhashable type: 'list'` on `main`.

```sh
uv run --locked pytest -q tests/boundary/process/test_cvc5_worker_result_protocol.py tests/unit/contracts/test_smt_contracts.py
uv run --locked ruff check src/jacobian/sat_smt/cvc5.py tests/boundary/process/test_cvc5_worker_result_protocol.py
uv run --locked ruff format --check src/jacobian/sat_smt/cvc5.py tests/boundary/process/test_cvc5_worker_result_protocol.py
git diff --check origin/main
make test-plan BASE=origin/main
```

Result: 7 tests passed; Ruff, formatting, and diff checks passed. The planner conservatively selects broader product lanes because the backend is transitively imported; those draft-PR checks are pending.

## Trust & Compatibility Impact

Malformed worker output fails closed through the intended typed path. Supported cvc5 statuses, proof handling, checker authorization, assurance, artifacts, wire contracts, and the public API are unchanged.

## Checklist

- [ ] Routine local validation passes (`make check`)
- [x] Relevant focused tests are listed above