### PR TITLE
fix(discovery): fail closed graph runtime invariants

### DIFF
--- a/src/jacobian/graphs/atlas_search.py
+++ b/src/jacobian/graphs/atlas_search.py
@@ -274,7 +274,18 @@ def _compute_all_properties(graph: nx_type.Graph[Any]) -> dict[str, Any]:
             nx().complement(graph),
             weight=None,
         )
-        assert len(independent_set) == independence_number
+        if len(independent_set) != independence_number:
+            raise CapabilityInvocationError(
+                CapabilityDiagnostic(
+                    code="INCONSISTENT_INDEPENDENCE_RESULT",
+                    stage="backend_execution",
+                    message=(
+                        "The graph backend returned an independent-set witness whose "
+                        "size does not match its reported independence number."
+                    ),
+                    hint="Retry with a supported graph backend.",
+                )
+            )
     else:
         independence_number = 0
     return {

--- a/src/jacobian/graphs/composition.py
+++ b/src/jacobian/graphs/composition.py
@@ -570,6 +570,22 @@ def _backend_suffix(operation: str) -> str:
     raise ValueError(f"unsupported composition operation: {operation}")
 
 
+def _require_right_graph(
+    operation: str,
+    right: nx.Graph[Any] | None,
+) -> nx.Graph[Any]:
+    if right is None:
+        raise CapabilityInvocationError(
+            CapabilityDiagnostic(
+                code="MISSING_RIGHT_GRAPH",
+                stage="composition",
+                message=f"{operation} requires a right graph.",
+                hint="Provide right_graph_uri for this binary operation.",
+            )
+        )
+    return right
+
+
 def _apply_composition(
     operation: str,
     left: nx.Graph[Any],
@@ -577,15 +593,15 @@ def _apply_composition(
 ) -> nx.Graph[Any]:
     backend = networkx_loader.get()
     if operation == "DISJOINT_UNION":
-        assert right is not None
+        right = _require_right_graph(operation, right)
         return cast("nx.Graph[Any]", backend.disjoint_union(left, right))
     if operation == "JOIN":
-        assert right is not None
+        right = _require_right_graph(operation, right)
         return _join(left, right)
     if operation == "COMPLEMENT":
         return cast("nx.Graph[Any]", backend.complement(left))
     if operation == "LEXICOGRAPHIC_PRODUCT":
-        assert right is not None
+        right = _require_right_graph(operation, right)
         return cast("nx.Graph[Any]", backend.lexicographic_product(left, right))
     raise ValueError(f"unsupported composition operation: {operation}")
 

--- a/src/jacobian/graphs/invariants.py
+++ b/src/jacobian/graphs/invariants.py
@@ -283,7 +283,18 @@ def _independence_number_property(graph: nx_type.Graph[Any], name: str) -> Any:
         nx().complement(graph),
         weight=None,
     )
-    assert len(independent_set) == independence_number
+    if len(independent_set) != independence_number:
+        raise CapabilityInvocationError(
+            CapabilityDiagnostic(
+                code="INCONSISTENT_INDEPENDENCE_RESULT",
+                stage="backend_execution",
+                message=(
+                    "The graph backend returned an independent-set witness whose "
+                    "size does not match its reported independence number."
+                ),
+                hint="Retry with a supported graph backend.",
+            )
+        )
     return independence_number
 
 

--- a/tests/composition/runtime/test_graph_composition.py
+++ b/tests/composition/runtime/test_graph_composition.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
+from jacobian.capability_service import CapabilityInvocationError
 from jacobian.contracts.capabilities import (
     CapabilityAssuranceLevel,
     CapabilityCompletenessStatus,
@@ -11,6 +14,8 @@ from jacobian.contracts.capabilities import (
     CapabilityRequest,
 )
 from jacobian.contracts.results import ExecutionStatus
+from jacobian.graphs.artifacts import nx
+from jacobian.graphs.composition import _apply_composition
 from jacobian.runtime import create_runtime
 from jacobian.runtime.model import JacobianRuntime
 
@@ -198,6 +203,19 @@ def test_compose_rejects_missing_right_graph_for_binary_operation(
     assert result.execution.status is ExecutionStatus.ERROR
     assert result.diagnostics
     assert result.diagnostics[0].code == "INVALID_COMPOSITION_REQUEST"
+
+
+@pytest.mark.parametrize(
+    "operation",
+    ("DISJOINT_UNION", "JOIN", "LEXICOGRAPHIC_PRODUCT"),
+)
+def test_internal_binary_composition_rejects_missing_right_graph(
+    operation: str,
+) -> None:
+    with pytest.raises(CapabilityInvocationError) as caught:
+        _apply_composition(operation, nx().Graph(), None)
+
+    assert caught.value.diagnostic.code == "MISSING_RIGHT_GRAPH"
 
 
 def test_compose_rejects_right_graph_for_unary_complement(

--- a/tests/domain/graph/test_graph_invariant_domain.py
+++ b/tests/domain/graph/test_graph_invariant_domain.py
@@ -6,12 +6,15 @@ from pathlib import Path
 import pytest
 from tests.support.services import DomainTestServices, open_domain_services
 
+from jacobian.capability_service import CapabilityInvocationError
 from jacobian.contracts.capabilities import CapabilityRequest
 from jacobian.contracts.results import ExecutionStatus
 from jacobian.domains.graph_optimization import (
     build_graph_invariant_bundle,
     build_graph_optimization_bundle,
 )
+from jacobian.graphs import atlas_search, invariants
+from jacobian.graphs.artifacts import nx
 
 
 @pytest.fixture
@@ -202,6 +205,42 @@ _CYCLE_5 = {
     "vertices": ["a", "b", "c", "d", "e"],
     "edges": [["a", "b"], ["b", "c"], ["c", "d"], ["d", "e"], ["a", "e"]],
 }
+
+
+class _InconsistentCliqueBackend:
+    def __init__(self, backend: object) -> None:
+        self._backend = backend
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self._backend, name)
+
+    def max_weight_clique(
+        self, *_args: object, **_kwargs: object
+    ) -> tuple[set[object], int]:
+        return set(), 1
+
+
+@pytest.mark.parametrize(
+    "compute",
+    (
+        lambda graph: invariants._independence_number_property(
+            graph, "independence_number"
+        ),
+        atlas_search._compute_all_properties,
+    ),
+)
+def test_graph_backends_with_inconsistent_independence_results_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    compute,
+) -> None:
+    backend = _InconsistentCliqueBackend(nx())
+    monkeypatch.setattr(invariants, "nx", lambda: backend)
+    monkeypatch.setattr(atlas_search, "nx", lambda: backend)
+
+    with pytest.raises(CapabilityInvocationError) as caught:
+        compute(nx().path_graph(2))
+
+    assert caught.value.diagnostic.code == "INCONSISTENT_INDEPENDENCE_RESULT"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Graph invariant and composition execution paths used five assert statements for runtime conditions. Python optimization removes assertions, allowing inconsistent backend results or a missing binary input to reach backend code without a typed capability failure.

This replaces each assertion with an explicit CapabilityInvocationError and diagnostic. Composition uses one shared right-graph guard; independence checks reject a backend witness whose cardinality conflicts with its reported optimum.

## Validation

- Graph invariant domain regression module passed.
- Graph composition regression module passed.
- Focused Ruff check passed.
- Independent Devin exact-diff review found no remaining graph asserts or overlapping PR.