### PR TITLE
fix(math): fail closed malformed magma evaluators

### DIFF
--- a/src/jacobian/universal_algebra_capabilities.py
+++ b/src/jacobian/universal_algebra_capabilities.py
@@ -845,9 +845,11 @@ def _z3_evaluate_term(
     z3: Any,
 ) -> Any:
     if term.kind == "VARIABLE":
-        assert term.variable is not None
+        if term.variable is None:
+            raise ValueError("variable terms require only a variable name")
         return assignment[term.variable]
-    assert term.left is not None and term.right is not None
+    if term.left is None or term.right is None:
+        raise ValueError("product terms require exactly two child terms")
     left = _z3_evaluate_term(term.left, cells, assignment, order, z3)
     right = _z3_evaluate_term(term.right, cells, assignment, order, z3)
     selected: Any = cells[-1][-1]
@@ -904,9 +906,11 @@ def _evaluate_term(
     assignment: dict[str, int],
 ) -> int:
     if term.kind == "VARIABLE":
-        assert term.variable is not None
+        if term.variable is None:
+            raise ValueError("variable terms require only a variable name")
         return assignment[term.variable]
-    assert term.left is not None and term.right is not None
+    if term.left is None or term.right is None:
+        raise ValueError("product terms require exactly two child terms")
     left = _evaluate_term(term.left, table, assignment)
     right = _evaluate_term(term.right, table, assignment)
     return table[left][right]

--- a/tests/composition/runtime/test_universal_algebra_capabilities.py
+++ b/tests/composition/runtime/test_universal_algebra_capabilities.py
@@ -12,7 +12,12 @@ from jacobian.contracts.capabilities import (
 )
 from jacobian.contracts.results import Conclusion
 from jacobian.contracts.universal_algebra import (
+    MagmaTerm,
     UniversalAlgebraCountermodelSearchRequest,
+)
+from jacobian.universal_algebra_capabilities import (
+    _evaluate_term,
+    _z3_evaluate_term,
 )
 
 
@@ -54,6 +59,20 @@ def _left_projection_problem() -> dict[str, object]:
             },
         ],
     }
+
+
+def test_magma_evaluators_reject_malformed_constructed_terms() -> None:
+    missing_variable = MagmaTerm.model_construct(kind="VARIABLE")
+    missing_children = MagmaTerm.model_construct(kind="PRODUCT")
+
+    with pytest.raises(ValueError, match="only a variable name"):
+        _evaluate_term(missing_variable, (), {})
+    with pytest.raises(ValueError, match="exactly two child terms"):
+        _evaluate_term(missing_children, (), {})
+    with pytest.raises(ValueError, match="only a variable name"):
+        _z3_evaluate_term(missing_variable, (), {}, 0, None)
+    with pytest.raises(ValueError, match="exactly two child terms"):
+        _z3_evaluate_term(missing_children, (), {}, 0, None)
 
 
 def test_countermodel_descriptor_publishes_a_model_valid_invocation_example(


### PR DESCRIPTION
Fixes the finite-magma evaluator portion of #691.

### Problem

Malformed term objects reached evaluator assertions. Under optimized Python, those assertions disappear and evaluation instead fails later with incidental implementation exceptions.

### Change

Both the concrete evaluator and its Z3 encoding now reject malformed term objects with explicit `ValueError` checks. Valid term behavior is unchanged.

### Validation

- Focused universal-algebra composition suite — passed
- Optimized-Python malformed-variable probe — passed
- `make check-static` — passed