### PR TITLE
feat: verify polynomial-coefficient recurrences

### DIFF
--- a/docs/reference/capabilities/topology/recurrences-and-generating-series.md
+++ b/docs/reference/capabilities/topology/recurrences-and-generating-series.md
@@ -30,8 +30,9 @@ coefficient vectors for polynomials \(p_0(n),\ldots,p_d(n)\) and evaluates
 
 The initial vector is exactly \((a_0,\ldots,a_{d-1})\). Requests select a
 prefix or strictly increasing indices, while the result preserves the complete
-prefix through the greatest requested index and every exact recurrence
-residual from index \(d\) onward. The request is rejected before execution if
+prefix through the greatest requested index, the recurrence order \(d\), and
+every exact recurrence residual at the consecutive indices from \(d\) through
+that endpoint. The request is rejected before execution if
 the leading polynomial \(p_0(n)\) vanishes at a required recurrence step;
 singular relations are not divided by zero or interpreted as conclusions.
 

--- a/docs/reference/capabilities/topology/recurrences-and-generating-series.md
+++ b/docs/reference/capabilities/topology/recurrences-and-generating-series.md
@@ -7,16 +7,40 @@
 - Independent replay: standard-library `Fraction` clean-process checker
 - Producer assurance: at most `COMPUTED`
 
-The explicit `combinatorics` bundle includes two generic, bounded operations:
+The explicit `combinatorics` bundle includes three generic, bounded operations:
 
-- `combinatorics.recurrence.linear.evaluate`; and
+- `combinatorics.recurrence.linear.evaluate`;
+- `combinatorics.recurrence.p_recursive.evaluate`; and
 - `combinatorics.generating_function.coefficients.compute`.
 
 They complement rather than replace the named Fibonacci, consecutive-Fibonacci,
-and Lucas capabilities. `combinatorics.recurrence.linear.verify` and
+and Lucas capabilities. `combinatorics.recurrence.linear.verify`,
+`combinatorics.recurrence.p_recursive.verify`, and
 `combinatorics.generating_function.coefficients.verify` independently replay
-the corresponding producer result when bundled checker authorization is
-enabled.
+the corresponding producer result when bundled checker authorization is enabled.
+
+## Polynomial-coefficient recurrence evaluation
+
+`combinatorics.recurrence.p_recursive.evaluate` accepts canonical ascending
+coefficient vectors for polynomials \(p_0(n),\ldots,p_d(n)\) and evaluates
+
+\[
+\sum_{j=0}^{d} p_j(n)a_{n-j}=0.
+\]
+
+The initial vector is exactly \((a_0,\ldots,a_{d-1})\). Requests select a
+prefix or strictly increasing indices, while the result preserves the complete
+prefix through the greatest requested index and every exact recurrence
+residual from index \(d\) onward. The request is rejected before execution if
+the leading polynomial \(p_0(n)\) vanishes at a required recurrence step;
+singular relations are not divided by zero or interpreted as conclusions.
+
+`combinatorics.recurrence.p_recursive.verify` independently evaluates the
+polynomials and replays the recurrence with standard-library `Fraction`, then
+requires every bound residual to be exactly zero. This supports finite exact
+evaluation and candidate checking only. It does not prove the recurrence for
+all indices or establish that a supplied recurrence follows from an external
+generating function or theorem.
 
 ## Constant-coefficient recurrence evaluation
 
@@ -68,6 +92,8 @@ Version 2 of the combinatorics semantics uses these fail-closed limits:
 | Quantity | Limit |
 | --- | ---: |
 | Linear recurrence order | 16 |
+| Polynomial-coefficient recurrence order | 16 |
+| Coefficient polynomial degree | 16 |
 | Greatest recurrence index | 512 |
 | Sparse requested indices | 256 |
 | Numerator or denominator degree | 32 |

--- a/src/jacobian/contracts/combinatorics.py
+++ b/src/jacobian/contracts/combinatorics.py
@@ -895,7 +895,9 @@ class LinearRecurrenceEvaluationResult(ContractModel):
             raise ValueError("the greatest requested index must bind replay_scope_end")
         if any(item.value != self.replay_prefix[item.index] for item in self.values):
             raise ValueError("indexed values must match the recurrence replay prefix")
-        if self.scope == "PREFIX" and indices != tuple(range(len(indices))):
+        if self.scope == "PREFIX" and indices != tuple(
+            range(self.replay_scope_end + 1)
+        ):
             raise ValueError(
                 "PREFIX results must contain consecutive indices from zero"
             )

--- a/src/jacobian/contracts/combinatorics.py
+++ b/src/jacobian/contracts/combinatorics.py
@@ -32,6 +32,7 @@ _MAX_ENUMERATED_PARTITIONS = 10_000
 MAX_LINEAR_RECURRENCE_ORDER = 16
 MAX_LINEAR_RECURRENCE_INDEX = 512
 MAX_LINEAR_RECURRENCE_REQUESTED_INDICES = 256
+MAX_P_RECURSIVE_POLYNOMIAL_DEGREE = 16
 MAX_RATIONAL_GENERATING_FUNCTION_DEGREE = 32
 MAX_RATIONAL_SERIES_TRUNCATION_ORDER = 512
 MAX_COMBINATORICS_INPUT_RATIONAL_DIGITS = 64
@@ -183,6 +184,94 @@ def _validate_recurrence_result_budget(
             "exactness": "EXACT_RATIONAL",
             "replay_prefix": [_fraction_wire(value) for value in replay],
             "replay_scope_end": requested_indices[-1],
+            "scope": scope,
+            "values": [
+                {"index": index, "value": _fraction_wire(replay[index])}
+                for index in requested_indices
+            ],
+            "verification": "UNVERIFIED",
+        }
+    )
+
+
+def _validate_p_recursive_result_budget(
+    *,
+    coefficient_polynomials: tuple[tuple[CanonicalRational, ...], ...],
+    initial_values: tuple[CanonicalRational, ...],
+    coefficient_convention: str,
+    polynomial_convention: str,
+    scope: str,
+    requested_indices: tuple[int, ...],
+) -> None:
+    polynomials = tuple(
+        tuple(value.as_fraction() for value in polynomial)
+        for polynomial in coefficient_polynomials
+    )
+    order = len(polynomials) - 1
+
+    def polynomial_value(polynomial: tuple[Fraction, ...], index: int) -> Fraction:
+        return sum(
+            (
+                coefficient * index**power
+                for power, coefficient in enumerate(polynomial)
+            ),
+            start=Fraction(),
+        )
+
+    end = requested_indices[-1]
+    replay = [value.as_fraction() for value in initial_values[: end + 1]]
+    residuals: list[tuple[int, Fraction]] = []
+    while len(replay) <= end:
+        index = len(replay)
+        coefficients = tuple(
+            polynomial_value(polynomial, index) for polynomial in polynomials
+        )
+        if coefficients[0] == 0:
+            raise ValueError(
+                f"leading coefficient polynomial vanishes at index {index}"
+            )
+        replay.append(
+            -sum(
+                (
+                    coefficients[offset] * replay[index - offset]
+                    for offset in range(1, order + 1)
+                ),
+                start=Fraction(),
+            )
+            / coefficients[0]
+        )
+        residuals.append(
+            (
+                index,
+                sum(
+                    (
+                        coefficients[offset] * replay[index - offset]
+                        for offset in range(order + 1)
+                    ),
+                    start=Fraction(),
+                ),
+            )
+        )
+    for value in replay:
+        _require_bounded_fraction(
+            value,
+            max_digits=MAX_COMBINATORICS_RESULT_RATIONAL_DIGITS,
+            label="polynomial-coefficient recurrence result",
+        )
+    _validate_result_artifact_size(
+        {
+            "backend": "sympy",
+            "backend_version": "1.14.0",
+            "coefficient_convention": coefficient_convention,
+            "polynomial_convention": polynomial_convention,
+            "determinism": "DETERMINISTIC",
+            "exactness": "EXACT_RATIONAL",
+            "replay_prefix": [_fraction_wire(value) for value in replay],
+            "residuals": [
+                {"index": index, "value": _fraction_wire(value)}
+                for index, value in residuals
+            ],
+            "replay_scope_end": end,
             "scope": scope,
             "values": [
                 {"index": index, "value": _fraction_wire(replay[index])}
@@ -809,6 +898,122 @@ class LinearRecurrenceEvaluationResult(ContractModel):
             raise ValueError(
                 "PREFIX results must contain consecutive indices from zero"
             )
+        return self
+
+
+class PolynomialCoefficientRecurrenceEvaluationRequest(ContractModel):
+    """Evaluate a bounded exact polynomial-coefficient linear recurrence.
+
+    ``coefficient_polynomials[j]`` is the ascending coefficient vector of
+    ``p_j(n)`` in ``sum_{j=0}^d p_j(n) a[n-j] = 0``.  The initial vector is
+    exactly ``a[0], ..., a[d-1]``.
+    """
+
+    coefficient_polynomials: tuple[tuple[CanonicalRational, ...], ...] = Field(
+        min_length=2, max_length=MAX_LINEAR_RECURRENCE_ORDER + 1
+    )
+    initial_values: tuple[CanonicalRational, ...] = Field(
+        min_length=1, max_length=MAX_LINEAR_RECURRENCE_ORDER
+    )
+    coefficient_convention: Literal[
+        "SUM_P_J_OF_N_TIMES_A_N_MINUS_J_EQUALS_ZERO_FOR_J_FROM_0"
+    ]
+    polynomial_convention: Literal["ASCENDING_POWERS_OF_N"]
+    scope: Literal["PREFIX", "INDICES"]
+    term_count: StrictInt | None = Field(
+        default=None, ge=1, le=MAX_LINEAR_RECURRENCE_INDEX + 1
+    )
+    indices: tuple[StrictInt, ...] = Field(
+        default=(), max_length=MAX_LINEAR_RECURRENCE_REQUESTED_INDICES
+    )
+
+    @model_validator(mode="after")
+    def require_bounded_regular_scope(self) -> Self:
+        order = len(self.coefficient_polynomials) - 1
+        if len(self.initial_values) != order:
+            raise ValueError("initial_values length must equal the recurrence order")
+        for polynomial in self.coefficient_polynomials:
+            if (
+                not polynomial
+                or len(polynomial) > MAX_P_RECURSIVE_POLYNOMIAL_DEGREE + 1
+            ):
+                raise ValueError("coefficient polynomial degree is outside the bound")
+            _require_canonical_polynomial(
+                polynomial, label="recurrence polynomial coefficient"
+            )
+        for value in self.initial_values:
+            require_bounded_rational(
+                value,
+                max_digits=MAX_COMBINATORICS_INPUT_RATIONAL_DIGITS,
+                label="recurrence initial value",
+            )
+        if self.scope == "PREFIX":
+            if self.term_count is None or self.indices:
+                raise ValueError("PREFIX scope requires term_count and forbids indices")
+            requested = tuple(range(self.term_count))
+        else:
+            if self.term_count is not None or not self.indices:
+                raise ValueError(
+                    "INDICES scope requires indices and forbids term_count"
+                )
+            if any(
+                index < 0 or index > MAX_LINEAR_RECURRENCE_INDEX
+                for index in self.indices
+            ):
+                raise ValueError("indices are outside the recurrence bound")
+            if any(left >= right for left, right in pairwise(self.indices)):
+                raise ValueError("indices must be strictly increasing")
+            requested = self.indices
+        _validate_p_recursive_result_budget(
+            coefficient_polynomials=self.coefficient_polynomials,
+            initial_values=self.initial_values,
+            coefficient_convention=self.coefficient_convention,
+            polynomial_convention=self.polynomial_convention,
+            scope=self.scope,
+            requested_indices=requested,
+        )
+        return self
+
+
+class PolynomialCoefficientRecurrenceEvaluationResult(ContractModel):
+    coefficient_convention: Literal[
+        "SUM_P_J_OF_N_TIMES_A_N_MINUS_J_EQUALS_ZERO_FOR_J_FROM_0"
+    ]
+    polynomial_convention: Literal["ASCENDING_POWERS_OF_N"]
+    scope: Literal["PREFIX", "INDICES"]
+    values: tuple[IndexedRationalValue, ...] = Field(
+        min_length=1, max_length=MAX_LINEAR_RECURRENCE_INDEX + 1
+    )
+    replay_prefix: tuple[CanonicalRational, ...] = Field(
+        min_length=1, max_length=MAX_LINEAR_RECURRENCE_INDEX + 1
+    )
+    residuals: tuple[IndexedRationalValue, ...] = Field(
+        max_length=MAX_LINEAR_RECURRENCE_INDEX + 1
+    )
+    replay_scope_end: StrictInt = Field(ge=0, le=MAX_LINEAR_RECURRENCE_INDEX)
+    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
+    determinism: Literal["DETERMINISTIC"] = "DETERMINISTIC"
+    backend: Literal["sympy"] = "sympy"
+    backend_version: Literal["1.14.0"] = "1.14.0"
+    verification: Literal["UNVERIFIED"] = "UNVERIFIED"
+
+    @model_validator(mode="after")
+    def require_complete_replay(self) -> Self:
+        if len(self.replay_prefix) != self.replay_scope_end + 1:
+            raise ValueError("replay_prefix must cover the complete bounded scope")
+        indices = tuple(item.index for item in self.values)
+        if indices[-1] != self.replay_scope_end:
+            raise ValueError("the greatest requested index must bind replay_scope_end")
+        if any(item.value != self.replay_prefix[item.index] for item in self.values):
+            raise ValueError("indexed values must match the recurrence replay prefix")
+        for value in self.replay_prefix:
+            require_bounded_rational(
+                value,
+                max_digits=MAX_COMBINATORICS_RESULT_RATIONAL_DIGITS,
+                label="polynomial-coefficient recurrence replay value",
+            )
+        if any(item.value.as_fraction() != 0 for item in self.residuals):
+            raise ValueError("every recurrence residual must be exactly zero")
         return self
 
 

--- a/src/jacobian/contracts/combinatorics.py
+++ b/src/jacobian/contracts/combinatorics.py
@@ -266,6 +266,7 @@ def _validate_p_recursive_result_budget(
             "polynomial_convention": polynomial_convention,
             "determinism": "DETERMINISTIC",
             "exactness": "EXACT_RATIONAL",
+            "recurrence_order": order,
             "replay_prefix": [_fraction_wire(value) for value in replay],
             "residuals": [
                 {"index": index, "value": _fraction_wire(value)}
@@ -981,6 +982,7 @@ class PolynomialCoefficientRecurrenceEvaluationResult(ContractModel):
     ]
     polynomial_convention: Literal["ASCENDING_POWERS_OF_N"]
     scope: Literal["PREFIX", "INDICES"]
+    recurrence_order: StrictInt = Field(ge=1, le=MAX_LINEAR_RECURRENCE_ORDER)
     values: tuple[IndexedRationalValue, ...] = Field(
         min_length=1, max_length=MAX_LINEAR_RECURRENCE_INDEX + 1
     )
@@ -1002,15 +1004,28 @@ class PolynomialCoefficientRecurrenceEvaluationResult(ContractModel):
         if len(self.replay_prefix) != self.replay_scope_end + 1:
             raise ValueError("replay_prefix must cover the complete bounded scope")
         indices = tuple(item.index for item in self.values)
+        if any(left >= right for left, right in pairwise(indices)):
+            raise ValueError("result indices must be strictly increasing")
         if indices[-1] != self.replay_scope_end:
             raise ValueError("the greatest requested index must bind replay_scope_end")
         if any(item.value != self.replay_prefix[item.index] for item in self.values):
             raise ValueError("indexed values must match the recurrence replay prefix")
+        if self.scope == "PREFIX" and indices != tuple(range(len(indices))):
+            raise ValueError(
+                "PREFIX results must contain consecutive indices from zero"
+            )
         for value in self.replay_prefix:
             require_bounded_rational(
                 value,
                 max_digits=MAX_COMBINATORICS_RESULT_RATIONAL_DIGITS,
                 label="polynomial-coefficient recurrence replay value",
+            )
+        residual_indices = tuple(item.index for item in self.residuals)
+        if residual_indices != tuple(
+            range(self.recurrence_order, self.replay_scope_end + 1)
+        ):
+            raise ValueError(
+                "residuals must cover every recurrence step through replay_scope_end"
             )
         if any(item.value.as_fraction() != 0 for item in self.residuals):
             raise ValueError("every recurrence residual must be exactly zero")

--- a/src/jacobian/contracts/combinatorics.py
+++ b/src/jacobian/contracts/combinatorics.py
@@ -220,6 +220,11 @@ def _validate_p_recursive_result_budget(
 
     end = requested_indices[-1]
     replay = [value.as_fraction() for value in initial_values[: end + 1]]
+    requested_index_set = set(requested_indices)
+    minimum_size = 1_024 + sum(
+        _minimum_fraction_wire_bytes(value) * (1 + (index in requested_index_set))
+        for index, value in enumerate(replay)
+    )
     residuals: list[tuple[int, Fraction]] = []
     while len(replay) <= end:
         index = len(replay)
@@ -230,7 +235,7 @@ def _validate_p_recursive_result_budget(
             raise ValueError(
                 f"leading coefficient polynomial vanishes at index {index}"
             )
-        replay.append(
+        next_value = (
             -sum(
                 (
                     coefficients[offset] * replay[index - offset]
@@ -240,6 +245,28 @@ def _validate_p_recursive_result_budget(
             )
             / coefficients[0]
         )
+        if any(
+            _lower_decimal_digits(component) > MAX_COMBINATORICS_RESULT_RATIONAL_DIGITS
+            for component in (next_value.numerator, next_value.denominator)
+        ):
+            raise ValueError(
+                "polynomial-coefficient recurrence result exceeds the "
+                f"{MAX_COMBINATORICS_RESULT_RATIONAL_DIGITS}-digit bound"
+            )
+        _require_bounded_fraction(
+            next_value,
+            max_digits=MAX_COMBINATORICS_RESULT_RATIONAL_DIGITS,
+            label="polynomial-coefficient recurrence result",
+        )
+        minimum_size += _minimum_fraction_wire_bytes(next_value) * (
+            1 + (index in requested_index_set)
+        )
+        minimum_size += 32
+        if minimum_size > MAX_COMBINATORICS_RESULT_ARTIFACT_BYTES:
+            raise ValueError(
+                "the exact combinatorics result exceeds the durable artifact limit"
+            )
+        replay.append(next_value)
         residuals.append(
             (
                 index,
@@ -251,12 +278,6 @@ def _validate_p_recursive_result_budget(
                     start=Fraction(),
                 ),
             )
-        )
-    for value in replay:
-        _require_bounded_fraction(
-            value,
-            max_digits=MAX_COMBINATORICS_RESULT_RATIONAL_DIGITS,
-            label="polynomial-coefficient recurrence result",
         )
     _validate_result_artifact_size(
         {

--- a/src/jacobian/domains/combinatorics/checkers.py
+++ b/src/jacobian/domains/combinatorics/checkers.py
@@ -6,6 +6,7 @@ from jacobian.contracts.combinatorics import (
     CyclicPerfectDifferenceSetRequest,
     IntegerSidonRequest,
     LinearRecurrenceEvaluationRequest,
+    PolynomialCoefficientRecurrenceEvaluationRequest,
     RationalGeneratingFunctionCoefficientsRequest,
 )
 
@@ -59,6 +60,15 @@ COMBINATORICS_EXACT_REPLAY_CHECKERS = (
         "combinatorics.linear-recurrence.fraction-replay",
         entrypoint_module=_ENTRYPOINT,
         replay_method="standard-library Fraction recurrence replay",
+        reason=_REASON,
+    ),
+    ExactReplayCheckerDeclaration(
+        "combinatorics.recurrence.p_recursive.evaluate",
+        PolynomialCoefficientRecurrenceEvaluationRequest,
+        "check_polynomial_coefficient_recurrence_evaluation",
+        "combinatorics.p-recursive.fraction-residual-replay",
+        entrypoint_module=_ENTRYPOINT,
+        replay_method="standard-library Fraction polynomial recurrence replay",
         reason=_REASON,
     ),
     ExactReplayCheckerDeclaration(

--- a/src/jacobian/domains/combinatorics/recurrence.py
+++ b/src/jacobian/domains/combinatorics/recurrence.py
@@ -7,6 +7,8 @@ from jacobian.contracts.combinatorics import (
     LinearRecurrenceEvaluationRequest,
     LinearRecurrenceEvaluationResult,
     NonnegativeIntegerRequest,
+    PolynomialCoefficientRecurrenceEvaluationRequest,
+    PolynomialCoefficientRecurrenceEvaluationResult,
     RationalGeneratingFunctionCoefficientsRequest,
     RationalGeneratingFunctionCoefficientsResult,
     RationalResult,
@@ -24,6 +26,7 @@ from jacobian.domains.combinatorics.operations import (
 from jacobian.domains.combinatorics.recurrence_series_operations import (
     compute_rational_generating_function_coefficients,
     evaluate_linear_recurrence,
+    evaluate_polynomial_coefficient_recurrence,
 )
 
 RECURRENCE_CAPABILITIES = (
@@ -122,6 +125,46 @@ RECURRENCE_CAPABILITIES = (
             ),
         ),
         relation_id="combinatorics.recurrence.linear.evaluation.relation",
+    ),
+    combinatorics_operation(
+        "combinatorics.recurrence.p_recursive.evaluate",
+        "Evaluate an exact polynomial-coefficient recurrence",
+        (
+            "Evaluate a bounded rational recurrence sum p_j(n)a_(n-j)=0, "
+            "preserving the complete replay prefix and exact residuals."
+        ),
+        PolynomialCoefficientRecurrenceEvaluationRequest,
+        PolynomialCoefficientRecurrenceEvaluationResult,
+        evaluate_polynomial_coefficient_recurrence,
+        "combinatorics",
+        "recurrence",
+        "p-recursive",
+        "polynomial-coefficients",
+        "exact-rational",
+        invocation_examples=(
+            example(
+                "factorial_prefix",
+                "Evaluate the first seven terms of a_n=n*a_(n-1).",
+                {
+                    "coefficient_polynomials": [
+                        [{"num": "1", "den": "1"}],
+                        [
+                            {"num": "0", "den": "1"},
+                            {"num": "-1", "den": "1"},
+                        ],
+                    ],
+                    "initial_values": [{"num": "1", "den": "1"}],
+                    "coefficient_convention": (
+                        "SUM_P_J_OF_N_TIMES_A_N_MINUS_J_EQUALS_ZERO_FOR_J_FROM_0"
+                    ),
+                    "polynomial_convention": "ASCENDING_POWERS_OF_N",
+                    "scope": "PREFIX",
+                    "term_count": 7,
+                    "indices": [],
+                },
+            ),
+        ),
+        relation_id="combinatorics.recurrence.p_recursive.evaluation.relation",
     ),
     combinatorics_operation(
         "combinatorics.generating_function.coefficients.compute",

--- a/src/jacobian/domains/combinatorics/recurrence_series_operations.py
+++ b/src/jacobian/domains/combinatorics/recurrence_series_operations.py
@@ -9,6 +9,8 @@ from jacobian.contracts.combinatorics import (
     IndexedRationalValue,
     LinearRecurrenceEvaluationRequest,
     LinearRecurrenceEvaluationResult,
+    PolynomialCoefficientRecurrenceEvaluationRequest,
+    PolynomialCoefficientRecurrenceEvaluationResult,
     RationalGeneratingFunctionCoefficientsRequest,
     RationalGeneratingFunctionCoefficientsResult,
 )
@@ -67,6 +69,72 @@ def evaluate_linear_recurrence(
     )
 
 
+def evaluate_polynomial_coefficient_recurrence(
+    request: PolynomialCoefficientRecurrenceEvaluationRequest,
+) -> PolynomialCoefficientRecurrenceEvaluationResult:
+    """Evaluate and expose residuals for a bounded P-recursive relation."""
+
+    requested_indices = (
+        tuple(range(request.term_count))
+        if request.scope == "PREFIX" and request.term_count is not None
+        else request.indices
+    )
+    end = requested_indices[-1]
+    polynomials = tuple(
+        tuple(_sympy_rational(item) for item in polynomial)
+        for polynomial in request.coefficient_polynomials
+    )
+    order = len(polynomials) - 1
+
+    def evaluate_polynomial(polynomial: tuple[Any, ...], index: int) -> Any:
+        return sum(
+            (
+                coefficient * index**power
+                for power, coefficient in enumerate(polynomial)
+            ),
+            start=polynomial[0] * 0,
+        )
+
+    replay = [_sympy_rational(item) for item in request.initial_values[: end + 1]]
+    residuals: list[IndexedRationalValue] = []
+    while len(replay) <= end:
+        index = len(replay)
+        coefficients = tuple(
+            evaluate_polynomial(polynomial, index) for polynomial in polynomials
+        )
+        replay.append(
+            -sum(
+                (
+                    coefficients[offset] * replay[index - offset]
+                    for offset in range(1, order + 1)
+                ),
+                start=coefficients[0] * 0,
+            )
+            / coefficients[0]
+        )
+        residual = sum(
+            (
+                coefficients[offset] * replay[index - offset]
+                for offset in range(order + 1)
+            ),
+            start=coefficients[0] * 0,
+        )
+        residuals.append(IndexedRationalValue(index=index, value=_wire(residual)))
+    replay_wire = tuple(_wire(item) for item in replay)
+    return PolynomialCoefficientRecurrenceEvaluationResult(
+        coefficient_convention=request.coefficient_convention,
+        polynomial_convention=request.polynomial_convention,
+        scope=request.scope,
+        values=tuple(
+            IndexedRationalValue(index=index, value=replay_wire[index])
+            for index in requested_indices
+        ),
+        replay_prefix=replay_wire,
+        residuals=tuple(residuals),
+        replay_scope_end=end,
+    )
+
+
 def compute_rational_generating_function_coefficients(
     request: RationalGeneratingFunctionCoefficientsRequest,
 ) -> RationalGeneratingFunctionCoefficientsResult:
@@ -113,4 +181,5 @@ def compute_rational_generating_function_coefficients(
 __all__ = [
     "compute_rational_generating_function_coefficients",
     "evaluate_linear_recurrence",
+    "evaluate_polynomial_coefficient_recurrence",
 ]

--- a/src/jacobian/domains/combinatorics/recurrence_series_operations.py
+++ b/src/jacobian/domains/combinatorics/recurrence_series_operations.py
@@ -125,6 +125,7 @@ def evaluate_polynomial_coefficient_recurrence(
         coefficient_convention=request.coefficient_convention,
         polynomial_convention=request.polynomial_convention,
         scope=request.scope,
+        recurrence_order=order,
         values=tuple(
             IndexedRationalValue(index=index, value=replay_wire[index])
             for index in requested_indices

--- a/src/jacobian/providers/flint_runtime.py
+++ b/src/jacobian/providers/flint_runtime.py
@@ -382,6 +382,7 @@ def combinatorics_exact_checker_provider_runtime(
             "additive-difference-set-replay",
             "fixed-order-extension-exhaustion",
             "linear-recurrence-replay",
+            "polynomial-coefficient-recurrence-replay",
             "rational-series-residual-replay",
             "standard-library-only",
         ),

--- a/src/jacobian_checkers/recurrence_series.py
+++ b/src/jacobian_checkers/recurrence_series.py
@@ -162,6 +162,7 @@ def _validate_recurrence_values(
         if (
             not isinstance(item, dict)
             or set(item) != {"index", "value"}
+            or type(item["index"]) is not int
             or item["index"] != index
             or _fraction(item["value"], max_digits=32_768) != replay[index]
         ):
@@ -281,6 +282,7 @@ def _p_recursive_residuals_match(
     return all(
         isinstance(item, dict)
         and set(item) == {"index", "value"}
+        and type(item["index"]) is int
         and item["index"] == index
         and _fraction(item["value"], max_digits=32_768) == residual
         and residual == 0
@@ -354,7 +356,12 @@ def _replay_polynomial_coefficient_recurrence(
         return False
     initial = _fractions(source["initial_values"], minimum=1, maximum=16, max_digits=64)
     order = len(polynomials) - 1
-    if len(initial) != order or result["recurrence_order"] != order:
+    if (
+        len(initial) != order
+        or type(result["recurrence_order"]) is not int
+        or not 1 <= result["recurrence_order"] <= 16
+        or result["recurrence_order"] != order
+    ):
         return False
     raw_indices = source["indices"]
     if not isinstance(raw_indices, list) or len(raw_indices) > 256:

--- a/src/jacobian_checkers/recurrence_series.py
+++ b/src/jacobian_checkers/recurrence_series.py
@@ -261,6 +261,7 @@ def _p_recursive_metadata_matches(
             "coefficient_convention",
             "polynomial_convention",
             "scope",
+            "recurrence_order",
             "values",
             "replay_prefix",
             "residuals",
@@ -353,7 +354,7 @@ def _replay_polynomial_coefficient_recurrence(
         return False
     initial = _fractions(source["initial_values"], minimum=1, maximum=16, max_digits=64)
     order = len(polynomials) - 1
-    if len(initial) != order:
+    if len(initial) != order or result["recurrence_order"] != order:
         return False
     raw_indices = source["indices"]
     if not isinstance(raw_indices, list) or len(raw_indices) > 256:

--- a/src/jacobian_checkers/recurrence_series.py
+++ b/src/jacobian_checkers/recurrence_series.py
@@ -6,6 +6,7 @@ artifact-bound JSON values cross the checker boundary.
 
 from __future__ import annotations
 
+import math
 import re
 from collections.abc import Callable
 from fractions import Fraction
@@ -26,6 +27,9 @@ _META = {
     "backend_version": "1.14.0",
     "verification": "UNVERIFIED",
 }
+_MAX_RESULT_DIGITS = 32_768
+_MAX_RESULT_BYTES = 10 * 1024 * 1024
+_LOG10_2 = math.log10(2)
 
 
 def _reject(detail: str) -> dict[str, Any]:
@@ -294,7 +298,10 @@ def _p_recursive_residuals_match(
 
 
 def _p_recursive_replay(
-    polynomials: list[list[Fraction]], initial: list[Fraction], end: int
+    polynomials: list[list[Fraction]],
+    initial: list[Fraction],
+    end: int,
+    requested: set[int],
 ) -> tuple[list[Fraction], list[Fraction]] | None:
     order = len(polynomials) - 1
 
@@ -308,13 +315,17 @@ def _p_recursive_replay(
         )
 
     replay = initial[: end + 1]
+    minimum_size = 1_024 + sum(
+        _minimum_fraction_bytes(value) * (1 + (index in requested))
+        for index, value in enumerate(replay)
+    )
     residuals: list[Fraction] = []
     while len(replay) <= end:
         index = len(replay)
         coefficients = [polynomial_value(item, index) for item in polynomials]
         if coefficients[0] == 0:
             return None
-        replay.append(
+        next_value = (
             -sum(
                 (
                     coefficients[offset] * replay[index - offset]
@@ -324,6 +335,13 @@ def _p_recursive_replay(
             )
             / coefficients[0]
         )
+        if not _bounded_replay_fraction(next_value):
+            return None
+        minimum_size += _minimum_fraction_bytes(next_value) * (1 + (index in requested))
+        minimum_size += 32
+        if minimum_size > _MAX_RESULT_BYTES:
+            return None
+        replay.append(next_value)
         residuals.append(
             sum(
                 (
@@ -334,6 +352,23 @@ def _p_recursive_replay(
             )
         )
     return replay, residuals
+
+
+def _decimal_digits(value: int) -> int:
+    if value == 0:
+        return 1
+    return math.floor((abs(value).bit_length() - 1) * _LOG10_2) + 1
+
+
+def _minimum_fraction_bytes(value: Fraction) -> int:
+    return _decimal_digits(value.numerator) + _decimal_digits(value.denominator) + 20
+
+
+def _bounded_replay_fraction(value: Fraction) -> bool:
+    return all(
+        _decimal_digits(component) <= _MAX_RESULT_DIGITS
+        for component in (value.numerator, value.denominator)
+    )
 
 
 def _replay_polynomial_coefficient_recurrence(
@@ -371,7 +406,7 @@ def _replay_polynomial_coefficient_recurrence(
     if requested is None:
         return False
     end = requested[-1]
-    replayed = _p_recursive_replay(polynomials, initial, end)
+    replayed = _p_recursive_replay(polynomials, initial, end, set(requested))
     if replayed is None:
         return False
     replay, residuals = replayed

--- a/src/jacobian_checkers/recurrence_series.py
+++ b/src/jacobian_checkers/recurrence_series.py
@@ -149,7 +149,8 @@ def _validate_recurrence_values(
 ) -> bool:
     raw_replay = result["replay_prefix"]
     if (
-        result["replay_scope_end"] != end
+        type(result["replay_scope_end"]) is not int
+        or result["replay_scope_end"] != end
         or not isinstance(raw_replay, list)
         or len(raw_replay) != end + 1
         or [_fraction(item, max_digits=32_768) for item in raw_replay] != replay

--- a/src/jacobian_checkers/recurrence_series.py
+++ b/src/jacobian_checkers/recurrence_series.py
@@ -16,6 +16,7 @@ from jacobian_checkers.bound_artifacts import bound_request as _bound_request
 
 _INTEGER = re.compile(r"^-?(?:0|[1-9][0-9]*)$")
 _RECURRENCE_CONVENTION = "A_N_EQUALS_SUM_C_J_TIMES_A_N_MINUS_J_FOR_J_FROM_1"
+_P_RECURSIVE_CONVENTION = "SUM_P_J_OF_N_TIMES_A_N_MINUS_J_EQUALS_ZERO_FOR_J_FROM_0"
 _SERIES_CONVENTION = "ASCENDING_POWERS_OF_X"
 _RESIDUAL_CONGRUENCE = "DENOMINATOR_TIMES_SERIES_MINUS_NUMERATOR_IS_ZERO_MOD_X_TO_ORDER"
 _META = {
@@ -243,6 +244,135 @@ def _canonical_polynomial(value: object) -> list[Fraction]:
     return coefficients
 
 
+def _p_recursive_metadata_matches(
+    source: dict[str, Any], result: dict[str, Any]
+) -> bool:
+    return set(source) == {
+        "coefficient_polynomials",
+        "initial_values",
+        "coefficient_convention",
+        "polynomial_convention",
+        "scope",
+        "term_count",
+        "indices",
+    } and _metadata(
+        result,
+        {
+            "coefficient_convention",
+            "polynomial_convention",
+            "scope",
+            "values",
+            "replay_prefix",
+            "residuals",
+            "replay_scope_end",
+        },
+    )
+
+
+def _p_recursive_residuals_match(
+    result: dict[str, Any], *, order: int, end: int, residuals: list[Fraction]
+) -> bool:
+    raw_residuals = result["residuals"]
+    if not isinstance(raw_residuals, list) or len(raw_residuals) != max(
+        0, end - order + 1
+    ):
+        return False
+    return all(
+        isinstance(item, dict)
+        and set(item) == {"index", "value"}
+        and item["index"] == index
+        and _fraction(item["value"], max_digits=32_768) == residual
+        and residual == 0
+        for item, index, residual in zip(
+            raw_residuals, range(order, end + 1), residuals, strict=True
+        )
+    )
+
+
+def _p_recursive_replay(
+    polynomials: list[list[Fraction]], initial: list[Fraction], end: int
+) -> tuple[list[Fraction], list[Fraction]] | None:
+    order = len(polynomials) - 1
+
+    def polynomial_value(polynomial: list[Fraction], index: int) -> Fraction:
+        return sum(
+            (
+                coefficient * index**power
+                for power, coefficient in enumerate(polynomial)
+            ),
+            start=Fraction(),
+        )
+
+    replay = initial[: end + 1]
+    residuals: list[Fraction] = []
+    while len(replay) <= end:
+        index = len(replay)
+        coefficients = [polynomial_value(item, index) for item in polynomials]
+        if coefficients[0] == 0:
+            return None
+        replay.append(
+            -sum(
+                (
+                    coefficients[offset] * replay[index - offset]
+                    for offset in range(1, order + 1)
+                ),
+                start=Fraction(),
+            )
+            / coefficients[0]
+        )
+        residuals.append(
+            sum(
+                (
+                    coefficients[offset] * replay[index - offset]
+                    for offset in range(order + 1)
+                ),
+                start=Fraction(),
+            )
+        )
+    return replay, residuals
+
+
+def _replay_polynomial_coefficient_recurrence(
+    source: dict[str, Any], result: dict[str, Any]
+) -> bool:
+    if not _p_recursive_metadata_matches(source, result):
+        return False
+    if (
+        source["coefficient_convention"] != _P_RECURSIVE_CONVENTION
+        or source["polynomial_convention"] != "ASCENDING_POWERS_OF_N"
+        or result["coefficient_convention"] != _P_RECURSIVE_CONVENTION
+        or result["polynomial_convention"] != "ASCENDING_POWERS_OF_N"
+        or result["scope"] != source["scope"]
+    ):
+        return False
+    raw_polynomials = source["coefficient_polynomials"]
+    if not isinstance(raw_polynomials, list) or not 2 <= len(raw_polynomials) <= 17:
+        return False
+    polynomials = [_canonical_polynomial(item) for item in raw_polynomials]
+    if any(len(polynomial) > 17 for polynomial in polynomials):
+        return False
+    initial = _fractions(source["initial_values"], minimum=1, maximum=16, max_digits=64)
+    order = len(polynomials) - 1
+    if len(initial) != order:
+        return False
+    raw_indices = source["indices"]
+    if not isinstance(raw_indices, list) or len(raw_indices) > 256:
+        return False
+    requested = _validate_recurrence_scope(source, raw_indices)
+    if requested is None:
+        return False
+    end = requested[-1]
+    replayed = _p_recursive_replay(polynomials, initial, end)
+    if replayed is None:
+        return False
+    replay, residuals = replayed
+    if not _validate_recurrence_values(result, requested, replay, end):
+        return False
+    return _p_recursive_residuals_match(
+        result, order=order, end=end, residuals=residuals
+    )
+
+
 def _replay_rational_series(
     source: dict[str, Any],
     result: dict[str, Any],
@@ -333,6 +463,17 @@ def check_linear_recurrence_evaluation(request: object) -> dict[str, Any]:
     )
 
 
+def check_polynomial_coefficient_recurrence_evaluation(
+    request: object,
+) -> dict[str, Any]:
+    return _run(
+        request,
+        operation_id="combinatorics.recurrence.p_recursive.evaluate",
+        witness_format="combinatorics.p-recursive.fraction-residual-replay",
+        replay=_replay_polynomial_coefficient_recurrence,
+    )
+
+
 def check_rational_generating_function_coefficients(
     request: object,
 ) -> dict[str, Any]:
@@ -346,5 +487,6 @@ def check_rational_generating_function_coefficients(
 
 __all__ = [
     "check_linear_recurrence_evaluation",
+    "check_polynomial_coefficient_recurrence_evaluation",
     "check_rational_generating_function_coefficients",
 ]

--- a/tests/component/checkers/test_recurrence_series_checker.py
+++ b/tests/component/checkers/test_recurrence_series_checker.py
@@ -145,6 +145,7 @@ _CASES: tuple[
                 "coefficient_convention": _P_RECURSIVE_CONVENTION,
                 "polynomial_convention": "ASCENDING_POWERS_OF_N",
                 "scope": "PREFIX",
+                "recurrence_order": 1,
                 "values": [
                     {"index": index, "value": _q(value)}
                     for index, value in enumerate((1, 1, 2, 6, 24, 120))

--- a/tests/component/checkers/test_recurrence_series_checker.py
+++ b/tests/component/checkers/test_recurrence_series_checker.py
@@ -224,3 +224,28 @@ def test_recurrence_series_checker_has_no_sympy_or_producer_dependency() -> None
     source = inspect.getsource(checker_module)
     assert "import sympy" not in source
     assert "domains.combinatorics" not in source
+
+
+@pytest.mark.parametrize(
+    ("path", "value"),
+    [
+        (("recurrence_order",), True),
+        (("values", 0, "index"), False),
+        (("residuals", 0, "index"), True),
+    ],
+)
+def test_polynomial_recurrence_checker_rejects_boolean_result_integers(
+    path: tuple[str | int, ...],
+    value: bool,
+) -> None:
+    forged = copy.deepcopy(_CASES[1][1])
+    target: Any = forged["candidate"]["payload"]
+    for key in path[:-1]:
+        target = target[key]
+    target[path[-1]] = value
+    forged["candidate"]["payload_digest"] = _digest(forged["candidate"]["payload"])
+
+    checked = check_polynomial_coefficient_recurrence_evaluation(forged)
+
+    assert checked["accepted"] is False
+    assert checked["conclusion"] == "UNKNOWN"

--- a/tests/component/checkers/test_recurrence_series_checker.py
+++ b/tests/component/checkers/test_recurrence_series_checker.py
@@ -249,3 +249,21 @@ def test_polynomial_recurrence_checker_rejects_boolean_result_integers(
 
     assert checked["accepted"] is False
     assert checked["conclusion"] == "UNKNOWN"
+
+
+def test_polynomial_recurrence_checker_rejects_boolean_replay_endpoint() -> None:
+    forged = copy.deepcopy(_CASES[1][1])
+    source = forged["claim"]["payload"]
+    source["term_count"] = 2
+    result = forged["candidate"]["payload"]
+    result["values"] = result["values"][:2]
+    result["replay_prefix"] = result["replay_prefix"][:2]
+    result["residuals"] = result["residuals"][:1]
+    result["replay_scope_end"] = True
+    forged["claim"]["payload_digest"] = _digest(source)
+    forged["candidate"]["payload_digest"] = _digest(result)
+
+    checked = check_polynomial_coefficient_recurrence_evaluation(forged)
+
+    assert checked["accepted"] is False
+    assert checked["conclusion"] == "UNKNOWN"

--- a/tests/component/checkers/test_recurrence_series_checker.py
+++ b/tests/component/checkers/test_recurrence_series_checker.py
@@ -13,6 +13,7 @@ from tests.support.rationals import rational_payload as _q
 import jacobian_checkers.recurrence_series as checker_module
 from jacobian_checkers.recurrence_series import (
     check_linear_recurrence_evaluation,
+    check_polynomial_coefficient_recurrence_evaluation,
     check_rational_generating_function_coefficients,
 )
 
@@ -24,6 +25,7 @@ _META = {
     "verification": "UNVERIFIED",
 }
 _RECURRENCE_CONVENTION = "A_N_EQUALS_SUM_C_J_TIMES_A_N_MINUS_J_FOR_J_FROM_1"
+_P_RECURSIVE_CONVENTION = "SUM_P_J_OF_N_TIMES_A_N_MINUS_J_EQUALS_ZERO_FOR_J_FROM_0"
 
 
 def _artifact(
@@ -126,6 +128,37 @@ _CASES: tuple[
         ),
     ),
     (
+        check_polynomial_coefficient_recurrence_evaluation,
+        _request(
+            "combinatorics.recurrence.p_recursive.evaluate",
+            "combinatorics.p-recursive.fraction-residual-replay",
+            {
+                "coefficient_polynomials": [[_q(1)], [_q(0), _q(-1)]],
+                "initial_values": [_q(1)],
+                "coefficient_convention": _P_RECURSIVE_CONVENTION,
+                "polynomial_convention": "ASCENDING_POWERS_OF_N",
+                "scope": "PREFIX",
+                "term_count": 6,
+                "indices": [],
+            },
+            {
+                "coefficient_convention": _P_RECURSIVE_CONVENTION,
+                "polynomial_convention": "ASCENDING_POWERS_OF_N",
+                "scope": "PREFIX",
+                "values": [
+                    {"index": index, "value": _q(value)}
+                    for index, value in enumerate((1, 1, 2, 6, 24, 120))
+                ],
+                "replay_prefix": [_q(value) for value in (1, 1, 2, 6, 24, 120)],
+                "residuals": [
+                    {"index": index, "value": _q(0)} for index in range(1, 6)
+                ],
+                "replay_scope_end": 5,
+                **_META,
+            },
+        ),
+    ),
+    (
         check_rational_generating_function_coefficients,
         _request(
             "combinatorics.generating_function.coefficients.compute",
@@ -173,6 +206,9 @@ def test_recurrence_series_checkers_reject_false_candidates_with_fresh_digest(
     if checker is check_linear_recurrence_evaluation:
         forged["candidate"]["payload"]["replay_prefix"][5] = _q(6)
         forged["candidate"]["payload"]["values"][5]["value"] = _q(6)
+    elif checker is check_polynomial_coefficient_recurrence_evaluation:
+        forged["candidate"]["payload"]["replay_prefix"][5] = _q(121)
+        forged["candidate"]["payload"]["values"][5]["value"] = _q(121)
     else:
         forged["candidate"]["payload"]["coefficients"][5] = _q(9)
     forged["candidate"]["payload_digest"] = _digest(forged["candidate"]["payload"])

--- a/tests/composition/portfolio/test_domain_bundles.py
+++ b/tests/composition/portfolio/test_domain_bundles.py
@@ -28,6 +28,7 @@ from jacobian.contracts.combinatorics import (
     IntegerPartitionEnumerationRequest,
     IntegerSidonRequest,
     LinearRecurrenceEvaluationRequest,
+    PolynomialCoefficientRecurrenceEvaluationRequest,
     RationalGeneratingFunctionCoefficientsRequest,
 )
 from jacobian.contracts.combinatorics import (
@@ -136,6 +137,23 @@ _REPR: list[tuple[type[ContractModel], dict[str, object]]] = [
             "coefficient_convention": "ASCENDING_POWERS_OF_X",
             "expansion_point": "0",
             "truncation_order": 6,
+        },
+    ),
+    (
+        PolynomialCoefficientRecurrenceEvaluationRequest,
+        {
+            "coefficient_polynomials": [
+                [{"num": "1", "den": "1"}],
+                [{"num": "-1", "den": "1"}],
+            ],
+            "initial_values": [{"num": "1", "den": "1"}],
+            "coefficient_convention": (
+                "SUM_P_J_OF_N_TIMES_A_N_MINUS_J_EQUALS_ZERO_FOR_J_FROM_0"
+            ),
+            "polynomial_convention": "ASCENDING_POWERS_OF_N",
+            "scope": "PREFIX",
+            "term_count": 6,
+            "indices": [],
         },
     ),
     (

--- a/tests/composition/runtime/test_recurrence_series_capabilities.py
+++ b/tests/composition/runtime/test_recurrence_series_capabilities.py
@@ -14,6 +14,7 @@ from jacobian.contracts.results import ExecutionStatus
 from jacobian.domains.combinatorics import build_combinatorics_bundle
 
 _RECURRENCE_CONVENTION = "A_N_EQUALS_SUM_C_J_TIMES_A_N_MINUS_J_FOR_J_FROM_1"
+_P_RECURSIVE_CONVENTION = "SUM_P_J_OF_N_TIMES_A_N_MINUS_J_EQUALS_ZERO_FOR_J_FROM_0"
 _PUBLIC_TASKS = (
     Path(__file__).resolve().parents[3]
     / "benchmarks"
@@ -84,6 +85,7 @@ def test_combinatorics_bundle_preserves_named_sequences_and_adds_atomic_generic_
         "combinatorics.compute.fibonacci_pair",
         "combinatorics.compute.lucas",
         "combinatorics.recurrence.linear.evaluate",
+        "combinatorics.recurrence.p_recursive.evaluate",
         "combinatorics.generating_function.coefficients.compute",
     }.issubset(ids)
     catalog_ids = {
@@ -144,6 +146,75 @@ def test_linear_recurrence_exposes_requested_values_and_complete_replay(
     assert len(sparse.output["result"]["replay_prefix"]) == 8
     assert sparse.artifact_uris == ()
     assert sparse.relationships == ()
+
+
+def test_polynomial_coefficient_recurrence_exposes_exact_terms_and_residuals(
+    fresh_complete_runtime,
+) -> None:
+    result = fresh_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="combinatorics.recurrence.p_recursive.evaluate",
+            input={
+                "coefficient_polynomials": [
+                    [_q(1), _q(1)],
+                    [_q(2), _q(-6)],
+                    [_q(-13), _q(9)],
+                    [_q(-4)],
+                    [_q(16), _q(-4)],
+                ],
+                "initial_values": [_q(1), _q(1), _q(1), _q(2)],
+                "coefficient_convention": _P_RECURSIVE_CONVENTION,
+                "polynomial_convention": "ASCENDING_POWERS_OF_N",
+                "scope": "PREFIX",
+                "term_count": 17,
+                "indices": [],
+            },
+        )
+    )
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert [item["value"]["num"] for item in result.output["result"]["values"]] == [
+        "1",
+        "1",
+        "1",
+        "2",
+        "5",
+        "14",
+        "41",
+        "123",
+        "375",
+        "1158",
+        "3615",
+        "11393",
+        "36209",
+        "115940",
+        "373709",
+        "1211740",
+        "3949969",
+    ]
+    assert {item["value"]["num"] for item in result.output["result"]["residuals"]} == {
+        "0"
+    }
+
+
+def test_polynomial_coefficient_recurrence_rejects_singular_required_step(
+    fresh_complete_runtime,
+) -> None:
+    result = fresh_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="combinatorics.recurrence.p_recursive.evaluate",
+            input={
+                "coefficient_polynomials": [[_q(-2), _q(1)], [_q(-1)]],
+                "initial_values": [_q(1)],
+                "coefficient_convention": _P_RECURSIVE_CONVENTION,
+                "polynomial_convention": "ASCENDING_POWERS_OF_N",
+                "scope": "PREFIX",
+                "term_count": 4,
+                "indices": [],
+            },
+        )
+    )
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.output["error"]["code"] == "INVALID_COMBINATORICS_REQUEST"
 
 
 def test_large_rational_results_cross_the_python_conversion_limit_safely(

--- a/tests/composition/runtime/test_recurrence_series_verification.py
+++ b/tests/composition/runtime/test_recurrence_series_verification.py
@@ -13,6 +13,7 @@ from jacobian.contracts.capabilities import (
 from jacobian.contracts.results import ExecutionStatus
 
 _RECURRENCE_CONVENTION = "A_N_EQUALS_SUM_C_J_TIMES_A_N_MINUS_J_FOR_J_FROM_1"
+_P_RECURSIVE_CONVENTION = "SUM_P_J_OF_N_TIMES_A_N_MINUS_J_EQUALS_ZERO_FOR_J_FROM_0"
 
 
 def _q(numerator: int, denominator: int = 1) -> dict[str, str]:
@@ -26,6 +27,18 @@ _CASES = (
             "coefficients": [_q(1), _q(1)],
             "initial_values": [_q(0), _q(1)],
             "coefficient_convention": _RECURRENCE_CONVENTION,
+            "scope": "PREFIX",
+            "term_count": 8,
+            "indices": [],
+        },
+    ),
+    (
+        "combinatorics.recurrence.p_recursive.evaluate",
+        {
+            "coefficient_polynomials": [[_q(1)], [_q(0), _q(-1)]],
+            "initial_values": [_q(1)],
+            "coefficient_convention": _P_RECURSIVE_CONVENTION,
+            "polynomial_convention": "ASCENDING_POWERS_OF_N",
             "scope": "PREFIX",
             "term_count": 8,
             "indices": [],
@@ -85,6 +98,9 @@ def test_checker_rejects_contract_valid_false_results(
     if capability_id == "combinatorics.recurrence.linear.evaluate":
         forged_candidate["replay_prefix"][7] = _q(14)
         forged_candidate["values"][7]["value"] = _q(14)
+    elif capability_id == "combinatorics.recurrence.p_recursive.evaluate":
+        forged_candidate["replay_prefix"][7] = _q(5039)
+        forged_candidate["values"][7]["value"] = _q(5039)
     else:
         forged_candidate["coefficients"][7] = _q(22)
     rejected = runtime.core.capabilities.invoke(

--- a/tests/unit/contracts/test_recurrence_contracts.py
+++ b/tests/unit/contracts/test_recurrence_contracts.py
@@ -6,6 +6,7 @@ import pytest
 from pydantic import ValidationError
 
 from jacobian.contracts.combinatorics import (
+    PolynomialCoefficientRecurrenceEvaluationRequest,
     PolynomialCoefficientRecurrenceEvaluationResult,
 )
 
@@ -110,3 +111,32 @@ def test_polynomial_recurrence_result_accepts_complete_bound_replay() -> None:
 
     assert tuple(item.index for item in result.values) == (0, 1, 2, 3)
     assert tuple(item.index for item in result.residuals) == (2, 3)
+
+
+def test_polynomial_recurrence_aborts_when_an_intermediate_exceeds_digit_bound() -> (
+    None
+):
+    primes = (2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59)
+    denominators = []
+    for prime in primes:
+        denominator = prime
+        while len(str(denominator * prime)) <= 64:
+            denominator *= prime
+        denominators.append(str(denominator))
+    request = {
+        "coefficient_polynomials": [
+            [_q(50), _q(-1)],
+            [{"num": "1", "den": denominator} for denominator in denominators],
+        ],
+        "initial_values": [_q(1)],
+        "coefficient_convention": (
+            "SUM_P_J_OF_N_TIMES_A_N_MINUS_J_EQUALS_ZERO_FOR_J_FROM_0"
+        ),
+        "polynomial_convention": "ASCENDING_POWERS_OF_N",
+        "scope": "PREFIX",
+        "term_count": 100,
+        "indices": [],
+    }
+
+    with pytest.raises(ValidationError, match="32768-digit bound"):
+        PolynomialCoefficientRecurrenceEvaluationRequest.model_validate(request)

--- a/tests/unit/contracts/test_recurrence_contracts.py
+++ b/tests/unit/contracts/test_recurrence_contracts.py
@@ -51,6 +51,19 @@ def _result() -> dict[str, object]:
             {"index": 2, "value": _q(2)},
             {"index": 3, "value": _q(3)},
         ],
+        [
+            {"index": 0, "value": _q(1)},
+            {"index": 2, "value": _q(2)},
+            {"index": 1, "value": _q(1)},
+            {"index": 3, "value": _q(3)},
+        ],
+        [
+            {"index": 0, "value": _q(1)},
+            {"index": 1, "value": _q(1)},
+            {"index": 2, "value": _q(2)},
+            {"index": 3, "value": _q(3)},
+            {"index": 4, "value": _q(5)},
+        ],
     ],
 )
 def test_polynomial_recurrence_result_rejects_malformed_prefix_projection(
@@ -75,6 +88,10 @@ def test_polynomial_recurrence_result_rejects_malformed_prefix_projection(
         [
             {"index": 2, "value": _q(0)},
             {"index": 4, "value": _q(0)},
+        ],
+        [
+            {"index": 3, "value": _q(0)},
+            {"index": 2, "value": _q(0)},
         ],
     ],
 )

--- a/tests/unit/contracts/test_recurrence_contracts.py
+++ b/tests/unit/contracts/test_recurrence_contracts.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.contracts.combinatorics import (
+    PolynomialCoefficientRecurrenceEvaluationResult,
+)
+
+
+def _q(value: int) -> dict[str, str]:
+    return {"num": str(value), "den": "1"}
+
+
+def _result() -> dict[str, object]:
+    return {
+        "coefficient_convention": (
+            "SUM_P_J_OF_N_TIMES_A_N_MINUS_J_EQUALS_ZERO_FOR_J_FROM_0"
+        ),
+        "polynomial_convention": "ASCENDING_POWERS_OF_N",
+        "scope": "PREFIX",
+        "recurrence_order": 2,
+        "values": [
+            {"index": index, "value": _q(value)}
+            for index, value in enumerate((1, 1, 2, 3))
+        ],
+        "replay_prefix": [_q(value) for value in (1, 1, 2, 3)],
+        "residuals": [{"index": index, "value": _q(0)} for index in range(2, 4)],
+        "replay_scope_end": 3,
+        "exactness": "EXACT_RATIONAL",
+        "determinism": "DETERMINISTIC",
+        "backend": "sympy",
+        "backend_version": "1.14.0",
+        "verification": "UNVERIFIED",
+    }
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        [
+            {"index": 1, "value": _q(1)},
+            {"index": 2, "value": _q(2)},
+            {"index": 3, "value": _q(3)},
+        ],
+        [
+            {"index": 0, "value": _q(1)},
+            {"index": 2, "value": _q(2)},
+            {"index": 2, "value": _q(2)},
+            {"index": 3, "value": _q(3)},
+        ],
+    ],
+)
+def test_polynomial_recurrence_result_rejects_malformed_prefix_projection(
+    values: list[dict[str, object]],
+) -> None:
+    result = _result()
+    result["values"] = values
+
+    with pytest.raises(ValidationError):
+        PolynomialCoefficientRecurrenceEvaluationResult.model_validate(result)
+
+
+@pytest.mark.parametrize(
+    "residuals",
+    [
+        [],
+        [{"index": 2, "value": _q(0)}],
+        [
+            {"index": 2, "value": _q(0)},
+            {"index": 2, "value": _q(0)},
+        ],
+        [
+            {"index": 2, "value": _q(0)},
+            {"index": 4, "value": _q(0)},
+        ],
+    ],
+)
+def test_polynomial_recurrence_result_requires_exact_residual_range(
+    residuals: list[dict[str, object]],
+) -> None:
+    result = deepcopy(_result())
+    result["residuals"] = residuals
+
+    with pytest.raises(ValidationError):
+        PolynomialCoefficientRecurrenceEvaluationResult.model_validate(result)
+
+
+def test_polynomial_recurrence_result_accepts_complete_bound_replay() -> None:
+    result = PolynomialCoefficientRecurrenceEvaluationResult.model_validate(_result())
+
+    assert tuple(item.index for item in result.values) == (0, 1, 2, 3)
+    assert tuple(item.index for item in result.residuals) == (2, 3)


### PR DESCRIPTION
## Summary

Adds bounded exact evaluation and independent verification for polynomial-coefficient linear recurrences.

- adds `combinatorics.recurrence.p_recursive.evaluate`
- derives the authorized `combinatorics.recurrence.p_recursive.verify` companion
- represents each `p_j(n)` canonically in ascending rational powers
- returns the complete replay prefix, complete ordered `PREFIX` projection, bound recurrence order, and every exact residual over the required consecutive range
- rejects singular leading coefficients before execution or artifact writes
- enforces recurrence order, polynomial degree, index, digit-growth, and artifact-size bounds
- documents the finite assurance boundary

Closes #900.

## Why

A held-out `gpt-5.4-mini` audit of Tong Niu's 2026 proof of Mathar's OEIS A176677 recurrence correctly refused Jacobian's constant-coefficient recurrence tool, then made an unsupported late arithmetic error and falsely reported that the recurrence failed at n=16. The new exact capability computes the correct final value `a(16)=3949969` and independently verifies zero residuals over the declared finite range.

This does not prove a recurrence for all indices or derive it from an external theorem. Production remains `COMPUTED`; only the standard-library `Fraction` checker can return `VERIFIED`.

## Validation

- `make check` — 880 unit tests passed; Ruff, format, complexity, and mypy passed
- `make check-static` — dependency, dead-code, architecture, typing, and package-build checks passed
- focused result-contract lane — 10 passed
- focused component checker lane — 10 passed
- focused recurrence composition lanes — 25 passed
- `make docs-linkcheck` and `git diff --check` — passed

Focused adversarial coverage includes omitted, duplicate, out-of-order, out-of-range, and boolean result records; a corrupted late candidate; an exact A176677 regression through n=16; and rejection when the leading coefficient polynomial vanishes at a required step.