### PR TITLE
fix(ci): format eval telemetry test signature

### DIFF
--- a/tests/unit/tooling/test_eval_telemetry.py
+++ b/tests/unit/tooling/test_eval_telemetry.py
@@ -429,7 +429,9 @@ def test_agent_telemetry_tracks_resource_link_follow_through_and_identity(
     assert telemetry["mcp_resource_digest_preservation_successes"] == 2
 
 
-def test_agent_telemetry_handles_non_hashable_resource_tool_field(tmp_path: Path) -> None:
+def test_agent_telemetry_handles_non_hashable_resource_tool_field(
+    tmp_path: Path,
+) -> None:
     uri = "artifact://sha256/" + ("f" * 64)
     malformed_tool_event = {
         "type": "item.completed",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`tests/unit/tooling/test_eval_telemetry.py` has an unformatted long function signature from #708. That fails `ruff format --check` on main and infected unrelated PRs (#775, #765, #763).

## Solution

Wrap the signature to satisfy Ruff format.

## Testing

```sh
uv run --locked ruff format --check tests/unit/tooling/test_eval_telemetry.py
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c16b6b58-fe4a-4f1c-affa-24176963e36f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c16b6b58-fe4a-4f1c-affa-24176963e36f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

