### PR TITLE
fix(benchmarks): clarify missing benchmark timing suite

### DIFF
--- a/benchmarks/validation/test_benchmark_planner.py
+++ b/benchmarks/validation/test_benchmark_planner.py
@@ -747,7 +747,11 @@ def test_schedule_event_runs_full_portfolio() -> None:
 
 def test_timing_weights_balance_slow_tasks_deterministically() -> None:
     suites = planner._harbor_suite().load_registry()
-    suite = next(item for item in suites if len(item.tasks) > 12)
+    suite = next((item for item in suites if len(item.tasks) > 12), None)
+    assert suite is not None, (
+        "expected a suite with more than 12 tasks for timing weight validation; "
+        "found: " + ", ".join(f"{item.id}={len(item.tasks)}" for item in suites)
+    )
     timings = {
         f"{suite.id}/{ref.path.name}": float(index + 1)
         for index, ref in enumerate(suite.tasks)


### PR DESCRIPTION
Fixes #722.

The timing-weight validation reads the live Harbor registry and previously selected a suite with a bare `next()`. If dataset changes removed every suite with more than twelve tasks, the test failed with an opaque `StopIteration`.

The test now asserts the expected suite explicitly and includes the observed suite task counts in the failure message. Fixture-controlled `next()` calls are intentionally unchanged.

Validation:
- `make harbor-validation-tests TESTS=benchmarks/validation/test_benchmark_planner.py`
- `make lint-full`