### PR TITLE
refactor(plugins): declare plugin module exports

### DIFF
--- a/src/jacobian/plugins/__init__.py
+++ b/src/jacobian/plugins/__init__.py
@@ -1,1 +1,3 @@
 """Search-side reference plugins for the current Jacobian runtime."""
+
+__all__: tuple[str, ...] = ()

--- a/src/jacobian/plugins/erdos_straus.py
+++ b/src/jacobian/plugins/erdos_straus.py
@@ -13,6 +13,8 @@ from jacobian.contracts.plugin_number_theory import (
     ErdosStrausClaim,
 )
 
+__all__ = ("evaluate_capability", "find_witness_capability")
+
 
 def _decompose(n: int) -> tuple[int, int, int] | None:
     """Find ordered positive denominators using exact rational arithmetic."""

--- a/src/jacobian/plugins/graph_paths.py
+++ b/src/jacobian/plugins/graph_paths.py
@@ -27,6 +27,15 @@ from jacobian.contracts.plugin_graphs import (
     GraphPathReductionRequest,
 )
 
+__all__ = (
+    "canonicalize_capability",
+    "enumerate_candidates_capability",
+    "evaluate_capability",
+    "find_witness_capability",
+    "materialize",
+    "reductions_capability",
+)
+
 
 def _path_coverage(claim: GraphPathClaim, candidate: GraphPathCandidate) -> str:
     return (

--- a/src/jacobian/plugins/graph_shrinking.py
+++ b/src/jacobian/plugins/graph_shrinking.py
@@ -8,6 +8,8 @@ from pydantic import ValidationError
 
 from jacobian.contracts.plugin_graphs import GraphShrinkRequest
 
+__all__ = ("reduce_simple_graph",)
+
 
 def reduce_simple_graph(request: dict[str, Any]) -> dict[str, Any]:
     """Propose every requested single deletion in canonical order."""

--- a/src/jacobian/plugins/matrices.py
+++ b/src/jacobian/plugins/matrices.py
@@ -30,6 +30,15 @@ from jacobian.contracts.plugin_matrices import (
     MatrixTransformRequest,
 )
 
+__all__ = (
+    "enumerate_candidates_capability",
+    "evaluate_capability",
+    "find_witness_capability",
+    "materialize",
+    "reductions_capability",
+    "transform_row_major_capability",
+)
+
 MAX_SEARCHED_MATRICES = 65_536
 
 # ---------------------------------------------------------------------------

--- a/src/jacobian/plugins/registry.py
+++ b/src/jacobian/plugins/registry.py
@@ -25,6 +25,8 @@ from jacobian.schema_registry import SchemaRegistry, model_schema
 from jacobian.storage.errors import StorageError
 from jacobian.storage.repository import ArtifactRepository
 
+__all__ = ("PluginRegistry", "PluginRegistryError", "ResolvedCapability")
+
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/tests/unit/public_api/test_plugin_exports.py
+++ b/tests/unit/public_api/test_plugin_exports.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+PLUGIN_EXPORTS = {
+    "jacobian.plugins": (),
+    "jacobian.plugins.erdos_straus": (
+        "evaluate_capability",
+        "find_witness_capability",
+    ),
+    "jacobian.plugins.graph_paths": (
+        "canonicalize_capability",
+        "enumerate_candidates_capability",
+        "evaluate_capability",
+        "find_witness_capability",
+        "materialize",
+        "reductions_capability",
+    ),
+    "jacobian.plugins.graph_shrinking": ("reduce_simple_graph",),
+    "jacobian.plugins.matrices": (
+        "enumerate_candidates_capability",
+        "evaluate_capability",
+        "find_witness_capability",
+        "materialize",
+        "reductions_capability",
+        "transform_row_major_capability",
+    ),
+    "jacobian.plugins.registry": (
+        "PluginRegistry",
+        "PluginRegistryError",
+        "ResolvedCapability",
+    ),
+}
+
+
+@pytest.mark.parametrize("module_name", PLUGIN_EXPORTS)
+def test_plugin_modules_declare_their_supported_symbols(module_name: str) -> None:
+    module = importlib.import_module(module_name)
+    names = PLUGIN_EXPORTS[module_name]
+
+    assert tuple(module.__all__) == names
+    assert all(hasattr(module, name) for name in names)


### PR DESCRIPTION
## Summary

Closes #705.

Declare the supported symbols for the search-side plugin modules. Entry-point modules export only the functions registered by the reference installation; the registry exports its two public service types and resolution value.

The new API test makes the manifests explicit without exposing module-local helpers.

## Validation

- `uv run --locked ruff check src/jacobian/plugins tests/unit/public_api/test_plugin_exports.py`
- `uv run --locked mypy src/jacobian/plugins`
- `make test-unit TESTS='tests/unit/public_api/test_plugin_exports.py tests/unit/public_api/test_namespace.py'`\n- `make test-component TESTS='tests/component/plugins/test_erdos_straus_plugin.py tests/component/plugins/test_graph_paths_plugin.py tests/component/plugins/test_matrix_plugin.py tests/component/plugins/test_plugin_execution.py'`\n- `make test-plan BASE=origin/main` (suite fallback from plugin package ownership)