### PR TITLE
fix(providers): correct Z3 mismatch diagnostic

### DIFF
--- a/src/jacobian/provider_runtime.py
+++ b/src/jacobian/provider_runtime.py
@@ -677,7 +677,7 @@ def known_provider_runtime(
                 license_id="MIT",
                 diagnostic=(
                     "Z3 is installed but does not match the pinned "
-                    f"{Z3_SOLVER_VERSION} graph-search profile."
+                    f"{Z3_SOLVER_VERSION} SMT solver profile."
                 ),
             )
         return runtime

--- a/tests/unit/contracts/test_provider_runtime.py
+++ b/tests/unit/contracts/test_provider_runtime.py
@@ -286,6 +286,25 @@ def test_python_provider_readiness_checks_required_attributes(
     assert raised.value.code is ProviderRuntimeErrorCode.READINESS_FAILED
 
 
+def test_z3_version_mismatch_reports_smt_solver_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mismatched = _runtime(provider="jacobian.z3", version="0.0.0")
+    monkeypatch.setattr(
+        provider_runtime,
+        "python_distribution_provider_runtime",
+        lambda *_args, **_kwargs: mismatched,
+    )
+
+    runtime = provider_runtime.known_provider_runtime("jacobian.z3")
+
+    assert runtime.availability is CapabilityProviderAvailability.UNAVAILABLE
+    assert runtime.diagnostic == (
+        "Z3 is installed but does not match the pinned "
+        f"{provider_runtime.Z3_SOLVER_VERSION} SMT solver profile."
+    )
+
+
 def test_disappeared_executable_is_unavailable(tmp_path: Path) -> None:
     runtime = _runtime(
         digest_kind=CapabilityProviderDigestKind.EXECUTABLE,


### PR DESCRIPTION
## Problem

When an installed Z3 distribution does not match the pinned version, its provider diagnostic describes the expected runtime as a “graph-search profile.” That wording was copied from a graph provider and is misleading for an SMT solver shared by several domains.

Fixes #740.

## Solution

Describe the pinned Z3 runtime as an “SMT solver profile.” The mismatch detection and unavailable-provider behavior are unchanged.

## Testing

```sh
uv run --locked pytest -q tests/unit/contracts/test_provider_runtime.py::test_z3_version_mismatch_reports_smt_solver_profile
uv run --locked pytest -q tests/unit/contracts/test_provider_runtime.py
uv run --locked ruff check src/jacobian/provider_runtime.py tests/unit/contracts/test_provider_runtime.py
uv run --locked ruff format --check src/jacobian/provider_runtime.py tests/unit/contracts/test_provider_runtime.py
TMPDIR=/var/tmp make test-plan BASE=origin/main
git diff --check origin/main
```

The regression forces an available typed Z3 runtime with a mismatched version and checks the exact unavailable diagnostic. The full provider-runtime contract module passes 20 tests.

## Trust & Compatibility Impact

Diagnostic text only. No provider identity, availability rule, public schema, checker authority, artifact format, or mathematical behavior changes.

## Checklist

- [ ] Routine local validation passes (`make check`)
- [x] Relevant focused tests are listed above
