### PR TITLE
perf(checkers): use itertools for checker Cartesian assignments

### DIFF
--- a/src/jacobian_checkers/exact_domain_operations.py
+++ b/src/jacobian_checkers/exact_domain_operations.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import re
 from collections.abc import Callable
 from fractions import Fraction
+from itertools import product
 from typing import Any
 
 import flint
@@ -460,12 +461,7 @@ def _modular_residue_terms(
 
 
 def _cartesian_assignments(domains: list[list[int]]) -> list[list[int]]:
-    assignments: list[list[int]] = [[]]
-    for domain in domains:
-        assignments = [
-            [*prefix, residue] for prefix in assignments for residue in domain
-        ]
-    return assignments
+    return [list(assignment) for assignment in product(*domains)]
 
 
 def _evaluate_modular_polynomial_with_flint(


### PR DESCRIPTION
## Summary

Closes #699.

Replace the hand-rolled Cartesian-product loop in the independent exact-domain checker with `itertools.product`, preserving the checker's ordered `list[list[int]]` output.\n\nThe remainder of #699 intentionally stays unchanged: its linear-algebra and polynomial helpers either provide independent verification of SymPy results or have checker-specific resource limits, so sharing a backend or helper would weaken verifier isolation.\n\n## Validation\n\n- `uv run --locked ruff check src/jacobian_checkers/exact_domain_operations.py`\n- `uv run --locked mypy src/jacobian_checkers/exact_domain_operations.py`\n- `make test-component TESTS='tests/component/checkers/test_exact_polynomial_checkers.py tests/component/checkers/test_exact_domain_checker_attacks.py'`\n- `make test-component TESTS='tests/component/checkers/test_exact_matrix_checkers.py tests/component/checkers/test_exact_number_theory_checkers.py'`\n- `make test-plan BASE=origin/main`