### PR TITLE
Accept materialized posets for linear-extension counts

### DIFF
--- a/src/jacobian/contracts/posets.py
+++ b/src/jacobian/contracts/posets.py
@@ -487,12 +487,13 @@ class PosetWidthResult(PosetExactResult):
         return self
 
 
-class LinearExtensionRequest(ContractModel):
-    poset: FinitePoset
-
+class LinearExtensionRequest(PosetRequest):
     @model_validator(mode="after")
     def require_subset_dp_bound(self) -> Self:
-        if len(self.poset.elements) > MAX_LINEAR_EXTENSION_ELEMENTS:
+        if (
+            self.poset is not None
+            and len(self.poset.elements) > MAX_LINEAR_EXTENSION_ELEMENTS
+        ):
             raise ValueError(
                 "linear-extension counting supports at most "
                 f"{MAX_LINEAR_EXTENSION_ELEMENTS} elements"

--- a/src/jacobian/domains/posets/operations.py
+++ b/src/jacobian/domains/posets/operations.py
@@ -187,10 +187,20 @@ def _convert_materialized_poset(
     ) if request.poset_artifact_uri else ()
 
 
+def _convert_materialized_linear_extension(
+    request: LinearExtensionRequest,
+    payload: FinitePosetMaterializationResult,
+) -> tuple[LinearExtensionRequest, tuple[str, ...]]:
+    return LinearExtensionRequest(poset=payload.poset), (
+        request.poset_artifact_uri,
+    ) if request.poset_artifact_uri else ()
+
+
 def _linear_extensions(
     request: LinearExtensionRequest,
 ) -> ComputedSuccess[LinearExtensionCountResult]:
     poset = request.poset
+    assert poset is not None
     elements = poset.elements
     index = {element: position for position, element in enumerate(elements)}
     predecessor_masks = [0] * len(elements)
@@ -400,6 +410,10 @@ FINITE_POSET_CAPABILITIES: tuple[MaterializedOperation[Any, Any, Any, Any], ...]
         result_model=LinearExtensionCountResult,
         implementation=_linear_extensions,
         relation_id="poset.linear_extensions.ideal_dp.relation",
+        accepted_result_capability_ids=("poset.finite.materialize",),
+        artifact_converter=_convert_materialized_linear_extension,
+        artifact_payload_model=FinitePosetMaterializationResult,
+        artifact_uri_field="poset_artifact_uri",
         tags=(
             "poset",
             "linear-extension",

--- a/src/jacobian_checkers/finite_posets.py
+++ b/src/jacobian_checkers/finite_posets.py
@@ -551,9 +551,10 @@ def _replay_linear_extensions(
     source: dict[str, Any],
     result: dict[str, Any],
 ) -> bool:
-    if set(source) != {"poset"}:
+    inline = _inline_poset_claim(source)
+    if inline is None:
         return False
-    poset = _parse_poset(source["poset"])
+    poset = _parse_poset(inline)
     states = _linear_state_table(poset)
     full_mask = (1 << len(poset["elements"])) - 1
     expected = {

--- a/tests/composition/runtime/test_poset_capabilities.py
+++ b/tests/composition/runtime/test_poset_capabilities.py
@@ -157,6 +157,34 @@ def test_materialized_poset_is_directly_consumable_by_width(
     )
 
 
+def test_materialized_poset_is_directly_consumable_by_linear_extension_count(
+    fresh_complete_runtime,
+) -> None:
+    materialized = fresh_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="poset.finite.materialize",
+            input=_DIAMOND,
+        )
+    )
+    result = fresh_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="poset.linear_extensions.count",
+            input={"poset_artifact_uri": materialized.output["result_uri"]},
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert _result_payload(fresh_complete_runtime, result)["count"] == 2
+    assert materialized.output["result_uri"] in result.artifact_uris
+    descriptors = {
+        descriptor.capability_id: descriptor
+        for descriptor in fresh_complete_runtime.core.capabilities.catalog().capabilities
+    }
+    assert descriptors["poset.finite.materialize"].produced_artifact_types == (
+        descriptors["poset.linear_extensions.count"].accepted_artifact_types
+    )
+
+
 def test_width_rejects_an_incompatible_artifact_before_writes(
     fresh_complete_runtime,
 ) -> None:


### PR DESCRIPTION
## What changed

- let `LinearExtensionRequest` accept exactly one of an inline canonical poset or a materialized-poset artifact URI;
- connect `poset.finite.materialize` to `poset.linear_extensions.count` through the repository's existing typed artifact converter boundary;
- preserve the 20-element subset-DP bound after artifact conversion;
- advertise producer/consumer artifact compatibility in discovery metadata;
- preserve independent checker replay for legacy inline requests whose model dump now includes a null artifact field;
- add a composition regression proving direct artifact consumption, lineage preservation, and the exact count.

## Root cause and evaluation evidence

The harder 24-run routing study found that the agent discovered `poset.linear_extensions.count`, but the operation could not consume the artifact produced by `poset.finite.materialize`. It attempted to reconstruct the opaque canonical poset manually and failed on element ordering, transitive reduction, ranks, and digest binding: 13 MCP calls, eight errors, 304,743 input tokens, and no completed expected capability.

With the exact contract-inspection Skill fix alone, the run improved to seven calls but still failed. With this artifact-composition fix plus that guidance, the same task completed successfully in six calls and 59.8 seconds, using the materialized result URI rather than reconstructing canonical internals.

## Overlap

Merged PR #619 established this typed materialization path for `poset.width.compute`, but `poset.linear_extensions.count` was not connected. This PR reuses that infrastructure and does not introduce a new artifact system.

## Safety

Artifact retrieval, schema identity, semantics identity, and conversion remain owned by `MaterializedOperationAdapter`. Inline requests remain supported. The checker accepts only an inline poset with a null artifact URI and still rejects artifact-only claims it cannot independently resolve. No mathematical algorithm, count, assurance level, or checker authority changes.

## Validation

- focused poset capability suite: 21 passed
- focused independent poset checker suite: 12 passed
- mypy on changed source modules: passed
- Ruff lint and format checks passed
- `git diff --check` passed
- focused real-model forward test: contract satisfied