### PR TITLE
fix(polynomials): cancel polynomial collision grid searches

### DIFF
--- a/src/jacobian/contracts/polynomials.py
+++ b/src/jacobian/contracts/polynomials.py
@@ -561,6 +561,7 @@ class PolynomialCollisionSearchRequest(ContractModel):
 class PolynomialCollisionSearchStopReason(StrEnum):
     FIRST_COLLISION = "FIRST_COLLISION"
     GRID_EXHAUSTED = "GRID_EXHAUSTED"
+    CANCELLED = "CANCELLED"
 
 
 class PolynomialCollisionVerifyRequest(ContractModel):
@@ -1022,11 +1023,19 @@ class PolynomialCollisionSearchOutput(ContractModel):
             self.stop_reason is not PolynomialCollisionSearchStopReason.FIRST_COLLISION
         ):
             raise ValueError("found results must stop at the first collision")
-        if not self.found and (
-            self.stop_reason is not PolynomialCollisionSearchStopReason.GRID_EXHAUSTED
-            or self.examined_point_count != self.grid_point_count
-        ):
-            raise ValueError("not-found results require an exhausted grid")
+        if not self.found:
+            if self.stop_reason is PolynomialCollisionSearchStopReason.GRID_EXHAUSTED:
+                if self.examined_point_count != self.grid_point_count:
+                    raise ValueError("exhausted grids must examine every point")
+            elif self.stop_reason is PolynomialCollisionSearchStopReason.CANCELLED:
+                if self.examined_point_count >= self.grid_point_count:
+                    raise ValueError(
+                        "cancelled searches require an unexamined grid suffix"
+                    )
+            else:
+                raise ValueError(
+                    "not-found results require an exhausted or cancelled grid"
+                )
         return self
 
 

--- a/src/jacobian/polynomials/collision.py
+++ b/src/jacobian/polynomials/collision.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import time
 from itertools import product
 
+from jacobian.bounded_process import bounded_process_cancelled
 from jacobian.canonical import format_canonical_integer
 from jacobian.contracts.capabilities import (
     CapabilityAssurance,
@@ -42,6 +43,8 @@ from jacobian.contracts.polynomials import (
 )
 from jacobian.contracts.results import (
     Conclusion,
+    Execution,
+    ExecutionStatus,
     Verification,
 )
 from jacobian.domains._examples import example
@@ -337,10 +340,14 @@ class PolynomialCollisionSearchAdapter:
         ) = None
         evaluation_uris: list[str] = []
         examined = 0
+        cancelled = False
         for point_values in product(
             scalar_values,
             repeat=len(polynomial_map.variables),
         ):
+            if bounded_process_cancelled():
+                cancelled = True
+                break
             examined += 1
             point = RationalPolynomialPoint(values=point_values)
             image = _evaluate(polynomial_map, point)
@@ -438,17 +445,23 @@ class PolynomialCollisionSearchAdapter:
             stop_reason=(
                 PolynomialCollisionSearchStopReason.FIRST_COLLISION
                 if found is not None
-                else PolynomialCollisionSearchStopReason.GRID_EXHAUSTED
+                else (
+                    PolynomialCollisionSearchStopReason.CANCELLED
+                    if cancelled
+                    else PolynomialCollisionSearchStopReason.GRID_EXHAUSTED
+                )
             ),
         )
         artifacts = [map_uri, *evaluation_uris]
-        relationships = [
-            CapabilityRelationship(
-                relation_id="polynomial.relation.evaluation-of",
-                source_artifact_uris=(map_uri,),
-                target_artifact_uris=tuple(evaluation_uris),
+        relationships: list[CapabilityRelationship] = []
+        if evaluation_uris:
+            relationships.append(
+                CapabilityRelationship(
+                    relation_id="polynomial.relation.evaluation-of",
+                    source_artifact_uris=(map_uri,),
+                    target_artifact_uris=tuple(evaluation_uris),
+                )
             )
-        ]
         if found is not None:
             assert first_evaluation_result is not None
             assert second_evaluation_result is not None
@@ -486,24 +499,57 @@ class PolynomialCollisionSearchAdapter:
                 )
             )
         exhausted_grid = examined == grid_point_count
+        scope = CapabilityScope(
+            description="declared finite rational grid",
+            parameters={
+                "max_abs_numerator": validated.max_abs_numerator,
+                "max_denominator": validated.max_denominator,
+                "grid_point_count": grid_point_count,
+            },
+            artifact_uri=map_uri,
+        )
+        artifact_uris = tuple(
+            dict.fromkeys(uri for uri in artifacts if uri is not None)
+        )
+        if cancelled:
+            return CapabilityResult(
+                capability_id=self.descriptor.capability_id,
+                capability_version=self.descriptor.version,
+                mode=request.mode,
+                execution=Execution(
+                    status=ExecutionStatus.CANCELLED,
+                    runtime_ms=max(0, round((time.monotonic() - started) * 1000)),
+                    detail="The client cancelled the collision-grid search.",
+                ),
+                completeness=CapabilityCompleteness(
+                    status=CapabilityCompletenessStatus.PARTIAL,
+                    basis=(
+                        "the deterministic grid prefix completed before client "
+                        "cancellation; no mathematical conclusion or independent "
+                        "verification is claimed"
+                    ),
+                    assurance_level=CapabilityAssuranceLevel.COMPUTED,
+                ),
+                assurance=CapabilityAssurance(
+                    level=CapabilityAssuranceLevel.COMPUTED,
+                    basis=(
+                        "deterministic exact SymPy search was cancelled before the "
+                        "declared grid was exhausted"
+                    ),
+                ),
+                output=output.model_dump(mode="json"),
+                scope=scope,
+                relationships=tuple(relationships),
+                artifact_uris=artifact_uris,
+            )
         return _computed_result(
             descriptor=self.descriptor,
             request=request,
             started=started,
             output=output.model_dump(mode="json"),
-            scope=CapabilityScope(
-                description="declared finite rational grid",
-                parameters={
-                    "max_abs_numerator": validated.max_abs_numerator,
-                    "max_denominator": validated.max_denominator,
-                    "grid_point_count": grid_point_count,
-                },
-                artifact_uri=map_uri,
-            ),
+            scope=scope,
             relationships=tuple(relationships),
-            artifact_uris=tuple(
-                dict.fromkeys(uri for uri in artifacts if uri is not None)
-            ),
+            artifact_uris=artifact_uris,
             completeness_basis=(
                 "the deterministic grid was fully enumerated"
                 if exhausted_grid

--- a/tests/domain/polynomial/test_polynomial_collision_search.py
+++ b/tests/domain/polynomial/test_polynomial_collision_search.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import threading
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
@@ -7,11 +8,13 @@ from typing import Any
 import pytest
 from tests.support.services import DomainTestServices, open_domain_services
 
+from jacobian.bounded_process import bounded_process_cancellation
 from jacobian.contracts.capabilities import (
     CapabilityAssuranceLevel,
     CapabilityCompletenessStatus,
     CapabilityRequest,
 )
+from jacobian.contracts.results import ExecutionStatus
 from jacobian.domains.polynomial import build_polynomial_bundle
 from jacobian.polynomials import install_polynomial_capabilities
 
@@ -142,6 +145,25 @@ def test_collision_search_reports_exact_completed_not_found_scope(
     assert set(result.relationships[0].target_artifact_uris) <= set(
         result.artifact_uris
     )
+
+
+def test_collision_search_preserves_partial_evidence_when_cancelled(
+    domain_services,
+) -> None:
+    cancellation_event = threading.Event()
+    cancellation_event.set()
+
+    with bounded_process_cancellation(cancellation_event):
+        result = domain_services.core.capabilities.invoke(_request(1))
+
+    assert result.execution.status is ExecutionStatus.CANCELLED
+    assert result.output["found"] is False
+    assert result.output["stop_reason"] == "CANCELLED"
+    assert result.output["examined_point_count"] == 0
+    assert result.output["grid_point_count"] == 3
+    assert result.completeness.status is CapabilityCompletenessStatus.PARTIAL
+    assert len(result.artifact_uris) == 1
+    assert result.relationships == ()
 
 
 def test_collision_search_validates_grid_bound_before_artifact_writes(


### PR DESCRIPTION
Fixes #698.

### Problem

Polynomial collision search can materialize up to 10,000 exact point evaluations, but the pure-Python grid loop did not poll the request cancellation authority. A cancelled client could therefore leave the loop running until it completed.

### Change

Poll the existing bounded-process cancellation context once per grid iteration. Cancellation now returns a `CANCELLED` execution with an explicit collision-search stop reason, partial completeness, the materialized grid prefix, and no mathematical conclusion.

### Contract

`PolynomialCollisionSearchStopReason` gains `CANCELLED`. A cancelled not-found result must retain an unexamined grid suffix; an exhausted result must still examine every point.

### Regression coverage

A pre-cancelled invocation stops before the first point, preserves only the map artifact, produces no invalid empty relationship, and reports partial scope.

### Validation

- `make test-domain TESTS="tests/domain/polynomial/test_polynomial_collision_search.py"` — 5 passed
- `uv run ruff check ...` and `uv run mypy src/jacobian/contracts/polynomials.py src/jacobian/polynomials/collision.py` — passed
- `make test-plan BASE=origin/main` — CI owns suite-fallback validation
- `/home/morluto/.codex/skills/autoreview/scripts/autoreview --mode local` — clean