### PR TITLE
fix(mcp): bound MCP cancellation drain

### DIFF
--- a/src/jacobian/adapters/mcp/tooling.py
+++ b/src/jacobian/adapters/mcp/tooling.py
@@ -26,6 +26,50 @@ from jacobian.reasoning_log import ReasoningProtocolError
 
 _LOGGER = logging.getLogger(__name__)
 
+_CANCEL_DRAIN_GRACE_SECONDS = 5.0
+
+
+async def _drain_cancelled_worker[BlockingResultT](
+    worker: asyncio.Task[BlockingResultT],
+) -> BlockingResultT | None:
+    """Wait for a cancelled worker up to the drain grace period.
+
+    Returns the worker result if it completes within the grace period,
+    otherwise ``None`` after logging that the worker did not drain.
+    """
+
+    drain_deadline = time.monotonic() + _CANCEL_DRAIN_GRACE_SECONDS
+    while not worker.done():
+        remaining = drain_deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        try:
+            return await asyncio.wait_for(asyncio.shield(worker), timeout=remaining)
+        except TimeoutError:
+            break
+        except asyncio.CancelledError:
+            continue
+        except BaseException:
+            _LOGGER.debug(
+                "blocking MCP worker failed while its cancelled request drained",
+                exc_info=True,
+            )
+            return None
+    if not worker.done():
+        _LOGGER.warning(
+            "blocking MCP worker did not drain within %.1fs grace period",
+            _CANCEL_DRAIN_GRACE_SECONDS,
+        )
+        return None
+    try:
+        return worker.result()
+    except BaseException:
+        _LOGGER.debug(
+            "blocking MCP worker failed while its cancelled request drained",
+            exc_info=True,
+        )
+        return None
+
 
 async def _run_blocking[BlockingResultT](
     function: Callable[..., BlockingResultT],
@@ -35,9 +79,12 @@ async def _run_blocking[BlockingResultT](
 ) -> BlockingResultT:
     """Run blocking MCP work without detaching it from request teardown.
 
-    On cancellation, waits for the worker to drain and stores the result
-    in the ``drained_result`` attribute so the caller can persist a
-    completed outcome instead of unconditionally recording cancellation.
+    On cancellation, waits for the worker to drain up to
+    ``_CANCEL_DRAIN_GRACE_SECONDS`` and stores the result in the
+    ``drained_result`` attribute so the caller can persist a completed
+    outcome instead of unconditionally recording cancellation.  If the
+    worker does not finish within the grace period, the caller is
+    unblocked without a drained result.
     """
 
     worker = asyncio.create_task(asyncio.to_thread(function, *args))
@@ -46,27 +93,7 @@ async def _run_blocking[BlockingResultT](
     except asyncio.CancelledError as exc:
         if on_cancel is not None:
             on_cancel()
-        drained: BlockingResultT | None = None
-        while not worker.done():
-            try:
-                drained = await asyncio.shield(worker)
-                break
-            except asyncio.CancelledError:
-                continue
-            except BaseException:
-                _LOGGER.debug(
-                    "blocking MCP worker failed while its cancelled request drained",
-                    exc_info=True,
-                )
-                break
-        if worker.done() and drained is None:
-            try:
-                drained = worker.result()
-            except BaseException:
-                _LOGGER.debug(
-                    "blocking MCP worker failed while its cancelled request drained",
-                    exc_info=True,
-                )
+        drained = await _drain_cancelled_worker(worker)
         exc.drained_result = drained  # type: ignore[attr-defined]
         raise
 

--- a/tests/boundary/mcp/test_mcp_operations.py
+++ b/tests/boundary/mcp/test_mcp_operations.py
@@ -8,6 +8,7 @@ import os
 import subprocess
 import sys
 import threading
+import time
 from importlib.metadata import version
 from pathlib import Path
 
@@ -271,6 +272,135 @@ def test_cancelled_mcp_blocking_work_drains_before_request_task_finishes() -> No
         with pytest.raises(asyncio.CancelledError):
             await task
         assert finished.is_set()
+
+    asyncio.run(scenario())
+
+
+def test_worker_draining_within_grace_is_awaited_and_persisted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A worker that completes within the grace period yields its drained result."""
+
+    monkeypatch.setattr(
+        "jacobian.adapters.mcp.tooling._CANCEL_DRAIN_GRACE_SECONDS", 1.0
+    )
+    release = threading.Event()
+    finished = threading.Event()
+
+    async def scenario() -> None:
+        loop = asyncio.get_running_loop()
+        started = asyncio.Event()
+        cancellation_signalled = asyncio.Event()
+
+        def blocking_operation() -> str:
+            loop.call_soon_threadsafe(started.set)
+            release.wait(timeout=2)
+            finished.set()
+            return "finished"
+
+        task = asyncio.create_task(
+            _run_blocking(
+                blocking_operation,
+                on_cancel=cancellation_signalled.set,
+            )
+        )
+        try:
+            await asyncio.wait_for(started.wait(), timeout=1)
+            task.cancel()
+            await asyncio.wait_for(cancellation_signalled.wait(), timeout=1)
+            release.set()
+            with pytest.raises(asyncio.CancelledError) as exc_info:
+                await task
+            assert finished.is_set()
+            assert exc_info.value.drained_result == "finished"
+        finally:
+            release.set()
+
+    asyncio.run(scenario())
+
+
+def test_worker_that_does_not_drain_lets_cancellation_propagate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A worker that never completes is abandoned after the grace period."""
+
+    monkeypatch.setattr(
+        "jacobian.adapters.mcp.tooling._CANCEL_DRAIN_GRACE_SECONDS", 0.1
+    )
+    release = threading.Event()
+
+    async def scenario() -> None:
+        loop = asyncio.get_running_loop()
+        started = asyncio.Event()
+        cancellation_signalled = asyncio.Event()
+
+        def blocking_operation() -> str:
+            loop.call_soon_threadsafe(started.set)
+            release.wait(timeout=5)
+            return "finished"
+
+        task = asyncio.create_task(
+            _run_blocking(
+                blocking_operation,
+                on_cancel=cancellation_signalled.set,
+            )
+        )
+        try:
+            await asyncio.wait_for(started.wait(), timeout=1)
+            task.cancel()
+            await asyncio.wait_for(cancellation_signalled.wait(), timeout=1)
+            cancel_time = time.monotonic()
+            with pytest.raises(asyncio.CancelledError) as exc_info:
+                await task
+            assert exc_info.value.drained_result is None
+            elapsed = time.monotonic() - cancel_time
+            assert elapsed < 0.5, elapsed
+        finally:
+            release.set()
+
+    asyncio.run(scenario())
+
+
+def test_repeated_cancellation_does_not_extend_drain_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repeated cancellation during the drain does not reset the deadline."""
+
+    monkeypatch.setattr(
+        "jacobian.adapters.mcp.tooling._CANCEL_DRAIN_GRACE_SECONDS", 0.2
+    )
+    release = threading.Event()
+
+    async def scenario() -> None:
+        loop = asyncio.get_running_loop()
+        started = asyncio.Event()
+        first_cancellation = asyncio.Event()
+        second_cancellation_dispatched = asyncio.Event()
+
+        def blocking_operation() -> str:
+            loop.call_soon_threadsafe(started.set)
+            release.wait(timeout=5)
+            return "finished"
+
+        task = asyncio.create_task(
+            _run_blocking(blocking_operation, on_cancel=first_cancellation.set)
+        )
+        try:
+            await asyncio.wait_for(started.wait(), timeout=1)
+            task.cancel()
+            await asyncio.wait_for(first_cancellation.wait(), timeout=1)
+            cancel_time = time.monotonic()
+            await asyncio.sleep(0.1)
+            task.cancel()
+            loop.call_soon(second_cancellation_dispatched.set)
+            await asyncio.wait_for(second_cancellation_dispatched.wait(), timeout=1)
+            with pytest.raises(asyncio.CancelledError) as exc_info:
+                await task
+            assert exc_info.value.drained_result is None
+            elapsed = time.monotonic() - cancel_time
+            assert elapsed < 0.28, elapsed
+        finally:
+            release.set()
 
     asyncio.run(scenario())
 


### PR DESCRIPTION
## Summary

Cancelling an MCP capability call no longer waits indefinitely for an uncooperative blocking worker. The bridge keeps waiting briefly for a completed result, then logs the survivor and propagates cancellation without publishing an unfinished result.

The worker is deliberately not killed: Python cannot safely terminate a running thread. It remains owned by the default executor and may complete normally, while the request handler is released after the bounded drain grace.

## Root cause

`_run_blocking` awaited a shielded `asyncio.to_thread` worker in an unbounded loop. Pure-Python capability implementations do not necessarily observe the cancellation event, so that await could never return. The new drain helper bounds each shielded await by the remaining monotonic grace window.

## Validation

- Five focused cancellation tests, including late completion, non-draining worker, and repeated cancellation deadline behavior
- `uv run --locked pytest tests/boundary/mcp/test_mcp_operations.py --timeout=30` (13 passed)
- `make test-mcp` (42 passed)
- Ruff format/check and mypy for the changed MCP bridge
- `make test-plan BASE=origin/main`

Fixes #662.