### PR TITLE
refactor(mcp): remove server namespace injection

### DIFF
--- a/src/jacobian/adapters/mcp/server.py
+++ b/src/jacobian/adapters/mcp/server.py
@@ -35,7 +35,11 @@ from jacobian.adapters.mcp.guidance import (
     operating_guide,
     server_instructions,
 )
-from jacobian.adapters.mcp.remote import TenantRuntimeRouter
+from jacobian.adapters.mcp.remote import (
+    DEFAULT_MAX_TENANT_RUNTIMES,
+    DEFAULT_TENANT_IDLE_TIMEOUT_SECONDS,
+    TenantRuntimeRouter,
+)
 from jacobian.adapters.mcp.resources import (
     _register_reasoning_resource,
     _register_resources_and_prompts,
@@ -401,24 +405,6 @@ def create_server(
     selected_reasoning_mode = _normalize_reasoning_log_mode(reasoning_log_mode)
     if tenant_isolation and capability_exclusions:
         raise ValueError("capability exclusions are supported only by local evaluation")
-
-    # Keep ``--help`` and ``--version`` independent of the MCP runtime's
-    # heavier imports and shutdown hooks.
-    from mcp.server.mcpserver import Context
-
-    from jacobian.adapters.mcp.remote import (
-        DEFAULT_MAX_TENANT_RUNTIMES,
-        DEFAULT_TENANT_IDLE_TIMEOUT_SECONDS,
-        TenantRuntimeRouter,
-    )
-    from jacobian.runtime.model import JacobianRuntime
-
-    globals().update(
-        {
-            "Context": Context,
-            "JacobianRuntime": JacobianRuntime,
-        }
-    )
 
     selected_authority = _selected_checker_authority(checker_authority)
     configured_root = _configured_root(state_dir)

--- a/tests/boundary/mcp/test_mcp_sdk_2_conformance.py
+++ b/tests/boundary/mcp/test_mcp_sdk_2_conformance.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 from mcp.server.extension import Extension, ResourceBinding, ToolBinding
 
+import jacobian.adapters.mcp.server as server_module
 from jacobian.adapters.mcp.constants import ReasoningLogMode
 from jacobian.adapters.mcp.server import JacobianCoreExtension, create_server
 from jacobian.contracts.capabilities import CapabilityResult
@@ -38,12 +39,17 @@ def test_mcp_sdk_is_exactly_pinned_and_v2_bindings_are_used() -> None:
 
 def test_mcp_v2_static_validation_context_errors_and_structured_resources(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.delattr(server_module, "Context", raising=False)
+
     async def scenario() -> None:
         from mcp import Client
         from mcp.shared.exceptions import MCPError
 
-        async with Client(create_server(tmp_path), raise_exceptions=True) as client:
+        server = create_server(tmp_path)
+        assert not hasattr(server_module, "Context")
+        async with Client(server, raise_exceptions=True) as client:
             listed = await client.list_tools()
             assert all(
                 tool.input_schema.get("additionalProperties") is False


### PR DESCRIPTION
## Problem

`create_server()` still injects `Context` and `JacobianRuntime` into its module namespace. That was once needed when annotated MCP handlers were defined inside the factory, but those handlers now live in dedicated modules and the runtime type is already imported normally.

The update is now hidden mutable state with no consumer.

Fixes #736.

## Solution

Remove the local annotation imports and `globals().update()`. The tenant defaults are imported alongside the already top-level tenant router, so server construction has no module-namespace side effect.

## Testing

```sh
uv run --locked pytest -q tests/boundary/mcp/test_mcp_sdk_2_conformance.py::test_mcp_v2_static_validation_context_errors_and_structured_resources
uv run --locked pytest -q tests/boundary/mcp/test_mcp_sdk_2_conformance.py
uv run --locked ruff check src/jacobian/adapters/mcp/server.py tests/boundary/mcp/test_mcp_sdk_2_conformance.py
uv run --locked ruff format --check src/jacobian/adapters/mcp/server.py tests/boundary/mcp/test_mcp_sdk_2_conformance.py
TMPDIR=/var/tmp make test-plan BASE=origin/main
git diff --check origin/main
```

The regression removes any pre-existing module-level `Context`, constructs a server, and proves the name is not reintroduced. The same client scenario still checks static tool schemas, SDK context injection, structured capability output, public input errors, and resource errors. Both MCP SDK conformance tests pass.

## Trust & Compatibility Impact

No MCP schema, context contract, tool behavior, checker authority, artifact format, or public API changes. This removes obsolete internal module mutation only.

## Checklist

- [ ] Routine local validation passes (`make check`)
- [x] Relevant focused tests are listed above
