### PR TITLE
refactor(checkers): share exact evidence-binding validation across checkers

### DIFF
--- a/src/jacobian_checkers/bound_artifacts.py
+++ b/src/jacobian_checkers/bound_artifacts.py
@@ -27,6 +27,19 @@ _BINDING_KEYS = {
 }
 
 
+def valid_unscoped_unencoded_bindings(value: object) -> bool:
+    """Validate exact five-key bindings without scope or encoding digests."""
+
+    if not isinstance(value, dict) or set(value) != _BINDING_KEYS:
+        return False
+    if value["scope_digest"] is not None or value["encoding_digest"] is not None:
+        return False
+    return all(
+        isinstance(value[key], str) and _DIGEST.fullmatch(value[key]) is not None
+        for key in ("claim_digest", "semantics_digest", "candidate_digest")
+    )
+
+
 def _digest(value: object) -> str:
     encoded = json.dumps(
         value,
@@ -100,10 +113,7 @@ def bound_request(
         raise ValueError("artifacts use different semantics")
     bindings = request["expected_bindings"]
     if (
-        not isinstance(bindings, dict)
-        or set(bindings) != _BINDING_KEYS
-        or bindings["scope_digest"] is not None
-        or bindings["encoding_digest"] is not None
+        not valid_unscoped_unencoded_bindings(bindings)
         or bindings["claim_digest"] != claim["object_digest"]
         or bindings["candidate_digest"] != candidate["object_digest"]
         or bindings["semantics_digest"] != semantics["object_digest"]
@@ -140,4 +150,4 @@ def bound_request(
     return claim["payload"], candidate["payload"]
 
 
-__all__ = ["bound_request"]
+__all__ = ["bound_request", "valid_unscoped_unencoded_bindings"]

--- a/src/jacobian_checkers/exact_geometry.py
+++ b/src/jacobian_checkers/exact_geometry.py
@@ -12,6 +12,8 @@ import re
 from fractions import Fraction
 from typing import Any
 
+from jacobian_checkers.bound_artifacts import valid_unscoped_unencoded_bindings
+
 _ARTIFACT_URI = re.compile(r"^artifact://sha256/[0-9a-f]{64}$")
 _DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
 _INTEGER = re.compile(r"^-?(?:0|[1-9][0-9]*)$")
@@ -23,13 +25,6 @@ _ARTIFACT_KEYS = {
     "semantics_uri",
     "parents",
     "payload",
-}
-_BINDING_KEYS = {
-    "claim_digest",
-    "semantics_digest",
-    "candidate_digest",
-    "scope_digest",
-    "encoding_digest",
 }
 _OPERATIONS = {
     "geometry.points.compute.squared_distance",
@@ -93,19 +88,6 @@ def _valid_artifact(value: object) -> bool:
         and all(
             isinstance(parent, str) and _ARTIFACT_URI.fullmatch(parent) is not None
             for parent in parents
-        )
-    )
-
-
-def _valid_bindings(value: object) -> bool:
-    return (
-        isinstance(value, dict)
-        and set(value) == _BINDING_KEYS
-        and value["scope_digest"] is None
-        and value["encoding_digest"] is None
-        and all(
-            isinstance(value[key], str) and _DIGEST.fullmatch(value[key]) is not None
-            for key in ("claim_digest", "semantics_digest", "candidate_digest")
         )
     )
 
@@ -580,7 +562,7 @@ def check_exact_geometry(request: dict[str, Any]) -> dict[str, Any]:
         ):
             return _reject("checker artifact metadata is malformed")
         bindings = request["expected_bindings"]
-        if not _valid_bindings(bindings):
+        if not valid_unscoped_unencoded_bindings(bindings):
             return _reject("expected evidence bindings are malformed")
         if (
             bindings["claim_digest"] != claim["object_digest"]

--- a/src/jacobian_checkers/linear.py
+++ b/src/jacobian_checkers/linear.py
@@ -12,6 +12,8 @@ import re
 from fractions import Fraction
 from typing import Any
 
+from jacobian_checkers.bound_artifacts import valid_unscoped_unencoded_bindings
+
 _ARTIFACT_URI = re.compile(r"^artifact://sha256/[0-9a-f]{64}$")
 _DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
 _INTEGER = re.compile(r"^-?(?:0|[1-9][0-9]*)$")
@@ -24,13 +26,6 @@ _ARTIFACT_KEYS = {
     "semantics_uri",
     "parents",
     "payload",
-}
-_BINDING_KEYS = {
-    "claim_digest",
-    "semantics_digest",
-    "candidate_digest",
-    "scope_digest",
-    "encoding_digest",
 }
 _SYSTEM_BINDING_KEYS = {
     "binding_version",
@@ -114,17 +109,6 @@ def _valid_artifact(value: object) -> bool:
             isinstance(parent, str) and _ARTIFACT_URI.fullmatch(parent) is not None
             for parent in parents
         )
-    )
-
-
-def _valid_bindings(value: object) -> bool:
-    if not isinstance(value, dict) or set(value) != _BINDING_KEYS:
-        return False
-    if value["scope_digest"] is not None or value["encoding_digest"] is not None:
-        return False
-    return all(
-        isinstance(value[key], str) and _DIGEST.fullmatch(value[key]) is not None
-        for key in ("claim_digest", "semantics_digest", "candidate_digest")
     )
 
 
@@ -369,7 +353,7 @@ def check_rational_solution(request: dict[str, Any]) -> dict[str, Any]:
         witness = request["witness"]
         if not all(_valid_artifact(item) for item in (claim, candidate, witness)):
             return _reject("checker artifact metadata is malformed")
-        if not _valid_bindings(request["expected_bindings"]):
+        if not valid_unscoped_unencoded_bindings(request["expected_bindings"]):
             return _reject("expected evidence bindings are malformed")
         if (
             claim["semantics_uri"] != candidate["semantics_uri"]
@@ -478,7 +462,7 @@ def check_rational_inconsistency(request: dict[str, Any]) -> dict[str, Any]:
         if not all(_valid_artifact(item) for item in (claim, candidate, witness)):
             return _reject("checker artifact metadata is malformed")
         expected_bindings = request["expected_bindings"]
-        if not _valid_bindings(expected_bindings):
+        if not valid_unscoped_unencoded_bindings(expected_bindings):
             return _reject("expected evidence bindings are malformed")
         if (
             claim["semantics_uri"] != candidate["semantics_uri"]

--- a/src/jacobian_checkers/matrix_normal_forms.py
+++ b/src/jacobian_checkers/matrix_normal_forms.py
@@ -11,6 +11,8 @@ import json
 import re
 from typing import Any
 
+from jacobian_checkers.bound_artifacts import valid_unscoped_unencoded_bindings
+
 _ARTIFACT_URI = re.compile(r"^artifact://sha256/[0-9a-f]{64}$")
 _DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
 _INTEGER = re.compile(r"^-?(?:0|[1-9][0-9]*)$")
@@ -22,13 +24,6 @@ _ARTIFACT_KEYS = {
     "semantics_uri",
     "parents",
     "payload",
-}
-_BINDING_KEYS = {
-    "claim_digest",
-    "semantics_digest",
-    "candidate_digest",
-    "scope_digest",
-    "encoding_digest",
 }
 _MATRIX_BINDING_KEYS = {
     "binding_version",
@@ -119,17 +114,6 @@ def _valid_artifact(value: object) -> bool:
             isinstance(parent, str) and _ARTIFACT_URI.fullmatch(parent) is not None
             for parent in parents
         )
-    )
-
-
-def _valid_bindings(value: object) -> bool:
-    if not isinstance(value, dict) or set(value) != _BINDING_KEYS:
-        return False
-    if value["scope_digest"] is not None or value["encoding_digest"] is not None:
-        return False
-    return all(
-        isinstance(value[key], str) and _DIGEST.fullmatch(value[key]) is not None
-        for key in ("claim_digest", "semantics_digest", "candidate_digest")
     )
 
 
@@ -344,7 +328,7 @@ def check_hermite_normal_form(request: dict[str, Any]) -> dict[str, Any]:
         if not all(_valid_artifact(item) for item in (claim, candidate, witness)):
             return _reject("checker artifact metadata is malformed")
         expected_bindings = request["expected_bindings"]
-        if not _valid_bindings(expected_bindings):
+        if not valid_unscoped_unencoded_bindings(expected_bindings):
             return _reject("expected evidence bindings are malformed")
         if (
             claim["semantics_uri"] != candidate["semantics_uri"]

--- a/src/jacobian_checkers/polynomial_expressions.py
+++ b/src/jacobian_checkers/polynomial_expressions.py
@@ -14,6 +14,8 @@ from fractions import Fraction
 from math import comb
 from typing import Any
 
+from jacobian_checkers.bound_artifacts import valid_unscoped_unencoded_bindings
+
 _ARTIFACT_URI = re.compile(r"^artifact://sha256/[0-9a-f]{64}$")
 _DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
 _INTEGER = re.compile(r"^-?(?:0|[1-9][0-9]*)$")
@@ -26,13 +28,6 @@ _ARTIFACT_KEYS = {
     "semantics_uri",
     "parents",
     "payload",
-}
-_BINDING_KEYS = {
-    "claim_digest",
-    "semantics_digest",
-    "candidate_digest",
-    "scope_digest",
-    "encoding_digest",
 }
 _EXPRESSION_BINDING_KEYS = {
     "binding_version",
@@ -145,17 +140,6 @@ def _valid_artifact(value: object) -> bool:
             isinstance(parent, str) and _ARTIFACT_URI.fullmatch(parent) is not None
             for parent in parents
         )
-    )
-
-
-def _valid_bindings(value: object) -> bool:
-    if not isinstance(value, dict) or set(value) != _BINDING_KEYS:
-        return False
-    if value["scope_digest"] is not None or value["encoding_digest"] is not None:
-        return False
-    return all(
-        isinstance(value[key], str) and _DIGEST.fullmatch(value[key]) is not None
-        for key in ("claim_digest", "semantics_digest", "candidate_digest")
     )
 
 
@@ -546,7 +530,7 @@ def check_polynomial_expression_normalization(
         if not all(_valid_artifact(item) for item in (claim, candidate, witness)):
             return _reject("checker artifact metadata is malformed")
         expected_bindings = request["expected_bindings"]
-        if not _valid_bindings(expected_bindings):
+        if not valid_unscoped_unencoded_bindings(expected_bindings):
             return _reject("expected evidence bindings are malformed")
         if (
             claim["semantics_uri"] != candidate["semantics_uri"]

--- a/src/jacobian_checkers/rational_determinants.py
+++ b/src/jacobian_checkers/rational_determinants.py
@@ -12,6 +12,8 @@ import re
 from fractions import Fraction
 from typing import Any
 
+from jacobian_checkers.bound_artifacts import valid_unscoped_unencoded_bindings
+
 _ARTIFACT_URI = re.compile(r"^artifact://sha256/[0-9a-f]{64}$")
 _DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
 _INTEGER = re.compile(r"^-?(?:0|[1-9][0-9]*)$")
@@ -23,13 +25,6 @@ _ARTIFACT_KEYS = {
     "semantics_uri",
     "parents",
     "payload",
-}
-_BINDING_KEYS = {
-    "claim_digest",
-    "semantics_digest",
-    "candidate_digest",
-    "scope_digest",
-    "encoding_digest",
 }
 _MAX_DIMENSION = 32
 
@@ -83,17 +78,6 @@ def _valid_artifact(value: object) -> bool:
             isinstance(parent, str) and _ARTIFACT_URI.fullmatch(parent) is not None
             for parent in parents
         )
-    )
-
-
-def _valid_bindings(value: object) -> bool:
-    if not isinstance(value, dict) or set(value) != _BINDING_KEYS:
-        return False
-    if value["scope_digest"] is not None or value["encoding_digest"] is not None:
-        return False
-    return all(
-        isinstance(value[key], str) and _DIGEST.fullmatch(value[key]) is not None
-        for key in ("claim_digest", "semantics_digest", "candidate_digest")
     )
 
 
@@ -214,7 +198,7 @@ def check_rational_determinant(request: dict[str, Any]) -> dict[str, Any]:
         if not all(_valid_artifact(item) for item in (claim, candidate, witness)):
             return _reject("checker artifact metadata is malformed")
         expected_bindings = request["expected_bindings"]
-        if not _valid_bindings(expected_bindings):
+        if not valid_unscoped_unencoded_bindings(expected_bindings):
             return _reject("expected evidence bindings are malformed")
         if (
             claim["semantics_uri"] != candidate["semantics_uri"]
@@ -323,7 +307,7 @@ def check_rational_rank(request: dict[str, Any]) -> dict[str, Any]:
             return _reject("rank artifacts have changed payloads or semantics")
         bindings = request["expected_bindings"]
         if (
-            not _valid_bindings(bindings)
+            not valid_unscoped_unencoded_bindings(bindings)
             or bindings["claim_digest"] != claim["object_digest"]
             or bindings["candidate_digest"] != candidate["object_digest"]
             or len(witness["parents"]) != 2

--- a/src/jacobian_checkers/sat.py
+++ b/src/jacobian_checkers/sat.py
@@ -23,6 +23,7 @@ from jacobian.process_policy import (
     execute_process,
 )
 from jacobian.worker_environment import worker_environment
+from jacobian_checkers.bound_artifacts import valid_unscoped_unencoded_bindings
 
 _ARTIFACT_URI = re.compile(r"^artifact://sha256/[0-9a-f]{64}$")
 _DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
@@ -36,13 +37,6 @@ _ARTIFACT_KEYS = {
     "semantics_uri",
     "parents",
     "payload",
-}
-_BINDING_KEYS = {
-    "claim_digest",
-    "semantics_digest",
-    "candidate_digest",
-    "scope_digest",
-    "encoding_digest",
 }
 DRAT_TRIM_OUTPUT_LIMIT = 1024 * 1024
 DRAT_TRIM_TIMEOUT_SECONDS = 120
@@ -116,17 +110,6 @@ def _valid_artifact(value: object) -> bool:
             isinstance(parent, str) and _ARTIFACT_URI.fullmatch(parent) is not None
             for parent in parents
         )
-    )
-
-
-def _valid_bindings(value: object) -> bool:
-    if not isinstance(value, dict) or set(value) != _BINDING_KEYS:
-        return False
-    if value["scope_digest"] is not None or value["encoding_digest"] is not None:
-        return False
-    return all(
-        isinstance(value[key], str) and _DIGEST.fullmatch(value[key]) is not None
-        for key in ("claim_digest", "semantics_digest", "candidate_digest")
     )
 
 
@@ -547,7 +530,7 @@ def check_unsat_proof(request: dict[str, Any]) -> dict[str, Any]:
         if not all(_valid_artifact(item) for item in (claim, candidate, certificate)):
             return _reject_proof("checker artifact metadata is malformed")
         expected_bindings = request["expected_bindings"]
-        if not _valid_bindings(expected_bindings):
+        if not valid_unscoped_unencoded_bindings(expected_bindings):
             return _reject_proof("expected evidence bindings are malformed")
         if (
             claim["semantics_uri"] != candidate["semantics_uri"]
@@ -633,7 +616,7 @@ def check_assignment(request: dict[str, Any]) -> dict[str, Any]:
         witness = request["witness"]
         if not all(_valid_artifact(item) for item in (claim, candidate, witness)):
             return _reject("checker artifact metadata is malformed")
-        if not _valid_bindings(request["expected_bindings"]):
+        if not valid_unscoped_unencoded_bindings(request["expected_bindings"]):
             return _reject("expected evidence bindings are malformed")
         if (
             claim["semantics_uri"] != candidate["semantics_uri"]

--- a/src/jacobian_checkers/smt.py
+++ b/src/jacobian_checkers/smt.py
@@ -22,6 +22,7 @@ from jacobian.process_policy import (
     execute_process,
 )
 from jacobian.worker_environment import worker_environment
+from jacobian_checkers.bound_artifacts import valid_unscoped_unencoded_bindings
 
 _ARTIFACT_URI = re.compile(r"^artifact://sha256/[0-9a-f]{64}$")
 _DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
@@ -33,13 +34,6 @@ _ARTIFACT_KEYS = {
     "semantics_uri",
     "parents",
     "payload",
-}
-_BINDING_KEYS = {
-    "claim_digest",
-    "semantics_digest",
-    "candidate_digest",
-    "scope_digest",
-    "encoding_digest",
 }
 _ALLOWED_COMMANDS = {
     "set-logic",
@@ -105,17 +99,6 @@ def _valid_artifact(value: object) -> bool:
             isinstance(parent, str) and _ARTIFACT_URI.fullmatch(parent) is not None
             for parent in parents
         )
-    )
-
-
-def _valid_bindings(value: object) -> bool:
-    if not isinstance(value, dict) or set(value) != _BINDING_KEYS:
-        return False
-    if value["scope_digest"] is not None or value["encoding_digest"] is not None:
-        return False
-    return all(
-        isinstance(value[key], str) and _DIGEST.fullmatch(value[key]) is not None
-        for key in ("claim_digest", "semantics_digest", "candidate_digest")
     )
 
 
@@ -495,7 +478,7 @@ def check_unsat_proof(request: dict[str, Any]) -> dict[str, Any]:
         if not all(_valid_artifact(item) for item in (claim, candidate, certificate)):
             return _reject("checker artifact metadata is malformed")
         expected_bindings = request["expected_bindings"]
-        if not _valid_bindings(expected_bindings):
+        if not valid_unscoped_unencoded_bindings(expected_bindings):
             return _reject("expected evidence bindings are malformed")
         if (
             claim["semantics_uri"] != candidate["semantics_uri"]

--- a/tests/component/checkers/test_bound_artifact_bindings.py
+++ b/tests/component/checkers/test_bound_artifact_bindings.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import pytest
+
+from jacobian_checkers.bound_artifacts import valid_unscoped_unencoded_bindings
+
+
+def _bindings() -> dict[str, object]:
+    return {
+        "claim_digest": "sha256:" + "1" * 64,
+        "semantics_digest": "sha256:" + "2" * 64,
+        "candidate_digest": "sha256:" + "3" * 64,
+        "scope_digest": None,
+        "encoding_digest": None,
+    }
+
+
+def test_unscoped_bindings_accept_exact_canonical_shape() -> None:
+    assert valid_unscoped_unencoded_bindings(_bindings())
+
+
+@pytest.mark.parametrize("mutation", ["missing", "extra"])
+def test_unscoped_bindings_reject_inexact_fields(mutation: str) -> None:
+    bindings = _bindings()
+    if mutation == "missing":
+        bindings.pop("candidate_digest")
+    else:
+        bindings["unexpected"] = None
+
+    assert not valid_unscoped_unencoded_bindings(bindings)
+
+
+@pytest.mark.parametrize(
+    "field", ["claim_digest", "semantics_digest", "candidate_digest"]
+)
+@pytest.mark.parametrize(
+    "value",
+    [
+        "sha256:" + "A" * 64,
+        "sha256:" + "4" * 63,
+        True,
+        7,
+    ],
+    ids=["uppercase", "wrong-length", "boolean", "non-string"],
+)
+def test_unscoped_bindings_reject_malformed_digests(field: str, value: object) -> None:
+    bindings = _bindings()
+    bindings[field] = value
+
+    assert not valid_unscoped_unencoded_bindings(bindings)
+
+
+@pytest.mark.parametrize("field", ["scope_digest", "encoding_digest"])
+def test_unscoped_bindings_reject_scope_or_encoding_digest(field: str) -> None:
+    bindings = _bindings()
+    bindings[field] = "sha256:" + "4" * 64
+
+    assert not valid_unscoped_unencoded_bindings(bindings)


### PR DESCRIPTION
## Problem

Eight checker modules independently validate the same five evidence-binding fields. The copies are semantically equivalent today, but keeping this trust-sensitive shape in eight places makes future validation changes easy to apply inconsistently.

Fixes #733.

## Solution

Move the exact unscoped, unencoded binding-shape predicate into the existing checker-owned `bound_artifacts` support module and use it from all eight checker implementations.

The shared predicate still requires exactly five fields, canonical lowercase SHA-256 claim/semantics/candidate digests, and null scope/encoding digests. Each checker retains its own artifact identity, lineage, semantic binding, witness, and mathematical replay checks.

## Testing

```sh
TMPDIR=/var/tmp PYTHONDONTWRITEBYTECODE=1 uv run --locked --no-sync pytest -q -p no:cacheprovider \
  tests/component/checkers/test_bound_artifact_bindings.py \
  tests/component/checkers/test_exact_geometry_checker.py \
  tests/component/checkers/test_linear_solution_checker.py \
  tests/component/checkers/test_linear_inconsistency_checker.py \
  tests/component/checkers/test_matrix_normal_form_checker.py \
  tests/component/checkers/test_polynomial_expression_checker.py \
  tests/component/checkers/test_rational_determinant_checker.py \
  tests/component/checkers/test_sat_assignment_checker.py \
  tests/component/checkers/test_sat_unsat_proof_checker.py \
  tests/component/checkers/test_smt_unsat_proof_checker.py

TMPDIR=/var/tmp PYTHONDONTWRITEBYTECODE=1 uv run --locked --no-sync pytest -q -p no:cacheprovider \
  tests/component/checkers/test_additive_combinatorics_checker.py \
  tests/component/checkers/test_exact_domain_checker_attacks.py \
  tests/component/checkers/test_exact_matrix_checkers.py \
  tests/component/checkers/test_exact_number_theory_checkers.py \
  tests/component/checkers/test_exact_polynomial_checkers.py \
  tests/component/checkers/test_exact_probability_operation_checkers.py \
  tests/component/checkers/test_exact_graph_checkers.py \
  tests/component/checkers/test_finite_poset_checker.py \
  tests/component/checkers/test_recurrence_series_checker.py \
  tests/component/checkers/test_simplicial_topology_checker.py

TMPDIR=/var/tmp PYTHONDONTWRITEBYTECODE=1 uv run --locked --no-sync pytest -q -p no:cacheprovider \
  tests/unit/contracts/test_checker_dependency_boundary.py
TMPDIR=/var/tmp uv run --locked ruff check src/jacobian_checkers tests/component/checkers/test_bound_artifact_bindings.py
TMPDIR=/var/tmp make test-plan BASE=origin/main
```

Results: 123 affected checker tests, 236 additional direct `bound_request` consumer tests, and the checker dependency-boundary test passed. An independent differential review also compared 165,382 adversarial values per removed helper with no result or exception differences.

## Trust & Compatibility Impact

This refactor changes no checker authorization, evidence format, artifact contract, or supported `jacobian.math` API. The helper remains inside `jacobian_checkers`, has no producer dependency, and is covered by the package source digest used for checker authorization.

## Checklist

- [ ] Routine local validation passes (`make check`)
- [x] Relevant focused tests are listed above
