### PR TITLE
feat(eval): record wall-clock duration in Codex visibility reports

### DIFF
--- a/benchmarks/tooling/codex_visibility.py
+++ b/benchmarks/tooling/codex_visibility.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 import os
 import tempfile
+import time
 from collections.abc import Mapping
 from enum import StrEnum
 from pathlib import Path
@@ -392,6 +393,7 @@ def _run_case(
     transcript_path = output / f"{stem}.jsonl"
     stderr_path = output / f"{stem}.stderr"
     environment = operator_environment(include=_CODEX_ENVIRONMENT)
+    command_start = time.monotonic()
     result = run_operator_command(
         "codex",
         _codex_arguments(
@@ -408,6 +410,7 @@ def _run_case(
         stderr_limit_bytes=2 * 1024 * 1024,
         environment=environment,
     )
+    elapsed_seconds = round(time.monotonic() - command_start, 6)
     transcript_path.write_bytes(result.stdout)
     stderr_path.write_bytes(result.stderr)
     telemetry = parse_agent_transcript(transcript_path)
@@ -426,6 +429,7 @@ def _run_case(
             "diagnostic": result.diagnostic,
             "stdout_exceeded": result.stdout_exceeded,
             "stderr_exceeded": result.stderr_exceeded,
+            "elapsed_seconds": elapsed_seconds,
         },
         "classification": {
             **classification,
@@ -497,6 +501,64 @@ def _validate_mcp_url(value: str) -> None:
         )
 
 
+def _build_summary(runs: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate per-run observations into the report summary block."""
+
+    return {
+        "run_count": len(runs),
+        "command_failure_count": sum(
+            run["command"]["status"] != ToolCommandStatus.EXITED
+            or run["command"]["exit_code"] != 0
+            for run in runs
+        ),
+        "contract_satisfied_count": sum(
+            run["classification"]["contract_satisfied"] for run in runs
+        ),
+        "discovered_count": sum(
+            run["classification"]["observed"]["discovered"] for run in runs
+        ),
+        "invoked_count": sum(
+            run["classification"]["observed"]["invoked"] for run in runs
+        ),
+        "verified_count": sum(
+            run["classification"]["observed"]["verified"] for run in runs
+        ),
+        "discovery_free_invocation_count": sum(
+            run["classification"]["observed"]["discovery_free_invocation"]
+            for run in runs
+        ),
+        "abstained_count": sum(
+            run["classification"]["observed"]["abstained"] for run in runs
+        ),
+        "cost_totals": {
+            "input_tokens": sum(
+                (run["classification"]["usage"] or {}).get("input_tokens", 0)
+                for run in runs
+            ),
+            "cached_input_tokens": sum(
+                (run["classification"]["usage"] or {}).get("cached_input_tokens", 0)
+                for run in runs
+            ),
+            "uncached_input_tokens": sum(
+                run["classification"]["uncached_input_tokens"] or 0 for run in runs
+            ),
+            "output_tokens": sum(
+                (run["classification"]["usage"] or {}).get("output_tokens", 0)
+                for run in runs
+            ),
+            "mcp_calls": sum(run["classification"]["mcp_call_count"] for run in runs),
+            "mcp_model_visible_bytes": sum(
+                run["classification"]["mcp_model_visible_bytes"] for run in runs
+            ),
+        },
+        "duration_totals": {
+            "elapsed_seconds": round(
+                sum(run["command"]["elapsed_seconds"] for run in runs), 6
+            ),
+        },
+    }
+
+
 def main() -> None:
     args = _parser().parse_args()
     if not args.execute:
@@ -543,11 +605,7 @@ def main() -> None:
             for repetition in range(1, args.repetitions + 1)
         ]
     suite_payload = suite.model_dump(mode="json")
-    command_failure_count = sum(
-        run["command"]["status"] != ToolCommandStatus.EXITED
-        or run["command"]["exit_code"] != 0
-        for run in runs
-    )
+    summary = _build_summary(runs)
     report = {
         "schema_version": "2",
         "suite": {
@@ -574,59 +632,14 @@ def main() -> None:
             "repository_revision": git_head_sha(_ROOT),
         },
         "runs": runs,
-        "summary": {
-            "run_count": len(runs),
-            "command_failure_count": command_failure_count,
-            "contract_satisfied_count": sum(
-                run["classification"]["contract_satisfied"] for run in runs
-            ),
-            "discovered_count": sum(
-                run["classification"]["observed"]["discovered"] for run in runs
-            ),
-            "invoked_count": sum(
-                run["classification"]["observed"]["invoked"] for run in runs
-            ),
-            "verified_count": sum(
-                run["classification"]["observed"]["verified"] for run in runs
-            ),
-            "discovery_free_invocation_count": sum(
-                run["classification"]["observed"]["discovery_free_invocation"]
-                for run in runs
-            ),
-            "abstained_count": sum(
-                run["classification"]["observed"]["abstained"] for run in runs
-            ),
-            "cost_totals": {
-                "input_tokens": sum(
-                    (run["classification"]["usage"] or {}).get("input_tokens", 0)
-                    for run in runs
-                ),
-                "cached_input_tokens": sum(
-                    (run["classification"]["usage"] or {}).get("cached_input_tokens", 0)
-                    for run in runs
-                ),
-                "uncached_input_tokens": sum(
-                    run["classification"]["uncached_input_tokens"] or 0 for run in runs
-                ),
-                "output_tokens": sum(
-                    (run["classification"]["usage"] or {}).get("output_tokens", 0)
-                    for run in runs
-                ),
-                "mcp_calls": sum(
-                    run["classification"]["mcp_call_count"] for run in runs
-                ),
-                "mcp_model_visible_bytes": sum(
-                    run["classification"]["mcp_model_visible_bytes"] for run in runs
-                ),
-            },
-        },
+        "summary": summary,
     }
     (output / "report.json").write_text(
         json.dumps(report, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
     )
     print(json.dumps(report["summary"], sort_keys=True))
-    if command_failure_count:
+    if summary["command_failure_count"]:
         raise SystemExit("one or more Codex commands failed; inspect report.json")
 
 

--- a/docs/how-to/run-codex-visibility-evaluation.md
+++ b/docs/how-to/run-codex-visibility-evaluation.md
@@ -44,13 +44,19 @@ remains available by setting
 
 Per-run observations report discovery, exact contract inspection, invocation,
 completion, discovery-free invocation, abstention, unexpected capabilities, and
-independently bound `VERIFIED` evidence. Summary cost totals separate cached and
-uncached input tokens and include MCP calls and model-visible bytes. Shell calls,
-tool errors, token counts, MCP wire bytes, and logical payload bytes remain
-independent diagnostics rather than proxies for mathematical correctness. The
-cumulative Codex input-token count may grow much faster than MCP payload bytes
-because each later model turn includes earlier tool results; compare both
-dimensions rather than treating adoption alone as a win.
+independently bound `VERIFIED` evidence. Each run also records an
+`elapsed_seconds` wall-clock duration measured with a monotonic clock around the
+Codex command invocation, and the summary exposes a `duration_totals.elapsed_seconds`
+sum. Duration is observational only: it does not affect contract satisfaction,
+reward, timeout policy, or mathematical assurance. Single-run wall time is noisy;
+paired or repeated comparisons are required before drawing an efficiency
+conclusion. Summary cost totals separate cached and uncached input tokens and
+include MCP calls and model-visible bytes. Shell calls, tool errors, token
+counts, MCP wire bytes, and logical payload bytes remain independent diagnostics
+rather than proxies for mathematical correctness. The cumulative Codex
+input-token count may grow much faster than MCP payload bytes because each later
+model turn includes earlier tool results; compare both dimensions rather than
+treating adoption alone as a win.
 
 For Harbor ATIF trajectories, measure that projection directly rather than
 inferring it from token totals:

--- a/tests/unit/tooling/test_codex_visibility.py
+++ b/tests/unit/tooling/test_codex_visibility.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import math
 import re
 from pathlib import Path
 
@@ -10,10 +11,13 @@ from benchmarks.tooling.codex_visibility import (
     CueLevel,
     ToolMode,
     VisibilityCase,
+    _build_summary,
     _codex_arguments,
+    _run_case,
     classify_visibility,
     load_suite,
 )
+from benchmarks.tooling.command_runner import ToolCommandResult, ToolCommandStatus
 from pydantic import ValidationError
 
 from jacobian.contracts.matrices import MatrixDeterminantRequest
@@ -409,3 +413,159 @@ def test_visibility_classification_treats_timeout_as_non_completion(
     assert result["observed"]["invoked"] is True
     assert result["observed"]["completed"] is False
     assert result["contract_satisfied"] is False
+
+
+def _patched_run_case(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    result: ToolCommandResult,
+) -> dict[str, object]:
+    """Run ``_run_case`` with ``run_operator_command`` replaced by a stub.
+
+    The stub avoids real Codex execution while exercising the real timing,
+    transcript write, telemetry parse, and classification paths.  An empty
+    JSONL transcript is sufficient for ``parse_agent_transcript`` and yields a
+    clean abstention classification for the USE case.
+    """
+
+    monkeypatch.setattr(
+        "benchmarks.tooling.codex_visibility.run_operator_command",
+        lambda *_args, **_kwargs: result,
+    )
+    return _run_case(
+        case=_case(),
+        repetition=1,
+        workspace=tmp_path / "workspace",
+        output=tmp_path,
+        model="test-model",
+        reasoning_effort="high",
+        mcp_url="https://example.test/mcp",
+        timeout_seconds=5.0,
+        tool_mode=ToolMode.DIRECT,
+    )
+
+
+def test_run_case_records_elapsed_seconds_for_successful_command(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    (tmp_path / "workspace").mkdir()
+    result = ToolCommandResult(
+        status=ToolCommandStatus.EXITED,
+        exit_code=0,
+        stdout=b"",
+        stderr=b"",
+    )
+
+    run = _patched_run_case(monkeypatch, tmp_path, result=result)
+
+    elapsed = run["command"]["elapsed_seconds"]
+    assert isinstance(elapsed, float)
+    assert math.isfinite(elapsed)
+    assert elapsed >= 0.0
+    assert run["command"]["status"] == ToolCommandStatus.EXITED
+    assert run["command"]["exit_code"] == 0
+
+
+def test_run_case_records_elapsed_seconds_for_failed_command(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    (tmp_path / "workspace").mkdir()
+    result = ToolCommandResult(
+        status=ToolCommandStatus.START_FAILED,
+        exit_code=None,
+        stdout=b"",
+        stderr=b"",
+        diagnostic="codex is unavailable",
+    )
+
+    run = _patched_run_case(monkeypatch, tmp_path, result=result)
+
+    elapsed = run["command"]["elapsed_seconds"]
+    assert isinstance(elapsed, float)
+    assert math.isfinite(elapsed)
+    assert elapsed >= 0.0
+    assert run["command"]["status"] == ToolCommandStatus.START_FAILED
+    assert run["command"]["exit_code"] is None
+    assert run["command"]["diagnostic"] == "codex is unavailable"
+
+
+def test_run_case_elapsed_seconds_does_not_affect_classification(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    (tmp_path / "workspace").mkdir()
+    result = ToolCommandResult(
+        status=ToolCommandStatus.EXITED,
+        exit_code=0,
+        stdout=b"",
+        stderr=b"",
+    )
+
+    run = _patched_run_case(monkeypatch, tmp_path, result=result)
+
+    assert "elapsed_seconds" not in run["classification"]
+    assert "elapsed_seconds" not in run["classification"]["observed"]
+    assert "elapsed_seconds" not in run["artifacts"]
+
+
+def test_visibility_report_serializes_duration_fields(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    (tmp_path / "workspace").mkdir()
+    exited = ToolCommandResult(
+        status=ToolCommandStatus.EXITED,
+        exit_code=0,
+        stdout=b"",
+        stderr=b"",
+    )
+    failed = ToolCommandResult(
+        status=ToolCommandStatus.START_FAILED,
+        exit_code=None,
+        stdout=b"",
+        stderr=b"",
+        diagnostic="codex is unavailable",
+    )
+
+    results = [exited, failed]
+    monkeypatch.setattr(
+        "benchmarks.tooling.codex_visibility.run_operator_command",
+        lambda *_args, **_kwargs: results.pop(0),
+    )
+    runs = [
+        _run_case(
+            case=_case(),
+            repetition=rep,
+            workspace=tmp_path / "workspace",
+            output=tmp_path,
+            model="test-model",
+            reasoning_effort="high",
+            mcp_url="https://example.test/mcp",
+            timeout_seconds=5.0,
+            tool_mode=ToolMode.DIRECT,
+        )
+        for rep in (1, 2)
+    ]
+
+    summary = _build_summary(runs)
+    report = {
+        "schema_version": "2",
+        "runs": runs,
+        "summary": summary,
+    }
+
+    serialized = json.dumps(report, indent=2, sort_keys=True)
+    parsed = json.loads(serialized)
+
+    for run in parsed["runs"]:
+        assert "elapsed_seconds" in run["command"]
+        assert isinstance(run["command"]["elapsed_seconds"], (int, float))
+        assert run["command"]["elapsed_seconds"] >= 0
+        assert "elapsed_seconds" not in run["classification"]
+    assert "duration_totals" in parsed["summary"]
+    assert "elapsed_seconds" in parsed["summary"]["duration_totals"]
+    assert isinstance(
+        parsed["summary"]["duration_totals"]["elapsed_seconds"], (int, float)
+    )
+    assert parsed["summary"]["duration_totals"]["elapsed_seconds"] >= 0
+    assert parsed["summary"]["run_count"] == 2
+    assert parsed["summary"]["command_failure_count"] == 1


### PR DESCRIPTION
## Summary

Closes #782.

Record a monotonic `elapsed_seconds` for each Codex command and aggregate it in the visibility-report summary. The report previously tracked tokens and MCP payloads but not elapsed wall time.

The duration is observational only: it does not affect classification, contract satisfaction, reward, timeout policy, or assurance. The shared `ToolCommandResult` contract remains unchanged.

## Validation

- `make check-changed`
- `make docs-linkcheck`

## Review notes

The summary is built by the same production helper exercised by the serialization test, so the reported aggregate cannot silently drift from the tested shape.