### PR TITLE
Teach agents to validate calls before fan-out

### DIFF
--- a/.agents/skills/jacobian-math/SKILL.md
+++ b/.agents/skills/jacobian-math/SKILL.md
@@ -48,6 +48,8 @@ known. When discovery exposes recovery paths, follow those fields (for example,
 `remove_unknown_domain_filter`, `remove_filters`, or `reformulate_query`) before
 treating absence as final. After invalid input, correct the reported constraint
 and retry within the task resource bounds as further errors appear. If one
+payload shape will be repeated in parallel, run one canary call first; fan out
+only after it succeeds. If one
 provider is unavailable, continue with other installed routes that can produce
 the outcome. Treat timeouts as non-conclusions. Accept only a completed result
 whose scope covers the input, and carry forward the smallest decisive value,

--- a/npm/skills/jacobian-math/SKILL.md
+++ b/npm/skills/jacobian-math/SKILL.md
@@ -48,6 +48,8 @@ known. When discovery exposes recovery paths, follow those fields (for example,
 `remove_unknown_domain_filter`, `remove_filters`, or `reformulate_query`) before
 treating absence as final. After invalid input, correct the reported constraint
 and retry within the task resource bounds as further errors appear. If one
+payload shape will be repeated in parallel, run one canary call first; fan out
+only after it succeeds. If one
 provider is unavailable, continue with other installed routes that can produce
 the outcome. Treat timeouts as non-conclusions. Accept only a completed result
 whose scope covers the input, and carry forward the smallest decisive value,

--- a/tests/unit/tooling/test_codex_visibility.py
+++ b/tests/unit/tooling/test_codex_visibility.py
@@ -197,10 +197,11 @@ def test_codex_skill_routes_exact_outcomes_without_catalog_projection() -> None:
         "composing already-known supporting operations remains allowed",
         "follow those fields",
         "retry within the task resource bounds",
+        "run one canary call first; fan out only after it succeeds",
         "continue with other installed routes",
         "completeness, and open obligations",
     ):
-        assert guidance in skill
+        assert guidance in skill_flat
 
 
 def test_visibility_classification_records_adoption_without_grading_shell(


### PR DESCRIPTION
## Problem

In two independent bounded graph-search trajectories, the agent sent eight parallel `graph.search.atlas` calls with the same invalid `limit: 2000` payload. The contract allows at most 100, so one unvalidated payload mistake became eight identical errors.

## Solution

Teach the managed Jacobian math Skill to run one representative canary call before repeating a payload shape in parallel, and fan out only after that call succeeds. Keep the repository and packaged Skill byte-identical and within the existing 4 KiB budget.

## Evaluation evidence

- Eager routing trajectory: eight duplicated invalid Atlas calls.
- Selective routing trajectory: eight duplicated invalid Atlas calls.
- Focused forward test with this patch: one successful order-0 canary preceded the batch; all later Atlas calls used valid limits; zero `INVALID_REQUEST` diagnostics.

## Overlap

PR #786 documents exact contract inspection. It does not address parallel amplification of one unvalidated payload. No open PR or current Skill guidance contains an equivalent canary-before-fan-out rule.

## Testing

- `uv run pytest tests/unit/tooling/test_codex_visibility.py -q` — 14 passed
- skill-creator `quick_validate.py` — passed
- Ruff — passed
- managed Skill parity — passed
- `git diff --check` — passed

## Trust & Compatibility Impact

Instruction-only change. No mathematical capability, verifier, artifact format, public API, or assurance behavior changes.

## Checklist

- [x] Relevant focused tests pass
- [x] Packaged and repository Skills remain identical
- [x] Skill remains within the 4 KiB budget
