### PR TITLE
refactor(checkers): declare checker entrypoint exports

### DIFF
--- a/src/jacobian_checkers/erdos_straus.py
+++ b/src/jacobian_checkers/erdos_straus.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from typing import Any, TypeGuard
 
+__all__ = ["check_decomposition_table"]
+
+
 _MIN_N = 2
 _MAX_N = 10_000
 

--- a/src/jacobian_checkers/exact_domain_operations.py
+++ b/src/jacobian_checkers/exact_domain_operations.py
@@ -998,6 +998,7 @@ __all__ = [
     "check_matrix_product",
     "check_matrix_rref",
     "check_matrix_smith_normal_form",
+    "check_modular_polynomial_residue_image",
     "check_polynomial_discriminant",
     "check_polynomial_gcd",
     "check_polynomial_resultant",

--- a/src/jacobian_checkers/exact_geometry.py
+++ b/src/jacobian_checkers/exact_geometry.py
@@ -14,6 +14,9 @@ from typing import Any
 
 from jacobian_checkers.bound_artifacts import valid_unscoped_unencoded_bindings
 
+__all__ = ["check_exact_geometry"]
+
+
 _ARTIFACT_URI = re.compile(r"^artifact://sha256/[0-9a-f]{64}$")
 _DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
 _INTEGER = re.compile(r"^-?(?:0|[1-9][0-9]*)$")

--- a/src/jacobian_checkers/finite_coverage.py
+++ b/src/jacobian_checkers/finite_coverage.py
@@ -7,6 +7,9 @@ from typing import Any
 
 from jacobian.canonical import canonicalize_json
 
+__all__ = ["check_finite_coverage"]
+
+
 _SPECS: dict[str, dict[str, str]] = {
     "finite.integer.decimal@1": {
         "item_type": "INTEGER",

--- a/src/jacobian_checkers/finite_partition.py
+++ b/src/jacobian_checkers/finite_partition.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from typing import Any
 
+__all__ = ["check_partition"]
+
+
 
 def _reject(detail: str) -> dict[str, Any]:
     return {

--- a/src/jacobian_checkers/finite_partition.py
+++ b/src/jacobian_checkers/finite_partition.py
@@ -7,7 +7,6 @@ from typing import Any
 __all__ = ["check_partition"]
 
 
-
 def _reject(detail: str) -> dict[str, Any]:
     return {
         "accepted": False,

--- a/src/jacobian_checkers/graph_coloring.py
+++ b/src/jacobian_checkers/graph_coloring.py
@@ -7,6 +7,9 @@ import json
 import re
 from typing import Any
 
+__all__ = ["check_encoding"]
+
+
 _ARTIFACT_URI = re.compile(r"^artifact://sha256/[0-9a-f]{64}$")
 _DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
 _MAX_VERTICES = 32

--- a/src/jacobian_checkers/graph_degree_sequence.py
+++ b/src/jacobian_checkers/graph_degree_sequence.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from typing import Any
 
+__all__ = ["check_degree_sequence"]
+
+
 _MAX_ORDER = 512
 
 

--- a/src/jacobian_checkers/graph_invariants.py
+++ b/src/jacobian_checkers/graph_invariants.py
@@ -6,6 +6,9 @@ import re
 from fractions import Fraction
 from typing import Any
 
+__all__ = ["check_neighborhood_independence"]
+
+
 _INTEGER = re.compile(r"^-?(?:0|[1-9][0-9]*)$")
 _MAX_GRAPH_ORDER = 256
 _MAX_NEIGHBORHOOD_ORDER = 24

--- a/src/jacobian_checkers/graph_isomorphism.py
+++ b/src/jacobian_checkers/graph_isomorphism.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from typing import Any
 
+__all__ = ["check_isomorphism"]
+
+
 _MAX_ORDER = 256
 
 

--- a/src/jacobian_checkers/graph_paths.py
+++ b/src/jacobian_checkers/graph_paths.py
@@ -8,6 +8,15 @@ from __future__ import annotations
 from itertools import pairwise
 from typing import Any
 
+__all__ = [
+    "check_counterexample_preservation",
+    "check_odd_cycle",
+    "check_omitted_path",
+    "check_path_enumeration",
+    "check_two_coloring",
+]
+
+
 
 def _reject(detail: str) -> dict[str, Any]:
     return {

--- a/src/jacobian_checkers/graph_paths.py
+++ b/src/jacobian_checkers/graph_paths.py
@@ -17,7 +17,6 @@ __all__ = [
 ]
 
 
-
 def _reject(detail: str) -> dict[str, Any]:
     return {
         "accepted": False,

--- a/src/jacobian_checkers/graph_shrinking.py
+++ b/src/jacobian_checkers/graph_shrinking.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from collections import deque
 from typing import Any
 
+__all__ = ["check_non_bipartite_preservation"]
+
+
 
 def check_non_bipartite_preservation(request: dict[str, Any]) -> dict[str, Any]:
     """Check independently that the reduced graph remains non-bipartite."""

--- a/src/jacobian_checkers/graph_shrinking.py
+++ b/src/jacobian_checkers/graph_shrinking.py
@@ -8,7 +8,6 @@ from typing import Any
 __all__ = ["check_non_bipartite_preservation"]
 
 
-
 def check_non_bipartite_preservation(request: dict[str, Any]) -> dict[str, Any]:
     """Check independently that the reduced graph remains non-bipartite."""
 

--- a/src/jacobian_checkers/lean4.py
+++ b/src/jacobian_checkers/lean4.py
@@ -19,6 +19,9 @@ from jacobian.process_policy import (
 )
 from jacobian.worker_environment import worker_environment
 
+__all__ = ["check_kernel_certificate"]
+
+
 _DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
 
 LEAN_VERSION = "4.31.0"

--- a/src/jacobian_checkers/linear.py
+++ b/src/jacobian_checkers/linear.py
@@ -14,6 +14,12 @@ from typing import Any
 
 from jacobian_checkers.bound_artifacts import valid_unscoped_unencoded_bindings
 
+__all__ = [
+    "check_rational_inconsistency",
+    "check_rational_solution",
+]
+
+
 _ARTIFACT_URI = re.compile(r"^artifact://sha256/[0-9a-f]{64}$")
 _DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
 _INTEGER = re.compile(r"^-?(?:0|[1-9][0-9]*)$")

--- a/src/jacobian_checkers/matrices.py
+++ b/src/jacobian_checkers/matrices.py
@@ -7,6 +7,15 @@ import re
 from fractions import Fraction
 from typing import Any
 
+__all__ = [
+    "check_kernel_vector",
+    "check_maxdet_enumeration",
+    "check_maximizer_witness",
+    "check_row_major_transformation",
+    "check_singular_preservation",
+]
+
+
 _INTEGER = re.compile(r"^-?(?:0|[1-9][0-9]*)$")
 MAX_ENUMERATED_MATRICES = 65_536
 

--- a/src/jacobian_checkers/matrix_normal_forms.py
+++ b/src/jacobian_checkers/matrix_normal_forms.py
@@ -13,6 +13,9 @@ from typing import Any
 
 from jacobian_checkers.bound_artifacts import valid_unscoped_unencoded_bindings
 
+__all__ = ["check_hermite_normal_form"]
+
+
 _ARTIFACT_URI = re.compile(r"^artifact://sha256/[0-9a-f]{64}$")
 _DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
 _INTEGER = re.compile(r"^-?(?:0|[1-9][0-9]*)$")

--- a/src/jacobian_checkers/polynomial_expressions.py
+++ b/src/jacobian_checkers/polynomial_expressions.py
@@ -16,6 +16,9 @@ from typing import Any
 
 from jacobian_checkers.bound_artifacts import valid_unscoped_unencoded_bindings
 
+__all__ = ["check_polynomial_expression_normalization"]
+
+
 _ARTIFACT_URI = re.compile(r"^artifact://sha256/[0-9a-f]{64}$")
 _DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
 _INTEGER = re.compile(r"^-?(?:0|[1-9][0-9]*)$")

--- a/src/jacobian_checkers/polynomial_intervals.py
+++ b/src/jacobian_checkers/polynomial_intervals.py
@@ -20,6 +20,9 @@ from fractions import Fraction
 from math import comb
 from typing import Any
 
+__all__ = ["check_enclosure"]
+
+
 _INTEGER = re.compile(r"^-?(?:0|[1-9][0-9]*)$")
 _VARIABLE = re.compile(r"^[A-Za-z][A-Za-z0-9_]{0,31}$")
 _MAX_DEGREE = 64

--- a/src/jacobian_checkers/polynomial_maps.py
+++ b/src/jacobian_checkers/polynomial_maps.py
@@ -7,6 +7,16 @@ from fractions import Fraction
 from itertools import permutations
 from typing import Any
 
+__all__ = [
+    "check_collision",
+    "check_collision_refutes_inverse",
+    "check_identity",
+    "check_jacobian",
+    "check_keller_condition",
+    "check_map_inverse",
+]
+
+
 _INTEGER = re.compile(r"^-?(?:0|[1-9][0-9]*)$")
 _VARIABLE = re.compile(r"^[A-Za-z][A-Za-z0-9_]{0,31}$")
 _MAX_DIMENSION = 4

--- a/src/jacobian_checkers/polynomial_positivity.py
+++ b/src/jacobian_checkers/polynomial_positivity.py
@@ -19,6 +19,9 @@ import re
 from fractions import Fraction
 from typing import Any
 
+__all__ = ["check_positivity"]
+
+
 _INTEGER = re.compile(r"^-?(?:0|[1-9][0-9]*)$")
 _VARIABLE = re.compile(r"^[A-Za-z][A-Za-z0-9_]{0,31}$")
 _MAX_DEGREE = 64

--- a/src/jacobian_checkers/polynomial_systems.py
+++ b/src/jacobian_checkers/polynomial_systems.py
@@ -6,6 +6,9 @@ import re
 from fractions import Fraction
 from typing import Any
 
+__all__ = ["check_solution"]
+
+
 _INTEGER = re.compile(r"^-?(?:0|[1-9][0-9]*)$")
 _VARIABLE = re.compile(r"^[A-Za-z][A-Za-z0-9_]{0,31}$")
 _MAX_DIMENSION = 4

--- a/src/jacobian_checkers/polytope.py
+++ b/src/jacobian_checkers/polytope.py
@@ -6,6 +6,12 @@ import re
 from fractions import Fraction
 from typing import Any
 
+__all__ = [
+    "check_convex_combination",
+    "check_linear_separator",
+]
+
+
 _INTEGER = re.compile(r"^-?(?:0|[1-9][0-9]*)$")
 _MAX_GENERATORS = 100_000
 _MAX_DIMENSION = 256

--- a/src/jacobian_checkers/rational_determinants.py
+++ b/src/jacobian_checkers/rational_determinants.py
@@ -14,6 +14,12 @@ from typing import Any
 
 from jacobian_checkers.bound_artifacts import valid_unscoped_unencoded_bindings
 
+__all__ = [
+    "check_rational_determinant",
+    "check_rational_rank",
+]
+
+
 _ARTIFACT_URI = re.compile(r"^artifact://sha256/[0-9a-f]{64}$")
 _DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
 _INTEGER = re.compile(r"^-?(?:0|[1-9][0-9]*)$")

--- a/src/jacobian_checkers/rational_functions.py
+++ b/src/jacobian_checkers/rational_functions.py
@@ -8,6 +8,9 @@ from typing import Any
 
 from jacobian.canonical import format_canonical_integer, parse_canonical_integer
 
+__all__ = ["check_rational_function_identity"]
+
+
 _INTEGER = re.compile(r"^-?(?:0|[1-9][0-9]*)$")
 _VARIABLE = re.compile(r"^[A-Za-z][A-Za-z0-9_]{0,31}$")
 _MAX_DIMENSION = 4

--- a/src/jacobian_checkers/sat.py
+++ b/src/jacobian_checkers/sat.py
@@ -25,6 +25,12 @@ from jacobian.process_policy import (
 from jacobian.worker_environment import worker_environment
 from jacobian_checkers.bound_artifacts import valid_unscoped_unencoded_bindings
 
+__all__ = [
+    "check_assignment",
+    "check_unsat_proof",
+]
+
+
 _ARTIFACT_URI = re.compile(r"^artifact://sha256/[0-9a-f]{64}$")
 _DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
 _VARIABLE_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_.:-]{0,127}$")

--- a/src/jacobian_checkers/sat_lrat.py
+++ b/src/jacobian_checkers/sat_lrat.py
@@ -9,6 +9,9 @@ import re
 import time
 from typing import Any
 
+__all__ = ["check_lrat"]
+
+
 _URI = re.compile(r"^artifact://sha256/[0-9a-f]{64}$")
 _DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
 

--- a/src/jacobian_checkers/smt.py
+++ b/src/jacobian_checkers/smt.py
@@ -24,6 +24,9 @@ from jacobian.process_policy import (
 from jacobian.worker_environment import worker_environment
 from jacobian_checkers.bound_artifacts import valid_unscoped_unencoded_bindings
 
+__all__ = ["check_unsat_proof"]
+
+
 _ARTIFACT_URI = re.compile(r"^artifact://sha256/[0-9a-f]{64}$")
 _DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
 _ARTIFACT_KEYS = {

--- a/src/jacobian_checkers/universal_algebra.py
+++ b/src/jacobian_checkers/universal_algebra.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from itertools import product
 from typing import Any, cast
 
+__all__ = ["check_law_evaluation"]
+
+
 _MAX_ORDER = 8
 _MAX_LAWS = 16
 _MAX_VARIABLES = 4

--- a/tests/unit/contracts/test_checker_entrypoint_exports.py
+++ b/tests/unit/contracts/test_checker_entrypoint_exports.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import ast
+import importlib
+import re
+from pathlib import Path
+
+_ROOT = Path(__file__).parents[3]
+
+
+def _collect_string_entrypoints(text: str, by_module: dict[str, set[str]]) -> None:
+    """Collect jacobian_checkers.module:function patterns from source text."""
+
+    for m in re.finditer(r"jacobian_checkers\.(\w+):(\w+)", text):
+        by_module.setdefault(m.group(1), set()).add(m.group(2))
+    for m in re.finditer(r'jacobian_checkers\.(\w+):\s*"\s*\n\s*"(\w+)"', text):
+        by_module.setdefault(m.group(1), set()).add(m.group(2))
+
+
+def _build_var_map(tree: ast.Module) -> dict[str, str]:
+    """Map top-level variable names to their constant string values."""
+
+    var_map: dict[str, str] = {}
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and isinstance(
+                    node.value, ast.Constant
+                ):
+                    value = node.value.value
+                    if isinstance(value, str):
+                        var_map[target.id] = value
+    return var_map
+
+
+def _resolve_entrypoint_module(
+    kw: ast.keyword, var_map: dict[str, str]
+) -> str:
+    """Resolve an entrypoint_module keyword to its module string."""
+
+    if isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+        return kw.value.value
+    if isinstance(kw.value, ast.Name) and kw.value.id in var_map:
+        return var_map[kw.value.id]
+    return "jacobian_checkers.exact_domain_operations"
+
+
+def _collect_declaration_entrypoints(
+    text: str, by_module: dict[str, set[str]]
+) -> None:
+    """Collect ExactReplayCheckerDeclaration function + entrypoint_module pairs."""
+
+    if "ExactReplayCheckerDeclaration" not in text:
+        return
+    tree = ast.parse(text)
+    var_map = _build_var_map(tree)
+    for node in ast.walk(tree):
+        if not (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "ExactReplayCheckerDeclaration"
+        ):
+            continue
+        func: str | None = None
+        mod = "exact_domain_operations"
+        if (
+            len(node.args) >= 3
+            and isinstance(node.args[2], ast.Constant)
+            and isinstance(node.args[2].value, str)
+        ):
+            func = node.args[2].value
+        for kw in node.keywords:
+            if (
+                kw.arg == "function"
+                and isinstance(kw.value, ast.Constant)
+                and isinstance(kw.value.value, str)
+            ):
+                func = kw.value.value
+            elif kw.arg == "entrypoint_module":
+                mod = _resolve_entrypoint_module(kw, var_map)
+        if func is not None:
+            by_module.setdefault(mod.replace("jacobian_checkers.", ""), set()).add(
+                func
+            )
+
+
+def _collect_registered_entrypoints() -> dict[str, set[str]]:
+    """Return {checker_module_short_name: {function_name, ...}}."""
+
+    by_module: dict[str, set[str]] = {}
+    src = _ROOT / "src" / "jacobian"
+    for py in sorted(src.rglob("*.py")):
+        text = py.read_text(encoding="utf-8")
+        _collect_string_entrypoints(text, by_module)
+        _collect_declaration_entrypoints(text, by_module)
+    return by_module
+
+
+_REGISTERED = _collect_registered_entrypoints()
+
+
+def test_registered_checker_entrypoints_are_exported() -> None:
+    """Every checker function referenced as a registered entrypoint in
+    ``src/jacobian`` must appear in its module's ``__all__`` manifest."""
+
+    violations: list[str] = []
+    for mod_short, funcs in sorted(_REGISTERED.items()):
+        module = importlib.import_module(f"jacobian_checkers.{mod_short}")
+        exported = set(getattr(module, "__all__", ()))
+        for func in sorted(funcs):
+            if func not in exported:
+                violations.append(
+                    f"jacobian_checkers.{mod_short}:{func} is registered as an "
+                    f"entrypoint but missing from __all__"
+                )
+    assert not violations, "\n".join(violations)

--- a/tests/unit/contracts/test_checker_entrypoint_exports.py
+++ b/tests/unit/contracts/test_checker_entrypoint_exports.py
@@ -33,9 +33,7 @@ def _build_var_map(tree: ast.Module) -> dict[str, str]:
     return var_map
 
 
-def _resolve_entrypoint_module(
-    kw: ast.keyword, var_map: dict[str, str]
-) -> str:
+def _resolve_entrypoint_module(kw: ast.keyword, var_map: dict[str, str]) -> str:
     """Resolve an entrypoint_module keyword to its module string."""
 
     if isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
@@ -45,9 +43,7 @@ def _resolve_entrypoint_module(
     return "jacobian_checkers.exact_domain_operations"
 
 
-def _collect_declaration_entrypoints(
-    text: str, by_module: dict[str, set[str]]
-) -> None:
+def _collect_declaration_entrypoints(text: str, by_module: dict[str, set[str]]) -> None:
     """Collect ExactReplayCheckerDeclaration function + entrypoint_module pairs."""
 
     if "ExactReplayCheckerDeclaration" not in text:
@@ -79,9 +75,7 @@ def _collect_declaration_entrypoints(
             elif kw.arg == "entrypoint_module":
                 mod = _resolve_entrypoint_module(kw, var_map)
         if func is not None:
-            by_module.setdefault(mod.replace("jacobian_checkers.", ""), set()).add(
-                func
-            )
+            by_module.setdefault(mod.replace("jacobian_checkers.", ""), set()).add(func)
 
 
 def _collect_registered_entrypoints() -> dict[str, set[str]]:


### PR DESCRIPTION
## Summary

Checker implementation modules now explicitly declare the functions used as registered checker entrypoints. This also adds the previously omitted `check_modular_polynomial_residue_image` export.

The regression test compares registered checker entrypoint declarations with module manifests, without widening the checker API to internal helpers.

## Validation

- `uv run pytest tests/unit/contracts/test_checker_entrypoint_exports.py tests/unit/contracts/test_checker_dependency_boundary.py tests/unit/contracts/test_checker_registration.py -x -q`
- `uv run mypy src/jacobian_checkers/ tests/unit/contracts/test_checker_entrypoint_exports.py`
- `uv run ruff check src/jacobian_checkers/ tests/unit/contracts/test_checker_entrypoint_exports.py`
- `make test-unit` (738 passed)
- `make test-plan BASE=origin/main`

Closes #701.