### PR TITLE
fix(polynomials): bound inverse solver termination

### DIFF
--- a/src/jacobian/polynomials/_support.py
+++ b/src/jacobian/polynomials/_support.py
@@ -50,6 +50,8 @@ from jacobian.storage.models import StoredArtifact
 if TYPE_CHECKING:
     from sympy import Poly
 
+_INVERSE_SOLVER_SHUTDOWN_TIMEOUT_SECONDS = 1.0
+
 
 def _materialize_map(
     resources: PolynomialResources,
@@ -376,7 +378,10 @@ def _solve_inverse_system(
     process.join(timeout_ms / 1000)
     if process.is_alive():
         process.terminate()
-        process.join()
+        process.join(timeout=_INVERSE_SOLVER_SHUTDOWN_TIMEOUT_SECONDS)
+        if process.is_alive():
+            process.kill()
+            process.join(timeout=_INVERSE_SOLVER_SHUTDOWN_TIMEOUT_SECONDS)
         return "TIMEOUT", None
     try:
         status, raw = result_queue.get_nowait()

--- a/tests/composition/runtime/test_polynomial_map_inverse_synthesize.py
+++ b/tests/composition/runtime/test_polynomial_map_inverse_synthesize.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 from copy import deepcopy
+from math import isfinite
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
 
 from jacobian.contracts.capabilities import CapabilityMode, CapabilityRequest
 from jacobian.contracts.results import ExecutionStatus
+from jacobian.polynomials import _support as polynomial_support
 
 
 def _term(coefficient: int, exponents: list[int]) -> dict[str, Any]:
@@ -146,6 +149,73 @@ def test_zero_timeout_and_unknown_budget_are_explicit(
     assert timeout.execution.status is ExecutionStatus.TIMEOUT
     assert timeout.output["status"] == "TIMEOUT"
     assert exhausted.output["status"] == "BUDGET_EXHAUSTED"
+
+
+def test_timeout_kills_stubborn_solver_without_unbounded_wait(
+    authorized_complete_runtime,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class StubbornProcess:
+        def __init__(self) -> None:
+            self.alive = True
+            self.events: list[str] = []
+            self.join_timeouts: list[float] = []
+
+        def start(self) -> None:
+            self.events.append("start")
+
+        def join(self, timeout: float | None = None) -> None:
+            if timeout is None:
+                raise AssertionError("polynomial solver join must remain bounded")
+            self.events.append("join")
+            self.join_timeouts.append(timeout)
+
+        def is_alive(self) -> bool:
+            return self.alive
+
+        def terminate(self) -> None:
+            self.events.append("terminate")
+
+        def kill(self) -> None:
+            self.events.append("kill")
+            self.alive = False
+
+    process = StubbornProcess()
+
+    def make_queue(*, maxsize: int) -> object:
+        assert maxsize == 1
+        return object()
+
+    def make_process(*, target: Any, args: tuple[Any, ...]) -> StubbornProcess:
+        assert callable(target)
+        assert args
+        return process
+
+    context = SimpleNamespace(Queue=make_queue, Process=make_process)
+
+    def get_context(method: str) -> SimpleNamespace:
+        assert method == "spawn"
+        return context
+
+    monkeypatch.setattr(polynomial_support.multiprocessing, "get_context", get_context)
+
+    result = authorized_complete_runtime.core.capabilities.invoke(_request(degree=2))
+
+    assert result.execution.status is ExecutionStatus.TIMEOUT
+    assert result.output["status"] == "TIMEOUT"
+    assert result.output["candidate_inverse_map"] is None
+    assert result.output["noninvertibility_proved"] is False
+    assert process.events == [
+        "start",
+        "join",
+        "terminate",
+        "join",
+        "kill",
+        "join",
+    ]
+    assert 0 < process.join_timeouts[0] <= 10.0
+    assert process.join_timeouts[1:] == [1.0, 1.0]
+    assert all(timeout > 0 and isfinite(timeout) for timeout in process.join_timeouts)
 
 
 def test_unknown_solver_is_unsupported_without_truth_claim(

--- a/tests/composition/runtime/test_polynomial_map_inverse_synthesize.py
+++ b/tests/composition/runtime/test_polynomial_map_inverse_synthesize.py
@@ -151,42 +151,40 @@ def test_zero_timeout_and_unknown_budget_are_explicit(
     assert exhausted.output["status"] == "BUDGET_EXHAUSTED"
 
 
-def test_timeout_kills_stubborn_solver_without_unbounded_wait(
-    authorized_complete_runtime,
-    monkeypatch: pytest.MonkeyPatch,
+class _StubbornProcess:
+    def __init__(self) -> None:
+        self.alive = True
+        self.events: list[str] = []
+        self.join_timeouts: list[float] = []
+
+    def start(self) -> None:
+        self.events.append("start")
+
+    def join(self, timeout: float | None = None) -> None:
+        if timeout is None:
+            raise AssertionError("polynomial solver join must remain bounded")
+        self.events.append("join")
+        self.join_timeouts.append(timeout)
+
+    def is_alive(self) -> bool:
+        return self.alive
+
+    def terminate(self) -> None:
+        self.events.append("terminate")
+
+    def kill(self) -> None:
+        self.events.append("kill")
+        self.alive = False
+
+
+def _install_stubborn_solver(
+    monkeypatch: pytest.MonkeyPatch, process: _StubbornProcess
 ) -> None:
-    class StubbornProcess:
-        def __init__(self) -> None:
-            self.alive = True
-            self.events: list[str] = []
-            self.join_timeouts: list[float] = []
-
-        def start(self) -> None:
-            self.events.append("start")
-
-        def join(self, timeout: float | None = None) -> None:
-            if timeout is None:
-                raise AssertionError("polynomial solver join must remain bounded")
-            self.events.append("join")
-            self.join_timeouts.append(timeout)
-
-        def is_alive(self) -> bool:
-            return self.alive
-
-        def terminate(self) -> None:
-            self.events.append("terminate")
-
-        def kill(self) -> None:
-            self.events.append("kill")
-            self.alive = False
-
-    process = StubbornProcess()
-
     def make_queue(*, maxsize: int) -> object:
         assert maxsize == 1
         return object()
 
-    def make_process(*, target: Any, args: tuple[Any, ...]) -> StubbornProcess:
+    def make_process(*, target: Any, args: tuple[Any, ...]) -> _StubbornProcess:
         assert callable(target)
         assert args
         return process
@@ -198,6 +196,14 @@ def test_timeout_kills_stubborn_solver_without_unbounded_wait(
         return context
 
     monkeypatch.setattr(polynomial_support.multiprocessing, "get_context", get_context)
+
+
+def test_timeout_kills_stubborn_solver_without_unbounded_wait(
+    authorized_complete_runtime,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = _StubbornProcess()
+    _install_stubborn_solver(monkeypatch, process)
 
     result = authorized_complete_runtime.core.capabilities.invoke(_request(degree=2))
 


### PR DESCRIPTION
## Problem

Polynomial inverse synthesis terminates a solver process when its budget expires, then calls an unbounded `join()`. A worker that does not exit after termination can therefore hold the request indefinitely after the advertised timeout.

Fixes #697.

## Solution

Give the terminated worker a one-second grace period. If it is still alive, escalate to `kill()` and perform one final bounded reap attempt. The capability still returns the same fail-closed `TIMEOUT` result with no candidate or noninvertibility claim.

## Testing

```sh
uv run --locked pytest -q tests/composition/runtime/test_polynomial_map_inverse_synthesize.py::test_timeout_kills_stubborn_solver_without_unbounded_wait
uv run --locked pytest -q   tests/composition/runtime/test_polynomial_map_inverse_synthesize.py::test_triangular_automorphism_is_found_and_verified   tests/composition/runtime/test_polynomial_map_inverse_synthesize.py::test_corrupted_found_candidate_does_not_verify
uv run --locked ruff check src/jacobian/polynomials/_support.py tests/composition/runtime/test_polynomial_map_inverse_synthesize.py
uv run --locked ruff format --check src/jacobian/polynomials/_support.py tests/composition/runtime/test_polynomial_map_inverse_synthesize.py
make test-plan BASE=origin/main
git diff --check origin/main
```

The regression uses a worker that remains alive after `terminate()`; it rejects an unbounded initial or cleanup join and proves the terminate/kill/final-join sequence.

## Trust & Compatibility Impact

No public schema, checker authority, artifact format, or mathematical conclusion changes. Timeout cleanup remains fail-closed and produces no candidate or verification artifact.

## Checklist

- [ ] Routine local validation passes (`make check`)
- [x] Relevant focused tests are listed above
