### PR TITLE
fix(math): normalize exact rational vectors

### DIFF
--- a/src/jacobian/contracts/projective_geometry.py
+++ b/src/jacobian/contracts/projective_geometry.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from math import comb, gcd
+from math import comb, gcd, lcm
 from typing import Annotated, Literal, Self
 
 from pydantic import Field, StringConstraints, model_validator
@@ -23,15 +23,9 @@ def _primitive_integer_triple(
     coefficients: tuple[CanonicalRational, CanonicalRational, CanonicalRational],
 ) -> tuple[int, int, int]:
     fractions = tuple(coefficient.as_fraction() for coefficient in coefficients)
-    denominator_lcm = 1
-    for coefficient in fractions:
-        denominator_lcm = (
-            denominator_lcm
-            * coefficient.denominator
-            // gcd(denominator_lcm, coefficient.denominator)
-        )
+    common_denominator = lcm(*(coefficient.denominator for coefficient in fractions))
     integers = tuple(
-        coefficient.numerator * (denominator_lcm // coefficient.denominator)
+        coefficient.numerator * (common_denominator // coefficient.denominator)
         for coefficient in fractions
     )
     divisor = 0
@@ -40,8 +34,7 @@ def _primitive_integer_triple(
     if divisor == 0:
         raise ValueError("a projective line coefficient triple must be nonzero")
     primitive = tuple(value // divisor for value in integers)
-    first = next(value for value in primitive if value)
-    if first < 0:
+    if next(value for value in primitive if value) < 0:
         primitive = tuple(-value for value in primitive)
     return (primitive[0], primitive[1], primitive[2])
 

--- a/src/jacobian/domains/polynomial/jacobian_syzygy.py
+++ b/src/jacobian/domains/polynomial/jacobian_syzygy.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import hashlib
 from fractions import Fraction
-from math import gcd
 from typing import Any, Literal, cast
 
 from jacobian.canonical import canonicalize_json, format_canonical_integer
@@ -28,6 +27,7 @@ from jacobian.contracts.polynomials import (
 )
 from jacobian.domains.polynomial._support import materialized_polynomial_operation
 from jacobian.domains.polynomial.operations import _poly, _rational, _symbols, _wire
+from jacobian.math.arithmetic import primitive_integer_vector
 
 
 def _homogeneous_basis(degree: int) -> tuple[tuple[int, int, int], ...]:
@@ -67,24 +67,10 @@ def _matrix_digest(
 
 def _primitive_kernel(vector: Any) -> tuple[Fraction, ...]:
     fractions = tuple(Fraction(value) for value in vector)
-    denominator_lcm = 1
-    for fraction_value in fractions:
-        denominator_lcm = (
-            denominator_lcm
-            * fraction_value.denominator
-            // gcd(denominator_lcm, fraction_value.denominator)
-        )
-    integers = tuple(
-        value.numerator * (denominator_lcm // value.denominator) for value in fractions
-    )
-    divisor = 0
-    for integer in integers:
-        divisor = gcd(divisor, abs(integer))
-    if divisor == 0:
-        raise RuntimeError("symbolic nullspace returned a zero basis vector")
-    primitive = tuple(value // divisor for value in integers)
-    if next(value for value in primitive if value) < 0:
-        primitive = tuple(-value for value in primitive)
+    try:
+        primitive = primitive_integer_vector(fractions)
+    except ValueError as exc:
+        raise RuntimeError("symbolic nullspace returned a zero basis vector") from exc
     return tuple(Fraction(value) for value in primitive)
 
 

--- a/src/jacobian/domains/projective_geometry/arrangements.py
+++ b/src/jacobian/domains/projective_geometry/arrangements.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from fractions import Fraction
-from math import comb, gcd
+from math import comb
 from typing import cast
 
 from jacobian.contracts.projective_geometry import (
@@ -16,6 +16,7 @@ from jacobian.contracts.projective_geometry import (
 )
 from jacobian.contracts.results import ContractModel
 from jacobian.domains._examples import example
+from jacobian.math.arithmetic import primitive_integer_vector
 from jacobian.operations import (
     MaterializedOperation,
     MaterializedOperationFactory,
@@ -24,24 +25,10 @@ from jacobian.operations import (
 
 
 def _primitive(values: tuple[Fraction, Fraction, Fraction]) -> tuple[int, int, int]:
-    denominator_lcm = 1
-    for fraction_value in values:
-        denominator_lcm = (
-            denominator_lcm
-            * fraction_value.denominator
-            // gcd(denominator_lcm, fraction_value.denominator)
-        )
-    integers = tuple(
-        value.numerator * (denominator_lcm // value.denominator) for value in values
-    )
-    divisor = 0
-    for integer in integers:
-        divisor = gcd(divisor, abs(integer))
-    if divisor == 0:
-        raise ValueError("projective homogeneous coordinates must be nonzero")
-    primitive = tuple(value // divisor for value in integers)
-    if next(value for value in primitive if value) < 0:
-        primitive = tuple(-value for value in primitive)
+    try:
+        primitive = primitive_integer_vector(values)
+    except ValueError as exc:
+        raise ValueError("projective homogeneous coordinates must be nonzero") from exc
     return cast(tuple[int, int, int], primitive)
 
 

--- a/src/jacobian/math/arithmetic.py
+++ b/src/jacobian/math/arithmetic.py
@@ -1,9 +1,19 @@
 """Exact arithmetic on Python integers and fractions."""
 
+from collections.abc import Iterable
 from fractions import Fraction
+from math import gcd, lcm
 from typing import SupportsIndex
 
-__all__ = ["absolute_value", "quotient", "reciprocal", "sign", "sum_rationals"]
+__all__ = [
+    "absolute_value",
+    "integerize_rational_vector",
+    "primitive_integer_vector",
+    "quotient",
+    "reciprocal",
+    "sign",
+    "sum_rationals",
+]
 
 
 def absolute_value(value: SupportsIndex) -> int:
@@ -32,6 +42,32 @@ def sum_rationals(left: Fraction | int, right: Fraction | int) -> Fraction:
     """Add two exact rational values."""
 
     return Fraction(left) + Fraction(right)
+
+
+def integerize_rational_vector(values: Iterable[Fraction | int]) -> tuple[int, ...]:
+    """Scale exact rationals to integer coordinates with a shared denominator."""
+
+    rationals = tuple(Fraction(value) for value in values)
+    common_denominator = lcm(*(value.denominator for value in rationals))
+    return tuple(
+        value.numerator * (common_denominator // value.denominator)
+        for value in rationals
+    )
+
+
+def primitive_integer_vector(values: Iterable[Fraction | int]) -> tuple[int, ...]:
+    """Normalize a nonzero rational vector to primitive, positive-leading integers."""
+
+    integers = integerize_rational_vector(values)
+    divisor = 0
+    for value in integers:
+        divisor = gcd(divisor, abs(value))
+    if not divisor:
+        raise ValueError("a primitive integer vector must be nonzero")
+    primitive = tuple(value // divisor for value in integers)
+    if next(value for value in primitive if value) < 0:
+        return tuple(-value for value in primitive)
+    return primitive
 
 
 def quotient(left: Fraction | int, right: Fraction | int) -> Fraction:

--- a/src/jacobian/polytope.py
+++ b/src/jacobian/polytope.py
@@ -43,6 +43,7 @@ from jacobian.contracts.results import (
     ResultEnvelope,
     Verification,
 )
+from jacobian.math.arithmetic import integerize_rational_vector
 from jacobian.schema_registry import SchemaRegistry, SchemaRegistryError, model_schema
 from jacobian.storage.errors import StorageError
 from jacobian.storage.models import StoredArtifact
@@ -430,16 +431,9 @@ class PolytopeService:
             _model_fraction(model, coefficient) for coefficient in coefficients
         )
         rational_rhs = _model_fraction(model, rhs)
-        common_denominator = math.lcm(
-            *(value.denominator for value in (*rational_values, rational_rhs))
-        )
-        integer_coefficients = tuple(
-            value.numerator * (common_denominator // value.denominator)
-            for value in rational_values
-        )
-        integer_rhs = rational_rhs.numerator * (
-            common_denominator // rational_rhs.denominator
-        )
+        integer_values = integerize_rational_vector((*rational_values, rational_rhs))
+        integer_coefficients = integer_values[:-1]
+        integer_rhs = integer_values[-1]
         divisor = reduce(
             math.gcd,
             (abs(value) for value in (*integer_coefficients, integer_rhs)),

--- a/tests/unit/public_api/test_arithmetic.py
+++ b/tests/unit/public_api/test_arithmetic.py
@@ -19,6 +19,25 @@ def test_exact_rational_operations() -> None:
     assert arithmetic.reciprocal(Fraction(-2, 3)) == Fraction(-3, 2)
 
 
+def test_integerize_and_normalize_exact_rational_vectors() -> None:
+    values = (Fraction(-1, 2), Fraction(3, 4), Fraction(-1, 8))
+
+    assert arithmetic.integerize_rational_vector(values) == (-4, 6, -1)
+    assert arithmetic.primitive_integer_vector(values) == (4, -6, 1)
+
+
+def test_integerize_rational_vector_uses_one_lcm_for_mixed_denominators() -> None:
+    values = (Fraction(1, 6), Fraction(1, 4), Fraction(1, 9), Fraction(5, 18))
+
+    assert arithmetic.integerize_rational_vector(values) == (6, 9, 4, 10)
+    assert arithmetic.primitive_integer_vector(values) == (6, 9, 4, 10)
+
+
+def test_primitive_integer_vector_rejects_zero_vector() -> None:
+    with pytest.raises(ValueError, match="nonzero"):
+        arithmetic.primitive_integer_vector((Fraction(0), Fraction(0)))
+
+
 @pytest.mark.parametrize(
     "operation", [arithmetic.reciprocal, lambda x: arithmetic.quotient(1, x)]
 )

--- a/tests/unit/public_api/test_namespace.py
+++ b/tests/unit/public_api/test_namespace.py
@@ -10,6 +10,8 @@ PUBLIC_API = {
     "jacobian.math": ("arithmetic", "graphs", "matrices"),
     "jacobian.math.arithmetic": (
         "absolute_value",
+        "integerize_rational_vector",
+        "primitive_integer_vector",
         "quotient",
         "reciprocal",
         "sign",


### PR DESCRIPTION
Fixes #735.

### Summary

Rational-vector normalization was implemented independently in the polynomial syzygy and projective-arrangement domains, while polytope separation separately repeated denominator clearing. This change establishes typed native arithmetic kernels for shared-denominator integerization and primitive, positive-leading normalization.

The domain paths now reuse those kernels. The Pydantic contract layer remains dependency-light and uses `math.lcm` directly for its equivalent boundary validation.

### Regression coverage

The public arithmetic tests cover mixed and partially shared denominators, sign normalization, and rejection of an all-zero vector. Projective arrangement and polynomial syzygy coverage exercise the migrated domain paths; the polytope provider suite covers separator scaling.

### Validation

- `make test-unit TESTS='tests/unit/public_api/test_arithmetic.py tests/unit/public_api/test_namespace.py'` — 12 passed\n- `make test-domain TESTS=tests/domain/polynomial/test_jacobian_syzygy_invariants.py` — 1 passed\n- `make test-component TESTS=tests/component/checkers/test_exact_domain_checker_installation.py` — 5 passed\n- `make test-composition TESTS='tests/composition/runtime/test_frontier_capabilities.py::test_projective_arrangement_materializes_the_nine_line_flat_lattice tests/composition/runtime/test_frontier_capabilities.py::test_projective_arrangement_rejects_projectively_duplicate_lines'` — 2 passed\n- `uv run --locked ruff check …` and `uv run --locked mypy …` — passed\n\nNo public wire format or capability contract changes.