### PR TITLE
docs(agents): document mathematical interoperability rules for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,21 @@ backend-native values and call typed mathematical kernels directly; they must
 not invoke `math.run`, construct a capability runtime, or expose MCP,
 artifact, provider-loading, or installation objects.
 
+### Mathematical interoperability
+
+Capabilities interoperate through shared, typed domain values and artifacts—not
+backend-specific objects, JSON round-trips, or wire encodings. Reuse existing
+contract models and typed kernels; add explicit domain-owned conversions when
+representations differ. Cover producer-to-consumer compatibility and canonical
+or backend-native round trips in tests. Architecture checks must reject internal
+JSON round-trips and unsafe canonical conversions.
+
+Canonical decimal strings are wire and persistence values, not computational
+values. Use the canonical conversion API before calling backends or constructing
+results. Do not directly apply `int()` or `str()` to canonical components or
+change `sys.set_int_max_str_digits()` as a workaround. Keep backend coercion in
+thin adapters, and test above 4,300 digits whenever the contract permits it.
+
 Keep Pydantic models authoritative at capability, persistence, artifact, and
 wire boundaries. Domain implementations and operation factories must preserve
 their concrete request, result, and obligation types: do not accept


### PR DESCRIPTION
## Problem

The agent guidance defines typed mathematical kernels and backend boundaries, but it does not state how capabilities should exchange mathematical values or how canonical decimal strings should cross into computation. That leaves room for backend-specific coupling, internal JSON round-trips, and direct `int()` or `str()` conversion of canonical values.

## Solution

Add a mathematical interoperability section that makes the intended boundary explicit:

- capabilities exchange shared typed domain values and artifacts;
- representation changes use explicit domain-owned conversions;
- canonical decimal strings remain wire and persistence values;
- backend adapters use the canonical conversion API;
- tests cover canonical or backend-native round trips, including values above Python's 4,300-digit conversion threshold when contracts allow them.

This is guidance-only and does not change runtime behavior.

## Testing

```sh
make test-plan BASE=origin/main
make docs-linkcheck
```

The planner selected the documentation lane. Documentation command validation and Markdown link checking both passed.

## Trust & Compatibility Impact

No verification-kernel, checker-registry, artifact-format, public-API, or runtime behavior changes. The new guidance clarifies the existing mathematical representation and adapter boundaries for future contributions.

## Checklist

- [x] Planner-selected documentation validation passes
- [x] Relevant validation is listed above
