### PR TITLE
fix(mcp): repair object-rooted math.find MCP output schema

### DIFF
--- a/src/jacobian/adapters/mcp/tools.py
+++ b/src/jacobian/adapters/mcp/tools.py
@@ -118,6 +118,11 @@ class CapabilityDiscoveryResponse(
 ):
     """Closed, discriminated structured output for math.find."""
 
+    # MCP tool output schemas describe structured content objects. Pydantic's
+    # RootModel preserves the discriminated union but omits the common object
+    # root from JSON Schema, which stricter MCP clients reject during tools/list.
+    model_config = ConfigDict(json_schema_extra={"type": "object"})
+
 
 CapabilityDiscoveryToolResult = Annotated[
     CallToolResult,

--- a/tests/boundary/mcp/test_mcp_sdk_2_conformance.py
+++ b/tests/boundary/mcp/test_mcp_sdk_2_conformance.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import pytest
 from mcp.server.extension import Extension, ResourceBinding, ToolBinding
+from mcp_types.methods import serialize_server_result
 
 import jacobian.adapters.mcp.server as server_module
 from jacobian.adapters.mcp.constants import ReasoningLogMode
@@ -58,6 +59,7 @@ def test_mcp_v2_static_validation_context_errors_and_structured_resources(
             invoke = next(tool for tool in listed.tools if tool.name == "math.run")
             assert invoke.output_schema == CapabilityResult.model_json_schema()
             find = next(tool for tool in listed.tools if tool.name == "math.find")
+            assert find.output_schema["type"] == "object"
             assert find.output_schema["discriminator"] == {
                 "mapping": {
                     "capability": "#/$defs/_CapabilityInspectionResult",
@@ -73,6 +75,12 @@ def test_mcp_v2_static_validation_context_errors_and_structured_resources(
             assert set(
                 find.output_schema["$defs"]["_CapabilityInspectionResult"]["required"]
             ) >= {"kind", "view", "capability"}
+            serialized_tools = serialize_server_result(
+                "tools/list",
+                "2026-07-28",
+                listed.model_dump(mode="json", by_alias=True, exclude_none=True),
+            )
+            assert serialized_tools["tools"][0]["outputSchema"]["type"] == "object"
 
             with pytest.raises(MCPError) as unknown:
                 await client.call_tool("math.find", {"unknown_key": "rejected"})


### PR DESCRIPTION
## Summary

- publish `math.find`'s discriminated structured result as an object-rooted MCP output schema
- preserve the existing `oneOf` and discriminator contract
- add a latest-protocol `tools/list` serialization regression test

## Why

A corrected recently-solved-conjecture treatment run reached Jacobian over HTTP but failed before tool use. The live MCP client rejected `tools/list` because `math.find.outputSchema` lacked the required top-level `type`. Pydantic's `RootModel` emitted the union definitions and discriminator without the shared object root.

The currently negotiated older protocol path can normalize this schema, which is why existing conformance coverage remained green. The regression test exercises the latest `2026-07-28` serializer boundary that exposed the incompatibility.

## Safety

This does not change tool behavior, routing, mathematical results, or isolation. It adds only the common object-root declaration already satisfied by every union member.

## Validation

- focused MCP SDK v2 conformance tests: 2 passed
- Ruff lint: passed
- Ruff format check: passed
- diff whitespace check: passed
