### PR TITLE
fix(eval): record trajectory validation diagnostics

### DIFF
--- a/src/jacobian/eval/trajectory_state.py
+++ b/src/jacobian/eval/trajectory_state.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 from enum import StrEnum
 from pathlib import Path
 from typing import Any, Literal, Self
@@ -20,6 +21,7 @@ from jacobian.canonical import CanonicalizationError, canonicalize_json
 from jacobian.contracts.capabilities import CapabilityResult
 from jacobian.contracts.results import ContractModel
 
+_LOGGER = logging.getLogger(__name__)
 _DIGEST_PATTERN = r"^sha256:[0-9a-f]{64}$"
 _ARTIFACT_PATTERN = r"^artifact://sha256/[0-9a-f]{64}$"
 _CONTROL_OUTPUT_FIELDS = frozenset(
@@ -787,7 +789,12 @@ def _record_math_result(
         return tuple(sorted(kinds, key=str))
     try:
         validated = CapabilityResult.model_validate(response)
-    except ValidationError:
+    except ValidationError as exc:
+        _LOGGER.warning(
+            "trajectory extraction rejected malformed capability result for %s: %s",
+            capability_id,
+            exc.errors(include_url=False)[0]["msg"],
+        )
         state.execution_status = "ERROR"
         kinds.update(_record_diagnostics(state, response))
         return tuple(sorted(kinds, key=str))

--- a/tests/unit/tooling/test_trajectory_state.py
+++ b/tests/unit/tooling/test_trajectory_state.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 from pathlib import Path
 
 import pytest
@@ -370,6 +371,39 @@ def test_malformed_or_substituted_typed_results_cannot_create_objects(
     assert tool_states[0].hard_state.typed_objects == ()
     assert tool_states[1].milestone_kinds == (MilestoneKind.BINDING_BECAME_INVALID,)
     assert tool_states[1].hard_state.typed_objects == ()
+
+
+def test_trajectory_extraction_records_discarded_validation_diagnostics(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    capability_id = "integer.compute.gcd"
+    malformed = _result(
+        capability_id,
+        artifacts=["not-an-artifact-uri"],
+    )
+    malformed["assurance"] = {"level": "VERIFIED"}
+    events = [_reasoning("PLAN", "Record invalid observed results.")]
+    events.extend(
+        _cycle(
+            CALL_IDS[0],
+            capability_id,
+            malformed,
+            after="Invalid observations must not become progress.",
+        )
+    )
+
+    with caplog.at_level(logging.WARNING, logger="jacobian.eval.trajectory_state"):
+        extraction = extract_codex_trajectory(
+            _write(tmp_path, events), task_family="exact-arithmetic"
+        )
+
+    messages = caplog.messages
+    assert any(
+        "rejected malformed capability result" in message for message in messages
+    )
+    assert any(capability_id in message for message in messages)
+    assert extraction.states[-2].hard_state.execution_status == "ERROR"
 
 
 def test_rejection_repair_obligations_and_verified_binding_are_milestones(


### PR DESCRIPTION
Fixes #700.

### Problem

Trajectory extraction marked malformed `CapabilityResult` payloads as `ERROR` but discarded the validation reason, leaving observed malformed traffic without actionable diagnostics.

The reported later artifact-URI drop is not a second live boundary: `CapabilityResult` validates artifact URIs before trajectory state reaches `_record_artifacts`. Adding a log there would only instrument unreachable code.

### Change

Log the first bounded Pydantic validation message at the authoritative `CapabilityResult` boundary, while preserving the existing fail-closed `ERROR` result and diagnostic extraction.

### Regression coverage

A malformed result with an invalid artifact URI now proves that extraction remains `ERROR` and emits the validation diagnostic.

### Validation

- `make test-unit TESTS="tests/unit/tooling/test_trajectory_state.py"` — 11 passed
- `uv run ruff check src/jacobian/eval/trajectory_state.py tests/unit/tooling/test_trajectory_state.py` — passed
- `uv run mypy src/jacobian/eval/trajectory_state.py` — passed
- `make test-plan BASE=origin/main` — focused selector; CI owns routed suite
- `/home/morluto/.codex/skills/autoreview/scripts/autoreview --mode local` — clean