### PR TITLE
fix(probability): preserve probability digit bounds above Python's string limit

### DIFF
--- a/src/jacobian/contracts/probability.py
+++ b/src/jacobian/contracts/probability.py
@@ -8,7 +8,7 @@ from typing import Literal, Self
 
 from pydantic import Field, StrictInt, model_validator
 
-from jacobian.canonical import canonicalize_json
+from jacobian.canonical import canonicalize_json, format_canonical_integer
 from jacobian.contracts.exact import CanonicalInteger, CanonicalRational
 from jacobian.contracts.graph_isomorphism import SimpleUndirectedGraph
 from jacobian.contracts.results import ContractModel
@@ -36,8 +36,8 @@ def _require_bounded_fraction(
     label: str,
 ) -> None:
     if (
-        len(str(abs(value.numerator))) > max_digits
-        or len(str(value.denominator)) > max_digits
+        len(format_canonical_integer(abs(value.numerator))) > max_digits
+        or len(format_canonical_integer(value.denominator)) > max_digits
     ):
         raise ValueError(f"{label} exceeds the {max_digits}-digit bound")
 
@@ -324,13 +324,25 @@ class GraphConnectionProbabilityRequest(ContractModel):
         )
         probability_numerator_digits = sum(
             max(
-                len(str(item.open_probability.as_fraction().numerator)),
-                len(str((1 - item.open_probability.as_fraction()).numerator)),
+                len(
+                    format_canonical_integer(
+                        item.open_probability.as_fraction().numerator
+                    )
+                ),
+                len(
+                    format_canonical_integer(
+                        (1 - item.open_probability.as_fraction()).numerator
+                    )
+                ),
             )
             for item in self.edge_probabilities
         )
         probability_denominator_digits = sum(
-            len(str(item.open_probability.as_fraction().denominator))
+            len(
+                format_canonical_integer(
+                    item.open_probability.as_fraction().denominator
+                )
+            )
             for item in self.edge_probabilities
         )
         maximum_state = {

--- a/tests/unit/contracts/test_probability_contracts.py
+++ b/tests/unit/contracts/test_probability_contracts.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import sys
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.contracts.probability import GraphReliabilityEdgeProbability
+
+
+@pytest.mark.parametrize(
+    ("num", "den"),
+    (
+        ("1" * (sys.int_info.default_max_str_digits + 1), "1"),
+        ("1", "1" * (sys.int_info.default_max_str_digits + 1)),
+    ),
+    ids=("numerator", "denominator"),
+)
+def test_large_probability_reports_the_contract_digit_bound(
+    num: str,
+    den: str,
+) -> None:
+    previous_limit = sys.get_int_max_str_digits()
+    sys.set_int_max_str_digits(sys.int_info.default_max_str_digits)
+    try:
+        with pytest.raises(
+            ValidationError,
+            match="graph reliability edge probability exceeds the 128-digit bound",
+        ):
+            GraphReliabilityEdgeProbability.model_validate(
+                {
+                    "edge": ["a", "b"],
+                    "open_probability": {
+                        "num": num,
+                        "den": den,
+                    },
+                }
+            )
+    finally:
+        sys.set_int_max_str_digits(previous_limit)

--- a/tests/unit/tooling/test_eval_telemetry.py
+++ b/tests/unit/tooling/test_eval_telemetry.py
@@ -429,7 +429,9 @@ def test_agent_telemetry_tracks_resource_link_follow_through_and_identity(
     assert telemetry["mcp_resource_digest_preservation_successes"] == 2
 
 
-def test_agent_telemetry_handles_non_hashable_resource_tool_field(tmp_path: Path) -> None:
+def test_agent_telemetry_handles_non_hashable_resource_tool_field(
+    tmp_path: Path,
+) -> None:
     uri = "artifact://sha256/" + ("f" * 64)
     malformed_tool_event = {
         "type": "item.completed",


### PR DESCRIPTION
## Problem

Probability contracts count exact rational digits with Python's decimal `str(int)` conversion. Inputs above Python's default 4,300-digit conversion limit therefore raise an interpreter-limit error before Jacobian can return its intended bounded-contract diagnostic.

Fixes #752.

## Solution

Use the repository's `format_canonical_integer()` helper for numerator and denominator digit accounting, matching the established combinatorics contract pattern. This bypasses the interpreter's configurable decimal conversion limit while preserving Jacobian's explicit 128-digit input bound and graph-ledger estimate.

## Testing

```sh
TMPDIR=/var/tmp make test-unit TESTS=tests/unit/contracts/test_probability_contracts.py
TMPDIR=/var/tmp make test-domain TESTS=tests/domain/probability/test_finite_probability.py
TMPDIR=/var/tmp uv run --locked ruff check src/jacobian/contracts/probability.py tests/unit/contracts/test_probability_contracts.py
TMPDIR=/var/tmp uv run --locked ruff format --check src/jacobian/contracts/probability.py tests/unit/contracts/test_probability_contracts.py
TMPDIR=/var/tmp uv run --locked mypy src/jacobian/contracts/probability.py
TMPDIR=/var/tmp make test-plan BASE=origin/main
```

Results: both oversized numerator and denominator regressions passed, and all 20 finite-probability domain tests passed. On the base tree, the numerator regression failed with Python's `Exceeds the limit (4300 digits)` message instead of the contract's 128-digit-bound error.

## Trust & Compatibility Impact

This changes only error-path digit accounting. Accepted probability values, exact arithmetic, ledger budgets, schemas, and verification semantics are unchanged. Oversized rationals now fail through the documented Jacobian contract rather than a process-global interpreter setting.

## Checklist

- [ ] Routine local validation passes (`make check`)
- [x] Relevant focused tests are listed above
