### PR TITLE
refactor(providers): deduplicate provider feasibility spike utilities

### DIFF
--- a/benchmarks/datasets/provider-feasibility-v1/cddlib/environment/Dockerfile
+++ b/benchmarks/datasets/provider-feasibility-v1/cddlib/environment/Dockerfile
@@ -16,6 +16,7 @@ WORKDIR /app
 COPY __init__.py /opt/benchmarks/__init__.py
 COPY tooling/__init__.py /opt/benchmarks/tooling/__init__.py
 COPY tooling/command_runner.py /opt/benchmarks/tooling/command_runner.py
+COPY tooling/spike_utils.py /opt/benchmarks/tooling/spike_utils.py
 COPY datasets/provider-feasibility-v1/cddlib/environment/input.json datasets/provider-feasibility-v1/cddlib/environment/pin.json datasets/provider-feasibility-v1/cddlib/environment/spike.py datasets/provider-feasibility-v1/cddlib/environment/submission_schema.json /app/
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONPATH=/opt

--- a/benchmarks/datasets/provider-feasibility-v1/cddlib/environment/input.json
+++ b/benchmarks/datasets/provider-feasibility-v1/cddlib/environment/input.json
@@ -2,5 +2,5 @@
   "task_id": "jacobian/cddlib",
   "provider": "cddlib/pycddlib",
   "contract": "jacobian.cddlib-hv-spike/v1",
-  "pin_sha256": "sha256:15b0b5b4d608bc2f354dd484c44aa3da7441d615ab9650d6f7611c7e97af7871"
+  "pin_sha256": "sha256:129610626988ff70540c9d7aef51efbda771ccee199eb44b629de50ad589104f"
 }

--- a/benchmarks/datasets/provider-feasibility-v1/cddlib/environment/pin.json
+++ b/benchmarks/datasets/provider-feasibility-v1/cddlib/environment/pin.json
@@ -1,5 +1,5 @@
 {
-  "adapter_source_sha256": "sha256:8a6f0c90929f3cf9582208844d4d9ce10258bc5721dbe8581171dbc180eb05cd",
+  "adapter_source_sha256": "sha256:ddbf25b188f6fd5ca6aca2fb0ac6f64c514cb76cc00a4cb504fd660baf343d38",
   "contract": "jacobian.cddlib-hv-spike/v1",
   "provider": "cddlib/pycddlib",
   "reproduction": {

--- a/benchmarks/datasets/provider-feasibility-v1/cddlib/environment/spike.py
+++ b/benchmarks/datasets/provider-feasibility-v1/cddlib/environment/spike.py
@@ -14,10 +14,13 @@ from pathlib import Path
 from typing import Any
 
 from benchmarks.tooling.command_runner import (
-    ToolCommandRequest,
     ToolCommandResult,
     ToolCommandStatus,
-    run_tool_command,
+)
+from benchmarks.tooling.spike_utils import (
+    canonical_json,
+    default_runner,
+    sha256_bytes,
 )
 
 PIN_PATH = Path(__file__).with_name("pin.json")
@@ -41,28 +44,6 @@ ProcessRunner = Callable[..., ToolCommandResult]
 _WORKER_ERROR_PREFIX = b"JACOBIAN_SPIKE_ERROR "
 
 
-def _default_runner(
-    command: Sequence[str],
-    *,
-    input_bytes: bytes,
-    timeout_seconds: float,
-    environment: Mapping[str, str],
-    stdout_limit: int,
-    stderr_limit: int,
-) -> ToolCommandResult:
-    request = ToolCommandRequest(
-        executable=command[0],
-        arguments=tuple(command[1:]),
-        environment=environment,
-        cwd=str(Path.cwd()),
-        timeout_seconds=timeout_seconds,
-        stdin_bytes=input_bytes,
-        stdout_limit_bytes=stdout_limit,
-        stderr_limit_bytes=stderr_limit,
-    )
-    return run_tool_command(request)
-
-
 class CddlibSpikeError(RuntimeError):
     """A typed non-conclusion from the optional-provider spike."""
 
@@ -73,23 +54,12 @@ class CddlibSpikeError(RuntimeError):
         self.detail = detail
 
 
-def _sha256_bytes(payload: bytes) -> str:
-    return f"sha256:{hashlib.sha256(payload).hexdigest()}"
-
-
 def _sha256_file(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as stream:
         for block in iter(lambda: stream.read(1024 * 1024), b""):
             digest.update(block)
     return f"sha256:{digest.hexdigest()}"
-
-
-def _canonical_json(payload: object) -> bytes:
-    return (
-        json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
-        + "\n"
-    ).encode("ascii")
 
 
 def _load_pin(path: Path) -> dict[str, Any]:
@@ -272,7 +242,7 @@ def _inspect_archive(
 
     for member_name, payload in contents.items():
         expected = source_pin["identity_members"][member_name]
-        if _sha256_bytes(payload) != expected["sha256"]:
+        if sha256_bytes(payload) != expected["sha256"]:
             raise CddlibSpikeError(
                 "REJECTED",
                 "SOURCE_METADATA_MISMATCH",
@@ -782,7 +752,7 @@ def _parse_provider_output(output: bytes, pin: Mapping[str, Any]) -> dict[str, A
             "PROVIDER_OUTPUT_MALFORMED",
             "The pycddlib output is not canonical ASCII JSON.",
         ) from exc
-    if not isinstance(payload, dict) or _canonical_json(payload) != output:
+    if not isinstance(payload, dict) or canonical_json(payload) != output:
         raise CddlibSpikeError(
             "ERROR",
             "PROVIDER_OUTPUT_MALFORMED",
@@ -817,7 +787,7 @@ def _parse_provider_output(output: bytes, pin: Mapping[str, Any]) -> dict[str, A
     reproduction = pin["reproduction"]
     if (
         mathematical != _expected_mathematical(pin)
-        or _sha256_bytes(_canonical_json(mathematical))
+        or sha256_bytes(canonical_json(mathematical))
         != reproduction["expected_mathematical_output_sha256"]
     ):
         raise CddlibSpikeError(
@@ -834,7 +804,7 @@ def run_spike(
     cddlib_source_archive: Path,
     pycddlib_source_archive: Path,
     timeout_seconds: float = 10,
-    runner: ProcessRunner = _default_runner,
+    runner: ProcessRunner = default_runner,
     pin_path: Path = PIN_PATH,
     adapter_source: Path = ADAPTER_SOURCE,
 ) -> dict[str, Any]:
@@ -904,7 +874,7 @@ def run_spike(
             },
             "reproduction": {
                 "scope": pin["reproduction"]["scope"],
-                "provider_output_sha256": _sha256_bytes(output),
+                "provider_output_sha256": sha256_bytes(output),
                 "exact_arithmetic": provider_output["exact_arithmetic"],
                 "cases": provider_output["cases"],
             },
@@ -964,7 +934,7 @@ def _worker(pin_path: Path) -> int:
     installed_version = importlib.metadata.version("pycddlib")
     if installed_version != pin["versions"]["pycddlib"]:
         sys.stdout.buffer.write(
-            _canonical_json(
+            canonical_json(
                 {
                     "contract": pin["contract"],
                     "provider": pin["provider"],
@@ -1072,7 +1042,7 @@ def _worker(pin_path: Path) -> int:
             "distribution_record_sha256": _sha256_file(record_path),
         },
     }
-    sys.stdout.buffer.write(_canonical_json(payload))
+    sys.stdout.buffer.write(canonical_json(payload))
     return 0
 
 
@@ -1094,7 +1064,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "code": exc.code,
                 "detail": exc.detail,
             }
-            sys.stderr.buffer.write(_WORKER_ERROR_PREFIX + _canonical_json(payload))
+            sys.stderr.buffer.write(_WORKER_ERROR_PREFIX + canonical_json(payload))
             return 64
     if (
         args.python_executable is None

--- a/benchmarks/datasets/provider-feasibility-v1/cddlib/environment/submission_schema.json
+++ b/benchmarks/datasets/provider-feasibility-v1/cddlib/environment/submission_schema.json
@@ -14,7 +14,7 @@
         "provider": {"const": "cddlib/pycddlib"},
         "contract": {"const": "jacobian.cddlib-hv-spike/v1"},
         "status": {"enum": ["COMPLETED", "TIMEOUT", "CANCELLED", "ERROR", "REJECTED"]},
-        "pin_sha256": {"const": "sha256:15b0b5b4d608bc2f354dd484c44aa3da7441d615ab9650d6f7611c7e97af7871"}
+        "pin_sha256": {"const": "sha256:129610626988ff70540c9d7aef51efbda771ccee199eb44b629de50ad589104f"}
       }
     },
     "claimed_assurance": {"enum": ["UNVERIFIED","COMPUTED"]},

--- a/benchmarks/datasets/provider-feasibility-v1/cddlib/solution/solve.py
+++ b/benchmarks/datasets/provider-feasibility-v1/cddlib/solution/solve.py
@@ -9,7 +9,7 @@ REPORT = APP / "evidence" / "provider-report.json"
 TASK_ID = "jacobian/cddlib"
 PROVIDER = "cddlib/pycddlib"
 CONTRACT = "jacobian.cddlib-hv-spike/v1"
-PIN = "sha256:15b0b5b4d608bc2f354dd484c44aa3da7441d615ab9650d6f7611c7e97af7871"
+PIN = "sha256:129610626988ff70540c9d7aef51efbda771ccee199eb44b629de50ad589104f"
 
 report = json.loads(REPORT.read_text())
 status = report.get("status", "ERROR")

--- a/benchmarks/datasets/provider-feasibility-v1/cddlib/tests/expected.json
+++ b/benchmarks/datasets/provider-feasibility-v1/cddlib/tests/expected.json
@@ -2,7 +2,7 @@
   "task_id": "jacobian/cddlib",
   "provider": "cddlib/pycddlib",
   "contract": "jacobian.cddlib-hv-spike/v1",
-  "pin_sha256": "sha256:15b0b5b4d608bc2f354dd484c44aa3da7441d615ab9650d6f7611c7e97af7871",
+  "pin_sha256": "sha256:129610626988ff70540c9d7aef51efbda771ccee199eb44b629de50ad589104f",
   "report_conclusion": "SPIKE_PASSED_PRODUCTION_DEFERRED",
   "report_assurance": "OBSERVED_EXACT_PROVIDER_BEHAVIOR_WITH_SOUNDNESS_REPLAY",
   "reproduction": {

--- a/benchmarks/datasets/provider-feasibility-v1/cddlib/tests/input.json
+++ b/benchmarks/datasets/provider-feasibility-v1/cddlib/tests/input.json
@@ -2,5 +2,5 @@
   "task_id": "jacobian/cddlib",
   "provider": "cddlib/pycddlib",
   "contract": "jacobian.cddlib-hv-spike/v1",
-  "pin_sha256": "sha256:15b0b5b4d608bc2f354dd484c44aa3da7441d615ab9650d6f7611c7e97af7871"
+  "pin_sha256": "sha256:129610626988ff70540c9d7aef51efbda771ccee199eb44b629de50ad589104f"
 }

--- a/benchmarks/datasets/provider-feasibility-v1/cddlib/tests/public_contract.json
+++ b/benchmarks/datasets/provider-feasibility-v1/cddlib/tests/public_contract.json
@@ -57,7 +57,7 @@
             "const": "jacobian.cddlib-hv-spike/v1"
           },
           "pin_sha256": {
-            "const": "sha256:15b0b5b4d608bc2f354dd484c44aa3da7441d615ab9650d6f7611c7e97af7871"
+            "const": "sha256:129610626988ff70540c9d7aef51efbda771ccee199eb44b629de50ad589104f"
           },
           "provider": {
             "const": "cddlib/pycddlib"

--- a/benchmarks/datasets/provider-feasibility-v1/cgal/environment/Dockerfile
+++ b/benchmarks/datasets/provider-feasibility-v1/cgal/environment/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /app
 COPY __init__.py /opt/benchmarks/__init__.py
 COPY tooling/__init__.py /opt/benchmarks/tooling/__init__.py
 COPY tooling/command_runner.py /opt/benchmarks/tooling/command_runner.py
+COPY tooling/spike_utils.py /opt/benchmarks/tooling/spike_utils.py
 COPY datasets/provider-feasibility-v1/cgal/environment/cgal_delaunay_spike.cpp datasets/provider-feasibility-v1/cgal/environment/input.json datasets/provider-feasibility-v1/cgal/environment/cgal_delaunay_pin.json datasets/provider-feasibility-v1/cgal/environment/spike.py datasets/provider-feasibility-v1/cgal/environment/submission_schema.json /app/
 RUN g++ -std=c++17 -O2 -I/opt/provider/CGAL-6.2/include /app/cgal_delaunay_spike.cpp -lgmp -lmpfr -o /opt/provider/cgal-spike
 ENV PYTHONDONTWRITEBYTECODE=1

--- a/benchmarks/datasets/provider-feasibility-v1/cgal/environment/spike.py
+++ b/benchmarks/datasets/provider-feasibility-v1/cgal/environment/spike.py
@@ -14,10 +14,12 @@ from pathlib import Path
 from typing import Any
 
 from benchmarks.tooling.command_runner import (
-    ToolCommandRequest,
     ToolCommandResult,
     ToolCommandStatus,
-    run_tool_command,
+)
+from benchmarks.tooling.spike_utils import (
+    default_runner,
+    sha256_bytes,
 )
 
 PIN_PATH = Path(__file__).with_name("cgal_delaunay_pin.json")
@@ -30,38 +32,12 @@ _ENVIRONMENT = {"LANG": "C", "LC_ALL": "C", "TZ": "UTC"}
 ProcessRunner = Callable[..., ToolCommandResult]
 
 
-def _default_runner(
-    command: Sequence[str],
-    *,
-    input_bytes: bytes,
-    timeout_seconds: float,
-    environment: Mapping[str, str],
-    stdout_limit: int,
-    stderr_limit: int,
-) -> ToolCommandResult:
-    request = ToolCommandRequest(
-        executable=command[0],
-        arguments=tuple(command[1:]),
-        environment=environment,
-        cwd=str(Path.cwd()),
-        timeout_seconds=timeout_seconds,
-        stdin_bytes=input_bytes,
-        stdout_limit_bytes=stdout_limit,
-        stderr_limit_bytes=stderr_limit,
-    )
-    return run_tool_command(request)
-
-
 class CgalSpikeError(RuntimeError):
     def __init__(self, status: str, code: str, detail: str) -> None:
         super().__init__(detail)
         self.status = status
         self.code = code
         self.detail = detail
-
-
-def _sha256_bytes(payload: bytes) -> str:
-    return f"sha256:{hashlib.sha256(payload).hexdigest()}"
 
 
 def _sha256_file(path: Path) -> str:
@@ -279,7 +255,7 @@ def run_spike(
     executable: Path,
     source_archive: Path,
     timeout_seconds: float = 5,
-    runner: ProcessRunner = _default_runner,
+    runner: ProcessRunner = default_runner,
     pin_path: Path = PIN_PATH,
     adapter_source: Path = ADAPTER_SOURCE,
 ) -> dict[str, Any]:
@@ -325,14 +301,14 @@ def run_spike(
                 ) from exc
             if (
                 decoded != case["expected_output"]
-                or _sha256_bytes(output) != case["expected_output_sha256"]
+                or sha256_bytes(output) != case["expected_output_sha256"]
             ):
                 raise CgalSpikeError(
                     "REJECTED",
                     "REPRODUCTION_MISMATCH",
                     f"The CGAL {name} reproduction differs from the frozen result.",
                 )
-            observed[name] = _sha256_bytes(output)
+            observed[name] = sha256_bytes(output)
         compiler_support = _compiler_support(
             toolchain["compiler"],
             pin["supported_gnu_compiler_minimum"],

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/environment/Dockerfile
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/environment/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /app
 COPY __init__.py /opt/benchmarks/__init__.py
 COPY tooling/__init__.py /opt/benchmarks/tooling/__init__.py
 COPY tooling/command_runner.py /opt/benchmarks/tooling/command_runner.py
+COPY tooling/spike_utils.py /opt/benchmarks/tooling/spike_utils.py
 COPY datasets/provider-feasibility-v1/gudhi/environment/input.json datasets/provider-feasibility-v1/gudhi/environment/pin.json datasets/provider-feasibility-v1/gudhi/environment/spike.py datasets/provider-feasibility-v1/gudhi/environment/submission_schema.json /app/
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONPATH=/opt

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/environment/input.json
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/environment/input.json
@@ -2,5 +2,5 @@
   "task_id": "jacobian/gudhi",
   "provider": "gudhi",
   "contract": "jacobian.gudhi-persistence-spike/v1",
-  "pin_sha256": "sha256:329e57f50ad88ddbf2f6a3fe7cbbb0b5121be7c92a01d3a0b57db9241b1e6813"
+  "pin_sha256": "sha256:3decd51546ff618689114fb57eff03e1abc50133207e50fcba5c473583c02f4f"
 }

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/environment/pin.json
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/environment/pin.json
@@ -1,5 +1,5 @@
 {
-  "adapter_source_sha256": "sha256:a6a8f83a0e6ebf6d4783506171e4f8f2be1c185a0a9032a7ff7ba3d2c4855131",
+  "adapter_source_sha256": "sha256:2406f703ceafb0bff19cda9210358f75670f9ae2a08f7688f7cf168a8975eb4a",
   "contract": "jacobian.gudhi-persistence-spike/v1",
   "documentation_url": "https://gudhi.inria.fr/python/3.13.0/simplex_tree_ref.html",
   "licensing_url": "https://gudhi.inria.fr/licensing/",

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/environment/spike.py
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/environment/spike.py
@@ -16,10 +16,13 @@ from pathlib import Path
 from typing import Any
 
 from benchmarks.tooling.command_runner import (
-    ToolCommandRequest,
     ToolCommandResult,
     ToolCommandStatus,
-    run_tool_command,
+)
+from benchmarks.tooling.spike_utils import (
+    canonical_json,
+    default_runner,
+    sha256_bytes,
 )
 
 PIN_PATH = Path(__file__).with_name("pin.json")
@@ -44,28 +47,6 @@ ProcessRunner = Callable[..., ToolCommandResult]
 _WORKER_ERROR_PREFIX = b"JACOBIAN_SPIKE_ERROR "
 
 
-def _default_runner(
-    command: Sequence[str],
-    *,
-    input_bytes: bytes,
-    timeout_seconds: float,
-    environment: Mapping[str, str],
-    stdout_limit: int,
-    stderr_limit: int,
-) -> ToolCommandResult:
-    request = ToolCommandRequest(
-        executable=command[0],
-        arguments=tuple(command[1:]),
-        environment=environment,
-        cwd=str(Path.cwd()),
-        timeout_seconds=timeout_seconds,
-        stdin_bytes=input_bytes,
-        stdout_limit_bytes=stdout_limit,
-        stderr_limit_bytes=stderr_limit,
-    )
-    return run_tool_command(request)
-
-
 class GudhiSpikeError(RuntimeError):
     """A typed non-conclusion from the optional-provider spike."""
 
@@ -74,10 +55,6 @@ class GudhiSpikeError(RuntimeError):
         self.status = status
         self.code = code
         self.detail = detail
-
-
-def _sha256_bytes(payload: bytes) -> str:
-    return f"sha256:{hashlib.sha256(payload).hexdigest()}"
 
 
 def _sha256_file(path: Path) -> str:
@@ -93,13 +70,6 @@ def _sha256_file(path: Path) -> str:
             "A selected GUDHI spike artifact could not be read.",
         ) from exc
     return f"sha256:{digest.hexdigest()}"
-
-
-def _canonical_json(payload: object) -> bytes:
-    return (
-        json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
-        + "\n"
-    ).encode("ascii")
 
 
 def _load_pin(path: Path) -> dict[str, Any]:
@@ -251,7 +221,7 @@ def _inspect_source_archive(path: Path, pin: Mapping[str, Any]) -> dict[str, Any
     for role, payload in contents.items():
         expected = module_pins[role]
         if (
-            _sha256_bytes(payload) != expected["header_sha256"]
+            sha256_bytes(payload) != expected["header_sha256"]
             or b"released under MIT" not in payload[:1024]
             or expected["license_id"] != "MIT"
         ):
@@ -291,7 +261,7 @@ def _inspect_wheel(path: Path, pin: Mapping[str, Any]) -> dict[str, Any]:
             "The pinned GUDHI wheel could not be inspected safely.",
         ) from exc
     if (
-        _sha256_bytes(license_payload) != wheel_pin["license_sha256"]
+        sha256_bytes(license_payload) != wheel_pin["license_sha256"]
         or not license_payload.startswith(b"MIT License\n")
         or b"Name: gudhi\n" not in metadata
         or f"Version: {pin['version']}\n".encode() not in metadata
@@ -462,7 +432,7 @@ def _parse_provider_output(output: bytes, pin: Mapping[str, Any]) -> dict[str, A
     }
     if (
         mathematical_output != expected
-        or _sha256_bytes(_canonical_json(mathematical_output))
+        or sha256_bytes(canonical_json(mathematical_output))
         != pin["reproduction"]["expected_mathematical_output_sha256"]
     ):
         raise GudhiSpikeError(
@@ -589,7 +559,7 @@ def run_spike(
     wheel: Path,
     source_archive: Path,
     timeout_seconds: float = 10,
-    runner: ProcessRunner = _default_runner,
+    runner: ProcessRunner = default_runner,
     pin_path: Path = PIN_PATH,
     adapter_source: Path = ADAPTER_SOURCE,
 ) -> dict[str, Any]:
@@ -629,7 +599,7 @@ def run_spike(
         mathematical_output = {
             key: value for key, value in provider_output.items() if key != "runtime"
         }
-        mathematical_digest = _sha256_bytes(_canonical_json(mathematical_output))
+        mathematical_digest = sha256_bytes(canonical_json(mathematical_output))
         prime = pin["reproduction"]["coefficient_prime"]
         independent = _independent_reduction(simplices, prime)
         if independent["pairs"] != provider_output["pairs"]:
@@ -660,7 +630,7 @@ def run_spike(
                 "coefficient_prime": prime,
                 "rank_transport": "UNIQUE_INTEGER_RANKS_NOT_EXACT_VALUES",
                 "exact_value_source": "FROZEN_CANONICAL_INPUT",
-                "provider_output_sha256": _sha256_bytes(output),
+                "provider_output_sha256": sha256_bytes(output),
                 "mathematical_output_sha256": mathematical_digest,
                 "pairs": provider_output["pairs"],
                 "filtration": provider_output["filtration"],
@@ -717,7 +687,7 @@ def _worker(pin_path: Path) -> int:
             "provider": pin["provider"],
             "version": gudhi.__version__,
         }
-        sys.stdout.buffer.write(_canonical_json(payload))
+        sys.stdout.buffer.write(canonical_json(payload))
         return 0
 
     tree = gudhi.SimplexTree()
@@ -784,7 +754,7 @@ def _worker(pin_path: Path) -> int:
         },
         "version": pin["version"],
     }
-    sys.stdout.buffer.write(_canonical_json(payload))
+    sys.stdout.buffer.write(canonical_json(payload))
     return 0
 
 
@@ -806,7 +776,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "code": exc.code,
                 "detail": exc.detail,
             }
-            sys.stderr.buffer.write(_WORKER_ERROR_PREFIX + _canonical_json(payload))
+            sys.stderr.buffer.write(_WORKER_ERROR_PREFIX + canonical_json(payload))
             return 64
     if (
         args.python_executable is None

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/environment/submission_schema.json
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/environment/submission_schema.json
@@ -14,7 +14,7 @@
         "provider": {"const": "gudhi"},
         "contract": {"const": "jacobian.gudhi-persistence-spike/v1"},
         "status": {"enum": ["COMPLETED", "TIMEOUT", "CANCELLED", "ERROR", "REJECTED"]},
-        "pin_sha256": {"const": "sha256:329e57f50ad88ddbf2f6a3fe7cbbb0b5121be7c92a01d3a0b57db9241b1e6813"}
+        "pin_sha256": {"const": "sha256:3decd51546ff618689114fb57eff03e1abc50133207e50fcba5c473583c02f4f"}
       }
     },
     "claimed_assurance": {"enum": ["UNVERIFIED","COMPUTED"]},

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/solution/solve.py
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/solution/solve.py
@@ -9,7 +9,7 @@ REPORT = APP / "evidence" / "provider-report.json"
 TASK_ID = "jacobian/gudhi"
 PROVIDER = "gudhi"
 CONTRACT = "jacobian.gudhi-persistence-spike/v1"
-PIN = "sha256:329e57f50ad88ddbf2f6a3fe7cbbb0b5121be7c92a01d3a0b57db9241b1e6813"
+PIN = "sha256:3decd51546ff618689114fb57eff03e1abc50133207e50fcba5c473583c02f4f"
 
 report = json.loads(REPORT.read_text())
 status = report.get("status", "ERROR")

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/expected.json
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/expected.json
@@ -1,6 +1,6 @@
 {
   "contract": "jacobian.gudhi-persistence-spike/v1",
-  "pin_sha256": "sha256:329e57f50ad88ddbf2f6a3fe7cbbb0b5121be7c92a01d3a0b57db9241b1e6813",
+  "pin_sha256": "sha256:3decd51546ff618689114fb57eff03e1abc50133207e50fcba5c473583c02f4f",
   "provider": "gudhi",
   "report_assurance": "OBSERVED_PROVIDER_BEHAVIOR_WITH_INDEPENDENT_REPLAY",
   "report_conclusion": "SPIKE_PASSED_PRODUCTION_DEFERRED",

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/input.json
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/input.json
@@ -2,5 +2,5 @@
   "task_id": "jacobian/gudhi",
   "provider": "gudhi",
   "contract": "jacobian.gudhi-persistence-spike/v1",
-  "pin_sha256": "sha256:329e57f50ad88ddbf2f6a3fe7cbbb0b5121be7c92a01d3a0b57db9241b1e6813"
+  "pin_sha256": "sha256:3decd51546ff618689114fb57eff03e1abc50133207e50fcba5c473583c02f4f"
 }

--- a/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/public_contract.json
+++ b/benchmarks/datasets/provider-feasibility-v1/gudhi/tests/public_contract.json
@@ -57,7 +57,7 @@
             "const": "jacobian.gudhi-persistence-spike/v1"
           },
           "pin_sha256": {
-            "const": "sha256:329e57f50ad88ddbf2f6a3fe7cbbb0b5121be7c92a01d3a0b57db9241b1e6813"
+            "const": "sha256:3decd51546ff618689114fb57eff03e1abc50133207e50fcba5c473583c02f4f"
           },
           "provider": {
             "const": "gudhi"

--- a/benchmarks/datasets/provider-feasibility-v1/nauty/environment/Dockerfile
+++ b/benchmarks/datasets/provider-feasibility-v1/nauty/environment/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /app
 COPY __init__.py /opt/benchmarks/__init__.py
 COPY tooling/__init__.py /opt/benchmarks/tooling/__init__.py
 COPY tooling/command_runner.py /opt/benchmarks/tooling/command_runner.py
+COPY tooling/spike_utils.py /opt/benchmarks/tooling/spike_utils.py
 COPY datasets/provider-feasibility-v1/nauty/environment/input.json datasets/provider-feasibility-v1/nauty/environment/nauty_provider_pin.json datasets/provider-feasibility-v1/nauty/environment/spike.py datasets/provider-feasibility-v1/nauty/environment/submission_schema.json /app/
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONPATH=/opt

--- a/benchmarks/datasets/provider-feasibility-v1/nauty/environment/spike.py
+++ b/benchmarks/datasets/provider-feasibility-v1/nauty/environment/spike.py
@@ -12,10 +12,12 @@ from pathlib import Path
 from typing import Any
 
 from benchmarks.tooling.command_runner import (
-    ToolCommandRequest,
     ToolCommandResult,
     ToolCommandStatus,
-    run_tool_command,
+)
+from benchmarks.tooling.spike_utils import (
+    default_runner,
+    sha256_bytes,
 )
 
 PIN_PATH = Path(__file__).with_name("nauty_provider_pin.json")
@@ -44,28 +46,6 @@ _SOURCE_MEMBERS = (
 ProcessRunner = Callable[..., ToolCommandResult]
 
 
-def _default_runner(
-    command: Sequence[str],
-    *,
-    input_bytes: bytes,
-    timeout_seconds: float,
-    environment: Mapping[str, str],
-    stdout_limit: int,
-    stderr_limit: int,
-) -> ToolCommandResult:
-    request = ToolCommandRequest(
-        executable=command[0],
-        arguments=tuple(command[1:]),
-        environment=environment,
-        cwd=str(Path.cwd()),
-        timeout_seconds=timeout_seconds,
-        stdin_bytes=input_bytes,
-        stdout_limit_bytes=stdout_limit,
-        stderr_limit_bytes=stderr_limit,
-    )
-    return run_tool_command(request)
-
-
 class NautySpikeError(RuntimeError):
     """A typed non-conclusion from the optional-provider spike."""
 
@@ -74,10 +54,6 @@ class NautySpikeError(RuntimeError):
         self.status = status
         self.code = code
         self.detail = detail
-
-
-def _sha256_bytes(payload: bytes) -> str:
-    return f"sha256:{hashlib.sha256(payload).hexdigest()}"
 
 
 def _sha256_file(path: Path) -> str:
@@ -448,11 +424,11 @@ def _success_report(
         "reproduction": {
             **pin["reproduction"],
             "observed_count": len(generated.splitlines()),
-            "observed_output_sha256": _sha256_bytes(generated),
+            "observed_output_sha256": sha256_bytes(generated),
         },
         "canonicalization": {
             **pin["canonicalization"],
-            "observed_output_sha256": _sha256_bytes(canonicalized),
+            "observed_output_sha256": sha256_bytes(canonicalized),
             "isomorphic_inputs_converged": len(set(canonicalized.splitlines())) == 1,
         },
         "checker_feasibility": {
@@ -488,7 +464,7 @@ def run_spike(
     labelg: Path,
     source_archive: Path,
     timeout_seconds: float = 5,
-    runner: ProcessRunner = _default_runner,
+    runner: ProcessRunner = default_runner,
     pin_path: Path = PIN_PATH,
 ) -> dict[str, Any]:
     """Run the frozen probe and return a JSON-safe success or non-conclusion."""
@@ -529,7 +505,7 @@ def run_spike(
         reproduction = pin["reproduction"]
         if (
             list(generated_lines) != reproduction["expected_graph6"]
-            or _sha256_bytes(generated) != reproduction["expected_output_sha256"]
+            or sha256_bytes(generated) != reproduction["expected_output_sha256"]
         ):
             raise NautySpikeError(
                 "REJECTED",
@@ -551,8 +527,7 @@ def run_spike(
         canonicalization = pin["canonicalization"]
         if (
             list(canonical_lines) != canonicalization["expected_output_graph6"]
-            or _sha256_bytes(canonicalized)
-            != canonicalization["expected_output_sha256"]
+            or sha256_bytes(canonicalized) != canonicalization["expected_output_sha256"]
         ):
             raise NautySpikeError(
                 "REJECTED",

--- a/benchmarks/datasets/provider-feasibility-v1/regina/environment/Dockerfile
+++ b/benchmarks/datasets/provider-feasibility-v1/regina/environment/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /app
 COPY __init__.py /opt/benchmarks/__init__.py
 COPY tooling/__init__.py /opt/benchmarks/tooling/__init__.py
 COPY tooling/command_runner.py /opt/benchmarks/tooling/command_runner.py
+COPY tooling/spike_utils.py /opt/benchmarks/tooling/spike_utils.py
 COPY datasets/provider-feasibility-v1/regina/environment/input.json datasets/provider-feasibility-v1/regina/environment/pin.json datasets/provider-feasibility-v1/regina/environment/spike.py datasets/provider-feasibility-v1/regina/environment/submission_schema.json /app/
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONPATH=/opt

--- a/benchmarks/datasets/provider-feasibility-v1/regina/environment/input.json
+++ b/benchmarks/datasets/provider-feasibility-v1/regina/environment/input.json
@@ -2,5 +2,5 @@
   "task_id": "jacobian/regina",
   "provider": "regina",
   "contract": "jacobian.regina-outcomes-spike/v1",
-  "pin_sha256": "sha256:188618c36f37e31609eb57158f6f8fba270f86c5c6520b816eda6b7634482563"
+  "pin_sha256": "sha256:5ba6d2743ace43fcc497122b6deaa5fcb99b73526f4a06e311a7418225fc145f"
 }

--- a/benchmarks/datasets/provider-feasibility-v1/regina/environment/pin.json
+++ b/benchmarks/datasets/provider-feasibility-v1/regina/environment/pin.json
@@ -1,5 +1,5 @@
 {
-  "adapter_source_sha256": "sha256:e017a6f203585eacf2e57551aba282af510635e45bade5e5d722e1fee724d005",
+  "adapter_source_sha256": "sha256:2c269ed7abb4b9f31815855533e77017b56fd6821d6ba406af353d2c91b7a574",
   "contract": "jacobian.regina-outcomes-spike/v1",
   "distribution_version": "7.4.1",
   "documentation_url": "https://regina-normal.github.io/engine-docs/",

--- a/benchmarks/datasets/provider-feasibility-v1/regina/environment/spike.py
+++ b/benchmarks/datasets/provider-feasibility-v1/regina/environment/spike.py
@@ -18,10 +18,13 @@ from pathlib import Path
 from typing import Any
 
 from benchmarks.tooling.command_runner import (
-    ToolCommandRequest,
     ToolCommandResult,
     ToolCommandStatus,
-    run_tool_command,
+)
+from benchmarks.tooling.spike_utils import (
+    canonical_json,
+    default_runner,
+    sha256_bytes,
 )
 
 PIN_PATH = Path(__file__).with_name("pin.json")
@@ -46,28 +49,6 @@ ProcessRunner = Callable[..., ToolCommandResult]
 _WORKER_ERROR_PREFIX = b"JACOBIAN_SPIKE_ERROR "
 
 
-def _default_runner(
-    command: Sequence[str],
-    *,
-    input_bytes: bytes,
-    timeout_seconds: float,
-    environment: Mapping[str, str],
-    stdout_limit: int,
-    stderr_limit: int,
-) -> ToolCommandResult:
-    request = ToolCommandRequest(
-        executable=command[0],
-        arguments=tuple(command[1:]),
-        environment=environment,
-        cwd=str(Path.cwd()),
-        timeout_seconds=timeout_seconds,
-        stdin_bytes=input_bytes,
-        stdout_limit_bytes=stdout_limit,
-        stderr_limit_bytes=stderr_limit,
-    )
-    return run_tool_command(request)
-
-
 class ReginaSpikeError(RuntimeError):
     """A typed non-conclusion from the optional-provider spike."""
 
@@ -78,23 +59,12 @@ class ReginaSpikeError(RuntimeError):
         self.detail = detail
 
 
-def _sha256_bytes(payload: bytes) -> str:
-    return f"sha256:{hashlib.sha256(payload).hexdigest()}"
-
-
 def _sha256_file(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as stream:
         for block in iter(lambda: stream.read(1024 * 1024), b""):
             digest.update(block)
     return f"sha256:{digest.hexdigest()}"
-
-
-def _canonical_json(payload: object) -> bytes:
-    return (
-        json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
-        + "\n"
-    ).encode("ascii")
 
 
 def _load_pin(path: Path) -> dict[str, Any]:
@@ -248,7 +218,7 @@ def _inspect_source_archive(path: Path, pin: Mapping[str, Any]) -> dict[str, Any
         ) from exc
     expected = source_pin["members"]
     if any(
-        _sha256_bytes(payload) != expected[role]["sha256"]
+        sha256_bytes(payload) != expected[role]["sha256"]
         for role, payload in contents.items()
     ) or not all(
         b"GNU General Public License" in contents[role][:2048]
@@ -295,8 +265,8 @@ def _inspect_wheel(path: Path, pin: Mapping[str, Any]) -> dict[str, Any]:
             "The pinned Regina wheel could not be inspected safely.",
         ) from exc
     if (
-        _sha256_bytes(metadata) != wheel_pin["metadata_sha256"]
-        or _sha256_bytes(wheel_metadata) != wheel_pin["wheel_sha256"]
+        sha256_bytes(metadata) != wheel_pin["metadata_sha256"]
+        or sha256_bytes(wheel_metadata) != wheel_pin["wheel_sha256"]
         or b"Name: regina\n" not in metadata
         or f"Version: {pin['distribution_version']}\n".encode() not in metadata
         or b"License: GPLv2+\n" not in metadata
@@ -446,7 +416,7 @@ def _parse_provider_output(output: bytes, pin: Mapping[str, Any]) -> dict[str, A
     expected = pin["reproduction"]["expected_provider_output"]
     if (
         mathematical != expected
-        or _sha256_bytes(_canonical_json(mathematical))
+        or sha256_bytes(canonical_json(mathematical))
         != pin["reproduction"]["expected_mathematical_output_sha256"]
     ):
         raise ReginaSpikeError(
@@ -734,7 +704,7 @@ def run_spike(
     wheel: Path,
     source_archive: Path,
     timeout_seconds: float = 20,
-    runner: ProcessRunner = _default_runner,
+    runner: ProcessRunner = default_runner,
     pin_path: Path = PIN_PATH,
     adapter_source: Path = ADAPTER_SOURCE,
 ) -> dict[str, Any]:
@@ -793,7 +763,7 @@ def run_spike(
             },
             "reproduction": {
                 "scope": pin["reproduction"]["scope"],
-                "provider_output_sha256": _sha256_bytes(output),
+                "provider_output_sha256": sha256_bytes(output),
                 "cases": provider_output["cases"],
                 "normal_surfaces": provider_output["normal_surfaces"],
             },
@@ -905,7 +875,7 @@ def _verify_installed_runtime(wheel_path: Path) -> int:
                         "PROVIDER_RUNTIME_MISMATCH",
                         "The installed Regina runtime is missing a pinned wheel member.",
                     )
-                if _sha256_file(installed_path) != _sha256_bytes(archive.read(member)):
+                if _sha256_file(installed_path) != sha256_bytes(archive.read(member)):
                     raise ReginaSpikeError(
                         "REJECTED",
                         "PROVIDER_RUNTIME_MISMATCH",
@@ -1022,7 +992,7 @@ def _worker(pin_path: Path, wheel_path: Path) -> int:
             "verified_runtime_files": verified_runtime_files,
         },
     }
-    sys.stdout.buffer.write(_canonical_json(payload))
+    sys.stdout.buffer.write(canonical_json(payload))
     return 0
 
 
@@ -1046,7 +1016,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "code": exc.code,
                 "detail": exc.detail,
             }
-            sys.stderr.buffer.write(_WORKER_ERROR_PREFIX + _canonical_json(payload))
+            sys.stderr.buffer.write(_WORKER_ERROR_PREFIX + canonical_json(payload))
             return 64
     if (
         args.python_executable is None

--- a/benchmarks/datasets/provider-feasibility-v1/regina/environment/submission_schema.json
+++ b/benchmarks/datasets/provider-feasibility-v1/regina/environment/submission_schema.json
@@ -14,7 +14,7 @@
         "provider": {"const": "regina"},
         "contract": {"const": "jacobian.regina-outcomes-spike/v1"},
         "status": {"enum": ["COMPLETED", "TIMEOUT", "CANCELLED", "ERROR", "REJECTED"]},
-        "pin_sha256": {"const": "sha256:188618c36f37e31609eb57158f6f8fba270f86c5c6520b816eda6b7634482563"}
+        "pin_sha256": {"const": "sha256:5ba6d2743ace43fcc497122b6deaa5fcb99b73526f4a06e311a7418225fc145f"}
       }
     },
     "claimed_assurance": {"enum": ["UNVERIFIED","COMPUTED"]},

--- a/benchmarks/datasets/provider-feasibility-v1/regina/solution/solve.py
+++ b/benchmarks/datasets/provider-feasibility-v1/regina/solution/solve.py
@@ -9,7 +9,7 @@ REPORT = APP / "evidence" / "provider-report.json"
 TASK_ID = "jacobian/regina"
 PROVIDER = "regina"
 CONTRACT = "jacobian.regina-outcomes-spike/v1"
-PIN = "sha256:188618c36f37e31609eb57158f6f8fba270f86c5c6520b816eda6b7634482563"
+PIN = "sha256:5ba6d2743ace43fcc497122b6deaa5fcb99b73526f4a06e311a7418225fc145f"
 
 report = json.loads(REPORT.read_text())
 status = report.get("status", "ERROR")

--- a/benchmarks/datasets/provider-feasibility-v1/regina/tests/expected.json
+++ b/benchmarks/datasets/provider-feasibility-v1/regina/tests/expected.json
@@ -2,7 +2,7 @@
   "task_id": "jacobian/regina",
   "provider": "regina",
   "contract": "jacobian.regina-outcomes-spike/v1",
-  "pin_sha256": "sha256:188618c36f37e31609eb57158f6f8fba270f86c5c6520b816eda6b7634482563",
+  "pin_sha256": "sha256:5ba6d2743ace43fcc497122b6deaa5fcb99b73526f4a06e311a7418225fc145f",
   "report_conclusion": "SPIKE_PASSED_PRODUCTION_DEFERRED",
   "report_assurance": "OBSERVED_PROVIDER_BEHAVIOR_WITH_PARTIAL_INDEPENDENT_REPLAY",
   "reproduction": {

--- a/benchmarks/datasets/provider-feasibility-v1/regina/tests/input.json
+++ b/benchmarks/datasets/provider-feasibility-v1/regina/tests/input.json
@@ -2,5 +2,5 @@
   "task_id": "jacobian/regina",
   "provider": "regina",
   "contract": "jacobian.regina-outcomes-spike/v1",
-  "pin_sha256": "sha256:188618c36f37e31609eb57158f6f8fba270f86c5c6520b816eda6b7634482563"
+  "pin_sha256": "sha256:5ba6d2743ace43fcc497122b6deaa5fcb99b73526f4a06e311a7418225fc145f"
 }

--- a/benchmarks/datasets/provider-feasibility-v1/regina/tests/public_contract.json
+++ b/benchmarks/datasets/provider-feasibility-v1/regina/tests/public_contract.json
@@ -57,7 +57,7 @@
             "const": "jacobian.regina-outcomes-spike/v1"
           },
           "pin_sha256": {
-            "const": "sha256:188618c36f37e31609eb57158f6f8fba270f86c5c6520b816eda6b7634482563"
+            "const": "sha256:5ba6d2743ace43fcc497122b6deaa5fcb99b73526f4a06e311a7418225fc145f"
           },
           "provider": {
             "const": "regina"

--- a/benchmarks/tooling/spike_utils.py
+++ b/benchmarks/tooling/spike_utils.py
@@ -1,0 +1,59 @@
+"""Shared pure helpers for provider-feasibility spike scripts.
+
+These utilities are byte-identical across every provider spike that uses
+them.  They depend only on :mod:`benchmarks.tooling.command_runner` and the
+standard library, so each provider ``environment/Dockerfile`` can ``COPY``
+this module alongside ``command_runner.py`` into the container.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+from benchmarks.tooling.command_runner import (
+    ToolCommandRequest,
+    ToolCommandResult,
+    run_tool_command,
+)
+
+__all__ = [
+    "canonical_json",
+    "default_runner",
+    "sha256_bytes",
+]
+
+
+def default_runner(
+    command: Sequence[str],
+    *,
+    input_bytes: bytes,
+    timeout_seconds: float,
+    environment: Mapping[str, str],
+    stdout_limit: int,
+    stderr_limit: int,
+) -> ToolCommandResult:
+    request = ToolCommandRequest(
+        executable=command[0],
+        arguments=tuple(command[1:]),
+        environment=environment,
+        cwd=str(Path.cwd()),
+        timeout_seconds=timeout_seconds,
+        stdin_bytes=input_bytes,
+        stdout_limit_bytes=stdout_limit,
+        stderr_limit_bytes=stderr_limit,
+    )
+    return run_tool_command(request)
+
+
+def sha256_bytes(payload: bytes) -> str:
+    return f"sha256:{hashlib.sha256(payload).hexdigest()}"
+
+
+def canonical_json(payload: object) -> bytes:
+    return (
+        json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+        + "\n"
+    ).encode("ascii")

--- a/tests/unit/tooling/test_spike_utils.py
+++ b/tests/unit/tooling/test_spike_utils.py
@@ -1,0 +1,61 @@
+"""Behavioral tests for the shared provider-spike utility helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+from benchmarks.tooling.spike_utils import (
+    canonical_json,
+    sha256_bytes,
+)
+
+
+def test_sha256_bytes_matches_reference_implementation() -> None:
+    payload = b"provider-spike-fixture"
+
+    assert sha256_bytes(payload) == f"sha256:{hashlib.sha256(payload).hexdigest()}"
+
+
+def test_sha256_bytes_prefixes_with_scheme() -> None:
+    assert sha256_bytes(b"").startswith("sha256:")
+
+
+def test_sha256_bytes_is_deterministic() -> None:
+    assert sha256_bytes(b"abc") == sha256_bytes(b"abc")
+
+
+def test_sha256_bytes_distinguishes_inputs() -> None:
+    assert sha256_bytes(b"abc") != sha256_bytes(b"abd")
+
+
+def test_canonical_json_sorts_keys() -> None:
+    payload = {"b": 2, "a": 1}
+
+    assert json.loads(canonical_json(payload)) == {"a": 1, "b": 2}
+
+
+def test_canonical_json_uses_compact_separators() -> None:
+    payload = {"a": 1, "b": 2}
+
+    assert canonical_json(payload) == b'{"a":1,"b":2}\n'
+
+
+def test_canonical_json_ensures_ascii() -> None:
+    payload = {"key": "\u00e9"}
+
+    assert canonical_json(payload) == b'{"key":"\\u00e9"}\n'
+
+
+def test_canonical_json_appends_trailing_newline() -> None:
+    assert canonical_json({"a": 1}).endswith(b"\n")
+
+
+def test_canonical_json_is_deterministic_across_key_orders() -> None:
+    assert canonical_json({"a": 1, "b": 2}) == canonical_json({"b": 2, "a": 1})
+
+
+def test_canonical_json_encodes_nested_structures() -> None:
+    payload = {"outer": {"inner": [3, 2, 1]}}
+
+    assert canonical_json(payload) == b'{"outer":{"inner":[3,2,1]}}\n'


### PR DESCRIPTION
## Summary

Addresses the actionable part of #717.

Extract the identical canonical-JSON, SHA-256, and command-runner helpers used by the cddlib, CGAL, GUDHI, nauty, and Regina provider spikes. Each provider container now copies the shared module into the existing `benchmarks.tooling` package.

The cddlib, GUDHI, and Regina adapters digest `spike.py`, so their source pins and every task-owned consumer (Oracle input, public schema, solution, and verifier fixtures) are refreshed in the same change. CGAL pins a separate C++ adapter and nauty has no `spike.py` source pin.

Provider-specific error handling and `_sha256_file` behavior remain local. Lean REPL and all clean-room Harbor verifier files are intentionally untouched: task-local verifier code is required by the separate-verifier build context and independence boundary.

## Validation

- `make test-unit TESTS=tests/unit/tooling/test_spike_utils.py`
- `uv run --locked python tools/check_benchmark_static.py`
- `make harbor-check-task DATASET=provider-feasibility-v1 TASKS="cddlib gudhi regina"`

CI runs the full host-validation matrix and exact provider Oracles for this shared-tooling/task-image change.