### PR TITLE
fix(discovery): fail closed contract nullability guards

### DIFF
--- a/src/jacobian/contracts/jacobian_syzygy.py
+++ b/src/jacobian/contracts/jacobian_syzygy.py
@@ -28,7 +28,8 @@ def _compute_homogeneous_source_degree(
         if len(degrees) != 1:
             raise ValueError("the source polynomial must be homogeneous")
         return next(iter(degrees))
-    assert linear_factors is not None
+    if linear_factors is None:
+        raise ValueError("labelled linear factors are required")
     return len(linear_factors)
 
 
@@ -66,25 +67,28 @@ class GradedJacobianSyzygyRequest(ContractModel):
 
     @model_validator(mode="after")
     def require_bounded_homogeneous_three_variable_input(self) -> Self:
-        if (self.polynomial is None) == (self.linear_factors is None):
-            raise ValueError(
-                "supply exactly one of polynomial or labelled linear_factors"
-            )
         if self.polynomial is not None:
+            if self.linear_factors is not None:
+                raise ValueError(
+                    "supply exactly one of polynomial or labelled linear_factors"
+                )
             if self.linear_factor_variables is not None:
                 raise ValueError(
                     "linear_factor_variables is only valid with linear_factors"
                 )
             polynomial = self.polynomial
             variables = polynomial.variables
-        else:
+        elif self.linear_factors is not None:
             if self.linear_factor_variables is None:
                 raise ValueError("linear_factors require an exact three-variable order")
-            assert self.linear_factors is not None
             labels = tuple(factor.label for factor in self.linear_factors)
             if len(labels) != len(set(labels)):
                 raise ValueError("labelled linear-factor names must be unique")
             variables = self.linear_factor_variables
+        else:
+            raise ValueError(
+                "supply exactly one of polynomial or labelled linear_factors"
+            )
         if len(variables) != 3:
             raise ValueError(
                 "graded Jacobian syzygies currently require exactly three variables"

--- a/src/jacobian/contracts/plugin_matrices.py
+++ b/src/jacobian/contracts/plugin_matrices.py
@@ -62,7 +62,8 @@ class MatrixCandidate(ContractModel):
         ):
             raise ValueError("determinant predicates require a square matrix")
         if claim.predicate == "maximize_absolute_determinant":
-            assert claim.scope is not None
+            if claim.scope is None:
+                raise ValueError("maximize_absolute_determinant requires a scope")
             if self.rows != claim.scope.rows or self.cols != claim.scope.cols:
                 raise ValueError("candidate dimensions do not match claim scope")
             allowed = {_matrix_integer(value) for value in claim.scope.entries}

--- a/src/jacobian/contracts/universal_algebra.py
+++ b/src/jacobian/contracts/universal_algebra.py
@@ -39,20 +39,24 @@ class MagmaTerm(ContractModel):
     def node_count(self) -> int:
         if self.kind == "VARIABLE":
             return 1
-        assert self.left is not None and self.right is not None
+        if self.left is None or self.right is None:
+            raise ValueError("product terms require exactly two child terms")
         return 1 + self.left.node_count() + self.right.node_count()
 
     def depth(self) -> int:
         if self.kind == "VARIABLE":
             return 1
-        assert self.left is not None and self.right is not None
+        if self.left is None or self.right is None:
+            raise ValueError("product terms require exactly two child terms")
         return 1 + max(self.left.depth(), self.right.depth())
 
     def variable_names(self) -> frozenset[str]:
         if self.kind == "VARIABLE":
-            assert self.variable is not None
+            if self.variable is None:
+                raise ValueError("variable terms require only a variable name")
             return frozenset((self.variable,))
-        assert self.left is not None and self.right is not None
+        if self.left is None or self.right is None:
+            raise ValueError("product terms require exactly two child terms")
         return self.left.variable_names() | self.right.variable_names()
 
 
@@ -331,15 +335,14 @@ class FiniteMagmaCountermodelArtifact(ContractModel):
     def require_status_evidence_shape(self) -> Self:
         evidence = (self.structure, self.source_records, self.target_record)
         if self.status is CountermodelSearchStatus.WITNESS_FOUND:
-            if any(value is None for value in evidence):
+            if (
+                self.structure is None
+                or self.source_records is None
+                or self.target_record is None
+            ):
                 raise ValueError(
                     "found countermodels require complete witness evidence"
                 )
-            assert (
-                self.structure is not None
-                and self.source_records is not None
-                and self.target_record is not None
-            )
             if self.structure.order != self.order:
                 raise ValueError(
                     "countermodel carrier order must match the search order"

--- a/src/jacobian/contracts/witness_search.py
+++ b/src/jacobian/contracts/witness_search.py
@@ -108,7 +108,6 @@ class WitnessFindResult(ContractModel):
         ):
             raise ValueError("NONE_CERTIFIED requires a verified certificate")
         if self.status == WitnessSearchStatus.NONE_CERTIFIED:
-            assert self.certificate_uri is not None
             if self.result.assurance.verification != Verification.VERIFIED:
                 raise ValueError("NONE_CERTIFIED requires verified assurance")
             if self.certificate_uri not in self.result.evidence_uris:

--- a/tests/unit/contracts/test_contract_nullability_guards.py
+++ b/tests/unit/contracts/test_contract_nullability_guards.py
@@ -1,0 +1,60 @@
+"""Regression coverage for malformed internal contract states."""
+
+from __future__ import annotations
+
+import pytest
+
+from jacobian.contracts.jacobian_syzygy import (
+    GradedJacobianSyzygyRequest,
+    _compute_homogeneous_source_degree,
+)
+from jacobian.contracts.plugin_matrices import MatrixCandidate, MatrixClaim
+from jacobian.contracts.universal_algebra import (
+    CountermodelSearchStatus,
+    FiniteMagmaCountermodelArtifact,
+    MagmaTerm,
+)
+
+
+def test_magma_term_methods_reject_missing_fields_in_constructed_states() -> None:
+    product = MagmaTerm.model_construct(kind="PRODUCT")
+    variable = MagmaTerm.model_construct(kind="VARIABLE")
+
+    with pytest.raises(ValueError, match="exactly two child terms"):
+        product.node_count()
+    with pytest.raises(ValueError, match="exactly two child terms"):
+        product.depth()
+    with pytest.raises(ValueError, match="exactly two child terms"):
+        product.variable_names()
+    with pytest.raises(ValueError, match="only a variable name"):
+        variable.variable_names()
+
+
+def test_contract_guards_reject_missing_required_nullability_state() -> None:
+    with pytest.raises(ValueError, match="labelled linear factors are required"):
+        _compute_homogeneous_source_degree(None, None)
+
+    syzygy_request = GradedJacobianSyzygyRequest.model_construct(
+        polynomial=None,
+        linear_factors=None,
+        linear_factor_variables=None,
+    )
+    with pytest.raises(ValueError, match="supply exactly one"):
+        syzygy_request.require_bounded_homogeneous_three_variable_input()
+
+    artifact = FiniteMagmaCountermodelArtifact.model_construct(
+        status=CountermodelSearchStatus.WITNESS_FOUND,
+        structure=None,
+        source_records=None,
+        target_record=None,
+    )
+    with pytest.raises(ValueError, match="complete witness evidence"):
+        artifact.require_status_evidence_shape()
+
+    candidate = MatrixCandidate.model_construct(rows=1, cols=1, entries=((1,),))
+    claim = MatrixClaim.model_construct(
+        predicate="maximize_absolute_determinant",
+        scope=None,
+    )
+    with pytest.raises(ValueError, match="requires a scope"):
+        candidate.validate_for_claim(claim)


### PR DESCRIPTION
## Summary

Fixes #702 by replacing contract assertions that disappear under optimized Python with explicit fail-closed validation. The affected malformed internal states now raise ValueError consistently.

The syzygy input validator now expresses its mutually exclusive sources structurally, and the witness-result assertion was removed because an immediately preceding ValueError check already establishes the invariant. No compatibility path or shim was added.

## Validation

- Focused contract regression suite: 13 passed
- Optimized Python probe for the syzygy nullability guard
- make check-static

## Review notes

An independent exact-diff review confirmed all nine targeted assertion sites are addressed, valid input behavior is preserved, and this PR does not overlap active changes to contracts/smt.py or contracts/validated_analysis.py.