### PR TITLE
Record Codex visibility run duration

### DIFF
--- a/benchmarks/tooling/codex_visibility.py
+++ b/benchmarks/tooling/codex_visibility.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 import os
 import tempfile
+import time
 from collections.abc import Mapping
 from enum import StrEnum
 from pathlib import Path
@@ -392,6 +393,7 @@ def _run_case(
     transcript_path = output / f"{stem}.jsonl"
     stderr_path = output / f"{stem}.stderr"
     environment = operator_environment(include=_CODEX_ENVIRONMENT)
+    started = time.monotonic()
     result = run_operator_command(
         "codex",
         _codex_arguments(
@@ -408,6 +410,7 @@ def _run_case(
         stderr_limit_bytes=2 * 1024 * 1024,
         environment=environment,
     )
+    elapsed_seconds = max(0.0, time.monotonic() - started)
     transcript_path.write_bytes(result.stdout)
     stderr_path.write_bytes(result.stderr)
     telemetry = parse_agent_transcript(transcript_path)
@@ -426,6 +429,7 @@ def _run_case(
             "diagnostic": result.diagnostic,
             "stdout_exceeded": result.stdout_exceeded,
             "stderr_exceeded": result.stderr_exceeded,
+            "elapsed_seconds": round(elapsed_seconds, 6),
         },
         "classification": {
             **classification,
@@ -617,6 +621,10 @@ def main() -> None:
                 ),
                 "mcp_model_visible_bytes": sum(
                     run["classification"]["mcp_model_visible_bytes"] for run in runs
+                ),
+                "elapsed_seconds": round(
+                    sum(run["command"]["elapsed_seconds"] for run in runs),
+                    6,
                 ),
             },
         },

--- a/tests/unit/tooling/test_codex_visibility.py
+++ b/tests/unit/tooling/test_codex_visibility.py
@@ -4,6 +4,7 @@ import json
 import re
 from pathlib import Path
 
+import benchmarks.tooling.codex_visibility as visibility
 import pytest
 from benchmarks.tooling.codex_visibility import (
     AdoptionExpectation,
@@ -14,6 +15,7 @@ from benchmarks.tooling.codex_visibility import (
     classify_visibility,
     load_suite,
 )
+from benchmarks.tooling.command_runner import ToolCommandResult, ToolCommandStatus
 from pydantic import ValidationError
 
 from jacobian.contracts.matrices import MatrixDeterminantRequest
@@ -144,6 +146,38 @@ def test_unified_exec_mode_is_opt_in(tmp_path: Path) -> None:
 
     assert "unified_exec" not in direct
     assert unified[-3:-1] == ("--enable", "unified_exec")
+
+
+def test_run_records_monotonic_elapsed_seconds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    moments = iter((10.0, 12.3456789))
+    monkeypatch.setattr(visibility.time, "monotonic", lambda: next(moments))
+    monkeypatch.setattr(
+        visibility,
+        "run_operator_command",
+        lambda *args, **kwargs: ToolCommandResult(
+            status=ToolCommandStatus.EXITED,
+            exit_code=0,
+            stdout=b'{"type":"turn.completed","usage":{}}\n',
+            stderr=b"",
+        ),
+    )
+
+    result = visibility._run_case(
+        case=_case(),
+        repetition=1,
+        workspace=tmp_path,
+        output=tmp_path,
+        model="test-model",
+        reasoning_effort="high",
+        mcp_url="https://example.test/mcp",
+        timeout_seconds=30,
+        tool_mode=ToolMode.DIRECT,
+    )
+
+    assert result["command"]["elapsed_seconds"] == 2.345679
 
 
 def test_codex_skill_keeps_bounded_stable_direct_run_contracts() -> None:


### PR DESCRIPTION
Closes #782.

## What changed

- measure each Codex invocation with a monotonic clock;
- persist rounded `elapsed_seconds` beside command status for every run;
- total elapsed seconds in the existing summary cost block;
- add a deterministic unit regression for timing serialization.

## Root cause

The evaluator preserved discovery, invocation, token, byte, and command telemetry but omitted wall-clock duration. That prevented repository reports from supporting paired efficiency evaluation without an external wrapper.

## Safety

Timing is observational only. It does not affect timeouts, contract satisfaction, reward, mathematical conclusions, or assurance.

## Validation

- Codex visibility unit suite: 15 passed
- Ruff lint and format checks passed
- `git diff --check` passed