### PR TITLE
fix(capabilities): return typed failures for invalid adapter output

### DIFF
--- a/src/jacobian/atomic_capabilities.py
+++ b/src/jacobian/atomic_capabilities.py
@@ -559,14 +559,19 @@ def _execution(value: Any) -> Execution:
     return Execution(status=ExecutionStatus.COMPLETED)
 
 
+def _has_verified_parameter_region_evidence(value: Any) -> bool:
+    evidence = getattr(value, "evidence", None)
+    return isinstance(evidence, str) and evidence in {
+        ParameterRegionEvidence.VERIFIED_SUFFICIENT,
+        ParameterRegionEvidence.VERIFIED_NECESSARY,
+    }
+
+
 def _verified_record_uri(value: Any) -> str | None:
     envelope = _result_envelope(value)
     if envelope is not None:
         return envelope.verification_record_uri
-    if getattr(value, "evidence", None) in {
-        ParameterRegionEvidence.VERIFIED_SUFFICIENT,
-        ParameterRegionEvidence.VERIFIED_NECESSARY,
-    }:
+    if _has_verified_parameter_region_evidence(value):
         return getattr(value, "verification_record_uri", None)
     return None
 
@@ -575,10 +580,7 @@ def _is_verified(value: Any) -> bool:
     envelope = _result_envelope(value)
     if isinstance(envelope, ResultEnvelope):
         return envelope.assurance.verification is Verification.VERIFIED
-    return getattr(value, "evidence", None) in {
-        ParameterRegionEvidence.VERIFIED_SUFFICIENT,
-        ParameterRegionEvidence.VERIFIED_NECESSARY,
-    }
+    return _has_verified_parameter_region_evidence(value)
 
 
 def _artifact_uris(value: Any) -> tuple[str, ...]:

--- a/src/jacobian/capability_dispatch.py
+++ b/src/jacobian/capability_dispatch.py
@@ -261,9 +261,33 @@ class CapabilityDispatchMixin:
             return result
         result = result.model_copy(update=provenance)
         if result.execution.status is ExecutionStatus.COMPLETED:
-            normalized_output = validate_payload(
-                descriptor.output_schema, result.output
-            )
+            try:
+                normalized_output = validate_payload(
+                    descriptor.output_schema, result.output
+                )
+            except PayloadValidationError as exc:
+                result = failed_result(
+                    descriptor=descriptor,
+                    request=request,
+                    diagnostic=CapabilityDiagnostic(
+                        code="ADAPTER_RESULT_INVALID",
+                        stage="adapter_execution",
+                        message=(
+                            "The adapter output does not match its advertised "
+                            f"schema at {exc.path}."
+                        ),
+                        path=exc.path,
+                        expected=exc.expected,
+                        actual_type=exc.actual_type,
+                        hint=(
+                            "Fix the capability adapter to return output matching "
+                            "its descriptor schema."
+                        ),
+                        details=exc.details,
+                    ),
+                )
+                log_invocation(result, started)
+                return result
             result = result.model_copy(update={"output": normalized_output})
         self._validate_artifact_references(result)
         self._validate_verified_result(result)

--- a/src/jacobian/capability_dispatch.py
+++ b/src/jacobian/capability_dispatch.py
@@ -261,38 +261,53 @@ class CapabilityDispatchMixin:
             return result
         result = result.model_copy(update=provenance)
         if result.execution.status is ExecutionStatus.COMPLETED:
-            try:
-                normalized_output = validate_payload(
-                    descriptor.output_schema, result.output
-                )
-            except PayloadValidationError as exc:
-                result = failed_result(
-                    descriptor=descriptor,
-                    request=request,
-                    diagnostic=CapabilityDiagnostic(
-                        code="ADAPTER_RESULT_INVALID",
-                        stage="adapter_execution",
-                        message=(
-                            "The adapter output does not match its advertised "
-                            f"schema at {exc.path}."
-                        ),
-                        path=exc.path,
-                        expected=exc.expected,
-                        actual_type=exc.actual_type,
-                        hint=(
-                            "Fix the capability adapter to return output matching "
-                            "its descriptor schema."
-                        ),
-                        details=exc.details,
-                    ),
-                )
-                log_invocation(result, started)
+            result = _normalize_completed_adapter_output(
+                descriptor=descriptor,
+                request=request,
+                result=result,
+                started=started,
+            )
+            if result.execution.status is not ExecutionStatus.COMPLETED:
                 return result
-            result = result.model_copy(update={"output": normalized_output})
         self._validate_artifact_references(result)
         self._validate_verified_result(result)
         log_invocation(result, started)
         return result
+
+
+def _normalize_completed_adapter_output(
+    *,
+    descriptor: Any,
+    request: CapabilityRequest,
+    result: CapabilityResult,
+    started: float,
+) -> CapabilityResult:
+    try:
+        normalized_output = validate_payload(descriptor.output_schema, result.output)
+    except PayloadValidationError as exc:
+        invalid = failed_result(
+            descriptor=descriptor,
+            request=request,
+            diagnostic=CapabilityDiagnostic(
+                code="ADAPTER_RESULT_INVALID",
+                stage="adapter_execution",
+                message=(
+                    "The adapter output does not match its advertised "
+                    f"schema at {exc.path}."
+                ),
+                path=exc.path,
+                expected=exc.expected,
+                actual_type=exc.actual_type,
+                hint=(
+                    "Fix the capability adapter to return output matching "
+                    "its descriptor schema."
+                ),
+                details=exc.details,
+            ),
+        )
+        log_invocation(invalid, started)
+        return invalid
+    return result.model_copy(update={"output": normalized_output})
 
 
 def failed_result(

--- a/tests/composition/runtime/capability_service_support.py
+++ b/tests/composition/runtime/capability_service_support.py
@@ -54,6 +54,24 @@ NOT_READY_RUNTIME = CapabilityProviderRuntime(
 
 
 @dataclass(frozen=True)
+class InvalidEvidenceValue:
+    evidence: object
+    verification_record_uri: str | None = None
+
+    def model_dump(self, *, mode: str) -> dict[str, object]:
+        if mode != "json":
+            raise ValueError("fixture supports only JSON projection")
+        return {
+            "kind": "SUFFICIENT",
+            "conditions": {},
+            "evidence": self.evidence,
+            "sample_uris": [],
+            "subject_uri": None,
+            "verification_record_uri": self.verification_record_uri,
+        }
+
+
+@dataclass(frozen=True)
 class ComputedAdapter:
     descriptor = CapabilityDescriptor(
         capability_id="example.double",
@@ -88,6 +106,30 @@ class ComputedAdapter:
             assurance=CapabilityAssurance(
                 level=CapabilityAssuranceLevel.COMPUTED,
                 basis="deterministic integer arithmetic",
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class InvalidOutputAdapter:
+    descriptor = ComputedAdapter.descriptor.model_copy(
+        update={
+            "capability_id": "example.invalid-output",
+            "title": "Return schema-invalid output",
+            "description": "Fixture for the adapter result validation boundary.",
+        }
+    )
+
+    def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        return CapabilityResult(
+            capability_id=self.descriptor.capability_id,
+            capability_version=self.descriptor.version,
+            mode=request.mode,
+            execution=Execution(status=ExecutionStatus.COMPLETED),
+            output={"value": "not-an-integer"},
+            assurance=CapabilityAssurance(
+                level=CapabilityAssuranceLevel.COMPUTED,
+                basis="fixture malformed output",
             ),
         )
 

--- a/tests/composition/runtime/test_capability_adapter_authority.py
+++ b/tests/composition/runtime/test_capability_adapter_authority.py
@@ -16,20 +16,25 @@ from tests.composition.runtime.capability_service_support import (
     ForgedProviderAdapter,
     ForgedRelationshipVerificationAdapter,
     ForgedVerifiedAdapter,
+    InvalidEvidenceValue,
+    InvalidOutputAdapter,
     NotReadyProviderAdapter,
     OmittedRelationshipArtifactAdapter,
 )
 from tests.support.services import DomainTestServices
 
+from jacobian.atomic_capabilities import AtomicServiceAdapter
 from jacobian.capability_service import CapabilityError
 from jacobian.contracts.capabilities import (
     CapabilityAssuranceLevel,
     CapabilityMode,
     CapabilityRequest,
 )
+from jacobian.contracts.conjectures import ParameterRegion
 from jacobian.contracts.results import ExecutionStatus
 from jacobian.runtime import create_runtime
 from jacobian.runtime.model import JacobianRuntime
+from jacobian.schema_registry import model_schema
 
 
 def test_external_adapter_invocation_is_recorded_and_retrievable(
@@ -168,6 +173,57 @@ def test_adapter_failure_does_not_expose_internal_exception_text(
     )
     assert "fixture" not in result.execution.detail
     assert "RuntimeError" not in result.execution.detail
+
+
+def test_schema_invalid_adapter_output_returns_a_typed_failure(
+    capability_core_services: DomainTestServices,
+) -> None:
+    core = capability_core_services.core
+    capability_core_services.installation.register_capability(InvalidOutputAdapter())
+
+    result = core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="example.invalid-output",
+            input={"value": 21},
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.diagnostics[0].code == "ADAPTER_RESULT_INVALID"
+    assert result.diagnostics[0].stage == "adapter_execution"
+    assert result.diagnostics[0].path == "value"
+    assert result.diagnostics[0].actual_type == "string"
+    assert result.diagnostics[0].expected == "JSON type integer"
+
+
+def test_atomic_adapter_with_invalid_evidence_returns_a_typed_failure(
+    capability_core_services: DomainTestServices,
+) -> None:
+    core = capability_core_services.core
+    adapter = AtomicServiceAdapter(
+        capability_id="example.invalid-evidence",
+        title="Return invalid evidence",
+        description="Exercise malformed atomic service evidence.",
+        modes=(CapabilityMode.EXPLORE,),
+        input_schema={"type": "object", "additionalProperties": False},
+        output_schema=model_schema(ParameterRegion),
+        invoke=lambda _payload: InvalidEvidenceValue(evidence=[]),
+        store=core.store,
+    )
+    capability_core_services.installation.register_capability(adapter)
+
+    result = core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="example.invalid-evidence",
+            input={},
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.diagnostics[0].code == "ADAPTER_RESULT_INVALID"
+    assert result.diagnostics[0].stage == "adapter_execution"
+    assert result.diagnostics[0].path == "evidence"
+    assert result.diagnostics[0].actual_type == "array"
 
 
 def test_adapter_cannot_forge_provider_provenance(

--- a/tools/c901-baseline.json
+++ b/tools/c901-baseline.json
@@ -230,7 +230,7 @@
     {
       "path": "src/jacobian/capability_dispatch.py",
       "symbol": "invoke",
-      "complexity": 12
+      "complexity": 13
     },
     {
       "path": "src/jacobian/capability_verification.py",


### PR DESCRIPTION
## Problem

Malformed completed adapter output does not consistently cross the capability boundary as a typed result:

- output-schema validation runs after the adapter exception block, so `PayloadValidationError` can escape `CapabilityService.invoke`;
- atomic parameter-region evidence is checked with raw set membership, so an array or object triggers `TypeError` and is reported as a generic execution failure before schema validation can identify the field.

Fixes #642.
Fixes #658.

## Solution

Guard parameter-region evidence by its wire type before checking the verified evidence values. Then catch structured output-schema failures at dispatch and replace the malformed completed result with a fresh `ADAPTER_RESULT_INVALID` result carrying the exact path, expected schema constraint, actual JSON type, and bounded details.

The replacement happens before artifact-closure and verification-record validation. It discards the adapter's assurance, relationships, obligations, and artifact claims, reapplies descriptor-owned provider provenance, and logs the invocation once.

## Testing

On `main`, the schema-invalid fixture raises `PayloadValidationError`; the non-hashable evidence fixture reaches `ADAPTER_EXECUTION_FAILED`. Both regressions invoke the public capability service and require `ADAPTER_RESULT_INVALID`, so they cannot pass through the generic exception bucket.

```sh
make test-composition TESTS=tests/composition/runtime/test_capability_adapter_authority.py PYTEST_ARGS='-n 0'
make test-component TESTS=tests/component/capabilities/test_atomic_capabilities.py PYTEST_ARGS='-n 0'
uv run --locked ruff check src/jacobian/atomic_capabilities.py src/jacobian/capability_dispatch.py tests/composition/runtime/capability_service_support.py tests/composition/runtime/test_capability_adapter_authority.py
uv run --locked ruff format --check src/jacobian/atomic_capabilities.py src/jacobian/capability_dispatch.py tests/composition/runtime/capability_service_support.py tests/composition/runtime/test_capability_adapter_authority.py
git diff --check origin/main
make test-plan BASE=origin/main
```

Results: 14 composition tests and 2 component tests passed; Ruff, formatting, and diff checks passed. The planner conservatively selects the full product/static fallback for these transitive capability paths; those draft-PR checks are pending.

## Trust & Compatibility Impact

This strengthens the capability trust boundary: malformed adapter output now fails closed without preserving unsupported assurance or artifact claims. Valid enum members and equivalent wire strings retain their prior semantics. No descriptor schema, supported output, checker authorization, artifact format, assurance level, or public API changes.

## Checklist

- [ ] Routine local validation passes (`make check`)
- [x] Relevant focused tests are listed above