### PR TITLE
fix(benchmarks): reject duplicate JSON object names in benchmark verifier support

### DIFF
--- a/benchmarks/datasets/conjecture-probes-v1/bsd-infinite-order-certificate/tests/verifier_support.py
+++ b/benchmarks/datasets/conjecture-probes-v1/bsd-infinite-order-certificate/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/conjecture-probes-v1/hadamard-order12-construction/tests/verifier_support.py
+++ b/benchmarks/datasets/conjecture-probes-v1/hadamard-order12-construction/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/conjecture-probes-v1/hadwiger-triangle-free-minor-certificate/tests/verifier_support.py
+++ b/benchmarks/datasets/conjecture-probes-v1/hadwiger-triangle-free-minor-certificate/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/conjecture-probes-v1/happy-ending-convex-position/tests/verifier_support.py
+++ b/benchmarks/datasets/conjecture-probes-v1/happy-ending-convex-position/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/conjecture-probes-v1/hodge-blowup-divisor-certificate/tests/verifier_support.py
+++ b/benchmarks/datasets/conjecture-probes-v1/hodge-blowup-divisor-certificate/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/conjecture-probes-v1/littlewood-certified-finite-search/tests/verifier_support.py
+++ b/benchmarks/datasets/conjecture-probes-v1/littlewood-certified-finite-search/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/conjecture-probes-v1/navier-stokes-polynomial-certificate/tests/verifier_support.py
+++ b/benchmarks/datasets/conjecture-probes-v1/navier-stokes-polynomial-certificate/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/conjecture-probes-v1/perfect-cuboid-scope-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/conjecture-probes-v1/perfect-cuboid-scope-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/conjecture-probes-v1/reconstruction-deck-certificate/tests/verifier_support.py
+++ b/benchmarks/datasets/conjecture-probes-v1/reconstruction-deck-certificate/tests/verifier_support.py
@@ -69,6 +69,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -77,6 +88,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -111,6 +123,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,7 @@ def _read_streaming_json_value(stream) -> Any:
     """
 
     decoder = codecs.getincrementaldecoder("utf-8")()
-    parser = json.JSONDecoder()
+    parser = json.JSONDecoder(object_pairs_hook=_reject_duplicate_keys)
     buffer = ""
     while True:
         block = stream.read(65_536)
@@ -366,7 +379,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/conjecture-probes-v1/vizing-bounded-cartesian-products/tests/verifier_support.py
+++ b/benchmarks/datasets/conjecture-probes-v1/vizing-bounded-cartesian-products/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/conjecture-probes-v1/yang-mills-gauge-invariance-certificate/tests/verifier_support.py
+++ b/benchmarks/datasets/conjecture-probes-v1/yang-mills-gauge-invariance-certificate/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/algebraic-independence-transfer-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/algebraic-independence-transfer-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/alternating-recurrence-stability-certificate/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/alternating-recurrence-stability-certificate/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/apollonius-gap-repair/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/apollonius-gap-repair/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/autoformalization-semantic-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/autoformalization-semantic-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/bounded-variation-uniform-limit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/bounded-variation-uniform-limit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/c4-characteristic-invariant-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/c4-characteristic-invariant-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/calendar-good-days-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/calendar-good-days-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/chebotarev-fixed-point-proof-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/chebotarev-fixed-point-proof-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/closed-one-form-polynomial-classification/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/closed-one-form-polynomial-classification/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/complex-power-sum-elimination/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/complex-power-sum-elimination/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/continuant-reversal-certificate/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/continuant-reversal-certificate/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/continuous-spike-integral-separation/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/continuous-spike-integral-separation/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/convergence-mode-separation/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/convergence-mode-separation/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/covering-path-lift-bijection/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/covering-path-lift-bijection/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/cubic-image-classification/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/cubic-image-classification/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/cyclic-lipschitz-duality/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/cyclic-lipschitz-duality/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/cyclic-polynomial-sum-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/cyclic-polynomial-sum-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/cyclotomic-reciprocity-certificate/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/cyclotomic-reciprocity-certificate/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/dead-end-local-density-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/dead-end-local-density-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/diophantine-ratio-family-repair/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/diophantine-ratio-family-repair/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/disjoint-closed-distance-scope-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/disjoint-closed-distance-scope-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/distinct-parity-primal-dual/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/distinct-parity-primal-dual/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/distinct-sum-pairing-optimum/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/distinct-sum-pairing-optimum/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/divisibility-construction-witness/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/divisibility-construction-witness/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/divisor-minimizer-exchange-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/divisor-minimizer-exchange-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/divisor-sum-square-sequence-repair/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/divisor-sum-square-sequence-repair/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/domino-profile-transfer-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/domino-profile-transfer-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/edge-pair-ordering-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/edge-pair-ordering-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/elementwise-fixed-no-global-invariant/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/elementwise-fixed-no-global-invariant/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/emerald-path-family-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/emerald-path-family-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/erdos-gallai-realization-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/erdos-gallai-realization-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/euler-fourth-power-scope-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/euler-fourth-power-scope-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/euler-line-symbolic-certificate/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/euler-line-symbolic-certificate/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/even-fixed-point-inclusion/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/even-fixed-point-inclusion/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/exact-farkas-ldl-slice/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/exact-farkas-ldl-slice/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/exponential-moment-rationality/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/exponential-moment-rationality/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/extremal-subset-sum-semantic-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/extremal-subset-sum-semantic-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/fiber-dimension-semicontinuity-repair/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/fiber-dimension-semicontinuity-repair/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/finite-field-irreducibility-repair/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/finite-field-irreducibility-repair/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/finite-magma-countermodel/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/finite-magma-countermodel/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/finite-partition/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/finite-partition/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/finite-scheme-rational-points-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/finite-scheme-rational-points-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/finite-support-sum-scope-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/finite-support-sum-scope-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/fractional-ratio-proof-repair/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/fractional-ratio-proof-repair/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/ga-action-local-finiteness-certificate/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/ga-action-local-finiteness-certificate/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/gaussian-moment-generality-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/gaussian-moment-generality-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/generalized-shift-proof-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/generalized-shift-proof-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/generated-lemma-vacuity-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/generated-lemma-vacuity-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/gf2-matrix-completion-quantifier-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/gf2-matrix-completion-quantifier-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/gram-schmidt-nonzero-filter-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/gram-schmidt-nonzero-filter-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/graph-artifact-composition/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/graph-artifact-composition/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/graph-counterexample/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/graph-counterexample/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/grid-independent-set-transfer/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/grid-independent-set-transfer/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/grounded-premise-proof/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/grounded-premise-proof/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/hermite-normal-form/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/hermite-normal-form/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/hyperplane-arrangement-regions/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/hyperplane-arrangement-regions/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/image-complement-commutation/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/image-complement-commutation/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/indexed-pairwise-vacuity/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/indexed-pairwise-vacuity/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/infinite-shift-spectrum-counterexample/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/infinite-shift-spectrum-counterexample/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/inseparable-minimal-polynomial-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/inseparable-minimal-polynomial-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/integer-perturbation-domain-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/integer-perturbation-domain-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/inverse-distance-remainder-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/inverse-distance-remainder-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/inversion-aggregate-mask-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/inversion-aggregate-mask-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/knight-cycle-game-strategy/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/knight-cycle-game-strategy/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/lagrangian-projection-proof-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/lagrangian-projection-proof-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/lcm-highly-abundant-scope-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/lcm-highly-abundant-scope-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/lean-guard-scope-assurance/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/lean-guard-scope-assurance/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/lean-transitive-axiom-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/lean-transitive-axiom-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/limsup-quantifier-alignment/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/limsup-quantifier-alignment/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/local-ring-diagonal-similarity-certificate/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/local-ring-diagonal-similarity-certificate/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/log-exponent-recovery/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/log-exponent-recovery/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/log-inequality-meta-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/log-inequality-meta-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/lp-integrability-separator/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/lp-integrability-separator/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/marginal-joint-product-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/marginal-joint-product-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/matrix-square-zero-counterexample/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/matrix-square-zero-counterexample/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/metamath-syllogism-repair/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/metamath-syllogism-repair/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/metric-tsp-proof-repair/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/metric-tsp-proof-repair/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/mobius-functional-equation/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/mobius-functional-equation/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/modular-cubic-obstruction/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/modular-cubic-obstruction/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/monotone-inverse-continuity-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/monotone-inverse-continuity-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/multiplicative-grid-extremum/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/multiplicative-grid-extremum/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/natural-subtraction-proof-repair/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/natural-subtraction-proof-repair/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/necklace-burnside-certificate/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/necklace-burnside-certificate/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/newton-polygon-factorization-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/newton-polygon-factorization-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/nonclosed-projection-image/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/nonclosed-projection-image/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/noncompact-lefschetz-proof-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/noncompact-lefschetz-proof-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/nondifferentiable-maximum-construction/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/nondifferentiable-maximum-construction/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/nonlinear-recurrence-crossing-certificate/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/nonlinear-recurrence-crossing-certificate/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/parameterized-sharp-bound-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/parameterized-sharp-bound-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/path-dependent-limit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/path-dependent-limit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/periodic-orbit-polynomial-obstruction/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/periodic-orbit-polynomial-obstruction/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/permutation-inversion-involution/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/permutation-inversion-involution/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/polynomial-divisibility-uniqueness/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/polynomial-divisibility-uniqueness/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/polynomial-map-collision/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/polynomial-map-collision/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/polynomial-normalization/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/polynomial-normalization/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/polynomial-precedence-unboundedness-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/polynomial-precedence-unboundedness-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/polynomial-root-localization-certificate/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/polynomial-root-localization-certificate/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/polynomial-tail-counterexample/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/polynomial-tail-counterexample/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/positive-lower-density-separation/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/positive-lower-density-separation/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/prime-power-divisibility-gap-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/prime-power-divisibility-gap-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/primitive-eisenstein-norm-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/primitive-eisenstein-norm-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/product-hausdorff-nonempty-scope-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/product-hausdorff-nonempty-scope-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/propositional-rewrite-trace-replay/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/propositional-rewrite-trace-replay/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/putnam-2adic-induction-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/putnam-2adic-induction-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/pythagorean-generator-recurrence/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/pythagorean-generator-recurrence/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/radical-distance-triangle-certificate/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/radical-distance-triangle-certificate/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/radical-system-uniqueness-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/radical-system-uniqueness-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/random-function-expectation-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/random-function-expectation-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/rank-one-determinant-limit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/rank-one-determinant-limit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/rank-one-spectral-limit-certificate/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/rank-one-spectral-limit-certificate/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/ratio-test-boundary-separation/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/ratio-test-boundary-separation/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/rational-linear-solution/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/rational-linear-solution/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/rational-pole-vieta-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/rational-pole-vieta-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/real-rooted-sign-polynomials/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/real-rooted-sign-polynomials/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/reciprocal-polynomial-classification/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/reciprocal-polynomial-classification/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/research-status-evidence-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/research-status-evidence-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -136,6 +149,7 @@ def load_submission_raw(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -289,7 +303,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -328,7 +345,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/rp2-homology-lattice/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/rp2-homology-lattice/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/rsa-exponent-domain-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/rsa-exponent-domain-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/sat-witness/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/sat-witness/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/series-domain-junk-zero/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/series-domain-junk-zero/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/sharp-cauchy-inequality/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/sharp-cauchy-inequality/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/sine-integral-asymptotic-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/sine-integral-asymptotic-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/squarefree-class-independence-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/squarefree-class-independence-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/steiner-triple-system-27/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/steiner-triple-system-27/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/subset-incidence-determinant/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/subset-incidence-determinant/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/subspace-direct-sum-counterexample/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/subspace-direct-sum-counterexample/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/symbolic-block-determinant-decomposition/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/symbolic-block-determinant-decomposition/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/symmetric-polynomial-divisibility/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/symmetric-polynomial-divisibility/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/ternary-distance-code-optimum/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/ternary-distance-code-optimum/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/topology-generation-order-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/topology-generation-order-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/trigonometric-power-sum-valuation/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/trigonometric-power-sum-valuation/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/triplewise-empty-extremal-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/triplewise-empty-extremal-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/unit-fraction-classification-repair/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/unit-fraction-classification-repair/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/valuation-gcd-quantifier-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/valuation-gcd-quantifier-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/well-total-domination-counterexample/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/well-total-domination-counterexample/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/provider-feasibility-v1/cddlib/tests/verifier_support.py
+++ b/benchmarks/datasets/provider-feasibility-v1/cddlib/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/provider-feasibility-v1/cgal/tests/verifier_support.py
+++ b/benchmarks/datasets/provider-feasibility-v1/cgal/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/verifier_support.py
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/provider-feasibility-v1/lean-repl/tests/verifier_support.py
+++ b/benchmarks/datasets/provider-feasibility-v1/lean-repl/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/provider-feasibility-v1/nauty/tests/verifier_support.py
+++ b/benchmarks/datasets/provider-feasibility-v1/nauty/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/provider-feasibility-v1/regina/tests/verifier_support.py
+++ b/benchmarks/datasets/provider-feasibility-v1/regina/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/public-reproductions-v1/balanced-row-permutation/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/balanced-row-permutation/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/public-reproductions-v1/closed-set-distance-strengthening-audit/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/closed-set-distance-strengthening-audit/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -136,6 +149,7 @@ def load_submission_raw(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -289,7 +303,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -328,7 +345,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/public-reproductions-v1/coin-process-potential/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/coin-process-potential/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/public-reproductions-v1/cyclic-vector-inequality/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/cyclic-vector-inequality/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/public-reproductions-v1/gaussian-complex-cancellation/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/gaussian-complex-cancellation/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/public-reproductions-v1/gaussian-sixth-moment/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/gaussian-sixth-moment/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/public-reproductions-v1/gaussian-two-sum-fourth-moment/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/gaussian-two-sum-fourth-moment/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/public-reproductions-v1/integral-circle/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/integral-circle/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/public-reproductions-v1/integral-projective-plane/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/integral-projective-plane/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/public-reproductions-v1/jacobian-inverse-obstruction/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/jacobian-inverse-obstruction/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/public-reproductions-v1/jacobian-keller/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/jacobian-keller/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/public-reproductions-v1/jacobian-negative-control/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/jacobian-negative-control/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/public-reproductions-v1/lean-retrieval/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/lean-retrieval/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/public-reproductions-v1/lean-transition/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/lean-transition/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/public-reproductions-v1/recurrence-fibonacci/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/recurrence-fibonacci/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/public-reproductions-v1/recurrence-linear-eval/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/recurrence-linear-eval/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/public-reproductions-v1/recurrence-lucas/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/recurrence-lucas/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/public-reproductions-v1/recurrence-rational-series/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/recurrence-rational-series/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/public-reproductions-v1/reduced-point/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/reduced-point/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/public-reproductions-v1/reliability-series-path/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/reliability-series-path/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/public-reproductions-v1/reliability-single-edge/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/reliability-single-edge/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/public-reproductions-v1/reliability-triangle-fair/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/reliability-triangle-fair/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/public-reproductions-v1/sat-bool-mus/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/sat-bool-mus/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/public-reproductions-v1/sat-erdos-schur-f4/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/sat-erdos-schur-f4/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/public-reproductions-v1/sat-pigeonhole/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/sat-pigeonhole/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/public-reproductions-v1/sat-small/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/sat-small/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/public-reproductions-v1/smith-rank-deficient/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/smith-rank-deficient/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/public-reproductions-v1/smith-rectangular/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/smith-rectangular/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/public-reproductions-v1/superposition-proof-replay/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/superposition-proof-replay/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/public-reproductions-v1/symmetry-colored-reflection/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/symmetry-colored-reflection/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/public-reproductions-v1/symmetry-cycle-rotation/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/symmetry-cycle-rotation/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/public-reproductions-v1/symmetry-identity-subgroup/tests/verifier_support.py
+++ b/benchmarks/datasets/public-reproductions-v1/symmetry-identity-subgroup/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-001/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-001/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-002/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-002/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-003/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-003/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-004/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-004/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -136,6 +149,7 @@ def load_submission_raw(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -289,7 +303,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -328,7 +345,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-005/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-005/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-006/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-006/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-007/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-007/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-008/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-008/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-009/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-009/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-010/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-010/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-011/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-011/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-012/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-012/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-013/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-013/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-014/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-014/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -136,6 +149,7 @@ def load_submission_raw(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -289,7 +303,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -328,7 +345,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-015/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-015/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -136,6 +149,7 @@ def load_submission_raw(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -289,7 +303,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -328,7 +345,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-016/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-016/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -136,6 +149,7 @@ def load_submission_raw(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -289,7 +303,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -328,7 +345,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-017/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-017/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-018/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-018/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -267,7 +280,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -306,7 +322,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-019/tests/verifier_support.py
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-019/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -136,6 +149,7 @@ def load_submission_raw(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -289,7 +303,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -328,7 +345,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-collision-found-01/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-collision-found-01/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -136,6 +149,7 @@ def load_submission_raw(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -295,7 +309,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -334,7 +351,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-collision-found-02/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-collision-found-02/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -136,6 +149,7 @@ def load_submission_raw(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -295,7 +309,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -334,7 +351,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-grid-exhausted-01/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-grid-exhausted-01/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -136,6 +149,7 @@ def load_submission_raw(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -295,7 +309,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -334,7 +351,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-grid-exhausted-02/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-grid-exhausted-02/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -136,6 +149,7 @@ def load_submission_raw(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -295,7 +309,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -334,7 +351,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-keller-only-01/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-keller-only-01/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -136,6 +149,7 @@ def load_submission_raw(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -295,7 +309,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -334,7 +351,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-keller-only-02/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-keller-only-02/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -136,6 +149,7 @@ def load_submission_raw(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -295,7 +309,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -334,7 +351,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-keller-only-03/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-keller-only-03/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -136,6 +149,7 @@ def load_submission_raw(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -295,7 +309,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -334,7 +351,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-keller-only-04/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-keller-only-04/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -136,6 +149,7 @@ def load_submission_raw(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -295,7 +309,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -334,7 +351,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-near-miss-01/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-near-miss-01/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -136,6 +149,7 @@ def load_submission_raw(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -295,7 +309,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -334,7 +351,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-near-miss-02/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-near-miss-02/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -136,6 +149,7 @@ def load_submission_raw(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -295,7 +309,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -334,7 +351,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-near-miss-03/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-near-miss-03/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -136,6 +149,7 @@ def load_submission_raw(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -295,7 +309,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -334,7 +351,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-near-miss-04/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-near-miss-04/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -136,6 +149,7 @@ def load_submission_raw(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -295,7 +309,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -334,7 +351,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-one-direction-01/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-one-direction-01/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -136,6 +149,7 @@ def load_submission_raw(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -295,7 +309,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -334,7 +351,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-one-direction-02/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-one-direction-02/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -136,6 +149,7 @@ def load_submission_raw(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -295,7 +309,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -334,7 +351,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-one-direction-03/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-one-direction-03/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -136,6 +149,7 @@ def load_submission_raw(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -295,7 +309,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -334,7 +351,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-search-incomplete-01/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-search-incomplete-01/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -136,6 +149,7 @@ def load_submission_raw(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -295,7 +309,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -334,7 +351,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-search-timeout-01/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-search-timeout-01/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -136,6 +149,7 @@ def load_submission_raw(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -295,7 +309,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -334,7 +351,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-semantic-equivalence-01/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-semantic-equivalence-01/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -136,6 +149,7 @@ def load_submission_raw(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -295,7 +309,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -334,7 +351,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-semantic-equivalence-02/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-semantic-equivalence-02/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -136,6 +149,7 @@ def load_submission_raw(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -295,7 +309,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -334,7 +351,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-semantic-equivalence-03/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-semantic-equivalence-03/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -136,6 +149,7 @@ def load_submission_raw(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -295,7 +309,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -334,7 +351,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-semantic-equivalence-04/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-semantic-equivalence-04/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -136,6 +149,7 @@ def load_submission_raw(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -295,7 +309,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -334,7 +351,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-valid-inverse-01/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-valid-inverse-01/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -136,6 +149,7 @@ def load_submission_raw(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -295,7 +309,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -334,7 +351,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-valid-inverse-02/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-valid-inverse-02/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -136,6 +149,7 @@ def load_submission_raw(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -295,7 +309,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -334,7 +351,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-valid-inverse-03/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-valid-inverse-03/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -136,6 +149,7 @@ def load_submission_raw(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -295,7 +309,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -334,7 +351,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-valid-inverse-04/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-valid-inverse-04/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -136,6 +149,7 @@ def load_submission_raw(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -295,7 +309,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -334,7 +351,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-valid-inverse-05/tests/verifier_support.py
+++ b/benchmarks/datasets/symbolic-coordination-v1/symbolic-coordination-valid-inverse-05/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -136,6 +149,7 @@ def load_submission_raw(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -295,7 +309,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -334,7 +351,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/templates/task/tests/verifier_support.py
+++ b/benchmarks/templates/task/tests/verifier_support.py
@@ -68,6 +68,17 @@ def _finite_json_float(value: str) -> float:
     return parsed
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject JSON objects with duplicate names at any nesting level."""
+
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _load_public_contract(
     path: Path = TESTS / "public_contract.json",
 ) -> dict[str, Any] | None:
@@ -76,6 +87,7 @@ def _load_public_contract(
     try:
         contract = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -110,6 +122,7 @@ def load_submission(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -136,6 +149,7 @@ def load_submission_raw(
     try:
         value = json.loads(
             path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_nonfinite_json,
             parse_float=_finite_json_float,
         )
@@ -289,7 +303,10 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(target.read_text())
+        value = json.loads(
+            target.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None
@@ -328,7 +345,10 @@ def authorized_record_is_bound(
         expected_path="evidence/verification-record.json",
     )
     try:
-        authorized = json.loads(authorized_path.read_text())
+        authorized = json.loads(
+            authorized_path.read_text(),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
     except (OSError, ValueError):
         return False
     if not isinstance(actual, dict) or not isinstance(authorized, dict):

--- a/benchmarks/tooling/validation_plan.py
+++ b/benchmarks/tooling/validation_plan.py
@@ -9,6 +9,8 @@ from typing import Any
 
 HOST_VALIDATION_ROOT = "benchmarks/validation"
 HOST_VALIDATION_FULL_SHARDS = 4
+# GitHub Actions matrix jobs are capped at 256; stay at or below that limit.
+HOST_VALIDATION_MAX_JOBS = 256
 HOST_VALIDATION_DATASET_FILES = {
     "conjecture-probes-v1": (
         "benchmarks/validation/conjecture_probes_v1/"
@@ -356,12 +358,18 @@ def host_validation_plan(
     ordered = tuple(
         sorted(unique.values(), key=lambda entry: (entry.selector, entry.keyword))
     )
+    if len(ordered) > HOST_VALIDATION_MAX_JOBS:
+        return HostValidationPlan(
+            full_host_validation(timings=timings),
+            ("focused host validation exceeded matrix job limit; using full suite",),
+        )
     reasons = tuple(f"focused host validation: {entry.name}" for entry in ordered)
     return HostValidationPlan(ordered, reasons)
 
 
 __all__ = [
     "CONTROL_PLANE_HOST_TESTS",
+    "HOST_VALIDATION_MAX_JOBS",
     "HostValidation",
     "HostValidationPlan",
     "dataset_host_validation",

--- a/benchmarks/validation/test_validation_plan.py
+++ b/benchmarks/validation/test_validation_plan.py
@@ -113,6 +113,33 @@ def test_makefile_change_remains_fail_closed_without_hunk_ownership(
     )
 
 
+def test_focused_host_matrix_over_limit_escalates_to_full_suite(
+    tmp_path: Path,
+) -> None:
+    """Portfolio-wide task support migrations must not exceed the matrix cap."""
+    from benchmarks.tooling.validation_plan import HOST_VALIDATION_MAX_JOBS
+
+    tasks = tuple(f"task-{index:03d}" for index in range(HOST_VALIDATION_MAX_JOBS + 1))
+    suite = SimpleNamespace(
+        tasks=tuple(SimpleNamespace(path=Path(task)) for task in tasks)
+    )
+    paths = [
+        f"benchmarks/datasets/mathematical-benchmarks-v1/{task}/tests/verifier_support.py"
+        for task in tasks
+    ]
+
+    plan = host_validation_plan(
+        tmp_path,
+        paths,
+        {"mathematical-benchmarks-v1": suite},
+    )
+
+    assert len(plan.entries) == 4
+    assert plan.reasons == (
+        "focused host validation exceeded matrix job limit; using full suite",
+    )
+
+
 def test_conjecture_probes_v1_task_change_selects_only_leaf(tmp_path: Path) -> None:
     """A conjecture-probes-v1 task change must select its dedicated leaf test
     when one exists, rather than escalating to full host validation."""

--- a/benchmarks/validation/test_verifier_support_schema.py
+++ b/benchmarks/validation/test_verifier_support_schema.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 import json
 import sys
@@ -200,3 +201,58 @@ def test_aggregate_reward_soft_assurance_partial_after_hard_gates() -> None:
 
 def test_template_exports_aggregate_reward() -> None:
     assert "aggregate_reward" in _VS.__all__
+
+
+def test_reject_duplicate_keys_raises_on_duplicate_object_name() -> None:
+    with pytest.raises(ValueError, match="duplicate JSON object key"):
+        _VS._reject_duplicate_keys([("a", 1), ("a", 2)])
+
+
+def test_reject_duplicate_keys_accepts_unique_object_names() -> None:
+    result = _VS._reject_duplicate_keys([("a", 1), ("b", 2)])
+    assert result == {"a": 1, "b": 2}
+
+
+def test_reject_duplicate_keys_accepts_empty_pairs() -> None:
+    assert _VS._reject_duplicate_keys([]) == {}
+
+
+def test_load_submission_rejects_duplicate_keys(
+    tmp_path: Path,
+    contract_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    submission = tmp_path / "submission.json"
+    submission.write_text('{"count": 1, "count": 2, "labels": []}')
+    monkeypatch.setattr(
+        _VS, "_load_public_contract", lambda: json.loads(contract_path.read_text())
+    )
+    assert _VS.load_submission(submission, require_input_binding=False) is None
+
+
+def test_load_submission_raw_rejects_duplicate_keys(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    submission = tmp_path / "submission.json"
+    submission.write_text('{"a": 1, "a": 2}')
+    monkeypatch.setattr(_VS, "workspace_input_is_bound", lambda: True)
+    assert _VS.load_submission_raw(submission, require_input_binding=False) is None
+
+
+def test_read_evidence_json_rejects_duplicate_keys(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    evidence = tmp_path / "evidence.json"
+    evidence.write_text('{"a": 1, "a": 2}')
+    digest = "sha256:" + hashlib.sha256(evidence.read_bytes()).hexdigest()
+    descriptor = {"path": "evidence/answer.txt", "sha256": digest}
+    monkeypatch.setattr(
+        _VS,
+        "resolve_evidence",
+        lambda descriptor, **kw: evidence,
+    )
+    assert (
+        _VS.read_evidence_json(descriptor, expected_path="evidence/answer.txt") is None
+    )


### PR DESCRIPTION
Fixes #762.

Rejects conflicting JSON object names at all shared verifier-support parsing boundaries and migrates each task-local support copy deliberately.

Validation: `test_verifier_support_schema.py` — 23 passed; Ruff check and format check passed. Full portfolio Oracle replay remains merge-queue scope for this broad task-local support migration.