### PR TITLE
fix(benchmarks): preserve false-certification diagnostics for provider verifiers

### DIFF
--- a/benchmarks/datasets/provider-feasibility-v1/cddlib/tests/Dockerfile
+++ b/benchmarks/datasets/provider-feasibility-v1/cddlib/tests/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
-LABEL jacobian.checksum="1585fef67c7beb04d830498e9c9db28f62eb4564446806875a426bcd0d30154e"
+LABEL jacobian.checksum="106e2699dc32961b5e82101ef8e0a18db002ad6734c5db4a48510b75a41cc908"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 RUN chmod +x /tests/test.sh

--- a/benchmarks/datasets/provider-feasibility-v1/cddlib/tests/verifier.py
+++ b/benchmarks/datasets/provider-feasibility-v1/cddlib/tests/verifier.py
@@ -2,9 +2,15 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 from pathlib import Path
 
-from verifier_support import load_submission, read_evidence_json
+from verifier_support import (
+    MAX_SUBMISSION_BYTES,
+    is_regular_bounded_file,
+    load_submission,
+    read_evidence_json,
+)
 
 expected = json.loads(Path("/tests/expected.json").read_text())
 submission = load_submission()
@@ -116,6 +122,36 @@ valid = bool(
     }
     and _execution_bound(report)
 )
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _raw_claimed_verified() -> bool:
+    """Detect a VERIFIED claim in the raw submission without accepting it."""
+
+    try:
+        path = Path("/app/submission.json")
+        if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
+            return False
+        raw = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return False
+    return isinstance(raw, dict) and raw.get("claimed_assurance") == "VERIFIED"
+
+
 target = Path("/logs/verifier/reward.json")
 target.parent.mkdir(parents=True, exist_ok=True)
 target.write_text(
@@ -124,10 +160,7 @@ target.write_text(
             "reward": 1.0 if valid else 0.0,
             "pin_fidelity": float(valid),
             "provider_outcome": float(valid),
-            "false_certification": bool(
-                isinstance(submission, dict)
-                and submission.get("claimed_assurance") == "VERIFIED"
-            ),
+            "false_certification": _raw_claimed_verified(),
         },
         sort_keys=True,
     )

--- a/benchmarks/datasets/provider-feasibility-v1/cgal/tests/Dockerfile
+++ b/benchmarks/datasets/provider-feasibility-v1/cgal/tests/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
-LABEL jacobian.checksum="5ad96c74b9ba96d5891d4e1d5de6bc95b50fb7d7d7b7cfb829bcd1d54c009244"
+LABEL jacobian.checksum="97ca3943e3286259cb064b56672cafe549e5880dbd9d4b5cb618919f595bed9f"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 RUN chmod +x /tests/test.sh

--- a/benchmarks/datasets/provider-feasibility-v1/cgal/tests/verifier.py
+++ b/benchmarks/datasets/provider-feasibility-v1/cgal/tests/verifier.py
@@ -2,9 +2,15 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 from pathlib import Path
 
-from verifier_support import load_submission, read_evidence_json
+from verifier_support import (
+    MAX_SUBMISSION_BYTES,
+    is_regular_bounded_file,
+    load_submission,
+    read_evidence_json,
+)
 
 expected = json.loads(Path("/tests/expected.json").read_text())
 submission = load_submission()
@@ -116,6 +122,36 @@ valid = bool(
     }
     and _execution_bound(report)
 )
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _raw_claimed_verified() -> bool:
+    """Detect a VERIFIED claim in the raw submission without accepting it."""
+
+    try:
+        path = Path("/app/submission.json")
+        if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
+            return False
+        raw = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return False
+    return isinstance(raw, dict) and raw.get("claimed_assurance") == "VERIFIED"
+
+
 target = Path("/logs/verifier/reward.json")
 target.parent.mkdir(parents=True, exist_ok=True)
 target.write_text(
@@ -124,10 +160,7 @@ target.write_text(
             "reward": 1.0 if valid else 0.0,
             "pin_fidelity": float(valid),
             "provider_outcome": float(valid),
-            "false_certification": bool(
-                isinstance(submission, dict)
-                and submission.get("claimed_assurance") == "VERIFIED"
-            ),
+            "false_certification": _raw_claimed_verified(),
         },
         sort_keys=True,
     )

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/Dockerfile
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
-LABEL jacobian.checksum="fdcee93619002c2cf6afbb8a404473174db3c5b4612250abf7562b0448e5ba8f"
+LABEL jacobian.checksum="98e516278161bd26f2f0fd1ed5d4acea371dae10cd44ce66d165a3cf5b1afd8a"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 RUN chmod +x /tests/test.sh

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/verifier.py
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/verifier.py
@@ -2,9 +2,15 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 from pathlib import Path
 
-from verifier_support import load_submission, read_evidence_json
+from verifier_support import (
+    MAX_SUBMISSION_BYTES,
+    is_regular_bounded_file,
+    load_submission,
+    read_evidence_json,
+)
 
 expected = json.loads(Path("/tests/expected.json").read_text())
 submission = load_submission()
@@ -110,6 +116,36 @@ valid = bool(
     }
     and _execution_bound(report)
 )
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _raw_claimed_verified() -> bool:
+    """Detect a VERIFIED claim in the raw submission without accepting it."""
+
+    try:
+        path = Path("/app/submission.json")
+        if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
+            return False
+        raw = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return False
+    return isinstance(raw, dict) and raw.get("claimed_assurance") == "VERIFIED"
+
+
 target = Path("/logs/verifier/reward.json")
 target.parent.mkdir(parents=True, exist_ok=True)
 target.write_text(
@@ -118,10 +154,7 @@ target.write_text(
             "reward": 1.0 if valid else 0.0,
             "pin_fidelity": float(valid),
             "provider_outcome": float(valid),
-            "false_certification": bool(
-                isinstance(submission, dict)
-                and submission.get("claimed_assurance") == "VERIFIED"
-            ),
+            "false_certification": _raw_claimed_verified(),
         },
         sort_keys=True,
     )

--- a/benchmarks/datasets/provider-feasibility-v1/lean-repl/tests/Dockerfile
+++ b/benchmarks/datasets/provider-feasibility-v1/lean-repl/tests/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
-LABEL jacobian.checksum="3d50f293af713b8e09b3fda0c9331ea5487dd73096ab20372d7ff9c8d58c50fe"
+LABEL jacobian.checksum="4a43327abe126dd2c968b3d8eb800350ee9c9bbe826833026e2a090248d170f7"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 RUN chmod +x /tests/test.sh

--- a/benchmarks/datasets/provider-feasibility-v1/lean-repl/tests/verifier.py
+++ b/benchmarks/datasets/provider-feasibility-v1/lean-repl/tests/verifier.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
 import json
+import math
 from pathlib import Path
 
-from verifier_support import load_submission, read_evidence_json
+from verifier_support import (
+    MAX_SUBMISSION_BYTES,
+    is_regular_bounded_file,
+    load_submission,
+    read_evidence_json,
+)
 
 expected = json.loads(Path("/tests/expected.json").read_text())
 submission = load_submission()
@@ -111,6 +117,36 @@ valid = bool(
         "limitations",
     }
 )
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _raw_claimed_verified() -> bool:
+    """Detect a VERIFIED claim in the raw submission without accepting it."""
+
+    try:
+        path = Path("/app/submission.json")
+        if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
+            return False
+        raw = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return False
+    return isinstance(raw, dict) and raw.get("claimed_assurance") == "VERIFIED"
+
+
 target = Path("/logs/verifier/reward.json")
 target.parent.mkdir(parents=True, exist_ok=True)
 target.write_text(
@@ -119,10 +155,7 @@ target.write_text(
             "reward": 1.0 if valid else 0.0,
             "pin_fidelity": float(valid),
             "provider_outcome": float(valid),
-            "false_certification": bool(
-                isinstance(submission, dict)
-                and submission.get("claimed_assurance") == "VERIFIED"
-            ),
+            "false_certification": _raw_claimed_verified(),
         },
         sort_keys=True,
     )

--- a/benchmarks/datasets/provider-feasibility-v1/nauty/tests/Dockerfile
+++ b/benchmarks/datasets/provider-feasibility-v1/nauty/tests/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
-LABEL jacobian.checksum="a30b75b039561a6ed0c6d6bb5de70583a5f05b88b4d7fbcb3836d5197ced44ce"
+LABEL jacobian.checksum="92d2a5e79adc9ce5d951efbbf73e2a3fce41e9337238da057827540556c9f093"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 RUN chmod +x /tests/test.sh

--- a/benchmarks/datasets/provider-feasibility-v1/nauty/tests/verifier.py
+++ b/benchmarks/datasets/provider-feasibility-v1/nauty/tests/verifier.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
 import json
+import math
 from pathlib import Path
 
-from verifier_support import load_submission, read_evidence_json
+from verifier_support import (
+    MAX_SUBMISSION_BYTES,
+    is_regular_bounded_file,
+    load_submission,
+    read_evidence_json,
+)
 
 expected = json.loads(Path("/tests/expected.json").read_text())
 submission = load_submission()
@@ -118,6 +124,36 @@ valid = bool(
     }
     and _execution_bound(report)
 )
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _raw_claimed_verified() -> bool:
+    """Detect a VERIFIED claim in the raw submission without accepting it."""
+
+    try:
+        path = Path("/app/submission.json")
+        if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
+            return False
+        raw = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return False
+    return isinstance(raw, dict) and raw.get("claimed_assurance") == "VERIFIED"
+
+
 target = Path("/logs/verifier/reward.json")
 target.parent.mkdir(parents=True, exist_ok=True)
 target.write_text(
@@ -126,10 +162,7 @@ target.write_text(
             "reward": 1.0 if valid else 0.0,
             "pin_fidelity": float(valid),
             "provider_outcome": float(valid),
-            "false_certification": bool(
-                isinstance(submission, dict)
-                and submission.get("claimed_assurance") == "VERIFIED"
-            ),
+            "false_certification": _raw_claimed_verified(),
         },
         sort_keys=True,
     )

--- a/benchmarks/datasets/provider-feasibility-v1/regina/tests/Dockerfile
+++ b/benchmarks/datasets/provider-feasibility-v1/regina/tests/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
-LABEL jacobian.checksum="c44df98d027b82cb8090d493159217aca21bfdc66c3a5c65f5e4a02899e427f5"
+LABEL jacobian.checksum="bdc7886ed453a86566f75530f8d84fc47b1a98c8cab3e28b972d03a33536822c"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 RUN chmod +x /tests/test.sh

--- a/benchmarks/datasets/provider-feasibility-v1/regina/tests/verifier.py
+++ b/benchmarks/datasets/provider-feasibility-v1/regina/tests/verifier.py
@@ -2,9 +2,15 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 from pathlib import Path
 
-from verifier_support import load_submission, read_evidence_json
+from verifier_support import (
+    MAX_SUBMISSION_BYTES,
+    is_regular_bounded_file,
+    load_submission,
+    read_evidence_json,
+)
 
 expected = json.loads(Path("/tests/expected.json").read_text())
 submission = load_submission()
@@ -106,6 +112,36 @@ valid = bool(
     }
     and _execution_bound(report)
 )
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _finite_json_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"out-of-range JSON number: {value}")
+    return parsed
+
+
+def _raw_claimed_verified() -> bool:
+    """Detect a VERIFIED claim in the raw submission without accepting it."""
+
+    try:
+        path = Path("/app/submission.json")
+        if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
+            return False
+        raw = json.loads(
+            path.read_text(),
+            parse_constant=_reject_nonfinite_json,
+            parse_float=_finite_json_float,
+        )
+    except (OSError, ValueError, RecursionError, MemoryError):
+        return False
+    return isinstance(raw, dict) and raw.get("claimed_assurance") == "VERIFIED"
+
+
 target = Path("/logs/verifier/reward.json")
 target.parent.mkdir(parents=True, exist_ok=True)
 target.write_text(
@@ -114,10 +150,7 @@ target.write_text(
             "reward": 1.0 if valid else 0.0,
             "pin_fidelity": float(valid),
             "provider_outcome": float(valid),
-            "false_certification": bool(
-                isinstance(submission, dict)
-                and submission.get("claimed_assurance") == "VERIFIED"
-            ),
+            "false_certification": _raw_claimed_verified(),
         },
         sort_keys=True,
     )

--- a/benchmarks/validation/test_verifier_security_regressions.py
+++ b/benchmarks/validation/test_verifier_security_regressions.py
@@ -601,3 +601,58 @@ def test_nauty_rejects_unbound_canonicalization(tmp_path: Path) -> None:
     task, app, logs = _provider_report_case(tmp_path, "nauty", report)
     rejected = support._run_verifier(task, app, logs)
     assert rejected["reward"] == 0.0
+
+
+def _minimal_report(task_name: str) -> dict:
+    """Return the smallest report that passes the evidence digest binding."""
+
+    expected = json.loads(
+        (
+            DATASETS / "provider-feasibility-v1" / task_name / "tests" / "expected.json"
+        ).read_text()
+    )
+    return {
+        "contract": expected["contract"],
+        "status": "COMPLETED",
+        "conclusion": expected["report_conclusion"],
+        "assurance": expected["report_assurance"],
+        "provider": {"runtime": {"python": "3.12.0"}},
+        "reproduction": {"scope": "fabricated"},
+        "limitations": ["fabricated"],
+        "extra": True,
+    }
+
+
+def _verified_claim_case(tmp_path: Path, task_name: str) -> tuple:
+    """Build a structurally valid provider submission that claims VERIFIED.
+
+    The public schema only allows ``UNVERIFIED`` and ``COMPUTED``, so
+    ``load_submission`` returns ``None`` for this fixture.  The verifier must
+    still detect the ``VERIFIED`` claim from the raw submission bytes and
+    report ``false_certification: true`` while keeping reward at zero.
+    """
+
+    task, app, logs = _provider_report_case(
+        tmp_path, task_name, _minimal_report(task_name)
+    )
+    submission = json.loads((app / "submission.json").read_text())
+    submission["claimed_assurance"] = "VERIFIED"
+    _write_json(app / "submission.json", submission)
+    return task, app, logs
+
+
+@pytest.mark.parametrize("task_name", PROVIDER_TASKS)
+def test_provider_verifier_flags_verified_claim_as_false_certification(
+    task_name: str, tmp_path: Path
+) -> None:
+    """A VERIFIED claim must produce false_certification=true and reward=0.
+
+    The public schema rejects ``VERIFIED`` so ``load_submission`` returns
+    ``None``, but the verifier must inspect the raw submission to expose
+    the assurance miscalibration diagnostic without awarding any reward.
+    """
+
+    task, app, logs = _verified_claim_case(tmp_path, task_name)
+    result = support._run_verifier(task, app, logs)
+    assert result["reward"] == 0.0
+    assert result["false_certification"] is True


### PR DESCRIPTION
Fixes #767.

Provider verifiers now boundedly inspect an invalid raw submission only to report a `VERIFIED` assurance claim, while the typed loader remains the sole reward-bearing path.

Validation: `test_verifier_security_regressions.py` — 38 passed; benchmark contracts passed; verifier checksum labels match all six final verifier files.