### PR TITLE
refactor(math): remove stale arithmetic operation export

### DIFF
--- a/src/jacobian/domains/arithmetic/operations.py
+++ b/src/jacobian/domains/arithmetic/operations.py
@@ -58,7 +58,6 @@ __all__ = [
     "reciprocal",
     "sign",
     "sum_rationals",
-    "to_fraction",
 ]
 
 


### PR DESCRIPTION
## Summary

The canonical-integer conversion change removed the unused to_fraction helper but left it in the arithmetic operations explicit export list. This made the public-export contract inconsistent and broke lint plus the operation-export unit test.

This removes the stale export. No compatibility alias or replacement is introduced because the helper has no remaining callers.

## Validation

- Focused operation-export unit test passed.
- Full lint gate passed.