### PR TITLE
fix(eval): preserve itemless Codex usage telemetry

### DIFF
--- a/src/jacobian/eval/telemetry.py
+++ b/src/jacobian/eval/telemetry.py
@@ -774,6 +774,10 @@ def parse_agent_transcript(path: Path) -> dict[str, Any]:
             continue
         if not isinstance(event, dict):
             continue
+        if event.get("type") == "turn.completed" and isinstance(
+            event.get("usage"), dict
+        ):
+            telemetry.usage = event["usage"]
         item = event.get("item")
         if not isinstance(item, dict):
             _record_mcp_resource_telemetry(telemetry.resource_telemetry, item)
@@ -784,8 +788,4 @@ def parse_agent_transcript(path: Path) -> dict[str, Any]:
         if _is_mcp_tool_call_event(event, item):
             _process_mcp_tool_call(telemetry, item)
         _record_mcp_resource_telemetry(telemetry.resource_telemetry, item)
-        if event.get("type") == "turn.completed" and isinstance(
-            event.get("usage"), dict
-        ):
-            telemetry.usage = event["usage"]
     return _transcript_payload(telemetry)

--- a/tests/unit/tooling/test_eval_telemetry.py
+++ b/tests/unit/tooling/test_eval_telemetry.py
@@ -31,6 +31,25 @@ def _tool_event(
     }
 
 
+def test_agent_telemetry_records_itemless_turn_usage(tmp_path: Path) -> None:
+    usage = {
+        "input_tokens": 13550,
+        "cached_input_tokens": 13056,
+        "cache_write_input_tokens": 0,
+        "output_tokens": 2522,
+        "reasoning_output_tokens": 1552,
+    }
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text(
+        json.dumps({"type": "turn.completed", "usage": usage}) + "\n",
+        encoding="utf-8",
+    )
+
+    telemetry = parse_agent_transcript(transcript)
+
+    assert telemetry["usage"] == usage
+
+
 def test_agent_telemetry_preserves_discovery_to_invocation_dataflow(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Problem

Fresh Codex visibility evaluations produced valid itemless `turn.completed` events containing token usage, but every generated report recorded `usage: null` and zero aggregate tokens.

The parser checked for usage only after requiring an `item` object, so the normal turn-completion event returned early. This was reproduced across all 12 paired runs (1,887,135 input tokens were present in transcripts but reported as zero).

Overlap check: the recent duration-reporting work records elapsed wall time in the runner. It does not parse token usage, so this fix is independent and does not duplicate that change.

## Solution

Record a valid `turn.completed.usage` payload before taking the item-specific path. MCP, shell, malformed-event, and resource telemetry handling remain unchanged.

Add a regression test using the exact current Codex itemless event shape and all current usage fields.

## Testing

- `make test-unit TESTS='tests/unit/tooling/test_eval_telemetry.py tests/unit/tooling/test_codex_visibility.py' PYTEST_ARGS='-n 0'` — 24 passed
- `make check` — 738 unit tests passed; Ruff, formatting, complexity, and mypy passed
- Replayed the parser against the 12 fresh transcripts: control 651,699 input tokens; tool-first 1,235,436 input tokens

## Trust & Compatibility Impact

No mathematical capability, verifier, checker, or assurance behavior changes. This restores evaluation accounting from an existing Codex event.

## Checklist

- [x] Routine local validation passes (`make check`)
- [x] Focused regression tests cover the observed production event
- [x] Existing duration work was checked for overlap
