### PR TITLE
perf(mcp): cache MCP tool argument names

### DIFF
--- a/src/jacobian/adapters/mcp/server.py
+++ b/src/jacobian/adapters/mcp/server.py
@@ -108,6 +108,14 @@ class JacobianCoreExtension(Extension):
         self._runtime = runtime
         self._tenant_router = tenant_router
         self._reasoning_log_mode = reasoning_log_mode
+        self._accepted_tool_arguments: dict[str, frozenset[str]] = {
+            binding.kwargs["name"]: frozenset(
+                name
+                for name in inspect.signature(binding.fn).parameters
+                if name != "ctx"
+            )
+            for binding in self.tools()
+        }
 
     def settings(self) -> dict[str, Any]:
         return {
@@ -254,16 +262,9 @@ class JacobianCoreExtension(Extension):
                 # Keep this narrow adapter check so the public tool boundary remains
                 # closed; domain-selected capability payloads are validated later by
                 # Jacobian's descriptor contract.
-                binding = next(
-                    binding
-                    for binding in self.tools()
-                    if binding.kwargs["name"] == params.name
-                )
-                accepted_arguments = {
-                    name
-                    for name in inspect.signature(binding.fn).parameters
-                    if name != "ctx"
-                }
+                accepted_arguments = self._accepted_tool_arguments.get(params.name)
+                if accepted_arguments is None:
+                    raise ValueError(f"unknown tool: {params.name}")
                 unknown_arguments = sorted(set(arguments) - accepted_arguments)
                 if unknown_arguments:
                     raise ValueError(

--- a/tests/unit/tooling/test_mcp_tool_surface.py
+++ b/tests/unit/tooling/test_mcp_tool_surface.py
@@ -22,6 +22,17 @@ def test_core_extension_exposes_exactly_the_stable_math_tools() -> None:
         "math.find",
         "math.run",
     )
+    assert set(extension._accepted_tool_arguments) == {"math.find", "math.run"}
+    assert "ctx" not in extension._accepted_tool_arguments["math.find"]
+    assert "capability_id" in extension._accepted_tool_arguments["math.find"]
+
+
+def test_core_extension_caches_reasoning_tool_arguments_when_enabled() -> None:
+    extension = JacobianCoreExtension(None, None, ReasoningLogMode.REQUIRED)
+
+    assert "reasoning.write" in extension._accepted_tool_arguments
+    assert "reasoning_run_id" in extension._accepted_tool_arguments["math.run"]
+    assert "reasoning_call_id" in extension._accepted_tool_arguments["math.run"]
 
 
 def test_model_visible_guidance_exposes_affordances_without_research_order() -> None:


### PR DESCRIPTION
Fixes #737.

### Change

Derive each tool’s accepted argument names once from the extension’s existing `tools()` bindings during initialization. Request interception now uses that immutable map instead of rebuilding bindings and inspecting handlers for every call.

The public tool definitions remain the single source of truth, including the reasoning-enabled `math.run` signature. Unknown unregistered tool names now take the adapter’s invalid-input error path if they reach the interceptor directly; normal MCP dispatch rejects them before that point.

### Coverage

The tool-surface tests cover the stable OFF mode plus the reasoning identifiers required by the enabled `math.run` handler. The MCP SDK conformance test exercises unknown-argument rejection through a live client/server call.

### Validation

- `make test-unit TESTS=tests/unit/tooling/test_mcp_tool_surface.py` — 6 passed
- `make test-mcp TESTS=tests/boundary/mcp/test_mcp_sdk_2_conformance.py` — 2 passed
- `make check-static` — passed
- `make npm-test` — 45 passed