### PR TITLE
fix(discovery): recover search service after close timeout

### DIFF
--- a/src/jacobian/search/service.py
+++ b/src/jacobian/search/service.py
@@ -174,6 +174,8 @@ class SearchService:
                 timeout_seconds=timeout_seconds,
             )
         except LifecycleTimeoutError as exc:
+            with self._thread_lock:
+                self._closing = False
             raise SearchError(
                 "search workers did not quiesce before runtime shutdown"
             ) from exc

--- a/tests/composition/runtime/test_runtime_lifecycle.py
+++ b/tests/composition/runtime/test_runtime_lifecycle.py
@@ -400,6 +400,8 @@ def test_search_close_timeout_keeps_store_open_for_retry(
 
     with pytest.raises(SearchError, match="did not quiesce"):
         runtime.services.search.close(timeout_seconds=0)
+    with pytest.raises(ValidationError):
+        runtime.services.search.start({})
 
     runtime.core.store.register_descriptor(
         kind="schema",


### PR DESCRIPTION
Addresses the search-service half of #679.

### Problem

A timeout while quiescing search workers left the service marked as closing even though the close operation had failed. Later `start()` calls were rejected before normal request validation, requiring a process restart.

### Change

Clear the transient closing state when worker quiescence times out. A successful close still marks the service closed.

### Regression coverage

The lifecycle test first forces a close timeout, then verifies that an invalid `start({})` request reaches Pydantic validation instead of failing as a closing service. This assertion fails on the base revision because the stale closing flag masks validation.

### Validation

- `make test-unit` — 750 passed
- `make test-component` — passed
- `make test-domain` — passed
- `make test-composition` — passed
- `make test-storage` — passed
- `make test-process` — 232 passed
- `make test-mcp` — passed
- `make test-e2e` — passed
- `make check-static` — passed