### PR TITLE
fix(polynomials): fail closed without polynomial checker identity

### DIFF
--- a/src/jacobian/polynomial_interval_capabilities.py
+++ b/src/jacobian/polynomial_interval_capabilities.py
@@ -419,7 +419,10 @@ class PolynomialIntervalEnclosureVerifyAdapter:
     def __init__(self, resources: PolynomialIntervalResources) -> None:
         self.resources = resources
         checker_id = resources.installation.checker_id
-        assert checker_id is not None
+        if checker_id is None:
+            raise RuntimeError(
+                "polynomial interval verify adapter requires an authorized checker"
+            )
         self._descriptor = CapabilityDescriptor(
             capability_id="polynomial.interval.enclosure.verify",
             version="1",
@@ -468,7 +471,12 @@ class PolynomialIntervalEnclosureVerifyAdapter:
         )
         installation = self.resources.installation
         checker_id = installation.checker_id
-        assert checker_id is not None
+        if checker_id is None:
+            raise _interval_error(
+                "POLYNOMIAL_INTERVAL_CHECKER_UNAVAILABLE",
+                "interval_enclosure_verification",
+                "The independent interval enclosure checker is not installed in this runtime.",
+            )
         polynomial = validated.polynomial
         interval = validated.interval
         polynomial_artifact = self.resources.artifacts.put(

--- a/src/jacobian/polynomial_positivity_capabilities.py
+++ b/src/jacobian/polynomial_positivity_capabilities.py
@@ -436,7 +436,10 @@ class PolynomialIntervalPositivityVerifyAdapter:
     def __init__(self, resources: PolynomialPositivityResources) -> None:
         self.resources = resources
         checker_id = resources.installation.checker_id
-        assert checker_id is not None
+        if checker_id is None:
+            raise RuntimeError(
+                "polynomial positivity verify adapter requires an authorized checker"
+            )
         self._descriptor = CapabilityDescriptor(
             capability_id="polynomial.interval.positivity.verify",
             version="1",
@@ -483,7 +486,12 @@ class PolynomialIntervalPositivityVerifyAdapter:
         )
         installation = self.resources.installation
         checker_id = installation.checker_id
-        assert checker_id is not None
+        if checker_id is None:
+            raise _positivity_error(
+                "POLYNOMIAL_POSITIVITY_CHECKER_UNAVAILABLE",
+                "positivity_verification",
+                "The independent positivity checker is not installed in this runtime.",
+            )
         polynomial = validated.polynomial
         interval = validated.interval
         polynomial_artifact = self.resources.artifacts.put(

--- a/tests/component/providers/polynomial/test_polynomial_positivity_capabilities.py
+++ b/tests/component/providers/polynomial/test_polynomial_positivity_capabilities.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
@@ -16,6 +17,7 @@ from jacobian.contracts.capabilities import (
 )
 from jacobian.contracts.results import ExecutionStatus
 from jacobian.polynomial_positivity_capabilities import (
+    PolynomialIntervalPositivityVerifyAdapter,
     install_polynomial_positivity_capabilities,
 )
 from jacobian_checkers.polynomial_positivity import check_positivity
@@ -268,6 +270,19 @@ def installation(tmp_path: Path):
         tmp_path, install_polynomial_positivity_capabilities
     ) as bundle:
         yield bundle
+
+
+def test_verify_adapter_rejects_missing_authorized_checker(installation) -> None:
+    adapters, _installed, _store = installation
+    _decide, verify = adapters
+    assert verify is not None
+    resources = replace(
+        verify.resources,
+        installation=replace(verify.resources.installation, checker_id=None),
+    )
+
+    with pytest.raises(RuntimeError, match="requires an authorized checker"):
+        PolynomialIntervalPositivityVerifyAdapter(resources)
 
 
 def test_decide_capability_finds_positive_linear(installation) -> None:

--- a/tests/domain/polynomial/test_polynomial_interval_capabilities.py
+++ b/tests/domain/polynomial/test_polynomial_interval_capabilities.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
@@ -16,6 +17,7 @@ from jacobian.contracts.capabilities import (
 )
 from jacobian.contracts.results import ExecutionStatus
 from jacobian.polynomial_interval_capabilities import (
+    PolynomialIntervalEnclosureVerifyAdapter,
     install_polynomial_interval_capabilities,
 )
 
@@ -43,6 +45,19 @@ def installation(tmp_path: Path):
         tmp_path, install_polynomial_interval_capabilities
     ) as bundle:
         yield bundle
+
+
+def test_verify_adapter_rejects_missing_authorized_checker(installation) -> None:
+    adapters, _installed, _store = installation
+    _enclose, verify = adapters
+    assert verify is not None
+    resources = replace(
+        verify.resources,
+        installation=replace(verify.resources.installation, checker_id=None),
+    )
+
+    with pytest.raises(RuntimeError, match="requires an authorized checker"):
+        PolynomialIntervalEnclosureVerifyAdapter(resources)
 
 
 def test_enclose_capability_computes_a_valid_bernstein_enclosure(


### PR DESCRIPTION
Fixes #732.

Verification adapters previously used `assert checker_id is not None`. Those guards disappear under optimized Python.

This change makes missing checker identity explicit: construction fails with an installation invariant error, while invocation fails through the existing structured diagnostic path. The normal installation gate remains unchanged.

Regression coverage constructs both adapters with an intentionally missing checker identity and verifies they reject the invalid state.

Validation:
- `make test-component TESTS=tests/component/providers/polynomial/test_polynomial_positivity_capabilities.py`
- `make test-domain TESTS=tests/domain/polynomial/test_polynomial_interval_capabilities.py`
- `make lint-full`