### PR TITLE
fix(benchmarks): reject duplicate keys in reconstruction verifier submissions

### DIFF
--- a/benchmarks/datasets/conjecture-probes-v1/reconstruction-deck-certificate/tests/Dockerfile
+++ b/benchmarks/datasets/conjecture-probes-v1/reconstruction-deck-certificate/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 LABEL jacobian.task="jacobian/reconstruction-deck-certificate" \
-      jacobian.checksum="c7955da66055449f9974b7e71ab31542e681c332cfcbd6436c54fa8259c43b99"
+      jacobian.checksum="e1b3939dac7b2f11bad8ac8184688b98ef466afba59959556792d2dc3bfeaaab"
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 COPY input.json public_contract.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json

--- a/benchmarks/datasets/conjecture-probes-v1/reconstruction-deck-certificate/tests/Dockerfile
+++ b/benchmarks/datasets/conjecture-probes-v1/reconstruction-deck-certificate/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 LABEL jacobian.task="jacobian/reconstruction-deck-certificate" \
-      jacobian.checksum="fa77625b897becea61f45d0a9a8e906df6b4932bde8061c8fe1824517f580368"
+      jacobian.checksum="c7955da66055449f9974b7e71ab31542e681c332cfcbd6436c54fa8259c43b99"
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 COPY input.json public_contract.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json

--- a/benchmarks/datasets/conjecture-probes-v1/reconstruction-deck-certificate/tests/verifier.py
+++ b/benchmarks/datasets/conjecture-probes-v1/reconstruction-deck-certificate/tests/verifier.py
@@ -124,13 +124,26 @@ def reward(v):
     (p / "reward.json").write_text(json.dumps(v, sort_keys=True))
 
 
+def _reject_duplicate_object_pairs(pairs):
+    """Reject JSON objects with duplicate member names (last-key-wins is unsafe)."""
+    seen = set()
+    for key, _value in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON object member: {key!r}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def _raw_submission() -> dict[str, Any] | None:
     """Read raw submission JSON before strict validation for false-certification detection."""
     path = Path("/app/submission.json")
     if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
         return None
     try:
-        value = json.loads(path.read_text())
+        value = json.loads(
+            path.read_text(),
+            object_pairs_hook=_reject_duplicate_object_pairs,
+        )
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None

--- a/benchmarks/datasets/conjecture-probes-v1/reconstruction-deck-certificate/tests/verifier.py
+++ b/benchmarks/datasets/conjecture-probes-v1/reconstruction-deck-certificate/tests/verifier.py
@@ -152,15 +152,18 @@ def _raw_submission() -> dict[str, Any] | None:
 def main():
     ib = workspace_input_is_bound()
     data = frozen()
-    s = load_submission(require_input_binding=False)
-    c = strict_submission_contract(
-        s,
-        task_id=TASK_ID,
-        conclusion="FINITE_GRAPH_DECK_RECONSTRUCTION",
-        allowed_assurances=frozenset({"UNVERIFIED", "COMPUTED", "CHECKED"}),
-        verification_record="forbidden",
-    )
     raw = _raw_submission()
+    s = load_submission(require_input_binding=False)
+    c = bool(
+        isinstance(raw, dict)
+        and strict_submission_contract(
+            s,
+            task_id=TASK_ID,
+            conclusion="FINITE_GRAPH_DECK_RECONSTRUCTION",
+            allowed_assurances=frozenset({"UNVERIFIED", "COMPUTED", "CHECKED"}),
+            verification_record="forbidden",
+        )
+    )
     m = bool(
         isinstance(raw, dict)
         and isinstance(data, dict)

--- a/benchmarks/validation/conjecture_probes_v1/test_reconstruction_deck_certificate.py
+++ b/benchmarks/validation/conjecture_probes_v1/test_reconstruction_deck_certificate.py
@@ -227,7 +227,7 @@ def test_duplicate_json_object_member_in_submission_rejected(tmp_path):
     conflicting ``task_id`` values (wrong first, canonical second) would parse
     to the canonical value and earn full reward despite being malformed.
     """
-    app, logs, s = case(tmp_path)
+    app, logs, _ = case(tmp_path)
     raw = (app / "submission.json").read_text()
     duplicate = raw.replace(
         '"task_id": "jacobian/reconstruction-deck-certificate"',

--- a/benchmarks/validation/conjecture_probes_v1/test_reconstruction_deck_certificate.py
+++ b/benchmarks/validation/conjecture_probes_v1/test_reconstruction_deck_certificate.py
@@ -217,3 +217,24 @@ def test_evidence_trailing_garbage_still_rejected(tmp_path):
     (app / "submission.json").write_text(json.dumps(s) + "\n")
     r = run(app, logs)
     assert r["evidence"] == 0.0 and r["aggregate_reward"] == 0.0
+
+
+def test_duplicate_json_object_member_in_submission_rejected(tmp_path):
+    """A duplicate JSON object member must not bypass the raw submission parser.
+
+    Python's default ``json.loads`` applies last-key-wins semantics.  Without
+    an ``object_pairs_hook`` that rejects duplicate names, a submission with
+    conflicting ``task_id`` values (wrong first, canonical second) would parse
+    to the canonical value and earn full reward despite being malformed.
+    """
+    app, logs, s = case(tmp_path)
+    raw = (app / "submission.json").read_text()
+    duplicate = raw.replace(
+        '"task_id": "jacobian/reconstruction-deck-certificate"',
+        '"task_id": "wrong", "task_id": "jacobian/reconstruction-deck-certificate"',
+    )
+    assert duplicate != raw, "replacement target not found in canonical submission"
+    (app / "submission.json").write_text(duplicate)
+    r = run(app, logs)
+    assert r["aggregate_reward"] == 0.0
+    assert r["reward"] == 0.0

--- a/benchmarks/validation/conjecture_probes_v1/test_reconstruction_deck_certificate.py
+++ b/benchmarks/validation/conjecture_probes_v1/test_reconstruction_deck_certificate.py
@@ -236,5 +236,6 @@ def test_duplicate_json_object_member_in_submission_rejected(tmp_path):
     assert duplicate != raw, "replacement target not found in canonical submission"
     (app / "submission.json").write_text(duplicate)
     r = run(app, logs)
+    assert r["protocol"] == 0.0
     assert r["aggregate_reward"] == 0.0
     assert r["reward"] == 0.0


### PR DESCRIPTION
Fixes #770.

The reconstruction-deck raw diagnostic parser now rejects duplicate JSON object names rather than applying last-key-wins semantics.

Regression coverage mutates a canonical submission with conflicting `task_id` entries and asserts zero aggregate reward.

Validation: `test_reconstruction_deck_certificate.py` — 10 passed; checksum label verified.