### PR TITLE
fix(benchmarks): skip vanished Oracle evidence candidates

### DIFF
--- a/benchmarks/validation/test_harbor_task_workflow.py
+++ b/benchmarks/validation/test_harbor_task_workflow.py
@@ -293,3 +293,34 @@ def test_oracle_evidence_freshness_rejects_unchanged_file(
         "sha256:new",
         "benchmarks/results/dataset-one-oracle/job/oracle-evidence.json",
     )
+
+
+def test_oracle_evidence_discovery_skips_candidate_deleted_before_stat(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    selection = workflow.TaskSelection("dataset-one", ("task-a",), (tmp_path,), ())
+    evidence_root = tmp_path / "benchmarks/results/dataset-one-oracle"
+    vanished = evidence_root / "vanished/oracle-evidence.json"
+    available = evidence_root / "available/oracle-evidence.json"
+    available.parent.mkdir(parents=True)
+    available.write_text(
+        json.dumps(
+            {
+                "dataset": "dataset-one",
+                "tasks": [{"task": "task-a", "digest": "sha256:available"}],
+            }
+        )
+    )
+
+    def evidence_candidates(path: Path, pattern: str) -> tuple[Path, Path]:
+        assert path == evidence_root
+        assert pattern == "*/oracle-evidence.json"
+        return vanished, available
+
+    monkeypatch.setattr(workflow, "ROOT", tmp_path)
+    monkeypatch.setattr(Path, "glob", evidence_candidates)
+
+    assert workflow._fresh_oracle_evidence(selection, "task-a", previous={}) == (
+        "sha256:available",
+        "benchmarks/results/dataset-one-oracle/available/oracle-evidence.json",
+    )

--- a/tools/harbor_task_workflow.py
+++ b/tools/harbor_task_workflow.py
@@ -254,13 +254,7 @@ def _oracle_evidence_snapshot(
     return snapshot
 
 
-def _fresh_oracle_evidence(
-    selection: TaskSelection,
-    task: str,
-    *,
-    previous: dict[Path, tuple[int, int, str]],
-) -> tuple[str, str]:
-    evidence_root = ROOT / "benchmarks" / "results" / f"{selection.dataset}-oracle"
+def _oracle_evidence_candidates(evidence_root: Path) -> list[Path]:
     candidates: list[tuple[int, Path]] = []
     for path in evidence_root.glob("*/oracle-evidence.json"):
         try:
@@ -269,29 +263,57 @@ def _fresh_oracle_evidence(
             continue
         candidates.append((modified_ns, path))
     candidates.sort(key=lambda item: item[0], reverse=True)
-    for _modified_ns, path in candidates:
-        try:
-            stat = path.stat()
-            raw = path.read_bytes()
-        except OSError:
-            continue
-        fingerprint = (stat.st_mtime_ns, stat.st_size, hashlib.sha256(raw).hexdigest())
-        if previous.get(path) == fingerprint:
-            continue
-        try:
-            payload: Any = json.loads(raw)
-        except (UnicodeDecodeError, json.JSONDecodeError):
-            continue
-        if not isinstance(payload, dict) or payload.get("dataset") != selection.dataset:
-            continue
-        task_entries = payload.get("tasks")
-        if not isinstance(task_entries, list):
-            continue
-        for entry in task_entries:
-            if isinstance(entry, dict) and entry.get("task") == task:
-                digest = entry.get("digest")
-                if isinstance(digest, str):
-                    return digest, path.relative_to(ROOT).as_posix()
+    return [path for _modified_ns, path in candidates]
+
+
+def _task_digest_from_evidence(
+    path: Path,
+    *,
+    dataset: str,
+    task: str,
+    previous: dict[Path, tuple[int, int, str]],
+) -> str | None:
+    try:
+        stat = path.stat()
+        raw = path.read_bytes()
+    except OSError:
+        return None
+    fingerprint = (stat.st_mtime_ns, stat.st_size, hashlib.sha256(raw).hexdigest())
+    if previous.get(path) == fingerprint:
+        return None
+    try:
+        payload: Any = json.loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict) or payload.get("dataset") != dataset:
+        return None
+    task_entries = payload.get("tasks")
+    if not isinstance(task_entries, list):
+        return None
+    for entry in task_entries:
+        if isinstance(entry, dict) and entry.get("task") == task:
+            digest = entry.get("digest")
+            if isinstance(digest, str):
+                return digest
+    return None
+
+
+def _fresh_oracle_evidence(
+    selection: TaskSelection,
+    task: str,
+    *,
+    previous: dict[Path, tuple[int, int, str]],
+) -> tuple[str, str]:
+    evidence_root = ROOT / "benchmarks" / "results" / f"{selection.dataset}-oracle"
+    for path in _oracle_evidence_candidates(evidence_root):
+        digest = _task_digest_from_evidence(
+            path,
+            dataset=selection.dataset,
+            task=task,
+            previous=previous,
+        )
+        if digest is not None:
+            return digest, path.relative_to(ROOT).as_posix()
     raise TaskWorkflowError(
         f"Oracle produced no fresh evidence for {selection.dataset}/{task}"
     )

--- a/tools/harbor_task_workflow.py
+++ b/tools/harbor_task_workflow.py
@@ -261,12 +261,15 @@ def _fresh_oracle_evidence(
     previous: dict[Path, tuple[int, int, str]],
 ) -> tuple[str, str]:
     evidence_root = ROOT / "benchmarks" / "results" / f"{selection.dataset}-oracle"
-    candidates = sorted(
-        evidence_root.glob("*/oracle-evidence.json"),
-        key=lambda path: path.stat().st_mtime_ns,
-        reverse=True,
-    )
-    for path in candidates:
+    candidates: list[tuple[int, Path]] = []
+    for path in evidence_root.glob("*/oracle-evidence.json"):
+        try:
+            modified_ns = path.stat().st_mtime_ns
+        except OSError:
+            continue
+        candidates.append((modified_ns, path))
+    candidates.sort(key=lambda item: item[0], reverse=True)
+    for _modified_ns, path in candidates:
         try:
             stat = path.stat()
             raw = path.read_bytes()


### PR DESCRIPTION
## Problem

The Harbor Oracle workflow sorts discovered evidence paths by calling `Path.stat()` in the sort key. If a candidate disappears after the glob but before that stat, discovery raises `FileNotFoundError` and ignores another available, correctly bound evidence file.

Fixes #719.

## Solution

Collect each candidate together with its observed modification time, skipping only candidates whose initial stat raises `OSError`, then sort that collected list. The existing second stat/read and freshness, dataset, task, and digest validation remain unchanged.

This deliberately hardens external file disappearance during discovery; it does not claim atomicity against concurrent evidence rewrites.

## Testing

```sh
uv run --locked pytest -q benchmarks/validation/test_harbor_task_workflow.py
uv run --locked ruff check tools/harbor_task_workflow.py benchmarks/validation/test_harbor_task_workflow.py
uv run --locked ruff format --check tools/harbor_task_workflow.py benchmarks/validation/test_harbor_task_workflow.py
TMPDIR=/var/tmp make harbor-plan BASE=origin/main
git diff --check origin/main
```

The regression fails on `origin/main` with `FileNotFoundError` and passes with this change; the full owning Harbor validation file passes (7 tests).

## Trust & Compatibility Impact

No checker registry, artifact format, public API, or evidence-binding rule changes. Freshness fingerprints and dataset/task/digest binding remain fail-closed.

## Checklist

- [ ] Routine local validation passes (`make check`)
- [x] Relevant focused tests are listed above
