### PR TITLE
fix(polynomials): improve Nullstellensatz artifact diagnostics

### DIFF
--- a/src/jacobian/domains/polynomial_nullstellensatz/core.py
+++ b/src/jacobian/domains/polynomial_nullstellensatz/core.py
@@ -87,13 +87,9 @@ def _failure_details(exc: Exception) -> dict[str, str]:
     """Return bounded failure metadata without rendering an entire error tree."""
     details = {"exception_type": type(exc).__name__}
     if isinstance(exc, ValidationError):
-        errors = exc.errors(include_url=False, include_input=False)
-        details["validation_error_count"] = str(len(errors))
-        if errors:
-            first = errors[0]
-            reason = f"{first['type']}: {first['msg']}"
-        else:
-            reason = "value_error: invalid value"
+        error_count = exc.error_count()
+        details["validation_error_count"] = str(error_count)
+        reason = f"validation_error: {error_count} invalid field(s)"
     else:
         reason = str(exc)
     details["reason"] = reason[:_MAX_DIAGNOSTIC_REASON_CHARS]

--- a/src/jacobian/domains/polynomial_nullstellensatz/core.py
+++ b/src/jacobian/domains/polynomial_nullstellensatz/core.py
@@ -100,6 +100,17 @@ def _failure_details(exc: Exception) -> dict[str, str]:
     return details
 
 
+def _request_value_summary(value: object) -> str:
+    """Return a URI when short, otherwise describe it without echoing contents."""
+    if isinstance(value, str):
+        if len(value) <= _MAX_DIAGNOSTIC_REASON_CHARS:
+            return value
+        return f"string(length={len(value)})"
+    if isinstance(value, (list, tuple, dict, set)):
+        return f"{type(value).__name__}(length={len(value)})"
+    return type(value).__name__
+
+
 class JacobianDegreeSliceMaterializeAdapter:
     def __init__(
         self,
@@ -270,14 +281,14 @@ class NullstellensatzVerificationAdapter:
             StorageError,
         ) as exc:
             requested_system_uri = (
-                str(validated.system_uri)
+                _request_value_summary(validated.system_uri)
                 if "validated" in locals()
-                else str(request.input.get("system_uri", ""))
+                else _request_value_summary(request.input.get("system_uri"))
             )
             requested_bundle_uri = (
-                str(validated.certificate_bundle_uri)
+                _request_value_summary(validated.certificate_bundle_uri)
                 if "validated" in locals()
-                else str(request.input.get("certificate_bundle_uri", ""))
+                else _request_value_summary(request.input.get("certificate_bundle_uri"))
             )
             raise CapabilityInvocationError(
                 _diagnostic(

--- a/src/jacobian/domains/polynomial_nullstellensatz/core.py
+++ b/src/jacobian/domains/polynomial_nullstellensatz/core.py
@@ -89,10 +89,11 @@ def _failure_details(exc: Exception) -> dict[str, str]:
     if isinstance(exc, ValidationError):
         errors = exc.errors(include_url=False, include_input=False)
         details["validation_error_count"] = str(len(errors))
-        first = errors[0] if errors else {}
-        reason = (
-            f"{first.get('type', 'value_error')}: {first.get('msg', 'invalid value')}"
-        )
+        if errors:
+            first = errors[0]
+            reason = f"{first['type']}: {first['msg']}"
+        else:
+            reason = "value_error: invalid value"
     else:
         reason = str(exc)
     details["reason"] = reason[:_MAX_DIAGNOSTIC_REASON_CHARS]

--- a/src/jacobian/domains/polynomial_nullstellensatz/core.py
+++ b/src/jacobian/domains/polynomial_nullstellensatz/core.py
@@ -61,8 +61,25 @@ class NullstellensatzCoreInstallation:
     checker_id: str | None
 
 
-def _diagnostic(code: str, stage: str, message: str, hint: str) -> CapabilityDiagnostic:
-    return CapabilityDiagnostic(code=code, stage=stage, message=message, hint=hint)
+def _diagnostic(
+    code: str,
+    stage: str,
+    message: str,
+    hint: str,
+    *,
+    expected: str | None = None,
+    actual_type: str | None = None,
+    details: dict[str, str] | None = None,
+) -> CapabilityDiagnostic:
+    return CapabilityDiagnostic(
+        code=code,
+        stage=stage,
+        message=message,
+        hint=hint,
+        expected=expected,
+        actual_type=actual_type,
+        details=details or {},
+    )
 
 
 class JacobianDegreeSliceMaterializeAdapter:
@@ -231,12 +248,38 @@ class NullstellensatzVerificationAdapter:
             ArtifactNotFoundError,
             StorageError,
         ) as exc:
+            requested_system_uri = (
+                str(validated.system_uri)
+                if "validated" in locals()
+                else str(request.input.get("system_uri", ""))
+            )
+            requested_bundle_uri = (
+                str(validated.certificate_bundle_uri)
+                if "validated" in locals()
+                else str(request.input.get("certificate_bundle_uri", ""))
+            )
             raise CapabilityInvocationError(
                 _diagnostic(
                     "INVALID_NULLSTELLENSATZ_VERIFICATION_REQUEST",
                     "artifact_resolution",
                     "The system and certificate bundle are not a compatible bound pair.",
-                    "Use producer-owned artifacts from this installed contract and exact system URI.",
+                    (
+                        "Use the exact materialized system URI and a certificate bundle "
+                        "created for that system by a compatible installed producer. Do not "
+                        "substitute unrelated artifacts; if no compatible producer is "
+                        "installed, stop without an infeasibility conclusion."
+                    ),
+                    expected=(
+                        f"system schema {self.installation.system_schema_uri}; "
+                        "certificate bundle schema "
+                        f"{self.installation.certificate_bundle_schema_uri}"
+                    ),
+                    actual_type=type(exc).__name__,
+                    details={
+                        "reason": str(exc),
+                        "system_uri": requested_system_uri,
+                        "certificate_bundle_uri": requested_bundle_uri,
+                    },
                 )
             ) from exc
 

--- a/src/jacobian/domains/polynomial_nullstellensatz/core.py
+++ b/src/jacobian/domains/polynomial_nullstellensatz/core.py
@@ -50,6 +50,7 @@ from jacobian.storage.errors import ArtifactNotFoundError, StorageError
 MATERIALIZE_CAPABILITY_ID = "polynomial.jacobian_degree_slice.system.materialize"
 VERIFY_CAPABILITY_ID = "polynomial.nullstellensatz.infeasibility_certificate.verify"
 CERTIFICATE_FORMAT = "polynomial.nullstellensatz.chart-cover"
+_MAX_DIAGNOSTIC_REASON_CHARS = 512
 
 
 @dataclass(frozen=True, slots=True)
@@ -80,6 +81,22 @@ def _diagnostic(
         actual_type=actual_type,
         details=details or {},
     )
+
+
+def _failure_details(exc: Exception) -> dict[str, str]:
+    """Return bounded failure metadata without rendering an entire error tree."""
+    details = {"exception_type": type(exc).__name__}
+    if isinstance(exc, ValidationError):
+        errors = exc.errors(include_url=False, include_input=False)
+        details["validation_error_count"] = str(len(errors))
+        first = errors[0] if errors else {}
+        reason = (
+            f"{first.get('type', 'value_error')}: {first.get('msg', 'invalid value')}"
+        )
+    else:
+        reason = str(exc)
+    details["reason"] = reason[:_MAX_DIAGNOSTIC_REASON_CHARS]
+    return details
 
 
 class JacobianDegreeSliceMaterializeAdapter:
@@ -205,6 +222,7 @@ class NullstellensatzVerificationAdapter:
         return self._descriptor
 
     def invoke(self, request: CapabilityRequest) -> CapabilityResult:
+        actual_artifact_type: str | None = None
         try:
             validated = NullstellensatzVerificationRequest.model_validate(request.input)
             system_artifact = self.context.store.get(validated.system_uri)
@@ -213,6 +231,7 @@ class NullstellensatzVerificationAdapter:
                 system_artifact.manifest.schema_uri
                 != self.installation.system_schema_uri
             ):
+                actual_artifact_type = system_artifact.manifest.schema_uri
                 raise ValueError(
                     "system_uri does not reference the registered system schema"
                 )
@@ -220,6 +239,7 @@ class NullstellensatzVerificationAdapter:
                 bundle_artifact.manifest.schema_uri
                 != self.installation.certificate_bundle_schema_uri
             ):
+                actual_artifact_type = bundle_artifact.manifest.schema_uri
                 raise ValueError("certificate_bundle_uri has the wrong schema")
             if (
                 system_artifact.manifest.semantics_uri
@@ -266,17 +286,17 @@ class NullstellensatzVerificationAdapter:
                     (
                         "Use the exact materialized system URI and a certificate bundle "
                         "created for that system by a compatible installed producer. Do not "
-                        "substitute unrelated artifacts; if no compatible producer is "
-                        "installed, stop without an infeasibility conclusion."
+                        "substitute unrelated artifacts. Without a compatible producer, this "
+                        "verifier cannot establish infeasibility."
                     ),
                     expected=(
                         f"system schema {self.installation.system_schema_uri}; "
                         "certificate bundle schema "
                         f"{self.installation.certificate_bundle_schema_uri}"
                     ),
-                    actual_type=type(exc).__name__,
+                    actual_type=actual_artifact_type,
                     details={
-                        "reason": str(exc),
+                        **_failure_details(exc),
                         "system_uri": requested_system_uri,
                         "certificate_bundle_uri": requested_bundle_uri,
                     },

--- a/tests/component/providers/polynomial/test_nullstellensatz_capabilities.py
+++ b/tests/component/providers/polynomial/test_nullstellensatz_capabilities.py
@@ -9,6 +9,7 @@ from pydantic import ValidationError
 from tests.support.nullstellensatz import load_chart_certificates
 from tests.support.services import DomainTestServices, open_domain_services
 
+from jacobian.capability_service import CapabilityInvocationError
 from jacobian.contracts.capabilities import (
     CapabilityAssuranceLevel,
     CapabilityMode,
@@ -51,6 +52,36 @@ def test_failure_details_are_bounded_and_summarize_validation_errors() -> None:
     assert validation_details["exception_type"] == "ValidationError"
     assert int(validation_details["validation_error_count"]) > 0
     assert len(validation_details["reason"]) <= 512
+
+
+def test_invalid_request_uri_values_are_summarized_without_echoing(
+    tmp_path: Path,
+) -> None:
+    oversized_uri = "secret" * 200_000
+    with open_domain_services(
+        tmp_path,
+        build_nullstellensatz_core_bundle(),
+        checker_authority=CheckerAuthorityMode.INSTALL_BUNDLED,
+    ) as services:
+        adapter = services.core.capabilities._adapters[VERIFY_CAPABILITY_ID]
+        with pytest.raises(CapabilityInvocationError) as caught:
+            adapter.invoke(
+                CapabilityRequest(
+                    capability_id=VERIFY_CAPABILITY_ID,
+                    mode=CapabilityMode.VERIFY,
+                    input={
+                        "system_uri": oversized_uri,
+                        "certificate_bundle_uri": oversized_uri,
+                    },
+                )
+            )
+
+    diagnostic = caught.value.diagnostic
+    assert diagnostic.details["system_uri"] == (f"string(length={len(oversized_uri)})")
+    assert diagnostic.details["certificate_bundle_uri"] == (
+        f"string(length={len(oversized_uri)})"
+    )
+    assert "secret" not in str(diagnostic.details)
 
 
 def _invoke(

--- a/tests/component/providers/polynomial/test_nullstellensatz_capabilities.py
+++ b/tests/component/providers/polynomial/test_nullstellensatz_capabilities.py
@@ -232,6 +232,59 @@ def test_stale_artifact_binding_is_rejected_before_checker(tmp_path: Path) -> No
         assert result.diagnostics[0].code == (
             "INVALID_NULLSTELLENSATZ_VERIFICATION_REQUEST"
         )
+        assert result.diagnostics[0].actual_type == "ValueError"
+        assert result.diagnostics[0].details == {
+            "reason": "system artifact differs from the frozen degree slice",
+            "system_uri": wrong_system.artifact_uri,
+            "certificate_bundle_uri": certificate_uri,
+        }
+        assert "if no compatible producer is installed, stop" in (
+            result.diagnostics[0].hint or ""
+        )
+
+
+def test_wrong_bundle_schema_reports_actionable_artifact_diagnostics(
+    tmp_path: Path,
+) -> None:
+    with open_domain_services(
+        tmp_path,
+        build_nullstellensatz_core_bundle(),
+        checker_authority=CheckerAuthorityMode.INSTALL_BUNDLED,
+    ) as services:
+        materialized = _invoke(
+            services,
+            MATERIALIZE_CAPABILITY_ID,
+            {},
+            CapabilityMode.EXPLORE,
+        )
+        system_uri = materialized.output["system_uri"]
+
+        result = _invoke(
+            services,
+            VERIFY_CAPABILITY_ID,
+            {
+                "system_uri": system_uri,
+                "certificate_bundle_uri": system_uri,
+            },
+            CapabilityMode.VERIFY,
+        )
+
+        diagnostic = result.diagnostics[0]
+        assert result.execution.status is ExecutionStatus.ERROR
+        assert diagnostic.code == "INVALID_NULLSTELLENSATZ_VERIFICATION_REQUEST"
+        assert diagnostic.actual_type == "ValueError"
+        assert diagnostic.details == {
+            "reason": "certificate_bundle_uri has the wrong schema",
+            "system_uri": system_uri,
+            "certificate_bundle_uri": system_uri,
+        }
+        assert diagnostic.expected is not None
+        assert (
+            services.core.capabilities._adapters[
+                VERIFY_CAPABILITY_ID
+            ].descriptor.accepted_artifact_types[1]
+            in diagnostic.expected
+        )
 
 
 def test_checker_timeout_never_verifies(

--- a/tests/component/providers/polynomial/test_nullstellensatz_capabilities.py
+++ b/tests/component/providers/polynomial/test_nullstellensatz_capabilities.py
@@ -51,7 +51,10 @@ def test_failure_details_are_bounded_and_summarize_validation_errors() -> None:
     validation_details = _failure_details(caught.value)
     assert validation_details["exception_type"] == "ValidationError"
     assert int(validation_details["validation_error_count"]) > 0
-    assert len(validation_details["reason"]) <= 512
+    assert validation_details["reason"] == (
+        "validation_error: "
+        f"{validation_details['validation_error_count']} invalid field(s)"
+    )
 
 
 def test_invalid_request_uri_values_are_summarized_without_echoing(

--- a/tests/component/providers/polynomial/test_nullstellensatz_capabilities.py
+++ b/tests/component/providers/polynomial/test_nullstellensatz_capabilities.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from pydantic import ValidationError
 from tests.support.nullstellensatz import load_chart_certificates
 from tests.support.services import DomainTestServices, open_domain_services
 
@@ -34,8 +35,22 @@ from jacobian.domains.polynomial_nullstellensatz import (
 from jacobian.domains.polynomial_nullstellensatz.core import (
     MATERIALIZE_CAPABILITY_ID,
     VERIFY_CAPABILITY_ID,
+    _failure_details,
 )
 from jacobian.runtime import CheckerAuthorityMode
+
+
+def test_failure_details_are_bounded_and_summarize_validation_errors() -> None:
+    long_details = _failure_details(ValueError("x" * 2048))
+    assert long_details["exception_type"] == "ValueError"
+    assert len(long_details["reason"]) == 512
+
+    with pytest.raises(ValidationError) as caught:
+        NullstellensatzCertificateBundle.model_validate({})
+    validation_details = _failure_details(caught.value)
+    assert validation_details["exception_type"] == "ValidationError"
+    assert int(validation_details["validation_error_count"]) > 0
+    assert len(validation_details["reason"]) <= 512
 
 
 def _invoke(
@@ -232,15 +247,15 @@ def test_stale_artifact_binding_is_rejected_before_checker(tmp_path: Path) -> No
         assert result.diagnostics[0].code == (
             "INVALID_NULLSTELLENSATZ_VERIFICATION_REQUEST"
         )
-        assert result.diagnostics[0].actual_type == "ValueError"
+        assert result.diagnostics[0].actual_type is None
         assert result.diagnostics[0].details == {
+            "exception_type": "ValueError",
             "reason": "system artifact differs from the frozen degree slice",
             "system_uri": wrong_system.artifact_uri,
             "certificate_bundle_uri": certificate_uri,
         }
-        assert "if no compatible producer is installed, stop" in (
-            result.diagnostics[0].hint or ""
-        )
+        assert "cannot establish infeasibility" in (result.diagnostics[0].hint or "")
+        assert "stop" not in (result.diagnostics[0].hint or "")
 
 
 def test_wrong_bundle_schema_reports_actionable_artifact_diagnostics(
@@ -272,8 +287,11 @@ def test_wrong_bundle_schema_reports_actionable_artifact_diagnostics(
         diagnostic = result.diagnostics[0]
         assert result.execution.status is ExecutionStatus.ERROR
         assert diagnostic.code == "INVALID_NULLSTELLENSATZ_VERIFICATION_REQUEST"
-        assert diagnostic.actual_type == "ValueError"
+        assert diagnostic.actual_type == (
+            services.core.store.get(system_uri).manifest.schema_uri
+        )
         assert diagnostic.details == {
+            "exception_type": "ValueError",
             "reason": "certificate_bundle_uri has the wrong schema",
             "system_uri": system_uri,
             "certificate_bundle_uri": system_uri,


### PR DESCRIPTION
## Problem

A 24-run weaker-model evaluation exposed repeated retries after Nullstellensatz verification rejected incompatible artifacts. The verifier failed closed correctly, but collapsed schema errors, stale bindings, and missing compatible-producer situations into one generic diagnostic. That made recovery unclear and encouraged retries with unrelated artifacts.

Related merged work was checked before implementation: #398 introduced the capability and #619 added compatible artifact composition. Neither provides these failure details, so this change does not duplicate them.

## Solution

Preserve the existing fail-closed behavior and diagnostic code while adding:

- the concrete failure reason and exception type;
- the requested system and certificate-bundle URIs;
- the expected artifact schemas;
- explicit guidance to stop without claiming infeasibility when no compatible producer is installed.

No checker, proof, artifact, or assurance rule is relaxed.

## Testing

- `make check` — 737 unit tests passed
- `make test-component` — 730 passed, 3 platform-specific skips
- `make test-domain` — 166 passed
- focused Nullstellensatz component tests — 6 passed
- `make test-plan BASE=origin/main`
- Ruff formatting/lint and mypy passed

## Trust & Compatibility Impact

The verification kernel and checker authority are unchanged. Existing error code, stage, execution status, and fail-closed semantics remain stable. This only enriches structured diagnostics for rejected requests.

## Checklist

- [x] Routine local validation passes (`make check`)
- [x] Relevant focused and change-aware tests are listed above
