### PR TITLE
fix(ci): allow Zarankiewicz validation subprocess

### DIFF
--- a/tools/check_architecture.py
+++ b/tools/check_architecture.py
@@ -198,6 +198,10 @@ _SUBPROCESS_ALLOWED_EXACT: frozenset[PurePosixPath] = frozenset(
             "benchmarks/validation/conjecture_probes_v1/"
             "test_yang_mills_gauge_invariance_certificate.py"
         ),
+        PurePosixPath(
+            "benchmarks/validation/conjecture_probes_v1/"
+            "test_zarankiewicz_projective_plane_certificate.py"
+        ),
         # Repository-command integration tests deliberately invoke CLI entrypoints.
         PurePosixPath("benchmarks/validation/test_benchmark_plan_validation.py"),
         PurePosixPath("benchmarks/validation/test_benchmark_planner.py"),


### PR DESCRIPTION
## Summary

- add the merged Zarankiewicz host validation fixture to the architecture check's exact subprocess allowlist
- restore the shared architecture gate inherited by unrelated open benchmark PRs
- keep the exception path-specific; no wildcard, product-code exception, or benchmark mathematics change

## Root cause

PR #785 added `benchmarks/validation/conjecture_probes_v1/test_zarankiewicz_projective_plane_certificate.py`. The fixture deliberately runs its task-owned solution entrypoint through `subprocess.run`, matching the existing benchmark-validation fixtures already listed in `_SUBPROCESS_ALLOWED_EXACT`, but its exact path was omitted from that list when the benchmark merged.

Current `main` therefore reports a `subprocess-confined` architecture violation, and open PRs rebased on that state inherit the failure even when their own changes are unrelated.

## Scope and overlap

Searches of open PRs found no existing fix for the Zarankiewicz path. This PR intentionally does not add entries for Moser or totient fixtures because those tasks remain unmerged and belong to their own PR branches.

## Validation

- full `tools/check_architecture.py` gate passed
- `tests/unit/tooling/test_architecture_process_policies.py` passed
- `tests/unit/tooling/test_architecture_policy.py` passed
- Ruff lint and format checks passed for `tools/check_architecture.py`
- `git diff --check` passed
