### PR TITLE
refactor(math): use canonical integer conversions

### DIFF
--- a/src/jacobian/contracts/certified_snf.py
+++ b/src/jacobian/contracts/certified_snf.py
@@ -7,6 +7,7 @@ from typing import Literal, Self
 
 from pydantic import Field, StrictInt, model_validator
 
+from jacobian.canonical import parse_canonical_integer
 from jacobian.contracts.exact import CanonicalInteger
 from jacobian.contracts.results import ContractModel
 
@@ -115,16 +116,19 @@ class SmithNormalFormCertificate(ContractModel):
             raise ValueError("Smith certificate matrix shapes are incompatible")
         diagonal_count = min(rows, columns)
         diagonal = tuple(
-            int(self.diagonal.entries[index][index]) for index in range(diagonal_count)
+            parse_canonical_integer(self.diagonal.entries[index][index])
+            for index in range(diagonal_count)
         )
         if any(
-            int(self.diagonal.entries[row][column]) != 0
+            parse_canonical_integer(self.diagonal.entries[row][column]) != 0
             for row in range(rows)
             for column in range(columns)
             if row != column
         ):
             raise ValueError("Smith normal form must be diagonal")
-        factors = tuple(int(value) for value in self.invariant_factors)
+        factors = tuple(
+            parse_canonical_integer(value) for value in self.invariant_factors
+        )
         if (
             self.rank != len(factors)
             or self.rank > diagonal_count

--- a/src/jacobian/contracts/combinatorics.py
+++ b/src/jacobian/contracts/combinatorics.py
@@ -16,6 +16,7 @@ from jacobian.canonical import (
     CanonicalLimits,
     canonicalize_json,
     format_canonical_integer,
+    parse_canonical_integer,
 )
 from jacobian.contracts.exact import CanonicalInteger, CanonicalRational
 from jacobian.contracts.results import ContractModel
@@ -629,7 +630,7 @@ class IntegerListRequest(ContractModel):
 
     @model_validator(mode="after")
     def require_nonnegative_parts(self) -> Self:
-        if any(int(v) < 0 for v in self.values):
+        if any(parse_canonical_integer(value) < 0 for value in self.values):
             raise ValueError("integer list values must be nonnegative")
         return self
 

--- a/src/jacobian/contracts/matrix_operations.py
+++ b/src/jacobian/contracts/matrix_operations.py
@@ -7,6 +7,7 @@ from typing import ClassVar, Literal, Self
 
 from pydantic import Field, StrictInt, field_validator, model_validator
 
+from jacobian.canonical import parse_canonical_integer
 from jacobian.contracts.exact import CanonicalInteger, CanonicalRational
 from jacobian.contracts.results import ContractModel
 
@@ -244,7 +245,9 @@ class SmithNormalFormResult(ContractModel):
         columns = len(self.normal_form.entries[0])
         if self.rank > min(rows, columns):
             raise ValueError("Smith rank cannot exceed the matrix dimensions")
-        factors = tuple(int(value) for value in self.invariant_factors)
+        factors = tuple(
+            parse_canonical_integer(value) for value in self.invariant_factors
+        )
         if any(value <= 0 for value in factors):
             raise ValueError("Smith invariant factors must be positive")
         if any(right % left != 0 for left, right in pairwise(factors)):
@@ -252,7 +255,7 @@ class SmithNormalFormResult(ContractModel):
         for row, entries in enumerate(self.normal_form.entries):
             for column, value in enumerate(entries):
                 expected = factors[row] if row == column and row < self.rank else 0
-                if int(value) != expected:
+                if parse_canonical_integer(value) != expected:
                     raise ValueError(
                         "Smith normal form must contain its positive invariant "
                         "factors on the leading diagonal and zero elsewhere"

--- a/src/jacobian/contracts/plugin_matrices.py
+++ b/src/jacobian/contracts/plugin_matrices.py
@@ -6,10 +6,15 @@ from typing import Literal, Self
 
 from pydantic import Field, StrictInt, StrictStr, model_validator
 
+from jacobian.canonical import parse_canonical_integer
 from jacobian.contracts.claims import flatten_claim_spec
 from jacobian.contracts.exact import CanonicalInteger
 from jacobian.contracts.plugin_protocol import PluginRequestContext
 from jacobian.contracts.results import ContractModel
+
+
+def _matrix_integer(value: int | str) -> int:
+    return value if isinstance(value, int) else parse_canonical_integer(value)
 
 
 class MatrixScope(ContractModel):
@@ -60,8 +65,12 @@ class MatrixCandidate(ContractModel):
             assert claim.scope is not None
             if self.rows != claim.scope.rows or self.cols != claim.scope.cols:
                 raise ValueError("candidate dimensions do not match claim scope")
-            allowed = {int(value) for value in claim.scope.entries}
-            if any(int(entry) not in allowed for row in self.entries for entry in row):
+            allowed = {_matrix_integer(value) for value in claim.scope.entries}
+            if any(
+                _matrix_integer(entry) not in allowed
+                for row in self.entries
+                for entry in row
+            ):
                 raise ValueError("candidate entry is outside claim scope")
 
 

--- a/src/jacobian/contracts/projective_geometry.py
+++ b/src/jacobian/contracts/projective_geometry.py
@@ -7,6 +7,7 @@ from typing import Annotated, Literal, Self
 
 from pydantic import Field, StringConstraints, model_validator
 
+from jacobian.canonical import format_canonical_integer, parse_canonical_integer
 from jacobian.contracts.exact import CanonicalRational
 from jacobian.contracts.results import ContractModel
 
@@ -94,10 +95,13 @@ class PrimitiveProjectiveTriple(ContractModel):
     @model_validator(mode="after")
     def require_canonical_primitive_coordinates(self) -> Self:
         try:
-            values = tuple(int(value) for value in self.coordinates)
+            values = tuple(parse_canonical_integer(value) for value in self.coordinates)
         except ValueError as exc:
             raise ValueError("projective coordinates must be integer strings") from exc
-        if tuple(str(value) for value in values) != self.coordinates:
+        if (
+            tuple(format_canonical_integer(value) for value in values)
+            != self.coordinates
+        ):
             raise ValueError("projective coordinates must be canonical integer strings")
         divisor = 0
         for value in values:

--- a/src/jacobian/domains/arithmetic/operations.py
+++ b/src/jacobian/domains/arithmetic/operations.py
@@ -16,7 +16,7 @@ import math
 from fractions import Fraction
 from typing import Literal
 
-from jacobian.canonical import format_canonical_integer
+from jacobian.canonical import format_canonical_integer, parse_canonical_integer
 from jacobian.contracts.arithmetic import (
     IntegerBaseDigitsRequest,
     IntegerBaseDigitsResult,
@@ -39,16 +39,11 @@ from jacobian.math import arithmetic as native_arithmetic
 
 
 def _int(value: str) -> int:
-    return int(value)
+    return parse_canonical_integer(value)
 
 
 def _canonical(value: int) -> str:
-    return str(value)
-
-
-def to_fraction(num: str, den: str) -> Fraction:
-    """Build a reduced ``Fraction`` from canonical integer strings."""
-    return Fraction(int(num), int(den))
+    return format_canonical_integer(value)
 
 
 def absolute_value(request: IntegerValueRequest) -> IntegerValueResult:
@@ -70,12 +65,12 @@ def sign(request: IntegerValueRequest) -> IntegerSignResult:
 
 def decimal_digit_sum(request: IntegerValueRequest) -> IntegerValueResult:
     return IntegerValueResult(
-        value=_canonical(sum(int(digit) for digit in str(abs(_int(request.value)))))
+        value=_canonical(sum(int(digit) for digit in request.value.lstrip("-")))
     )
 
 
 def decimal_digit_count(request: IntegerValueRequest) -> IntegerValueResult:
-    return IntegerValueResult(value=_canonical(len(str(abs(_int(request.value))))))
+    return IntegerValueResult(value=_canonical(len(request.value.lstrip("-"))))
 
 
 def base_digits(request: IntegerBaseDigitsRequest) -> IntegerBaseDigitsResult:
@@ -181,11 +176,15 @@ def maximum(request: RationalPairRequest) -> RationalValueResult:
 
 
 def floor(request: RationalValueRequest) -> RationalIntegerResult:
-    return RationalIntegerResult(value=str(math.floor(_fraction(request.value))))
+    return RationalIntegerResult(
+        value=format_canonical_integer(math.floor(_fraction(request.value)))
+    )
 
 
 def ceiling(request: RationalValueRequest) -> RationalIntegerResult:
-    return RationalIntegerResult(value=str(math.ceil(_fraction(request.value))))
+    return RationalIntegerResult(
+        value=format_canonical_integer(math.ceil(_fraction(request.value)))
+    )
 
 
 def continued_fraction(
@@ -197,7 +196,7 @@ def continued_fraction(
     value = _fraction(request.value)
     terms = sympy_continued_fraction(SympyRational(value.numerator, value.denominator))
     return RationalContinuedFractionResult(
-        terms=tuple(str(int(term)) for term in terms)
+        terms=tuple(format_canonical_integer(int(term)) for term in terms)
     )
 
 

--- a/src/jacobian/domains/combinatorics/operations.py
+++ b/src/jacobian/domains/combinatorics/operations.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from functools import reduce
 from operator import mul
 
-from jacobian.canonical import format_canonical_integer
+from jacobian.canonical import format_canonical_integer, parse_canonical_integer
 from jacobian.contracts.combinatorics import (
     FibonacciPairRequest,
     FibonacciPairResult,
@@ -21,7 +21,7 @@ from jacobian.contracts.exact import CanonicalRational
 
 
 def _integer_result(value: int) -> IntegerResult:
-    return IntegerResult(value=str(int(value)))
+    return IntegerResult(value=format_canonical_integer(value))
 
 
 def factorial(request: NonnegativeIntegerRequest) -> IntegerResult:
@@ -57,7 +57,7 @@ def binomial(request: NonnegativePairRequest) -> IntegerResult:
 def multinomial(request: IntegerListRequest) -> IntegerResult:
     import math
 
-    values = [int(v) for v in request.values]
+    values = [parse_canonical_integer(value) for value in request.values]
     numerator = math.factorial(sum(values))
     denominator = reduce(mul, (math.factorial(v) for v in values), 1)
     return _integer_result(numerator // denominator)

--- a/src/jacobian/domains/matrix_lattice/operations.py
+++ b/src/jacobian/domains/matrix_lattice/operations.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from fractions import Fraction
 from typing import Any
 
-from jacobian.canonical import format_canonical_integer
+from jacobian.canonical import format_canonical_integer, parse_canonical_integer
 from jacobian.contracts.matrix_operations import (
     CharacteristicPolynomialResult,
     IntegerMatrixRequest,
@@ -115,7 +115,10 @@ def compute_smith_normal_form(
     from sympy.matrices.normalforms import smith_normal_form
 
     source = sympy.Matrix(
-        [[int(value) for value in row] for row in request.matrix.entries]
+        [
+            [parse_canonical_integer(value) for value in row]
+            for row in request.matrix.entries
+        ]
     )
     raw = smith_normal_form(source, domain=sympy.ZZ)
     diagonal_count = min(raw.rows, raw.cols)
@@ -133,12 +136,17 @@ def compute_smith_normal_form(
     return SmithNormalFormResult(
         normal_form=IntegerOutputMatrix(
             entries=tuple(
-                tuple(str(int(canonical[row, column])) for column in range(raw.cols))
+                tuple(
+                    format_canonical_integer(canonical[row, column])
+                    for column in range(raw.cols)
+                )
                 for row in range(raw.rows)
             )
         ),
         rank=rank,
-        invariant_factors=tuple(str(value) for value in invariant_factors),
+        invariant_factors=tuple(
+            format_canonical_integer(value) for value in invariant_factors
+        ),
     )
 
 
@@ -146,7 +154,10 @@ def compute_inverse(request: SquareIntegerMatrixRequest) -> MatrixInverseResult:
     import sympy
 
     source = sympy.Matrix(
-        [[int(value) for value in row] for row in request.matrix.entries]
+        [
+            [parse_canonical_integer(value) for value in row]
+            for row in request.matrix.entries
+        ]
     )
     inverse = native_matrices.inverse(source)
     return MatrixInverseResult(
@@ -165,7 +176,9 @@ def compute_trace(request: SquareIntegerMatrixRequest) -> MatrixTraceResult:
     source = sympy.Matrix(
         [[int(value) for value in row] for row in request.matrix.entries]
     )
-    return MatrixTraceResult(trace=str(int(native_matrices.trace(source))))
+    return MatrixTraceResult(
+        trace=format_canonical_integer(native_matrices.trace(source))
+    )
 
 
 def compute_product(request: RationalMatrixProductRequest) -> MatrixProductResult:
@@ -204,7 +217,10 @@ def compute_adjugate(request: SquareIntegerMatrixRequest) -> MatrixAdjugateResul
     import sympy
 
     source = sympy.Matrix(
-        [[int(value) for value in row] for row in request.matrix.entries]
+        [
+            [parse_canonical_integer(value) for value in row]
+            for row in request.matrix.entries
+        ]
     )
     if source.rows != source.cols:
         raise ValueError("adjugate requires a square matrix")
@@ -213,7 +229,8 @@ def compute_adjugate(request: SquareIntegerMatrixRequest) -> MatrixAdjugateResul
         adjugate=IntegerOutputMatrix(
             entries=tuple(
                 tuple(
-                    str(int(adjugate[row, column])) for column in range(adjugate.cols)
+                    format_canonical_integer(adjugate[row, column])
+                    for column in range(adjugate.cols)
                 )
                 for row in range(adjugate.rows)
             )

--- a/src/jacobian/domains/polynomial/elementary_operations.py
+++ b/src/jacobian/domains/polynomial/elementary_operations.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from functools import cache
 from typing import Any
 
+from jacobian.canonical import format_canonical_integer, parse_canonical_integer
 from jacobian.contracts.polynomial_operations import (
     IntegerPolynomial,
     IntegerPolynomialCompositionRequest,
@@ -45,7 +46,10 @@ def _integer_poly(polynomial: IntegerPolynomial) -> Any:
     from sympy import Poly
 
     return Poly.from_list(
-        [int(coefficient) for coefficient in polynomial.coefficients],
+        [
+            parse_canonical_integer(coefficient)
+            for coefficient in polynomial.coefficients
+        ],
         _x(),
         domain="ZZ",
     )
@@ -54,7 +58,8 @@ def _integer_poly(polynomial: IntegerPolynomial) -> Any:
 def _integer_wire(polynomial: Any) -> IntegerPolynomial:
     return IntegerPolynomial(
         coefficients=tuple(
-            str(int(coefficient)) for coefficient in polynomial.all_coeffs()
+            format_canonical_integer(int(coefficient))
+            for coefficient in polynomial.all_coeffs()
         )
     )
 
@@ -67,9 +72,9 @@ def integer_polynomial_gcd(
     gcd = left.gcd(right)
     return IntegerPolynomialGcdResult(
         gcd=_integer_wire(gcd),
-        left_content=str(int(left.content())),
-        right_content=str(int(right.content())),
-        gcd_content=str(int(gcd.content())),
+        left_content=format_canonical_integer(int(left.content())),
+        right_content=format_canonical_integer(int(right.content())),
+        gcd_content=format_canonical_integer(int(gcd.content())),
     )
 
 
@@ -77,7 +82,9 @@ def integer_polynomial_content(
     request: IntegerPolynomialRequest,
 ) -> IntegerPolynomialContentResult:
     return IntegerPolynomialContentResult(
-        content=str(int(_integer_poly(request.polynomial).content()))
+        content=format_canonical_integer(
+            int(_integer_poly(request.polynomial).content())
+        )
     )
 
 
@@ -88,7 +95,7 @@ def integer_polynomial_primitive_part(
     content, primitive = source.primitive()
     reconstructed = primitive.mul_ground(content)
     return IntegerPolynomialPrimitivePartResult(
-        content=str(int(content)),
+        content=format_canonical_integer(int(content)),
         primitive_part=_integer_wire(primitive),
         reconstruction=_integer_wire(reconstructed),
     )
@@ -97,9 +104,12 @@ def integer_polynomial_primitive_part(
 def integer_polynomial_evaluate(
     request: IntegerPolynomialEvaluationRequest,
 ) -> IntegerPolynomialEvaluationResult:
-    point = int(request.point)
+    point = parse_canonical_integer(request.point)
     value = _integer_poly(request.polynomial).eval(point)
-    return IntegerPolynomialEvaluationResult(point=request.point, value=str(int(value)))
+    return IntegerPolynomialEvaluationResult(
+        point=request.point,
+        value=format_canonical_integer(int(value)),
+    )
 
 
 def integer_polynomial_compose(

--- a/src/jacobian/domains/projective_geometry/arrangements.py
+++ b/src/jacobian/domains/projective_geometry/arrangements.py
@@ -6,6 +6,7 @@ from fractions import Fraction
 from math import comb, gcd
 from typing import cast
 
+from jacobian.canonical import format_canonical_integer
 from jacobian.contracts.projective_geometry import (
     NormalizedProjectiveLine,
     PrimitiveProjectiveTriple,
@@ -60,7 +61,11 @@ def _cross(
 
 def _wire_triple(values: tuple[int, int, int]) -> PrimitiveProjectiveTriple:
     return PrimitiveProjectiveTriple(
-        coordinates=(str(values[0]), str(values[1]), str(values[2]))
+        coordinates=(
+            format_canonical_integer(values[0]),
+            format_canonical_integer(values[1]),
+            format_canonical_integer(values[2]),
+        )
     )
 
 

--- a/src/jacobian/domains/sequences/operations.py
+++ b/src/jacobian/domains/sequences/operations.py
@@ -8,7 +8,7 @@ from fractions import Fraction
 from functools import reduce
 from itertools import pairwise
 
-from jacobian.canonical import format_canonical_integer
+from jacobian.canonical import format_canonical_integer, parse_canonical_integer
 from jacobian.contracts.exact import CanonicalRational
 from jacobian.contracts.sequences import (
     FrequencyEntry,
@@ -23,15 +23,17 @@ from jacobian.contracts.sequences import (
 
 
 def _values(request: IntegerSequenceRequest) -> list[int]:
-    return [int(value) for value in request.values]
+    return [parse_canonical_integer(value) for value in request.values]
 
 
 def _value_result(value: int) -> IntegerSequenceValueResult:
-    return IntegerSequenceValueResult(value=str(value))
+    return IntegerSequenceValueResult(value=format_canonical_integer(value))
 
 
 def _list_result(values: list[int]) -> IntegerSequenceListResult:
-    return IntegerSequenceListResult(values=tuple(str(v) for v in values))
+    return IntegerSequenceListResult(
+        values=tuple(format_canonical_integer(value) for value in values)
+    )
 
 
 def sequence_sum(request: IntegerSequenceRequest) -> IntegerSequenceValueResult:
@@ -179,7 +181,7 @@ def signs(request: IntegerSequenceRequest) -> IntegerSequenceListResult:
 def frequencies(request: IntegerSequenceRequest) -> IntegerSequenceFrequenciesResult:
     counts = Counter(_values(request))
     entries = tuple(
-        FrequencyEntry(value=str(value), count=counts[value])
+        FrequencyEntry(value=format_canonical_integer(value), count=counts[value])
         for value in sorted(counts)
     )
     return IntegerSequenceFrequenciesResult(entries=entries)

--- a/src/jacobian/plugins/matrices.py
+++ b/src/jacobian/plugins/matrices.py
@@ -18,7 +18,7 @@ from typing import Any
 
 from pydantic import ValidationError
 
-from jacobian.canonical import format_canonical_integer
+from jacobian.canonical import format_canonical_integer, parse_canonical_integer
 from jacobian.contracts.plugin_matrices import (
     MatrixCandidate,
     MatrixCapabilityRequest,
@@ -38,7 +38,11 @@ MAX_SEARCHED_MATRICES = 65_536
 
 
 def _to_int(value: Any) -> int:
-    return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        return parse_canonical_integer(value)
+    raise ValueError("matrix entries must be integers")
 
 
 def _to_int_matrix(entries: Any) -> list[list[int]]:
@@ -79,7 +83,7 @@ def _enumerate_typed(
         index = flat_index
         flat: list[str] = []
         for _ in range(rows * cols):
-            flat.append(str(values[index % len(values)]))
+            flat.append(format_canonical_integer(values[index % len(values)]))
             index //= len(values)
         entries = [flat[row * cols : (row + 1) * cols] for row in range(rows)]
         candidates.append({"rows": rows, "cols": cols, "entries": entries})
@@ -93,7 +97,7 @@ def _enumerate_typed(
         "scope": {
             "rows": rows,
             "cols": cols,
-            "entries": [str(value) for value in values],
+            "entries": [format_canonical_integer(value) for value in values],
             "labeled": True,
             "candidate_count": total,
         },
@@ -127,7 +131,11 @@ def transform_row_major_capability(request: dict[str, Any]) -> dict[str, Any]:
         ) from exc
     rows = selected.source.rows
     cols = selected.source.cols
-    values = [str(value) for row in _candidate_matrix(selected.source) for value in row]
+    values = [
+        format_canonical_integer(value)
+        for row in _candidate_matrix(selected.source)
+        for value in row
+    ]
     return {
         "response_version": "1",
         "transform_format": "matrix.row_major",

--- a/src/jacobian/shrinking.py
+++ b/src/jacobian/shrinking.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from pydantic import ValidationError
 
-from jacobian.canonical import format_canonical_integer
+from jacobian.canonical import format_canonical_integer, parse_canonical_integer
 from jacobian.claims import ClaimValidationService
 from jacobian.contracts.artifacts import ArtifactPutResult
 from jacobian.contracts.checkers import EvidenceKind
@@ -624,7 +624,7 @@ def _objective_value(value: Any) -> Fraction:
     if isinstance(value, int):
         return Fraction(value)
     if isinstance(value, str) and _INTEGER_OBJECTIVE.fullmatch(value):
-        return Fraction(int(value))
+        return Fraction(parse_canonical_integer(value))
     if isinstance(value, dict) and set(value) == {"num", "den"}:
         numerator = value.get("num")
         denominator = value.get("den")
@@ -634,7 +634,10 @@ def _objective_value(value: Any) -> Fraction:
             and _INTEGER_OBJECTIVE.fullmatch(numerator)
             and _INTEGER_OBJECTIVE.fullmatch(denominator)
         ):
-            result = Fraction(int(numerator), int(denominator))
+            result = Fraction(
+                parse_canonical_integer(numerator),
+                parse_canonical_integer(denominator),
+            )
             if value == {
                 "num": format_canonical_integer(result.numerator),
                 "den": format_canonical_integer(result.denominator),

--- a/tests/component/plugins/test_matrix_plugin.py
+++ b/tests/component/plugins/test_matrix_plugin.py
@@ -74,6 +74,19 @@ def test_evaluate_kernel_matrix_is_singular() -> None:
     assert response["failure_classifications"] == ["nontrivial_kernel"]
 
 
+def test_evaluate_matrix_accepts_canonical_entries_beyond_python_digit_limit() -> None:
+    value = "1" + ("0" * 5_000)
+
+    response = evaluate_capability(
+        {
+            "claim": {"predicate": "is_nonsingular"},
+            "candidate": {"rows": 1, "cols": 1, "entries": [[value]]},
+        }
+    )
+
+    assert response["conclusion"] == "TRUE"
+
+
 def test_find_witness_kernel_vector() -> None:
     claim = {"predicate": "is_nonsingular"}
     resp = find_witness_capability(

--- a/tests/domain/arithmetic/test_arithmetic_capabilities.py
+++ b/tests/domain/arithmetic/test_arithmetic_capabilities.py
@@ -86,3 +86,59 @@ def test_rational_difference_accepts_contract_sized_components(
 
     assert result.execution.status is ExecutionStatus.COMPLETED
     assert result.output["result"] == {"value": {"num": "0", "den": "1"}}
+
+
+def test_integer_and_rational_operations_cross_the_large_integer_boundary(
+    domain_services: DomainTestServices,
+) -> None:
+    value = "1" + ("0" * 5_000)
+
+    absolute_value = domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="integer.compute.absolute_value",
+            input={"value": value},
+        )
+    )
+    digit_count = domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="integer.compute.decimal_digit_count",
+            input={"value": value},
+        )
+    )
+    digit_sum = domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="integer.compute.decimal_digit_sum",
+            input={"value": value},
+        )
+    )
+    floor = domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="rational.compute.floor",
+            input={"value": {"num": value, "den": "1"}},
+        )
+    )
+    ceiling = domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="rational.compute.ceiling",
+            input={"value": {"num": value, "den": "1"}},
+        )
+    )
+    continued_fraction = domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="rational.compute.continued_fraction",
+            input={"value": {"num": value, "den": "1"}},
+        )
+    )
+
+    assert absolute_value.execution.status is ExecutionStatus.COMPLETED
+    assert absolute_value.output["result"] == {"value": value}
+    assert digit_count.execution.status is ExecutionStatus.COMPLETED
+    assert digit_count.output["result"] == {"value": "5001"}
+    assert digit_sum.execution.status is ExecutionStatus.COMPLETED
+    assert digit_sum.output["result"] == {"value": "1"}
+    assert floor.execution.status is ExecutionStatus.COMPLETED
+    assert floor.output["result"] == {"value": value}
+    assert ceiling.execution.status is ExecutionStatus.COMPLETED
+    assert ceiling.output["result"] == {"value": value}
+    assert continued_fraction.execution.status is ExecutionStatus.COMPLETED
+    assert continued_fraction.output["result"] == {"terms": [value]}

--- a/tests/domain/polynomial/test_elementary_polynomial_domain.py
+++ b/tests/domain/polynomial/test_elementary_polynomial_domain.py
@@ -106,6 +106,23 @@ def test_integer_polynomial_operations_preserve_ring_semantics(
     )["composition"]["coefficients"] == ["1", "2", "2"]
 
 
+def test_integer_polynomial_evaluation_formats_large_exact_result(
+    domain_services: DomainTestServices,
+) -> None:
+    point = "9" * 256
+    result = _invoke(
+        domain_services,
+        "polynomial.integer.compute.evaluate",
+        {
+            "polynomial": {"coefficients": ["1"] + (["0"] * 127)},
+            "point": point,
+        },
+    )
+
+    assert result["point"] == point
+    assert len(result["value"]) > 4_300
+
+
 def test_rational_polynomial_operations_return_typed_intermediates(
     domain_services,
 ) -> None:

--- a/tests/domain/sequences/test_sequence_capabilities.py
+++ b/tests/domain/sequences/test_sequence_capabilities.py
@@ -54,3 +54,28 @@ def test_geometric_sequence_handles_zero_terms_exactly(
 
     assert result.execution.status is ExecutionStatus.COMPLETED
     assert result.output["result"] == {"holds": expected}
+
+
+def test_sequence_products_format_results_beyond_python_digit_limit(
+    domain_services: DomainTestServices,
+) -> None:
+    factor = "1" + ("0" * 2_500)
+    expected_product = "1" + ("0" * 5_000)
+
+    product = domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="sequence.compute.product",
+            input={"values": [factor, factor]},
+        )
+    )
+    prefixes = domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="sequence.compute.prefix_products",
+            input={"values": [factor, factor]},
+        )
+    )
+
+    assert product.execution.status is ExecutionStatus.COMPLETED
+    assert product.output["result"] == {"value": expected_product}
+    assert prefixes.execution.status is ExecutionStatus.COMPLETED
+    assert prefixes.output["result"] == {"values": [factor, expected_product]}

--- a/tests/unit/contracts/test_canonical_integer_boundaries.py
+++ b/tests/unit/contracts/test_canonical_integer_boundaries.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from jacobian.contracts.certified_snf import (
+    CertifiedIntegerMatrix,
+    SmithNormalFormCertificate,
+)
+from jacobian.contracts.combinatorics import IntegerListRequest
+from jacobian.contracts.projective_geometry import PrimitiveProjectiveTriple
+
+
+def test_nonnegative_integer_list_accepts_canonical_values_beyond_python_limit() -> (
+    None
+):
+    value = "1" + ("0" * 5_000)
+
+    request = IntegerListRequest(values=(value,))
+
+    assert request.values == (value,)
+
+
+def test_smith_certificate_validates_large_canonical_invariant_factor() -> None:
+    factor = "1" + ("0" * 5_000)
+    source = CertifiedIntegerMatrix(row_count=1, column_count=1, entries=(("0",),))
+    diagonal = CertifiedIntegerMatrix(
+        row_count=1,
+        column_count=1,
+        entries=((factor,),),
+    )
+    identity = CertifiedIntegerMatrix(row_count=1, column_count=1, entries=(("1",),))
+
+    certificate = SmithNormalFormCertificate(
+        source=source,
+        diagonal=diagonal,
+        left_transformation=identity,
+        right_transformation=identity,
+        rank=1,
+        invariant_factors=(factor,),
+        left_determinant="1",
+        right_determinant="1",
+    )
+
+    assert certificate.invariant_factors == (factor,)
+
+
+def test_primitive_projective_triple_accepts_large_canonical_coordinate() -> None:
+    coordinate = "1" + ("0" * 5_000)
+
+    triple = PrimitiveProjectiveTriple(coordinates=("1", coordinate, "0"))
+
+    assert triple.coordinates == ("1", coordinate, "0")


### PR DESCRIPTION
Fixes #756.

Replace direct Python decimal conversions at unbounded canonical-integer boundaries with the canonical parser and formatter. This covers contracts, arithmetic, combinatorics, matrix-lattice, polynomial, projective geometry, sequences, plugins, and shrinking.

Regression coverage exercises values beyond CPython's 4,300-digit conversion guard.

Validation:
- focused arithmetic and contract-boundary tests — 6 + 3 passed
- affected domain suite — 29 passed
- matrix-lattice domain suite — 13 passed
- `make lint-full` — passed