### PR TITLE
refactor(mcp): type math.find recovery paths as closed contracts

### DIFF
--- a/src/jacobian/adapters/mcp/projections.py
+++ b/src/jacobian/adapters/mcp/projections.py
@@ -14,6 +14,12 @@ from jacobian.canonical import canonicalize_json
 from jacobian.capability_service import CapabilityDiscoveryCursorError
 from jacobian.contracts.capabilities import (
     CapabilityDescriptor,
+    CapabilityDiscoveryBrowseRecoveryPath,
+    CapabilityDiscoveryInspectCatalogRecoveryPath,
+    CapabilityDiscoveryRecoveryPath,
+    CapabilityDiscoveryReformulateQueryRecoveryPath,
+    CapabilityDiscoveryRemoveFiltersRecoveryPath,
+    CapabilityDiscoveryRemoveUnknownDomainRecoveryPath,
     CapabilityDiscoveryRequest,
     CapabilityInputKind,
     CapabilityMode,
@@ -258,7 +264,7 @@ def _discovery_recovery_paths(
     domain_filter_status: str,
     portfolio_fit: str,
     routing_status: str,
-) -> list[dict[str, Any]]:
+) -> tuple[CapabilityDiscoveryRecoveryPath, ...]:
     """Return unranked access choices for weak, empty, or incompatible discovery."""
 
     if (
@@ -266,24 +272,19 @@ def _discovery_recovery_paths(
         and portfolio_fit not in {"ONLY_WEAK_LEXICAL_MATCHES", "NO_LEXICAL_MATCHES"}
         and routing_status != "NO_ROUTE"
     ):
-        return []
-    paths: list[dict[str, Any]] = []
+        return ()
+    paths: list[CapabilityDiscoveryRecoveryPath] = []
     if request.query is not None:
         paths.append(
-            {
-                "action": "reformulate_query",
-                "tool": "math.find",
-                "change": "Use different or broader mathematical language for query.",
-            }
+            CapabilityDiscoveryReformulateQueryRecoveryPath(action="reformulate_query")
         )
     if domain_filter_status == "UNKNOWN":
+        if request.domain is None:
+            raise ValueError("an unknown domain filter requires a supplied domain")
         paths.append(
-            {
-                "action": "remove_unknown_domain_filter",
-                "tool": "math.find",
-                "rejected_domain": request.domain,
-                "change": "Retry without the unrecognized domain filter.",
-            }
+            CapabilityDiscoveryRemoveUnknownDomainRecoveryPath(
+                action="remove_unknown_domain_filter", rejected_domain=request.domain
+            )
         )
     if domain_filter_status != "UNKNOWN" and any(
         value is not None
@@ -295,26 +296,15 @@ def _discovery_recovery_paths(
         )
     ):
         paths.append(
-            {
-                "action": "remove_filters",
-                "tool": "math.find",
-                "change": "Remove domain, mode, input_kind, or artifact_type filters.",
-            }
+            CapabilityDiscoveryRemoveFiltersRecoveryPath(action="remove_filters")
         )
     paths.extend(
         (
-            {
-                "action": "browse",
-                "tool": "math.find",
-                "arguments": {},
-            },
-            {
-                "action": "inspect_catalog",
-                "resource_uri": "capability://catalog",
-            },
+            CapabilityDiscoveryBrowseRecoveryPath(action="browse"),
+            CapabilityDiscoveryInspectCatalogRecoveryPath(action="inspect_catalog"),
         )
     )
-    return paths
+    return tuple(paths)
 
 
 def _capability_descriptor_view(
@@ -449,12 +439,15 @@ def _capability_discovery_response(
         )
         for match in cast(list[dict[str, Any]], discovered_payload["matches"])
     ]
-    recovery_paths = _discovery_recovery_paths(
-        discovery_request,
-        domain_filter_status=discovered.domain_filter_status,
-        portfolio_fit=discovered.portfolio_fit,
-        routing_status=discovered.routing_status,
-    )
+    recovery_paths = [
+        path.model_dump(mode="json")
+        for path in _discovery_recovery_paths(
+            discovery_request,
+            domain_filter_status=discovered.domain_filter_status,
+            portfolio_fit=discovered.portfolio_fit,
+            routing_status=discovered.routing_status,
+        )
+    ]
     response = {
         "kind": "discovery",
         "catalog_version": catalog.catalog_version,

--- a/src/jacobian/contracts/capabilities.py
+++ b/src/jacobian/contracts/capabilities.py
@@ -105,6 +105,64 @@ class CapabilityDiscoveryRequest(ContractModel):
         return self
 
 
+class CapabilityDiscoveryReformulateQueryRecoveryPath(ContractModel):
+    """Offer a differently worded query without prescribing one."""
+
+    action: Literal["reformulate_query"]
+    tool: Literal["math.find"] = "math.find"
+    change: Literal["Use different or broader mathematical language for query."] = (
+        "Use different or broader mathematical language for query."
+    )
+
+
+class CapabilityDiscoveryRemoveUnknownDomainRecoveryPath(ContractModel):
+    """Expose the rejected domain filter as one removable constraint."""
+
+    action: Literal["remove_unknown_domain_filter"]
+    tool: Literal["math.find"] = "math.find"
+    rejected_domain: str = Field(
+        pattern=r"^[A-Za-z][A-Za-z0-9_-]{0,127}$",
+    )
+    change: Literal["Retry without the unrecognized domain filter."] = (
+        "Retry without the unrecognized domain filter."
+    )
+
+
+class CapabilityDiscoveryRemoveFiltersRecoveryPath(ContractModel):
+    """Offer unfiltered discovery without ranking it above other choices."""
+
+    action: Literal["remove_filters"]
+    tool: Literal["math.find"] = "math.find"
+    change: Literal["Remove domain, mode, input_kind, or artifact_type filters."] = (
+        "Remove domain, mode, input_kind, or artifact_type filters."
+    )
+
+
+class CapabilityDiscoveryBrowseRecoveryPath(ContractModel):
+    """Expose the existing empty-query browse operation."""
+
+    action: Literal["browse"]
+    tool: Literal["math.find"] = "math.find"
+    arguments: dict[str, Any] = Field(default_factory=dict, max_length=0)
+
+
+class CapabilityDiscoveryInspectCatalogRecoveryPath(ContractModel):
+    """Expose the complete catalog resource as an alternative access path."""
+
+    action: Literal["inspect_catalog"]
+    resource_uri: Literal["capability://catalog"] = "capability://catalog"
+
+
+CapabilityDiscoveryRecoveryPath = Annotated[
+    CapabilityDiscoveryReformulateQueryRecoveryPath
+    | CapabilityDiscoveryRemoveUnknownDomainRecoveryPath
+    | CapabilityDiscoveryRemoveFiltersRecoveryPath
+    | CapabilityDiscoveryBrowseRecoveryPath
+    | CapabilityDiscoveryInspectCatalogRecoveryPath,
+    Field(discriminator="action"),
+]
+
+
 class CapabilityDiscoveryMatch(ContractModel):
     """One compact installed outcome returned by capability discovery."""
 

--- a/tests/unit/contracts/test_capability_contracts.py
+++ b/tests/unit/contracts/test_capability_contracts.py
@@ -1,13 +1,20 @@
 from __future__ import annotations
 
 import pytest
-from pydantic import ValidationError
+from jsonschema import Draft202012Validator
+from pydantic import TypeAdapter, ValidationError
 
 from jacobian.contracts.capabilities import (
     CapabilityAssurance,
     CapabilityAssuranceLevel,
     CapabilityCompleteness,
     CapabilityCompletenessStatus,
+    CapabilityDiscoveryBrowseRecoveryPath,
+    CapabilityDiscoveryInspectCatalogRecoveryPath,
+    CapabilityDiscoveryRecoveryPath,
+    CapabilityDiscoveryReformulateQueryRecoveryPath,
+    CapabilityDiscoveryRemoveFiltersRecoveryPath,
+    CapabilityDiscoveryRemoveUnknownDomainRecoveryPath,
     CapabilityMode,
     CapabilityObligation,
     CapabilityObligationStatus,
@@ -19,6 +26,53 @@ from jacobian.contracts.capabilities import (
 from jacobian.contracts.results import Execution, ExecutionStatus
 
 RECORD_URI = "artifact://sha256/" + "a" * 64
+
+
+def test_discovery_recovery_paths_are_closed_discriminated_contracts() -> None:
+    paths: tuple[CapabilityDiscoveryRecoveryPath, ...] = (
+        CapabilityDiscoveryReformulateQueryRecoveryPath(action="reformulate_query"),
+        CapabilityDiscoveryRemoveUnknownDomainRecoveryPath(
+            action="remove_unknown_domain_filter", rejected_domain="arithmetic"
+        ),
+        CapabilityDiscoveryRemoveFiltersRecoveryPath(action="remove_filters"),
+        CapabilityDiscoveryBrowseRecoveryPath(action="browse"),
+        CapabilityDiscoveryInspectCatalogRecoveryPath(action="inspect_catalog"),
+    )
+    adapter = TypeAdapter(CapabilityDiscoveryRecoveryPath)
+    schema = adapter.json_schema()
+
+    assert {path.action for path in paths} == {
+        "reformulate_query",
+        "remove_unknown_domain_filter",
+        "remove_filters",
+        "browse",
+        "inspect_catalog",
+    }
+    assert schema["discriminator"]["propertyName"] == "action"
+    assert all(
+        "action" in definition["required"] for definition in schema["$defs"].values()
+    )
+    assert CapabilityDiscoveryBrowseRecoveryPath(action="browse").model_dump(
+        mode="json"
+    ) == {
+        "action": "browse",
+        "tool": "math.find",
+        "arguments": {},
+    }
+    with pytest.raises(ValidationError):
+        adapter.validate_python(
+            {
+                "action": "browse",
+                "tool": "math.find",
+                "arguments": {"limit": 5},
+            }
+        )
+    with pytest.raises(ValidationError):
+        adapter.validate_python({"action": "recommended_next_step"})
+    tagless_path = {"arguments": {}}
+    assert list(Draft202012Validator(schema).iter_errors(tagless_path))
+    with pytest.raises(ValidationError):
+        adapter.validate_python(tagless_path)
 
 
 def test_explore_lane_cannot_claim_verified_assurance() -> None:


### PR DESCRIPTION
## Problem

`math.find` projects `available_recovery_paths` as free-form dictionaries. Action names and action-specific fields are convention-only, so a typo or shape change can reach the MCP wire without a Pydantic contract detecting it.

Fixes #635.

## Solution

- add five closed Pydantic recovery-path variants under the capability contracts
- combine them as an `action`-discriminated union
- have the MCP adapter construct typed variants and dump them only at the final wire projection
- preserve the existing wire fields, choice set, and explicit `recovery_paths_are_unranked: true` invariant

The discriminator is required in every variant. This keeps generated JSON Schema and Pydantic validation aligned; both reject tagless recovery objects.

## Testing

```sh
TMPDIR=/var/tmp make test-unit TESTS=tests/unit/contracts/test_capability_contracts.py
TMPDIR=/var/tmp make test-mcp TESTS=tests/boundary/mcp/test_mcp_adapter.py
TMPDIR=/var/tmp uv run --locked ruff check src/jacobian/contracts/capabilities.py src/jacobian/adapters/mcp/projections.py tests/unit/contracts/test_capability_contracts.py
TMPDIR=/var/tmp uv run --locked ruff format --check src/jacobian/contracts/capabilities.py src/jacobian/adapters/mcp/projections.py tests/unit/contracts/test_capability_contracts.py
TMPDIR=/var/tmp uv run --locked mypy src/jacobian/contracts/capabilities.py src/jacobian/adapters/mcp/projections.py
TMPDIR=/var/tmp make test-plan BASE=origin/main
```

Results: 7 contract tests and 6 MCP boundary tests passed on the final tree. The contract regression also validates the generated Draft 2020-12 schema and Pydantic runtime against the same tagless malformed object.

## Trust & Compatibility Impact

This tightens the producer-side contract without changing the existing JSON response shapes or adding recommendation scores/order semantics. Recovery choices remain optional, unranked access paths; no checker authorization, evidence, assurance, or mathematical execution behavior changes.

## Checklist

- [ ] Routine local validation passes (`make check`)
- [x] Relevant focused tests are listed above
