### PR TITLE
fix(providers): fail closed provider measurement probes

### DIFF
--- a/src/jacobian/provider_measurements.py
+++ b/src/jacobian/provider_measurements.py
@@ -33,24 +33,31 @@ import sys
 provider = sys.argv[1]
 operation = sys.argv[2]
 
+def require(condition, message):
+    if not condition:
+        raise RuntimeError(message)
+
 if provider == "jacobian.networkx":
     import networkx as backend
     if operation == "reproduction":
         graph = backend.path_graph(32)
-        assert backend.is_connected(graph)
+        require(backend.is_connected(graph), "networkx connectivity reproduction failed")
 elif provider == "jacobian.sympy":
     import sympy as backend
     if operation == "reproduction":
         x, y = backend.symbols("x y")
         matrix = backend.Matrix([x**2 + y, x * y])
-        assert matrix.jacobian((x, y)).shape == (2, 2)
+        require(
+            matrix.jacobian((x, y)).shape == (2, 2),
+            "sympy Jacobian reproduction failed",
+        )
 elif provider == "jacobian.z3":
     import z3 as backend
     if operation == "reproduction":
         x = backend.Real("x")
         solver = backend.Solver()
         solver.add(x == 1)
-        assert solver.check() == backend.sat
+        require(solver.check() == backend.sat, "z3 satisfiability reproduction failed")
 elif provider == "cvc5":
     import cvc5 as backend
     if operation == "reproduction":
@@ -75,21 +82,30 @@ elif provider == "cvc5":
             output = command.invoke(solver, parser.getSymbolManager())
             if command.getCommandName() == "check-sat":
                 result = output.strip()
-        assert result == "unsat"
+        require(result == "unsat", "cvc5 satisfiability reproduction failed")
         proofs = solver.getProof(backend.ProofComponent.FULL)
-        assert len(proofs) == 1
-        assert solver.proofToString(proofs[0], backend.ProofFormat.ALETHE)
+        require(len(proofs) == 1, "cvc5 proof count reproduction failed")
+        require(
+            solver.proofToString(proofs[0], backend.ProofFormat.ALETHE),
+            "cvc5 Alethe proof reproduction failed",
+        )
 elif provider == "python-flint":
     import flint as backend
     if operation == "reproduction":
         augmented = backend.fmpq_mat([[2, 1, 5], [1, -1, 1]])
         reduced, rank = augmented.rref()
-        assert rank == 2
-        assert reduced == backend.fmpq_mat([[1, 0, 2], [0, 1, 1]])
+        require(rank == 2, "python-flint rank reproduction failed")
+        require(
+            reduced == backend.fmpq_mat([[1, 0, 2], [0, 1, 1]]),
+            "python-flint reduction reproduction failed",
+        )
 else:
     import jacobian.canonical as backend
     if operation == "reproduction":
-        assert backend.canonicalize_json({"value": 1})
+        require(
+            backend.canonicalize_json({"value": 1}),
+            "Jacobian canonicalization reproduction failed",
+        )
 
 # Report this child's own peak resident set so a short probe that exits
 # before the engine's procfs sampler can poll it still yields a trustworthy

--- a/tests/unit/contracts/test_provider_measurements.py
+++ b/tests/unit/contracts/test_provider_measurements.py
@@ -9,6 +9,7 @@ from jacobian.provider_measurements import (
     _PYTHON_PROBE,
     _child_peak_rss_bytes,
     _measure_command,
+    _process_environment,
 )
 
 
@@ -46,6 +47,31 @@ def test_python_probe_emits_rss_marker_for_short_completed_child() -> None:
     assert sample.status is ProviderMeasurementStatus.COMPLETED
     assert sample.peak_rss_bytes is not None
     assert sample.peak_rss_bytes > 0
+
+
+def test_python_probe_fails_closed_under_optimization(tmp_path) -> None:
+    (tmp_path / "networkx.py").write_text(
+        "def path_graph(_count):\n"
+        "    return object()\n\n"
+        "def is_connected(_graph):\n"
+        "    return False\n"
+    )
+    environment = _process_environment()
+    environment["PYTHONPATH"] = str(tmp_path)
+
+    sample = _measure_command(
+        [
+            sys.executable,
+            "-O",
+            "-c",
+            _PYTHON_PROBE,
+            "jacobian.networkx",
+            "reproduction",
+        ],
+        environment=environment,
+    )
+
+    assert sample.status is ProviderMeasurementStatus.ERROR
 
 
 def test_measure_command_without_marker_falls_back_to_engine_sample() -> None:


### PR DESCRIPTION
Fixes #661.

### Problem

Provider reproduction probes used Python `assert`. If a probe runs with optimization enabled, Python strips those checks and a failed reproduction can be reported as completed.

### Change

Replace probe assertions with explicit `RuntimeError` checks. A failed provider reproduction now exits nonzero regardless of optimization mode.

### Regression coverage

The new regression executes the probe with `python -O` and a fake `networkx` implementation that reports a disconnected graph. It must yield `ProviderMeasurementStatus.ERROR`; the assertion-based probe would have exited successfully under optimization.

### Validation

- `make test-unit TESTS="tests/unit/contracts/test_provider_measurements.py"` — 6 passed
- `uv run ruff format --check src/jacobian/provider_measurements.py tests/unit/contracts/test_provider_measurements.py` — passed
- `uv run ruff check src/jacobian/provider_measurements.py tests/unit/contracts/test_provider_measurements.py` — passed
- `uv run mypy src/jacobian/provider_measurements.py` — passed
- `make test-plan BASE=origin/main` — selective plan; CI owns the expanded routed suite
- `/home/morluto/.codex/skills/autoreview/scripts/autoreview --mode local` — clean