### PR TITLE
ci(lean): publish pinned Lean evaluation images

### DIFF
--- a/.github/workflows/lean-images.yml
+++ b/.github/workflows/lean-images.yml
@@ -1,0 +1,145 @@
+name: Lean Evaluation Images
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "containers/lean-checker/**"
+      - "containers/lean-repl-agent/**"
+      - ".github/workflows/lean-images.yml"
+  push:
+    branches: [main]
+    paths:
+      - "containers/lean-checker/**"
+      - "containers/lean-repl-agent/**"
+      - ".github/workflows/lean-images.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: lean-images-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+env:
+  REGISTRY: ghcr.io
+  PLATFORM: linux/amd64
+
+jobs:
+  build-pr:
+    name: Build ${{ matrix.image }}
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [jacobian-lean-checker, jacobian-lean-repl-agent]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+      - name: Build and load image for measurement
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          file: containers/${{ matrix.image }}/Dockerfile
+          platforms: ${{ env.PLATFORM }}
+          load: true
+          push: false
+          tags: local/${{ matrix.image }}:${{ github.sha }}
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}
+      - name: Record unpacked image size
+        env:
+          IMAGE: local/${{ matrix.image }}:${{ github.sha }}
+        run: |
+          bytes=$(docker image inspect "$IMAGE" --format '{{.Size}}')
+          jq -n \
+            --arg image "$IMAGE" \
+            --arg source_sha "$GITHUB_SHA" \
+            --arg platform "$PLATFORM" \
+            --argjson unpacked_size_bytes "$bytes" \
+            '{image: $image, source_sha: $source_sha, platform: $platform, unpacked_size_bytes: $unpacked_size_bytes}' \
+            | tee "$RUNNER_TEMP/${{ matrix.image }}-size.json" \
+            >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload size evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ matrix.image }}-size-${{ github.sha }}
+          path: ${{ runner.temp }}/${{ matrix.image }}-size.json
+          if-no-files-found: error
+          retention-days: 90
+
+  publish:
+    name: Publish ${{ matrix.image }}
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [jacobian-lean-checker, jacobian-lean-repl-agent]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}
+          tags: |
+            type=raw,value=sha-${{ github.sha }}
+            type=raw,value=main
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            io.jacobian.source-dirty=false
+      - id: build
+        name: Build and publish
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          file: containers/${{ matrix.image }}/Dockerfile
+          platforms: ${{ env.PLATFORM }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}
+          provenance: mode=max
+          sbom: true
+      - name: Record digest and unpacked size
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          docker pull "$IMAGE@$DIGEST"
+          size=$(docker image inspect "$IMAGE@$DIGEST" --format '{{.Size}}')
+          jq -n \
+            --arg source_sha "$GITHUB_SHA" \
+            --arg image "$IMAGE@$DIGEST" \
+            --arg image_digest "$DIGEST" \
+            --arg platform "$PLATFORM" \
+            --argjson unpacked_size_bytes "$size" \
+            '{source_sha: $source_sha, image: $image, image_digest: $image_digest, platform: $platform, unpacked_size_bytes: $unpacked_size_bytes}' \
+            | tee "$RUNNER_TEMP/${{ matrix.image }}-publication.json" \
+            >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload publication evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ matrix.image }}-publication-${{ github.sha }}
+          path: ${{ runner.temp }}/${{ matrix.image }}-publication.json
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/lean-images.yml
+++ b/.github/workflows/lean-images.yml
@@ -35,7 +35,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [jacobian-lean-checker, jacobian-lean-repl-agent]
+        include:
+          - image: jacobian-lean-checker
+            directory: lean-checker
+          - image: jacobian-lean-repl-agent
+            directory: lean-repl-agent
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -45,7 +49,7 @@ jobs:
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
-          file: containers/${{ matrix.image }}/Dockerfile
+          file: containers/${{ matrix.directory }}/Dockerfile
           platforms: ${{ env.PLATFORM }}
           load: true
           push: false
@@ -84,7 +88,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [jacobian-lean-checker, jacobian-lean-repl-agent]
+        include:
+          - image: jacobian-lean-checker
+            directory: lean-checker
+          - image: jacobian-lean-repl-agent
+            directory: lean-repl-agent
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -111,7 +119,7 @@ jobs:
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
-          file: containers/${{ matrix.image }}/Dockerfile
+          file: containers/${{ matrix.directory }}/Dockerfile
           platforms: ${{ env.PLATFORM }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/lean-images.yml
+++ b/.github/workflows/lean-images.yml
@@ -29,7 +29,7 @@ env:
 jobs:
   build-pr:
     name: Build ${{ matrix.image }}
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:

--- a/containers/README.md
+++ b/containers/README.md
@@ -1,0 +1,20 @@
+# Reusable evaluation runtimes
+
+These images separate an agent/provider's exploratory toolchain from a
+verifier's authority to replay a submitted mathematical artifact.
+
+| Image | Purpose | Must not contain |
+| --- | --- | --- |
+| `jacobian-lean-checker` | Compile and inspect submitted Lean source in a clean verifier. | Task solution, task-specific expected output, or the REPL. |
+| `jacobian-lean-repl-agent` | Run the pinned Lean REPL for provider-feasibility and agent environments. | Authority to certify a report as independently verified. |
+
+The release workflow publishes both images to GHCR after a trusted `main` push.
+It emits immutable commit tags, an OCI digest, SBOM, provenance, and a size
+receipt. A Harbor task must pin the resulting `@sha256:` reference in its
+environment profile or task Dockerfile. Tags are discovery conveniences, not
+evaluation identity.
+
+The checker image is intentionally Lean-only. A future task that genuinely
+requires Mathlib must use a separately measured and published runtime; adding
+Mathlib to this base would impose its multi-gigabyte footprint on every Lean
+source replay.

--- a/containers/lean-checker/Dockerfile
+++ b/containers/lean-checker/Dockerfile
@@ -1,0 +1,36 @@
+#
+# A deliberately small trusted runtime for Harbor verifiers that replay Lean
+# source. It contains Lean's kernel/compiler, but neither task material nor an
+# agent-facing REPL. Tasks must consume a published digest, never a tag.
+FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
+
+ARG LEAN_VERSION=4.31.0
+ARG LEAN_ARCHIVE_SHA256=07a633cc8d9151cbc08825ea4cdda50d4b02a2c9cb852c0131b13046f49cad7f
+
+LABEL org.opencontainers.image.source=https://github.com/morluto/jacobian
+LABEL org.opencontainers.image.description="Pinned Lean compiler for independent Jacobian verifier replay"
+LABEL io.jacobian.lean.version=${LEAN_VERSION}
+LABEL io.jacobian.lean.archive-sha256=${LEAN_ARCHIVE_SHA256}
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl libgmp10 zstd \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /opt/lean \
+    && curl -fsSL "https://github.com/leanprover/lean4/releases/download/v${LEAN_VERSION}/lean-${LEAN_VERSION}-linux.tar.zst" \
+      -o /opt/lean/lean.tar.zst \
+    && printf '%s  %s\n' "$LEAN_ARCHIVE_SHA256" /opt/lean/lean.tar.zst | sha256sum -c - \
+    && tar --use-compress-program=unzstd -xf /opt/lean/lean.tar.zst -C /opt/lean \
+    && rm /opt/lean/lean.tar.zst \
+    && /opt/lean/lean-${LEAN_VERSION}-linux/bin/lean --version \
+    && python -m pip install --no-cache-dir \
+      attrs==26.1.0 \
+      jsonschema==4.26.0 \
+      jsonschema-specifications==2025.9.1 \
+      referencing==0.37.0 \
+      rpds-py==2026.6.3 \
+      typing-extensions==4.16.0
+
+ENV PATH=/opt/lean/lean-4.31.0-linux/bin:$PATH
+ENV PYTHONDONTWRITEBYTECODE=1
+
+WORKDIR /app

--- a/containers/lean-repl-agent/Dockerfile
+++ b/containers/lean-repl-agent/Dockerfile
@@ -1,0 +1,36 @@
+#
+# This is an agent/provider runtime. It intentionally remains distinct from
+# lean-checker: REPL telemetry is not independent verification evidence.
+FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
+
+ARG LEAN_VERSION=4.31.0
+ARG LEAN_ARCHIVE_SHA256=07a633cc8d9151cbc08825ea4cdda50d4b02a2c9cb852c0131b13046f49cad7f
+ARG LEAN_REPL_REVISION=0cc60263319308000bbaa5354427f775fe3dc7d0
+
+LABEL org.opencontainers.image.source=https://github.com/morluto/jacobian
+LABEL org.opencontainers.image.description="Pinned Lean REPL runtime for Jacobian provider-feasibility tasks"
+LABEL io.jacobian.lean.version=${LEAN_VERSION}
+LABEL io.jacobian.lean.archive-sha256=${LEAN_ARCHIVE_SHA256}
+LABEL io.jacobian.lean-repl.revision=${LEAN_REPL_REVISION}
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl git libgmp10 zstd \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /opt/provider \
+    && curl -fsSL "https://github.com/leanprover/lean4/releases/download/v${LEAN_VERSION}/lean-${LEAN_VERSION}-linux.tar.zst" \
+      -o /opt/provider/lean.tar.zst \
+    && printf '%s  %s\n' "$LEAN_ARCHIVE_SHA256" /opt/provider/lean.tar.zst | sha256sum -c - \
+    && tar --use-compress-program=unzstd -xf /opt/provider/lean.tar.zst -C /opt/provider \
+    && rm /opt/provider/lean.tar.zst \
+    && git init /opt/provider/repl \
+    && git -C /opt/provider/repl remote add origin https://github.com/leanprover-community/repl.git \
+    && git -C /opt/provider/repl fetch --depth 1 origin "$LEAN_REPL_REVISION" \
+    && git -C /opt/provider/repl checkout --detach FETCH_HEAD \
+    && PATH=/opt/provider/lean-${LEAN_VERSION}-linux/bin:$PATH lake -d /opt/provider/repl build \
+    && /opt/provider/lean-${LEAN_VERSION}-linux/bin/lean --version
+
+ENV PATH=/opt/provider/lean-4.31.0-linux/bin:$PATH
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONPATH=/opt
+
+WORKDIR /app

--- a/docs/explanation/prebuilt-agent-environment-direction.md
+++ b/docs/explanation/prebuilt-agent-environment-direction.md
@@ -25,6 +25,13 @@ Jacobian tooling
   └─ records agent-image digest and MCP-server identity in observation evidence
 ```
 
+Formal-provider tasks use the same identity discipline but a different trust
+boundary: the agent image may carry an exploratory provider, while a separate
+digest-pinned checker image replays the submitted source artifact. A successful
+provider trace alone remains diagnostic evidence, not independent verification.
+The maintained Lean bases and their publication evidence are documented in
+[benchmark contracts](../reference/evaluations/benchmark-contracts.md#reusable-evaluation-images).
+
 ## Repository hooks (current)
 
 - Task environments resolve through

--- a/docs/how-to/author-harbor-benchmark-task.md
+++ b/docs/how-to/author-harbor-benchmark-task.md
@@ -26,6 +26,9 @@ task input and schemas; they do not run `apt-get`. Provider-specific tasks may
 install the dependencies that define that provider experiment. Use Harbor's
 native `public`, `no-network`, or `allowlist` task network policy. Proxy-backed
 operation belongs in the Harbor job composition and does not select an image.
+For a shared checker or provider runtime, keep the agent and verifier images
+separate and pin the published `@sha256:` reference; see
+[reusable evaluation images](../reference/evaluations/benchmark-contracts.md#reusable-evaluation-images).
 
 Run `make harbor-plan BASE=origin/main`, inspect the prospective digest and
 exact changed-task lane, then validate and Oracle only the task being authored:

--- a/docs/reference/evaluations/benchmark-contracts.md
+++ b/docs/reference/evaluations/benchmark-contracts.md
@@ -48,6 +48,33 @@ digest-bound evidence, optional verification record, and limitations. Unknown
 fields fail closed. Task-specific schemas may narrow the result but cannot
 weaken the envelope.
 
+### Reusable evaluation images
+
+Use a shared image only when its toolchain is part of the task's reproducible
+runtime. The image digest, platform, toolchain version, and task digest together
+identify the executable evaluation; a tag is only a human-facing discovery
+label. Task Dockerfiles and environment profiles therefore use
+`name@sha256:<digest>`, never `main`, a version tag, or an unpinned base.
+
+Keep agent/provider images separate from verifier images. An agent image may
+contain an exploratory service such as Lean REPL. A verifier image contains
+only the independently needed checker and its pinned dependencies, then
+replays a submitted artifact. Provider telemetry, tactic traces, and a
+successful agent-side process are useful diagnostics but do not authorize a
+mathematical conclusion.
+
+The controlled `main`-only image workflow publishes the reusable Lean bases:
+
+- `ghcr.io/morluto/jacobian-lean-checker` for Lean-source replay; and
+- `ghcr.io/morluto/jacobian-lean-repl-agent` for the pinned provider runtime.
+
+Publication records the immutable image digest, source revision, platform,
+SBOM/provenance attestations, and unpacked image size. Measure runtime writable
+storage separately in the actual Harbor runner before setting `storage_mb`:
+image-layer size and writable-layer accounting are different quantities. Update
+an image pin only in a deliberate task-contract change, recompute prospective
+task digests, and rerun the selected Oracle.
+
 ## Task and verifier validation
 
 Task and verifier validation is separate from model observation. For an

--- a/tests/unit/tooling/test_eval_telemetry.py
+++ b/tests/unit/tooling/test_eval_telemetry.py
@@ -429,7 +429,9 @@ def test_agent_telemetry_tracks_resource_link_follow_through_and_identity(
     assert telemetry["mcp_resource_digest_preservation_successes"] == 2
 
 
-def test_agent_telemetry_handles_non_hashable_resource_tool_field(tmp_path: Path) -> None:
+def test_agent_telemetry_handles_non_hashable_resource_tool_field(
+    tmp_path: Path,
+) -> None:
     uri = "artifact://sha256/" + ("f" * 64)
     malformed_tool_event = {
         "type": "item.completed",


### PR DESCRIPTION
## Summary

Adds two reusable OCI runtimes for Harbor evaluations:

- `jacobian-lean-checker` contains the pinned Lean compiler and verifier dependencies for independent source replay.
- `jacobian-lean-repl-agent` contains the pinned Lean REPL provider runtime for agent and feasibility environments.

They are intentionally separate: a successful REPL trace is diagnostic telemetry, while a checker must replay a submitted artifact.

A trusted `main`-only workflow publishes both to GHCR, records an immutable digest and unpacked-size receipt, and requests SBOM and provenance attestations. PRs build both images without publishing. The evaluation docs now define digest pinning, the authority boundary, and the need to measure Harbor writable storage separately from image layers.

This is the publication foundation for #764. A follow-up will consume the published checker digest in the Lean Harbor task and replace report-only acceptance with proof-source replay.

## Validation

- `uv run pre-commit run actionlint --files .github/workflows/lean-images.yml` — passed
- `make docs-linkcheck` — passed
- `make check-static` — blocked by an existing formatting failure in `tests/unit/tooling/test_eval_telemetry.py` on `origin/main`
- Local Docker build — blocked because this host could not reach Docker Hub for the digest-pinned Python parent image; the new PR build matrix exercises that exact build and records its size.

## Review order

1. `containers/lean-checker/Dockerfile` and `containers/lean-repl-agent/Dockerfile`
2. `.github/workflows/lean-images.yml`
3. Evaluation-contract documentation