### PR TITLE
refactor(math): deduplicate rational digit-bound validation

### DIFF
--- a/src/jacobian/contracts/combinatorics.py
+++ b/src/jacobian/contracts/combinatorics.py
@@ -17,7 +17,11 @@ from jacobian.canonical import (
     canonicalize_json,
     format_canonical_integer,
 )
-from jacobian.contracts.exact import CanonicalInteger, CanonicalRational
+from jacobian.contracts.exact import (
+    CanonicalInteger,
+    CanonicalRational,
+    require_bounded_rational,
+)
 from jacobian.contracts.results import ContractModel
 
 _MAX_N = 1_000
@@ -98,22 +102,6 @@ def _minimum_fraction_wire_bytes(value: Fraction) -> int:
         + _lower_decimal_digits(value.denominator)
         + 20
     )
-
-
-def _require_bounded_rational(
-    value: CanonicalRational,
-    *,
-    max_digits: int,
-    label: str,
-) -> Fraction:
-    if (
-        len(value.num.lstrip("-")) > max_digits
-        or len(value.den.lstrip("-")) > max_digits
-    ):
-        raise ValueError(f"{label} exceeds the {max_digits}-digit bound")
-    fraction = value.as_fraction()
-    _require_bounded_fraction(fraction, max_digits=max_digits, label=label)
-    return fraction
 
 
 def _validate_result_artifact_size(payload: dict[str, object]) -> None:
@@ -275,7 +263,7 @@ def _require_canonical_polynomial(
     label: str,
 ) -> None:
     for coefficient in coefficients:
-        _require_bounded_rational(
+        require_bounded_rational(
             coefficient,
             max_digits=MAX_COMBINATORICS_INPUT_RATIONAL_DIGITS,
             label=label,
@@ -728,7 +716,7 @@ class LinearRecurrenceEvaluationRequest(ContractModel):
             ("recurrence initial value", self.initial_values),
         ):
             for value in values:
-                _require_bounded_rational(
+                require_bounded_rational(
                     value,
                     max_digits=MAX_COMBINATORICS_INPUT_RATIONAL_DIGITS,
                     label=label,
@@ -771,7 +759,7 @@ class IndexedRationalValue(ContractModel):
 
     @model_validator(mode="after")
     def require_bounded_value(self) -> Self:
-        _require_bounded_rational(
+        require_bounded_rational(
             self.value,
             max_digits=MAX_COMBINATORICS_RESULT_RATIONAL_DIGITS,
             label="recurrence result",
@@ -804,7 +792,7 @@ class LinearRecurrenceEvaluationResult(ContractModel):
                 "replay_prefix must cover indices 0 through replay_scope_end"
             )
         for value in self.replay_prefix:
-            _require_bounded_rational(
+            require_bounded_rational(
                 value,
                 max_digits=MAX_COMBINATORICS_RESULT_RATIONAL_DIGITS,
                 label="recurrence replay value",
@@ -898,7 +886,7 @@ class RationalGeneratingFunctionCoefficientsResult(ContractModel):
             ("series residual", self.residual_coefficients),
         ):
             for value in values:
-                _require_bounded_rational(
+                require_bounded_rational(
                     value,
                     max_digits=MAX_COMBINATORICS_RESULT_RATIONAL_DIGITS,
                     label=label,

--- a/src/jacobian/contracts/exact.py
+++ b/src/jacobian/contracts/exact.py
@@ -56,6 +56,21 @@ def bounded_rational_grid_size(
     return size
 
 
+def require_bounded_rational(
+    value: CanonicalRational,
+    *,
+    max_digits: int,
+    label: str,
+) -> None:
+    """Reject a canonical rational whose components exceed a domain bound."""
+
+    if (
+        len(value.num.lstrip("-")) > max_digits
+        or len(value.den.lstrip("-")) > max_digits
+    ):
+        raise ValueError(f"{label} exceeds the {max_digits}-digit bound")
+
+
 class CanonicalRational(ContractModel):
     num: CanonicalInteger
     den: CanonicalInteger

--- a/src/jacobian/contracts/graph_optimization.py
+++ b/src/jacobian/contracts/graph_optimization.py
@@ -6,7 +6,7 @@ from typing import Literal, Self
 
 from pydantic import Field, StrictInt, model_validator
 
-from jacobian.contracts.exact import CanonicalRational
+from jacobian.contracts.exact import CanonicalRational, require_bounded_rational
 from jacobian.contracts.graph_coloring import ChromaticGraph, GraphVertex
 from jacobian.contracts.results import ContractModel
 
@@ -22,16 +22,6 @@ OptimizationTermination = Literal[
 MAX_GRAPH_WEIGHT_DIGITS = 256
 
 
-def _require_bounded_weight(value: CanonicalRational) -> None:
-    if (
-        len(value.num.lstrip("-")) > MAX_GRAPH_WEIGHT_DIGITS
-        or len(value.den) > MAX_GRAPH_WEIGHT_DIGITS
-    ):
-        raise ValueError(
-            f"graph weights are limited to {MAX_GRAPH_WEIGHT_DIGITS} decimal digits"
-        )
-
-
 class RationalWeightedEdge(ContractModel):
     """One exact rational edge of a bounded simple undirected graph."""
 
@@ -42,7 +32,11 @@ class RationalWeightedEdge(ContractModel):
     def require_distinct_endpoints_and_bounded_weight(self) -> Self:
         if self.endpoints[0] == self.endpoints[1]:
             raise ValueError("weighted graph edges must not contain self-loops")
-        _require_bounded_weight(self.weight)
+        require_bounded_rational(
+            self.weight,
+            max_digits=MAX_GRAPH_WEIGHT_DIGITS,
+            label="graph weight",
+        )
         return self
 
 
@@ -88,7 +82,11 @@ class CanonicalWeightedTreeEdge(ContractModel):
             raise ValueError(
                 "tree edge endpoints must be in strict lexicographic order"
             )
-        _require_bounded_weight(self.weight)
+        require_bounded_rational(
+            self.weight,
+            max_digits=MAX_GRAPH_WEIGHT_DIGITS,
+            label="graph weight",
+        )
         return self
 
 
@@ -120,8 +118,12 @@ class GraphMstCycleCheck(ContractModel):
             raise ValueError(
                 "tree path must be simple and join the non-tree edge endpoints"
             )
-        _require_bounded_weight(self.edge_weight)
-        _require_bounded_weight(self.maximum_tree_path_weight)
+        for weight in (self.edge_weight, self.maximum_tree_path_weight):
+            require_bounded_rational(
+                weight,
+                max_digits=MAX_GRAPH_WEIGHT_DIGITS,
+                label="graph weight",
+            )
         return self
 
 

--- a/src/jacobian/contracts/linear.py
+++ b/src/jacobian/contracts/linear.py
@@ -13,7 +13,7 @@ from jacobian.contracts.capabilities import (
     CapabilityProviderRuntime,
 )
 from jacobian.contracts.common import ArtifactUri, CheckerUri, Sha256Digest
-from jacobian.contracts.exact import CanonicalRational
+from jacobian.contracts.exact import CanonicalRational, require_bounded_rational
 from jacobian.contracts.matrices import ExactRationalMatrix
 from jacobian.contracts.results import ContractModel
 
@@ -41,14 +41,11 @@ def linear_variable_order_digest(variables: tuple[str, ...]) -> str:
 
 def _require_bounded_rationals(values: tuple[CanonicalRational, ...]) -> None:
     for value in values:
-        if (
-            len(value.num.lstrip("-")) > MAX_RATIONAL_DIGITS
-            or len(value.den.lstrip("-")) > MAX_RATIONAL_DIGITS
-        ):
-            raise ValueError(
-                "linear-system rationals are limited to 256 decimal digits "
-                "per numerator and denominator"
-            )
+        require_bounded_rational(
+            value,
+            max_digits=MAX_RATIONAL_DIGITS,
+            label="linear-system rational",
+        )
 
 
 class LinearRationalSystem(ContractModel):

--- a/src/jacobian/contracts/probability.py
+++ b/src/jacobian/contracts/probability.py
@@ -9,7 +9,11 @@ from typing import Literal, Self
 from pydantic import Field, StrictInt, model_validator
 
 from jacobian.canonical import canonicalize_json, format_canonical_integer
-from jacobian.contracts.exact import CanonicalInteger, CanonicalRational
+from jacobian.contracts.exact import (
+    CanonicalInteger,
+    CanonicalRational,
+    require_bounded_rational,
+)
 from jacobian.contracts.graph_isomorphism import SimpleUndirectedGraph
 from jacobian.contracts.results import ContractModel
 
@@ -40,19 +44,6 @@ def _require_bounded_fraction(
         or len(format_canonical_integer(value.denominator)) > max_digits
     ):
         raise ValueError(f"{label} exceeds the {max_digits}-digit bound")
-
-
-def _require_bounded_rational(
-    value: CanonicalRational,
-    *,
-    max_digits: int,
-    label: str,
-) -> None:
-    _require_bounded_fraction(
-        value.as_fraction(),
-        max_digits=max_digits,
-        label=label,
-    )
 
 
 def _require_strictly_increasing(
@@ -90,7 +81,7 @@ class ExactComplexRational(ContractModel):
             ("complex real component", self.real),
             ("complex imaginary component", self.imaginary),
         ):
-            _require_bounded_rational(
+            require_bounded_rational(
                 value,
                 max_digits=MAX_GAUSSIAN_RESULT_RATIONAL_DIGITS,
                 label=label,
@@ -121,7 +112,7 @@ class GaussianPolynomialTerm(ContractModel):
         if self.coefficient.as_fractions() == (Fraction(), Fraction()):
             raise ValueError("Gaussian polynomial terms must have nonzero coefficients")
         for component in (self.coefficient.real, self.coefficient.imaginary):
-            _require_bounded_rational(
+            require_bounded_rational(
                 component,
                 max_digits=MAX_INPUT_RATIONAL_DIGITS,
                 label="Gaussian polynomial input coefficient",
@@ -274,7 +265,7 @@ class GraphReliabilityEdgeProbability(ContractModel):
     def require_canonical_bounded_probability(self) -> Self:
         if len(self.edge) != 2 or self.edge[0] >= self.edge[1]:
             raise ValueError("reliability edge must contain two ordered vertices")
-        _require_bounded_rational(
+        require_bounded_rational(
             self.open_probability,
             max_digits=MAX_INPUT_RATIONAL_DIGITS,
             label="graph reliability edge probability",
@@ -432,12 +423,12 @@ class FiniteDistributionAtom(ContractModel):
 
     @model_validator(mode="after")
     def require_bounded_nonnegative_probability(self) -> Self:
-        _require_bounded_rational(
+        require_bounded_rational(
             self.value,
             max_digits=MAX_RESULT_RATIONAL_DIGITS,
             label="finite-distribution atom",
         )
-        _require_bounded_rational(
+        require_bounded_rational(
             self.probability,
             max_digits=MAX_RESULT_RATIONAL_DIGITS,
             label="finite-distribution probability",
@@ -483,12 +474,12 @@ def require_input_distribution(
             "finite-distribution support values must be strictly increasing"
         )
     for atom in atoms:
-        _require_bounded_rational(
+        require_bounded_rational(
             atom.value,
             max_digits=MAX_INPUT_RATIONAL_DIGITS,
             label="finite-distribution input atom",
         )
-        _require_bounded_rational(
+        require_bounded_rational(
             atom.probability,
             max_digits=MAX_INPUT_RATIONAL_DIGITS,
             label="finite-distribution input probability",
@@ -523,7 +514,7 @@ class FiniteEventRequest(ContractModel):
             label="finite event values",
         )
         for value in self.event_values:
-            _require_bounded_rational(
+            require_bounded_rational(
                 value,
                 max_digits=MAX_INPUT_RATIONAL_DIGITS,
                 label="finite event value",
@@ -584,7 +575,7 @@ class FiniteConditionalContribution(ContractModel):
             ("conditional source probability", self.source_probability),
             ("conditioned probability", self.conditioned_probability),
         ):
-            _require_bounded_rational(
+            require_bounded_rational(
                 value,
                 max_digits=MAX_RESULT_RATIONAL_DIGITS,
                 label=label,
@@ -665,12 +656,12 @@ class FinitePushforwardRequest(ContractModel):
             )
         aggregated: dict[Fraction, Fraction] = {}
         for atom, item in zip(self.distribution.atoms, self.mapping, strict=True):
-            _require_bounded_rational(
+            require_bounded_rational(
                 item.source,
                 max_digits=MAX_INPUT_RATIONAL_DIGITS,
                 label="pushforward source",
             )
-            _require_bounded_rational(
+            require_bounded_rational(
                 item.target,
                 max_digits=MAX_INPUT_RATIONAL_DIGITS,
                 label="pushforward target",
@@ -705,7 +696,7 @@ class FinitePushforwardContribution(ContractModel):
             ("pushforward target", self.target),
             ("pushforward probability", self.probability),
         ):
-            _require_bounded_rational(
+            require_bounded_rational(
                 value,
                 max_digits=MAX_RESULT_RATIONAL_DIGITS,
                 label=label,
@@ -803,7 +794,7 @@ class FiniteConvolutionContribution(ContractModel):
             ("convolution sum value", self.sum_value),
             ("convolution probability", self.probability),
         ):
-            _require_bounded_rational(
+            require_bounded_rational(
                 value,
                 max_digits=MAX_RESULT_RATIONAL_DIGITS,
                 label=label,

--- a/src/jacobian/contracts/validated_analysis.py
+++ b/src/jacobian/contracts/validated_analysis.py
@@ -8,7 +8,7 @@ from typing import Literal, Self
 
 from pydantic import Field, StrictInt, model_validator
 
-from jacobian.contracts.exact import CanonicalRational
+from jacobian.contracts.exact import CanonicalRational, require_bounded_rational
 from jacobian.contracts.probability import (
     FiniteDistributionAtom,
     require_input_distribution,
@@ -23,17 +23,6 @@ type RationalLinearProgramStatus = Literal[
     "TIMEOUT",
     "BACKEND_ERROR",
 ]
-
-
-def _require_bounded_rational(value: CanonicalRational) -> None:
-    if (
-        len(value.num.lstrip("-")) > MAX_RATIONAL_DIGITS
-        or len(value.den) > MAX_RATIONAL_DIGITS
-    ):
-        raise ValueError(
-            "validated-analysis rationals are limited to 128 decimal digits "
-            "per numerator and denominator"
-        )
 
 
 class RealUnaryFunction(StrEnum):
@@ -52,7 +41,11 @@ class ArbPointEnclosureRequest(ContractModel):
 
     @model_validator(mode="after")
     def bound_argument_size(self) -> Self:
-        _require_bounded_rational(self.argument)
+        require_bounded_rational(
+            self.argument,
+            max_digits=MAX_RATIONAL_DIGITS,
+            label="validated-analysis rational",
+        )
         return self
 
 
@@ -211,7 +204,11 @@ class StandardFormRationalLinearProgram(ContractModel):
             *self.rhs,
             *(item for row in self.coefficients for item in row),
         ):
-            _require_bounded_rational(value)
+            require_bounded_rational(
+                value,
+                max_digits=MAX_RATIONAL_DIGITS,
+                label="validated-analysis rational",
+            )
         return self
 
 

--- a/tests/domain/graph/test_graph_minimum_spanning_tree.py
+++ b/tests/domain/graph/test_graph_minimum_spanning_tree.py
@@ -258,7 +258,7 @@ def test_weighted_graph_contract_rejects_parallel_edges_and_oversized_weights() 
             }
         )
 
-    with raises(ValidationError, match="256 decimal digits"):
+    with raises(ValidationError, match="256-digit bound"):
         GraphMinimumSpanningTreeRequest.model_validate(
             {
                 "graph": _weighted_graph(

--- a/tests/unit/contracts/test_canonical_json.py
+++ b/tests/unit/contracts/test_canonical_json.py
@@ -10,7 +10,7 @@ from jacobian.canonical import (
     CanonicalLimits,
     canonicalize_json,
 )
-from jacobian.contracts.exact import CanonicalRational
+from jacobian.contracts.exact import CanonicalRational, require_bounded_rational
 
 
 def test_equivalent_rationals_have_identical_canonical_bytes() -> None:
@@ -59,6 +59,24 @@ def test_canonical_errors_preserve_only_repair_relevant_context(
 def test_canonical_rational_wire_model_rejects_unreduced_input() -> None:
     with pytest.raises(ValidationError):
         CanonicalRational.model_validate({"num": "2", "den": "4"})
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        {"num": "-101", "den": "1"},
+        {"num": "1", "den": "101"},
+    ],
+)
+def test_bounded_rational_rejects_oversized_canonical_components(
+    value: dict[str, str],
+) -> None:
+    with pytest.raises(ValueError, match="test rational exceeds the 2-digit bound"):
+        require_bounded_rational(
+            CanonicalRational.model_validate(value),
+            max_digits=2,
+            label="test rational",
+        )
 
 
 def test_negative_zero_is_not_a_canonical_integer_encoding() -> None:

--- a/tests/unit/contracts/test_linear_contracts.py
+++ b/tests/unit/contracts/test_linear_contracts.py
@@ -56,7 +56,7 @@ def test_linear_find_request_rejects_ambiguous_or_oversized_rationals() -> None:
         {"num": "1" * 257, "den": "1"},
         _q(1),
     ]
-    with pytest.raises(ValidationError, match="256 decimal digits"):
+    with pytest.raises(ValidationError, match="256-digit bound"):
         LinearRationalSolutionFindRequest.model_validate(
             {"system": oversized, "resource_budget": {"wall_seconds": 5}}
         )


### PR DESCRIPTION
## Summary

Closes #696.

Move canonical-rational component digit validation into `contracts.exact` and make every affected contract call that one owner. This removes the inconsistent string and Fraction-based implementations, including the redundant revalidation after canonical parsing.

The contract errors now use the shared `… exceeds the N-digit bound` form.

## Validation

- `uv run --locked ruff check src/jacobian/contracts/exact.py src/jacobian/contracts/probability.py src/jacobian/contracts/combinatorics.py src/jacobian/contracts/validated_analysis.py src/jacobian/contracts/graph_optimization.py src/jacobian/contracts/linear.py tests/unit/contracts/test_canonical_json.py`
- `uv run --locked mypy src/jacobian/contracts/exact.py src/jacobian/contracts/probability.py src/jacobian/contracts/combinatorics.py src/jacobian/contracts/validated_analysis.py src/jacobian/contracts/graph_optimization.py src/jacobian/contracts/linear.py`
- `make test-unit TESTS='tests/unit/contracts/test_canonical_json.py tests/unit/contracts/test_linear_contracts.py'`\n- `make test-domain TESTS='tests/domain/graph/test_graph_minimum_spanning_tree.py'`\n- `make test-plan BASE=origin/main` (suite fallback from transitive combinatorics ownership)