### PR TITLE
Surface operation validation constraints

### DIFF
--- a/src/jacobian/operation_installation.py
+++ b/src/jacobian/operation_installation.py
@@ -16,6 +16,7 @@ from jacobian.contracts.capabilities import (
     CapabilityCompleteness,
     CapabilityCompletenessStatus,
     CapabilityDescriptor,
+    CapabilityDiagnostic,
     CapabilityInputKind,
     CapabilityMode,
     CapabilityObligation,
@@ -65,6 +66,37 @@ class _OperationResources:
     input_schema_uris: dict[type[ContractModel], str]
     result_schema_uris: dict[str, str]
     obligation_schema_uris: dict[str, str]
+
+
+def _validation_diagnostic(
+    base: CapabilityDiagnostic,
+    error: ValidationError,
+) -> CapabilityDiagnostic:
+    """Preserve the actionable Pydantic constraint in a domain diagnostic."""
+    validation_errors = error.errors(
+        include_url=False,
+        include_context=False,
+        include_input=False,
+    )
+    if not validation_errors:
+        return base
+    first_error = validation_errors[0]
+    path = ".".join(str(part) for part in first_error["loc"])[:512]
+    hint = str(first_error["msg"]).removeprefix("Value error, ")[:1024]
+    return base.model_copy(
+        update={
+            "path": path or base.path,
+            "hint": hint or base.hint,
+            "details": {
+                **base.details,
+                "validation_error": {
+                    "type": str(first_error["type"])[:128],
+                    "path": path,
+                    "message": hint,
+                },
+            },
+        }
+    )
 
 
 def _execution_failure_result(
@@ -231,8 +263,11 @@ class ComputedOperationAdapter:
             )
         except ValidationError as exc:
             raise CapabilityInvocationError(
-                self.operation.invalid_request
-                or self.bundle.diagnostics.invalid_request
+                _validation_diagnostic(
+                    self.operation.invalid_request
+                    or self.bundle.diagnostics.invalid_request,
+                    exc,
+                )
             ) from exc
 
         started = time.monotonic()
@@ -350,10 +385,17 @@ class MaterializedOperationAdapter:
                     validated_request, source_artifact_uris = (
                         self.operation.artifact_converter(validated_request, payload)
                     )
+        except ValidationError as exc:
+            raise CapabilityInvocationError(
+                _validation_diagnostic(
+                    self.operation.invalid_request
+                    or self.bundle.diagnostics.invalid_request,
+                    exc,
+                )
+            ) from exc
         except (
             ArtifactNotFoundError,
             ArtifactIntegrityError,
-            ValidationError,
             ValueError,
         ) as exc:
             raise CapabilityInvocationError(
@@ -476,8 +518,11 @@ class BoundedSearchOperationAdapter:
             )
         except ValidationError as exc:
             raise CapabilityInvocationError(
-                self.operation.invalid_request
-                or self.bundle.diagnostics.invalid_request
+                _validation_diagnostic(
+                    self.operation.invalid_request
+                    or self.bundle.diagnostics.invalid_request,
+                    exc,
+                )
             ) from exc
 
         started = time.monotonic()

--- a/tests/composition/portfolio/test_operation_installation.py
+++ b/tests/composition/portfolio/test_operation_installation.py
@@ -460,7 +460,9 @@ def test_bounded_adapter_preserves_the_rejected_field_and_constraint(
         description="Exercise bounded-search request validation diagnostics.",
         request_model=_SyntheticRequest,
         result_model=_BoundedResult,
-        implementation=lambda _request: BoundedSearchWitness(_BoundedResult(complete=True)),
+        implementation=lambda _request: BoundedSearchWitness(
+            _BoundedResult(complete=True)
+        ),
         relation_id="synthetic.search.validate.relation",
         scope_parameters=lambda _request, _result: {},
         is_complete=lambda result: result.complete,

--- a/tests/composition/portfolio/test_operation_installation.py
+++ b/tests/composition/portfolio/test_operation_installation.py
@@ -2,7 +2,7 @@ from dataclasses import replace
 from typing import Any, cast
 
 import pytest
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from jacobian.contracts.capabilities import (
     CapabilityAssuranceLevel,
@@ -32,6 +32,15 @@ from jacobian.runtime.model import JacobianRuntime
 
 class _SyntheticRequest(ContractModel):
     value: int = Field(ge=0, le=100)
+
+    @field_validator("value")
+    @classmethod
+    def require_non_sentinel_value(cls, value: int) -> int:
+        if value == 99:
+            raise ValueError("synthetic value 99 is reserved")
+        if value == 98:
+            raise ValueError("x" * 2_000)
+        return value
 
 
 class _SyntheticResult(ContractModel):
@@ -138,6 +147,48 @@ def test_synthetic_bundle_returns_an_inline_typed_result(
     assert result.scope is not None
     assert result.scope.parameters == {"value": 6}
     assert result.scope.artifact_uri is None
+
+
+def test_validation_error_preserves_the_rejected_field_and_constraint(
+    fresh_complete_runtime,
+) -> None:
+    _install(fresh_complete_runtime, _synthetic_bundle())
+
+    result = fresh_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="synthetic.compute.double",
+            input={"value": 99},
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.artifact_uris == ()
+    diagnostic = result.diagnostics[0]
+    assert diagnostic.code == "INVALID_SYNTHETIC_REQUEST"
+    assert diagnostic.path == "value"
+    assert diagnostic.hint == "synthetic value 99 is reserved"
+    assert diagnostic.details["validation_error"] == {
+        "type": "value_error",
+        "path": "value",
+        "message": "synthetic value 99 is reserved",
+    }
+
+
+def test_validation_error_respects_diagnostic_text_bounds(
+    fresh_complete_runtime,
+) -> None:
+    _install(fresh_complete_runtime, _synthetic_bundle())
+
+    result = fresh_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="synthetic.compute.double",
+            input={"value": 98},
+        )
+    )
+
+    diagnostic = result.diagnostics[0]
+    assert len(diagnostic.hint or "") == 1024
+    assert diagnostic.details["validation_error"]["message"] == diagnostic.hint
 
 
 def test_materialized_operation_retains_artifacts_lineage_and_typed_preview(
@@ -397,6 +448,44 @@ def test_bounded_adapter_preserves_timeout_without_partial_artifacts(
     assert result.execution.status is ExecutionStatus.TIMEOUT
     assert result.diagnostics == (diagnostic,)
     assert result.artifact_uris == ()
+
+
+def test_bounded_adapter_preserves_the_rejected_field_and_constraint(
+    fresh_complete_runtime,
+) -> None:
+    bundle = _synthetic_bundle()
+    operation = BoundedSearchOperation(
+        capability_id="synthetic.search.validate",
+        title="Validate a bounded synthetic search",
+        description="Exercise bounded-search request validation diagnostics.",
+        request_model=_SyntheticRequest,
+        result_model=_BoundedResult,
+        implementation=lambda _request: BoundedSearchWitness(_BoundedResult(complete=True)),
+        relation_id="synthetic.search.validate.relation",
+        scope_parameters=lambda _request, _result: {},
+        is_complete=lambda result: result.complete,
+        obligation_model=_BoundedResult,
+        obligation=lambda _request, result: result,
+        incomplete_basis="the synthetic search did not complete",
+    )
+    _install(fresh_complete_runtime, replace(bundle, capabilities=(operation,)))
+
+    result = fresh_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="synthetic.search.validate",
+            input={"value": 99},
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.artifact_uris == ()
+    assert result.diagnostics[0].path == "value"
+    assert result.diagnostics[0].hint == "synthetic value 99 is reserved"
+    assert result.diagnostics[0].details["validation_error"] == {
+        "type": "value_error",
+        "path": "value",
+        "message": "synthetic value 99 is reserved",
+    }
 
 
 def test_bounded_adapter_materializes_interrupted_partial_result(

--- a/tests/composition/runtime/test_topology_capabilities.py
+++ b/tests/composition/runtime/test_topology_capabilities.py
@@ -429,3 +429,28 @@ def test_invalid_topology_request_fails_before_artifact_writes(
     assert result.execution.status is ExecutionStatus.ERROR
     assert result.diagnostics[0].code == "INVALID_FINITE_SIMPLICIAL_TOPOLOGY_REQUEST"
     assert result.artifact_uris == ()
+
+
+def test_stale_complex_digest_surfaces_its_constraint(
+    fresh_complete_runtime,
+) -> None:
+    complex_ = _materialize(fresh_complete_runtime, _CIRCLE)
+    complex_["complex_digest"] = "sha256:" + "0" * 64
+
+    result = fresh_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="topology.simplicial_homology.integral.compute",
+            input={"complex": complex_},
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.artifact_uris == ()
+    diagnostic = result.diagnostics[0]
+    assert diagnostic.code == "INVALID_FINITE_SIMPLICIAL_TOPOLOGY_REQUEST"
+    assert diagnostic.hint == "complex_digest does not bind the canonical complex"
+    assert diagnostic.details["validation_error"] == {
+        "type": "value_error",
+        "path": "complex",
+        "message": "complex_digest does not bind the canonical complex",
+    }


### PR DESCRIPTION
Fixes #781.

### Problem

A Pydantic model-validation failure was reduced to the domain's generic invalid-request diagnostic. For a stale topology `complex_digest`, the runtime failed closed but did not explain the failing constraint.

### Change

Preserve one bounded, data-minimized validation record when installed computed, materialized, or bounded-search operations reject a Pydantic request. The static domain code and failure semantics remain unchanged; only the diagnostic gains its path when available, a constraint hint, and structural type/path/message data.

The record excludes the rejected input, validation context, and Pydantic URLs. It also caps dynamic text to the existing diagnostic field bounds.

### Regression coverage

Covers a stale topology digest end to end and each operation adapter's Pydantic-validation branch, including a 2,000-character validator message that must remain bounded.

### Validation

- `make test-component TESTS='tests/composition/portfolio/test_operation_installation.py::test_validation_error_preserves_the_rejected_field_and_constraint tests/composition/portfolio/test_operation_installation.py::test_validation_error_respects_diagnostic_text_bounds tests/composition/runtime/test_topology_capabilities.py::test_stale_complex_digest_surfaces_its_constraint'` — 3 passed
- `make test-component TESTS='tests/composition/portfolio/test_operation_installation.py::test_bounded_adapter_preserves_the_rejected_field_and_constraint'` — 1 passed
- `make check-static` — passed