### PR TITLE
refactor(lean): share Lean proof-state validation without starting inspect runtimes

### DIFF
--- a/src/jacobian/lean_frontend/_state_validation.py
+++ b/src/jacobian/lean_frontend/_state_validation.py
@@ -1,0 +1,93 @@
+"""Validation of immutable proof states against a caller-selected Lean profile."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Protocol
+
+from pydantic import ValidationError
+
+from jacobian.capability_service import CapabilityInvocationError
+from jacobian.contracts.capabilities import CapabilityDiagnostic
+from jacobian.contracts.lean import LeanEnvironment
+from jacobian.contracts.lean_exploration import LeanProofStateArtifact
+from jacobian.lean_frontend.artifacts import (
+    _environment_imports,
+    _source_digest,
+    _state_digest_payload,
+)
+from jacobian.references import LeanCheckerInstallation
+from jacobian.storage.errors import StorageError
+from jacobian.storage.repository import ArtifactRepository
+
+
+class _StoredProofStateResources(Protocol):
+    @property
+    def store(self) -> ArtifactRepository: ...
+
+    @property
+    def semantics_uri(self) -> str: ...
+
+    @property
+    def state_schema_uri(self) -> str: ...
+
+    @property
+    def installations(
+        self,
+    ) -> Mapping[LeanEnvironment, LeanCheckerInstallation]: ...
+
+
+def _load_validated_proof_state(
+    resources: _StoredProofStateResources,
+    state_uri: str,
+    *,
+    expected_environment: LeanEnvironment,
+    expected_environment_digest: str,
+    invalid_state_hint: str,
+) -> LeanProofStateArtifact:
+    """Load one state bound to the profile selected by the current request."""
+
+    try:
+        stored = resources.store.get(state_uri)
+        if (
+            stored.manifest.schema_uri != resources.state_schema_uri
+            or stored.manifest.semantics_uri != resources.semantics_uri
+        ):
+            raise ValueError("artifact is not a Lean proof state")
+        state = LeanProofStateArtifact.model_validate(stored.payload)
+    except (StorageError, ValidationError, ValueError) as exc:
+        raise CapabilityInvocationError(
+            CapabilityDiagnostic(
+                code="INVALID_LEAN_PROOF_STATE",
+                stage="state_loading",
+                message="The supplied state artifact is unavailable or invalid.",
+                hint=invalid_state_hint,
+            )
+        ) from exc
+
+    installation = resources.installations[expected_environment]
+    if (
+        state.environment is not expected_environment
+        or state.environment_digest != expected_environment_digest
+        or state.imports != _environment_imports(expected_environment)
+        or state.lean_version != installation.lean_version
+        or state.lean_commit != installation.lean_commit
+        or state.mathlib_commit != installation.mathlib_commit
+        or state.source_digest != _source_digest(state.statement, state.tactic_prefix)
+        or state.state_digest != _state_digest_payload(state)
+    ):
+        raise CapabilityInvocationError(
+            CapabilityDiagnostic(
+                code="STALE_LEAN_PROOF_STATE",
+                stage="state_validation",
+                message=(
+                    "The proof state no longer matches its source or the "
+                    "current pinned Lean environment."
+                ),
+                hint="Recreate the proof state under the current environment.",
+            )
+        )
+    return state
+
+
+__all__ = ["_StoredProofStateResources", "_load_validated_proof_state"]

--- a/src/jacobian/lean_frontend/metavariable_fields.py
+++ b/src/jacobian/lean_frontend/metavariable_fields.py
@@ -33,8 +33,6 @@ from jacobian.contracts.capabilities import (
     CapabilityResult,
     CapabilityScope,
 )
-from jacobian.contracts.lean import LeanEnvironment
-from jacobian.contracts.lean_exploration import LeanProofStateArtifact
 from jacobian.contracts.lean_metavariable_fields import (
     LeanElaborationContext,
     LeanMetavariableFieldsArtifact,
@@ -43,12 +41,11 @@ from jacobian.contracts.lean_metavariable_fields import (
     LeanStructuredMetavariable,
 )
 from jacobian.contracts.results import Execution, ExecutionStatus
+from jacobian.lean_frontend._state_validation import _load_validated_proof_state
 from jacobian.lean_frontend.artifacts import (
     _environment_digest,
-    _environment_imports,
     _proof_state_command,
     _source_digest,
-    _state_digest_payload,
 )
 from jacobian.lean_frontend.exploration import (
     _Resources,
@@ -56,7 +53,6 @@ from jacobian.lean_frontend.exploration import (
     _validate_source_parts,
 )
 from jacobian.lean_frontend.repl import _response_errors
-from jacobian.storage.errors import StorageError
 
 
 class LeanMetavariableFieldsAdapter:
@@ -113,10 +109,14 @@ class LeanMetavariableFieldsAdapter:
             validated.environment,
             installation,
         )
-        bound_state = self._load_bound_state(
+        bound_state = _load_validated_proof_state(
+            self.resources,
             validated.state_uri,
             expected_environment=validated.environment,
             expected_environment_digest=environment_digest,
+            invalid_state_hint=(
+                "Use a state URI returned by a proof-state capability."
+            ),
         )
         if bound_state.completed:
             raise CapabilityInvocationError(
@@ -325,56 +325,6 @@ class LeanMetavariableFieldsAdapter:
             ),
             artifact_uris=(validated.state_uri, artifact.artifact_uri),
         )
-
-    def _load_bound_state(
-        self,
-        state_uri: str,
-        *,
-        expected_environment: LeanEnvironment,
-        expected_environment_digest: str,
-    ) -> LeanProofStateArtifact:
-        try:
-            stored = self.resources.store.get(state_uri)
-            if (
-                stored.manifest.schema_uri != self.resources.state_schema_uri
-                or stored.manifest.semantics_uri != self.resources.semantics_uri
-            ):
-                raise ValueError("artifact is not a Lean proof state")
-            state = LeanProofStateArtifact.model_validate(stored.payload)
-        except (StorageError, ValidationError, ValueError) as exc:
-            raise CapabilityInvocationError(
-                CapabilityDiagnostic(
-                    code="INVALID_LEAN_PROOF_STATE",
-                    stage="state_loading",
-                    message="The supplied state artifact is unavailable or invalid.",
-                    hint="Use a state URI returned by a proof-state capability.",
-                )
-            ) from exc
-        installation = self.resources.installations[expected_environment]
-        expected_imports = _environment_imports(expected_environment)
-        if (
-            state.environment is not expected_environment
-            or state.environment_digest != expected_environment_digest
-            or state.imports != expected_imports
-            or state.lean_version != installation.lean_version
-            or state.lean_commit != installation.lean_commit
-            or state.mathlib_commit != installation.mathlib_commit
-            or state.source_digest
-            != _source_digest(state.statement, state.tactic_prefix)
-            or state.state_digest != _state_digest_payload(state)
-        ):
-            raise CapabilityInvocationError(
-                CapabilityDiagnostic(
-                    code="STALE_LEAN_PROOF_STATE",
-                    stage="state_validation",
-                    message=(
-                        "The proof state no longer matches its source or the "
-                        "current pinned Lean environment."
-                    ),
-                    hint="Recreate the proof state under the current environment.",
-                )
-            )
-        return state
 
 
 def install_lean_metavariable_fields_capability(

--- a/src/jacobian/lean_frontend/proof_state.py
+++ b/src/jacobian/lean_frontend/proof_state.py
@@ -23,9 +23,7 @@ from jacobian.contracts.capabilities import (
     CapabilityResult,
     CapabilityScope,
 )
-from jacobian.contracts.lean import LeanEnvironment
 from jacobian.contracts.lean_exploration import (
-    LeanProofStateArtifact,
     LeanProofStateOutput,
     LeanProofStateRequest,
     LeanProofStateTransitionArtifact,
@@ -33,12 +31,11 @@ from jacobian.contracts.lean_exploration import (
     LeanTypedGoal,
 )
 from jacobian.contracts.results import Execution, ExecutionStatus
+from jacobian.lean_frontend._state_validation import _load_validated_proof_state
 from jacobian.lean_frontend.artifacts import (
     _environment_digest,
-    _environment_imports,
     _proof_state_command,
     _source_digest,
-    _state_digest_payload,
     _state_payload,
 )
 from jacobian.lean_frontend.exploration import (
@@ -49,7 +46,6 @@ from jacobian.lean_frontend.exploration import (
     _validate_source_parts,
 )
 from jacobian.lean_frontend.repl import _response_errors
-from jacobian.storage.errors import StorageError
 
 
 class LeanProofStateAdapter:
@@ -132,10 +128,12 @@ class LeanProofStateAdapter:
             proof_prefix = validated.proof_prefix
             bound_state = None
         else:
-            bound_state = self._load_bound_state(
+            bound_state = _load_validated_proof_state(
+                self.resources,
                 validated.state_uri,
                 expected_environment=validated.environment,
                 expected_environment_digest=environment_digest,
+                invalid_state_hint="Use a state URI returned by this capability.",
             )
             if bound_state.completed:
                 raise CapabilityInvocationError(
@@ -401,56 +399,6 @@ class LeanProofStateAdapter:
             ),
             artifact_uris=artifact_uris,
         )
-
-    def _load_bound_state(
-        self,
-        state_uri: str,
-        *,
-        expected_environment: LeanEnvironment,
-        expected_environment_digest: str,
-    ) -> LeanProofStateArtifact:
-        try:
-            stored = self.resources.store.get(state_uri)
-            if (
-                stored.manifest.schema_uri != self.resources.state_schema_uri
-                or stored.manifest.semantics_uri != self.resources.semantics_uri
-            ):
-                raise ValueError("artifact is not a Lean proof state")
-            state = LeanProofStateArtifact.model_validate(stored.payload)
-        except (StorageError, ValidationError, ValueError) as exc:
-            raise CapabilityInvocationError(
-                CapabilityDiagnostic(
-                    code="INVALID_LEAN_PROOF_STATE",
-                    stage="state_loading",
-                    message="The supplied state artifact is unavailable or invalid.",
-                    hint="Use a state URI returned by this capability.",
-                )
-            ) from exc
-        installation = self.resources.installations[expected_environment]
-        expected_imports = _environment_imports(expected_environment)
-        if (
-            state.environment is not expected_environment
-            or state.environment_digest != expected_environment_digest
-            or state.imports != expected_imports
-            or state.lean_version != installation.lean_version
-            or state.lean_commit != installation.lean_commit
-            or state.mathlib_commit != installation.mathlib_commit
-            or state.source_digest
-            != _source_digest(state.statement, state.tactic_prefix)
-            or state.state_digest != _state_digest_payload(state)
-        ):
-            raise CapabilityInvocationError(
-                CapabilityDiagnostic(
-                    code="STALE_LEAN_PROOF_STATE",
-                    stage="state_validation",
-                    message=(
-                        "The proof state no longer matches its source or the "
-                        "current pinned Lean environment."
-                    ),
-                    hint="Recreate the proof state under the current environment.",
-                )
-            )
-        return state
 
 
 __all__ = ["LeanProofStateAdapter"]

--- a/src/jacobian/lean_frontend/proof_state_inspect.py
+++ b/src/jacobian/lean_frontend/proof_state_inspect.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import time
 from collections.abc import Mapping
+from dataclasses import dataclass
 
 from pydantic import ValidationError
 
@@ -32,30 +33,33 @@ from jacobian.contracts.capabilities import (
     CapabilityScope,
 )
 from jacobian.contracts.lean import LeanEnvironment
-from jacobian.contracts.lean_exploration import LeanProofStateArtifact
 from jacobian.contracts.lean_proof_state_inspect import (
     LeanProofStateInspectOutput,
     LeanProofStateInspectRequest,
 )
 from jacobian.contracts.results import Execution, ExecutionStatus
-from jacobian.lean_frontend.artifacts import (
-    _environment_digest,
-    _environment_imports,
-    _source_digest,
-    _state_digest_payload,
+from jacobian.lean_frontend._state_validation import (
+    _load_validated_proof_state,
+    _StoredProofStateResources,
 )
-from jacobian.lean_frontend.exploration import _Resources, _runtime_ms
-from jacobian.lean_frontend.repl import LeanExplorationReplRuntime
+from jacobian.lean_frontend.artifacts import _environment_digest
 from jacobian.references import LeanCheckerInstallation
 from jacobian.schema_registry import SchemaRegistry
-from jacobian.storage.errors import StorageError
 from jacobian.storage.repository import ArtifactRepository
+
+
+@dataclass(frozen=True, slots=True)
+class _InspectionResources:
+    store: ArtifactRepository
+    semantics_uri: str
+    state_schema_uri: str
+    installations: Mapping[LeanEnvironment, LeanCheckerInstallation]
 
 
 class LeanProofStateInspectAdapter:
     def __init__(
         self,
-        resources: _Resources,
+        resources: _StoredProofStateResources,
         provider_runtime: CapabilityProviderRuntime,
     ) -> None:
         self.resources = resources
@@ -107,10 +111,14 @@ class LeanProofStateInspectAdapter:
             validated.environment,
             installation,
         )
-        state = self._load_state(
+        state = _load_validated_proof_state(
+            self.resources,
             validated.state_uri,
             expected_environment=validated.environment,
             expected_environment_digest=environment_digest,
+            invalid_state_hint=(
+                "Use a state URI returned by a proof-state capability."
+            ),
         )
         output = LeanProofStateInspectOutput(
             state_uri=validated.state_uri,
@@ -134,7 +142,7 @@ class LeanProofStateInspectAdapter:
             mode=request.mode,
             execution=Execution(
                 status=ExecutionStatus.COMPLETED,
-                runtime_ms=_runtime_ms(started),
+                runtime_ms=max(0, round((time.monotonic() - started) * 1000)),
                 detail="read-only inspection; no Lean process was started",
             ),
             output=output.model_dump(mode="json"),
@@ -164,59 +172,9 @@ class LeanProofStateInspectAdapter:
             artifact_uris=(validated.state_uri,),
         )
 
-    def _load_state(
-        self,
-        state_uri: str,
-        *,
-        expected_environment: LeanEnvironment,
-        expected_environment_digest: str,
-    ) -> LeanProofStateArtifact:
-        try:
-            stored = self.resources.store.get(state_uri)
-            if (
-                stored.manifest.schema_uri != self.resources.state_schema_uri
-                or stored.manifest.semantics_uri != self.resources.semantics_uri
-            ):
-                raise ValueError("artifact is not a Lean proof state")
-            state = LeanProofStateArtifact.model_validate(stored.payload)
-        except (StorageError, ValidationError, ValueError) as exc:
-            raise CapabilityInvocationError(
-                CapabilityDiagnostic(
-                    code="INVALID_LEAN_PROOF_STATE",
-                    stage="state_loading",
-                    message="The supplied state artifact is unavailable or invalid.",
-                    hint="Use a state URI returned by a proof-state capability.",
-                )
-            ) from exc
-        installation = self.resources.installations[expected_environment]
-        expected_imports = _environment_imports(expected_environment)
-        if (
-            state.environment is not expected_environment
-            or state.environment_digest != expected_environment_digest
-            or state.imports != expected_imports
-            or state.lean_version != installation.lean_version
-            or state.lean_commit != installation.lean_commit
-            or state.mathlib_commit != installation.mathlib_commit
-            or state.source_digest
-            != _source_digest(state.statement, state.tactic_prefix)
-            or state.state_digest != _state_digest_payload(state)
-        ):
-            raise CapabilityInvocationError(
-                CapabilityDiagnostic(
-                    code="STALE_LEAN_PROOF_STATE",
-                    stage="state_validation",
-                    message=(
-                        "The proof state no longer matches its source or the "
-                        "current pinned Lean environment."
-                    ),
-                    hint="Recreate the proof state under the current environment.",
-                )
-            )
-        return state
-
 
 def install_lean_proof_state_inspect_capability(
-    resources: _Resources,
+    resources: _StoredProofStateResources,
     provider_runtime: CapabilityProviderRuntime,
 ) -> LeanProofStateInspectAdapter:
     return LeanProofStateInspectAdapter(resources, provider_runtime)
@@ -237,9 +195,9 @@ def install_lean_proof_state_inspect_only(
     full exploration installer when the runtime is available.
     """
 
-    from pathlib import Path
-
     from jacobian.contracts.lean_exploration import LeanProofStateArtifact
+
+    del artifacts
 
     core = installations[LeanEnvironment.CORE]
     mathlib = installations[LeanEnvironment.MATHLIB]
@@ -264,19 +222,11 @@ def install_lean_proof_state_inspect_only(
         version="1",
         schema=LeanProofStateArtifact.model_json_schema(),
     )
-    runtime = Path(__file__).resolve().parents[3] / "lean"
-    repl = LeanExplorationReplRuntime(runtime, installations)
-    resources = _Resources(
+    resources = _InspectionResources(
         store=store,
-        artifacts=artifacts,
         semantics_uri=semantics_uri,
         state_schema_uri=state_schema_uri,
-        transition_schema_uri="",
-        retrieval_schema_uri="",
         installations=installations,
-        runtime=runtime,
-        provider_runtime=provider_runtime,
-        repl=repl,
     )
     return LeanProofStateInspectAdapter(resources, provider_runtime)
 

--- a/tests/boundary/providers/lean/test_lean_residual_contracts.py
+++ b/tests/boundary/providers/lean/test_lean_residual_contracts.py
@@ -202,6 +202,62 @@ def _stub_metavariable_runtime(
     )
 
 
+def _stored_input_state_uri(
+    monkeypatch: pytest.MonkeyPatch,
+    proof_state: LeanProofStateAdapter,
+    environment: LeanEnvironment,
+) -> str:
+    _stub_apply_runtime(
+        monkeypatch,
+        proof_state,
+        lambda: _responses(before=["⊢ True"], after=["⊢ True"]),
+    )
+    opened = proof_state.invoke(
+        CapabilityRequest(
+            capability_id="lean.proof_state.apply_tactic",
+            mode=CapabilityMode.EXPLORE,
+            input={
+                "environment": environment.value,
+                "statement": "True",
+                "tactic": "skip",
+            },
+        )
+    )
+    return str(opened.output["input_state_uri"])
+
+
+def _invoke_stored_state_consumer(
+    consumer: str,
+    *,
+    proof_state: LeanProofStateAdapter,
+    inspect: LeanProofStateInspectAdapter,
+    metavariable: LeanMetavariableFieldsAdapter,
+    environment: LeanEnvironment,
+    state_uri: str,
+) -> None:
+    request_input: dict[str, object] = {
+        "environment": environment.value,
+        "state_uri": state_uri,
+    }
+    if consumer == "apply_tactic":
+        adapter = proof_state
+        capability_id = "lean.proof_state.apply_tactic"
+        request_input["tactic"] = "skip"
+    elif consumer == "inspect":
+        adapter = inspect
+        capability_id = "lean.proof_state.inspect"
+    else:
+        adapter = metavariable
+        capability_id = "lean.proof_state.metavariable_fields"
+    adapter.invoke(
+        CapabilityRequest(
+            capability_id=capability_id,
+            mode=CapabilityMode.EXPLORE,
+            input=request_input,
+        )
+    )
+
+
 # ---------------------------------------------------------------------------
 # lean.term.apply
 # ---------------------------------------------------------------------------
@@ -744,11 +800,26 @@ def test_helper_result_envelope_still_parses_normally() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_inspect_adapter_available_without_lean_runtime(tmp_path: Path) -> None:
+def test_inspect_adapter_available_without_lean_runtime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import jacobian.lean_frontend.proof_state_inspect as inspect_module
     from jacobian.lean_frontend.proof_state_inspect import (
         install_lean_proof_state_inspect_only,
     )
     from jacobian.provider_runtime import jacobian_provider_runtime
+
+    def _unexpected_runtime(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        raise AssertionError("read-only inspection constructed a Lean runtime")
+
+    monkeypatch.setattr(
+        inspect_module,
+        "LeanExplorationReplRuntime",
+        _unexpected_runtime,
+        raising=False,
+    )
 
     store = ArtifactRepository(tmp_path)
     schemas = SchemaRegistry(store)
@@ -766,8 +837,174 @@ def test_inspect_adapter_available_without_lean_runtime(tmp_path: Path) -> None:
             features=("immutable-proof-state",),
         ),
     )
+
+    from jacobian.lean_frontend.artifacts import (
+        _environment_digest,
+        _state_payload,
+    )
+
+    installation = installations[LeanEnvironment.CORE]
+    state = artifacts.put(
+        schema_uri=adapter.resources.state_schema_uri,
+        semantics_uri=adapter.resources.semantics_uri,
+        payload=_state_payload(
+            environment=LeanEnvironment.CORE,
+            environment_digest=_environment_digest(
+                LeanEnvironment.CORE,
+                installation,
+            ),
+            statement="True",
+            tactic_prefix=(),
+            normalized_goals=("⊢ True",),
+            installation=installation,
+        ).model_dump(mode="json"),
+        summary="stored CORE proof state",
+    )
+    result = adapter.invoke(
+        CapabilityRequest(
+            capability_id="lean.proof_state.inspect",
+            mode=CapabilityMode.EXPLORE,
+            input={
+                "environment": "CORE",
+                "state_uri": state.artifact_uri,
+            },
+        )
+    )
+
     assert adapter.descriptor.capability_id == "lean.proof_state.inspect"
     assert adapter.descriptor.read_only is True
+    assert result.output["normalized_goals"] == ["⊢ True"]
+    assert (
+        result.execution.detail == "read-only inspection; no Lean process was started"
+    )
+
+
+@pytest.mark.parametrize(
+    ("stored_environment", "requested_environment"),
+    (
+        (LeanEnvironment.CORE, LeanEnvironment.MATHLIB),
+        (LeanEnvironment.MATHLIB, LeanEnvironment.CORE),
+    ),
+)
+@pytest.mark.parametrize(
+    "consumer",
+    ("apply_tactic", "inspect", "metavariable_fields"),
+)
+def test_stored_state_consumers_reject_cross_profile_artifacts_before_replay(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    stored_environment: LeanEnvironment,
+    requested_environment: LeanEnvironment,
+    consumer: str,
+) -> None:
+    proof_state, _, inspect, metavariable, resources = _adapters(tmp_path)
+    state_uri = _stored_input_state_uri(
+        monkeypatch,
+        proof_state,
+        stored_environment,
+    )
+
+    def _unexpected_replay(**kwargs: object) -> None:
+        del kwargs
+        raise AssertionError("cross-profile state reached the Lean runtime")
+
+    monkeypatch.setattr(resources.repl, "execute_clean", _unexpected_replay)
+    with pytest.raises(CapabilityInvocationError) as raised:
+        _invoke_stored_state_consumer(
+            consumer,
+            proof_state=proof_state,
+            inspect=inspect,
+            metavariable=metavariable,
+            environment=requested_environment,
+            state_uri=state_uri,
+        )
+
+    assert raised.value.diagnostic.code == "STALE_LEAN_PROOF_STATE"
+    assert raised.value.diagnostic.stage == "state_validation"
+
+
+@pytest.mark.parametrize(
+    ("consumer", "expected_hint"),
+    (
+        ("apply_tactic", "Use a state URI returned by this capability."),
+        (
+            "inspect",
+            "Use a state URI returned by a proof-state capability.",
+        ),
+        (
+            "metavariable_fields",
+            "Use a state URI returned by a proof-state capability.",
+        ),
+    ),
+)
+def test_invalid_state_diagnostics_keep_consumer_specific_hints(
+    tmp_path: Path,
+    consumer: str,
+    expected_hint: str,
+) -> None:
+    proof_state, _, inspect, metavariable, _ = _adapters(tmp_path)
+    missing_uri = "artifact://sha256/" + "d" * 64
+    with pytest.raises(CapabilityInvocationError) as raised:
+        _invoke_stored_state_consumer(
+            consumer,
+            proof_state=proof_state,
+            inspect=inspect,
+            metavariable=metavariable,
+            environment=LeanEnvironment.CORE,
+            state_uri=missing_uri,
+        )
+
+    assert raised.value.diagnostic.code == "INVALID_LEAN_PROOF_STATE"
+    assert raised.value.diagnostic.hint == expected_hint
+
+
+@pytest.mark.parametrize("stale_binding", ("source_digest", "state_digest"))
+def test_metavariable_fields_rejects_stale_state_before_replay(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    stale_binding: str,
+) -> None:
+    proof_state, _, _, metavariable, resources = _adapters(tmp_path)
+    state_uri = _stored_input_state_uri(
+        monkeypatch,
+        proof_state,
+        LeanEnvironment.CORE,
+    )
+    stored = resources.store.get(state_uri)
+    stale_payload = dict(stored.payload)
+    stale_payload[stale_binding] = "sha256:" + "f" * 64
+    if stale_binding == "source_digest":
+        from jacobian.contracts.lean_exploration import LeanProofStateArtifact
+        from jacobian.lean_frontend.artifacts import _state_digest_payload
+
+        stale_payload["state_digest"] = _state_digest_payload(
+            LeanProofStateArtifact.model_validate(stale_payload)
+        )
+    stale = resources.artifacts.put(
+        schema_uri=resources.state_schema_uri,
+        semantics_uri=resources.semantics_uri,
+        payload=stale_payload,
+        summary=f"fixture with stale {stale_binding}",
+    )
+
+    def _unexpected_replay(**kwargs: object) -> None:
+        del kwargs
+        raise AssertionError("stale state reached the Lean runtime")
+
+    monkeypatch.setattr(resources.repl, "execute_clean", _unexpected_replay)
+    with pytest.raises(CapabilityInvocationError) as raised:
+        metavariable.invoke(
+            CapabilityRequest(
+                capability_id="lean.proof_state.metavariable_fields",
+                mode=CapabilityMode.EXPLORE,
+                input={
+                    "environment": "CORE",
+                    "state_uri": stale.artifact_uri,
+                },
+            )
+        )
+
+    assert raised.value.diagnostic.code == "STALE_LEAN_PROOF_STATE"
 
 
 # ---------------------------------------------------------------------------
@@ -775,26 +1012,32 @@ def test_inspect_adapter_available_without_lean_runtime(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize(
+    ("environment", "field", "forged_value"),
+    (
+        (LeanEnvironment.CORE, "imports", ["Mathlib"]),
+        (LeanEnvironment.MATHLIB, "imports", ["Init"]),
+        (LeanEnvironment.CORE, "lean_version", "9.9.9"),
+        (LeanEnvironment.CORE, "lean_commit", "forged-lean-commit"),
+        (LeanEnvironment.MATHLIB, "mathlib_commit", "forged-mathlib-commit"),
+    ),
+)
 def test_inspect_rejects_forged_environment_metadata(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    environment: LeanEnvironment,
+    field: str,
+    forged_value: object,
 ) -> None:
     proof_state, _, inspect, _, resources = _adapters(tmp_path)
-    _stub_apply_runtime(
+    state_uri = _stored_input_state_uri(
         monkeypatch,
         proof_state,
-        lambda: _responses(before=["⊢ True"], after=["⊢ True"]),
+        environment,
     )
-    opened = proof_state.invoke(
-        CapabilityRequest(
-            capability_id="lean.proof_state.apply_tactic",
-            mode=CapabilityMode.EXPLORE,
-            input={"environment": "CORE", "statement": "True", "tactic": "skip"},
-        )
-    )
-    state = resources.store.get(opened.output["input_state_uri"])
+    state = resources.store.get(state_uri)
     forged_payload = dict(state.payload)
-    forged_payload["lean_version"] = "9.9.9"
+    forged_payload[field] = forged_value
     # Recompute state_digest so the digest check alone would pass.
     from jacobian.contracts.lean_exploration import LeanProofStateArtifact
     from jacobian.lean_frontend.artifacts import _state_digest_payload
@@ -813,7 +1056,7 @@ def test_inspect_rejects_forged_environment_metadata(
                 capability_id="lean.proof_state.inspect",
                 mode=CapabilityMode.EXPLORE,
                 input={
-                    "environment": "CORE",
+                    "environment": environment.value,
                     "state_uri": forged.artifact_uri,
                 },
             )


### PR DESCRIPTION
## Problem

Three Lean proof-state consumers independently implement the same stored-state validation. The copies bind environment profile, imports, installation versions/commits, source digest, and state digest, so future drift could make one replay path accept evidence another rejects.

The standalone read-only inspect installer also constructs a Lean REPL runtime even though inspection only reads immutable artifacts.

Fixes #742.

## Solution

- extract one private stored-proof-state validator shared by tactic replay, inspection, and metavariable-field extraction
- keep the expected environment and environment digest caller-owned
- preserve each consumer's existing invalid-state hint
- retain exact schema, semantics, profile, import, version, commit, source-digest, and state-digest checks
- narrow inspect-only resources to storage, schema/semantics identity, and pinned installations so no REPL/runtime is constructed

## Testing

```sh
TMPDIR=/var/tmp make test-lean TESTS='tests/boundary/providers/lean/test_lean_residual_contracts.py tests/boundary/providers/lean/test_lean_replayable_state_capability.py'
TMPDIR=/var/tmp uv run --locked ruff check src/jacobian/lean_frontend/_state_validation.py src/jacobian/lean_frontend/metavariable_fields.py src/jacobian/lean_frontend/proof_state.py src/jacobian/lean_frontend/proof_state_inspect.py tests/boundary/providers/lean/test_lean_residual_contracts.py
TMPDIR=/var/tmp uv run --locked ruff format --check src/jacobian/lean_frontend/_state_validation.py src/jacobian/lean_frontend/metavariable_fields.py src/jacobian/lean_frontend/proof_state.py src/jacobian/lean_frontend/proof_state_inspect.py tests/boundary/providers/lean/test_lean_residual_contracts.py
TMPDIR=/var/tmp uv run --locked mypy src/jacobian/lean_frontend/_state_validation.py src/jacobian/lean_frontend/metavariable_fields.py src/jacobian/lean_frontend/proof_state.py src/jacobian/lean_frontend/proof_state_inspect.py
TMPDIR=/var/tmp make test-plan BASE=origin/main
```

Results: 45 focused Lean boundary tests passed on the final tree. Coverage includes both cross-profile directions, CORE/Mathlib imports, Lean and Mathlib commits, stale source/state digests, consumer-specific diagnostics, replay short-circuiting, and storage-only inspection.

A real Lean/Mathlib smoke was not run; the tests exercise the state boundary with the repository's stub runtime.

## Trust & Compatibility Impact

This does not change checker authorization or promote inspection to verification. Stored states must satisfy the same exact bindings as before, and replay-capable consumers still own the selected profile. The inspect-only installer becomes strictly narrower: it no longer creates process/runtime resources for a read-only operation.

## Checklist

- [ ] Routine local validation passes (`make check`)
- [x] Relevant focused tests are listed above
