### PR TITLE
test: isolate fixture state and remove ambient dependencies

### DIFF
--- a/tests/boundary/mcp/test_mcp_operations.py
+++ b/tests/boundary/mcp/test_mcp_operations.py
@@ -240,28 +240,30 @@ def test_mcp_entrypoint_reports_distribution_version() -> None:
 
 
 def test_cancelled_mcp_blocking_work_drains_before_request_task_finishes() -> None:
-    started = threading.Event()
     release = threading.Event()
     finished = threading.Event()
-    cancellation_signalled = threading.Event()
-
-    def blocking_operation() -> str:
-        started.set()
-        release.wait(timeout=2)
-        finished.set()
-        return "finished"
 
     async def scenario() -> None:
+        loop = asyncio.get_running_loop()
+        started = asyncio.Event()
+        cancellation_signalled = asyncio.Event()
+
+        def blocking_operation() -> str:
+            loop.call_soon_threadsafe(started.set)
+            if not release.wait(timeout=2):
+                raise AssertionError("test did not release blocking MCP work")
+            finished.set()
+            return "finished"
+
         task = asyncio.create_task(
             _run_blocking(
                 blocking_operation,
                 on_cancel=cancellation_signalled.set,
             )
         )
-        while not started.is_set():
-            await asyncio.sleep(0)
+        await asyncio.wait_for(started.wait(), timeout=1)
         task.cancel()
-        await asyncio.sleep(0.05)
+        await asyncio.wait_for(cancellation_signalled.wait(), timeout=1)
         assert cancellation_signalled.is_set()
         assert not task.done()
         assert not finished.is_set()
@@ -274,24 +276,31 @@ def test_cancelled_mcp_blocking_work_drains_before_request_task_finishes() -> No
 
 
 def test_repeated_cancellation_keeps_draining_blocking_work() -> None:
-    started = threading.Event()
     release = threading.Event()
     finished = threading.Event()
 
-    def blocking_operation() -> str:
-        started.set()
-        release.wait(timeout=2)
-        finished.set()
-        return "finished"
-
     async def scenario() -> None:
-        task = asyncio.create_task(_run_blocking(blocking_operation))
-        while not started.is_set():
-            await asyncio.sleep(0)
+        loop = asyncio.get_running_loop()
+        started = asyncio.Event()
+        first_cancellation = asyncio.Event()
+        second_cancellation_dispatched = asyncio.Event()
+
+        def blocking_operation() -> str:
+            loop.call_soon_threadsafe(started.set)
+            if not release.wait(timeout=2):
+                raise AssertionError("test did not release blocking MCP work")
+            finished.set()
+            return "finished"
+
+        task = asyncio.create_task(
+            _run_blocking(blocking_operation, on_cancel=first_cancellation.set)
+        )
+        await asyncio.wait_for(started.wait(), timeout=1)
         task.cancel()
-        await asyncio.sleep(0.05)
+        await asyncio.wait_for(first_cancellation.wait(), timeout=1)
         task.cancel()
-        await asyncio.sleep(0.05)
+        loop.call_soon(second_cancellation_dispatched.set)
+        await asyncio.wait_for(second_cancellation_dispatched.wait(), timeout=1)
         assert not task.done()
         release.set()
         with pytest.raises(asyncio.CancelledError):

--- a/tests/boundary/process/tooling/test_topology_runner.py
+++ b/tests/boundary/process/tooling/test_topology_runner.py
@@ -10,9 +10,6 @@ from tools.test_topology import lane_environment, load_topology, main, pytest_co
 
 ROOT = Path(__file__).resolve().parents[4]
 
-_FAKE_HOME = "/tmp/jacobian-fake-home"
-_FAKE_ELAN = "/tmp/jacobian-fake-elan"
-
 
 def test_domain_lane_dry_run_is_explicit_and_topology_owned() -> None:
     result = subprocess.run(
@@ -268,25 +265,28 @@ def test_dry_run_serial_lane_reports_no_workers(capsys) -> None:
 
 
 def test_lane_environment_forwards_only_allowlisted_lean_variables(
+    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     topology = load_topology(ROOT / "tests" / "topology.toml")
-    monkeypatch.setenv("HOME", _FAKE_HOME)
-    monkeypatch.setenv("ELAN_HOME", _FAKE_ELAN)
+    fake_home = str(tmp_path / "home")
+    fake_elan = str(tmp_path / "elan")
+    monkeypatch.setenv("HOME", fake_home)
+    monkeypatch.setenv("ELAN_HOME", fake_elan)
     monkeypatch.setenv("JACOBIAN_TOPOLOGY_LEAK", "secret")
 
     lean = lane_environment(topology.lane("lean"))
     assert lean["JACOBIAN_TEST_LANE"] == "lean"
     assert lean["PATH"] == os.environ["PATH"]
-    assert lean["HOME"] == _FAKE_HOME
-    assert lean["ELAN_HOME"] == _FAKE_ELAN
+    assert lean["HOME"] == fake_home
+    assert lean["ELAN_HOME"] == fake_elan
     assert "JACOBIAN_TOPOLOGY_LEAK" not in lean
 
     provider = lane_environment(topology.lane("provider"))
     assert provider["JACOBIAN_TEST_LANE"] == "provider"
     assert provider["PATH"] == os.environ["PATH"]
-    assert provider["HOME"] == _FAKE_HOME
-    assert provider["ELAN_HOME"] == _FAKE_ELAN
+    assert provider["HOME"] == fake_home
+    assert provider["ELAN_HOME"] == fake_elan
     assert "JACOBIAN_TOPOLOGY_LEAK" not in provider
 
     unit = lane_environment(topology.lane("unit"))
@@ -298,11 +298,12 @@ def test_lane_environment_forwards_only_allowlisted_lean_variables(
 
 
 def test_lane_environment_never_forwards_unauthorized_host_variables(
+    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     topology = load_topology(ROOT / "tests" / "topology.toml")
     monkeypatch.setenv("JACOBIAN_TOPOLOGY_LEAK", "secret")
-    monkeypatch.setenv("HOME", _FAKE_HOME)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
 
     for lane_name in ("lean", "provider", "unit", "process", "storage"):
         environment = lane_environment(topology.lane(lane_name))

--- a/tests/boundary/providers/cvc5/startup/test_cvc5.py
+++ b/tests/boundary/providers/cvc5/startup/test_cvc5.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import json
-import shutil
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
 import pytest
+from tests.support.services import DomainTestServices, open_domain_services
 
 from jacobian.contracts.capabilities import (
     CapabilityAssuranceLevel,
@@ -20,7 +20,7 @@ from jacobian.process_policy import ProcessRequest, ProcessResult, ProcessTermin
 from jacobian.provider_measurements import measure_provider
 from jacobian.providers.external_solver_runtime import cvc5_provider_runtime
 from jacobian.runtime import create_runtime
-from jacobian.runtime.model import JacobianRuntime
+from jacobian.sat_smt.cvc5 import install_cvc5_capability
 from jacobian.sat_smt.smt import SmtArtifactError
 
 # Provider lane owns readiness and isolation for this module.
@@ -51,7 +51,7 @@ _QF_LRA_UNSAT = (
 _QF_UF_SAT = "(set-logic QF_UF)\n(declare-fun p () Bool)\n(assert p)\n(check-sat)\n"
 
 
-def _invoke(runtime: JacobianRuntime, text: str, *, logic: str = "QF_UF"):
+def _invoke(runtime: DomainTestServices, text: str, *, logic: str = "QF_UF"):
     return runtime.core.capabilities.invoke(
         CapabilityRequest(
             capability_id="smt.unsat_proof.find",
@@ -64,52 +64,55 @@ def _invoke(runtime: JacobianRuntime, text: str, *, logic: str = "QF_UF"):
     )
 
 
-@pytest.fixture(scope="module")
-def cvc5_runtime(
-    tmp_path_factory: pytest.TempPathFactory,
-    complete_portfolio_template: Path,
-) -> Iterator[JacobianRuntime]:
+@pytest.fixture
+def cvc5_provider() -> CapabilityProviderRuntime:
     provider = cvc5_provider_runtime()
     if provider.availability is not CapabilityProviderAvailability.AVAILABLE:
         pytest.skip("the pinned cvc5 runtime is unavailable")
-    root = tmp_path_factory.mktemp("cvc5-runtime")
-    shutil.copytree(complete_portfolio_template, root, dirs_exist_ok=True)
-    runtime = create_runtime(root)
-    try:
-        yield runtime
-    finally:
-        runtime.close()
+    return provider
 
 
-def test_pinned_cvc5_capability_is_discoverable(cvc5_runtime: JacobianRuntime) -> None:
-    assert (
-        cvc5_runtime.portfolio.cvc5_runtime.availability
-        is CapabilityProviderAvailability.AVAILABLE
-    )
-    catalog = cvc5_runtime.core.capabilities.catalog().capabilities
+@pytest.fixture
+def cvc5_services(
+    tmp_path: Path,
+    cvc5_provider: CapabilityProviderRuntime,
+) -> Iterator[DomainTestServices]:
+    with open_domain_services(tmp_path / "state") as services:
+        services.installation.register_capability(
+            install_cvc5_capability(services.core.smt, cvc5_provider)
+        )
+        yield services
+
+
+def test_pinned_cvc5_capability_is_discoverable(
+    cvc5_services: DomainTestServices,
+    cvc5_provider: CapabilityProviderRuntime,
+) -> None:
+    assert cvc5_provider.availability is CapabilityProviderAvailability.AVAILABLE
+    catalog = cvc5_services.core.capabilities.catalog().capabilities
     descriptor = next(
         descriptor
         for descriptor in catalog
         if descriptor.capability_id == "smt.unsat_proof.find"
     )
     assert descriptor.provider == "cvc5"
-    assert descriptor.provider_runtime == cvc5_runtime.portfolio.cvc5_runtime
+    assert descriptor.provider_runtime == cvc5_provider
     assert descriptor.provider_runtime.checker_ids == ()
     assert "smt.unsat_proof.verify" not in {
         installed.capability_id for installed in catalog
     }
-    assert cvc5_runtime.core.smt.installation.problem_schema_uri.startswith(
+    assert cvc5_services.core.smt.installation.problem_schema_uri.startswith(
         "artifact://sha256/"
     )
-    assert cvc5_runtime.core.smt.installation.proof_schema_uri.startswith(
+    assert cvc5_services.core.smt.installation.proof_schema_uri.startswith(
         "artifact://sha256/"
     )
 
 
 def test_pinned_cvc5_measurement_runs_its_proof_reproduction(
-    cvc5_runtime: JacobianRuntime,
+    cvc5_provider: CapabilityProviderRuntime,
 ) -> None:
-    measurement = measure_provider(cvc5_runtime.portfolio.cvc5_runtime)
+    measurement = measure_provider(cvc5_provider)
 
     assert measurement.cold_start.status.value == "COMPLETED"
     assert measurement.reproduction_case.status.value == "COMPLETED"
@@ -118,9 +121,9 @@ def test_pinned_cvc5_measurement_runs_its_proof_reproduction(
 
 
 def test_qf_uf_proof_is_durable_computed_evidence(
-    cvc5_runtime: JacobianRuntime,
+    cvc5_services: DomainTestServices,
 ) -> None:
-    result = _invoke(cvc5_runtime, _QF_UF_UNSAT)
+    result = _invoke(cvc5_services, _QF_UF_UNSAT)
 
     assert result.execution.status is ExecutionStatus.COMPLETED
     assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
@@ -132,7 +135,7 @@ def test_qf_uf_proof_is_durable_computed_evidence(
     assert result.assurance.verification_record_uri is None
     assert len(result.artifact_uris) == 2
 
-    resolved = cvc5_runtime.core.smt.resolve_proof(result.output["proof_uri"])
+    resolved = cvc5_services.core.smt.resolve_proof(result.output["proof_uri"])
     assert resolved.proof.problem.problem_artifact_uri == result.output["problem_uri"]
     assert resolved.proof.raw_bytes().startswith(b"(\n")
     assert resolved.proof.contains_holes is False
@@ -147,11 +150,11 @@ def test_qf_uf_proof_is_durable_computed_evidence(
     ),
 )
 def test_linear_arithmetic_holes_stay_explicit_and_unverified(
-    cvc5_runtime: JacobianRuntime,
+    cvc5_services: DomainTestServices,
     logic: str,
     text: str,
 ) -> None:
-    result = _invoke(cvc5_runtime, text, logic=logic)
+    result = _invoke(cvc5_services, text, logic=logic)
 
     assert result.execution.status is ExecutionStatus.COMPLETED
     assert result.output["status"] == "PROOF_PRODUCED"
@@ -163,9 +166,9 @@ def test_linear_arithmetic_holes_stay_explicit_and_unverified(
 
 
 def test_sat_report_produces_no_unsat_artifact_or_conclusion(
-    cvc5_runtime: JacobianRuntime,
+    cvc5_services: DomainTestServices,
 ) -> None:
-    result = _invoke(cvc5_runtime, _QF_UF_SAT)
+    result = _invoke(cvc5_services, _QF_UF_SAT)
 
     assert result.execution.status is ExecutionStatus.COMPLETED
     assert result.output == {
@@ -184,23 +187,29 @@ def test_sat_report_produces_no_unsat_artifact_or_conclusion(
     assert result.artifact_uris == (result.output["problem_uri"],)
 
 
-def test_incremental_or_mismatched_queries_are_rejected_before_solver_evidence(
-    cvc5_runtime: JacobianRuntime,
-) -> None:
-    for invalid in (
+@pytest.mark.parametrize(
+    "invalid",
+    (
         _QF_UF_UNSAT.replace("(check-sat)\n", "(push 1)\n(check-sat)\n"),
         _QF_UF_UNSAT.replace("QF_UF", "QF_LIA"),
         _QF_UF_UNSAT + "(check-sat)\n",
-    ):
-        result = _invoke(cvc5_runtime, invalid)
-        assert result.execution.status is ExecutionStatus.ERROR
-        assert result.output["error"]["code"] == "INVALID_SMT_UNSAT_PROOF_REQUEST"
-        assert result.artifact_uris == ()
-        assert result.diagnostics[0].code == "INVALID_SMT_UNSAT_PROOF_REQUEST"
+    ),
+    ids=("incremental", "logic-mismatch", "multiple-queries"),
+)
+def test_incremental_or_mismatched_queries_are_rejected_before_solver_evidence(
+    cvc5_services: DomainTestServices,
+    invalid: str,
+) -> None:
+    result = _invoke(cvc5_services, invalid)
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.output["error"]["code"] == "INVALID_SMT_UNSAT_PROOF_REQUEST"
+    assert result.artifact_uris == ()
+    assert result.diagnostics[0].code == "INVALID_SMT_UNSAT_PROOF_REQUEST"
 
 
 def test_theory_outside_declared_logic_fails_in_isolated_parser(
-    cvc5_runtime: JacobianRuntime,
+    cvc5_services: DomainTestServices,
 ) -> None:
     nonlinear_lia = (
         "(set-logic QF_LIA)\n"
@@ -209,7 +218,7 @@ def test_theory_outside_declared_logic_fails_in_isolated_parser(
         "(check-sat)\n"
     )
 
-    result = _invoke(cvc5_runtime, nonlinear_lia, logic="QF_LIA")
+    result = _invoke(cvc5_services, nonlinear_lia, logic="QF_LIA")
 
     assert result.execution.status is ExecutionStatus.ERROR
     assert result.output == {}
@@ -219,21 +228,21 @@ def test_theory_outside_declared_logic_fails_in_isolated_parser(
 
 
 def test_problem_and_proof_bindings_reject_cross_domain_artifacts(
-    cvc5_runtime: JacobianRuntime,
+    cvc5_services: DomainTestServices,
 ) -> None:
-    cnf_uri = cvc5_runtime.core.sat.put_cnf(
+    cnf_uri = cvc5_services.core.sat.put_cnf(
         variable_names=("x",),
         clauses=((1,),),
     ).artifact_uri
 
     with pytest.raises(SmtArtifactError):
-        cvc5_runtime.core.smt.resolve_problem(cnf_uri)
+        cvc5_services.core.smt.resolve_problem(cnf_uri)
     with pytest.raises(SmtArtifactError):
-        cvc5_runtime.core.smt.resolve_proof(cnf_uri)
+        cvc5_services.core.smt.resolve_proof(cnf_uri)
 
 
 def test_worker_proof_metadata_mismatch_fails_closed(
-    cvc5_runtime: JacobianRuntime,
+    cvc5_services: DomainTestServices,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def fake_worker(request: ProcessRequest, **_kwargs: Any) -> ProcessResult:
@@ -260,7 +269,7 @@ def test_worker_proof_metadata_mismatch_fails_closed(
 
     monkeypatch.setattr("jacobian.sat_smt.cvc5.execute_process", fake_worker)
 
-    result = _invoke(cvc5_runtime, _QF_UF_UNSAT)
+    result = _invoke(cvc5_services, _QF_UF_UNSAT)
 
     assert result.execution.status is ExecutionStatus.ERROR
     assert result.output == {}
@@ -270,7 +279,7 @@ def test_worker_proof_metadata_mismatch_fails_closed(
 
 
 def test_worker_timeout_fails_without_solver_conclusion(
-    cvc5_runtime: JacobianRuntime,
+    cvc5_services: DomainTestServices,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
@@ -285,7 +294,7 @@ def test_worker_timeout_fails_without_solver_conclusion(
         ),
     )
 
-    result = _invoke(cvc5_runtime, _QF_UF_UNSAT)
+    result = _invoke(cvc5_services, _QF_UF_UNSAT)
 
     assert result.execution.status is ExecutionStatus.TIMEOUT
     assert result.output == {}
@@ -296,7 +305,6 @@ def test_worker_timeout_fails_without_solver_conclusion(
 
 def test_missing_optional_cvc5_leaves_artifact_boundary_but_no_capability(
     tmp_path: Path,
-    attached_complete_runtime: None,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     unavailable = CapabilityProviderRuntime(
@@ -312,12 +320,11 @@ def test_missing_optional_cvc5_leaves_artifact_boundary_but_no_capability(
         lambda: unavailable,
     )
 
-    without_cvc5 = create_runtime(tmp_path)
-
-    assert "smt.unsat_proof.find" not in {
-        descriptor.capability_id
-        for descriptor in without_cvc5.core.capabilities.catalog().capabilities
-    }
-    assert without_cvc5.core.smt.installation.problem_schema_uri.startswith(
-        "artifact://sha256/"
-    )
+    with create_runtime(tmp_path) as without_cvc5:
+        assert "smt.unsat_proof.find" not in {
+            descriptor.capability_id
+            for descriptor in without_cvc5.core.capabilities.catalog().capabilities
+        }
+        assert without_cvc5.core.smt.installation.problem_schema_uri.startswith(
+            "artifact://sha256/"
+        )

--- a/tests/boundary/providers/external_sat/runtime/test_cadical_capabilities.py
+++ b/tests/boundary/providers/external_sat/runtime/test_cadical_capabilities.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 import threading
 from pathlib import Path
 
@@ -25,7 +26,7 @@ def _fake_cadical(tmp_path: Path, body: str) -> Path:
     executable = tmp_path / "fake-cadical"
     executable.write_text(
         (
-            "#!/usr/bin/python3\n"
+            f"#!{sys.executable}\n"
             "import pathlib\n"
             "import sys\n"
             "import time\n"

--- a/tests/boundary/providers/external_sat/startup/test_carcara.py
+++ b/tests/boundary/providers/external_sat/startup/test_carcara.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-import shutil
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
+from tests.support.services import DomainTestServices, open_domain_services
 
 from jacobian.contracts.capabilities import (
     CapabilityAssuranceLevel,
@@ -13,41 +14,51 @@ from jacobian.contracts.capabilities import (
 )
 from jacobian.contracts.results import ExecutionStatus
 from jacobian.contracts.smt import SmtResourceBudget
-from jacobian.providers.external_solver_runtime import carcara_provider_runtime
-from jacobian.runtime import CheckerAuthorityMode, create_runtime
-from jacobian.runtime.model import JacobianRuntime
-
-_FIXTURES = (
-    Path(__file__).resolve().parents[5]
-    / "tests"
-    / "boundary"
-    / "providers"
-    / "external_sat"
-    / "fixtures"
+from jacobian.providers.external_solver_runtime import (
+    carcara_provider_runtime,
+    cvc5_provider_runtime,
 )
+from jacobian.runtime.config import CheckerAuthorityMode
+from jacobian.sat_smt.cvc5 import install_cvc5_capability
+from jacobian.sat_smt.smt_capabilities import install_smt_unsat_proof_checker
+
+_FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
 
 
-@pytest.fixture(scope="module")
-def carcara_runtime(
-    tmp_path_factory: pytest.TempPathFactory,
-    authorized_portfolio_template: Path,
-) -> JacobianRuntime:
-    runtime = carcara_provider_runtime()
-    if runtime.availability is not CapabilityProviderAvailability.AVAILABLE:
+@pytest.fixture
+def carcara_services(
+    tmp_path: Path,
+) -> Iterator[DomainTestServices]:
+    carcara = carcara_provider_runtime()
+    if carcara.availability is not CapabilityProviderAvailability.AVAILABLE:
         pytest.skip("the exact operator-provenanced Carcara runtime is unavailable")
-    root = tmp_path_factory.mktemp("carcara-runtime")
-    shutil.copytree(authorized_portfolio_template, root, dirs_exist_ok=True)
-    installed = create_runtime(
-        root, checker_authority=CheckerAuthorityMode.INSTALL_BUNDLED
-    )
-    assert installed.portfolio.carcara_runtime == runtime
-    try:
-        yield installed
-    finally:
-        installed.close()
+    cvc5 = cvc5_provider_runtime()
+    if cvc5.availability is not CapabilityProviderAvailability.AVAILABLE:
+        pytest.skip("the pinned cvc5 runtime is unavailable")
+    with open_domain_services(
+        tmp_path / "state",
+        checker_authority=CheckerAuthorityMode.INSTALL_BUNDLED,
+    ) as services:
+        services.installation.register_capability(
+            install_cvc5_capability(services.core.smt, cvc5)
+        )
+        verifier, installation = install_smt_unsat_proof_checker(
+            services.core.store,
+            services.core.schemas,
+            services.core.artifacts,
+            services.core.smt,
+            services.application.verification,
+            services.core.checkers,
+            carcara,
+            authorize_checker=services.installation.authorizes_bundled_checkers,
+        )
+        assert verifier is not None
+        assert installation.checker_id is not None
+        services.installation.register_capability(verifier)
+        yield services
 
 
-def _produce(runtime: JacobianRuntime, logic: str, fixture: str):
+def _produce(runtime: DomainTestServices, logic: str, fixture: str):
     return runtime.core.capabilities.invoke(
         CapabilityRequest(
             capability_id="smt.unsat_proof.find",
@@ -60,7 +71,7 @@ def _produce(runtime: JacobianRuntime, logic: str, fixture: str):
     )
 
 
-def _verify(runtime: JacobianRuntime, proof_uri: str):
+def _verify(runtime: DomainTestServices, proof_uri: str):
     return runtime.core.capabilities.invoke(
         CapabilityRequest(
             capability_id="smt.unsat_proof.verify",
@@ -71,13 +82,13 @@ def _verify(runtime: JacobianRuntime, proof_uri: str):
 
 
 def test_zero_hole_qf_uf_proof_is_independently_verified(
-    carcara_runtime: JacobianRuntime,
+    carcara_services: DomainTestServices,
 ) -> None:
-    produced = _produce(carcara_runtime, "QF_UF", "qf_uf_equality_unsat.smt2")
+    produced = _produce(carcara_services, "QF_UF", "qf_uf_equality_unsat.smt2")
 
     assert produced.output["contains_holes"] is False
     assert produced.output["conclusion"] == "UNKNOWN"
-    verified = _verify(carcara_runtime, produced.output["proof_uri"])
+    verified = _verify(carcara_services, produced.output["proof_uri"])
 
     assert verified.execution.status is ExecutionStatus.COMPLETED
     assert verified.output["status"] == "VERIFIED_UNSAT"
@@ -94,15 +105,15 @@ def test_zero_hole_qf_uf_proof_is_independently_verified(
     ),
 )
 def test_holey_arithmetic_proofs_remain_unverified(
-    carcara_runtime: JacobianRuntime,
+    carcara_services: DomainTestServices,
     logic: str,
     fixture: str,
 ) -> None:
-    produced = _produce(carcara_runtime, logic, fixture)
+    produced = _produce(carcara_services, logic, fixture)
 
     assert produced.output["contains_holes"] is True
     assert produced.output["alethe_hole_count"] >= 1
-    checked = _verify(carcara_runtime, produced.output["proof_uri"])
+    checked = _verify(carcara_services, produced.output["proof_uri"])
 
     assert checked.execution.status is ExecutionStatus.COMPLETED
     assert checked.output["status"] == "REJECTED"
@@ -112,22 +123,22 @@ def test_holey_arithmetic_proofs_remain_unverified(
 
 
 def test_unknown_rule_is_not_silently_treated_as_verified(
-    carcara_runtime: JacobianRuntime,
+    carcara_services: DomainTestServices,
 ) -> None:
-    produced = _produce(carcara_runtime, "QF_UF", "qf_uf_equality_unsat.smt2")
-    resolved = carcara_runtime.core.smt.resolve_proof(produced.output["proof_uri"])
+    produced = _produce(carcara_services, "QF_UF", "qf_uf_equality_unsat.smt2")
+    resolved = carcara_services.core.smt.resolve_proof(produced.output["proof_uri"])
     unknown_rule = resolved.proof.raw_bytes().replace(
         b":rule resolution",
         b":rule jacobian_unknown_rule",
     )
-    mutated = carcara_runtime.core.smt.put_proof(
+    mutated = carcara_services.core.smt.put_proof(
         problem_uri=produced.output["problem_uri"],
         proof=unknown_rule,
-        producer=carcara_runtime.portfolio.cvc5_runtime,
+        producer=resolved.proof.producer,
         resource_budget=SmtResourceBudget(wall_seconds=5),
     )
 
-    checked = _verify(carcara_runtime, mutated.artifact_uri)
+    checked = _verify(carcara_services, mutated.artifact_uri)
 
     assert checked.execution.status is ExecutionStatus.COMPLETED
     assert checked.output["status"] == "REJECTED"

--- a/tests/boundary/providers/external_sat/startup/test_sat_unsat_proof_verification.py
+++ b/tests/boundary/providers/external_sat/startup/test_sat_unsat_proof_verification.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import sys
+from collections.abc import Iterator
+from contextlib import ExitStack
 from pathlib import Path
 from typing import Any
 
@@ -30,7 +33,7 @@ def _fake_drat_trim(tmp_path: Path, body: str) -> Path:
     executable = tmp_path / "drat-trim"
     executable.write_text(
         (
-            "#!/usr/bin/python3\n"
+            f"#!{sys.executable}\n"
             "import sys\n"
             "if '-h' in sys.argv:\n"
             "    print('usage: drat-trim [INPUT] [<PROOF>] [<option> ...]')\n"
@@ -76,6 +79,7 @@ def _runtime_with_runtime(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     executable: Path,
+    resources: ExitStack,
     *,
     checker_authority: CheckerAuthorityMode = CheckerAuthorityMode.INSTALL_BUNDLED,
 ) -> JacobianRuntime:
@@ -85,10 +89,18 @@ def _runtime_with_runtime(
         "jacobian.portfolio.provider_resolution.drat_trim_provider_runtime",
         lambda *_args, **_kwargs: runtime,
     )
-    return create_runtime(
-        tmp_path / "store",
-        checker_authority=checker_authority,
+    return resources.enter_context(
+        create_runtime(
+            tmp_path / "store",
+            checker_authority=checker_authority,
+        )
     )
+
+
+@pytest.fixture
+def runtime_resources() -> Iterator[ExitStack]:
+    with ExitStack() as resources:
+        yield resources
 
 
 @pytest.mark.parametrize(
@@ -153,12 +165,15 @@ def _verify(runtime: JacobianRuntime, proof_uri: str):
 def test_unsat_proof_is_verified_by_authorized_external_runtime(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    runtime_resources: ExitStack,
 ) -> None:
     executable = _fake_drat_trim(
         tmp_path,
         "print('s VERIFIED')\nraise SystemExit(0)",
     )
-    runtime = _runtime_with_runtime(tmp_path, monkeypatch, executable)
+    runtime = _runtime_with_runtime(
+        tmp_path, monkeypatch, executable, runtime_resources
+    )
     cnf_uri, proof_uri = _proof(runtime)
     monkeypatch.setattr(
         jacobian_checkers.sat,
@@ -214,12 +229,15 @@ def test_unsat_proof_is_verified_by_authorized_external_runtime(
 def test_rejected_proof_never_establishes_sat_or_unsat(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    runtime_resources: ExitStack,
 ) -> None:
     executable = _fake_drat_trim(
         tmp_path,
         "print('s NOT VERIFIED')\nraise SystemExit(1)",
     )
-    runtime = _runtime_with_runtime(tmp_path, monkeypatch, executable)
+    runtime = _runtime_with_runtime(
+        tmp_path, monkeypatch, executable, runtime_resources
+    )
     _cnf_uri, proof_uri = _proof(runtime)
 
     result = _verify(runtime, proof_uri)
@@ -235,6 +253,7 @@ def test_rejected_proof_never_establishes_sat_or_unsat(
 def test_proof_verify_requires_runtime_and_operator_authorization(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    runtime_resources: ExitStack,
 ) -> None:
     executable = _fake_drat_trim(
         tmp_path,
@@ -244,6 +263,7 @@ def test_proof_verify_requires_runtime_and_operator_authorization(
         tmp_path / "without-references",
         monkeypatch,
         executable,
+        runtime_resources,
         checker_authority=CheckerAuthorityMode.NONE,
     )
     unavailable = drat_trim_provider_runtime(tmp_path / "missing")
@@ -251,9 +271,11 @@ def test_proof_verify_requires_runtime_and_operator_authorization(
         "jacobian.portfolio.provider_resolution.drat_trim_provider_runtime",
         lambda *_args, **_kwargs: unavailable,
     )
-    without_runtime = create_runtime(
-        tmp_path / "without-runtime",
-        checker_authority=CheckerAuthorityMode.INSTALL_BUNDLED,
+    without_runtime = runtime_resources.enter_context(
+        create_runtime(
+            tmp_path / "without-runtime",
+            checker_authority=CheckerAuthorityMode.INSTALL_BUNDLED,
+        )
     )
 
     assert without_references.portfolio.sat_unsat_proof_checker.checker_id is None
@@ -283,6 +305,7 @@ def test_proof_verify_requires_runtime_and_operator_authorization(
 def test_checker_operational_failure_never_creates_a_conclusion(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    runtime_resources: ExitStack,
     exception: Exception,
     expected_status: ExecutionStatus,
     expected_output_status: str,
@@ -291,7 +314,9 @@ def test_checker_operational_failure_never_creates_a_conclusion(
         tmp_path,
         "print('s VERIFIED')\nraise SystemExit(0)",
     )
-    runtime = _runtime_with_runtime(tmp_path, monkeypatch, executable)
+    runtime = _runtime_with_runtime(
+        tmp_path, monkeypatch, executable, runtime_resources
+    )
     _cnf_uri, proof_uri = _proof(runtime)
 
     def fail(**_kwargs: Any):
@@ -310,12 +335,15 @@ def test_checker_operational_failure_never_creates_a_conclusion(
 def test_runtime_replacement_after_authorization_fails_closed(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    runtime_resources: ExitStack,
 ) -> None:
     executable = _fake_drat_trim(
         tmp_path,
         "print('s VERIFIED')\nraise SystemExit(0)",
     )
-    runtime = _runtime_with_runtime(tmp_path, monkeypatch, executable)
+    runtime = _runtime_with_runtime(
+        tmp_path, monkeypatch, executable, runtime_resources
+    )
     _cnf_uri, proof_uri = _proof(runtime)
     executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
     executable.chmod(0o755)

--- a/tests/boundary/providers/external_sat/startup/test_smt_unsat_proof_verification.py
+++ b/tests/boundary/providers/external_sat/startup/test_smt_unsat_proof_verification.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import sys
+from collections.abc import Iterator
+from contextlib import ExitStack
 from pathlib import Path
 from typing import Any
 
@@ -25,14 +28,7 @@ from jacobian.runtime import CheckerAuthorityMode, create_runtime
 from jacobian.runtime.model import JacobianRuntime
 from jacobian.verification import CheckerExecutionError
 
-_FIXTURES = (
-    Path(__file__).resolve().parents[5]
-    / "tests"
-    / "boundary"
-    / "providers"
-    / "external_sat"
-    / "fixtures"
-)
+_FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
 _PROBLEM = (_FIXTURES / "qf_uf_equality_unsat.smt2").read_text(encoding="ascii")
 _PROOF = (_FIXTURES / "qf_uf_equality_unsat.alethe").read_bytes()
 
@@ -41,7 +37,7 @@ def _fake_carcara(tmp_path: Path, body: str) -> Path:
     executable = tmp_path / "carcara"
     executable.write_text(
         (
-            "#!/usr/bin/python3\n"
+            f"#!{sys.executable}\n"
             "import sys\n"
             "if '--version' in sys.argv:\n"
             "    print('carcara 1.1.0 [git master 394edbb]')\n"
@@ -96,6 +92,7 @@ def _runtime_with_runtime(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     executable: Path,
+    resources: ExitStack,
     *,
     checker_authority: CheckerAuthorityMode = CheckerAuthorityMode.INSTALL_BUNDLED,
 ) -> JacobianRuntime:
@@ -105,10 +102,18 @@ def _runtime_with_runtime(
         "jacobian.portfolio.provider_resolution.carcara_provider_runtime",
         lambda *_args, **_kwargs: runtime,
     )
-    return create_runtime(
-        tmp_path / "store",
-        checker_authority=checker_authority,
+    return resources.enter_context(
+        create_runtime(
+            tmp_path / "store",
+            checker_authority=checker_authority,
+        )
     )
+
+
+@pytest.fixture
+def runtime_resources() -> Iterator[ExitStack]:
+    with ExitStack() as resources:
+        yield resources
 
 
 @pytest.mark.parametrize(
@@ -170,12 +175,15 @@ def _verify(runtime: JacobianRuntime, proof_uri: str):
 def test_invalid_proof_diagnostic_routes_through_public_capabilities(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    runtime_resources: ExitStack,
 ) -> None:
     executable = _fake_carcara(
         tmp_path,
         "print('valid')\nraise SystemExit(0)",
     )
-    runtime = _runtime_with_runtime(tmp_path, monkeypatch, executable)
+    runtime = _runtime_with_runtime(
+        tmp_path, monkeypatch, executable, runtime_resources
+    )
 
     result = _verify(runtime, "artifact://sha256/" + "0" * 64)
 
@@ -191,12 +199,15 @@ def test_invalid_proof_diagnostic_routes_through_public_capabilities(
 def test_unsat_proof_is_verified_by_authorized_strict_carcara(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    runtime_resources: ExitStack,
 ) -> None:
     executable = _fake_carcara(
         tmp_path,
         "print('valid')\nraise SystemExit(0)",
     )
-    runtime = _runtime_with_runtime(tmp_path, monkeypatch, executable)
+    runtime = _runtime_with_runtime(
+        tmp_path, monkeypatch, executable, runtime_resources
+    )
     problem_uri, proof_uri = _proof(runtime)
     monkeypatch.setattr(
         jacobian_checkers.smt,
@@ -249,12 +260,15 @@ def test_unsat_proof_is_verified_by_authorized_strict_carcara(
 def test_holey_checker_report_never_establishes_sat_or_unsat(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    runtime_resources: ExitStack,
 ) -> None:
     executable = _fake_carcara(
         tmp_path,
         "print('holey')\nraise SystemExit(0)",
     )
-    runtime = _runtime_with_runtime(tmp_path, monkeypatch, executable)
+    runtime = _runtime_with_runtime(
+        tmp_path, monkeypatch, executable, runtime_resources
+    )
     _problem_uri, proof_uri = _proof(runtime)
 
     result = _verify(runtime, proof_uri)
@@ -269,6 +283,7 @@ def test_holey_checker_report_never_establishes_sat_or_unsat(
 def test_proof_verify_requires_runtime_and_operator_authorization(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    runtime_resources: ExitStack,
 ) -> None:
     executable = _fake_carcara(
         tmp_path,
@@ -278,6 +293,7 @@ def test_proof_verify_requires_runtime_and_operator_authorization(
         tmp_path / "without-references",
         monkeypatch,
         executable,
+        runtime_resources,
         checker_authority=CheckerAuthorityMode.NONE,
     )
     unavailable = carcara_provider_runtime(tmp_path / "missing")
@@ -285,9 +301,11 @@ def test_proof_verify_requires_runtime_and_operator_authorization(
         "jacobian.portfolio.provider_resolution.carcara_provider_runtime",
         lambda *_args, **_kwargs: unavailable,
     )
-    without_runtime = create_runtime(
-        tmp_path / "without-runtime",
-        checker_authority=CheckerAuthorityMode.INSTALL_BUNDLED,
+    without_runtime = runtime_resources.enter_context(
+        create_runtime(
+            tmp_path / "without-runtime",
+            checker_authority=CheckerAuthorityMode.INSTALL_BUNDLED,
+        )
     )
 
     assert without_references.portfolio.smt_unsat_proof_checker.checker_id is None
@@ -317,6 +335,7 @@ def test_proof_verify_requires_runtime_and_operator_authorization(
 def test_checker_operational_failure_never_creates_a_conclusion(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    runtime_resources: ExitStack,
     exception: Exception,
     expected_status: ExecutionStatus,
     expected_output_status: str,
@@ -325,7 +344,9 @@ def test_checker_operational_failure_never_creates_a_conclusion(
         tmp_path,
         "print('valid')\nraise SystemExit(0)",
     )
-    runtime = _runtime_with_runtime(tmp_path, monkeypatch, executable)
+    runtime = _runtime_with_runtime(
+        tmp_path, monkeypatch, executable, runtime_resources
+    )
     _problem_uri, proof_uri = _proof(runtime)
 
     def fail(**_kwargs: Any):
@@ -344,12 +365,15 @@ def test_checker_operational_failure_never_creates_a_conclusion(
 def test_runtime_replacement_after_authorization_fails_closed(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    runtime_resources: ExitStack,
 ) -> None:
     executable = _fake_carcara(
         tmp_path,
         "print('valid')\nraise SystemExit(0)",
     )
-    runtime = _runtime_with_runtime(tmp_path, monkeypatch, executable)
+    runtime = _runtime_with_runtime(
+        tmp_path, monkeypatch, executable, runtime_resources
+    )
     _problem_uri, proof_uri = _proof(runtime)
     executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
     executable.chmod(0o755)

--- a/tests/boundary/providers/flint/runtime/test_linear_rational_solution.py
+++ b/tests/boundary/providers/flint/runtime/test_linear_rational_solution.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import shutil
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -12,6 +11,7 @@ import pytest
 from tests.support.capabilities import invoke_capability as _invoke
 from tests.support.rationals import rational_payload as _q
 from tests.support.services import open_domain_services
+from tests.support.state import copy_template
 
 import jacobian.providers.flint_runtime as flint_runtime
 from jacobian.canonical import canonicalize_json
@@ -194,8 +194,8 @@ def test_verifier_authorization_is_separate_from_provider_availability(
 
     default_root = tmp_path / "default"
     authorized_root = tmp_path / "authorized"
-    shutil.copytree(complete_portfolio_template, default_root)
-    shutil.copytree(complete_portfolio_template, authorized_root)
+    copy_template(complete_portfolio_template, default_root)
+    copy_template(complete_portfolio_template, authorized_root)
     with create_runtime(default_root) as default:
         default_ids = {
             descriptor.capability_id

--- a/tests/boundary/providers/graph/runtime/test_finite_graph_optimization.py
+++ b/tests/boundary/providers/graph/runtime/test_finite_graph_optimization.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import itertools
-import shutil
 from collections.abc import Iterator
 from pathlib import Path
 
 import networkx as nx
 import pytest
 import z3
+from tests.support.services import DomainTestServices, open_domain_services
 
 from jacobian.contracts.capabilities import (
     CapabilityAssuranceLevel,
@@ -17,27 +17,20 @@ from jacobian.contracts.capabilities import (
     CapabilityRequest,
 )
 from jacobian.contracts.results import ExecutionStatus
-from jacobian.runtime import create_runtime
-from jacobian.runtime.model import JacobianRuntime
+from jacobian.domains.graph_optimization.bundle import (
+    build_graph_optimization_bundle,
+)
 
 
-@pytest.fixture(scope="module")
-def oracle_runtime(
-    tmp_path_factory: pytest.TempPathFactory,
-    complete_portfolio_template: Path,
-) -> Iterator[JacobianRuntime]:
-    """Reuse the immutable core store snapshot for shared oracle invokes."""
-
-    root = tmp_path_factory.mktemp("finite-graph-oracles")
-    shutil.copytree(complete_portfolio_template, root, dirs_exist_ok=True)
-    runtime = create_runtime(root)
-    # Pay Z3/solver startup once in fixture setup instead of on the first case.
-    warm = nx.relabel_nodes(nx.path_graph(3), lambda vertex: f"v{vertex}")
-    _invoke(runtime, "graph.domination.minimum.compute", warm)
-    try:
-        yield runtime
-    finally:
-        runtime.close()
+@pytest.fixture
+def graph_optimization_services(
+    tmp_path: Path,
+) -> Iterator[DomainTestServices]:
+    with open_domain_services(
+        tmp_path / "state",
+        build_graph_optimization_bundle(),
+    ) as services:
+        yield services
 
 
 def _payload(graph: nx.Graph[str], **budget: int) -> dict[str, object]:
@@ -56,7 +49,7 @@ def _payload(graph: nx.Graph[str], **budget: int) -> dict[str, object]:
 
 
 def _invoke(
-    runtime: JacobianRuntime,
+    runtime: DomainTestServices,
     capability_id: str,
     graph: nx.Graph[str],
     **budget: int,
@@ -144,13 +137,13 @@ _ORACLE_CAPABILITIES = (
     ids=("path", "odd-cycle", "complete", "disconnected"),
 )
 def test_graph_optimizer_matches_independent_small_brute_force_oracle(
-    oracle_runtime: JacobianRuntime,
+    graph_optimization_services: DomainTestServices,
     capability_id: str,
     graph: nx.Graph[int],
 ) -> None:
     relabeled: nx.Graph[str] = nx.relabel_nodes(graph, lambda vertex: f"v{vertex}")
 
-    result = _invoke(oracle_runtime, capability_id, relabeled)
+    result = _invoke(graph_optimization_services, capability_id, relabeled)
 
     assert result.execution.status is ExecutionStatus.COMPLETED
     assert result.output["status"] == "EXACT"
@@ -200,7 +193,7 @@ def test_graph_optimizer_matches_independent_small_brute_force_oracle(
     ),
 )
 def test_graph_optimizer_returns_exact_witness_and_open_obligation(
-    tmp_path: Path,
+    graph_optimization_services: DomainTestServices,
     capability_id: str,
     graph: nx.Graph[int],
     optimum: int,
@@ -208,7 +201,7 @@ def test_graph_optimizer_returns_exact_witness_and_open_obligation(
     predicate: str,
 ) -> None:
     relabeled = nx.relabel_nodes(graph, lambda vertex: f"v{vertex}")
-    runtime = create_runtime(tmp_path)
+    runtime = graph_optimization_services
 
     result = _invoke(runtime, capability_id, relabeled)
 
@@ -243,9 +236,9 @@ def test_graph_optimizer_returns_exact_witness_and_open_obligation(
 
 
 def test_solver_call_budget_preserves_incumbent_without_claiming_optimum(
-    tmp_path: Path,
+    graph_optimization_services: DomainTestServices,
 ) -> None:
-    runtime = create_runtime(tmp_path)
+    runtime = graph_optimization_services
     graph = nx.relabel_nodes(nx.complete_graph(5), lambda vertex: f"v{vertex}")
 
     result = _invoke(
@@ -267,10 +260,10 @@ def test_solver_call_budget_preserves_incumbent_without_claiming_optimum(
 
 
 def test_solver_timeout_preserves_partial_witness_as_non_conclusion(
-    tmp_path: Path,
+    graph_optimization_services: DomainTestServices,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    runtime = create_runtime(tmp_path)
+    runtime = graph_optimization_services
     graph = nx.path_graph(["a", "b", "c", "d"])
     monkeypatch.setattr(z3.Solver, "check", lambda _solver: z3.unknown)
 
@@ -315,7 +308,7 @@ def test_solver_timeout_preserves_partial_witness_as_non_conclusion(
     ),
 )
 def test_invalid_solver_witness_fails_closed_before_artifact_writes(
-    tmp_path: Path,
+    graph_optimization_services: DomainTestServices,
     monkeypatch: pytest.MonkeyPatch,
     solver_name: str,
     capability_id: str,
@@ -330,7 +323,7 @@ def test_invalid_solver_witness_fails_closed_before_artifact_writes(
         return result.model_copy(update=update)
 
     monkeypatch.setattr(finite_optimization, solver_name, invalid_witness)
-    runtime = create_runtime(tmp_path)
+    runtime = graph_optimization_services
     result = _invoke(
         runtime,
         capability_id,
@@ -353,10 +346,10 @@ def test_invalid_solver_witness_fails_closed_before_artifact_writes(
     ),
 )
 def test_empty_graph_boundary_is_exact_zero(
-    tmp_path: Path,
+    graph_optimization_services: DomainTestServices,
     capability_id: str,
 ) -> None:
-    runtime = create_runtime(tmp_path)
+    runtime = graph_optimization_services
     result = _invoke(runtime, capability_id, nx.Graph())
 
     assert result.output["status"] == "EXACT"
@@ -365,8 +358,10 @@ def test_empty_graph_boundary_is_exact_zero(
     assert result.output["termination_reason"] == "SPECIAL_CASE"
 
 
-def test_order_budget_fails_before_artifact_writes(tmp_path: Path) -> None:
-    runtime = create_runtime(tmp_path)
+def test_order_budget_fails_before_artifact_writes(
+    graph_optimization_services: DomainTestServices,
+) -> None:
+    runtime = graph_optimization_services
     graph = nx.relabel_nodes(nx.path_graph(3), lambda vertex: f"v{vertex}")
 
     result = _invoke(

--- a/tests/boundary/providers/lean/startup/test_lean.py
+++ b/tests/boundary/providers/lean/startup/test_lean.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import shutil
 import threading
 from pathlib import Path
 from typing import Any, cast
@@ -11,6 +10,7 @@ from tests.support.provider_lean import (
     PINNED_MATHLIB_RUNTIME_UNAVAILABLE_REASON,
     pinned_mathlib_runtime_available,
 )
+from tests.support.state import copy_template
 
 from jacobian.adapters.mcp.server import create_server
 from jacobian.contracts.capabilities import (
@@ -65,8 +65,8 @@ def test_core_declaration_catalog_matches_a_fresh_scan_and_detects_tampering(
 ) -> None:
     indexed_root = tmp_path / "indexed"
     fresh_root = tmp_path / "fresh"
-    shutil.copytree(authorized_portfolio_template, indexed_root)
-    shutil.copytree(authorized_portfolio_template, fresh_root)
+    copy_template(authorized_portfolio_template, indexed_root)
+    copy_template(authorized_portfolio_template, fresh_root)
     indexed_runtime = create_runtime(
         indexed_root, checker_authority=CheckerAuthorityMode.INSTALL_BUNDLED
     )

--- a/tests/component/checkers/test_sat_unsat_proof_checker.py
+++ b/tests/component/checkers/test_sat_unsat_proof_checker.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import hashlib
-from collections.abc import Callable
+import sys
+from collections.abc import Callable, Iterator
 from copy import deepcopy
 from pathlib import Path
 from typing import Any
@@ -56,9 +57,9 @@ def _checker_artifact(artifact: StoredArtifact) -> dict[str, Any]:
 
 @pytest.fixture
 def proof_request_factory(
-    tmp_path_factory: pytest.TempPathFactory,
-) -> ProofRequestFactory:
-    store = ArtifactRepository(tmp_path_factory.mktemp("sat-proof-checker-store"))
+    tmp_path: Path,
+) -> Iterator[ProofRequestFactory]:
+    store = ArtifactRepository(tmp_path / "store")
     schemas = SchemaRegistry(store)
     artifacts = ArtifactService(store, schemas)
     sat = install_sat_artifacts(store, schemas, artifacts)
@@ -117,7 +118,10 @@ def proof_request_factory(
             "expected_bindings": bindings.model_dump(mode="json"),
         }
 
-    return build
+    try:
+        yield build
+    finally:
+        store.close()
 
 
 def _fake_checker(tmp_path: Path, body: str) -> tuple[Path, Path]:
@@ -125,7 +129,7 @@ def _fake_checker(tmp_path: Path, body: str) -> tuple[Path, Path]:
     executable = tmp_path / "drat-trim"
     executable.write_text(
         (
-            "#!/usr/bin/python3\n"
+            f"#!{sys.executable}\n"
             "import pathlib\n"
             "import sys\n"
             f"marker = pathlib.Path({str(marker)!r})\n"

--- a/tests/component/checkers/test_smt_unsat_proof_checker.py
+++ b/tests/component/checkers/test_smt_unsat_proof_checker.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import hashlib
-from collections.abc import Callable
+import sys
+from collections.abc import Callable, Iterator
 from copy import deepcopy
 from pathlib import Path
 from typing import Any
@@ -68,11 +69,11 @@ def _checker_artifact(artifact: StoredArtifact) -> dict[str, Any]:
     }
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def proof_request_factory(
-    tmp_path_factory: pytest.TempPathFactory,
-) -> ProofRequestFactory:
-    store = ArtifactRepository(tmp_path_factory.mktemp("smt-proof-checker-store"))
+    tmp_path: Path,
+) -> Iterator[ProofRequestFactory]:
+    store = ArtifactRepository(tmp_path / "store")
     schemas = SchemaRegistry(store)
     artifacts = ArtifactService(store, schemas)
     smt = install_smt_artifacts(store, schemas, artifacts)
@@ -136,7 +137,10 @@ def proof_request_factory(
             "expected_bindings": bindings.model_dump(mode="json"),
         }
 
-    return build
+    try:
+        yield build
+    finally:
+        store.close()
 
 
 def _fake_checker(tmp_path: Path, body: str) -> tuple[Path, Path]:
@@ -145,7 +149,7 @@ def _fake_checker(tmp_path: Path, body: str) -> tuple[Path, Path]:
     executable = tmp_path / "carcara"
     executable.write_text(
         (
-            "#!/usr/bin/python3\n"
+            f"#!{sys.executable}\n"
             "import pathlib\n"
             "import sys\n"
             f"marker = pathlib.Path({str(marker)!r})\n"

--- a/tests/component/providers/lean/test_lean_checker_errors.py
+++ b/tests/component/providers/lean/test_lean_checker_errors.py
@@ -178,13 +178,15 @@ def test_elan_toolchain_resolution_rejects_elan_proxy_path(
 
 
 def test_system_elan_uses_the_original_user_toolchain_home(
+    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv("ELAN_HOME", raising=False)
-    monkeypatch.setenv("HOME", "/tmp/jacobian-test-home")
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
 
     assert _elan_home(("/usr/bin/elan", "run", LEAN_TOOLCHAIN, "lean")) == (
-        "/tmp/jacobian-test-home/.elan"
+        str(home / ".elan")
     )
 
 

--- a/tests/composition/authority/test_hydrate_authorized.py
+++ b/tests/composition/authority/test_hydrate_authorized.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-import shutil
 import sqlite3
 from pathlib import Path
 
-import pytest
+from tests.support.state import copy_template
 
 from jacobian.runtime import CheckerAuthorityMode, create_runtime
 from jacobian.runtime.model import JacobianRuntime
@@ -31,36 +30,32 @@ def _audit_count(root: Path) -> int:
 
 
 def test_hydrate_authorized_matches_bundled_authority_without_audit(
-    tmp_path_factory: pytest.TempPathFactory,
+    tmp_path: Path,
 ) -> None:
-    seed = tmp_path_factory.mktemp("hydrate-seed")
-    authorized = create_runtime(
+    seed = tmp_path / "seed"
+    with create_runtime(
         seed, checker_authority=CheckerAuthorityMode.INSTALL_BUNDLED
-    )
-    expected = _verify_ids(authorized)
-    baseline_audit = _audit_count(seed)
-    authorized.close()
+    ) as authorized:
+        expected = _verify_ids(authorized)
+        baseline_audit = _audit_count(seed)
 
-    attached = tmp_path_factory.mktemp("hydrate-attach")
-    shutil.copytree(seed, attached, dirs_exist_ok=True)
-    hydrated = create_runtime(
+    attached = copy_template(seed, tmp_path / "attached")
+    with create_runtime(
         attached, checker_authority=CheckerAuthorityMode.HYDRATE_EXISTING
-    )
-
-    assert _verify_ids(hydrated) == expected
-    assert _audit_count(attached) == baseline_audit
+    ) as hydrated:
+        assert _verify_ids(hydrated) == expected
+        assert _audit_count(attached) == baseline_audit
 
 
 def test_hydrate_authorized_on_empty_store_is_fail_closed(tmp_path: Path) -> None:
-    runtime = create_runtime(
+    with create_runtime(
         tmp_path, checker_authority=CheckerAuthorityMode.HYDRATE_EXISTING
-    )
-
-    assert _audit_count(tmp_path) == 0
-    # Atomic / resource verify surfaces may still appear; domain checkers must not.
-    assert "polynomial.gcd.verify" not in _verify_ids(runtime)
-    assert "sat.model.verify" not in _verify_ids(runtime)
-    assert "matrix.determinant.verify" not in _verify_ids(runtime)
+    ) as runtime:
+        assert _audit_count(tmp_path) == 0
+        # Atomic / resource verify surfaces may still appear; domain checkers must not.
+        assert "polynomial.gcd.verify" not in _verify_ids(runtime)
+        assert "sat.model.verify" not in _verify_ids(runtime)
+        assert "matrix.determinant.verify" not in _verify_ids(runtime)
 
 
 def test_authorized_runtime_hydrates_reference_checkers(

--- a/tests/composition/portfolio/test_domain_bundles.py
+++ b/tests/composition/portfolio/test_domain_bundles.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from pathlib import Path
 
 import pytest
 
@@ -228,9 +229,9 @@ def test_unique_domain_ids() -> None:
     assert len(domain_ids) == len(set(domain_ids)), f"duplicates: {domain_ids}"
 
 
-@pytest.fixture(scope="module")
-def service(tmp_path_factory: pytest.TempPathFactory) -> Iterator[CapabilityService]:
-    store = ArtifactRepository(tmp_path_factory.mktemp("domain-bundles"))
+@pytest.fixture
+def service(tmp_path: Path) -> Iterator[CapabilityService]:
+    store = ArtifactRepository(tmp_path / "state")
     schemas = SchemaRegistry(store)
     artifacts = ArtifactService(store, schemas)
     service = CapabilityService(store)

--- a/tests/composition/portfolio/test_plugin_registry_snapshots.py
+++ b/tests/composition/portfolio/test_plugin_registry_snapshots.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import os
-import shutil
 import sqlite3
 import sys
 from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
+from tests.support.state import copy_template
 
 import jacobian.plugins.registry as registry_module
 from jacobian.contracts.claims import ClaimSpec
@@ -35,8 +35,7 @@ def plugin_runtime(
 ) -> Iterator[JacobianRuntime]:
     """Runtime rooted at ``tmp_path/state`` so plugin packages can live beside it."""
 
-    state = tmp_path / "state"
-    shutil.copytree(complete_portfolio_template, state)
+    state = copy_template(complete_portfolio_template, tmp_path / "state")
     runtime = create_runtime(state)
     try:
         yield runtime

--- a/tests/composition/runtime/test_frontier_capabilities.py
+++ b/tests/composition/runtime/test_frontier_capabilities.py
@@ -2,32 +2,58 @@
 
 from __future__ import annotations
 
-import shutil
+from collections.abc import Iterator
 from copy import deepcopy
+from pathlib import Path
 from typing import Any
 
 import pytest
+from tests.support.services import DomainTestServices, open_domain_services
 
 from jacobian.contracts.capabilities import CapabilityMode, CapabilityRequest
 from jacobian.contracts.results import ExecutionStatus
-from jacobian.runtime import CheckerAuthorityMode, create_runtime
-from jacobian.runtime.model import JacobianRuntime
+from jacobian.domains.graph_optimization.bundle import (
+    build_graph_optimization_bundle,
+)
+from jacobian.domains.polynomial.bundle import build_polynomial_bundle
+from jacobian.domains.projective_geometry.bundle import (
+    build_projective_geometry_bundle,
+)
+from jacobian.exact_domain_checkers import install_exact_domain_verification
+from jacobian.portfolio.domain_installation import DomainBundleInstaller
+from jacobian.portfolio.model import PortfolioPlan
+from jacobian.runtime.config import CheckerAuthorityMode
 
 
-@pytest.fixture(scope="module")
-def frontier_runtime(
-    tmp_path_factory: pytest.TempPathFactory,
-    authorized_portfolio_template,
-) -> JacobianRuntime:
-    root = tmp_path_factory.mktemp("frontier-capabilities")
-    shutil.copytree(authorized_portfolio_template, root, dirs_exist_ok=True)
-    runtime = create_runtime(
-        root, checker_authority=CheckerAuthorityMode.HYDRATE_EXISTING
+@pytest.fixture
+def frontier_services(tmp_path: Path) -> Iterator[DomainTestServices]:
+    bundles = (
+        build_projective_geometry_bundle(),
+        build_graph_optimization_bundle(),
+        build_polynomial_bundle(),
     )
-    try:
-        yield runtime
-    finally:
-        runtime.close()
+    with open_domain_services(
+        tmp_path / "state",
+        checker_authority=CheckerAuthorityMode.INSTALL_BUNDLED,
+    ) as services:
+        installed = DomainBundleInstaller(services.installation).install(
+            PortfolioPlan(domain_bundles=bundles)
+        )
+        verifier_adapters, _ = install_exact_domain_verification(
+            services.core.store,
+            services.core.schemas,
+            services.core.artifacts,
+            services.application.verification,
+            services.core.checkers,
+            bundles={
+                bundle.domain_id: (bundle, installed.installed[bundle.domain_id])
+                for bundle in bundles
+            },
+            authorize=services.installation.authorizes_bundled_checkers,
+        )
+        for adapter in verifier_adapters:
+            services.installation.register_capability(adapter)
+        yield services
 
 
 def _q(value: int) -> dict[str, str]:
@@ -52,14 +78,14 @@ def _polynomial(
 
 
 def _result_payload(
-    runtime: JacobianRuntime,
+    runtime: DomainTestServices,
     computed: Any,
 ) -> dict[str, Any]:
     return runtime.core.store.get(computed.output["result_uri"]).payload
 
 
 def test_projective_arrangement_materializes_the_nine_line_flat_lattice(
-    frontier_runtime: JacobianRuntime,
+    frontier_services: DomainTestServices,
 ) -> None:
     coefficients = (
         (0, 1, -1),
@@ -72,7 +98,7 @@ def test_projective_arrangement_materializes_the_nine_line_flat_lattice(
         (1, 1, 2),
         (2, -1, -2),
     )
-    result = frontier_runtime.core.capabilities.invoke(
+    result = frontier_services.core.capabilities.invoke(
         CapabilityRequest(
             capability_id=("geometry.projective_line_arrangement.flats.materialize"),
             input={
@@ -88,7 +114,7 @@ def test_projective_arrangement_materializes_the_nine_line_flat_lattice(
     )
 
     assert result.execution.status is ExecutionStatus.COMPLETED
-    payload = _result_payload(frontier_runtime, result)
+    payload = _result_payload(frontier_services, result)
     assert payload["non_double_flats"] == [
         ["1", "2", "3"],
         ["1", "4", "5"],
@@ -105,7 +131,7 @@ def test_projective_arrangement_materializes_the_nine_line_flat_lattice(
         {"multiplicity": 4, "flat_count": 1},
     ]
     assert payload["pair_count_total"] == 36
-    verified = frontier_runtime.core.capabilities.invoke(
+    verified = frontier_services.core.capabilities.invoke(
         CapabilityRequest(
             capability_id=("geometry.projective_line_arrangement.flats.verify"),
             mode=CapabilityMode.VERIFY,
@@ -117,9 +143,9 @@ def test_projective_arrangement_materializes_the_nine_line_flat_lattice(
 
 
 def test_projective_arrangement_rejects_projectively_duplicate_lines(
-    frontier_runtime: JacobianRuntime,
+    frontier_services: DomainTestServices,
 ) -> None:
-    result = frontier_runtime.core.capabilities.invoke(
+    result = frontier_services.core.capabilities.invoke(
         CapabilityRequest(
             capability_id=("geometry.projective_line_arrangement.flats.materialize"),
             input={
@@ -136,9 +162,9 @@ def test_projective_arrangement_rejects_projectively_duplicate_lines(
 
 
 def test_arrangement_checker_rejects_schema_valid_forged_normalization(
-    frontier_runtime: JacobianRuntime,
+    frontier_services: DomainTestServices,
 ) -> None:
-    computed = frontier_runtime.core.capabilities.invoke(
+    computed = frontier_services.core.capabilities.invoke(
         CapabilityRequest(
             capability_id=("geometry.projective_line_arrangement.flats.materialize"),
             input={
@@ -149,23 +175,21 @@ def test_arrangement_checker_rejects_schema_valid_forged_normalization(
             },
         )
     )
-    forged = deepcopy(_result_payload(frontier_runtime, computed))
+    stored = frontier_services.core.store.get(computed.output["result_uri"])
+    forged = deepcopy(stored.payload)
     forged["normalized_lines"][0]["coefficients"]["coordinates"] = [
         "1",
         "1",
         "0",
     ]
-    installation = frontier_runtime.portfolio.domain_bundles["projective_geometry"]
-    forged_uri = frontier_runtime.core.artifacts.put(
-        schema_uri=installation.result_schema_uris[
-            "geometry.projective_line_arrangement.flats.materialize"
-        ],
-        semantics_uri=installation.semantics_uri,
+    forged_uri = frontier_services.core.artifacts.put(
+        schema_uri=stored.manifest.schema_uri,
+        semantics_uri=stored.manifest.semantics_uri,
         payload=forged,
         parents=(computed.output["input_uri"],),
         summary="schema-valid forged projective normalization",
     ).artifact_uri
-    checked = frontier_runtime.core.capabilities.invoke(
+    checked = frontier_services.core.capabilities.invoke(
         CapabilityRequest(
             capability_id=("geometry.projective_line_arrangement.flats.verify"),
             mode=CapabilityMode.VERIFY,
@@ -196,20 +220,20 @@ def test_arrangement_checker_rejects_schema_valid_forged_normalization(
     ],
 )
 def test_hamiltonian_path_decision_has_independent_replay(
-    frontier_runtime: JacobianRuntime,
+    frontier_services: DomainTestServices,
     graph: dict[str, object],
     decision: str,
 ) -> None:
-    computed = frontier_runtime.core.capabilities.invoke(
+    computed = frontier_services.core.capabilities.invoke(
         CapabilityRequest(
             capability_id="graph.hamiltonian_path.decide",
             input={"graph": graph},
         )
     )
     assert computed.execution.status is ExecutionStatus.COMPLETED
-    assert _result_payload(frontier_runtime, computed)["decision"] == decision
+    assert _result_payload(frontier_services, computed)["decision"] == decision
 
-    verified = frontier_runtime.core.capabilities.invoke(
+    verified = frontier_services.core.capabilities.invoke(
         CapabilityRequest(
             capability_id="graph.hamiltonian_path.verify",
             mode=CapabilityMode.VERIFY,
@@ -221,9 +245,9 @@ def test_hamiltonian_path_decision_has_independent_replay(
 
 
 def test_graded_jacobian_syzygy_finds_and_verifies_the_first_kernel(
-    frontier_runtime: JacobianRuntime,
+    frontier_services: DomainTestServices,
 ) -> None:
-    computed = frontier_runtime.core.capabilities.invoke(
+    computed = frontier_services.core.capabilities.invoke(
         CapabilityRequest(
             capability_id=("polynomial.jacobian_syzygy.minimum_degree.compute"),
             input={
@@ -234,7 +258,7 @@ def test_graded_jacobian_syzygy_finds_and_verifies_the_first_kernel(
     )
 
     assert computed.execution.status is ExecutionStatus.COMPLETED
-    result = _result_payload(frontier_runtime, computed)
+    result = _result_payload(frontier_services, computed)
     assert result["status"] == "FOUND"
     assert result["first_syzygy_degree"] == 1
     assert [(item["rank"], item["nullity"]) for item in result["degree_maps"]] == [
@@ -245,7 +269,7 @@ def test_graded_jacobian_syzygy_finds_and_verifies_the_first_kernel(
     assert result["coefficient_map_detail"] == "CERTIFICATES"
     assert all(not item["sparse_entries"] for item in result["degree_maps"])
 
-    verified = frontier_runtime.core.capabilities.invoke(
+    verified = frontier_services.core.capabilities.invoke(
         CapabilityRequest(
             capability_id=("polynomial.jacobian_syzygy.minimum_degree.verify"),
             mode=CapabilityMode.VERIFY,
@@ -256,10 +280,15 @@ def test_graded_jacobian_syzygy_finds_and_verifies_the_first_kernel(
     assert verified.output["status"] == "VERIFIED"
 
 
+@pytest.mark.parametrize(
+    "forgery",
+    ("map_digest", "rank_minor", "kernel_vector", "partial_derivative"),
+)
 def test_syzygy_checker_rejects_schema_valid_forged_evidence(
-    frontier_runtime: JacobianRuntime,
+    frontier_services: DomainTestServices,
+    forgery: str,
 ) -> None:
-    computed = frontier_runtime.core.capabilities.invoke(
+    computed = frontier_services.core.capabilities.invoke(
         CapabilityRequest(
             capability_id=("polynomial.jacobian_syzygy.minimum_degree.compute"),
             input={
@@ -268,52 +297,44 @@ def test_syzygy_checker_rejects_schema_valid_forged_evidence(
             },
         )
     )
-    installation = frontier_runtime.portfolio.domain_bundles["polynomial"]
     input_uri = computed.output["input_uri"]
-    for name in (
-        "map_digest",
-        "rank_minor",
-        "kernel_vector",
-        "partial_derivative",
-    ):
-        forged = deepcopy(_result_payload(frontier_runtime, computed))
-        if name == "map_digest":
-            forged["degree_maps"][0]["matrix_digest"] = f"sha256:{'0' * 64}"
-        elif name == "rank_minor":
-            determinant = forged["degree_maps"][0]["rank_minor"]["determinant"]
-            determinant["num"] = str(-int(determinant["num"]))
-        elif name == "kernel_vector":
-            forged["kernel_witness"]["coefficient_vector"][0] = _q(2)
-        else:
-            forged["partial_derivatives"][0]["polynomial"]["terms"][0][
-                "coefficient"
-            ] = _q(2)
-        forged_uri = frontier_runtime.core.artifacts.put(
-            schema_uri=installation.result_schema_uris[
-                "polynomial.jacobian_syzygy.minimum_degree.compute"
-            ],
-            semantics_uri=installation.semantics_uri,
-            payload=forged,
-            parents=(input_uri,),
-            summary=f"schema-valid adversarial graded-map result: {name}",
-        ).artifact_uri
-
-        checked = frontier_runtime.core.capabilities.invoke(
-            CapabilityRequest(
-                capability_id=("polynomial.jacobian_syzygy.minimum_degree.verify"),
-                mode=CapabilityMode.VERIFY,
-                input={"result_uri": forged_uri},
-            )
+    stored = frontier_services.core.store.get(computed.output["result_uri"])
+    forged = deepcopy(stored.payload)
+    if forgery == "map_digest":
+        forged["degree_maps"][0]["matrix_digest"] = f"sha256:{'0' * 64}"
+    elif forgery == "rank_minor":
+        determinant = forged["degree_maps"][0]["rank_minor"]["determinant"]
+        determinant["num"] = str(-int(determinant["num"]))
+    elif forgery == "kernel_vector":
+        forged["kernel_witness"]["coefficient_vector"][0] = _q(2)
+    else:
+        forged["partial_derivatives"][0]["polynomial"]["terms"][0]["coefficient"] = _q(
+            2
         )
-        assert checked.execution.status is ExecutionStatus.COMPLETED
-        assert checked.output["status"] == "REJECTED"
-        assert checked.output["conclusion"] == "UNKNOWN"
+    forged_uri = frontier_services.core.artifacts.put(
+        schema_uri=stored.manifest.schema_uri,
+        semantics_uri=stored.manifest.semantics_uri,
+        payload=forged,
+        parents=(input_uri,),
+        summary=f"schema-valid adversarial graded-map result: {forgery}",
+    ).artifact_uri
+
+    checked = frontier_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id=("polynomial.jacobian_syzygy.minimum_degree.verify"),
+            mode=CapabilityMode.VERIFY,
+            input={"result_uri": forged_uri},
+        )
+    )
+    assert checked.execution.status is ExecutionStatus.COMPLETED
+    assert checked.output["status"] == "REJECTED"
+    assert checked.output["conclusion"] == "UNKNOWN"
 
 
 def test_hamiltonian_checker_rejects_a_forged_negative_decision(
-    frontier_runtime: JacobianRuntime,
+    frontier_services: DomainTestServices,
 ) -> None:
-    computed = frontier_runtime.core.capabilities.invoke(
+    computed = frontier_services.core.capabilities.invoke(
         CapabilityRequest(
             capability_id="graph.hamiltonian_path.decide",
             input={
@@ -324,19 +345,19 @@ def test_hamiltonian_checker_rejects_a_forged_negative_decision(
             },
         )
     )
-    forged = deepcopy(_result_payload(frontier_runtime, computed))
+    stored = frontier_services.core.store.get(computed.output["result_uri"])
+    forged = deepcopy(stored.payload)
     forged["decision"] = "DOES_NOT_EXIST"
     forged["path"] = []
-    installation = frontier_runtime.portfolio.domain_bundles["graph_optimization"]
-    forged_uri = frontier_runtime.core.artifacts.put(
-        schema_uri=installation.result_schema_uris["graph.hamiltonian_path.decide"],
-        semantics_uri=installation.semantics_uri,
+    forged_uri = frontier_services.core.artifacts.put(
+        schema_uri=stored.manifest.schema_uri,
+        semantics_uri=stored.manifest.semantics_uri,
         payload=forged,
         parents=(computed.output["input_uri"],),
         summary="schema-valid forged negative Hamiltonian-path decision",
     ).artifact_uri
 
-    checked = frontier_runtime.core.capabilities.invoke(
+    checked = frontier_services.core.capabilities.invoke(
         CapabilityRequest(
             capability_id="graph.hamiltonian_path.verify",
             mode=CapabilityMode.VERIFY,
@@ -349,9 +370,9 @@ def test_hamiltonian_checker_rejects_a_forged_negative_decision(
 
 
 def test_sparse_map_detail_is_explicitly_opt_in(
-    frontier_runtime: JacobianRuntime,
+    frontier_services: DomainTestServices,
 ) -> None:
-    computed = frontier_runtime.core.capabilities.invoke(
+    computed = frontier_services.core.capabilities.invoke(
         CapabilityRequest(
             capability_id=("polynomial.jacobian_syzygy.minimum_degree.compute"),
             input={
@@ -361,17 +382,16 @@ def test_sparse_map_detail_is_explicitly_opt_in(
             },
         )
     )
-    entries = _result_payload(frontier_runtime, computed)["degree_maps"][0][
+    entries = _result_payload(frontier_services, computed)["degree_maps"][0][
         "sparse_entries"
     ]
     assert entries
     assert entries == sorted(entries, key=lambda item: (item["row"], item["column"]))
 
 
-def test_nine_line_challenge_mdr_values_are_end_to_end_verified(
-    frontier_runtime: JacobianRuntime,
-) -> None:
-    cases = (
+@pytest.mark.parametrize(
+    ("factors", "expected_degree"),
+    (
         (
             (
                 (0, 1, -1),
@@ -400,35 +420,41 @@ def test_nine_line_challenge_mdr_values_are_end_to_end_verified(
             ),
             5,
         ),
+    ),
+    ids=("mdr-4", "mdr-5"),
+)
+def test_nine_line_challenge_mdr_values_are_end_to_end_verified(
+    frontier_services: DomainTestServices,
+    factors: tuple[tuple[int, int, int], ...],
+    expected_degree: int,
+) -> None:
+    computed = frontier_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id=("polynomial.jacobian_syzygy.minimum_degree.compute"),
+            input={
+                "linear_factors": [
+                    {
+                        "label": str(index),
+                        "coefficients": [_q(value) for value in coefficients],
+                    }
+                    for index, coefficients in enumerate(factors, start=1)
+                ],
+                "linear_factor_variables": ["x", "y", "z"],
+                "max_degree": expected_degree,
+            },
+        )
     )
-    for factors, expected_degree in cases:
-        computed = frontier_runtime.core.capabilities.invoke(
-            CapabilityRequest(
-                capability_id=("polynomial.jacobian_syzygy.minimum_degree.compute"),
-                input={
-                    "linear_factors": [
-                        {
-                            "label": str(index),
-                            "coefficients": [_q(value) for value in coefficients],
-                        }
-                        for index, coefficients in enumerate(factors, start=1)
-                    ],
-                    "linear_factor_variables": ["x", "y", "z"],
-                    "max_degree": expected_degree,
-                },
-            )
+    assert computed.execution.status is ExecutionStatus.COMPLETED
+    assert (
+        _result_payload(frontier_services, computed)["first_syzygy_degree"]
+        == expected_degree
+    )
+    verified = frontier_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id=("polynomial.jacobian_syzygy.minimum_degree.verify"),
+            mode=CapabilityMode.VERIFY,
+            input={"result_uri": computed.output["result_uri"]},
         )
-        assert computed.execution.status is ExecutionStatus.COMPLETED
-        assert (
-            _result_payload(frontier_runtime, computed)["first_syzygy_degree"]
-            == expected_degree
-        )
-        verified = frontier_runtime.core.capabilities.invoke(
-            CapabilityRequest(
-                capability_id=("polynomial.jacobian_syzygy.minimum_degree.verify"),
-                mode=CapabilityMode.VERIFY,
-                input={"result_uri": computed.output["result_uri"]},
-            )
-        )
-        assert verified.execution.status is ExecutionStatus.COMPLETED
-        assert verified.output["status"] == "VERIFIED"
+    )
+    assert verified.execution.status is ExecutionStatus.COMPLETED
+    assert verified.output["status"] == "VERIFIED"

--- a/tests/composition/runtime/test_graph_counterexample_shrinking.py
+++ b/tests/composition/runtime/test_graph_counterexample_shrinking.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
-import shutil
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
+
+import pytest
+from tests.support.state import copy_template
 
 from jacobian.contracts.capabilities import (
     CapabilityAssuranceLevel,
@@ -15,14 +19,22 @@ from jacobian.runtime import CheckerAuthorityMode, create_runtime
 from jacobian.runtime.model import JacobianRuntime
 
 
-def test_graph_counterexample_shrink_records_verified_steps_and_exact_local_scope(
+@pytest.fixture
+def redundant_odd_cycle_runtime(
     tmp_path: Path,
     authorized_portfolio_template: Path,
-) -> None:
-    runtime, graph_uri = _runtime_with_redundant_odd_cycle(
+) -> Iterator[tuple[JacobianRuntime, str]]:
+    with _open_runtime_with_redundant_odd_cycle(
         tmp_path,
         template=authorized_portfolio_template,
-    )
+    ) as opened:
+        yield opened
+
+
+def test_graph_counterexample_shrink_records_verified_steps_and_exact_local_scope(
+    redundant_odd_cycle_runtime: tuple[JacobianRuntime, str],
+) -> None:
+    runtime, graph_uri = redundant_odd_cycle_runtime
 
     result = _shrink(runtime, graph_uri)
 
@@ -69,12 +81,9 @@ def test_graph_counterexample_shrink_records_verified_steps_and_exact_local_scop
 
 
 def test_graph_counterexample_shrink_budget_reports_only_tested_scope(
-    tmp_path: Path,
-    authorized_portfolio_template: Path,
+    redundant_odd_cycle_runtime: tuple[JacobianRuntime, str],
 ) -> None:
-    runtime, graph_uri = _runtime_with_redundant_odd_cycle(
-        tmp_path, template=authorized_portfolio_template
-    )
+    runtime, graph_uri = redundant_odd_cycle_runtime
 
     result = _shrink(runtime, graph_uri, evaluation_budget=2)
 
@@ -86,12 +95,9 @@ def test_graph_counterexample_shrink_budget_reports_only_tested_scope(
 
 
 def test_graph_counterexample_shrink_timeout_returns_incumbent_without_minimality(
-    tmp_path: Path,
-    authorized_portfolio_template: Path,
+    redundant_odd_cycle_runtime: tuple[JacobianRuntime, str],
 ) -> None:
-    runtime, graph_uri = _runtime_with_redundant_odd_cycle(
-        tmp_path, template=authorized_portfolio_template
-    )
+    runtime, graph_uri = redundant_odd_cycle_runtime
     runtime.services.shrinking.executor = _TimeoutExecutor()  # type: ignore[assignment]
 
     result = _shrink(runtime, graph_uri)
@@ -104,12 +110,9 @@ def test_graph_counterexample_shrink_timeout_returns_incumbent_without_minimalit
 
 
 def test_graph_counterexample_shrink_requires_compatible_registered_checker(
-    tmp_path: Path,
-    authorized_portfolio_template: Path,
+    redundant_odd_cycle_runtime: tuple[JacobianRuntime, str],
 ) -> None:
-    runtime, graph_uri = _runtime_with_redundant_odd_cycle(
-        tmp_path, template=authorized_portfolio_template
-    )
+    runtime, graph_uri = redundant_odd_cycle_runtime
     incompatible = runtime.portfolio.graph.degree_sequence_checker_id
     assert incompatible is not None
 
@@ -131,12 +134,9 @@ def test_graph_counterexample_shrink_requires_compatible_registered_checker(
 
 
 def test_graph_counterexample_shrink_fails_closed_on_tampered_graph(
-    tmp_path: Path,
-    authorized_portfolio_template: Path,
+    redundant_odd_cycle_runtime: tuple[JacobianRuntime, str],
 ) -> None:
-    runtime, graph_uri = _runtime_with_redundant_odd_cycle(
-        tmp_path, template=authorized_portfolio_template
-    )
+    runtime, graph_uri = redundant_odd_cycle_runtime
     graph = runtime.core.store.get(graph_uri)
     runtime.core.store._blob_path(graph.manifest.payload_digest).write_bytes(
         b"tampered"
@@ -150,12 +150,9 @@ def test_graph_counterexample_shrink_fails_closed_on_tampered_graph(
 
 
 def test_graph_counterexample_shrink_rejects_unrelated_reducer_edits(
-    tmp_path: Path,
-    authorized_portfolio_template: Path,
+    redundant_odd_cycle_runtime: tuple[JacobianRuntime, str],
 ) -> None:
-    runtime, graph_uri = _runtime_with_redundant_odd_cycle(
-        tmp_path, template=authorized_portfolio_template
-    )
+    runtime, graph_uri = redundant_odd_cycle_runtime
     runtime.services.shrinking.executor = _UnrelatedEditExecutor()  # type: ignore[assignment]
 
     result = _shrink(runtime, graph_uri)
@@ -172,31 +169,33 @@ def test_graph_counterexample_shrink_order_is_deterministic(
 ) -> None:
     first_root = tmp_path / "first"
     second_root = tmp_path / "second"
-    first, first_graph = _runtime_with_redundant_odd_cycle(
-        first_root, template=authorized_portfolio_template
-    )
-    second, second_graph = _runtime_with_redundant_odd_cycle(
-        second_root, template=authorized_portfolio_template
-    )
+    with (
+        _open_runtime_with_redundant_odd_cycle(
+            first_root, template=authorized_portfolio_template
+        ) as (first, first_graph),
+        _open_runtime_with_redundant_odd_cycle(
+            second_root, template=authorized_portfolio_template
+        ) as (second, second_graph),
+    ):
+        first_result = _shrink(first, first_graph)
+        second_result = _shrink(second, second_graph)
 
-    first_result = _shrink(first, first_graph)
-    second_result = _shrink(second, second_graph)
+        def signature(output: dict[str, Any]) -> list[tuple[Any, ...]]:
+            return [
+                (
+                    attempt["reducer"],
+                    attempt["deleted_vertex"],
+                    attempt["deleted_edge"],
+                    attempt["outcome"],
+                )
+                for attempt in output["attempts"]
+            ]
 
-    def signature(output: dict[str, Any]) -> list[tuple[Any, ...]]:
-        return [
-            (
-                attempt["reducer"],
-                attempt["deleted_vertex"],
-                attempt["deleted_edge"],
-                attempt["outcome"],
-            )
-            for attempt in output["attempts"]
-        ]
-
-    assert signature(first_result.output) == signature(second_result.output)
-    assert first.core.store.get(first_result.output["final_graph_uri"]).payload == (
-        second.core.store.get(second_result.output["final_graph_uri"]).payload
-    )
+        assert signature(first_result.output) == signature(second_result.output)
+        assert (
+            first.core.store.get(first_result.output["final_graph_uri"]).payload
+            == second.core.store.get(second_result.output["final_graph_uri"]).payload
+        )
 
 
 class _TimeoutExecutor:
@@ -239,27 +238,27 @@ class _UnrelatedEditExecutor:
         )
 
 
-def _runtime_with_redundant_odd_cycle(
+@contextmanager
+def _open_runtime_with_redundant_odd_cycle(
     root: Path,
     *,
     template: Path,
-) -> tuple[JacobianRuntime, str]:
-    root.mkdir(parents=True, exist_ok=True)
-    shutil.copytree(template, root, dirs_exist_ok=True)
-    runtime = create_runtime(
+) -> Iterator[tuple[JacobianRuntime, str]]:
+    root = copy_template(template, root / "state")
+    with create_runtime(
         root, checker_authority=CheckerAuthorityMode.INSTALL_BUNDLED
-    )
-    graph = runtime.core.artifacts.put(
-        schema_uri=runtime.portfolio.graph.graph_schema_uri,
-        semantics_uri=runtime.portfolio.graph.semantics_uri,
-        payload={
-            "graph_schema_version": "1",
-            "vertices": ["a", "b", "c", "d"],
-            "edges": [["a", "b"], ["a", "c"], ["b", "c"], ["c", "d"]],
-        },
-        summary="non-bipartite graph with one redundant leaf",
-    )
-    return runtime, graph.artifact_uri
+    ) as runtime:
+        graph = runtime.core.artifacts.put(
+            schema_uri=runtime.portfolio.graph.graph_schema_uri,
+            semantics_uri=runtime.portfolio.graph.semantics_uri,
+            payload={
+                "graph_schema_version": "1",
+                "vertices": ["a", "b", "c", "d"],
+                "edges": [["a", "b"], ["a", "c"], ["b", "c"], ["c", "d"]],
+            },
+            summary="non-bipartite graph with one redundant leaf",
+        )
+        yield runtime, graph.artifact_uri
 
 
 def _shrink(

--- a/tests/unit/tooling/test_fixture_architecture.py
+++ b/tests/unit/tooling/test_fixture_architecture.py
@@ -4,12 +4,67 @@ from __future__ import annotations
 
 import ast
 import runpy
+from functools import cache
 from pathlib import Path
 
 import pytest
 from tests.support.state import copy_template, publish_template
 
 ROOT = Path(__file__).parents[2]
+REPOSITORY_ROOT = ROOT.parent
+
+
+def _call_name(call: ast.Call) -> str | None:
+    if isinstance(call.func, ast.Name):
+        return call.func.id
+    if isinstance(call.func, ast.Attribute):
+        return call.func.attr
+    return None
+
+
+def _fixture_scope(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> str | None:
+    for decorator in node.decorator_list:
+        call = decorator if isinstance(decorator, ast.Call) else None
+        target = call.func if call is not None else decorator
+        is_fixture = (isinstance(target, ast.Name) and target.id == "fixture") or (
+            isinstance(target, ast.Attribute)
+            and isinstance(target.value, ast.Name)
+            and target.value.id == "pytest"
+            and target.attr == "fixture"
+        )
+        if not is_fixture:
+            continue
+        if call is None:
+            return "function"
+        for keyword in call.keywords:
+            if (
+                keyword.arg == "scope"
+                and isinstance(keyword.value, ast.Constant)
+                and isinstance(keyword.value.value, str)
+            ):
+                return keyword.value.value
+        return "function"
+    return None
+
+
+@cache
+def _fixture_functions() -> tuple[
+    tuple[Path, ast.FunctionDef | ast.AsyncFunctionDef], ...
+]:
+    fixtures: list[tuple[Path, ast.FunctionDef | ast.AsyncFunctionDef]] = []
+    roots = (ROOT, REPOSITORY_ROOT / "benchmarks" / "validation")
+    for fixture_root in roots:
+        for path in sorted(fixture_root.rglob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            fixtures.extend(
+                (path, node)
+                for node in tree.body
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and _fixture_scope(node) is not None
+            )
+    return tuple(fixtures)
 
 
 def _imports(path: Path) -> set[str]:
@@ -99,3 +154,80 @@ def test_template_isolation_gives_each_test_mutable_state(tmp_path: Path) -> Non
 
     assert (template / "metadata.txt").read_text(encoding="utf-8") == "immutable"
     assert (second / "metadata.txt").read_text(encoding="utf-8") == "immutable"
+
+
+def test_broad_fixtures_do_not_share_mutable_test_services() -> None:
+    """Service graphs and repositories stay local unless frozen as templates."""
+
+    mutable_constructors = {
+        "ArtifactRepository",
+        "CapabilityService",
+        "create_runtime",
+        "open_domain_services",
+    }
+    violations: list[tuple[str, str, str | None, tuple[str, ...]]] = []
+    for path, node in _fixture_functions():
+        scope = _fixture_scope(node)
+        if scope == "function":
+            continue
+        called_names = {
+            name
+            for call in ast.walk(node)
+            if isinstance(call, ast.Call) and (name := _call_name(call)) is not None
+        }
+        mutable_calls = tuple(sorted(called_names & mutable_constructors))
+        if mutable_calls and "publish_template" not in called_names:
+            violations.append(
+                (
+                    path.relative_to(REPOSITORY_ROOT).as_posix(),
+                    node.name,
+                    scope,
+                    mutable_calls,
+                )
+            )
+
+    assert violations == []
+
+
+def test_resource_owning_fixtures_close_the_resource_they_construct() -> None:
+    """A fixture-owned runtime or repository must have deterministic teardown."""
+
+    resource_constructors = {"ArtifactRepository", "create_runtime"}
+    leaks: list[tuple[str, str, str]] = []
+    for path, node in _fixture_functions():
+        owned: set[str] = set()
+        for assignment in ast.walk(node):
+            if isinstance(assignment, ast.Assign):
+                value = assignment.value
+                targets = assignment.targets
+            elif isinstance(assignment, ast.AnnAssign):
+                value = assignment.value
+                targets = (assignment.target,)
+            else:
+                continue
+            if (
+                not isinstance(value, ast.Call)
+                or _call_name(value) not in resource_constructors
+            ):
+                continue
+            owned.update(
+                target.id for target in targets if isinstance(target, ast.Name)
+            )
+        closed = {
+            call.func.value.id
+            for call in ast.walk(node)
+            if isinstance(call, ast.Call)
+            and isinstance(call.func, ast.Attribute)
+            and call.func.attr == "close"
+            and isinstance(call.func.value, ast.Name)
+        }
+        leaks.extend(
+            (
+                path.relative_to(REPOSITORY_ROOT).as_posix(),
+                node.name,
+                resource,
+            )
+            for resource in sorted(owned - closed)
+        )
+
+    assert leaks == []


### PR DESCRIPTION
## Problem

No linked issue; this follows up on the repository's fixture and test-integrity audits.

The suite had mutable service graphs and repositories shared across cases, resource-owning fixtures without deterministic teardown, runtime-template copies that bypassed the isolation helper, sleep-based cancellation checks, and host-specific paths. Those patterns made test order, parallel execution, and the local machine part of the test contract.

The inventory covers all 58 top-level fixtures under `tests/` and `benchmarks/validation`: 56 are now function-scoped, while the two session fixtures publish immutable runtime templates. During the red phase, the new architecture checks reported six broad mutable fixtures and two fixture-owned resources without teardown.

## Solution

- Add semantic fixture-architecture checks that reject broad mutable runtimes/services and fixture-owned runtimes or repositories without teardown. The checks handle bare, qualified, and annotated constructor assignments.
- Give each mutable runtime, repository, and service graph function scope with deterministic cleanup. Provider and frontier tests install only their real domain bundles and checker adapters through production composition seams instead of recreating the complete portfolio.
- Copy immutable runtime templates through `copy_template`, and close helper-created runtimes with context managers or `ExitStack`.
- Replace cancellation sleeps with explicit thread/event-loop handshakes, derive fake homes from `tmp_path`, and generate fake executables with the active Python interpreter.
- Parameterize multi-case cvc5 and frontier assertions so each case has an independent result and name.

## Testing

Passed on the final tree:

```sh
make test-plan BASE=origin/main
make test-unit
make test-component TESTS='tests/component/checkers/test_sat_unsat_proof_checker.py tests/component/checkers/test_smt_unsat_proof_checker.py tests/component/providers/lean/test_lean_checker_errors.py'
make test-composition TESTS='tests/composition/authority/test_hydrate_authorized.py tests/composition/portfolio/test_domain_bundles.py tests/composition/portfolio/test_plugin_registry_snapshots.py tests/composition/runtime/test_frontier_capabilities.py tests/composition/runtime/test_graph_counterexample_shrinking.py'
make test-process TESTS=tests/boundary/process/tooling/test_topology_runner.py
make test-mcp TESTS=tests/boundary/mcp/test_mcp_operations.py
make test-provider TESTS='tests/boundary/providers/cvc5/startup/test_cvc5.py tests/boundary/providers/external_sat/runtime/test_cadical_capabilities.py tests/boundary/providers/external_sat/startup/test_carcara.py tests/boundary/providers/external_sat/startup/test_sat_unsat_proof_verification.py tests/boundary/providers/external_sat/startup/test_smt_unsat_proof_verification.py tests/boundary/providers/flint/runtime/test_linear_rational_solution.py tests/boundary/providers/graph/runtime/test_finite_graph_optimization.py'
make test-lean TESTS=tests/boundary/providers/lean/startup/test_lean.py
make typecheck
```

Results: 723 unit, 45 component, 34 composition, 18 process, 10 MCP, and 105 provider tests passed. The Lean selector collected 15 tests and skipped them because the pinned Lean/Mathlib runtime is not installed, as documented for this repository.

`make check` passed Ruff lint and formatting, then stopped at the current `origin/main` complexity baseline introduced by #683: the unchanged cgal, gudhi, and nauty provider verifier functions exceed their recorded scores. `make typecheck` and `make test-unit`, which follow that check, were run separately and passed.

## Trust & Compatibility Impact

Test-only. This does not change the verification kernel, checker authorization policy, artifact formats, public API, schemas, or CI routing. Provider and checker coverage still uses the production installation and invocation seams.

## Review order

1. `tests/unit/tooling/test_fixture_architecture.py` for the enforced ownership rules.
2. The provider/frontier fixture changes for the narrow production service graphs and teardown.
3. The MCP/process changes for deterministic synchronization and ambient-path removal.

## Checklist

- [ ] Routine local validation passes (`make check`) — blocked by the unchanged #683 complexity-baseline mismatch described above.
- [x] Relevant focused tests are listed above.
