### PR TITLE
fix(benchmarks): discover conjecture host validations

### DIFF
--- a/benchmarks/tooling/validation_plan.py
+++ b/benchmarks/tooling/validation_plan.py
@@ -11,15 +11,8 @@ HOST_VALIDATION_ROOT = "benchmarks/validation"
 HOST_VALIDATION_FULL_SHARDS = 4
 # GitHub Actions matrix jobs are capped at 256; stay at or below that limit.
 HOST_VALIDATION_MAX_JOBS = 256
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
 HOST_VALIDATION_DATASET_FILES = {
-    "conjecture-probes-v1": (
-        "benchmarks/validation/conjecture_probes_v1/"
-        "test_vizing_bounded_cartesian_products.py",
-        "benchmarks/validation/conjecture_probes_v1/"
-        "test_yang_mills_gauge_invariance_certificate.py",
-        "benchmarks/validation/conjecture_probes_v1/"
-        "test_hadamard_order12_construction.py",
-    ),
     "symbolic-coordination-v1": (
         "benchmarks/validation/symbolic_coordination_v1/test_pilot_contract.py",
     ),
@@ -30,6 +23,18 @@ HOST_VALIDATION_DATASET_FILES = {
         "benchmarks/validation/test_provider_download_integrity.py",
     ),
 }
+
+
+def _discover_conjecture_host_tests() -> tuple[str, ...]:
+    """Discover dedicated conjecture-probes-v1 host test files in sorted order."""
+
+    root = _PROJECT_ROOT / "benchmarks" / "validation" / "conjecture_probes_v1"
+    return tuple(
+        str(path.relative_to(_PROJECT_ROOT).as_posix())
+        for path in sorted(root.glob("test_*.py"))
+    )
+
+
 CONTROL_PLANE_HOST_TESTS = {
     ".github/scripts/emit-plan-receipt": (),
     ".github/scripts/manage-test-timings": (),
@@ -157,11 +162,13 @@ def full_host_validation(
 def dataset_host_validation(
     dataset: str, *, timings: Mapping[str, float] | None = None
 ) -> tuple[HostValidation, ...]:
+    if dataset == "conjecture-probes-v1":
+        selectors = _discover_conjecture_host_tests()
+    else:
+        selectors = HOST_VALIDATION_DATASET_FILES.get(dataset, ())
     return tuple(
         _entry(name=f"{dataset}-{index}", selector=selector, timings=timings)
-        for index, selector in enumerate(
-            HOST_VALIDATION_DATASET_FILES.get(dataset, ()), start=1
-        )
+        for index, selector in enumerate(selectors, start=1)
     )
 
 

--- a/benchmarks/validation/test_host_validation.py
+++ b/benchmarks/validation/test_host_validation.py
@@ -239,3 +239,34 @@ def test_duration_collection_writes_separate_output(tmp_path: Path) -> None:
     assert timing_path.read_text(encoding="utf-8") == "{}\n"
     assert "test_example.py::test_it" in output.read_text(encoding="utf-8")
     assert not (tmp_path / ".pytest_cache/benchmark-host-timing").exists()
+
+
+def test_conjecture_dataset_host_validation_discovers_all_dedicated_tests() -> None:
+    """Dataset-wide conjecture-probes-v1 changes select every dedicated test file."""
+
+    from benchmarks.tooling.validation_plan import dataset_host_validation
+
+    entries = dataset_host_validation("conjecture-probes-v1")
+    selectors = [entry.selector for entry in entries]
+
+    project_root = Path(__file__).resolve().parents[2]
+    expected_dir = project_root / "benchmarks" / "validation" / "conjecture_probes_v1"
+    expected = sorted(
+        str(p.relative_to(project_root).as_posix())
+        for p in expected_dir.glob("test_*.py")
+    )
+
+    assert selectors == expected
+    assert len(selectors) > 3
+
+
+def test_non_conjecture_dataset_host_validation_uses_static_entries() -> None:
+    """Other datasets still use the hand-maintained static file list."""
+
+    from benchmarks.tooling.validation_plan import dataset_host_validation
+
+    entries = dataset_host_validation("symbolic-coordination-v1")
+    assert len(entries) == 1
+    assert entries[0].selector == (
+        "benchmarks/validation/symbolic_coordination_v1/test_pilot_contract.py"
+    )


### PR DESCRIPTION
## Problem

Dataset-wide changes to `conjecture-probes-v1` selected a hand-maintained three-test subset, while eleven task-owned host validations now exist. That under-covered dataset-wide changes and made each new task contend for the same planner list.

## Change

Discover the sorted task-owned `test_*.py` inventory from the repository for this dataset. Other datasets retain their explicit static selectors. This removes the stale registry entry rather than adding another synchronization path.

## Validation

- `uv run --locked pytest benchmarks/validation/test_host_validation.py -v --timeout=30`
- `uv run ruff format --check benchmarks/tooling/validation_plan.py benchmarks/validation/test_host_validation.py`
- `uv run ruff check benchmarks/tooling/validation_plan.py benchmarks/validation/test_host_validation.py`
- `uv run mypy benchmarks/tooling/validation_plan.py`
- `make test-plan BASE=origin/main`