### PR TITLE
fix(discovery): bound search nomination lineage before archive persistence

### DIFF
--- a/src/jacobian/search/run_loop.py
+++ b/src/jacobian/search/run_loop.py
@@ -220,10 +220,26 @@ def _run_iteration(state: _SearchIterationState) -> bool:
     if proposal is None:
         return False
     evaluation = _evaluate_candidates(state, proposal, budget)
-    refinement = _run_refiner(state, proposal, evaluation.records, budget)
+    max_additional_lineage_parents = _max_additional_nomination_parents(
+        state, evaluation.records
+    )
+    refinement = _run_refiner(
+        state,
+        proposal,
+        evaluation.records,
+        budget,
+        max_additional_lineage_parents=max_additional_lineage_parents,
+    )
     if refinement is None:
         return False
-    return _persist_iteration(state, proposal, refinement, evaluation, budget)
+    return _persist_iteration(
+        state,
+        proposal,
+        refinement,
+        evaluation,
+        budget,
+        max_additional_lineage_parents=max_additional_lineage_parents,
+    )
 
 
 def _run_proposer(
@@ -510,6 +526,8 @@ def _run_refiner(
     proposal: PluginProposalResponse,
     records: tuple[SearchCandidateRecord, ...],
     budget: SearchBudget,
+    *,
+    max_additional_lineage_parents: int,
 ) -> PluginRefinementResponse | None:
     request = {
         "request_version": "1",
@@ -518,6 +536,7 @@ def _run_refiner(
         "feedback": [record.model_dump(mode="json") for record in records],
         "strategy_reported_complete": proposal.complete,
         "seed": state.request.seed,
+        "max_additional_lineage_parents": max_additional_lineage_parents,
         "bindings": {
             "claim_digest": state.claim.manifest.object_digest,
             "semantics_digest": state.semantics.manifest.object_digest,
@@ -573,18 +592,40 @@ def _run_refiner(
     return refinement
 
 
+def _max_additional_nomination_parents(
+    state: _SearchIterationState,
+    records: tuple[SearchCandidateRecord, ...],
+) -> int:
+    required_parents = {
+        state.request.claim_uri,
+        state.request.plugin_id,
+        *_record_parents(list(records), ()),
+    }
+    return max(0, state.service.store.limits.max_parents - len(required_parents))
+
+
 def _persist_iteration(
     state: _SearchIterationState,
     proposal: PluginProposalResponse,
     refinement: PluginRefinementResponse,
     evaluation: _CandidateEvaluation,
     budget: SearchBudget,
+    *,
+    max_additional_lineage_parents: int,
 ) -> bool:
     nominations = tuple(
         nomination
         for nomination in _deduplicate_nominations(refinement.nominations)
         if nomination.candidate_uri not in state.nominated_uris
     )
+    record_parents = set(_record_parents(list(evaluation.records), ()))
+    additional_nomination_parents = {
+        nomination.candidate_uri for nomination in nominations
+    } - record_parents
+    if len(additional_nomination_parents) > max_additional_lineage_parents:
+        raise SearchError(
+            "refiner returned more nomination lineage than the archive can preserve"
+        )
     state.nominated_uris.update(nomination.candidate_uri for nomination in nominations)
     next_accounting = SearchAccounting(
         proposed_candidates=evaluation.proposed,

--- a/tests/boundary/storage/recovery/test_search_plugin_fail_closed.py
+++ b/tests/boundary/storage/recovery/test_search_plugin_fail_closed.py
@@ -270,6 +270,87 @@ def test_search_batch_respects_archive_parent_limit(fresh_complete_runtime) -> N
         )
 
 
+def test_refiner_can_fit_previous_nominations_to_archive_parent_limit(
+    fresh_complete_runtime,
+) -> None:
+    claim_uri, plugin_id = _install_search_plugin(
+        fresh_complete_runtime,
+        proposer_entrypoint=(
+            "tests.support.search_entrypoints:"
+            "propose_fixture_values_with_strategy_state"
+        ),
+        refiner_entrypoint=(
+            "tests.support.search_entrypoints:"
+            "refine_with_bounded_previous_batch_nominations"
+        ),
+    )
+    fresh_complete_runtime.core.store.limits = StorageLimits(max_parents=6)
+    handle = fresh_complete_runtime.services.search.start(
+        _request(
+            claim_uri,
+            plugin_id,
+            idempotency_key="search-nomination-parent-policy-001",
+            batch_size=4,
+        )
+    )
+
+    snapshot = fresh_complete_runtime.services.search.wait(
+        handle.experiment_uri, timeout_seconds=30
+    )
+
+    assert snapshot.state is ExperimentState.COMPLETED
+    assert snapshot.effective_budget.batch_size == 3
+    assert snapshot.accounting.iterations == 2
+    assert snapshot.accounting.nominations == 2
+    assert snapshot.checkpoint_uri is not None
+    checkpoint = SearchCheckpoint.model_validate(
+        fresh_complete_runtime.core.store.get(snapshot.checkpoint_uri).payload
+    )
+    assert checkpoint.state["observed_lineage_parent_limit"] == 2
+    for page_uri in snapshot.archive_page_uris:
+        assert (
+            len(fresh_complete_runtime.core.store.get(page_uri).manifest.parents) <= 6
+        )
+
+
+def test_refiner_cannot_exceed_archive_nomination_parent_limit(
+    fresh_complete_runtime,
+) -> None:
+    claim_uri, plugin_id = _install_search_plugin(
+        fresh_complete_runtime,
+        proposer_entrypoint=(
+            "tests.support.search_entrypoints:"
+            "propose_fixture_values_with_strategy_state"
+        ),
+        refiner_entrypoint=(
+            "tests.support.search_entrypoints:"
+            "refine_ignoring_previous_batch_nomination_limit"
+        ),
+    )
+    fresh_complete_runtime.core.store.limits = StorageLimits(max_parents=6)
+    handle = fresh_complete_runtime.services.search.start(
+        _request(
+            claim_uri,
+            plugin_id,
+            idempotency_key="search-nomination-parent-policy-002",
+            batch_size=4,
+        )
+    )
+
+    snapshot = fresh_complete_runtime.services.search.wait(
+        handle.experiment_uri, timeout_seconds=30
+    )
+
+    assert snapshot.state is ExperimentState.ERROR
+    assert snapshot.stop_reason is SearchStopReason.ERROR
+    assert snapshot.accounting.nominations == 0
+    assert len(snapshot.archive_page_uris) == 1
+    assert (
+        snapshot.detail
+        == "refiner returned more nomination lineage than the archive can preserve"
+    )
+
+
 def test_refiner_cannot_claim_verification(fresh_complete_runtime) -> None:
     claim_uri, plugin_id = _install_search_plugin(
         fresh_complete_runtime,

--- a/tests/support/search_entrypoints.py
+++ b/tests/support/search_entrypoints.py
@@ -59,6 +59,14 @@ def propose_fixture_values(request: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def propose_fixture_values_with_strategy_state(
+    request: dict[str, Any],
+) -> dict[str, Any]:
+    response = propose_fixture_values(request)
+    response["state"] = {**request["state"], **response["state"]}
+    return response
+
+
 def refine_fixture_search(request: dict[str, Any]) -> dict[str, Any]:
     feedback = request["feedback"]
     nominations = (
@@ -76,6 +84,49 @@ def refine_fixture_search(request: dict[str, Any]) -> dict[str, Any]:
         "state": request["state"],
         "nominations": nominations,
         "detail": "fixture refinement",
+    }
+
+
+def refine_with_bounded_previous_batch_nominations(
+    request: dict[str, Any],
+) -> dict[str, Any]:
+    limit = int(request["max_additional_lineage_parents"])
+    previous = request["state"].get("previous_candidate_uris", [])
+    current = [item["candidate_uri"] for item in request["feedback"]]
+    return {
+        "response_version": "1",
+        "state": {
+            **request["state"],
+            "previous_candidate_uris": current,
+            "observed_lineage_parent_limit": limit,
+        },
+        "nominations": [
+            {
+                "candidate_uri": candidate_uri,
+                "reason": "previously evaluated candidate",
+            }
+            for candidate_uri in previous[:limit]
+        ],
+        "detail": "nominated within the advertised lineage capacity",
+    }
+
+
+def refine_ignoring_previous_batch_nomination_limit(
+    request: dict[str, Any],
+) -> dict[str, Any]:
+    previous = request["state"].get("previous_candidate_uris", [])
+    current = [item["candidate_uri"] for item in request["feedback"]]
+    return {
+        "response_version": "1",
+        "state": {**request["state"], "previous_candidate_uris": current},
+        "nominations": [
+            {
+                "candidate_uri": candidate_uri,
+                "reason": "previously evaluated candidate",
+            }
+            for candidate_uri in previous
+        ],
+        "detail": "ignored the advertised lineage capacity",
     }
 
 


### PR DESCRIPTION
## Problem

A search refiner can nominate candidates from earlier batches without knowing how many additional archive-parent slots remain. If those nominations exceed the store's parent limit, persistence fails only after nomination state and accounting have already been mutated.

Fixes #651.

## Solution

- expose the exact remaining additional lineage-parent capacity in each refiner request
- compute that capacity from the claim, plugin, and current candidate-record parents
- treat current-batch nominations as already represented rather than charging them twice
- reject a refiner response that exceeds the advertised capacity before nomination state, accounting, archive pages, or checkpoints are updated

The archive still records every accepted nomination; this does not silently truncate lineage or rank candidate choices.

## Testing

```sh
TMPDIR=/var/tmp make test-storage TESTS='tests/boundary/storage/recovery/test_search_plugin_fail_closed.py::test_search_batch_respects_archive_parent_limit tests/boundary/storage/recovery/test_search_plugin_fail_closed.py::test_refiner_can_fit_previous_nominations_to_archive_parent_limit tests/boundary/storage/recovery/test_search_plugin_fail_closed.py::test_refiner_cannot_exceed_archive_nomination_parent_limit'
TMPDIR=/var/tmp uv run --locked ruff check src/jacobian/search/run_loop.py tests/support/search_entrypoints.py tests/boundary/storage/recovery/test_search_plugin_fail_closed.py
TMPDIR=/var/tmp uv run --locked ruff format --check src/jacobian/search/run_loop.py tests/support/search_entrypoints.py tests/boundary/storage/recovery/test_search_plugin_fail_closed.py
TMPDIR=/var/tmp make test-plan BASE=origin/main
```

The three final-head storage regressions passed. The two new tests also fail against the base for distinct reasons: a cooperative refiner receives no capacity on base, while a noncompliant refiner reaches the real storage limit after recording three nominations.

## Trust & Compatibility Impact

This changes the search-plugin refiner request by adding an advisory-but-enforced capacity field. Refiner strategy remains plugin-owned; the server only communicates and enforces its storage invariant. Artifact formats, checker authorization, assurance, and verification semantics are unchanged.

## Checklist

- [ ] Routine local validation passes (`make check`)
- [x] Relevant focused tests are listed above
