### PR TITLE
refactor(polynomials): deduplicate polynomial capability plumbing

### DIFF
--- a/src/jacobian/polynomial_interval_capabilities.py
+++ b/src/jacobian/polynomial_interval_capabilities.py
@@ -32,8 +32,6 @@ from fractions import Fraction
 from math import comb
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple, cast
 
-from pydantic import ValidationError
-
 from jacobian.artifacts import ArtifactService
 from jacobian.canonical import canonicalize_json, format_canonical_integer
 from jacobian.capability_service import CapabilityInvocationError
@@ -69,12 +67,11 @@ from jacobian.contracts.polynomial_intervals import (
 )
 from jacobian.contracts.results import (
     Conclusion,
-    ContractModel,
-    Execution,
     ExecutionStatus,
     Verification,
 )
 from jacobian.domains._examples import example
+from jacobian.polynomials._support import _computed_result, _validate_request
 from jacobian.provider_runtime import SYMPY_VERSION, known_provider_runtime
 from jacobian.providers import LazyLoader
 from jacobian.registry import CheckerRegistry
@@ -317,6 +314,7 @@ class PolynomialIntervalEncloseAdapter:
             request.input,
             code="INVALID_POLYNOMIAL_INTERVAL_ENCLOSURE_REQUEST",
             operation="interval enclosure",
+            error_factory=_interval_error,
         )
         started = time.monotonic()
         polynomial = validated.polynomial
@@ -465,6 +463,7 @@ class PolynomialIntervalEnclosureVerifyAdapter:
             request.input,
             code="INVALID_POLYNOMIAL_INTERVAL_ENCLOSURE_VERIFY_REQUEST",
             operation="interval enclosure verification",
+            error_factory=_interval_error,
         )
         installation = self.resources.installation
         checker_id = installation.checker_id
@@ -666,23 +665,6 @@ class PolynomialIntervalEnclosureVerifyAdapter:
         )
 
 
-def _validate_request[RequestModel: ContractModel](
-    model: type[RequestModel],
-    payload: object,
-    *,
-    code: str,
-    operation: str,
-) -> RequestModel:
-    try:
-        return model.model_validate(payload)
-    except ValidationError as exc:
-        raise _interval_error(
-            code,
-            "request_validation",
-            f"The complete polynomial {operation} request is invalid.",
-        ) from exc
-
-
 def _bernstein_coefficients(
     polynomial: UnivariateRationalPolynomial,
     interval: RationalInterval,
@@ -731,45 +713,6 @@ def _rational(value: Fraction) -> CanonicalRational:
     return CanonicalRational(
         num=format_canonical_integer(value.numerator),
         den=format_canonical_integer(value.denominator),
-    )
-
-
-def _computed_result(
-    *,
-    descriptor: CapabilityDescriptor,
-    request: CapabilityRequest,
-    started: float,
-    output: dict[str, Any],
-    scope: CapabilityScope,
-    relationships: tuple[CapabilityRelationship, ...],
-    artifact_uris: tuple[str, ...],
-    completeness_basis: str,
-    assurance_basis: str,
-) -> CapabilityResult:
-    return CapabilityResult(
-        capability_id=descriptor.capability_id,
-        capability_version=descriptor.version,
-        mode=request.mode,
-        execution=Execution(
-            status=ExecutionStatus.COMPLETED,
-            runtime_ms=max(0, round((time.monotonic() - started) * 1000)),
-        ),
-        output=output,
-        scope=scope,
-        completeness=CapabilityCompleteness(
-            status=CapabilityCompletenessStatus.COMPLETE,
-            basis=(
-                f"{completeness_basis}; no mathematical conclusion or "
-                "independent verification is claimed"
-            ),
-            assurance_level=CapabilityAssuranceLevel.COMPUTED,
-        ),
-        relationships=relationships,
-        assurance=CapabilityAssurance(
-            level=CapabilityAssuranceLevel.COMPUTED,
-            basis=assurance_basis,
-        ),
-        artifact_uris=artifact_uris,
     )
 
 

--- a/src/jacobian/polynomial_positivity_capabilities.py
+++ b/src/jacobian/polynomial_positivity_capabilities.py
@@ -27,10 +27,8 @@ from dataclasses import dataclass
 from fractions import Fraction
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple, cast
 
-from pydantic import ValidationError
-
 from jacobian.artifacts import ArtifactService
-from jacobian.canonical import canonicalize_json, format_canonical_integer
+from jacobian.canonical import canonicalize_json
 from jacobian.capability_service import CapabilityInvocationError
 from jacobian.checker_installation import CheckerInstaller
 from jacobian.checker_operations import CheckerOperation
@@ -50,7 +48,6 @@ from jacobian.contracts.capabilities import (
 )
 from jacobian.contracts.checkers import EvidenceKind
 from jacobian.contracts.evidence import CertificateEnvelope, EvidenceBindings
-from jacobian.contracts.exact import CanonicalRational
 from jacobian.contracts.polynomial_intervals import (
     RationalInterval,
     UnivariateRationalPolynomial,
@@ -70,12 +67,15 @@ from jacobian.contracts.polynomials import (
 )
 from jacobian.contracts.results import (
     Conclusion,
-    ContractModel,
-    Execution,
     ExecutionStatus,
     Verification,
 )
 from jacobian.domains._examples import example
+from jacobian.polynomials._support import (
+    _computed_result,
+    _validate_request,
+    _wire_rational,
+)
 from jacobian.provider_runtime import SYMPY_VERSION, known_provider_runtime
 from jacobian.providers import LazyLoader
 from jacobian.registry import CheckerRegistry
@@ -321,6 +321,7 @@ class PolynomialIntervalPositivityDecideAdapter:
             request.input,
             code="INVALID_POLYNOMIAL_POSITIVITY_REQUEST",
             operation="positivity decision",
+            error_factory=_positivity_error,
         )
         started = time.monotonic()
         polynomial = validated.polynomial
@@ -480,6 +481,7 @@ class PolynomialIntervalPositivityVerifyAdapter:
             request.input,
             code="INVALID_POLYNOMIAL_POSITIVITY_VERIFY_REQUEST",
             operation="positivity verification",
+            error_factory=_positivity_error,
         )
         installation = self.resources.installation
         checker_id = installation.checker_id
@@ -704,23 +706,6 @@ class PolynomialIntervalPositivityVerifyAdapter:
         )
 
 
-def _validate_request[RequestModel: ContractModel](
-    model: type[RequestModel],
-    payload: object,
-    *,
-    code: str,
-    operation: str,
-) -> RequestModel:
-    try:
-        return model.model_validate(payload)
-    except ValidationError as exc:
-        raise _positivity_error(
-            code,
-            "request_validation",
-            f"The complete polynomial {operation} request is invalid.",
-        ) from exc
-
-
 def _sturm_positivity(
     polynomial: UnivariateRationalPolynomial,
     interval: RationalInterval,
@@ -807,59 +792,12 @@ def _wire_univariate_poly(poly: Poly) -> SparseRationalPolynomial:
     return SparseRationalPolynomial(
         terms=tuple(
             RationalPolynomialTerm(
-                coefficient=_rational(coefficient),
+                coefficient=_wire_rational(coefficient),
                 exponents=(exponent,),
             )
             for (exponent,), coefficient in poly.terms()
             if coefficient != 0
         )
-    )
-
-
-def _rational(value: Any) -> CanonicalRational:
-    rational = _sympy.get().Rational(value)
-    return CanonicalRational(
-        num=format_canonical_integer(int(rational.p)),
-        den=format_canonical_integer(int(rational.q)),
-    )
-
-
-def _computed_result(
-    *,
-    descriptor: CapabilityDescriptor,
-    request: CapabilityRequest,
-    started: float,
-    output: dict[str, Any],
-    scope: CapabilityScope,
-    relationships: tuple[CapabilityRelationship, ...],
-    artifact_uris: tuple[str, ...],
-    completeness_basis: str,
-    assurance_basis: str,
-) -> CapabilityResult:
-    return CapabilityResult(
-        capability_id=descriptor.capability_id,
-        capability_version=descriptor.version,
-        mode=request.mode,
-        execution=Execution(
-            status=ExecutionStatus.COMPLETED,
-            runtime_ms=max(0, round((time.monotonic() - started) * 1000)),
-        ),
-        output=output,
-        scope=scope,
-        completeness=CapabilityCompleteness(
-            status=CapabilityCompletenessStatus.COMPLETE,
-            basis=(
-                f"{completeness_basis}; no mathematical conclusion or "
-                "independent verification is claimed"
-            ),
-            assurance_level=CapabilityAssuranceLevel.COMPUTED,
-        ),
-        relationships=relationships,
-        assurance=CapabilityAssurance(
-            level=CapabilityAssuranceLevel.COMPUTED,
-            basis=assurance_basis,
-        ),
-        artifact_uris=artifact_uris,
     )
 
 

--- a/src/jacobian/polynomials/_support.py
+++ b/src/jacobian/polynomials/_support.py
@@ -469,8 +469,6 @@ def _map_inverse_residuals(
     )
 
 
-
-
 def _validate_request[RequestModel: ContractModel](
     model: type[RequestModel],
     payload: object,

--- a/src/jacobian/polynomials/_support.py
+++ b/src/jacobian/polynomials/_support.py
@@ -1,10 +1,10 @@
-"""Shared helpers for polynomial-map capability adapters."""
+"""Shared helpers for exact polynomial capability adapters."""
 
 from __future__ import annotations
 
 import multiprocessing
 import time
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from math import prod as multiply
 from queue import Empty
 from typing import TYPE_CHECKING, Any, cast
@@ -469,17 +469,20 @@ def _map_inverse_residuals(
     )
 
 
+
+
 def _validate_request[RequestModel: ContractModel](
     model: type[RequestModel],
     payload: object,
     *,
     code: str,
     operation: str,
+    error_factory: Callable[[str, str, str], CapabilityInvocationError] | None = None,
 ) -> RequestModel:
     try:
         return model.model_validate(payload)
     except ValidationError as exc:
-        raise _polynomial_error(
+        raise (error_factory or _polynomial_error)(
             code,
             "request_validation",
             f"The complete polynomial {operation} request is invalid.",


### PR DESCRIPTION
## Summary

Closes #695.

Consolidate the shared polynomial capability mechanics in `jacobian.polynomials._support`:

- request-model validation keeps each capability family's own diagnostic factory;\n- computed result construction has one owner; and\n- positivity reuses the existing SymPy-to-canonical-rational conversion.\n\nThe interval adapter retains its `Fraction` conversion because it is a different, domain-owned representation boundary. No compatibility aliases or duplicate helper bodies remain.\n\n## Validation\n\n- `uv run --locked ruff check src/jacobian/polynomials/_support.py src/jacobian/polynomial_positivity_capabilities.py src/jacobian/polynomial_interval_capabilities.py`\n- `uv run --locked mypy src/jacobian/polynomials/_support.py src/jacobian/polynomial_positivity_capabilities.py src/jacobian/polynomial_interval_capabilities.py`\n- `make test-component TESTS='tests/component/providers/polynomial/test_polynomial_positivity_capabilities.py'`\n- `make test-domain TESTS='tests/domain/polynomial/test_polynomial_interval_capabilities.py'`\n- `make test-plan BASE=origin/main` (suite fallback from transitive resource-installation ownership)\n\nAn independent exact-diff review found no correctness, API, import-layer, or fail-closed regression.