### PR TITLE
feat(providers): expose precise domain validation diagnostics

### DIFF
--- a/src/jacobian/contracts/topology.py
+++ b/src/jacobian/contracts/topology.py
@@ -7,7 +7,14 @@ from enum import StrEnum
 from itertools import combinations, pairwise
 from typing import Annotated, Literal, Self
 
-from pydantic import Field, StrictInt, StringConstraints, model_validator
+from pydantic import (
+    Field,
+    StrictInt,
+    StringConstraints,
+    ValidationInfo,
+    field_validator,
+    model_validator,
+)
 
 from jacobian.canonical import canonicalize_json
 from jacobian.contracts.certified_snf import (
@@ -214,6 +221,47 @@ class FiniteSimplicialComplex(ContractModel):
     empty_simplex_stored: Literal[False] = False
     complex_digest: Sha256Digest
 
+    @field_validator("complex_digest", mode="after")
+    @classmethod
+    def require_digest_binds_canonical_complex(
+        cls, value: str, info: ValidationInfo
+    ) -> str:
+        """Bind ``complex_digest`` to the canonical complex derived from the
+        other fields.  Runs as a field validator so Pydantic reports the
+        error location as ``complex_digest`` (nested inside the parent
+        model's ``loc``), not as a model-level error.
+        """
+
+        required = (
+            "vertices",
+            "maximal_simplices",
+            "faces_by_dimension",
+            "dimension",
+            "f_vector",
+            "closure_size",
+        )
+        if not all(key in info.data for key in required):
+            return value
+        vertices: tuple[str, ...] = info.data["vertices"]
+        maximal_simplices: tuple[tuple[str, ...], ...] = info.data["maximal_simplices"]
+        faces_by_dimension: tuple[FacesInDimension, ...] = info.data[
+            "faces_by_dimension"
+        ]
+        dimension: int = info.data["dimension"]
+        f_vector: tuple[int, ...] = info.data["f_vector"]
+        closure_size: int = info.data["closure_size"]
+        expected_digest = simplicial_complex_digest(
+            vertices=vertices,
+            maximal_simplices=maximal_simplices,
+            faces_by_dimension=faces_by_dimension,
+            dimension=dimension,
+            f_vector=f_vector,
+            closure_size=closure_size,
+        )
+        if value != expected_digest:
+            raise ValueError("complex_digest does not bind the canonical complex")
+        return value
+
     @model_validator(mode="after")
     def require_complete_canonical_complex(self) -> Self:
         if tuple(sorted(set(self.vertices))) != self.vertices:
@@ -238,16 +286,6 @@ class FiniteSimplicialComplex(ContractModel):
             or self.closure_size != sum(expected_f_vector)
         ):
             raise ValueError("complex dimension, f-vector, or closure size is invalid")
-        expected_digest = simplicial_complex_digest(
-            vertices=self.vertices,
-            maximal_simplices=self.maximal_simplices,
-            faces_by_dimension=self.faces_by_dimension,
-            dimension=self.dimension,
-            f_vector=self.f_vector,
-            closure_size=self.closure_size,
-        )
-        if self.complex_digest != expected_digest:
-            raise ValueError("complex_digest does not bind the canonical complex")
         return self
 
 

--- a/src/jacobian/operation_installation.py
+++ b/src/jacobian/operation_installation.py
@@ -16,6 +16,7 @@ from jacobian.contracts.capabilities import (
     CapabilityCompleteness,
     CapabilityCompletenessStatus,
     CapabilityDescriptor,
+    CapabilityDiagnostic,
     CapabilityInputKind,
     CapabilityMode,
     CapabilityObligation,
@@ -94,6 +95,35 @@ def _execution_failure_result(
             level=CapabilityAssuranceLevel.HEURISTIC,
             basis="operation did not complete; no mathematical conclusion",
         ),
+    )
+
+
+def _enriched_invalid_request(
+    base: CapabilityDiagnostic,
+    exc: ValidationError,
+) -> CapabilityDiagnostic:
+    """Copy *base* and surface the first Pydantic error's location and message.
+
+    Used only when no per-operation ``invalid_request`` is set, so the
+    generic bundle diagnostic gains a precise ``path`` (from the Pydantic
+    ``loc``) and ``hint`` (from the validator's own message) without
+    changing its ``code`` or ``stage``.
+    """
+
+    errors = exc.errors()
+    if not errors:
+        return base
+    first = errors[0]
+    loc = first.get("loc", ())
+    path = "/".join(str(part) for part in loc) if loc else None
+    msg = str(first.get("msg", ""))
+    if msg.startswith("Value error, "):
+        msg = msg[len("Value error, ") :]
+    return base.model_copy(
+        update={
+            "path": path,
+            "hint": msg if msg else base.hint,
+        }
     )
 
 
@@ -230,9 +260,14 @@ class ComputedOperationAdapter:
                 request.input
             )
         except ValidationError as exc:
-            raise CapabilityInvocationError(
+            base = (
                 self.operation.invalid_request
                 or self.bundle.diagnostics.invalid_request
+            )
+            raise CapabilityInvocationError(
+                base
+                if self.operation.invalid_request is not None
+                else _enriched_invalid_request(base, exc)
             ) from exc
 
         started = time.monotonic()
@@ -356,10 +391,17 @@ class MaterializedOperationAdapter:
             ValidationError,
             ValueError,
         ) as exc:
-            raise CapabilityInvocationError(
+            base = (
                 self.operation.invalid_request
                 or self.bundle.diagnostics.invalid_request
-            ) from exc
+            )
+            if self.operation.invalid_request is not None or not isinstance(
+                exc, ValidationError
+            ):
+                diagnostic = base
+            else:
+                diagnostic = _enriched_invalid_request(base, exc)
+            raise CapabilityInvocationError(diagnostic) from exc
         started = time.monotonic()
         outcome = self.operation.implementation(validated_request)
         if isinstance(outcome, ComputedNotApplicable):
@@ -475,9 +517,14 @@ class BoundedSearchOperationAdapter:
                 request.input
             )
         except ValidationError as exc:
-            raise CapabilityInvocationError(
+            base = (
                 self.operation.invalid_request
                 or self.bundle.diagnostics.invalid_request
+            )
+            raise CapabilityInvocationError(
+                base
+                if self.operation.invalid_request is not None
+                else _enriched_invalid_request(base, exc)
             ) from exc
 
         started = time.monotonic()

--- a/tests/composition/portfolio/test_operation_installation.py
+++ b/tests/composition/portfolio/test_operation_installation.py
@@ -1,8 +1,8 @@
 from dataclasses import replace
-from typing import Any, cast
+from typing import Any, Self, cast
 
 import pytest
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from jacobian.contracts.capabilities import (
     CapabilityAssuranceLevel,
@@ -32,6 +32,23 @@ from jacobian.runtime.model import JacobianRuntime
 
 class _SyntheticRequest(ContractModel):
     value: int = Field(ge=0, le=100)
+
+
+class _CrossFieldRequest(ContractModel):
+    """A request whose cross-field validator rejects a value that passes
+    JSON Schema (both fields are valid integers in range) but fails
+    Pydantic's ``model_validator`` — exercising the adapter-level
+    ``ValidationError`` path, not the dispatch-level schema path.
+    """
+
+    value: int = Field(ge=0, le=100)
+    limit: int = Field(ge=0, le=100)
+
+    @model_validator(mode="after")
+    def require_value_below_limit(self) -> Self:
+        if self.value >= self.limit:
+            raise ValueError("value must be strictly less than limit")
+        return self
 
 
 class _SyntheticResult(ContractModel):
@@ -483,6 +500,54 @@ def test_computed_adapter_rejects_invalid_implementation_result(
 
     assert result.execution.status is ExecutionStatus.ERROR
     assert result.diagnostics[0].code == "ADAPTER_EXECUTION_FAILED"
+    assert result.artifact_uris == ()
+
+
+def test_operation_specific_invalid_request_is_not_enriched(
+    fresh_complete_runtime,
+) -> None:
+    """An operation that sets its own ``invalid_request`` diagnostic must
+    receive it verbatim on ``ValidationError`` — the enrichment helper must
+    not overwrite its ``path``, ``hint``, or any other field.
+
+    Uses ``_CrossFieldRequest`` so the input passes JSON Schema validation
+    (both fields are valid integers in range) but fails the Pydantic
+    ``model_validator``, reaching the adapter-level ``except ValidationError``
+    block where enrichment is gated on ``operation.invalid_request is None``.
+    """
+
+    bundle = _synthetic_bundle()
+    operation_diagnostic = CapabilityDiagnostic(
+        code="SYNTHETIC_OPERATION_INVALID_REQUEST",
+        stage="synthetic_operation_validation",
+        message="This operation-specific diagnostic must be preserved verbatim.",
+        hint="Use a value between 0 and 100.",
+        path="value",
+    )
+    operation = ComputedOperation(
+        capability_id="synthetic.compute.operation_diagnostic",
+        title="Cross-field validated synthetic operation",
+        description="Exercise operation-specific invalid_request preservation.",
+        request_model=_CrossFieldRequest,
+        result_model=_SyntheticResult,
+        implementation=lambda request: ComputedSuccess(
+            _SyntheticResult(doubled=request.value * 2)
+        ),
+        relation_id="synthetic.relation.cross_field",
+        tags=("synthetic",),
+        invalid_request=operation_diagnostic,
+    )
+    _install(fresh_complete_runtime, replace(bundle, capabilities=(operation,)))
+
+    result = fresh_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="synthetic.compute.operation_diagnostic",
+            input={"value": 50, "limit": 10},
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.diagnostics[0] == operation_diagnostic
     assert result.artifact_uris == ()
 
 

--- a/tests/composition/runtime/test_topology_capabilities.py
+++ b/tests/composition/runtime/test_topology_capabilities.py
@@ -429,3 +429,75 @@ def test_invalid_topology_request_fails_before_artifact_writes(
     assert result.execution.status is ExecutionStatus.ERROR
     assert result.diagnostics[0].code == "INVALID_FINITE_SIMPLICIAL_TOPOLOGY_REQUEST"
     assert result.artifact_uris == ()
+
+
+def test_stale_complex_digest_surfaces_precise_field_in_diagnostic(
+    fresh_complete_runtime,
+) -> None:
+    """A stale ``complex_digest`` must fail closed *and* surface the precise
+    Pydantic validator message in the diagnostic ``hint`` and the nested
+    field path in ``path`` — not just the generic bundle wording.
+    """
+
+    result = fresh_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="topology.simplicial_homology.integral.compute",
+            input={
+                "complex": {
+                    "complex_format": "jacobian.finite-simplicial-complex/v1",
+                    "vertices": ["x", "y", "z"],
+                    "maximal_simplices": [["x", "y"], ["x", "z"], ["y", "z"]],
+                    "faces_by_dimension": [
+                        {
+                            "dimension": 0,
+                            "faces": [["x"], ["y"], ["z"]],
+                        },
+                        {
+                            "dimension": 1,
+                            "faces": [["x", "y"], ["x", "z"], ["y", "z"]],
+                        },
+                    ],
+                    "dimension": 1,
+                    "f_vector": [3, 3],
+                    "closure_size": 6,
+                    "orientation_convention": "LEXICOGRAPHIC_VERTEX_ORDER",
+                    "empty_simplex_stored": False,
+                    "complex_digest": (
+                        "sha256:"
+                        "6f797991bac967e2a8e572707df487061655df0f094c"
+                        "bde0f52f82c5401fc043"
+                    ),
+                },
+            },
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.diagnostics[0].code == "INVALID_FINITE_SIMPLICIAL_TOPOLOGY_REQUEST"
+    assert result.diagnostics[0].path == "complex/complex_digest"
+    assert "complex_digest" in (result.diagnostics[0].hint or "")
+    assert result.artifact_uris == ()
+
+
+def test_enriched_diagnostic_still_fails_closed_for_non_digest_error(
+    fresh_complete_runtime,
+) -> None:
+    """A non-digest validation error (non-maximal facets) must still fail
+    closed with the correct code and no artifacts, while the enriched
+    ``hint`` surfaces the specific validator message.
+    """
+
+    result = fresh_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="topology.simplicial_complex.materialize",
+            input={
+                "vertices": ["a", "b"],
+                "facets": [["a"], ["a", "b"]],
+            },
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.diagnostics[0].code == "INVALID_FINITE_SIMPLICIAL_TOPOLOGY_REQUEST"
+    assert "maximal" in (result.diagnostics[0].hint or "")
+    assert result.artifact_uris == ()

--- a/tests/unit/contracts/test_topology_contracts.py
+++ b/tests/unit/contracts/test_topology_contracts.py
@@ -6,6 +6,7 @@ from pydantic import ValidationError
 from jacobian.contracts.topology import (
     ChainCoefficientRing,
     ChainComplexRequest,
+    FiniteSimplicialComplex,
     IntegralSimplicialHomologyRequest,
     SimplicialComplexRequest,
     SimplicialHomologyRequest,
@@ -97,3 +98,20 @@ def test_integral_homology_has_tighter_certificate_size_bounds() -> None:
     assert sum(total_rank_too_large.f_vector) == 33
     with pytest.raises(ValidationError, match="total chain rank at most 32"):
         IntegralSimplicialHomologyRequest(complex=total_rank_too_large)
+
+
+def test_stale_complex_digest_reports_field_level_loc() -> None:
+    """A stale ``complex_digest`` must produce a Pydantic error whose ``loc``
+    targets the ``complex_digest`` field (not a model-level ``()``), so the
+    enrichment helper can surface ``complex/complex_digest`` to the agent.
+    """
+
+    good = _materialized_complex(("a", "b", "c"), (("a", "b"), ("b", "c")))
+    bad_payload = good.model_dump(mode="python")
+    bad_payload["complex_digest"] = "sha256:" + "0" * 64
+    with pytest.raises(ValidationError) as exc_info:
+        FiniteSimplicialComplex.model_validate(bad_payload)
+    errors = exc_info.value.errors()
+    assert len(errors) == 1
+    assert errors[0]["loc"] == ("complex_digest",)
+    assert "complex_digest" in errors[0]["msg"]


### PR DESCRIPTION
## Summary

Fixes #781.

Installed operation adapters now enrich a generic domain-level invalid-request diagnostic with the first bounded Pydantic validation location and message. Operation-specific diagnostics remain authoritative and unchanged.

Finite simplicial-complex digest binding is now a `complex_digest` field validator, so a stale digest reports `complex/complex_digest` instead of collapsing into an anonymous model-level error. The capability remains fail-closed and produces no artifacts.

## Validation

- `ruff check` and `ruff format --check` on changed files
- `mypy src/jacobian/contracts/topology.py src/jacobian/operation_installation.py`
- focused topology contract/runtime tests (26 passed)
- `tests/composition/portfolio/test_operation_installation.py` (16 passed)
- `make test-plan BASE=origin/main` (selective fallback; CI owns the routed full suite)