### PR TITLE
refactor(runtime): reuse prepared artifact identities during runtime assembly

### DIFF
--- a/src/jacobian/schema_registry.py
+++ b/src/jacobian/schema_registry.py
@@ -114,6 +114,21 @@ class SchemaRegistry:
 
         self._reconcile_pending()
         canonical_schema = canonicalize_json(schema)
+        return self._register_canonical(
+            name=name,
+            version=version,
+            canonical_schema=canonical_schema,
+        )
+
+    def _register_canonical(
+        self,
+        *,
+        name: str,
+        version: str,
+        canonical_schema: bytes,
+    ) -> str:
+        """Register an already canonical schema without serializing it again."""
+
         registration = (name, version, canonical_schema)
         transaction_identity = self.store.transaction_identity
         registrations = self._registrations
@@ -126,27 +141,20 @@ class SchemaRegistry:
         if cached_uri is not None:
             return cached_uri
 
+        schema = cast(dict[str, Any], loads_strict_json(canonical_schema))
         # Descriptor identity is content-addressed, but an existing descriptor
         # may have been written through ArtifactRepository.register_descriptor()
         # without ever passing Draft 2020-12 validation.  Keep the validation
         # boundary here; _validated_schema is content-cached, so repeated
         # registrations still reuse the compiled validator.
         _reject_external_references(schema)
-        expected_uri = self.store.descriptor_uri(
-            kind="schema",
-            name=name,
-            version=version,
-            definition=schema,
-        )
         _validated_schema(canonical_schema)
         schema_uri = self.store.register_descriptor(
             kind="schema",
             name=name,
             version=version,
-            definition=loads_strict_json(canonical_schema),
+            definition=schema,
         )
-        if schema_uri != expected_uri:  # pragma: no cover - identity invariant
-            raise SchemaRegistryError("schema descriptor identity changed unexpectedly")
         registrations[registration] = schema_uri
         if transaction_identity is None:
             self._schema_bytes[schema_uri] = canonical_schema
@@ -170,10 +178,11 @@ class SchemaRegistry:
         repeats this registration after every restart before accepting writes.
         """
 
-        schema_uri = self.register(
+        self._reconcile_pending()
+        schema_uri = self._register_canonical(
             name=name,
             version=version,
-            schema=model_schema(model),
+            canonical_schema=_model_schema_bytes(model),
         )
         self._bind_model_contract(schema_uri, model)
         if producer_only:

--- a/src/jacobian/storage/identity.py
+++ b/src/jacobian/storage/identity.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+from dataclasses import dataclass
 from typing import Final
 
 from jacobian.canonical import CanonicalLimits, canonicalize_json
@@ -21,6 +22,17 @@ BOOTSTRAP_SEMANTICS_URI: Final = (
     "artifact://sha256/"
     + hashlib.sha256(b"jacobian.bootstrap.semantics.v1").hexdigest()
 )
+
+
+@dataclass(frozen=True, slots=True)
+class _ArtifactIdentity:
+    """Canonical artifact identity plus the manifest bytes that define it."""
+
+    artifact_uri: str
+    object_digest: str
+    manifest_digest: str
+    manifest: ArtifactManifest
+    manifest_bytes: bytes
 
 
 def sha256_digest(data: bytes) -> str:
@@ -55,7 +67,7 @@ def framed_digest(tag: bytes, parts: tuple[bytes, ...]) -> str:
     return "sha256:" + digest.hexdigest()
 
 
-def artifact_identity(
+def _prepare_artifact_identity(
     *,
     canonical_limits: CanonicalLimits,
     schema_uri: str,
@@ -63,8 +75,8 @@ def artifact_identity(
     canonical_bytes: bytes,
     parents: tuple[str, ...],
     summary: str,
-) -> tuple[str, str, str]:
-    """Calculate an artifact identity without touching storage."""
+) -> _ArtifactIdentity:
+    """Prepare an artifact identity and its canonical manifest projection."""
 
     object_digest = framed_digest(
         OBJECT_FORMAT_VERSION,
@@ -88,7 +100,39 @@ def artifact_identity(
         manifest.model_dump(mode="json"), limits=canonical_limits
     )
     manifest_digest = sha256_digest(manifest_bytes)
-    return uri_from_digest(manifest_digest), object_digest, manifest_digest
+    return _ArtifactIdentity(
+        artifact_uri=uri_from_digest(manifest_digest),
+        object_digest=object_digest,
+        manifest_digest=manifest_digest,
+        manifest=manifest,
+        manifest_bytes=manifest_bytes,
+    )
+
+
+def artifact_identity(
+    *,
+    canonical_limits: CanonicalLimits,
+    schema_uri: str,
+    semantics_uri: str,
+    canonical_bytes: bytes,
+    parents: tuple[str, ...],
+    summary: str,
+) -> tuple[str, str, str]:
+    """Calculate an artifact identity without touching storage."""
+
+    identity = _prepare_artifact_identity(
+        canonical_limits=canonical_limits,
+        schema_uri=schema_uri,
+        semantics_uri=semantics_uri,
+        canonical_bytes=canonical_bytes,
+        parents=parents,
+        summary=summary,
+    )
+    return (
+        identity.artifact_uri,
+        identity.object_digest,
+        identity.manifest_digest,
+    )
 
 
 __all__ = [

--- a/src/jacobian/storage/metadata.py
+++ b/src/jacobian/storage/metadata.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
 from jacobian.canonical import canonicalize_json, loads_strict_json
@@ -23,12 +24,18 @@ from jacobian.storage.identity import (
     BOOTSTRAP_SEMANTICS_URI,
     CANONICALIZER_DIGEST,
     OBJECT_FORMAT_VERSION,
-    artifact_identity,
+    _ArtifactIdentity,
+    _prepare_artifact_identity,
     digest_from_uri,
     framed_digest,
-    sha256_digest,
 )
 from jacobian.storage.models import StoredArtifact
+
+
+@dataclass(frozen=True, slots=True)
+class _PreparedArtifact:
+    canonical_bytes: bytes
+    identity: _ArtifactIdentity
 
 
 class ArtifactMetadata:
@@ -52,28 +59,29 @@ class ArtifactMetadata:
     ) -> str:
         """Register an operator-owned infrastructure descriptor."""
 
-        if kind not in {
-            "schema",
-            "semantics",
-            "canonicalizer",
-            "implementation",
-        }:
-            raise ValueError(f"unsupported descriptor kind: {kind!r}")
-        result = self._put(
+        summary = self._descriptor_summary(kind=kind, name=name, version=version)
+        self._validate_put_request(
             schema_uri=BOOTSTRAP_SCHEMA_URI,
             semantics_uri=BOOTSTRAP_SEMANTICS_URI,
-            payload={
-                "descriptor_version": "1",
-                "kind": kind,
-                "name": name,
-                "version": version,
-                "definition": definition,
-            },
             parents=(),
-            summary=f"{kind}: {name}@{version}",
+            summary=summary,
             allow_bootstrap_references=True,
         )
-        return result.artifact_uri
+        canonical_bytes = self._canonicalize_descriptor(
+            kind=kind,
+            name=name,
+            version=version,
+            definition=definition,
+        )
+        self._validate_artifact_size(canonical_bytes)
+        prepared = self._prepare_identity(
+            schema_uri=BOOTSTRAP_SCHEMA_URI,
+            semantics_uri=BOOTSTRAP_SEMANTICS_URI,
+            canonical_bytes=canonical_bytes,
+            parents=(),
+            summary=summary,
+        )
+        return self._commit_prepared(prepared).artifact_uri
 
     def descriptor_uri(
         self,
@@ -85,30 +93,50 @@ class ArtifactMetadata:
     ) -> str:
         """Return the deterministic URI for an infrastructure descriptor.
 
-        This is a read-only identity calculation.  Schema registration uses it
-        to distinguish an already validated descriptor from a new definition
-        before doing expensive Draft 2020-12 meta-validation.
+        This read-only calculation shares canonical preparation with descriptor
+        registration but does not apply repository commit limits.
         """
 
-        if kind not in {"schema", "semantics", "canonicalizer", "implementation"}:
-            raise ValueError(f"unsupported descriptor kind: {kind!r}")
-        payload = {
-            "descriptor_version": "1",
-            "kind": kind,
-            "name": name,
-            "version": version,
-            "definition": definition,
-        }
-        canonical_bytes = canonicalize_json(payload, limits=self.canonical_limits)
-        artifact_uri, _object_digest, _manifest_digest = artifact_identity(
-            canonical_limits=self.canonical_limits,
+        summary = self._descriptor_summary(kind=kind, name=name, version=version)
+        canonical_bytes = self._canonicalize_descriptor(
+            kind=kind,
+            name=name,
+            version=version,
+            definition=definition,
+        )
+        prepared = self._prepare_identity(
             schema_uri=BOOTSTRAP_SCHEMA_URI,
             semantics_uri=BOOTSTRAP_SEMANTICS_URI,
             canonical_bytes=canonical_bytes,
             parents=(),
-            summary=f"{kind}: {name}@{version}",
+            summary=summary,
         )
-        return artifact_uri
+        return prepared.identity.artifact_uri
+
+    @staticmethod
+    def _descriptor_summary(*, kind: str, name: str, version: str) -> str:
+        if kind not in {"schema", "semantics", "canonicalizer", "implementation"}:
+            raise ValueError(f"unsupported descriptor kind: {kind!r}")
+        return f"{kind}: {name}@{version}"
+
+    def _canonicalize_descriptor(
+        self,
+        *,
+        kind: str,
+        name: str,
+        version: str,
+        definition: Any,
+    ) -> bytes:
+        return canonicalize_json(
+            {
+                "descriptor_version": "1",
+                "kind": kind,
+                "name": name,
+                "version": version,
+                "definition": definition,
+            },
+            limits=self.canonical_limits,
+        )
 
     def get_descriptor(
         self,
@@ -163,6 +191,33 @@ class ArtifactMetadata:
         summary: str,
         allow_bootstrap_references: bool,
     ) -> ArtifactPutResult:
+        self._validate_put_request(
+            schema_uri=schema_uri,
+            semantics_uri=semantics_uri,
+            parents=parents,
+            summary=summary,
+            allow_bootstrap_references=allow_bootstrap_references,
+        )
+        canonical_bytes = canonicalize_json(payload, limits=self.canonical_limits)
+        self._validate_artifact_size(canonical_bytes)
+        prepared = self._prepare_identity(
+            schema_uri=schema_uri,
+            semantics_uri=semantics_uri,
+            canonical_bytes=canonical_bytes,
+            parents=parents,
+            summary=summary,
+        )
+        return self._commit_prepared(prepared)
+
+    def _validate_put_request(
+        self,
+        *,
+        schema_uri: str,
+        semantics_uri: str,
+        parents: tuple[str, ...],
+        summary: str,
+        allow_bootstrap_references: bool,
+    ) -> None:
         if len(summary) > self.limits.max_summary_chars:
             raise StorageLimitError("artifact summary exceeds the configured limit")
         if len(parents) > self.limits.max_parents:
@@ -179,56 +234,55 @@ class ArtifactMetadata:
                         f"referenced artifact is not committed: {reference}"
                     )
 
-        canonical_bytes = canonicalize_json(payload, limits=self.canonical_limits)
+    def _validate_artifact_size(self, canonical_bytes: bytes) -> None:
         if len(canonical_bytes) > self.limits.max_artifact_bytes:
             raise StorageLimitError("artifact exceeds the configured size limit")
 
-        artifact_uri, object_digest, manifest_digest = artifact_identity(
-            canonical_limits=self.canonical_limits,
-            schema_uri=schema_uri,
-            semantics_uri=semantics_uri,
+    def _prepare_identity(
+        self,
+        *,
+        schema_uri: str,
+        semantics_uri: str,
+        canonical_bytes: bytes,
+        parents: tuple[str, ...],
+        summary: str,
+    ) -> _PreparedArtifact:
+        """Calculate an identity from already canonical artifact bytes."""
+
+        return _PreparedArtifact(
             canonical_bytes=canonical_bytes,
-            parents=parents,
-            summary=summary,
-        )
-        normalized_parents = tuple(sorted(parents))
-        manifest = ArtifactManifest(
-            object_digest=object_digest,
-            payload_digest=sha256_digest(canonical_bytes),
-            schema_uri=schema_uri,
-            semantics_uri=semantics_uri,
-            canonicalizer_digest=CANONICALIZER_DIGEST,
-            parents=normalized_parents,
-            summary=summary,
-        )
-        manifest_bytes = canonicalize_json(
-            manifest.model_dump(mode="json"),
-            limits=self.canonical_limits,
+            identity=_prepare_artifact_identity(
+                canonical_limits=self.canonical_limits,
+                schema_uri=schema_uri,
+                semantics_uri=semantics_uri,
+                canonical_bytes=canonical_bytes,
+                parents=parents,
+                summary=summary,
+            ),
         )
 
-        # The identity helper computes the same manifest digest.  Keep this
-        # assertion close to construction so future changes cannot make the
-        # read-only descriptor identity drift from normal puts.
-        if manifest_digest != sha256_digest(
-            manifest_bytes
-        ):  # pragma: no cover - invariant
-            raise AssertionError("artifact identity and manifest digest diverged")
+    def _commit_prepared(self, prepared: _PreparedArtifact) -> ArtifactPutResult:
+        """Persist one fully validated artifact without recomputing its identity."""
+
+        canonical_bytes = prepared.canonical_bytes
+        identity = prepared.identity
+        manifest = identity.manifest
 
         # Re-registering identical content is common while assembling built-in
         # portfolios. Validate the committed artifact before returning so the
         # idempotent path avoids both blob publication and metadata writes
         # without allowing missing or corrupted content to be silently healed.
-        if self._artifact_exists(artifact_uri):
-            self.get(artifact_uri)
+        if self._artifact_exists(identity.artifact_uri):
+            self.get(identity.artifact_uri)
             return ArtifactPutResult(
-                artifact_uri=artifact_uri,
-                object_digest=object_digest,
-                manifest_digest=manifest_digest,
+                artifact_uri=identity.artifact_uri,
+                object_digest=identity.object_digest,
+                manifest_digest=identity.manifest_digest,
                 canonicalizer_digest=CANONICALIZER_DIGEST,
             )
 
         self._write_blob(canonical_bytes)
-        self._write_blob(manifest_bytes)
+        self._write_blob(identity.manifest_bytes)
 
         with self.connection() as connection:
             connection.execute(
@@ -245,30 +299,30 @@ class ArtifactMetadata:
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
-                    artifact_uri,
-                    manifest_digest,
-                    object_digest,
-                    sha256_digest(canonical_bytes),
-                    schema_uri,
-                    semantics_uri,
+                    identity.artifact_uri,
+                    identity.manifest_digest,
+                    identity.object_digest,
+                    manifest.payload_digest,
+                    manifest.schema_uri,
+                    manifest.semantics_uri,
                     CANONICALIZER_DIGEST,
-                    summary,
+                    manifest.summary,
                 ),
             )
-            for position, parent_uri in enumerate(normalized_parents):
+            for position, parent_uri in enumerate(manifest.parents):
                 connection.execute(
                     """
                     INSERT OR IGNORE INTO artifact_parents (
                         artifact_uri, position, parent_uri
                     ) VALUES (?, ?, ?)
                     """,
-                    (artifact_uri, position, parent_uri),
+                    (identity.artifact_uri, position, parent_uri),
                 )
 
         return ArtifactPutResult(
-            artifact_uri=artifact_uri,
-            object_digest=object_digest,
-            manifest_digest=manifest_digest,
+            artifact_uri=identity.artifact_uri,
+            object_digest=identity.object_digest,
+            manifest_digest=identity.manifest_digest,
             canonicalizer_digest=CANONICALIZER_DIGEST,
         )
 

--- a/tests/boundary/storage/transactions/test_artifact_integrity.py
+++ b/tests/boundary/storage/transactions/test_artifact_integrity.py
@@ -5,8 +5,109 @@ from pathlib import Path
 
 import pytest
 
-from jacobian.storage.errors import ArtifactIntegrityError, StorageError
+from jacobian.canonical import CanonicalLimits, canonicalize_json
+from jacobian.storage.errors import (
+    ArtifactIntegrityError,
+    StorageError,
+    StorageLimitError,
+)
+from jacobian.storage.identity import (
+    BOOTSTRAP_SCHEMA_URI,
+    BOOTSTRAP_SEMANTICS_URI,
+    artifact_identity,
+)
+from jacobian.storage.models import StorageLimits
 from jacobian.storage.repository import ArtifactRepository
+
+
+def test_artifact_identity_preserves_digest_tuple_contract() -> None:
+    artifact_uri, object_digest, manifest_digest = artifact_identity(
+        canonical_limits=CanonicalLimits(),
+        schema_uri=BOOTSTRAP_SCHEMA_URI,
+        semantics_uri=BOOTSTRAP_SEMANTICS_URI,
+        canonical_bytes=b"{}",
+        parents=(),
+        summary="identity contract",
+    )
+
+    assert artifact_uri == "artifact://sha256/" + manifest_digest.removeprefix(
+        "sha256:"
+    )
+    assert object_digest.startswith("sha256:")
+
+
+@pytest.mark.parametrize(
+    ("limits", "canonical_limits", "error"),
+    [
+        (StorageLimits(max_summary_chars=5), None, "summary"),
+        (
+            StorageLimits(max_artifact_bytes=128),
+            CanonicalLimits(max_input_bytes=4096, max_output_bytes=4096),
+            "size",
+        ),
+    ],
+)
+def test_descriptor_uri_is_independent_of_commit_limits(
+    tmp_path: Path,
+    limits: StorageLimits,
+    canonical_limits: CanonicalLimits | None,
+    error: str,
+) -> None:
+    reference = ArtifactRepository(
+        tmp_path / "reference",
+        canonical_limits=canonical_limits,
+    )
+    constrained = ArtifactRepository(
+        tmp_path / "constrained",
+        limits=limits,
+        canonical_limits=canonical_limits,
+    )
+    descriptor = {
+        "kind": "schema",
+        "name": "example.identity",
+        "version": "1",
+        "definition": {"description": "x" * 256},
+    }
+    try:
+        assert constrained.descriptor_uri(**descriptor) == reference.descriptor_uri(
+            **descriptor
+        )
+        with pytest.raises(StorageLimitError, match=error):
+            constrained.register_descriptor(**descriptor)
+    finally:
+        constrained.close()
+        reference.close()
+
+
+def test_descriptor_registration_checks_payload_size_before_manifest_size(
+    tmp_path: Path,
+) -> None:
+    descriptor = {
+        "kind": "schema",
+        "name": "x",
+        "version": "1",
+        "definition": {},
+    }
+    canonical_bytes = canonicalize_json(
+        {
+            "descriptor_version": "1",
+            **descriptor,
+        }
+    )
+    canonical_budget = len(canonical_bytes) * 2
+    store = ArtifactRepository(
+        tmp_path,
+        limits=StorageLimits(max_artifact_bytes=len(canonical_bytes) - 1),
+        canonical_limits=CanonicalLimits(
+            max_input_bytes=canonical_budget,
+            max_output_bytes=canonical_budget,
+        ),
+    )
+    try:
+        with pytest.raises(StorageLimitError, match="artifact exceeds"):
+            store.register_descriptor(**descriptor)
+    finally:
+        store.close()
 
 
 def test_artifact_identity_uses_canonical_payload_schema_and_semantics(
@@ -168,6 +269,29 @@ def test_repeated_put_rejects_corrupted_committed_blob(tmp_path: Path) -> None:
             schema_uri=schema,
             semantics_uri=semantics,
             payload={"value": "original"},
+        )
+
+
+def test_repeated_descriptor_registration_rejects_corrupted_blob(
+    tmp_path: Path,
+) -> None:
+    store = ArtifactRepository(tmp_path)
+    definition = {"type": "object", "properties": {"value": {"type": "integer"}}}
+    descriptor_uri = store.register_descriptor(
+        kind="schema",
+        name="example.descriptor-integrity",
+        version="1",
+        definition=definition,
+    )
+    descriptor = store.get(descriptor_uri)
+    store._blob_path(descriptor.manifest.payload_digest).write_bytes(b"corrupt")
+
+    with pytest.raises(ArtifactIntegrityError, match="blob digest mismatch"):
+        store.register_descriptor(
+            kind="schema",
+            name="example.descriptor-integrity",
+            version="1",
+            definition=definition,
         )
 
 

--- a/tools/c901-baseline.json
+++ b/tools/c901-baseline.json
@@ -403,11 +403,6 @@
       "complexity": 13
     },
     {
-      "path": "src/jacobian/storage/metadata.py",
-      "symbol": "_put",
-      "complexity": 11
-    },
-    {
       "path": "src/jacobian/storage/transactions.py",
       "symbol": "transaction",
       "complexity": 22


### PR DESCRIPTION
## Problem

Runtime assembly repeatedly canonicalizes data that is already canonical. Model schemas are serialized again during registration, descriptor identity is calculated before the same descriptor is registered, and artifact manifests are rebuilt after identity calculation.

In matched runtime-construction profiles, that path accounted for 5,368 JSON canonicalizations and 895 artifact-identity preparations.

## Solution

Reuse one prepared representation at each boundary:

- register model schemas through an internal already-canonical path while retaining external-reference checks and Draft 2020-12 meta-validation;
- carry the canonical artifact bytes, manifest, manifest bytes, and digests from identity preparation into the commit path;
- keep descriptor URI calculation independent of repository commit limits, while registration preserves the existing validation and size-check order;
- retain the existing idempotent-read corruption check and public `artifact_identity()` tuple contract.

The simpler commit path also drops `_put` below the repository's complexity threshold, so this removes its stale C901 baseline entry.

On this host, six paired fresh-state runtime constructions improved from a 5.336 s warmed median to 4.368 s (18.1%); teardown was outside the timed region and each tree's first run was excluded from the median. First-run time improved from 9.372 s to 8.163 s. The host was noisy, so the deterministic call-count reduction is the stronger signal: JSON canonicalizations fell from 5,368 to 3,706, and identity preparations from 895 to 479.

## Testing

```sh
make test-plan BASE=25141d0e293ea0d8023273cea3ad20049ef47340
make test-unit test-component test-domain test-composition test-storage test-process test-mcp test-e2e
make npm-test
make security-audit duplicate-code
make check-static
```

All selected semantic test lanes passed, including 119 storage tests, 227 process tests, 36 MCP tests, and the end-to-end lane (with the expected unavailable-Lean skip). All 45 npm tests passed, as did the security audit and duplicate-code scan.

A 50-artifact differential corpus produced byte-identical URIs, manifests, payloads, canonical bytes, and serialized records on the base and candidate trees (61,622 bytes each).

`make check-static` passes Ruff, formatting, the updated complexity ratchet, dependency analysis, dead-code analysis, mypy, and test architecture. Its final architecture scan remains blocked by ten unchanged benchmark validation fixtures on current `main` that directly invoke subprocesses; neither those fixtures nor the architecture policy are changed here.

## Trust & Compatibility Impact

This does not change artifact URIs, stored formats, the public API, checker authority, or verification assurance. Schema meta-validation remains mandatory. Descriptor registration still enforces storage limits before identity preparation, and repeated registration still detects corrupted committed blobs.

## Checklist

- [ ] Routine local validation passes (`make check`)
- [x] Relevant focused tests are listed above
