### PR TITLE
feat(eval): add observation-only trajectory scoring

### DIFF
--- a/docs/reference/evaluations/schemas/trajectory-score-replay-v1.schema.json
+++ b/docs/reference/evaluations/schemas/trajectory-score-replay-v1.schema.json
@@ -1,0 +1,320 @@
+{
+  "$defs": {
+    "CreditReason": {
+      "enum": [
+        "INITIAL_STATE",
+        "NON_MILESTONE_ZERO",
+        "MILESTONE_VALUE_DELTA"
+      ],
+      "title": "CreditReason",
+      "type": "string"
+    },
+    "EstimatorKind": {
+      "enum": [
+        "GROUP_ROLLOUT",
+        "NUMCA_NUMERICAL",
+        "REASONING_TEXT",
+        "JACOBIAN_TYPED",
+        "HYBRID_TYPED_TEXT"
+      ],
+      "title": "EstimatorKind",
+      "type": "string"
+    },
+    "ScoredTrajectoryState": {
+      "additionalProperties": false,
+      "properties": {
+        "assurance_authority": {
+          "const": false,
+          "default": false,
+          "title": "Assurance Authority",
+          "type": "boolean"
+        },
+        "boundary": {
+          "$ref": "#/$defs/StateBoundary"
+        },
+        "cluster_feature_summary": {
+          "maxLength": 1024,
+          "minLength": 1,
+          "title": "Cluster Feature Summary",
+          "type": "string"
+        },
+        "cluster_id": {
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "title": "Cluster Id",
+          "type": "string"
+        },
+        "credit_reason": {
+          "$ref": "#/$defs/CreditReason"
+        },
+        "cumulative_milestone_credit": {
+          "maximum": 1000.0,
+          "minimum": -1000.0,
+          "title": "Cumulative Milestone Credit",
+          "type": "number"
+        },
+        "estimated_value": {
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Estimated Value",
+          "type": "number"
+        },
+        "estimator": {
+          "$ref": "#/$defs/EstimatorKind"
+        },
+        "eventual_terminal_result": {
+          "$ref": "#/$defs/TerminalResult"
+        },
+        "eventual_terminal_reward": {
+          "enum": [
+            0,
+            1
+          ],
+          "title": "Eventual Terminal Reward",
+          "type": "integer"
+        },
+        "milestone_eligible": {
+          "title": "Milestone Eligible",
+          "type": "boolean"
+        },
+        "observation_id": {
+          "maxLength": 256,
+          "minLength": 3,
+          "title": "Observation Id",
+          "type": "string"
+        },
+        "observation_only": {
+          "const": true,
+          "default": true,
+          "title": "Observation Only",
+          "type": "boolean"
+        },
+        "previous_observation_id": {
+          "anyOf": [
+            {
+              "maxLength": 256,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Previous Observation Id"
+        },
+        "state_index": {
+          "minimum": 0,
+          "title": "State Index",
+          "type": "integer"
+        },
+        "supporting_trajectory_ids": {
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Supporting Trajectory Ids",
+          "type": "array"
+        },
+        "task_group": {
+          "pattern": "^[a-z0-9][a-z0-9._-]{0,127}$",
+          "title": "Task Group",
+          "type": "string"
+        },
+        "trajectory_id": {
+          "pattern": "^[a-z0-9][a-z0-9._-]{0,127}$",
+          "title": "Trajectory Id",
+          "type": "string"
+        },
+        "transition_credit": {
+          "maximum": 1.0,
+          "minimum": -1.0,
+          "title": "Transition Credit",
+          "type": "number"
+        },
+        "typed_state_digest": {
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "title": "Typed State Digest",
+          "type": "string"
+        },
+        "value_delta": {
+          "anyOf": [
+            {
+              "maximum": 1.0,
+              "minimum": -1.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Value Delta"
+        },
+        "value_source": {
+          "$ref": "#/$defs/ValueSource"
+        }
+      },
+      "required": [
+        "observation_id",
+        "trajectory_id",
+        "task_group",
+        "state_index",
+        "boundary",
+        "typed_state_digest",
+        "milestone_eligible",
+        "estimator",
+        "cluster_id",
+        "cluster_feature_summary",
+        "value_source",
+        "supporting_trajectory_ids",
+        "estimated_value",
+        "transition_credit",
+        "cumulative_milestone_credit",
+        "credit_reason",
+        "eventual_terminal_result",
+        "eventual_terminal_reward"
+      ],
+      "title": "ScoredTrajectoryState",
+      "type": "object"
+    },
+    "StateBoundary": {
+      "enum": [
+        "PLAN",
+        "TOOL_RESULT",
+        "AFTER_TOOL",
+        "FINAL",
+        "TERMINAL"
+      ],
+      "title": "StateBoundary",
+      "type": "string"
+    },
+    "TerminalResult": {
+      "enum": [
+        "ACCEPTED",
+        "REJECTED"
+      ],
+      "title": "TerminalResult",
+      "type": "string"
+    },
+    "ValueSource": {
+      "enum": [
+        "CLUSTER",
+        "TASK_GROUP_PRIOR"
+      ],
+      "title": "ValueSource",
+      "type": "string"
+    }
+  },
+  "$id": "https://jacobian.invalid/docs/reference/evaluations/schemas/trajectory-score-replay-v1.schema.json",
+  "additionalProperties": false,
+  "properties": {
+    "assurance_authority": {
+      "const": false,
+      "default": false,
+      "title": "Assurance Authority",
+      "type": "boolean"
+    },
+    "changes_prompts": {
+      "const": false,
+      "default": false,
+      "title": "Changes Prompts",
+      "type": "boolean"
+    },
+    "chooses_tools": {
+      "const": false,
+      "default": false,
+      "title": "Chooses Tools",
+      "type": "boolean"
+    },
+    "comparison_digest": {
+      "pattern": "^sha256:[0-9a-f]{64}$",
+      "title": "Comparison Digest",
+      "type": "string"
+    },
+    "credit_semantics": {
+      "const": "non-milestone=0;milestone=current-value-minus-previous-selected-value",
+      "default": "non-milestone=0;milestone=current-value-minus-previous-selected-value",
+      "title": "Credit Semantics",
+      "type": "string"
+    },
+    "estimator": {
+      "$ref": "#/$defs/EstimatorKind"
+    },
+    "eventual_terminal_result": {
+      "$ref": "#/$defs/TerminalResult"
+    },
+    "eventual_terminal_reward": {
+      "enum": [
+        0,
+        1
+      ],
+      "title": "Eventual Terminal Reward",
+      "type": "integer"
+    },
+    "mutates_runtime": {
+      "const": false,
+      "default": false,
+      "title": "Mutates Runtime",
+      "type": "boolean"
+    },
+    "observation_only": {
+      "const": true,
+      "default": true,
+      "title": "Observation Only",
+      "type": "boolean"
+    },
+    "replay_schema_version": {
+      "const": "1",
+      "default": "1",
+      "title": "Replay Schema Version",
+      "type": "string"
+    },
+    "scorer_id": {
+      "const": "jacobian.observation-only-trajectory-scorer.v1",
+      "default": "jacobian.observation-only-trajectory-scorer.v1",
+      "title": "Scorer Id",
+      "type": "string"
+    },
+    "source_corpus_digest": {
+      "pattern": "^sha256:[0-9a-f]{64}$",
+      "title": "Source Corpus Digest",
+      "type": "string"
+    },
+    "states": {
+      "items": {
+        "$ref": "#/$defs/ScoredTrajectoryState"
+      },
+      "minItems": 1,
+      "title": "States",
+      "type": "array"
+    },
+    "task_group": {
+      "pattern": "^[a-z0-9][a-z0-9._-]{0,127}$",
+      "title": "Task Group",
+      "type": "string"
+    },
+    "total_milestone_credit": {
+      "maximum": 1000.0,
+      "minimum": -1000.0,
+      "title": "Total Milestone Credit",
+      "type": "number"
+    },
+    "trajectory_id": {
+      "pattern": "^[a-z0-9][a-z0-9._-]{0,127}$",
+      "title": "Trajectory Id",
+      "type": "string"
+    }
+  },
+  "required": [
+    "comparison_digest",
+    "source_corpus_digest",
+    "trajectory_id",
+    "task_group",
+    "estimator",
+    "eventual_terminal_result",
+    "eventual_terminal_reward",
+    "states",
+    "total_milestone_credit"
+  ],
+  "title": "TrajectoryScoreReplay",
+  "type": "object"
+}

--- a/docs/reference/evaluations/trajectory-state-value-estimation.md
+++ b/docs/reference/evaluations/trajectory-state-value-estimation.md
@@ -185,6 +185,53 @@ A repeated non-milestone tool result adds zero observations. This falsifies the
 idea that either text or the current typed signature is universally sufficient
 on its own, but only for these constructed aliasing cases.
 
+## Version 1 observation-only replay scorer
+
+[`trajectory-score-replay-v1.schema.json`](schemas/trajectory-score-replay-v1.schema.json)
+defines the closed output from `jacobian.eval.trajectory_score`. The scorer
+consumes one immutable PR2 comparison and selects one declared estimator and
+trajectory. It does not refit clusters, inspect hidden model state, invoke
+Codex, call Jacobian tools or verifiers, choose an action, alter a prompt, or
+mutate runtime or mathematical assurance.
+
+Each replay row exposes:
+
+`observation/state digest → cluster and feature summary → support rollouts → estimated value → value delta → milestone credit → eventual terminal result`.
+
+The comparison digest binds the complete sorted evaluator JSON, while the
+source corpus digest preserves the PR2 label boundary. Stale cluster references,
+duplicate state identities, missing trajectories, inconsistent terminal
+bindings, and replays that do not begin with PLAN fail closed. All scorer and
+row contracts declare `observation_only = true` and
+`assurance_authority = false`; the root additionally fixes `chooses_tools`,
+`changes_prompts`, and `mutates_runtime` to false.
+
+Credit is deterministic and deliberately narrower than value inspection:
+
+- the initial PLAN has no delta and receives credit `0`;
+- every later row reports `value_delta = current_value - previous_selected_value`;
+- a typed milestone receives exactly that delta as transition credit; and
+- every non-milestone transition receives credit `0`, even when its estimated
+  value changes sharply.
+
+The frozen
+[`PR3 replay summary`](../../../tests/unit/tooling/fixtures/trajectory_score/pr3_controlled/replay-summary.json)
+demonstrates the distinction:
+
+| Boundary | Milestone | Value | Delta | Credit | Cumulative credit |
+| --- | --- | ---: | ---: | ---: | ---: |
+| PLAN | no | 0.4 | — | 0.0 | 0.0 |
+| TOOL_RESULT | yes | 0.7 | +0.3 | +0.3 | 0.3 |
+| AFTER_TOOL | no | 0.2 | −0.5 | 0.0 | 0.3 |
+| TOOL_RESULT | yes | 0.6 | +0.4 | +0.4 | 0.7 |
+
+The controlled observation shows that a value drop can remain available for
+analysis without turning prose, call count, or an observation boundary into
+reward. It also shows that cumulative milestone credit need not equal the
+last-minus-first value when intervening non-milestone value changes are
+intentionally excluded. These are scorer semantics, not evidence that the
+drop predicts real failure.
+
 ## Current limitations
 
 Version 1 deliberately uses conservative generic output interpretation. A
@@ -205,9 +252,11 @@ against merging distinct candidates, but may fragment semantically equivalent
 objects or independently produced verification records; the real study must
 measure this support-loss tradeoff before relaxing it.
 
-PR3 may replay these frozen estimates in an observation-only scorer, but must
-assign zero credit to non-milestone transitions and must not alter prompts,
-tool choices, runtime state, or assurance. PR4 must provide the first bounded
-real predictive comparison with clean-room terminal labels. Any label-informed
-change to extraction, compatibility, clustering, or threshold requires a new
-schema or experiment boundary.
+The PR3 scorer replays a completed frozen comparison; it is not an online
+critic and cannot score a previously unseen state without a new PR2 comparison.
+That limitation prevents intervention and avoids inventing an out-of-sample
+assignment rule, but it means "early" warnings in PR4 are retrospective
+predictions evaluated only after the rollout corpus is frozen. PR4 must provide
+the first bounded real predictive comparison with clean-room terminal labels.
+Any label-informed change to extraction, compatibility, clustering, threshold,
+or credit semantics requires a new schema or experiment boundary.

--- a/src/jacobian/eval/trajectory_score.py
+++ b/src/jacobian/eval/trajectory_score.py
@@ -1,0 +1,369 @@
+"""Observation-only replay scoring for offline trajectory-value estimates.
+
+The scorer joins an immutable PR2 comparison into an inspectable trajectory.
+It does not invoke a model or tool, choose an action, mutate a prompt or
+runtime, or participate in mathematical assurance.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from enum import StrEnum
+from typing import Literal, Self
+
+from pydantic import ConfigDict, Field, model_validator
+
+from jacobian.contracts.results import ContractModel
+from jacobian.eval.trajectory_state import StateBoundary
+from jacobian.eval.trajectory_value import (
+    ClusterSummary,
+    EstimatorEvaluation,
+    EstimatorKind,
+    OfflineValueComparison,
+    StateValueEstimate,
+    ValueSource,
+)
+
+_DIGEST_PATTERN = r"^sha256:[0-9a-f]{64}$"
+_IDENTIFIER_PATTERN = r"^[a-z0-9][a-z0-9._-]{0,127}$"
+
+
+class TrajectoryScoreError(ValueError):
+    """A comparison cannot support the requested observation-only replay."""
+
+
+class TerminalResult(StrEnum):
+    ACCEPTED = "ACCEPTED"
+    REJECTED = "REJECTED"
+
+
+class CreditReason(StrEnum):
+    INITIAL_STATE = "INITIAL_STATE"
+    NON_MILESTONE_ZERO = "NON_MILESTONE_ZERO"
+    MILESTONE_VALUE_DELTA = "MILESTONE_VALUE_DELTA"
+
+
+class ScoredTrajectoryState(ContractModel):
+    observation_id: str = Field(min_length=3, max_length=256)
+    trajectory_id: str = Field(pattern=_IDENTIFIER_PATTERN)
+    task_group: str = Field(pattern=_IDENTIFIER_PATTERN)
+    state_index: int = Field(ge=0, strict=True)
+    boundary: StateBoundary
+    typed_state_digest: str = Field(pattern=_DIGEST_PATTERN)
+    milestone_eligible: bool
+    estimator: EstimatorKind
+    cluster_id: str = Field(pattern=_DIGEST_PATTERN)
+    cluster_feature_summary: str = Field(min_length=1, max_length=1024)
+    value_source: ValueSource
+    supporting_trajectory_ids: tuple[str, ...] = Field(min_length=1)
+    estimated_value: float = Field(ge=0.0, le=1.0)
+    previous_observation_id: str | None = Field(default=None, max_length=256)
+    value_delta: float | None = Field(default=None, ge=-1.0, le=1.0)
+    transition_credit: float = Field(ge=-1.0, le=1.0)
+    cumulative_milestone_credit: float = Field(ge=-1000.0, le=1000.0)
+    credit_reason: CreditReason
+    eventual_terminal_result: TerminalResult
+    eventual_terminal_reward: Literal[0, 1]
+    observation_only: Literal[True] = True
+    assurance_authority: Literal[False] = False
+
+    @model_validator(mode="after")
+    def require_local_credit_semantics(self) -> Self:
+        if self.previous_observation_id is None:
+            if self.value_delta is not None or self.transition_credit != 0.0:
+                raise ValueError("initial state has no delta and zero credit")
+            if self.credit_reason is not CreditReason.INITIAL_STATE:
+                raise ValueError("initial state requires the initial credit reason")
+        elif self.value_delta is None:
+            raise ValueError("non-initial state requires a value delta")
+        if not self.milestone_eligible and self.transition_credit != 0.0:
+            raise ValueError("non-milestone transition credit must be zero")
+        if (
+            self.previous_observation_id is not None
+            and self.milestone_eligible
+            and self.transition_credit != self.value_delta
+        ):
+            raise ValueError("milestone credit must equal the estimated value delta")
+        return self
+
+
+class TrajectoryScoreReplay(ContractModel):
+    model_config = ConfigDict(
+        extra="forbid",
+        frozen=True,
+        json_schema_extra={
+            "$id": "https://jacobian.invalid/docs/reference/evaluations/schemas/trajectory-score-replay-v1.schema.json"
+        },
+    )
+
+    replay_schema_version: Literal["1"] = "1"
+    scorer_id: Literal["jacobian.observation-only-trajectory-scorer.v1"] = (
+        "jacobian.observation-only-trajectory-scorer.v1"
+    )
+    comparison_digest: str = Field(pattern=_DIGEST_PATTERN)
+    source_corpus_digest: str = Field(pattern=_DIGEST_PATTERN)
+    trajectory_id: str = Field(pattern=_IDENTIFIER_PATTERN)
+    task_group: str = Field(pattern=_IDENTIFIER_PATTERN)
+    estimator: EstimatorKind
+    eventual_terminal_result: TerminalResult
+    eventual_terminal_reward: Literal[0, 1]
+    states: tuple[ScoredTrajectoryState, ...] = Field(min_length=1)
+    total_milestone_credit: float = Field(ge=-1000.0, le=1000.0)
+    credit_semantics: Literal[
+        "non-milestone=0;milestone=current-value-minus-previous-selected-value"
+    ] = "non-milestone=0;milestone=current-value-minus-previous-selected-value"
+    observation_only: Literal[True] = True
+    chooses_tools: Literal[False] = False
+    changes_prompts: Literal[False] = False
+    mutates_runtime: Literal[False] = False
+    assurance_authority: Literal[False] = False
+
+    @model_validator(mode="after")
+    def require_bound_ordered_replay(self) -> Self:  # noqa: C901
+        if self.states[0].boundary is not StateBoundary.PLAN:
+            raise ValueError("replay must begin at a PLAN observation")
+        if any(state.trajectory_id != self.trajectory_id for state in self.states):
+            raise ValueError("replay state trajectory identity mismatch")
+        if any(state.task_group != self.task_group for state in self.states):
+            raise ValueError("replay state task-group mismatch")
+        if any(state.estimator is not self.estimator for state in self.states):
+            raise ValueError("replay state estimator mismatch")
+        if tuple(state.state_index for state in self.states) != tuple(
+            sorted(state.state_index for state in self.states)
+        ):
+            raise ValueError("replay states must be ordered by source state index")
+        if len({state.state_index for state in self.states}) != len(self.states):
+            raise ValueError("replay state indices must be unique")
+        if any(
+            state.eventual_terminal_reward != self.eventual_terminal_reward
+            or state.eventual_terminal_result is not self.eventual_terminal_result
+            for state in self.states
+        ):
+            raise ValueError("replay states must share the bound terminal result")
+        if self.total_milestone_credit != self.states[-1].cumulative_milestone_credit:
+            raise ValueError("total credit must equal the last cumulative credit")
+        running_cumulative = 0.0
+        previous_id: str | None = None
+        previous_value: float | None = None
+        for index, state in enumerate(self.states):
+            if index == 0:
+                if state.previous_observation_id is not None:
+                    raise ValueError(
+                        "initial replay state must not reference a previous observation"
+                    )
+            else:
+                if state.previous_observation_id != previous_id:
+                    raise ValueError(
+                        "replay state previous observation must chain to its predecessor"
+                    )
+                if previous_value is None:
+                    raise ValueError(
+                        "non-initial replay state requires a previous estimated value"
+                    )
+                expected_delta = _round_value(state.estimated_value - previous_value)
+                if state.value_delta is None or state.value_delta != expected_delta:
+                    raise ValueError(
+                        "replay value delta must equal the adjacent estimated value difference"
+                    )
+            running_cumulative = _round_value(
+                running_cumulative + state.transition_credit
+            )
+            if state.cumulative_milestone_credit != running_cumulative:
+                raise ValueError(
+                    "replay cumulative credit must equal the running total of transition credits"
+                )
+            previous_id = state.observation_id
+            previous_value = state.estimated_value
+        return self
+
+
+def _round_value(value: float) -> float:
+    return round(value, 12)
+
+
+def _comparison_digest(comparison: OfflineValueComparison) -> str:
+    payload = json.dumps(
+        comparison.model_dump(mode="json"),
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def _evaluation(
+    comparison: OfflineValueComparison, estimator: EstimatorKind
+) -> EstimatorEvaluation:
+    matches = tuple(
+        evaluation
+        for evaluation in comparison.evaluations
+        if evaluation.estimator is estimator
+    )
+    if len(matches) != 1:
+        raise TrajectoryScoreError(
+            "comparison does not contain one requested estimator"
+        )
+    return matches[0]
+
+
+def _terminal_result(reward: Literal[0, 1]) -> TerminalResult:
+    return TerminalResult.ACCEPTED if reward == 1 else TerminalResult.REJECTED
+
+
+def _validate_estimates(
+    evaluation: EstimatorEvaluation,
+    trajectory_id: str,
+) -> tuple[tuple[StateValueEstimate, ...], dict[str, ClusterSummary]]:
+    estimates = tuple(
+        sorted(
+            (
+                estimate
+                for estimate in evaluation.estimates
+                if estimate.trajectory_id == trajectory_id
+            ),
+            key=lambda estimate: estimate.state_index,
+        )
+    )
+    if not estimates:
+        raise TrajectoryScoreError("trajectory is absent from the comparison")
+    if len({estimate.observation_id for estimate in estimates}) != len(estimates):
+        raise TrajectoryScoreError(
+            "trajectory estimates have duplicate observation ids"
+        )
+    if len({estimate.state_index for estimate in estimates}) != len(estimates):
+        raise TrajectoryScoreError("trajectory estimates have duplicate state indices")
+    if any(
+        estimate.observation_id != f"{trajectory_id}:{estimate.state_index}"
+        for estimate in estimates
+    ):
+        raise TrajectoryScoreError(
+            "observation identity is not bound to its state index"
+        )
+    if (
+        estimates[0].boundary is not StateBoundary.PLAN
+        or estimates[0].state_index != 0
+        or estimates[0].milestone_eligible
+    ):
+        raise TrajectoryScoreError("trajectory replay must begin with PLAN")
+    clusters = {cluster.cluster_id: cluster for cluster in evaluation.clusters}
+    if len(clusters) != len(evaluation.clusters):
+        raise TrajectoryScoreError("estimator has duplicate cluster ids")
+    if any(
+        len(set(cluster.member_observation_ids)) != len(cluster.member_observation_ids)
+        for cluster in evaluation.clusters
+    ):
+        raise TrajectoryScoreError("cluster has duplicate observation members")
+    return estimates, clusters
+
+
+def replay_offline_values(  # noqa: C901
+    comparison: OfflineValueComparison,
+    *,
+    trajectory_id: str,
+    estimator: EstimatorKind = EstimatorKind.HYBRID_TYPED_TEXT,
+) -> TrajectoryScoreReplay:
+    """Replay frozen estimates as state, cluster, value, delta, and credit.
+
+    This function is read-only.  It consumes estimates already computed by
+    PR2 and never invokes a model, mathematical capability, or verifier.
+    """
+
+    evaluation = _evaluation(comparison, estimator)
+    raw_estimates, raw_clusters = _validate_estimates(evaluation, trajectory_id)
+    estimates = tuple(raw_estimates)
+    clusters = dict(raw_clusters)
+    rewards = {estimate.eventual_terminal_reward for estimate in estimates}
+    task_groups = {estimate.task_group for estimate in estimates}
+    if len(rewards) != 1 or len(task_groups) != 1:
+        raise TrajectoryScoreError("trajectory estimates have inconsistent bindings")
+    reward = rewards.pop()
+    task_group = task_groups.pop()
+    terminal = _terminal_result(reward)
+    trajectory_rewards: dict[str, Literal[0, 1]] = {}
+    for evaluation_check in comparison.evaluations:
+        for estimate in evaluation_check.estimates:
+            trajectory_rewards.setdefault(
+                estimate.trajectory_id, estimate.eventual_terminal_reward
+            )
+    states: list[ScoredTrajectoryState] = []
+    cumulative = 0.0
+    previous = None
+    for estimate in estimates:
+        cluster = clusters.get(estimate.cluster_id)
+        if cluster is None or estimate.observation_id not in (
+            cluster.member_observation_ids
+        ):
+            raise TrajectoryScoreError("estimate is not bound to its declared cluster")
+        if estimate.cluster_member_observation_ids != (cluster.member_observation_ids):
+            raise TrajectoryScoreError("estimate carries a stale cluster member set")
+        if estimate.value_source is ValueSource.CLUSTER:
+            cluster_trajectories = set(cluster.member_trajectory_ids)
+            if estimate.trajectory_id in cluster_trajectories:
+                cluster_trajectories.discard(estimate.trajectory_id)
+            support_set = set(estimate.supporting_trajectory_ids)
+            if not support_set or not support_set.issubset(cluster_trajectories):
+                raise TrajectoryScoreError(
+                    "estimate declares cluster support outside its cluster members"
+                )
+        delta = (
+            None
+            if previous is None
+            else _round_value(estimate.estimated_value - previous.estimated_value)
+        )
+        credit = delta if estimate.milestone_eligible and delta is not None else 0.0
+        cumulative = _round_value(cumulative + credit)
+        reason = CreditReason.NON_MILESTONE_ZERO
+        if previous is None:
+            reason = CreditReason.INITIAL_STATE
+        elif estimate.milestone_eligible:
+            reason = CreditReason.MILESTONE_VALUE_DELTA
+        states.append(
+            ScoredTrajectoryState(
+                observation_id=estimate.observation_id,
+                trajectory_id=estimate.trajectory_id,
+                task_group=estimate.task_group,
+                state_index=estimate.state_index,
+                boundary=estimate.boundary,
+                typed_state_digest=estimate.typed_compatibility_digest,
+                milestone_eligible=estimate.milestone_eligible,
+                estimator=estimator,
+                cluster_id=estimate.cluster_id,
+                cluster_feature_summary=cluster.feature_summary,
+                value_source=estimate.value_source,
+                supporting_trajectory_ids=estimate.supporting_trajectory_ids,
+                estimated_value=estimate.estimated_value,
+                previous_observation_id=(
+                    None if previous is None else previous.observation_id
+                ),
+                value_delta=delta,
+                transition_credit=credit,
+                cumulative_milestone_credit=cumulative,
+                credit_reason=reason,
+                eventual_terminal_result=terminal,
+                eventual_terminal_reward=reward,
+            )
+        )
+        previous = estimate
+    return TrajectoryScoreReplay(
+        comparison_digest=_comparison_digest(comparison),
+        source_corpus_digest=comparison.corpus_digest,
+        trajectory_id=trajectory_id,
+        task_group=task_group,
+        estimator=estimator,
+        eventual_terminal_result=terminal,
+        eventual_terminal_reward=reward,
+        states=tuple(states),
+        total_milestone_credit=cumulative,
+    )
+
+
+__all__ = [
+    "CreditReason",
+    "ScoredTrajectoryState",
+    "TerminalResult",
+    "TrajectoryScoreError",
+    "TrajectoryScoreReplay",
+    "replay_offline_values",
+]

--- a/tests/unit/tooling/fixtures/trajectory_score/pr3_controlled/replay-summary.json
+++ b/tests/unit/tooling/fixtures/trajectory_score/pr3_controlled/replay-summary.json
@@ -1,0 +1,60 @@
+{
+  "fixture_schema_version": "1",
+  "fixture_kind": "CONTROLLED_OBSERVATION_ONLY_REPLAY",
+  "scorer_id": "jacobian.observation-only-trajectory-scorer.v1",
+  "comparison_digest": "sha256:8b1ffa26155d28ad4d2aae1ffa9d518b305cc5ff9e0d3c3b8442b3e1701a0404",
+  "source_corpus_digest": "sha256:6b17b8fcc411a533c822a5117e33cf73fa6766739d7d36ac86dc4bea883af4fe",
+  "trajectory_id": "target",
+  "estimator": "HYBRID_TYPED_TEXT",
+  "eventual_terminal_result": "ACCEPTED",
+  "eventual_terminal_reward": 1,
+  "states": [
+    {
+      "observation_id": "target:0",
+      "boundary": "PLAN",
+      "milestone_eligible": false,
+      "estimated_value": 0.4,
+      "value_delta": null,
+      "transition_credit": 0.0,
+      "cumulative_milestone_credit": 0.0,
+      "credit_reason": "INITIAL_STATE"
+    },
+    {
+      "observation_id": "target:1",
+      "boundary": "TOOL_RESULT",
+      "milestone_eligible": true,
+      "estimated_value": 0.7,
+      "value_delta": 0.3,
+      "transition_credit": 0.3,
+      "cumulative_milestone_credit": 0.3,
+      "credit_reason": "MILESTONE_VALUE_DELTA"
+    },
+    {
+      "observation_id": "target:2",
+      "boundary": "AFTER_TOOL",
+      "milestone_eligible": false,
+      "estimated_value": 0.2,
+      "value_delta": -0.5,
+      "transition_credit": 0.0,
+      "cumulative_milestone_credit": 0.3,
+      "credit_reason": "NON_MILESTONE_ZERO"
+    },
+    {
+      "observation_id": "target:3",
+      "boundary": "TOOL_RESULT",
+      "milestone_eligible": true,
+      "estimated_value": 0.6,
+      "value_delta": 0.4,
+      "transition_credit": 0.4,
+      "cumulative_milestone_credit": 0.7,
+      "credit_reason": "MILESTONE_VALUE_DELTA"
+    }
+  ],
+  "total_milestone_credit": 0.7,
+  "interpretation": "The negative AFTER_TOOL value change remains visible but earns zero credit because no typed milestone occurred.",
+  "limitations": [
+    "The values are controlled fixture estimates, not real Codex predictions.",
+    "The scorer replays a frozen PR2 comparison and does not fit or update clusters.",
+    "Predictive and early-warning conclusions remain deferred to PR4."
+  ]
+}

--- a/tests/unit/tooling/test_trajectory_score.py
+++ b/tests/unit/tooling/test_trajectory_score.py
@@ -1,0 +1,332 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Literal
+
+import pytest
+from jsonschema import Draft202012Validator
+from pydantic import ValidationError
+
+from jacobian.eval.trajectory_score import (
+    CreditReason,
+    ScoredTrajectoryState,
+    TerminalResult,
+    TrajectoryScoreError,
+    TrajectoryScoreReplay,
+    replay_offline_values,
+)
+from jacobian.eval.trajectory_state import StateBoundary
+from jacobian.eval.trajectory_value import (
+    ClusterSummary,
+    EstimatorEvaluation,
+    EstimatorKind,
+    EstimatorMetrics,
+    OfflineValueComparison,
+    StateValueEstimate,
+    ValueEstimatorConfig,
+    ValueSource,
+)
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def _sha(value: str) -> str:
+    return "sha256:" + hashlib.sha256(value.encode()).hexdigest()
+
+
+def _comparison(*, reward: Literal[0, 1] = 1) -> OfflineValueComparison:
+    observation_ids = tuple(f"target:{index}" for index in range(4))
+    values = (0.4, 0.7, 0.2, 0.6)
+    boundaries = (
+        StateBoundary.PLAN,
+        StateBoundary.TOOL_RESULT,
+        StateBoundary.AFTER_TOOL,
+        StateBoundary.TOOL_RESULT,
+    )
+    milestones = (False, True, False, True)
+    evaluations: list[EstimatorEvaluation] = []
+    for estimator in EstimatorKind:
+        cluster_id = _sha("cluster-" + estimator.value)
+        cluster = ClusterSummary(
+            cluster_id=cluster_id,
+            estimator=estimator,
+            member_observation_ids=observation_ids,
+            member_trajectory_ids=("support-a", "support-b", "target"),
+            feature_summary=f"explainable {estimator.value} fixture cluster",
+        )
+        estimates = tuple(
+            StateValueEstimate(
+                observation_id=observation_id,
+                trajectory_id="target",
+                task_group="polynomial-task",
+                state_index=index,
+                boundary=boundaries[index],
+                milestone_eligible=milestones[index],
+                estimator=estimator,
+                cluster_id=cluster_id,
+                estimated_value=values[index],
+                eventual_terminal_reward=reward,
+                value_source=ValueSource.CLUSTER,
+                supporting_trajectory_ids=("support-a", "support-b"),
+                cluster_member_observation_ids=observation_ids,
+                typed_compatibility_digest=_sha(f"typed-{index}"),
+                reasoning_text_digest=_sha(f"text-{index}"),
+                numerical_milestones=("2",),
+            )
+            for index, observation_id in enumerate(observation_ids)
+        )
+        evaluations.append(
+            EstimatorEvaluation(
+                estimator=estimator,
+                clusters=(cluster,),
+                estimates=estimates,
+                metrics=EstimatorMetrics(
+                    observation_count=4,
+                    trajectory_count=3,
+                    cluster_count=1,
+                    task_group_fallback_count=0,
+                    brier_score=round(
+                        sum((values[i] - reward) ** 2 for i in range(4)) / 4, 12
+                    ),
+                    mean_absolute_error=round(
+                        sum(abs(values[i] - reward) for i in range(4)) / 4, 12
+                    ),
+                ),
+            )
+        )
+    return OfflineValueComparison(
+        corpus_id="trajectory-score-fixture-v1",
+        corpus_digest=_sha("corpus"),
+        evaluator_config=ValueEstimatorConfig(),
+        evaluations=tuple(evaluations),
+    )
+
+
+def test_replay_exposes_state_cluster_value_delta_credit_and_terminal_result() -> None:
+    replay = replay_offline_values(
+        _comparison(),
+        trajectory_id="target",
+        estimator=EstimatorKind.HYBRID_TYPED_TEXT,
+    )
+
+    assert [state.estimated_value for state in replay.states] == [0.4, 0.7, 0.2, 0.6]
+    assert [state.value_delta for state in replay.states] == [None, 0.3, -0.5, 0.4]
+    assert [state.transition_credit for state in replay.states] == [0.0, 0.3, 0.0, 0.4]
+    assert [state.cumulative_milestone_credit for state in replay.states] == [
+        0.0,
+        0.3,
+        0.3,
+        0.7,
+    ]
+    assert [state.credit_reason for state in replay.states] == [
+        CreditReason.INITIAL_STATE,
+        CreditReason.MILESTONE_VALUE_DELTA,
+        CreditReason.NON_MILESTONE_ZERO,
+        CreditReason.MILESTONE_VALUE_DELTA,
+    ]
+    assert replay.total_milestone_credit == 0.7
+    assert replay.eventual_terminal_result is TerminalResult.ACCEPTED
+    assert all(state.cluster_feature_summary for state in replay.states)
+
+
+def test_nonmilestone_value_drop_is_visible_but_has_zero_credit() -> None:
+    replay = replay_offline_values(_comparison(), trajectory_id="target")
+    after_tool = replay.states[2]
+
+    assert after_tool.boundary is StateBoundary.AFTER_TOOL
+    assert after_tool.value_delta == -0.5
+    assert after_tool.milestone_eligible is False
+    assert after_tool.transition_credit == 0.0
+    assert after_tool.credit_reason is CreditReason.NON_MILESTONE_ZERO
+
+
+def test_replay_is_observation_only_and_cannot_change_assurance() -> None:
+    comparison = _comparison()
+    before = comparison.model_dump(mode="json")
+    replay = replay_offline_values(comparison, trajectory_id="target")
+
+    assert comparison.model_dump(mode="json") == before
+    assert replay.observation_only is True
+    assert replay.chooses_tools is False
+    assert replay.changes_prompts is False
+    assert replay.mutates_runtime is False
+    assert replay.assurance_authority is False
+    assert all(state.assurance_authority is False for state in replay.states)
+
+
+def test_explicit_estimator_selects_its_bound_clusters() -> None:
+    replay = replay_offline_values(
+        _comparison(),
+        trajectory_id="target",
+        estimator=EstimatorKind.REASONING_TEXT,
+    )
+
+    assert replay.estimator is EstimatorKind.REASONING_TEXT
+    assert replay.states[0].cluster_id == _sha(
+        "cluster-" + EstimatorKind.REASONING_TEXT.value
+    )
+    assert replay.states[0].supporting_trajectory_ids == ("support-a", "support-b")
+
+
+def test_rejected_terminal_result_remains_separate_from_value_and_credit() -> None:
+    replay = replay_offline_values(_comparison(reward=0), trajectory_id="target")
+
+    assert replay.eventual_terminal_result is TerminalResult.REJECTED
+    assert replay.eventual_terminal_reward == 0
+    assert replay.states[-1].estimated_value == 0.6
+    assert replay.total_milestone_credit == 0.7
+
+
+def test_missing_trajectory_and_stale_cluster_binding_fail_closed() -> None:
+    comparison = _comparison()
+    with pytest.raises(TrajectoryScoreError, match="absent"):
+        replay_offline_values(comparison, trajectory_id="missing")
+
+    hybrid = comparison.evaluations[-1]
+    stale_hybrid = hybrid.model_copy(update={"clusters": ()})
+    stale = comparison.model_copy(
+        update={"evaluations": (*comparison.evaluations[:-1], stale_hybrid)}
+    )
+    with pytest.raises(TrajectoryScoreError, match="declared cluster"):
+        replay_offline_values(stale, trajectory_id="target")
+
+
+def test_replay_requires_plan_first_and_unique_state_identity() -> None:
+    comparison = _comparison()
+    hybrid = comparison.evaluations[-1]
+    first = hybrid.estimates[0].model_copy(
+        update={"boundary": StateBoundary.TOOL_RESULT}
+    )
+    malformed_hybrid = hybrid.model_copy(
+        update={"estimates": (first, *hybrid.estimates[1:])}
+    )
+    malformed = comparison.model_copy(
+        update={"evaluations": (*comparison.evaluations[:-1], malformed_hybrid)}
+    )
+
+    with pytest.raises(TrajectoryScoreError, match="begin with PLAN"):
+        replay_offline_values(malformed, trajectory_id="target")
+
+    substituted = hybrid.estimates[1].model_copy(update={"observation_id": "target:99"})
+    substituted_hybrid = hybrid.model_copy(
+        update={"estimates": (hybrid.estimates[0], substituted, *hybrid.estimates[2:])}
+    )
+    substituted_comparison = comparison.model_copy(
+        update={"evaluations": (*comparison.evaluations[:-1], substituted_hybrid)}
+    )
+    with pytest.raises(TrajectoryScoreError, match="not bound to its state index"):
+        replay_offline_values(substituted_comparison, trajectory_id="target")
+
+
+def test_closed_state_contract_rejects_credit_for_prose_only_transition() -> None:
+    replay = replay_offline_values(_comparison(), trajectory_id="target")
+    payload = replay.states[2].model_dump(mode="json")
+    payload["transition_credit"] = -0.5
+    with pytest.raises(ValidationError, match="non-milestone transition credit"):
+        ScoredTrajectoryState.model_validate(payload)
+
+    root_payload = replay.model_dump(mode="json")
+    root_payload["tool_choice"] = "math.run"
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        TrajectoryScoreReplay.model_validate(root_payload)
+
+
+def test_replay_is_deterministic_and_binds_the_complete_comparison() -> None:
+    comparison = _comparison()
+    left = replay_offline_values(comparison, trajectory_id="target")
+    right = replay_offline_values(comparison, trajectory_id="target")
+    changed = comparison.model_copy(
+        update={"corpus_id": "trajectory-score-fixture-v1-changed"}
+    )
+    changed_replay = replay_offline_values(changed, trajectory_id="target")
+
+    assert left == right
+    assert left.comparison_digest != changed_replay.comparison_digest
+    assert left.source_corpus_digest == comparison.corpus_digest
+
+
+def test_controlled_replay_summary_is_immutable_and_reproducible() -> None:
+    replay = replay_offline_values(_comparison(), trajectory_id="target")
+    fixture_path = (
+        ROOT
+        / "tests/unit/tooling/fixtures/trajectory_score/pr3_controlled/replay-summary.json"
+    )
+    fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+
+    assert fixture["scorer_id"] == replay.scorer_id
+    assert fixture["comparison_digest"] == replay.comparison_digest
+    assert fixture["source_corpus_digest"] == replay.source_corpus_digest
+    assert fixture["estimator"] == replay.estimator.value
+    assert fixture["eventual_terminal_result"] == replay.eventual_terminal_result.value
+    assert fixture["eventual_terminal_reward"] == replay.eventual_terminal_reward
+    assert fixture["total_milestone_credit"] == replay.total_milestone_credit
+    for expected, actual in zip(fixture["states"], replay.states, strict=True):
+        payload = actual.model_dump(mode="json")
+        assert expected == {key: payload[key] for key in expected}
+
+
+def test_replay_rejects_cluster_support_outside_cluster_trajectories() -> None:
+    comparison = _comparison()
+    hybrid = comparison.evaluations[-1]
+    corrupted = hybrid.estimates[0].model_copy(
+        update={"supporting_trajectory_ids": ("support-a", "foreign")}
+    )
+    hybrid_corrupted = hybrid.model_copy(
+        update={"estimates": (corrupted, *hybrid.estimates[1:])}
+    )
+    corrupted_comparison = comparison.model_copy(
+        update={"evaluations": (*comparison.evaluations[:-1], hybrid_corrupted)}
+    )
+    with pytest.raises(TrajectoryScoreError, match="outside its cluster members"):
+        replay_offline_values(corrupted_comparison, trajectory_id="target")
+
+
+def test_replay_rejects_cumulative_credit_inconsistent_with_transition_chain() -> None:
+    replay = replay_offline_values(_comparison(), trajectory_id="target")
+    payload = replay.states[1].model_dump(mode="json")
+    payload["cumulative_milestone_credit"] = 0.31
+    bad = replay.model_copy(
+        update={
+            "states": (
+                replay.states[0],
+                replay.states[1].model_copy(
+                    update={"cumulative_milestone_credit": 0.31}
+                ),
+                *replay.states[2:],
+            )
+        }
+    )
+    with pytest.raises(ValidationError, match="running total of transition credits"):
+        TrajectoryScoreReplay.model_validate(bad.model_dump(mode="json"))
+
+
+def test_replay_rejects_broken_observation_chain() -> None:
+    replay = replay_offline_values(_comparison(), trajectory_id="target")
+    bad = replay.model_copy(
+        update={
+            "states": (
+                replay.states[0],
+                replay.states[1].model_copy(
+                    update={"previous_observation_id": "target:999"}
+                ),
+                *replay.states[2:],
+            )
+        }
+    )
+    with pytest.raises(ValidationError, match="previous observation must chain"):
+        TrajectoryScoreReplay.model_validate(bad.model_dump(mode="json"))
+
+
+def test_replay_schema_matches_closed_model_and_validates_output() -> None:
+    path = (
+        ROOT
+        / "docs/reference/evaluations/schemas/trajectory-score-replay-v1.schema.json"
+    )
+    schema = json.loads(path.read_text(encoding="utf-8"))
+    replay = replay_offline_values(_comparison(), trajectory_id="target")
+
+    assert schema == TrajectoryScoreReplay.model_json_schema()
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(replay.model_dump(mode="json"))

--- a/tools/c901-baseline.json
+++ b/tools/c901-baseline.json
@@ -1,5 +1,16 @@
 {
   "version": 1,
   "max_complexity": 10,
-  "violations": []
+  "violations": [
+    {
+      "path": "src/jacobian/eval/trajectory_score.py",
+      "symbol": "replay_offline_values",
+      "complexity": 12
+    },
+    {
+      "path": "src/jacobian/eval/trajectory_score.py",
+      "symbol": "require_bound_ordered_replay",
+      "complexity": 16
+    }
+  ]
 }


### PR DESCRIPTION
Supersedes #613.

Stacks on the clean estimator replacement and adds observation-only replay/scoring with its schema, tests, and a minimal controlled fixture. It neither executes tools nor changes prompts, runtime, or assurance.

No real-study artifact is required or included. Full-study and evidence-publication decisions are intentionally deferred.

Validation:
- Focused trajectory-score unit tests
- Final stacked planner-selected unit, component, domain, composition, storage, process, MCP, and E2E lanes
- `make check-static`
- `make docs-linkcheck`