### PR TITLE
fix(math): parse canonical rationals before backend coercion

### DIFF
--- a/src/jacobian/domains/arithmetic/operations.py
+++ b/src/jacobian/domains/arithmetic/operations.py
@@ -109,7 +109,7 @@ def nth_root(request: IntegerNthRootRequest) -> IntegerNthRootResult:
 
 
 def _fraction(value: CanonicalRational) -> Fraction:
-    return Fraction(int(value.num), int(value.den))
+    return value.as_fraction()
 
 
 def _wire(value: Fraction) -> CanonicalRational:

--- a/src/jacobian/domains/geometry/operations.py
+++ b/src/jacobian/domains/geometry/operations.py
@@ -56,8 +56,8 @@ def _point(value: RationalPoint2D) -> Any:
     from sympy.geometry import Point2D
 
     return Point2D(
-        sympy.Rational(int(value.x.num), int(value.x.den)),
-        sympy.Rational(int(value.y.num), int(value.y.den)),
+        sympy.Rational(value.x.as_fraction()),
+        sympy.Rational(value.y.as_fraction()),
     )
 
 

--- a/src/jacobian/domains/matrix_lattice/operations.py
+++ b/src/jacobian/domains/matrix_lattice/operations.py
@@ -42,7 +42,7 @@ def _qq_matrix(matrix: RationalMatrix) -> Any:
 
     return sympy.Matrix(
         [
-            [sympy.Rational(int(value.num), int(value.den)) for value in row]
+            [sympy.Rational(value.as_fraction()) for value in row]
             for row in matrix.entries
         ]
     )
@@ -190,9 +190,7 @@ def compute_rational_linear_solve(
     import sympy
 
     source = _qq_matrix(request.matrix)
-    rhs = sympy.Matrix(
-        [sympy.Rational(int(value.num), int(value.den)) for value in request.rhs]
-    )
+    rhs = sympy.Matrix([sympy.Rational(value.as_fraction()) for value in request.rhs])
     solution, parameters = source.gauss_jordan_solve(rhs)
     if parameters.rows:
         raise ValueError("linear system does not have a unique solution")

--- a/src/jacobian/domains/optimization/worker.py
+++ b/src/jacobian/domains/optimization/worker.py
@@ -19,7 +19,7 @@ from jacobian.contracts.validated_analysis import RationalLinearProgramRequest
 def _rational(value: CanonicalRational) -> Any:
     import sympy
 
-    return sympy.Rational(int(value.num), int(value.den))
+    return sympy.Rational(value.as_fraction())
 
 
 def _wire(value: Any) -> dict[str, str]:

--- a/src/jacobian/domains/polynomial/elementary_operations.py
+++ b/src/jacobian/domains/polynomial/elementary_operations.py
@@ -197,15 +197,17 @@ def _partial_fraction_term(
 def _partial_fraction_sort_key(
     term: RationalPartialFractionTerm,
 ) -> tuple[tuple[tuple[tuple[int, ...], int, int], ...], int]:
-    factor_terms = tuple(
-        (
-            factor_term.exponents,
-            int(factor_term.coefficient.num),
-            int(factor_term.coefficient.den),
+    factor_terms: list[tuple[tuple[int, ...], int, int]] = []
+    for factor_term in term.denominator_factor.polynomial.terms:
+        coefficient = factor_term.coefficient.as_fraction()
+        factor_terms.append(
+            (
+                factor_term.exponents,
+                coefficient.numerator,
+                coefficient.denominator,
+            )
         )
-        for factor_term in term.denominator_factor.polynomial.terms
-    )
-    return factor_terms, term.denominator_exponent
+    return tuple(factor_terms), term.denominator_exponent
 
 
 def rational_partial_fraction_decomposition(

--- a/src/jacobian/domains/polynomial/jacobian_syzygy.py
+++ b/src/jacobian/domains/polynomial/jacobian_syzygy.py
@@ -172,11 +172,7 @@ def compute_graded_jacobian_syzygy(
         for factor in request.linear_factors:
             source *= Poly(
                 sum(
-                    Rational(
-                        int(coefficient.num),
-                        int(coefficient.den),
-                    )
-                    * generator
+                    Rational(coefficient.as_fraction()) * generator
                     for coefficient, generator in zip(
                         factor.coefficients,
                         generators,

--- a/src/jacobian/domains/polynomial/operations.py
+++ b/src/jacobian/domains/polynomial/operations.py
@@ -47,10 +47,7 @@ def _poly(polynomial: RationalPolynomial) -> Any:
 
     generators = _symbols(polynomial.variables)
     coefficients = {
-        term.exponents: Rational(
-            int(term.coefficient.num),
-            int(term.coefficient.den),
-        )
+        term.exponents: Rational(term.coefficient.as_fraction())
         for term in polynomial.polynomial.terms
     }
     return Poly.from_dict(coefficients, *generators, domain=QQ)

--- a/src/jacobian/domains/probability/operations.py
+++ b/src/jacobian/domains/probability/operations.py
@@ -49,7 +49,8 @@ def _wire(value: Any) -> CanonicalRational:
 def _fmpq(value: CanonicalRational) -> Any:
     from flint import fmpq
 
-    return fmpq(int(value.num), int(value.den))
+    fraction = value.as_fraction()
+    return fmpq(fraction.numerator, fraction.denominator)
 
 
 def _complex_wire(value: tuple[Any, Any]) -> ExactComplexRational:

--- a/src/jacobian/matrices/capabilities.py
+++ b/src/jacobian/matrices/capabilities.py
@@ -316,10 +316,7 @@ def _sympy_matrix(matrix: ExactRationalMatrix) -> Matrix:
     from sympy import Matrix, Rational
 
     return Matrix(
-        [
-            [Rational(int(entry.num), int(entry.den)) for entry in row]
-            for row in matrix.entries
-        ]
+        [[Rational(entry.as_fraction()) for entry in row] for row in matrix.entries]
     )
 
 

--- a/src/jacobian/polynomial_interval_capabilities.py
+++ b/src/jacobian/polynomial_interval_capabilities.py
@@ -701,10 +701,10 @@ def _bernstein_coefficients(
     degree = polynomial.degree
     sp = _sympy.get()
     generator: Symbol = sp.symbols(polynomial.variable)
-    terms = {
-        term.exponents: sp.QQ(int(term.coefficient.num), int(term.coefficient.den))
-        for term in polynomial.polynomial.terms
-    }
+    terms = {}
+    for term in polynomial.polynomial.terms:
+        coefficient = term.coefficient.as_fraction()
+        terms[term.exponents] = sp.QQ(coefficient.numerator, coefficient.denominator)
     source = sp.Poly.from_dict(terms, generator, domain=sp.QQ)
     shifted = sp.Poly(
         sp.expand(source.as_expr().subs(generator, a + width * generator)),

--- a/src/jacobian/polynomial_positivity_capabilities.py
+++ b/src/jacobian/polynomial_positivity_capabilities.py
@@ -746,10 +746,10 @@ def _sturm_positivity(
     b = interval.hi.as_fraction()
     sp = _sympy.get()
     generator: Symbol = sp.symbols(polynomial.variable)
-    terms = {
-        term.exponents: sp.QQ(int(term.coefficient.num), int(term.coefficient.den))
-        for term in polynomial.polynomial.terms
-    }
+    terms = {}
+    for term in polynomial.polynomial.terms:
+        coefficient = term.coefficient.as_fraction()
+        terms[term.exponents] = sp.QQ(coefficient.numerator, coefficient.denominator)
     source = sp.Poly.from_dict(terms, generator, domain=sp.QQ)
     degree = polynomial.degree
     if degree == 0:

--- a/src/jacobian/polynomials/_support.py
+++ b/src/jacobian/polynomials/_support.py
@@ -505,13 +505,10 @@ def _sympy_polynomial(
     generators: tuple[Any, ...],
 ) -> Poly:
     sp = _sympy.get()
-    terms = {
-        term.exponents: sp.QQ(
-            int(term.coefficient.num),
-            int(term.coefficient.den),
-        )
-        for term in polynomial.terms
-    }
+    terms = {}
+    for term in polynomial.terms:
+        coefficient = term.coefficient.as_fraction()
+        terms[term.exponents] = sp.QQ(coefficient.numerator, coefficient.denominator)
     return sp.Poly.from_dict(terms, generators, domain=sp.QQ)
 
 
@@ -540,17 +537,10 @@ def _evaluate(
     sp = _sympy.get()
     try:
         generators, coordinates = _sympy_map(polynomial_map)
-        substitutions = {
-            generator: sp.QQ(
-                int(value.num),
-                int(value.den),
-            )
-            for generator, value in zip(
-                generators,
-                point.values,
-                strict=True,
-            )
-        }
+        substitutions = {}
+        for generator, value in zip(generators, point.values, strict=True):
+            fraction = value.as_fraction()
+            substitutions[generator] = sp.QQ(fraction.numerator, fraction.denominator)
         return tuple(_wire_rational(poly.eval(substitutions)) for poly in coordinates)
     except (
         cast(type[BaseException], sp.PolynomialError),

--- a/src/jacobian/sympy_polynomial_worker.py
+++ b/src/jacobian/sympy_polynomial_worker.py
@@ -36,7 +36,7 @@ def _sympy_expression(
     symbols: dict[str, Any],
 ) -> Any:
     if isinstance(expression, PolynomialRationalExpression):
-        return sympy.Rational(int(expression.value.num), int(expression.value.den))
+        return sympy.Rational(expression.value.as_fraction())
     if isinstance(expression, PolynomialVariableExpression):
         return symbols[expression.name]
     if isinstance(expression, PolynomialAddExpression):

--- a/tests/component/providers/matrix/test_matrix_capabilities.py
+++ b/tests/component/providers/matrix/test_matrix_capabilities.py
@@ -31,6 +31,8 @@ from jacobian.runtime import CheckerAuthorityMode
 from jacobian.runtime.services import CoreServices
 from jacobian.verification import VerificationService
 
+_LARGE_CANONICAL_INTEGER = "1" + ("0" * 4_999) + "1"
+
 
 def _rational(value: int | Fraction) -> dict[str, str]:
     exact = Fraction(value)
@@ -289,6 +291,27 @@ def test_matrix_rank_compute_returns_rectangular_pivot_evidence(
     rank_artifact = runtime.core.store.get(result.output["rank_uri"])
     assert rank_artifact.payload["backend"] == "sympy"
     assert rank_artifact.payload["backend_version"] == sympy.__version__
+
+
+def test_matrix_rank_accepts_contract_sized_rational_entries(
+    matrix_services: _MatrixRuntime,
+) -> None:
+    result = matrix_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="matrix.rank.compute",
+            input={
+                "matrix": {
+                    "matrix_schema_version": "1",
+                    "domain": "QQ",
+                    "entries": [[{"num": _LARGE_CANONICAL_INTEGER, "den": "1"}]],
+                }
+            },
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output["rank"] == 1
+    assert result.output["pivot_columns"] == [0]
 
 
 def test_matrix_determinant_rejects_rectangular_input(

--- a/tests/domain/arithmetic/test_arithmetic_capabilities.py
+++ b/tests/domain/arithmetic/test_arithmetic_capabilities.py
@@ -8,6 +8,8 @@ from jacobian.contracts.capabilities import CapabilityRequest
 from jacobian.contracts.results import ExecutionStatus
 from jacobian.domains.arithmetic import build_arithmetic_bundle
 
+_LARGE_CANONICAL_INTEGER = "1" + ("0" * 4_999) + "1"
+
 
 @pytest.fixture
 def domain_services(tmp_path: Path) -> Iterator[DomainTestServices]:
@@ -49,3 +51,19 @@ def test_arithmetic_capabilities_return_exact_results(
 
     assert result.execution.status is ExecutionStatus.COMPLETED
     assert result.output["result"] == expected
+
+
+def test_rational_difference_accepts_contract_sized_components(
+    domain_services: DomainTestServices,
+) -> None:
+    value = {"num": _LARGE_CANONICAL_INTEGER, "den": "1"}
+
+    result = domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="rational.compute.difference",
+            input={"left": value, "right": value},
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output["result"] == {"value": {"num": "0", "den": "1"}}

--- a/tests/domain/geometry/test_geometry_capabilities.py
+++ b/tests/domain/geometry/test_geometry_capabilities.py
@@ -22,6 +22,7 @@ P0 = {"x": ZERO, "y": ZERO}
 PX = {"x": TWO, "y": ZERO}
 PY = {"x": ZERO, "y": TWO}
 PXY = {"x": TWO, "y": TWO}
+LARGE_CANONICAL_INTEGER = "1" + ("0" * 4_999) + "1"
 
 
 def _point(x: int, y: int) -> dict[str, dict[str, str]]:
@@ -98,6 +99,21 @@ def test_geometry_exact_outputs_are_inline(domain_services) -> None:
     }
     assert distance.artifact_uris == ()
     assert circle.artifact_uris == ()
+
+
+def test_squared_distance_accepts_contract_sized_coordinates(domain_services) -> None:
+    coordinate = {"num": LARGE_CANONICAL_INTEGER, "den": "1"}
+    point = {"x": coordinate, "y": ZERO}
+
+    result = domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="geometry.points.compute.squared_distance",
+            input={"first": point, "second": point},
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output["result"] == {"value": ZERO}
 
 
 def test_convex_hull_returns_segment_endpoints_for_two_points(

--- a/tests/unit/tooling/test_architecture_canonical_conversions.py
+++ b/tests/unit/tooling/test_architecture_canonical_conversions.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools.check_architecture import check_architecture
+
+
+def _write_source(
+    root: Path,
+    source: str,
+    relative: str = "src/jacobian/adapter.py",
+) -> None:
+    path = root / relative
+    path.parent.mkdir(parents=True)
+    path.write_text(source, encoding="utf-8")
+
+
+def test_architecture_rejects_direct_canonical_rational_text_conversions(
+    tmp_path: Path,
+) -> None:
+    source = (
+        "def convert(value):\n"
+        "    numerator = int(value.num)\n"
+        "    denominator = int(value.den, 10)\n"
+        "    text = str(value.num)\n"
+        "    return numerator, denominator, text\n"
+    )
+    _write_source(tmp_path, source)
+    _write_source(tmp_path, source, "src/jacobian_checkers/checker.py")
+
+    violations = [
+        violation
+        for violation in check_architecture(tmp_path).violations
+        if violation.code == "unsafe-canonical-conversion"
+    ]
+
+    assert len(violations) == 6
+    assert {violation.line for violation in violations} == {2, 3, 4}
+    assert {violation.path for violation in violations} == {
+        "src/jacobian/adapter.py",
+        "src/jacobian_checkers/checker.py",
+    }
+    assert all("canonical conversion API" in item.message for item in violations)
+
+
+def test_architecture_accepts_canonical_conversion_api(tmp_path: Path) -> None:
+    _write_source(
+        tmp_path,
+        "def convert(value):\n"
+        "    fraction = value.as_fraction()\n"
+        "    return fraction.numerator, fraction.denominator\n",
+    )
+
+    report = check_architecture(tmp_path)
+
+    assert all(
+        violation.code != "unsafe-canonical-conversion"
+        for violation in report.violations
+    )

--- a/tests/unit/tooling/test_eval_telemetry.py
+++ b/tests/unit/tooling/test_eval_telemetry.py
@@ -429,7 +429,9 @@ def test_agent_telemetry_tracks_resource_link_follow_through_and_identity(
     assert telemetry["mcp_resource_digest_preservation_successes"] == 2
 
 
-def test_agent_telemetry_handles_non_hashable_resource_tool_field(tmp_path: Path) -> None:
+def test_agent_telemetry_handles_non_hashable_resource_tool_field(
+    tmp_path: Path,
+) -> None:
     uri = "artifact://sha256/" + ("f" * 64)
     malformed_tool_event = {
         "type": "item.completed",

--- a/tools/check_architecture.py
+++ b/tools/check_architecture.py
@@ -1,7 +1,7 @@
 """Static architecture enforcement for product source boundaries.
 
 This checker is an AST/filesystem tool that does not import the Jacobian
-runtime.  It enforces six PR10 invariants:
+runtime.  It enforces seven PR10 invariants:
 
 1. **subprocess-confined**: direct ``subprocess`` usage and ``os.execvpe``/
    ``os.execvp`` are allowed only in ``bounded_process.py``,
@@ -21,12 +21,16 @@ runtime.  It enforces six PR10 invariants:
    environment (``dict(os.environ)``, ``os.environ.copy()``, ``**os.environ``)
    into child-process calls.  Selective ``os.environ.get`` access is fine.
 
-5. **public-contract-drift**: every canonical benchmark task in a dataset with
+5. **unsafe-canonical-conversion**: product code must use canonical conversion
+   APIs instead of applying ``int()`` or ``str()`` directly to rational
+   ``.num`` and ``.den`` wire components.
+
+6. **public-contract-drift**: every canonical benchmark task in a dataset with
    public contracts must have a ``public_contract.json`` and its projection must
    match the rendered ``submission_schema.json`` and ``instruction.md``.  A
    missing contract is a violation, not a skip.
 
-6. **unsupported-surface**: removed experimental memory/search identifiers must
+7. **unsupported-surface**: removed experimental memory/search identifiers must
    not appear in supported product source, tests, schemas, catalog, or docs.
 
 The checker excludes ``wt-438/`` and generated directories from all scans.
@@ -685,7 +689,46 @@ def _environ_spread_violations(
 
 
 # ---------------------------------------------------------------------------
-# Check 5: public-contract drift (missing contract is a violation)
+# Check 5: canonical wire values must cross the canonical conversion API
+# ---------------------------------------------------------------------------
+
+
+def _unsafe_canonical_conversion_violations(
+    relative: PurePosixPath, tree: ast.AST
+) -> tuple[Violation, ...]:
+    if not any(
+        _is_under(relative, root)
+        for root in (
+            PurePosixPath("src/jacobian"),
+            PurePosixPath("src/jacobian_checkers"),
+        )
+    ):
+        return ()
+    violations: list[Violation] = []
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id in {"int", "str"}
+            and node.args
+            and isinstance(node.args[0], ast.Attribute)
+            and node.args[0].attr in {"num", "den"}
+        ):
+            violations.append(
+                Violation(
+                    str(relative),
+                    "unsafe-canonical-conversion",
+                    f"{node.func.id}() must not consume canonical rational "
+                    f".{node.args[0].attr} wire text directly; use the canonical "
+                    "conversion API",
+                    node.lineno,
+                )
+            )
+    return tuple(violations)
+
+
+# ---------------------------------------------------------------------------
+# Check 6: public-contract drift (missing contract is a violation)
 # ---------------------------------------------------------------------------
 
 
@@ -733,7 +776,7 @@ def _public_contract_drift_violations(root: Path) -> tuple[Violation, ...]:
 
 
 # ---------------------------------------------------------------------------
-# Check 6: unsupported surfaces (Python AST + text scan)
+# Check 7: unsupported surfaces (Python AST + text scan)
 # ---------------------------------------------------------------------------
 
 
@@ -873,6 +916,7 @@ def _check_python_file(root: Path, path: Path) -> tuple[Violation, ...]:
     violations.extend(_run_bounded_process_violations(relative, tree))
     violations.extend(_shutil_which_violations(relative, tree))
     violations.extend(_environ_spread_violations(relative, tree))
+    violations.extend(_unsafe_canonical_conversion_violations(relative, tree))
     violations.extend(_unsupported_surface_ast_violations(relative, tree))
     return tuple(violations)
 
@@ -882,10 +926,11 @@ def check_architecture(root: Path | str = ROOT) -> ArchitectureReport:
 
     Scans all non-excluded Python files for subprocess confinement,
     run_bounded_process gateway confinement, shutil.which resolver
-    confinement, os.environ spreading, and unsupported experimental
-    surfaces.  Scans non-Python text files (docs, schemas, catalog) for
-    unsupported surfaces.  Additionally checks every public-contract dataset's
-    task projection for drift (missing contracts are violations).
+    confinement, os.environ spreading, unsafe canonical-rational conversions,
+    and unsupported experimental surfaces.  Scans non-Python text files (docs,
+    schemas, catalog) for unsupported surfaces.  Additionally checks every
+    public-contract dataset's task projection for drift (missing contracts are
+    violations).
     """
     project_root = Path(root).resolve()
     py_files = _python_files(project_root)


### PR DESCRIPTION
## Problem

Several exact-math adapters called `int(value.num)` and `int(value.den)` directly on `CanonicalRational` wire strings. Python 3.11+ rejects decimal-to-integer conversions above 4,300 digits by default, while `CanonicalRational` permits up to 32,768 digits.

On untouched current main, valid 5,001-digit inputs fail with the same conversion `ValueError` in three public, currently reachable paths:

- `rational.compute.difference`
- `geometry.points.compute.squared_distance`
- `matrix.rank.compute`

Other affected adapters currently have tighter public digit budgets, but used the same unsafe coercion internally.

Fixes #755.

## Solution

Route every canonical-rational backend conversion through `CanonicalRational.as_fraction()`, which uses the repository's chunked canonical integer parser. SymPy `Rational` consumes the resulting `Fraction` directly; SymPy `QQ` and python-flint `fmpq` receive its already-parsed numerator and denominator.

This removes all 21 direct `int(.num/.den)` sites across arithmetic, geometry, matrices, polynomials, optimization, probability, and subprocess workers.

A new AST architecture rule rejects direct `int()` or `str()` calls on canonical rational `.num`/`.den` components in product and checker source, including explicit-base calls such as `int(value.num, 10)`.

## Testing

The three 5,001-digit regressions fail on current main for the intended Python conversion-limit reason and pass with this change.

```sh
make test-plan BASE=origin/main
uv run --locked pytest <nine owning arithmetic/geometry/matrix/polynomial/probability/worker files> --durations=10
make test-unit test-component test-domain test-composition test-storage test-process test-mcp test-e2e
uv run --locked pytest tests/unit/tooling/test_architecture_canonical_conversions.py -q
uv run --locked ruff check <changed paths>
uv run --locked ruff format --check <changed paths>
uv run --locked deptry .
uv run --locked vulture src tests --min-confidence=80
uv run --locked mypy
make complexity-check architecture test-architecture build
```

The owning selection passed 96 tests. The planner-selected semantic gate passed 728 unit, 725 component, 164 domain, 468 composition, 122 storage, 232 process, 39 MCP, and 8 e2e tests; the three skips are the expected unavailable-Lean cases.

All patch-owned static and build gates pass. Full `make check-static` reaches formatting and reports only the pre-existing untouched formatting defect in `tests/unit/tooling/test_eval_telemetry.py`.

## Trust & Compatibility Impact

This changes only conversion from canonical wire values into maintained backend-native exact rationals. Contracts, public result shapes, artifact formats, assurance, checker authority, and ordinary small-rational behavior remain unchanged. The new architecture rule enforces the repository's canonical conversion boundary.

## Checklist

- [ ] Routine local validation passes (`make check`) — blocked only by the upstream formatting defect noted above
- [x] Relevant focused tests are listed above
