### PR TITLE
Compose materialized complexes into topology operations

### DIFF
--- a/src/jacobian/contracts/topology.py
+++ b/src/jacobian/contracts/topology.py
@@ -14,7 +14,7 @@ from jacobian.contracts.certified_snf import (
     CertifiedIntegerMatrix,
     SmithNormalFormCertificate,
 )
-from jacobian.contracts.common import Sha256Digest
+from jacobian.contracts.common import ArtifactUri, Sha256Digest
 from jacobian.contracts.exact import CanonicalInteger
 from jacobian.contracts.results import ContractModel
 
@@ -279,8 +279,20 @@ def require_linear_algebra_bounds(complex_: FiniteSimplicialComplex) -> None:
         )
 
 
-class ChainComplexRequest(ContractModel):
-    complex: FiniteSimplicialComplex
+class SimplicialComplexSource(ContractModel):
+    """Select one inline or previously materialized simplicial complex."""
+
+    complex: FiniteSimplicialComplex | None = None
+    complex_artifact_uri: ArtifactUri | None = Field(default=None, exclude=True)
+
+    @model_validator(mode="after")
+    def require_exactly_one_complex_source(self) -> Self:
+        if (self.complex is None) == (self.complex_artifact_uri is None):
+            raise ValueError("provide exactly one of complex or complex_artifact_uri")
+        return self
+
+
+class ChainComplexRequest(SimplicialComplexSource):
     coefficient_ring: ChainCoefficientRing = ChainCoefficientRing.INTEGER
     prime: StrictInt | None = Field(default=None, ge=2, le=MAX_TOPOLOGY_PRIME)
     convention: HomologyConvention = HomologyConvention.UNREDUCED
@@ -292,7 +304,8 @@ class ChainComplexRequest(ContractModel):
                 raise ValueError("integer chain complexes must not declare a prime")
         elif self.prime is None or not is_bounded_prime(self.prime):
             raise ValueError("prime-field chain complexes require a bounded prime")
-        require_linear_algebra_bounds(self.complex)
+        if self.complex is not None:
+            require_linear_algebra_bounds(self.complex)
         return self
 
 
@@ -408,8 +421,7 @@ class ChainComplexResult(TopologyExactResult):
         return self
 
 
-class SimplicialHomologyRequest(ContractModel):
-    complex: FiniteSimplicialComplex
+class SimplicialHomologyRequest(SimplicialComplexSource):
     prime: StrictInt = Field(ge=2, le=MAX_TOPOLOGY_PRIME)
     convention: HomologyConvention = HomologyConvention.UNREDUCED
 
@@ -417,7 +429,8 @@ class SimplicialHomologyRequest(ContractModel):
     def require_prime_and_bounds(self) -> Self:
         if not is_bounded_prime(self.prime):
             raise ValueError("homology coefficients require a bounded prime")
-        require_linear_algebra_bounds(self.complex)
+        if self.complex is not None:
+            require_linear_algebra_bounds(self.complex)
         return self
 
 
@@ -509,12 +522,13 @@ class SimplicialHomologyResult(TopologyExactResult):
         return self
 
 
-class IntegralSimplicialHomologyRequest(ContractModel):
-    complex: FiniteSimplicialComplex
+class IntegralSimplicialHomologyRequest(SimplicialComplexSource):
     convention: HomologyConvention = HomologyConvention.UNREDUCED
 
     @model_validator(mode="after")
     def require_integral_certificate_bounds(self) -> Self:
+        if self.complex is None:
+            return self
         require_linear_algebra_bounds(self.complex)
         if any(
             size > MAX_INTEGRAL_HOMOLOGY_CHAIN_GROUP for size in self.complex.f_vector

--- a/src/jacobian/domains/topology/operations.py
+++ b/src/jacobian/domains/topology/operations.py
@@ -181,6 +181,7 @@ def _product_is_zero(
 
 def _chain_result(request: ChainComplexRequest) -> ChainComplexResult:
     complex_ = request.complex
+    assert complex_ is not None
     bases = tuple(
         SimplexBasis(dimension=item.dimension, simplices=item.faces)
         for item in complex_.faces_by_dimension
@@ -237,7 +238,41 @@ def _chain_result(request: ChainComplexRequest) -> ChainComplexResult:
 def _chain(
     request: ChainComplexRequest,
 ) -> ComputedSuccess[ChainComplexResult]:
+    assert request.complex is not None
     return ComputedSuccess(_chain_result(request))
+
+
+def _convert_materialized_chain(
+    request: ChainComplexRequest,
+    payload: SimplicialComplexMaterializationResult,
+) -> tuple[ChainComplexRequest, tuple[str, ...]]:
+    return ChainComplexRequest(
+        complex=payload.complex,
+        coefficient_ring=request.coefficient_ring,
+        prime=request.prime,
+        convention=request.convention,
+    ), ((request.complex_artifact_uri,) if request.complex_artifact_uri else ())
+
+
+def _convert_materialized_homology(
+    request: SimplicialHomologyRequest,
+    payload: SimplicialComplexMaterializationResult,
+) -> tuple[SimplicialHomologyRequest, tuple[str, ...]]:
+    return SimplicialHomologyRequest(
+        complex=payload.complex,
+        prime=request.prime,
+        convention=request.convention,
+    ), ((request.complex_artifact_uri,) if request.complex_artifact_uri else ())
+
+
+def _convert_materialized_integral_homology(
+    request: IntegralSimplicialHomologyRequest,
+    payload: SimplicialComplexMaterializationResult,
+) -> tuple[IntegralSimplicialHomologyRequest, tuple[str, ...]]:
+    return IntegralSimplicialHomologyRequest(
+        complex=payload.complex,
+        convention=request.convention,
+    ), ((request.complex_artifact_uri,) if request.complex_artifact_uri else ())
 
 
 def _domain_matrix(
@@ -393,6 +428,7 @@ def _quotient_basis(
 def _homology(
     request: SimplicialHomologyRequest,
 ) -> ComputedSuccess[SimplicialHomologyResult]:
+    assert request.complex is not None
     chain = _chain_result(
         ChainComplexRequest(
             complex=request.complex,
@@ -499,6 +535,7 @@ def _integral_vector(values: list[int]) -> IntegralVector:
 def _integral_homology(
     request: IntegralSimplicialHomologyRequest,
 ) -> ComputedSuccess[IntegralSimplicialHomologyResult]:
+    assert request.complex is not None
     chain = _chain_result(
         ChainComplexRequest(
             complex=request.complex,
@@ -679,6 +716,10 @@ TOPOLOGY_CAPABILITIES: tuple[MaterializedOperation[Any, Any, Any, Any], ...] = (
         result_model=ChainComplexResult,
         implementation=_chain,
         relation_id="topology.simplicial_complex.chain_complex.relation",
+        accepted_result_capability_ids=("topology.simplicial_complex.materialize",),
+        artifact_converter=_convert_materialized_chain,
+        artifact_payload_model=SimplicialComplexMaterializationResult,
+        artifact_uri_field="complex_artifact_uri",
         tags=(
             "topology",
             "simplicial-complex",
@@ -686,7 +727,7 @@ TOPOLOGY_CAPABILITIES: tuple[MaterializedOperation[Any, Any, Any, Any], ...] = (
             "boundary-matrix",
             "exact",
         ),
-        version="3",
+        version="4",
     ),
     MaterializedOperation(
         capability_id="topology.simplicial_homology.compute",
@@ -699,6 +740,10 @@ TOPOLOGY_CAPABILITIES: tuple[MaterializedOperation[Any, Any, Any, Any], ...] = (
         result_model=SimplicialHomologyResult,
         implementation=_homology,
         relation_id="topology.simplicial_homology.relation",
+        accepted_result_capability_ids=("topology.simplicial_complex.materialize",),
+        artifact_converter=_convert_materialized_homology,
+        artifact_payload_model=SimplicialComplexMaterializationResult,
+        artifact_uri_field="complex_artifact_uri",
         tags=(
             "topology",
             "simplicial-homology",
@@ -707,7 +752,7 @@ TOPOLOGY_CAPABILITIES: tuple[MaterializedOperation[Any, Any, Any, Any], ...] = (
             "prime-field",
             "exact",
         ),
-        version="3",
+        version="4",
     ),
     MaterializedOperation(
         capability_id="topology.simplicial_homology.integral.compute",
@@ -721,6 +766,10 @@ TOPOLOGY_CAPABILITIES: tuple[MaterializedOperation[Any, Any, Any, Any], ...] = (
         result_model=IntegralSimplicialHomologyResult,
         implementation=_integral_homology,
         relation_id="topology.simplicial_homology.integral.relation",
+        accepted_result_capability_ids=("topology.simplicial_complex.materialize",),
+        artifact_converter=_convert_materialized_integral_homology,
+        artifact_payload_model=SimplicialComplexMaterializationResult,
+        artifact_uri_field="complex_artifact_uri",
         tags=(
             "topology",
             "simplicial-homology",
@@ -770,7 +819,7 @@ TOPOLOGY_CAPABILITIES: tuple[MaterializedOperation[Any, Any, Any, Any], ...] = (
                 },
             ),
         ),
-        version="3",
+        version="4",
     ),
 )
 

--- a/tests/composition/runtime/test_topology_capabilities.py
+++ b/tests/composition/runtime/test_topology_capabilities.py
@@ -147,6 +147,46 @@ def test_materialization_is_canonical_complete_and_artifact_backed(
     )
 
 
+@pytest.mark.parametrize(
+    ("capability_id", "extra_input"),
+    (
+        (
+            "topology.simplicial_complex.chain_complex.compute",
+            {"coefficient_ring": "INTEGER"},
+        ),
+        ("topology.simplicial_homology.compute", {"prime": 2}),
+        ("topology.simplicial_homology.integral.compute", {}),
+    ),
+)
+def test_materialized_complex_composes_into_topology_consumers(
+    fresh_complete_runtime,
+    capability_id: str,
+    extra_input: dict[str, Any],
+) -> None:
+    materialized = fresh_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="topology.simplicial_complex.materialize",
+            input=_CIRCLE,
+        )
+    )
+    complex_uri = materialized.output["result_uri"]
+
+    result = fresh_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id=capability_id,
+            input={"complex_artifact_uri": complex_uri, **extra_input},
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert result.artifact_uris[0] == complex_uri
+    input_artifact = fresh_complete_runtime.core.store.get(result.output["input_uri"])
+    assert input_artifact.manifest.parents == (complex_uri,)
+    assert "complex_artifact_uri" not in input_artifact.payload
+    assert input_artifact.payload["complex"]["complex_digest"].startswith("sha256:")
+
+
 def test_chain_complex_exposes_oriented_sparse_boundaries_and_augmentation(
     fresh_complete_runtime,
 ) -> None:


### PR DESCRIPTION
## Summary
- let all three topology consumers accept a typed result from `topology.simplicial_complex.materialize`
- preserve exact input/result lineage while storing the canonical inline request used by independent replay
- keep inline requests backward-compatible and bump the changed operation contracts to version 4

## Evaluation evidence
A focused paired routing evaluation repeatedly exposed the same composition failure. Agents successfully materialized the projective-plane complex, but `topology.simplicial_homology.integral.compute` could not consume the returned artifact and fell back to manual Smith-form work.

With this branch and the same Terra model, prompt, Skill, and budget, the projective-plane workflow:
- completed the intended compute + verify contract
- reached `VERIFIED`
- used 8 MCP calls in 99.5 seconds

Before the fix, the two matched Skill runs both failed the intended topology contract after 15–16 MCP calls and 154–231 seconds.

## Safety
This uses the existing `MaterializedOperationAdapter` conversion boundary. The adapter verifies artifact schema and semantics before deserialization. The materialized source URI remains in artifact lineage; the independently replayed request contains the canonical inline complex and no unresolved URI.

## Validation
- focused artifact-composition regressions: 3 passed
- topology verification suite: 7 passed
- focused end-to-end model trajectory: contract satisfied and independently VERIFIED
- Ruff check and format: passed
- mypy for changed source modules: passed
- `git diff --check`: passed

Draft only; do not merge automatically.