### PR TITLE
fix(eval): recover experiment service after close timeout

### DIFF
--- a/src/jacobian/experiments/service.py
+++ b/src/jacobian/experiments/service.py
@@ -187,6 +187,8 @@ class ExperimentService:
                 timeout_seconds=timeout_seconds,
             )
         except LifecycleTimeoutError as exc:
+            with self._thread_lock:
+                self._closing = False
             raise ExperimentError(
                 "enumeration workers did not quiesce before runtime shutdown"
             ) from exc

--- a/tests/composition/runtime/test_runtime_lifecycle.py
+++ b/tests/composition/runtime/test_runtime_lifecycle.py
@@ -217,6 +217,8 @@ def test_enumeration_close_timeout_keeps_store_open_for_retry(
 
     with pytest.raises(ExperimentError, match="did not quiesce"):
         runtime.services.experiments.close(timeout_seconds=0)
+    with pytest.raises(ValidationError):
+        runtime.services.experiments.start_enumeration({})
     runtime.core.store.register_descriptor(
         kind="schema",
         name="store-open-after-enumeration-timeout",


### PR DESCRIPTION
Addresses the experiments-service half of #679.

### Problem

A timeout while quiescing enumeration workers left the experiments service marked as closing even though its close operation had failed. Later starts were rejected before request validation, requiring a process restart.

### Change

Clear the transient closing state while handling the quiescence timeout. A successful close still marks the service closed. The analogous search-service lifecycle path is not changed here and remains tracked by #679.

### Regression coverage

The runtime lifecycle test now verifies that, after a timeout, an enumeration start reaches ordinary request validation rather than failing as a closing service.

### Validation

- `make test-composition TESTS=tests/composition/runtime/test_runtime_lifecycle.py` — 17 passed
- `make test-unit` — 750 passed
- `make test-component`, `make test-domain`, `make test-storage`, `make test-process`, `make test-mcp`, `make test-e2e`, and `make check-static` — passed