### PR TITLE
fix(math): format canonical rational results beyond Python's digit limit

### DIFF
--- a/src/jacobian/domains/arithmetic/operations.py
+++ b/src/jacobian/domains/arithmetic/operations.py
@@ -16,6 +16,7 @@ import math
 from fractions import Fraction
 from typing import Literal
 
+from jacobian.canonical import format_canonical_integer
 from jacobian.contracts.arithmetic import (
     IntegerBaseDigitsRequest,
     IntegerBaseDigitsResult,
@@ -114,8 +115,8 @@ def _fraction(value: CanonicalRational) -> Fraction:
 
 def _wire(value: Fraction) -> CanonicalRational:
     return CanonicalRational(
-        num=str(value.numerator),
-        den=str(value.denominator),
+        num=format_canonical_integer(value.numerator),
+        den=format_canonical_integer(value.denominator),
     )
 
 

--- a/src/jacobian/domains/combinatorics/operations.py
+++ b/src/jacobian/domains/combinatorics/operations.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from functools import reduce
 from operator import mul
 
+from jacobian.canonical import format_canonical_integer
 from jacobian.contracts.combinatorics import (
     FibonacciPairRequest,
     FibonacciPairResult,
@@ -168,7 +169,10 @@ def bernoulli(request: NonnegativeIntegerRequest) -> RationalResult:
     n = request.n
     value = sympy.bernoulli(n)
     return RationalResult(
-        value=CanonicalRational(num=str(value.p), den=str(value.q)),
+        value=CanonicalRational(
+            num=format_canonical_integer(int(value.p)),
+            den=format_canonical_integer(int(value.q)),
+        ),
     )
 
 

--- a/src/jacobian/domains/geometry/operations.py
+++ b/src/jacobian/domains/geometry/operations.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from fractions import Fraction
 from typing import Any, cast
 
+from jacobian.canonical import format_canonical_integer
 from jacobian.contracts.exact import CanonicalRational
 from jacobian.contracts.geometry import (
     ClosedSegment2D,
@@ -46,8 +47,8 @@ def _fraction(value: Any) -> Fraction:
 def _wire_rational(value: Any) -> CanonicalRational:
     fraction = _fraction(value)
     return CanonicalRational(
-        num=str(fraction.numerator),
-        den=str(fraction.denominator),
+        num=format_canonical_integer(fraction.numerator),
+        den=format_canonical_integer(fraction.denominator),
     )
 
 

--- a/src/jacobian/domains/graph_optimization/minimum_spanning_tree.py
+++ b/src/jacobian/domains/graph_optimization/minimum_spanning_tree.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from fractions import Fraction
 from typing import TYPE_CHECKING
 
+from jacobian.canonical import format_canonical_integer
 from jacobian.contracts.capabilities import (
     CapabilityDiagnostic,
     CapabilityInvocationExample,
@@ -43,7 +44,10 @@ _INVALID_REQUEST = CapabilityDiagnostic(
 
 
 def _rational(value: Fraction) -> CanonicalRational:
-    return CanonicalRational(num=str(value.numerator), den=str(value.denominator))
+    return CanonicalRational(
+        num=format_canonical_integer(value.numerator),
+        den=format_canonical_integer(value.denominator),
+    )
 
 
 def _canonical_endpoints(left: str, right: str) -> tuple[str, str]:

--- a/src/jacobian/domains/matrix_lattice/operations.py
+++ b/src/jacobian/domains/matrix_lattice/operations.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from fractions import Fraction
 from typing import Any
 
+from jacobian.canonical import format_canonical_integer
 from jacobian.contracts.matrix_operations import (
     CharacteristicPolynomialResult,
     IntegerMatrixRequest,
@@ -32,8 +33,8 @@ from jacobian.math import matrices as native_matrices
 def _rational(value: Any) -> OutputRational:
     fraction = Fraction(value)
     return OutputRational(
-        num=str(fraction.numerator),
-        den=str(fraction.denominator),
+        num=format_canonical_integer(fraction.numerator),
+        den=format_canonical_integer(fraction.denominator),
     )
 
 

--- a/src/jacobian/domains/optimization/worker.py
+++ b/src/jacobian/domains/optimization/worker.py
@@ -10,6 +10,7 @@ from pydantic import ValidationError
 from jacobian.canonical import (
     CanonicalizationError,
     canonicalize_json,
+    format_canonical_integer,
     loads_strict_json,
 )
 from jacobian.contracts.exact import CanonicalRational
@@ -26,7 +27,10 @@ def _wire(value: Any) -> dict[str, str]:
     import sympy
 
     rational = sympy.Rational(value)
-    return {"num": str(rational.p), "den": str(rational.q)}
+    return {
+        "num": format_canonical_integer(int(rational.p)),
+        "den": format_canonical_integer(int(rational.q)),
+    }
 
 
 def _linear_program(request: RationalLinearProgramRequest) -> dict[str, Any]:

--- a/src/jacobian/domains/polynomial/jacobian_syzygy.py
+++ b/src/jacobian/domains/polynomial/jacobian_syzygy.py
@@ -7,7 +7,7 @@ from fractions import Fraction
 from math import gcd
 from typing import Any, Literal, cast
 
-from jacobian.canonical import canonicalize_json
+from jacobian.canonical import canonicalize_json, format_canonical_integer
 from jacobian.contracts.capabilities import (
     CapabilityInvocationExample,
     CapabilityMode,
@@ -40,7 +40,10 @@ def _homogeneous_basis(degree: int) -> tuple[tuple[int, int, int], ...]:
 
 def _fraction_text(value: Any) -> str:
     fraction = Fraction(value)
-    return f"{fraction.numerator}/{fraction.denominator}"
+    return (
+        f"{format_canonical_integer(fraction.numerator)}/"
+        f"{format_canonical_integer(fraction.denominator)}"
+    )
 
 
 def _matrix_digest(
@@ -97,8 +100,8 @@ def _multiplier_polynomial(
             terms=tuple(
                 RationalPolynomialTerm(
                     coefficient=CanonicalRational(
-                        num=str(coefficient.numerator),
-                        den=str(coefficient.denominator),
+                        num=format_canonical_integer(coefficient.numerator),
+                        den=format_canonical_integer(coefficient.denominator),
                     ),
                     exponents=exponents,
                 )
@@ -271,8 +274,8 @@ def compute_graded_jacobian_syzygy(
                 multiplier_degree=multiplier_degree,
                 coefficient_vector=tuple(
                     CanonicalRational(
-                        num=str(value.numerator),
-                        den=str(value.denominator),
+                        num=format_canonical_integer(value.numerator),
+                        den=format_canonical_integer(value.denominator),
                     )
                     for value in vector
                 ),

--- a/src/jacobian/domains/polynomial/operations.py
+++ b/src/jacobian/domains/polynomial/operations.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from fractions import Fraction
 from typing import Any
 
+from jacobian.canonical import format_canonical_integer
 from jacobian.contracts.exact import CanonicalRational
 from jacobian.contracts.polynomial_operations import (
     PolynomialBezoutIdentity,
@@ -58,7 +59,10 @@ def _poly(polynomial: RationalPolynomial) -> Any:
 
 def _rational(value: Any) -> CanonicalRational:
     fraction = Fraction(value)
-    return CanonicalRational(num=str(fraction.numerator), den=str(fraction.denominator))
+    return CanonicalRational(
+        num=format_canonical_integer(fraction.numerator),
+        den=format_canonical_integer(fraction.denominator),
+    )
 
 
 def _wire(poly: Any, variables: tuple[str, ...]) -> RationalPolynomial:

--- a/src/jacobian/domains/polynomial_nullstellensatz/singular.py
+++ b/src/jacobian/domains/polynomial_nullstellensatz/singular.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from pydantic import ValidationError
 
-from jacobian.canonical import canonicalize_json
+from jacobian.canonical import canonicalize_json, format_canonical_integer
 from jacobian.capability_service import CapabilityInvocationError
 from jacobian.contracts.capabilities import (
     CapabilityAssurance,
@@ -125,7 +125,10 @@ def _parse_coefficient(value: str) -> CanonicalRational:
     if _INTEGER_OR_RATIONAL.fullmatch(value) is None:
         raise ValueError("Singular returned a non-rational coefficient")
     parsed = Fraction(value)
-    return CanonicalRational(num=str(parsed.numerator), den=str(parsed.denominator))
+    return CanonicalRational(
+        num=format_canonical_integer(parsed.numerator),
+        den=format_canonical_integer(parsed.denominator),
+    )
 
 
 class _TaggedOutputParser:

--- a/src/jacobian/domains/polynomial_nullstellensatz/system.py
+++ b/src/jacobian/domains/polynomial_nullstellensatz/system.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 from fractions import Fraction
 from typing import Literal
 
+from jacobian.canonical import format_canonical_integer
 from jacobian.contracts.exact import CanonicalRational
 from jacobian.contracts.nullstellensatz import (
     BoundedRationalPolynomial,
@@ -57,8 +58,8 @@ def _polynomial(
         terms=tuple(
             BoundedRationalPolynomialTerm(
                 coefficient=CanonicalRational(
-                    num=str(coefficient.numerator),
-                    den=str(coefficient.denominator),
+                    num=format_canonical_integer(coefficient.numerator),
+                    den=format_canonical_integer(coefficient.denominator),
                 ),
                 exponents=exponent,
             )

--- a/src/jacobian/domains/probability/operations.py
+++ b/src/jacobian/domains/probability/operations.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from fractions import Fraction
 from typing import Any
 
+from jacobian.canonical import format_canonical_integer
 from jacobian.contracts.capabilities import CapabilityDiagnostic
 from jacobian.contracts.exact import CanonicalRational
 from jacobian.contracts.probability import (
@@ -43,7 +44,10 @@ from jacobian.operations import (
 
 
 def _wire(value: Any) -> CanonicalRational:
-    return CanonicalRational(num=str(value.p), den=str(value.q))
+    return CanonicalRational(
+        num=format_canonical_integer(int(value.p)),
+        den=format_canonical_integer(int(value.q)),
+    )
 
 
 def _fmpq(value: CanonicalRational) -> Any:
@@ -80,8 +84,8 @@ def _distribution(values: dict[Fraction, Any]) -> FiniteRationalDistribution:
         atoms=tuple(
             FiniteDistributionAtom(
                 value=CanonicalRational(
-                    num=str(value.numerator),
-                    den=str(value.denominator),
+                    num=format_canonical_integer(value.numerator),
+                    den=format_canonical_integer(value.denominator),
                 ),
                 probability=_wire(probability),
             )
@@ -237,8 +241,8 @@ def _convolution(
                     left_value=left.value,
                     right_value=right.value,
                     sum_value=CanonicalRational(
-                        num=str(sum_value.numerator),
-                        den=str(sum_value.denominator),
+                        num=format_canonical_integer(sum_value.numerator),
+                        den=format_canonical_integer(sum_value.denominator),
                     ),
                     probability=_wire(probability),
                 )

--- a/src/jacobian/domains/sequences/operations.py
+++ b/src/jacobian/domains/sequences/operations.py
@@ -8,6 +8,7 @@ from fractions import Fraction
 from functools import reduce
 from itertools import pairwise
 
+from jacobian.canonical import format_canonical_integer
 from jacobian.contracts.exact import CanonicalRational
 from jacobian.contracts.sequences import (
     FrequencyEntry,
@@ -67,8 +68,8 @@ def sequence_mean(request: IntegerSequenceRequest) -> IntegerSequenceRationalRes
     fraction = Fraction(sum(values), len(values))
     return IntegerSequenceRationalResult(
         value=CanonicalRational(
-            num=str(fraction.numerator),
-            den=str(fraction.denominator),
+            num=format_canonical_integer(fraction.numerator),
+            den=format_canonical_integer(fraction.denominator),
         )
     )
 
@@ -82,8 +83,8 @@ def sequence_median(request: IntegerSequenceRequest) -> IntegerSequenceRationalR
         fraction = Fraction(values[middle - 1] + values[middle], 2)
     return IntegerSequenceRationalResult(
         value=CanonicalRational(
-            num=str(fraction.numerator),
-            den=str(fraction.denominator),
+            num=format_canonical_integer(fraction.numerator),
+            den=format_canonical_integer(fraction.denominator),
         )
     )
 

--- a/src/jacobian/graphs/invariants.py
+++ b/src/jacobian/graphs/invariants.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from pydantic import ValidationError
 
+from jacobian.canonical import format_canonical_integer
 from jacobian.capability_service import CapabilityInvocationError
 from jacobian.contracts.capabilities import (
     CapabilityAssurance,
@@ -326,7 +327,10 @@ def _havel_hakimi_trace(graph: nx_type.Graph[Any]) -> list[list[int]]:
 
 
 def _rational_payload(value: Fraction) -> dict[str, str]:
-    return {"num": str(value.numerator), "den": str(value.denominator)}
+    return {
+        "num": format_canonical_integer(value.numerator),
+        "den": format_canonical_integer(value.denominator),
+    }
 
 
 def _property_backend(name: str) -> str:

--- a/src/jacobian/graphs/neighborhood_independence.py
+++ b/src/jacobian/graphs/neighborhood_independence.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 
 from pydantic import ValidationError
 
-from jacobian.canonical import canonicalize_json
+from jacobian.canonical import canonicalize_json, format_canonical_integer
 from jacobian.capability_service import CapabilityInvocationError
 from jacobian.contracts.capabilities import (
     CapabilityAssurance,
@@ -156,8 +156,8 @@ class GraphNeighborhoodIndependenceAdapter:
         total = sum(record.independence_number for record in records)
         average = Fraction(total, len(records)) if records else Fraction(0)
         average_wire = CanonicalRational(
-            num=str(average.numerator),
-            den=str(average.denominator),
+            num=format_canonical_integer(average.numerator),
+            den=format_canonical_integer(average.denominator),
         )
         invariant = GraphNeighborhoodIndependenceArtifact(
             graph_uri=validated.graph_uri,

--- a/src/jacobian/matrices/capabilities.py
+++ b/src/jacobian/matrices/capabilities.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 from pydantic import ValidationError
 
 from jacobian.artifacts import ArtifactService
+from jacobian.canonical import format_canonical_integer
 from jacobian.capability_service import CapabilityInvocationError
 from jacobian.contracts.capabilities import (
     CapabilityAssurance,
@@ -324,7 +325,10 @@ def _sympy_matrix(matrix: ExactRationalMatrix) -> Matrix:
 
 
 def _wire(value: Rational) -> CanonicalRational:
-    return CanonicalRational(num=str(value.p), den=str(value.q))
+    return CanonicalRational(
+        num=format_canonical_integer(int(value.p)),
+        den=format_canonical_integer(int(value.q)),
+    )
 
 
 def _computed_result(

--- a/src/jacobian/matrices/flint_linear_worker.py
+++ b/src/jacobian/matrices/flint_linear_worker.py
@@ -11,6 +11,7 @@ from typing import Any
 from jacobian.canonical import (
     CanonicalizationError,
     canonicalize_json,
+    format_canonical_integer,
     loads_strict_json,
 )
 
@@ -213,7 +214,10 @@ def _run(request: dict[str, Any]) -> dict[str, object]:
             "status": "CERTIFICATE_PRODUCED",
             "backend_version": "0.9.0",
             "left_witness": [
-                {"num": str(value.numerator), "den": str(value.denominator)}
+                {
+                    "num": format_canonical_integer(value.numerator),
+                    "den": format_canonical_integer(value.denominator),
+                }
                 for value in values
             ],
             "rhs_pairing": {"num": "1", "den": "1"},
@@ -222,7 +226,10 @@ def _run(request: dict[str, Any]) -> dict[str, object]:
         "status": "SOLUTION_PRODUCED",
         "backend_version": "0.9.0",
         "values": [
-            {"num": str(value.numerator), "den": str(value.denominator)}
+            {
+                "num": format_canonical_integer(value.numerator),
+                "den": format_canonical_integer(value.denominator),
+            }
             for value in values
         ],
     }

--- a/src/jacobian/plugins/matrices.py
+++ b/src/jacobian/plugins/matrices.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from pydantic import ValidationError
 
+from jacobian.canonical import format_canonical_integer
 from jacobian.contracts.plugin_matrices import (
     MatrixCandidate,
     MatrixCapabilityRequest,
@@ -56,7 +57,10 @@ def _candidate_matrix(candidate: MatrixCandidate) -> list[list[int]]:
 
 
 def _canonical_rational(frac: Fraction) -> dict[str, str]:
-    return {"num": str(frac.numerator), "den": str(frac.denominator)}
+    return {
+        "num": format_canonical_integer(frac.numerator),
+        "den": format_canonical_integer(frac.denominator),
+    }
 
 
 def _enumerate_typed(

--- a/src/jacobian/polynomial_interval_capabilities.py
+++ b/src/jacobian/polynomial_interval_capabilities.py
@@ -35,7 +35,7 @@ from typing import TYPE_CHECKING, Any, Literal, NamedTuple, cast
 from pydantic import ValidationError
 
 from jacobian.artifacts import ArtifactService
-from jacobian.canonical import canonicalize_json
+from jacobian.canonical import canonicalize_json, format_canonical_integer
 from jacobian.capability_service import CapabilityInvocationError
 from jacobian.checker_installation import CheckerInstaller
 from jacobian.checker_operations import CheckerOperation
@@ -728,7 +728,10 @@ def _bernstein_coefficients(
 
 
 def _rational(value: Fraction) -> CanonicalRational:
-    return CanonicalRational(num=str(value.numerator), den=str(value.denominator))
+    return CanonicalRational(
+        num=format_canonical_integer(value.numerator),
+        den=format_canonical_integer(value.denominator),
+    )
 
 
 def _computed_result(

--- a/src/jacobian/polynomial_positivity_capabilities.py
+++ b/src/jacobian/polynomial_positivity_capabilities.py
@@ -30,7 +30,7 @@ from typing import TYPE_CHECKING, Any, Literal, NamedTuple, cast
 from pydantic import ValidationError
 
 from jacobian.artifacts import ArtifactService
-from jacobian.canonical import canonicalize_json
+from jacobian.canonical import canonicalize_json, format_canonical_integer
 from jacobian.capability_service import CapabilityInvocationError
 from jacobian.checker_installation import CheckerInstaller
 from jacobian.checker_operations import CheckerOperation
@@ -818,7 +818,10 @@ def _wire_univariate_poly(poly: Poly) -> SparseRationalPolynomial:
 
 def _rational(value: Any) -> CanonicalRational:
     rational = _sympy.get().Rational(value)
-    return CanonicalRational(num=str(rational.p), den=str(rational.q))
+    return CanonicalRational(
+        num=format_canonical_integer(int(rational.p)),
+        den=format_canonical_integer(int(rational.q)),
+    )
 
 
 def _computed_result(

--- a/src/jacobian/polynomial_system_capabilities.py
+++ b/src/jacobian/polynomial_system_capabilities.py
@@ -10,7 +10,7 @@ from typing import Literal, cast
 from pydantic import ValidationError
 
 from jacobian.artifacts import ArtifactService
-from jacobian.canonical import canonicalize_json
+from jacobian.canonical import canonicalize_json, format_canonical_integer
 from jacobian.capability_service import CapabilityInvocationError
 from jacobian.checker_installation import CheckerInstaller
 from jacobian.checker_operations import CheckerOperation
@@ -406,7 +406,10 @@ def _evaluate_request(
             ):
                 value *= coordinate**exponent
             total += value
-        return CanonicalRational(num=str(total.numerator), den=str(total.denominator))
+        return CanonicalRational(
+            num=format_canonical_integer(total.numerator),
+            den=format_canonical_integer(total.denominator),
+        )
 
     return (
         tuple(evaluate(polynomial) for polynomial in request.system.equations),

--- a/src/jacobian/polynomial_system_search.py
+++ b/src/jacobian/polynomial_system_search.py
@@ -8,6 +8,7 @@ from itertools import product
 from pydantic import ValidationError
 
 from jacobian.artifacts import ArtifactService
+from jacobian.canonical import format_canonical_integer
 from jacobian.capability_service import CapabilityInvocationError
 from jacobian.contracts.capabilities import (
     CapabilityAssurance,
@@ -100,7 +101,10 @@ class PolynomialSystemRationalSearchAdapter:
             ) from exc
         started = time.monotonic()
         values = tuple(
-            CanonicalRational(num=str(value.numerator), den=str(value.denominator))
+            CanonicalRational(
+                num=format_canonical_integer(value.numerator),
+                den=format_canonical_integer(value.denominator),
+            )
             for value in bounded_rational_scalars(
                 validated.max_abs_numerator, validated.max_denominator
             )

--- a/src/jacobian/polynomials/_support.py
+++ b/src/jacobian/polynomials/_support.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from pydantic import ValidationError
 
+from jacobian.canonical import format_canonical_integer
 from jacobian.capability_service import CapabilityInvocationError
 from jacobian.contracts.capabilities import (
     CapabilityAssurance,
@@ -530,7 +531,10 @@ def _wire_polynomial(polynomial: Poly) -> SparseRationalPolynomial:
 
 def _wire_rational(value: object) -> CanonicalRational:
     rational = _sympy.get().Rational(value)
-    return CanonicalRational(num=str(rational.p), den=str(rational.q))
+    return CanonicalRational(
+        num=format_canonical_integer(int(rational.p)),
+        den=format_canonical_integer(int(rational.q)),
+    )
 
 
 def _evaluate(

--- a/src/jacobian/polynomials/collision.py
+++ b/src/jacobian/polynomials/collision.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import time
 from itertools import product
 
+from jacobian.canonical import format_canonical_integer
 from jacobian.contracts.capabilities import (
     CapabilityAssurance,
     CapabilityAssuranceLevel,
@@ -311,7 +312,10 @@ class PolynomialCollisionSearchAdapter:
         started = time.monotonic()
         polynomial_map, map_uri = _materialize_map(self.resources, validated.map)
         scalar_values = tuple(
-            CanonicalRational(num=str(value.numerator), den=str(value.denominator))
+            CanonicalRational(
+                num=format_canonical_integer(value.numerator),
+                den=format_canonical_integer(value.denominator),
+            )
             for value in bounded_rational_scalars(
                 validated.max_abs_numerator, validated.max_denominator
             )

--- a/src/jacobian/polytope.py
+++ b/src/jacobian/polytope.py
@@ -13,7 +13,7 @@ from typing import Any
 
 from pydantic import ValidationError
 
-from jacobian.canonical import canonicalize_json
+from jacobian.canonical import canonicalize_json, format_canonical_integer
 from jacobian.contracts.evidence import (
     CertificateEnvelope,
     EvidenceBindings,
@@ -58,7 +58,10 @@ def _z3() -> Any:
 
 
 def _wire_rational(value: Fraction) -> dict[str, str]:
-    return {"num": str(value.numerator), "den": str(value.denominator)}
+    return {
+        "num": format_canonical_integer(value.numerator),
+        "den": format_canonical_integer(value.denominator),
+    }
 
 
 def _require_schema_version(

--- a/src/jacobian/shrinking.py
+++ b/src/jacobian/shrinking.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from pydantic import ValidationError
 
+from jacobian.canonical import format_canonical_integer
 from jacobian.claims import ClaimValidationService
 from jacobian.contracts.artifacts import ArtifactPutResult
 from jacobian.contracts.checkers import EvidenceKind
@@ -634,6 +635,9 @@ def _objective_value(value: Any) -> Fraction:
             and _INTEGER_OBJECTIVE.fullmatch(denominator)
         ):
             result = Fraction(int(numerator), int(denominator))
-            if value == {"num": str(result.numerator), "den": str(result.denominator)}:
+            if value == {
+                "num": format_canonical_integer(result.numerator),
+                "den": format_canonical_integer(result.denominator),
+            }:
                 return result
     raise ValueError("objective values must be canonical exact numbers")

--- a/src/jacobian/sympy_polynomial_worker.py
+++ b/src/jacobian/sympy_polynomial_worker.py
@@ -9,7 +9,11 @@ import sympy
 from pydantic import ValidationError
 from sympy import QQ, Poly
 
-from jacobian.canonical import canonicalize_json, loads_strict_json
+from jacobian.canonical import (
+    canonicalize_json,
+    format_canonical_integer,
+    loads_strict_json,
+)
 from jacobian.contracts.exact import CanonicalRational
 from jacobian.contracts.polynomial_expressions import (
     PolynomialAddExpression,
@@ -62,8 +66,8 @@ def _wire_polynomial(polynomial: Poly) -> SparseRationalPolynomial:
         terms=tuple(
             RationalPolynomialTerm(
                 coefficient=CanonicalRational(
-                    num=str(coefficient.numerator),
-                    den=str(coefficient.denominator),
+                    num=format_canonical_integer(coefficient.numerator),
+                    den=format_canonical_integer(coefficient.denominator),
                 ),
                 exponents=tuple(int(exponent) for exponent in exponents),
             )

--- a/tests/domain/arithmetic/test_arithmetic_capabilities.py
+++ b/tests/domain/arithmetic/test_arithmetic_capabilities.py
@@ -49,3 +49,22 @@ def test_arithmetic_capabilities_return_exact_results(
 
     assert result.execution.status is ExecutionStatus.COMPLETED
     assert result.output["result"] == expected
+
+
+def test_rational_product_formats_results_above_python_digit_limit(
+    domain_services: DomainTestServices,
+) -> None:
+    factor = "1" + "0" * 2500
+
+    result = domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="rational.compute.product",
+            input={
+                "left": {"num": factor, "den": "1"},
+                "right": {"num": factor, "den": "1"},
+            },
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output["result"] == {"value": {"num": "1" + "0" * 5000, "den": "1"}}

--- a/tests/unit/tooling/test_architecture_canonical_results.py
+++ b/tests/unit/tooling/test_architecture_canonical_results.py
@@ -1,0 +1,75 @@
+"""Architecture checks for digit-limit-safe exact rational results."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools.check_architecture import check_architecture
+
+
+def _write_source(root: Path, source: str) -> None:
+    path = root / "src/jacobian/domain.py"
+    path.parent.mkdir(parents=True)
+    path.write_text(source, encoding="utf-8")
+
+
+def test_direct_rational_result_component_formatting_is_rejected(
+    tmp_path: Path,
+) -> None:
+    _write_source(
+        tmp_path,
+        "result = CanonicalRational(\n"
+        "    num=str(value.numerator),\n"
+        "    den=str(value.denominator),\n"
+        ")\n"
+        'payload = {"num": str(value.p), "den": str(value.q)}\n'
+        "nested = CanonicalRational(\n"
+        "    num=str(int(value.p)),\n"
+        "    den=str(int(value.q)),\n"
+        ")\n"
+        'formatted = {"num": format(value.numerator), '
+        '"den": "{}".format(value.denominator)}\n'
+        'text = f"{value.numerator}/{value.denominator}"\n'
+        "decimal = format(value.numerator)\n"
+        'ratio = "{}".format(value.denominator)\n',
+    )
+
+    report = check_architecture(tmp_path)
+
+    violations = [
+        violation
+        for violation in report.violations
+        if violation.code == "unsafe-canonical-rational-output"
+    ]
+    assert len(violations) == 12
+
+
+def test_canonical_integer_formatter_is_accepted(tmp_path: Path) -> None:
+    _write_source(
+        tmp_path,
+        "result = CanonicalRational(\n"
+        "    num=format_canonical_integer(value.numerator),\n"
+        "    den=format_canonical_integer(value.denominator),\n"
+        ")\n"
+        'text = f"{format_canonical_integer(value.numerator)}/'
+        '{format_canonical_integer(value.denominator)}"\n'
+        'decimal = "{}".format(format_canonical_integer(value.numerator))\n',
+    )
+
+    report = check_architecture(tmp_path)
+
+    assert not any(
+        violation.code == "unsafe-canonical-rational-output"
+        for violation in report.violations
+    )
+
+
+def test_unrelated_short_attribute_interpolation_is_accepted(tmp_path: Path) -> None:
+    _write_source(tmp_path, 'message = f"{point.p},{point.q}"\n')
+
+    report = check_architecture(tmp_path)
+
+    assert not any(
+        violation.code == "unsafe-canonical-rational-output"
+        for violation in report.violations
+    )

--- a/tools/check_architecture.py
+++ b/tools/check_architecture.py
@@ -907,6 +907,26 @@ def _unsafe_rational_render_nodes(
     return ()
 
 
+def _direct_output_value(node: ast.AST) -> ast.AST | None:
+    if isinstance(node, (ast.Assign, ast.AnnAssign, ast.Return)):
+        return node.value
+    return None
+
+
+def _canonical_rational_sink_values(node: ast.AST) -> tuple[ast.AST, ...]:
+    if isinstance(node, ast.Call):
+        return tuple(
+            keyword.value for keyword in node.keywords if keyword.arg in {"num", "den"}
+        )
+    if isinstance(node, ast.Dict):
+        return tuple(
+            value
+            for key, value in zip(node.keys, node.values, strict=True)
+            if isinstance(key, ast.Constant) and key.value in {"num", "den"}
+        )
+    return ()
+
+
 def _unsafe_canonical_rational_output_violations(
     relative: PurePosixPath, tree: ast.AST
 ) -> tuple[Violation, ...]:
@@ -915,25 +935,16 @@ def _unsafe_canonical_rational_output_violations(
 
     unsafe_values: dict[int, ast.AST] = {}
     for node in ast.walk(tree):
-        assigned_or_returned: ast.AST | None = None
-        if isinstance(node, (ast.Assign, ast.AnnAssign, ast.Return)):
-            assigned_or_returned = node.value
-        if assigned_or_returned is not None:
+        direct_output = _direct_output_value(node)
+        if direct_output is not None:
             for value in _unsafe_rational_render_nodes(
-                assigned_or_returned,
+                direct_output,
                 attributes=_DESCRIPTIVE_RATIONAL_COMPONENT_ATTRIBUTES,
             ):
                 unsafe_values[id(value)] = value
-        if isinstance(node, ast.Call):
-            for keyword in node.keywords:
-                if keyword.arg in {"num", "den"}:
-                    for value in _unsafe_rational_render_nodes(keyword.value):
-                        unsafe_values[id(value)] = value
-        elif isinstance(node, ast.Dict):
-            for key, value in zip(node.keys, node.values, strict=True):
-                if isinstance(key, ast.Constant) and key.value in {"num", "den"}:
-                    for unsafe_value in _unsafe_rational_render_nodes(value):
-                        unsafe_values[id(unsafe_value)] = unsafe_value
+        for sink_value in _canonical_rational_sink_values(node):
+            for value in _unsafe_rational_render_nodes(sink_value):
+                unsafe_values[id(value)] = value
 
     return tuple(
         Violation(

--- a/tools/check_architecture.py
+++ b/tools/check_architecture.py
@@ -1,7 +1,7 @@
 """Static architecture enforcement for product source boundaries.
 
 This checker is an AST/filesystem tool that does not import the Jacobian
-runtime.  It enforces six PR10 invariants:
+runtime.  It enforces seven PR10 invariants:
 
 1. **subprocess-confined**: direct ``subprocess`` usage and ``os.execvpe``/
    ``os.execvp`` are allowed only in ``bounded_process.py``,
@@ -28,6 +28,9 @@ runtime.  It enforces six PR10 invariants:
 
 6. **unsupported-surface**: removed experimental memory/search identifiers must
    not appear in supported product source, tests, schemas, catalog, or docs.
+
+7. **unsafe-canonical-rational-output**: rational result components must use the
+   digit-limit-safe canonical formatter rather than direct ``str()`` conversion.
 
 The checker excludes ``wt-438/`` and generated directories from all scans.
 ``CHANGELOG.md`` is excluded from the unsupported-surface text scan as
@@ -801,6 +804,106 @@ def _unsupported_surface_ast_violations(
     return tuple(violations)
 
 
+_RATIONAL_COMPONENT_ATTRIBUTES = frozenset({"numerator", "denominator", "p", "q"})
+_DESCRIPTIVE_RATIONAL_COMPONENT_ATTRIBUTES = frozenset({"numerator", "denominator"})
+
+
+def _contains_rational_component(
+    node: ast.AST, *, attributes: frozenset[str] = _RATIONAL_COMPONENT_ATTRIBUTES
+) -> bool:
+    return any(
+        isinstance(descendant, ast.Attribute) and descendant.attr in attributes
+        for descendant in ast.walk(node)
+    )
+
+
+def _is_canonical_integer_format(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "format_canonical_integer"
+    )
+
+
+def _unsafe_rational_render_nodes(
+    node: ast.AST,
+    *,
+    attributes: frozenset[str] = _RATIONAL_COMPONENT_ATTRIBUTES,
+) -> tuple[ast.AST, ...]:
+    if isinstance(node, ast.JoinedStr):
+        return tuple(
+            value
+            for value in node.values
+            if isinstance(value, ast.FormattedValue)
+            and _contains_rational_component(value.value, attributes=attributes)
+            and not _is_canonical_integer_format(value.value)
+        )
+    if not isinstance(node, ast.Call):
+        return ()
+    if isinstance(node.func, ast.Name) and node.func.id in {"str", "format"}:
+        return (
+            (node,)
+            if any(
+                _contains_rational_component(argument, attributes=attributes)
+                and not _is_canonical_integer_format(argument)
+                for argument in node.args
+            )
+            else ()
+        )
+    if isinstance(node.func, ast.Attribute) and node.func.attr == "format":
+        arguments = (*node.args, *(keyword.value for keyword in node.keywords))
+        return (
+            (node,)
+            if any(
+                _contains_rational_component(argument, attributes=attributes)
+                and not _is_canonical_integer_format(argument)
+                for argument in arguments
+            )
+            else ()
+        )
+    return ()
+
+
+def _unsafe_canonical_rational_output_violations(
+    relative: PurePosixPath, tree: ast.AST
+) -> tuple[Violation, ...]:
+    if not str(relative).startswith("src/jacobian/"):
+        return ()
+
+    unsafe_values: dict[int, ast.AST] = {}
+    for node in ast.walk(tree):
+        assigned_or_returned: ast.AST | None = None
+        if isinstance(node, (ast.Assign, ast.AnnAssign, ast.Return)):
+            assigned_or_returned = node.value
+        if assigned_or_returned is not None:
+            for value in _unsafe_rational_render_nodes(
+                assigned_or_returned,
+                attributes=_DESCRIPTIVE_RATIONAL_COMPONENT_ATTRIBUTES,
+            ):
+                unsafe_values[id(value)] = value
+        if isinstance(node, ast.Call):
+            for keyword in node.keywords:
+                if keyword.arg in {"num", "den"}:
+                    for value in _unsafe_rational_render_nodes(keyword.value):
+                        unsafe_values[id(value)] = value
+        elif isinstance(node, ast.Dict):
+            for key, value in zip(node.keys, node.values, strict=True):
+                if isinstance(key, ast.Constant) and key.value in {"num", "den"}:
+                    for unsafe_value in _unsafe_rational_render_nodes(value):
+                        unsafe_values[id(unsafe_value)] = unsafe_value
+
+    return tuple(
+        Violation(
+            str(relative),
+            "unsafe-canonical-rational-output",
+            "canonical rational results must format integer components "
+            "with format_canonical_integer",
+            value.lineno,
+        )
+        for value in unsafe_values.values()
+    )
+
+
 def _unsupported_surface_text_violations(
     root: Path, relative: PurePosixPath, path: Path
 ) -> tuple[Violation, ...]:
@@ -873,6 +976,7 @@ def _check_python_file(root: Path, path: Path) -> tuple[Violation, ...]:
     violations.extend(_run_bounded_process_violations(relative, tree))
     violations.extend(_shutil_which_violations(relative, tree))
     violations.extend(_environ_spread_violations(relative, tree))
+    violations.extend(_unsafe_canonical_rational_output_violations(relative, tree))
     violations.extend(_unsupported_surface_ast_violations(relative, tree))
     return tuple(violations)
 


### PR DESCRIPTION
## Problem

Jacobian accepts canonical rational components up to 32,768 digits, but many exact computation paths serialized backend numerators and denominators with Python ordinary `str()`. On supported Python versions that conversion fails above 4,300 digits, so valid exact results could terminate with `ValueError` before reaching the wire contract.

A clean-base reproduction evaluated a square at a valid 2,501-digit integer and failed while formatting the 5,001-digit exact result.

## What changed

- Route exact rational result components through `format_canonical_integer()` across the arithmetic, combinatorics, geometry, graph, matrix, optimization, polynomial, probability, sequence, polytope, shrinking, and worker producers.
- Preserve backend values exactly: Python `Fraction` components remain integers, while SymPy `p`/`q` values are converted exactly to Python integers before canonical formatting.
- Add a public arithmetic capability regression that multiplies two valid 2,501-digit rationals and checks the complete 5,001-digit result.
- Add an architecture rule covering unsafe direct and wrapped `str`, built-in `format`, method `.format`, and f-string rational result rendering without globally treating unrelated `p`/`q` fields as rationals.

This intentionally leaves the separate validation work tracked by #752 unchanged. The branch includes current `main`, including the input-conversion fix from #755, and preserves both architecture policies and both large-rational regressions.

## Validation

On the original clean-main implementation tree, every planner-selected semantic lane passed:

- unit: 730 passed
- component: 724 passed
- domain: 163 passed
- composition: 468 passed, 2 expected Lean skips
- storage: 122 passed
- process: 232 passed
- MCP: 39 passed
- e2e: 8 passed, 1 expected Lean skip

After merging the advanced current `main` and resolving the two adjacent test/tooling conflicts:

- `make test-unit`: 735 passed
- `make test-domain`: 166 passed
- Combined canonical architecture regressions: 5 passed
- `make check-static`: passed, including Ruff, formatting, dependency and dead-code checks, full mypy (451 source files), complexity baseline, test architecture, product architecture (1,583 files), and package build

Fixes #754