### PR TITLE
docs: clarify exact Jacobian contract inspection

### DIFF
--- a/.agents/skills/jacobian-math/SKILL.md
+++ b/.agents/skills/jacobian-math/SKILL.md
@@ -40,8 +40,10 @@ stable built-in contracts; replace examples but preserve JSON types:
 
 For other outcomes or unfamiliar payloads, use `math.find` with a specific
 plain-language outcome and implied domain or mode; no capability ID is required.
-Use low `limit` values. Inspect `CONTRACT` only when the typed schema is needed.
-A card's `invocation_example`, or required top-level fields, may be enough.
+Use low `limit` values. For a selected operation's schema, call
+`math.find({"capability_id":"<exact-id>","view":"CONTRACT"})`; never send
+`mode: "CONTRACT"` to `math.run` or put `CONTRACT` in a query. A card's
+`invocation_example`, or required top-level fields, may be enough.
 
 Do not add a discovery domain filter unless its exact installed spelling is
 known. When discovery exposes recovery paths, follow those fields (for example,

--- a/npm/skills/jacobian-math/SKILL.md
+++ b/npm/skills/jacobian-math/SKILL.md
@@ -40,8 +40,10 @@ stable built-in contracts; replace examples but preserve JSON types:
 
 For other outcomes or unfamiliar payloads, use `math.find` with a specific
 plain-language outcome and implied domain or mode; no capability ID is required.
-Use low `limit` values. Inspect `CONTRACT` only when the typed schema is needed.
-A card's `invocation_example`, or required top-level fields, may be enough.
+Use low `limit` values. For a selected operation's schema, call
+`math.find({"capability_id":"<exact-id>","view":"CONTRACT"})`; never send
+`mode: "CONTRACT"` to `math.run` or put `CONTRACT` in a query. A card's
+`invocation_example`, or required top-level fields, may be enough.
 
 Do not add a discovery domain filter unless its exact installed spelling is
 known. When discovery exposes recovery paths, follow those fields (for example,

--- a/tests/unit/tooling/test_codex_visibility.py
+++ b/tests/unit/tooling/test_codex_visibility.py
@@ -190,6 +190,8 @@ def test_codex_skill_routes_exact_outcomes_without_catalog_projection() -> None:
     skill_flat = re.sub(r"\s+", " ", skill)
     assert "Do not enumerate, filter, or print `ALL_TOOLS`" in skill_flat
     assert "text(r.structuredContent ?? r)" in skill
+    assert 'math.find({"capability_id":"<exact-id>","view":"CONTRACT"})' in skill
+    assert 'never send `mode: "CONTRACT"` to `math.run`' in skill_flat
     assert "never reconstruct or paraphrase such a record" in skill_flat
     assert "required task authorization and bindings are preserved" in skill_flat
     for guidance in (


### PR DESCRIPTION
## What changed

- give the exact `math.find({capability_id, view: "CONTRACT"})` form for inspecting a selected operation;
- explicitly forbid sending `mode: "CONTRACT"` to `math.run` or putting `CONTRACT` into a discovery query;
- keep the repository and packaged managed Skills byte-identical;
- add a regression for the guidance while retaining the 4 KiB Skill budget.

## Evaluation evidence

In the 24-run harder routing study, the Skill-guided agent found `poset.linear_extensions.count` but attempted the invalid `math.run(... mode: "CONTRACT")` form and then searched for the word `CONTRACT`. Similar inspection confusion contributed to excess graph turns.

A focused forward-test with this patch used the correct exact inspection form. On the poset case it reduced MCP calls from 13 to 7 and input tokens from 304,743 to 168,176. The run still exposed a separate missing artifact-composition path for linear-extension counting; this PR does not claim to fix that product capability.

## Overlap

PR #567 optimized common direct-run contracts and card metadata. It did not document the exact selected-capability inspection call or forbid the invalid forms observed here.

## Validation

- Codex visibility unit suite: 14 passed
- skill-creator `quick_validate.py`: passed
- managed Skill parity: passed
- Ruff and `git diff --check`: passed