### PR TITLE
refactor(math): declare domain operation exports

### DIFF
--- a/src/jacobian/domains/arithmetic/operations.py
+++ b/src/jacobian/domains/arithmetic/operations.py
@@ -37,6 +37,30 @@ from jacobian.contracts.rationals import (
 )
 from jacobian.math import arithmetic as native_arithmetic
 
+__all__ = [
+    "absolute_value",
+    "base_digits",
+    "ceiling",
+    "continued_fraction",
+    "decimal_digit_count",
+    "decimal_digit_sum",
+    "difference",
+    "equal",
+    "floor",
+    "less_than",
+    "maximum",
+    "minimum",
+    "negation",
+    "nth_root",
+    "product",
+    "quotient",
+    "rational_absolute_value",
+    "reciprocal",
+    "sign",
+    "sum_rationals",
+    "to_fraction",
+]
+
 
 def _int(value: str) -> int:
     return int(value)

--- a/src/jacobian/domains/combinatorics/operations.py
+++ b/src/jacobian/domains/combinatorics/operations.py
@@ -19,6 +19,28 @@ from jacobian.contracts.combinatorics import (
 )
 from jacobian.contracts.exact import CanonicalRational
 
+__all__ = [
+    "bell",
+    "bernoulli",
+    "binomial",
+    "catalan",
+    "central_binomial",
+    "compositions",
+    "derangements",
+    "double_factorial",
+    "enumerate_integer_partitions",
+    "factorial",
+    "fibonacci",
+    "fibonacci_pair",
+    "lucas",
+    "motzkin",
+    "multinomial",
+    "partition_number",
+    "permutations",
+    "stirling_first",
+    "stirling_second",
+]
+
 
 def _integer_result(value: int) -> IntegerResult:
     return IntegerResult(value=str(int(value)))

--- a/src/jacobian/domains/finite_sets/operations.py
+++ b/src/jacobian/domains/finite_sets/operations.py
@@ -9,6 +9,19 @@ from jacobian.contracts.finite_sets import (
     FiniteSetPairRequest,
 )
 
+__all__ = [
+    "decide_disjoint",
+    "decide_proper_subset",
+    "decide_subset",
+    "intersection_cardinality",
+    "left_cardinality",
+    "set_difference",
+    "set_intersection",
+    "set_symmetric_difference",
+    "set_union",
+    "union_cardinality",
+]
+
 
 def _pair(request: FiniteSetPairRequest) -> tuple[set[int], set[int]]:
     pair = request

--- a/src/jacobian/domains/geometry/operations.py
+++ b/src/jacobian/domains/geometry/operations.py
@@ -36,6 +36,24 @@ from jacobian.contracts.geometry import (
 
 Compute = Callable[[LinePairRequest], GeometryBooleanResult]
 
+__all__ = [
+    "centroid",
+    "circumcircle",
+    "classify_polygon_point",
+    "collinear",
+    "concyclic",
+    "convex_hull_points",
+    "line_intersection",
+    "line_predicate",
+    "midpoint",
+    "orientation",
+    "projection",
+    "segment_intersection",
+    "signed_area",
+    "simple_polygon",
+    "squared_distance",
+]
+
 
 def _fraction(value: Any) -> Fraction:
     import sympy

--- a/src/jacobian/domains/graph_optimization/operations.py
+++ b/src/jacobian/domains/graph_optimization/operations.py
@@ -12,6 +12,8 @@ from jacobian.contracts.graph_coloring import (
 )
 from jacobian.graphs.coloring_semantics import canonical_graph, coloring_cnf
 
+__all__ = ["build_simple_graph", "solve_chromatic_number"]
+
 
 def build_simple_graph(graph: ChromaticGraph) -> Any:
     """Build a networkx Graph from a validated :class:`ChromaticGraph`.

--- a/src/jacobian/domains/matrix_lattice/operations.py
+++ b/src/jacobian/domains/matrix_lattice/operations.py
@@ -29,6 +29,18 @@ from jacobian.contracts.matrix_operations import (
 )
 from jacobian.math import matrices as native_matrices
 
+__all__ = [
+    "compute_adjugate",
+    "compute_characteristic_polynomial",
+    "compute_inverse",
+    "compute_nullspace",
+    "compute_product",
+    "compute_rational_linear_solve",
+    "compute_rref",
+    "compute_smith_normal_form",
+    "compute_trace",
+]
+
 
 def _rational(value: Any) -> OutputRational:
     fraction = Fraction(value)

--- a/src/jacobian/domains/number_theory/operations.py
+++ b/src/jacobian/domains/number_theory/operations.py
@@ -55,6 +55,47 @@ from jacobian.contracts.number_theory import (
     ValuationRequest,
 )
 
+__all__ = [
+    "compute_aliquot_sum",
+    "compute_divisor_count",
+    "compute_divisor_sum",
+    "compute_euler_totient",
+    "compute_extended_gcd",
+    "compute_factorial_valuation",
+    "compute_floor_square_root",
+    "compute_gcd",
+    "compute_jacobi_symbol",
+    "compute_lcm",
+    "compute_legendre_symbol",
+    "compute_mobius",
+    "compute_modular_inverse",
+    "compute_modular_polynomial_residue_image",
+    "compute_multiplicative_order",
+    "compute_next_prime",
+    "compute_nth_prime",
+    "compute_previous_prime",
+    "compute_prime_count",
+    "compute_primorial",
+    "compute_radical",
+    "compute_valuation",
+    "decide_abundant",
+    "decide_coprime",
+    "decide_deficient",
+    "decide_divides",
+    "decide_even",
+    "decide_odd",
+    "decide_perfect",
+    "decide_powerful",
+    "decide_prime",
+    "decide_square",
+    "decide_squarefree",
+    "enumerate_divisors",
+    "enumerate_proper_divisors",
+    "enumerate_quadratic_residues",
+    "factorize_primes",
+    "solve_chinese_remainder",
+]
+
 
 def compute_gcd(request: IntegerPairRequest) -> IntegerValueResult:
     """Compute gcd(a, b) using ``math.gcd``."""

--- a/src/jacobian/domains/polynomial/operations.py
+++ b/src/jacobian/domains/polynomial/operations.py
@@ -32,6 +32,15 @@ from jacobian.contracts.polynomials import (
 
 _MAX_OUTPUT_TERMS = 1024
 
+__all__ = [
+    "PolynomialOutputBudgetError",
+    "polynomial_discriminant",
+    "polynomial_gcd",
+    "polynomial_groebner_basis",
+    "polynomial_resultant",
+    "polynomial_square_free_decomposition",
+]
+
 
 class PolynomialOutputBudgetError(RuntimeError):
     """A valid computation produced more output than its public contract permits."""

--- a/src/jacobian/domains/sequences/operations.py
+++ b/src/jacobian/domains/sequences/operations.py
@@ -21,6 +21,38 @@ from jacobian.contracts.sequences import (
     IntegerSequenceValueResult,
 )
 
+__all__ = [
+    "decide_arithmetic",
+    "decide_geometric",
+    "decide_nondecreasing",
+    "decide_strictly_increasing",
+    "first_differences",
+    "frequencies",
+    "parities",
+    "prefix_gcds",
+    "prefix_lcms",
+    "prefix_maxima",
+    "prefix_minima",
+    "prefix_products",
+    "prefix_sums",
+    "reverse_sequence",
+    "second_differences",
+    "sequence_distinct_count",
+    "sequence_gcd",
+    "sequence_lcm",
+    "sequence_maximum",
+    "sequence_mean",
+    "sequence_median",
+    "sequence_minimum",
+    "sequence_product",
+    "sequence_range",
+    "sequence_sum",
+    "signs",
+    "sort_sequence",
+    "sorted_unique",
+    "zero_indices",
+]
+
 
 def _values(request: IntegerSequenceRequest) -> list[int]:
     return [int(value) for value in request.values]

--- a/tests/unit/domains/test_operation_exports.py
+++ b/tests/unit/domains/test_operation_exports.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+OPERATION_MODULES = (
+    "jacobian.domains.arithmetic.operations",
+    "jacobian.domains.combinatorics.operations",
+    "jacobian.domains.finite_sets.operations",
+    "jacobian.domains.geometry.operations",
+    "jacobian.domains.graph_optimization.operations",
+    "jacobian.domains.matrix_lattice.operations",
+    "jacobian.domains.number_theory.operations",
+    "jacobian.domains.polynomial.operations",
+    "jacobian.domains.sequences.operations",
+)
+
+
+@pytest.mark.parametrize("module_name", OPERATION_MODULES)
+def test_operation_modules_export_exactly_their_defined_public_symbols(
+    module_name: str,
+) -> None:
+    module = importlib.import_module(module_name)
+    defined_public_symbols = {
+        name
+        for name, value in vars(module).items()
+        if not name.startswith("_")
+        and getattr(value, "__module__", None) == module.__name__
+    }
+
+    assert module.__all__ == sorted(defined_public_symbols)


### PR DESCRIPTION
Fixes #734.

Nine domain operation modules were function libraries with implicit public surfaces. This adds sorted `__all__` manifests for their defined functions and `PolynomialOutputBudgetError`, excluding imported models and backend types.

A structural unit test verifies each manifest exactly matches the module-defined public symbols, preventing additions or removals from silently drifting. The seven existing bundle-only operation modules already have their own exports and are intentionally outside this test.

Validation:
- `make test-unit TESTS=tests/unit/domains/test_operation_exports.py`
- `make lint-full`

The repository test plan selected suite fallback because the operation modules are transitively imported; this change is export metadata plus the focused structural regression test only.