### PR TITLE
fix(pre-commit): remove the stale verifier-support hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,13 +37,6 @@ repos:
 
   - repo: local
     hooks:
-      - id: jacobian-harbor-verifier-support
-        name: Jacobian Harbor verifier-support generation check
-        entry: uv run --locked python tools/sync_harbor_verifier_support.py --check
-        language: system
-        pass_filenames: false
-        files: ^(benchmarks/tooling/verifier_support\.py|benchmarks/datasets/.*/tests/verifier_support\.py)$
-        stages: [pre-commit]
       - id: jacobian-pre-push
         name: Jacobian pre-push static checks
         # Keep the push hook below the interactive feedback budget.  The

--- a/tests/unit/tooling/test_ci_execution_policy.py
+++ b/tests/unit/tooling/test_ci_execution_policy.py
@@ -1,7 +1,16 @@
 from __future__ import annotations
 
+import argparse
 import json
+import runpy
+import sys
+from collections.abc import Sequence
 from pathlib import Path
+
+import pytest
+from pre_commit.clientlib import load_config
+from pre_commit.lang_base import hook_cmd
+from pre_commit.parse_shebang import normalize_cmd
 
 ROOT = Path(__file__).parents[3]
 
@@ -83,12 +92,56 @@ def test_global_timeout_is_not_a_pytest_deadline() -> None:
     assert 'timeout_method = "thread"' in pyproject
 
 
-def test_pre_push_hook_stays_in_the_static_feedback_lane() -> None:
-    config = (ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8")
-    hook = config.split("id: jacobian-pre-push", 1)[1]
+def test_local_hook_commands_have_parseable_entrypoints_and_arguments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = load_config(str(ROOT / ".pre-commit-config.yaml"))
+    hooks = [
+        hook
+        for repo in config["repos"]
+        if repo["repo"] == "local"
+        for hook in repo["hooks"]
+    ]
+    assert hooks
 
-    assert "entry: make lint typecheck" in hook
-    assert "entry: make check" not in hook
+    class ArgumentsParsedError(Exception):
+        pass
+
+    original_parse_args = argparse.ArgumentParser.parse_args
+
+    def stop_after_parse(
+        parser: argparse.ArgumentParser,
+        args: Sequence[str] | None = None,
+        namespace: argparse.Namespace | None = None,
+    ) -> None:
+        original_parse_args(parser, args, namespace)
+        raise ArgumentsParsedError
+
+    monkeypatch.setattr(argparse.ArgumentParser, "parse_args", stop_after_parse)
+
+    for hook in hooks:
+        command = hook_cmd(hook["entry"], hook["args"])
+        normalize_cmd(command)
+        if hook["id"] == "jacobian-pre-push":
+            assert command == ("make", "lint", "typecheck")
+            continue
+
+        assert command[:4] == ("uv", "run", "--locked", "python"), hook["id"]
+        script_index = 4
+        assert script_index < len(command), hook["id"]
+        script = (ROOT / command[script_index]).resolve()
+        assert script.is_relative_to(ROOT) and script.is_file(), hook["id"]
+
+        namespace = runpy.run_path(str(script))
+        main = namespace.get("main")
+        assert callable(main), hook["id"]
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [str(script), *command[script_index + 1 :]],
+        )
+        with pytest.raises(ArgumentsParsedError):
+            main()
 
 
 def test_process_lane_is_invoked_by_ci() -> None:


### PR DESCRIPTION
## Problem

The pre-commit configuration still invokes `tools/sync_harbor_verifier_support.py --check` and watches a deleted shared support path. The script no longer accepts `--check`, so any matching commit fails at argument parsing. This is the stale-hook portion of #631; it does not change Harbor's intentional task-local support-file ownership.

Refs #631.

## Solution

Remove the obsolete verifier-support hook. Strengthen the existing CI execution-policy regression to load the real pre-commit configuration and validate every local hook's command, script path, and arguments. The pre-push hook is still pinned exactly to `make lint typecheck`; Python hooks must resolve to repository scripts whose `main()` accepts the configured arguments.

This deliberately does not add global synchronization or modify any task-local `verifier_support.py` copy.

## Testing

With the stale hook restored, the new regression fails because `sync_harbor_verifier_support.py` rejects `--check`.

```sh
uv run --locked pytest -q tests/unit/tooling/test_ci_execution_policy.py
uv run --locked pre-commit validate-config .pre-commit-config.yaml
uv run --locked ruff check tests/unit/tooling/test_ci_execution_policy.py
uv run --locked ruff format --check tests/unit/tooling/test_ci_execution_policy.py
git diff --check origin/main
make test-plan BASE=origin/main
make harbor-plan BASE=origin/main
```

Result: 26 tests passed; pre-commit configuration, Ruff, formatting, and diff checks passed. Harbor planning returned `mode=none`. The planner selects the full unit/static fallback for the configuration change; those broader draft-PR checks are pending.

## Trust & Compatibility Impact

No benchmark task, verifier, Oracle, evidence, artifact, checker authorization, wire contract, or public API changes. Task-local verifier support remains authoritative and digest-bound.

## Checklist

- [ ] Routine local validation passes (`make check`)
- [x] Relevant focused tests are listed above