### PR TITLE
fix(discovery): require search archive parent capacity

### DIFF
--- a/src/jacobian/search/service.py
+++ b/src/jacobian/search/service.py
@@ -710,12 +710,17 @@ class SearchService:
 
         fixed_page_parents = 3  # claim, plugin, and one shared evaluation
         parents_per_candidate = 3 if include_witness_lineage else 1
+        minimum_parent_capacity = fixed_page_parents + parents_per_candidate
         lineage_batch_size = (
             self.store.limits.max_parents - fixed_page_parents
         ) // parents_per_candidate
         if lineage_batch_size < 1:
+            search_kind = (
+                "witness-enabled search" if include_witness_lineage else "search"
+            )
             raise SearchError(
-                "store parent limit cannot represent one search archive record"
+                "store parent limit must be at least "
+                f"{minimum_parent_capacity} for one {search_kind} archive record"
             )
         return SearchBudget(
             candidates_max=min(requested.candidates_max, self.max_candidates),

--- a/src/jacobian/storage/models.py
+++ b/src/jacobian/storage/models.py
@@ -18,8 +18,8 @@ class StorageLimits:
     max_total_blob_bytes: int = 1024 * 1024 * 1024
 
     def __post_init__(self) -> None:
-        if self.max_parents < 3:
-            raise ValueError("max_parents must be at least 3")
+        if self.max_parents < 4:
+            raise ValueError("max_parents must be at least 4")
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/boundary/storage/recovery/test_enumeration_experiments.py
+++ b/tests/boundary/storage/recovery/test_enumeration_experiments.py
@@ -251,7 +251,7 @@ def test_enumeration_pages_respect_evaluator_batch_limit(
 def test_enumeration_uses_available_parent_capacity_per_page(
     authorized_complete_runtime,
 ) -> None:
-    authorized_complete_runtime.core.store.limits = StorageLimits(max_parents=3)
+    authorized_complete_runtime.core.store.limits = StorageLimits(max_parents=4)
     claim_uri, plugin_id = _claim(
         authorized_complete_runtime,
         reference_name="matrices",
@@ -262,11 +262,11 @@ def test_enumeration_uses_available_parent_capacity_per_page(
         SearchEnumerateRequest(
             claim_uri=claim_uri,
             plugin_id=plugin_id,
-            bounds={"rows": 1, "cols": 1, "entries": [0, 1, 2, 3]},
+            bounds={"rows": 1, "cols": 1, "entries": [0, 1, 2, 3, 4, 5]},
             budget=EnumerationBudget(
-                candidates_max=4,
+                candidates_max=6,
                 wall_seconds=30,
-                page_size=2,
+                page_size=3,
             ),
         )
     )
@@ -279,7 +279,7 @@ def test_enumeration_uses_available_parent_capacity_per_page(
     assert snapshot.stop_reason is EnumerationStopReason.COMPLETE
     first_page_uri = snapshot.archive_page_uris[0]
     first_page = authorized_complete_runtime.core.store.get(first_page_uri)
-    assert len(first_page.payload["candidate_uris"]) == 2
+    assert len(first_page.payload["candidate_uris"]) == 3
     assert set(first_page.manifest.parents) == {
         first_page.payload["evaluation_uris"][0],
         *first_page.payload["candidate_uris"],
@@ -287,7 +287,7 @@ def test_enumeration_uses_available_parent_capacity_per_page(
     assert len(snapshot.archive_page_uris) == 3
     for index, page_uri in enumerate(snapshot.archive_page_uris[1:], start=1):
         page = authorized_complete_runtime.core.store.get(page_uri)
-        assert len(page.payload["candidate_uris"]) == 1
+        assert len(page.payload["candidate_uris"]) == 3 - index
         assert set(page.manifest.parents) == {
             page.payload["evaluation_uris"][0],
             *page.payload["candidate_uris"],

--- a/tests/boundary/storage/recovery/test_search_plugin_fail_closed.py
+++ b/tests/boundary/storage/recovery/test_search_plugin_fail_closed.py
@@ -15,6 +15,7 @@ from search_orchestration_support import _install_search_plugin, _request
 from jacobian.contracts.discovery import ExperimentState
 from jacobian.contracts.evidence import WitnessRole
 from jacobian.contracts.search import SearchCheckpoint, SearchStopReason
+from jacobian.search.errors import SearchError
 from jacobian.storage.errors import StorageError
 from jacobian.storage.models import StorageLimits
 
@@ -267,6 +268,32 @@ def test_search_batch_respects_archive_parent_limit(fresh_complete_runtime) -> N
     for page_uri in snapshot.archive_page_uris:
         assert (
             len(fresh_complete_runtime.core.store.get(page_uri).manifest.parents) <= 6
+        )
+
+
+@pytest.mark.parametrize("max_parents", [4, 5])
+def test_witness_search_requires_archive_parent_capacity(
+    fresh_complete_runtime,
+    max_parents: int,
+) -> None:
+    claim_uri, plugin_id = _install_search_plugin(
+        fresh_complete_runtime,
+        include_witness_oracle=True,
+    )
+    fresh_complete_runtime.core.store.limits = StorageLimits(max_parents=max_parents)
+
+    with pytest.raises(
+        SearchError,
+        match="must be at least 6 for one witness-enabled search archive record",
+    ):
+        fresh_complete_runtime.services.search.start(
+            _request(
+                claim_uri,
+                plugin_id,
+                idempotency_key=f"search-witness-parent-capacity-{max_parents}",
+                witness_role=WitnessRole.DEFEATS_CANDIDATE,
+                counterexample_checker_id="checker://sha256/" + "0" * 64,
+            )
         )
 
 

--- a/tests/boundary/storage/test_storage_limits_max_parents.py
+++ b/tests/boundary/storage/test_storage_limits_max_parents.py
@@ -1,9 +1,9 @@
 """Focused tests for the StorageLimits max_parents construction invariant.
 
-PR3 requires ``max_parents >= 3`` at construction so a misconfigured store
-cannot fragment the parent-archive chain below the search service's fixed-page
-assumption.  The check runs in ``__post_init__`` and refuses construction, not
-clamping or warning.
+The runtime's search archive pages without witness lineage have three fixed
+parents and require at least one candidate lineage parent. ``max_parents >=
+4`` is therefore enforced at construction, rather than allowing a
+configuration that every such search start would reject later.
 """
 
 from __future__ import annotations
@@ -18,11 +18,11 @@ def test_default_storage_limits_keeps_max_parents() -> None:
     assert limits.max_parents == 4096
 
 
-def test_storage_limits_accepts_three_parents() -> None:
-    assert StorageLimits(max_parents=3).max_parents == 3
+def test_storage_limits_accepts_minimum_search_capacity() -> None:
+    assert StorageLimits(max_parents=4).max_parents == 4
 
 
-@pytest.mark.parametrize("value", [0, 1, 2, -1])
-def test_storage_limits_rejects_below_three(value: int) -> None:
-    with pytest.raises(ValueError, match="max_parents must be at least 3"):
+@pytest.mark.parametrize("value", [0, 1, 2, 3, -1])
+def test_storage_limits_rejects_below_minimum_search_capacity(value: int) -> None:
+    with pytest.raises(ValueError, match="max_parents must be at least 4"):
         StorageLimits(max_parents=value)


### PR DESCRIPTION
## Motivation

StorageLimits accepted max_parents=3 even though a normal search archive page needs three fixed parents plus one candidate lineage parent. A normal search therefore failed only after request handling began. Witness-enabled search has a separate request-level minimum of six parents because each candidate also contributes witness and verification lineage.

## Changes

- Reject max_parents below 4 when StorageLimits is constructed.
- Keep witness capacity request-specific and reject 4 or 5 parents before experiment persistence with an actionable six-parent error.
- Update the enumeration capacity regression at the new global minimum.

## Validation

- focused StorageLimits and enumeration regression: 8 passed
- focused witness capacity regression: 2 passed
- ruff check and format check for changed files
- previous PR tree: make test-unit: 750 passed; make check-static; all 27 hosted checks green
- Devin exact-diff review: no findings

## Compatibility

This intentionally makes max_parents=3 an invalid runtime configuration. It was already unable to start a non-witness search and has no compatibility shim. Witness-enabled requests retain their explicit higher resource requirement rather than globally invalidating configurations that support ordinary search and enumeration.