### PR TITLE
fix(graphs): fail closed without graph isomorphism checker

### DIFF
--- a/src/jacobian/graphs/isomorphism.py
+++ b/src/jacobian/graphs/isomorphism.py
@@ -162,7 +162,10 @@ class GraphIsomorphismAdapter:
         self.artifacts = artifacts
         self.verification = verification
         self.installation = installation
-        assert installation.checker_id is not None
+        if installation.checker_id is None:
+            raise RuntimeError(
+                "graph isomorphism verify adapter requires an authorized checker"
+            )
         self._descriptor = CapabilityDescriptor(
             capability_id="graph.isomorphism.verify",
             version="1",
@@ -190,7 +193,17 @@ class GraphIsomorphismAdapter:
     def invoke(self, request: CapabilityRequest) -> CapabilityResult:
         validated = GraphIsomorphismVerifyRequest.model_validate(request.input)
         checker_id = self.installation.checker_id
-        assert checker_id is not None
+        if checker_id is None:
+            raise CapabilityInvocationError(
+                CapabilityDiagnostic(
+                    code="GRAPH_ISOMORPHISM_CHECKER_UNAVAILABLE",
+                    stage="isomorphism_verification",
+                    message=(
+                        "The independent graph isomorphism checker is not installed "
+                        "in this runtime."
+                    ),
+                )
+            )
         left = self._load_source_graph(
             validated.left_graph_uri,
             path="left_graph_uri",


### PR DESCRIPTION
Fixes #704.

Graph-isomorphism verification relied on assertion guards for its authorized checker identity. Those disappear under optimized Python.

This change uses an explicit installation invariant during adapter construction and an existing structured capability diagnostic during invocation. The normal registration gate remains unchanged.

Validation:
- `make test-composition TESTS=tests/composition/runtime/test_graph_isomorphism.py`
- `make lint-full`