### PR TITLE
perf(mcp): compact unknown capability run responses

### DIFF
--- a/src/jacobian/adapters/mcp/tools.py
+++ b/src/jacobian/adapters/mcp/tools.py
@@ -148,8 +148,19 @@ def _find_text_projection(response: dict[str, Any]) -> dict[str, Any]:
 
 def _run_text_projection(result: CapabilityResult) -> dict[str, Any]:
     payload = result.model_dump(mode="json")
+    output = payload["output"]
+    if (
+        result.diagnostics
+        and result.diagnostics[0].code == "UNKNOWN_CAPABILITY"
+        and "available_capability_ids" in output
+    ):
+        output = {
+            key: value
+            for key, value in output.items()
+            if key != "available_capability_ids"
+        }
     return {
-        key: payload[key]
+        key: output if key == "output" else payload[key]
         for key in (
             "capability_id",
             "mode",

--- a/tests/boundary/mcp/test_mcp_adapter.py
+++ b/tests/boundary/mcp/test_mcp_adapter.py
@@ -543,6 +543,10 @@ def test_mcp_describes_and_invokes_capabilities(tmp_path: Path) -> None:
             assert unknown.is_error is False
             assert unknown_result["execution"]["status"] == "ERROR"
             assert unknown_result["output"]["error"]["code"] == "UNKNOWN_CAPABILITY"
+            assert "available_capability_ids" not in unknown_result["output"]
+            assert len(unknown.content[0].text.encode("utf-8")) < 2_048
+            assert isinstance(unknown.structured_content, dict)
+            assert unknown.structured_content["output"]["available_capability_ids"]
             assert unknown_result["assurance"]["level"] != "VERIFIED"
 
     asyncio.run(scenario())


### PR DESCRIPTION
## Problem

A saved tool-first evaluation guessed a nonexistent `math.run` capability. The resulting `UNKNOWN_CAPABILITY` text repeated every installed capability ID and consumed 12,664 model-visible bytes before giving the normal recovery hint.

The equivalent `math.find` failure already keeps the full catalog in typed `structured_content` while projecting a compact text error.

## Change

- omit `available_capability_ids` only from the agent-facing `math.run` text projection for `UNKNOWN_CAPABILITY`;
- preserve the complete typed result, diagnostics, assurance, and recovery hint;
- add an MCP boundary regression proving the compact text stays below 2 KiB while the structured result retains the installed IDs.

On the observed trajectory, the bound guarantees at least 10,616 fewer visible bytes (83.8%).

## Overlap and independence

This is independent of:

- #830, which changes Nullstellensatz artifact diagnostics;
- #832, which fixes evaluation token accounting;
- #786, which clarifies exact contract inspection;
- the selective-router experiment running separately.

No mathematical operation, ranking, checker, scope, or assurance behavior changes.

## Validation

After updating the branch to current `main` (including #834):

- focused MCP boundary regression: passed;
- full unit lane: 750 passed;
- full lint/format/complexity/dependency/dead-code lane: passed;
- component lane: 740 passed, 3 platform skips;
- MCP lane: 38 passed; the one loopback-bind test blocked by the sandbox passed when rerun with loopback permission;
- end-to-end lane: 8 passed, 1 expected Lean skip;
- build: source distribution and wheel passed;
- `git diff --check`: passed.
