### PR TITLE
refactor(lean): finalize Lean declaration sessions

### DIFF
--- a/src/jacobian/lean_frontend/declarations.py
+++ b/src/jacobian/lean_frontend/declarations.py
@@ -299,6 +299,7 @@ def _close_declaration_sessions(
     for environment, entry in list(sessions.items()):
         with session_locks[environment]:
             entry.session.close()
+    sessions.clear()
 
 
 class LeanSubprocessDeclarationBackend:

--- a/src/jacobian/lean_frontend/declarations.py
+++ b/src/jacobian/lean_frontend/declarations.py
@@ -8,6 +8,7 @@ import os
 import tempfile
 import threading
 import uuid
+import weakref
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol
@@ -290,6 +291,16 @@ class _SessionEntry:
     session: _DeclarationQuerySession
 
 
+def _close_declaration_sessions(
+    sessions: dict[LeanEnvironment, _SessionEntry],
+    session_locks: dict[LeanEnvironment, threading.Lock],
+) -> None:
+    """Release declaration sessions retained past their backend's lifetime."""
+    for environment, entry in list(sessions.items()):
+        with session_locks[environment]:
+            entry.session.close()
+
+
 class LeanSubprocessDeclarationBackend:
     """Reuse one catalog across bounded processes for each validated environment."""
 
@@ -312,6 +323,12 @@ class LeanSubprocessDeclarationBackend:
         self._session_locks = {
             environment: threading.Lock() for environment in LeanEnvironment
         }
+        self._finalizer = weakref.finalize(
+            self,
+            _close_declaration_sessions,
+            self._sessions,
+            self._session_locks,
+        )
 
     def environment_digest(self, environment: LeanEnvironment) -> str:
         try:
@@ -450,6 +467,7 @@ class LeanSubprocessDeclarationBackend:
         for environment, lock in self._session_locks.items():
             with lock:
                 self._discard_session(environment)
+        self._finalizer.detach()
 
     def _start_session(
         self,

--- a/tests/component/providers/lean/test_lean_declaration_sessions.py
+++ b/tests/component/providers/lean/test_lean_declaration_sessions.py
@@ -75,6 +75,8 @@ class RecordingSession:
                 self.active -= 1
 
     def close(self) -> None:
+        if self.closed:
+            return
         self.closed = True
 
 
@@ -160,6 +162,7 @@ def test_subprocess_backend_finalizer_closes_sessions_after_garbage_collection(
     session = RecordingSession(responses=[{"operation": "search", "declarations": []}])
     backend, _ = _recording_backend(tmp_path, [session])
     backend.query(LeanEnvironment.CORE, {"operation": "search"})
+    sessions = backend._sessions
     reference = weakref.ref(backend)
 
     del backend
@@ -167,6 +170,7 @@ def test_subprocess_backend_finalizer_closes_sessions_after_garbage_collection(
 
     assert reference() is None
     assert session.closed
+    assert not sessions
 
 
 def test_subprocess_backend_close_detaches_finalizer(tmp_path: Path) -> None:

--- a/tests/component/providers/lean/test_lean_declaration_sessions.py
+++ b/tests/component/providers/lean/test_lean_declaration_sessions.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import gc
 import hashlib
 import threading
+import weakref
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -150,6 +152,32 @@ def test_subprocess_backend_reuses_one_pinned_session_per_environment(
     assert searched["_environment_digest"] == inspected["_environment_digest"]
     backend.close()
     assert session.closed
+
+
+def test_subprocess_backend_finalizer_closes_sessions_after_garbage_collection(
+    tmp_path: Path,
+) -> None:
+    session = RecordingSession(responses=[{"operation": "search", "declarations": []}])
+    backend, _ = _recording_backend(tmp_path, [session])
+    backend.query(LeanEnvironment.CORE, {"operation": "search"})
+    reference = weakref.ref(backend)
+
+    del backend
+    gc.collect()
+
+    assert reference() is None
+    assert session.closed
+
+
+def test_subprocess_backend_close_detaches_finalizer(tmp_path: Path) -> None:
+    session = RecordingSession(responses=[{"operation": "search", "declarations": []}])
+    backend, _ = _recording_backend(tmp_path, [session])
+    backend.query(LeanEnvironment.CORE, {"operation": "search"})
+
+    backend.close()
+
+    assert session.closed
+    assert not backend._finalizer.alive
 
 
 def test_subprocess_backend_serializes_concurrent_session_requests(


### PR DESCRIPTION
Fixes #759.

The declaration backend retains temporary-directory-backed query sessions until explicit close. Add a backend-owned weakref finalizer that closes cached sessions when the backend is collected, then detach it after explicit cleanup.

This addresses temporary-directory leakage; declaration queries use bounded one-shot processes and do not retain a live Lean subprocess.

Validation:
- `make test-component TESTS=tests/component/providers/lean/test_lean_declaration_sessions.py` — 9 passed
- `make lint-full` — passed