### PR TITLE
fix(benchmarks): clarify missing publication TOML body

### DIFF
--- a/benchmarks/validation/test_benchmark_snapshots.py
+++ b/benchmarks/validation/test_benchmark_snapshots.py
@@ -591,8 +591,18 @@ def test_snapshot_id_and_publication_dir_are_content_addressed(
 
 def _strip_header(text: str) -> str:
     lines = text.splitlines()
-    body_start = next(i for i, line in enumerate(lines) if not line.startswith("#"))
+    body_start = next(
+        (index for index, line in enumerate(lines) if not line.startswith("#")),
+        None,
+    )
+    if body_start is None:
+        raise AssertionError("publication must contain a TOML body after its header")
     return "\n".join(lines[body_start:]) + "\n"
+
+
+def test_strip_header_requires_toml_body() -> None:
+    with pytest.raises(AssertionError, match="must contain a TOML body"):
+        _strip_header("# publication header\n# still a header\n")
 
 
 def test_generate_publication_writes_frozen_dataset_toml(


### PR DESCRIPTION
## Motivation

The snapshot publication test assumed rendered output always contains a non-comment TOML body. If that renderer invariant regressed, the helper raised an opaque StopIteration. This addresses the remaining snapshot-validator portion of #722; PR #812 separately handles the planner call.

## Changes

- Make the test helper state the missing-TOML-body invariant explicitly.
- Add the direct regression case for comment-only publication text.

## Validation

- make harbor-validation-tests TESTS=benchmarks/validation/test_benchmark_snapshots.py: 32 passed
- uv run --locked ruff check and format check for the changed file
- Devin exact-diff review: no findings