### PR TITLE
test: isolate benchmark planner process state

### DIFF
--- a/docs/reference/testing-strategy.md
+++ b/docs/reference/testing-strategy.md
@@ -686,6 +686,22 @@ The checked-in JSON Schemas should be exercised both through Pydantic and a
 standards-oriented JSON Schema validator. A Pydantic model successfully reading
 its own generated schema is not independent contract evidence.
 
+### Pytest antipatterns
+
+- Use `monkeypatch` for process-global state such as `sys.modules`, `sys.argv`,
+  and environment variables. When restoration is the behavior under test,
+  assert that the original object or missing state is restored.
+- Name the expected exception type and a stable diagnostic instead of using
+  bare `pytest.raises(Exception)`.
+- Assert the observable outcome or independently parsed wire contract; a model
+  successfully validating its own output is not sufficient evidence.
+- Name source-shape checks honestly and reserve them for supported text or
+  architecture contracts. Do not disguise source substrings as behavior tests.
+- Do not add an empty `pytestmark`; markers exist only for execution-affecting
+  traits owned by the test topology.
+- Keep Harbor regressions in their owning dataset and task leaf. Shared
+  validation modules should contain only suite-wide contracts.
+
 Use the standard library's `tempfile`, `subprocess`, and process primitives for
 artifact and replay tests. Do not use an in-memory filesystem or `pyfakefs` to
 claim evidence about atomic rename, SQLite WAL recovery, symlink handling, or

--- a/tests/boundary/process/tooling/test_benchmark_classification.py
+++ b/tests/boundary/process/tooling/test_benchmark_classification.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import sys
+from collections.abc import Iterator
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
@@ -9,17 +10,33 @@ from types import ModuleType, SimpleNamespace
 import pytest
 from tests.boundary.process.tooling.ci import ROOT
 
+_MISSING = object()
 
-def _load() -> ModuleType:
+
+def _load(module_state: pytest.MonkeyPatch) -> ModuleType:
     path = ROOT / ".github/scripts/plan-benchmarks"
     loader = SourceFileLoader("plan_benchmarks", str(path))
     spec = importlib.util.spec_from_loader("plan_benchmarks", loader)
     assert spec is not None
     assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
-    sys.modules["plan_benchmarks"] = module
+    module_state.setitem(sys.modules, "plan_benchmarks", module)
     spec.loader.exec_module(module)
     return module
+
+
+@pytest.fixture
+def isolated_plan_benchmarks_module() -> Iterator[ModuleType]:
+    previous = sys.modules.get("plan_benchmarks", _MISSING)
+    with pytest.MonkeyPatch.context() as module_state:
+        yield _load(module_state)
+    assert sys.modules.get("plan_benchmarks", _MISSING) is previous
+
+
+def test_loaded_planner_restores_module_state(
+    isolated_plan_benchmarks_module: ModuleType,
+) -> None:
+    assert sys.modules["plan_benchmarks"] is isolated_plan_benchmarks_module
 
 
 def _patch_plan(module: ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -42,7 +59,7 @@ def _patch_plan(module: ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
 def test_task_documentation_does_not_select_oracle(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    module = _load()
+    module = _load(monkeypatch)
     _patch_plan(module, monkeypatch)
 
     plan = module.plan(
@@ -67,7 +84,7 @@ def test_benchmark_control_tools_run_contract_gate_without_oracle(
     path: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    module = _load()
+    module = _load(monkeypatch)
     _patch_plan(module, monkeypatch)
 
     plan = module.plan([path], base="a" * 40, head="b" * 40)
@@ -80,7 +97,7 @@ def test_benchmark_control_tools_run_contract_gate_without_oracle(
 def test_task_environment_selects_exact_task_oracle(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    module = _load()
+    module = _load(monkeypatch)
     _patch_plan(module, monkeypatch)
 
     plan = module.plan(
@@ -100,7 +117,7 @@ def test_task_environment_selects_exact_task_oracle(
 def test_shared_environment_profile_escalates_only_on_integration_event(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    module = _load()
+    module = _load(monkeypatch)
     _patch_plan(module, monkeypatch)
 
     pull_request = module.plan(
@@ -124,7 +141,7 @@ def test_shared_environment_profile_escalates_only_on_integration_event(
 def test_main_push_is_an_integration_owner(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    module = _load()
+    module = _load(monkeypatch)
     _patch_plan(module, monkeypatch)
 
     push = module.plan(

--- a/tests/unit/tooling/test_audit_fixes.py
+++ b/tests/unit/tooling/test_audit_fixes.py
@@ -44,6 +44,7 @@ def test_observation_pair_failures_fails_closed_on_non_dict(
 def test_usage_rejects_non_dict_stats() -> None:
     """Formally prove that non-dict stats is rejected."""
     from benchmarks.tooling import heldout_runner
+    from benchmarks.tooling.errors import HarborSuiteError
 
     # Create a temporary result file with stats as null
     with tempfile.NamedTemporaryFile(suffix=".json", mode="w", delete=False) as f:
@@ -51,9 +52,8 @@ def test_usage_rejects_non_dict_stats() -> None:
         path = Path(f.name)
 
     try:
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(HarborSuiteError, match="stats must be an object"):
             heldout_runner._usage(path)
-        assert "stats" in str(exc_info.value).lower()
     finally:
         path.unlink(missing_ok=True)
 

--- a/tests/unit/tooling/test_ci_planner_catalog.py
+++ b/tests/unit/tooling/test_ci_planner_catalog.py
@@ -36,13 +36,10 @@ def _load_script(name: str) -> ModuleType:
 def _ci_plan(*args: str) -> dict[str, str]:
     classifier = _load_script("classify-ci-paths")
     output = io.StringIO()
-    original_argv = sys.argv
-    try:
-        sys.argv = ["classify-ci-paths", *args]
+    with pytest.MonkeyPatch.context() as process_state:
+        process_state.setattr(sys, "argv", ["classify-ci-paths", *args])
         with contextlib.redirect_stdout(output):
             classifier.main()
-    finally:
-        sys.argv = original_argv
     return dict(line.split("=", 1) for line in output.getvalue().splitlines())
 
 


### PR DESCRIPTION
## Problem

Benchmark-planner tests install a dynamically loaded module in `sys.modules` without restoring the previous process state. Adjacent tooling tests also mutate `sys.argv` manually and use a broad exception assertion. Together these make order-dependent failures easier to hide and leave the repository's test-isolation expectations implicit.

This implements the focused first-PR scope proposed in #634. The issue's broader source-guard and cleanup ideas remain intentionally separate.

Refs #634.

## Solution

- Load `plan_benchmarks` through pytest-managed `sys.modules` state and assert the exact prior object or missing state is restored.
- Use `pytest.MonkeyPatch.context()` for the CI planner's `sys.argv` mutation.
- Narrow the heldout usage regression to `HarborSuiteError` and its stable diagnostic.
- Add a short pytest-antipatterns section to the testing reference, including process-global state, typed exceptions, observable outcomes, honest source guards, marker ownership, and Harbor leaf ownership.

## Testing

The new restoration assertion fails against the previous loader because `plan_benchmarks` remains installed after the test.

```sh
uv run --locked pytest -q tests/boundary/process/tooling/test_benchmark_classification.py tests/unit/tooling/test_audit_fixes.py
uv run --locked pytest -q tests/unit/tooling/test_ci_planner_catalog.py
uv run --locked ruff check tests/boundary/process/tooling/test_benchmark_classification.py tests/unit/tooling/test_audit_fixes.py tests/unit/tooling/test_ci_planner_catalog.py
uv run --locked ruff format --check tests/boundary/process/tooling/test_benchmark_classification.py tests/unit/tooling/test_audit_fixes.py tests/unit/tooling/test_ci_planner_catalog.py
make docs-linkcheck
git diff --check origin/main
make test-plan BASE=origin/main
make harbor-plan BASE=origin/main
```

Results: 31 tests passed across the focused runs; Ruff, formatting, documentation links, and diff checks passed. Harbor planning returned `mode=none`. The planner selects full unit/process/static/docs coverage for this mixed test-and-reference change; the remaining draft-PR checks are pending.

## Trust & Compatibility Impact

Test and documentation only. No benchmark task, verifier, Oracle, product runtime, checker authorization, evidence, artifact, protocol, or public API behavior changes.

## Checklist

- [ ] Routine local validation passes (`make check`)
- [x] Relevant focused tests are listed above