### PR TITLE
test(benchmarks): isolate synthetic module loading

### DIFF
--- a/benchmarks/validation/test_benchmark_planner.py
+++ b/benchmarks/validation/test_benchmark_planner.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
@@ -18,13 +18,21 @@ PLANNER_PATH = ROOT / ".github" / "scripts" / "plan-benchmarks"
 PATH_POLICY_PATH = ROOT / ".github" / "scripts" / "_ci_paths.py"
 VALIDATION_PLAN_PATH = ROOT / "benchmarks" / "tooling" / "validation_plan.py"
 VALIDATOR_PATH = ROOT / ".github" / "scripts" / "validate-benchmark-plan"
-_SPEC = importlib.util.spec_from_loader(
-    "benchmark_planner", SourceFileLoader("benchmark_planner", str(PLANNER_PATH))
-)
-assert _SPEC is not None and _SPEC.loader is not None
-planner = importlib.util.module_from_spec(_SPEC)
-sys.modules["benchmark_planner"] = planner
-_SPEC.loader.exec_module(planner)
+
+
+def _load_script(module_name: str, path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_loader(
+        module_name, SourceFileLoader(module_name, str(path))
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    with pytest.MonkeyPatch.context() as module_state:
+        module_state.setitem(sys.modules, module_name, module)
+        spec.loader.exec_module(module)
+    return module
+
+
+planner = _load_script("benchmark_planner", PLANNER_PATH)
 
 
 @pytest.fixture(autouse=True)
@@ -36,6 +44,34 @@ def stable_digests(monkeypatch: pytest.MonkeyPatch) -> None:
         "_digest",
         lambda path: f"sha256:{hashlib.sha256(path.name.encode()).hexdigest()}",
     )
+
+
+@pytest.mark.parametrize("preserve_existing", [False, True])
+def test_load_script_scopes_sys_modules_registration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    preserve_existing: bool,
+) -> None:
+    module_name = "_benchmark_planner_module_probe"
+    source = tmp_path / "module_probe.py"
+    source.write_text(
+        "import sys\nregistered_while_loading = sys.modules[__name__]\n",
+        encoding="utf-8",
+    )
+    sentinel = ModuleType("sentinel")
+    if preserve_existing:
+        monkeypatch.setitem(sys.modules, module_name, sentinel)
+    else:
+        monkeypatch.delitem(sys.modules, module_name, raising=False)
+
+    loaded = _load_script(module_name, source)
+
+    assert vars(loaded)["registered_while_loading"] is loaded
+    if preserve_existing:
+        assert sys.modules[module_name] is sentinel
+    else:
+        assert module_name not in sys.modules
 
 
 def _matrix(result: dict[str, str]) -> list[dict[str, object]]:

--- a/benchmarks/validation/test_harbor_task_workflow.py
+++ b/benchmarks/validation/test_harbor_task_workflow.py
@@ -7,19 +7,56 @@ import json
 import sys
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
+from types import ModuleType
 from typing import Any
 
 import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
 TOOL_PATH = ROOT / "tools" / "harbor_task_workflow.py"
-_SPEC = importlib.util.spec_from_loader(
-    "harbor_task_workflow", SourceFileLoader("harbor_task_workflow", str(TOOL_PATH))
-)
-assert _SPEC is not None and _SPEC.loader is not None
-workflow = importlib.util.module_from_spec(_SPEC)
-sys.modules[_SPEC.name] = workflow
-_SPEC.loader.exec_module(workflow)
+
+
+def _load_script(module_name: str, path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_loader(
+        module_name, SourceFileLoader(module_name, str(path))
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    with pytest.MonkeyPatch.context() as module_state:
+        module_state.setitem(sys.modules, module_name, module)
+        spec.loader.exec_module(module)
+    return module
+
+
+workflow = _load_script("harbor_task_workflow", TOOL_PATH)
+
+
+@pytest.mark.parametrize("preserve_existing", [False, True])
+def test_load_script_scopes_sys_modules_registration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    preserve_existing: bool,
+) -> None:
+    module_name = "_harbor_task_workflow_module_probe"
+    source = tmp_path / "module_probe.py"
+    source.write_text(
+        "import sys\nregistered_while_loading = sys.modules[__name__]\n",
+        encoding="utf-8",
+    )
+    sentinel = ModuleType("sentinel")
+    if preserve_existing:
+        monkeypatch.setitem(sys.modules, module_name, sentinel)
+    else:
+        monkeypatch.delitem(sys.modules, module_name, raising=False)
+
+    loaded = _load_script(module_name, source)
+
+    assert vars(loaded)["registered_while_loading"] is loaded
+    if preserve_existing:
+        assert sys.modules[module_name] is sentinel
+    else:
+        assert module_name not in sys.modules
 
 
 def test_resolve_selection_uses_planner_owned_host_matrix() -> None:

--- a/benchmarks/validation/test_verifier_support_schema.py
+++ b/benchmarks/validation/test_verifier_support_schema.py
@@ -6,6 +6,7 @@ import importlib.util
 import json
 import sys
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
@@ -18,16 +19,45 @@ _TEMPLATE = (
 )
 
 
-def _load_module():
-    spec = importlib.util.spec_from_file_location("_vs_under_test", _TEMPLATE)
+def _load_module(module_name: str, path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(module_name, path)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
-    sys.modules["_vs_under_test"] = module
-    spec.loader.exec_module(module)
+    with pytest.MonkeyPatch.context() as module_state:
+        module_state.setitem(sys.modules, module_name, module)
+        spec.loader.exec_module(module)
     return module
 
 
-_VS = _load_module()
+_VS = _load_module("_vs_under_test", _TEMPLATE)
+
+
+@pytest.mark.parametrize("preserve_existing", [False, True])
+def test_load_module_scopes_sys_modules_registration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    preserve_existing: bool,
+) -> None:
+    module_name = "_verifier_support_schema_module_probe"
+    source = tmp_path / "module_probe.py"
+    source.write_text(
+        "import sys\nregistered_while_loading = sys.modules[__name__]\n",
+        encoding="utf-8",
+    )
+    sentinel = ModuleType("sentinel")
+    if preserve_existing:
+        monkeypatch.setitem(sys.modules, module_name, sentinel)
+    else:
+        monkeypatch.delitem(sys.modules, module_name, raising=False)
+
+    loaded = _load_module(module_name, source)
+
+    assert vars(loaded)["registered_while_loading"] is loaded
+    if preserve_existing:
+        assert sys.modules[module_name] is sentinel
+    else:
+        assert module_name not in sys.modules
 
 
 @pytest.fixture


### PR DESCRIPTION
## Problem

Three benchmark validation loaders register synthetic modules in `sys.modules` so dataclass and import-time machinery can resolve them, but leave those entries behind after execution. They also overwrite a pre-existing entry with the same synthetic name, making later tests depend on collection and execution order.

Fixes #720.

## Solution

Execute each synthetic module inside a bounded `pytest.MonkeyPatch.context()`. The module is present under its own name while `exec_module()` runs, then the exact prior state is restored: the key is removed if it was absent, or the original object is put back if it already existed.

Behavioral regressions use a tiny temporary module to prove all three requirements: registration during execution, cleanup of an absent key, and identity-preserving restoration of an existing sentinel.

## Testing

```sh
uv run --locked pytest -q   benchmarks/validation/test_benchmark_planner.py   benchmarks/validation/test_harbor_task_workflow.py   benchmarks/validation/test_verifier_support_schema.py
uv run --locked ruff check   benchmarks/validation/test_benchmark_planner.py   benchmarks/validation/test_harbor_task_workflow.py   benchmarks/validation/test_verifier_support_schema.py
uv run --locked ruff format --check   benchmarks/validation/test_benchmark_planner.py   benchmarks/validation/test_harbor_task_workflow.py   benchmarks/validation/test_verifier_support_schema.py
TMPDIR=/var/tmp make harbor-plan BASE=origin/main
make harbor-contracts
make docs-linkcheck
git diff --check origin/main
```

The three owning validation modules pass 72 tests. The Harbor plan selects exactly those three host-validation files and no Oracle work.

## Trust & Compatibility Impact

Test-only. No task bundle, verifier, evidence binding, schema, digest, checker authority, artifact format, or public API changes.

## Checklist

- [ ] Routine local validation passes (`make check`)
- [x] Relevant focused tests are listed above
