### PR TITLE
docs: reserve VERIFIED assurance in control evaluations

### DIFF
--- a/docs/how-to/run-agent-evaluations.md
+++ b/docs/how-to/run-agent-evaluations.md
@@ -204,6 +204,16 @@ make agent-eval DATASET=mathematical-benchmarks-v1 \
 MCP configuration. In the held-out runner, that condition records
 infrastructure status `NOT_CONFIGURED` and routing status `NOT_APPLICABLE`, and
 performs no Jacobian probe.
+
+Keep the assurance vocabulary identical in both conditions. In particular,
+reserve `VERIFIED` for a result bound to the exact task input by an
+operator-authorized checker and its verification record. A correct manual
+derivation, self-written check, source citation, or producer result may support
+`COMPUTED`, but it is not `VERIFIED`. Put this rule in any ad hoc prompt that
+does not already expose the task's structured submission contract. Otherwise a
+control answer can reuse `VERIFIED` as an ordinary English synonym and make the
+assurance comparison misleading.
+
 `JACOBIAN_ENABLED=1` selects the treatment job and passes
 Harbor's `--mcp-config` option. `JACOBIAN_EVAL_PROXY=1` selects matching
 proxy-enabled control/treatment job configs and requires at least one proxy
@@ -274,6 +284,14 @@ for the full evidence roles and interpretation boundaries.
 Record the git tree, task digests, provider/runtime, model and prompt settings,
 raw trace location, and validation actually run. A public workflow result is
 regression or observation evidence; it is not held-out causal evidence.
+
+For unstructured pilot answers, record an assurance-vocabulary violation when
+the answer labels a result `VERIFIED` without the required verification record.
+Score that separately from mathematical correctness: a correct scalar or proof
+can still be correct while its assurance claim is false. Missing checker
+availability, a timeout, or failure to obtain a verification record is not
+evidence that the claim is false, but it also cannot raise the claim to
+`VERIFIED`.
 
 ## Troubleshooting
 

--- a/docs/how-to/run-agent-evaluations.md
+++ b/docs/how-to/run-agent-evaluations.md
@@ -206,13 +206,14 @@ infrastructure status `NOT_CONFIGURED` and routing status `NOT_APPLICABLE`, and
 performs no Jacobian probe.
 
 Keep the assurance vocabulary identical in both conditions. In particular,
-reserve `VERIFIED` for a result bound to the exact task input by an
-operator-authorized checker and its verification record. A correct manual
-derivation, self-written check, or source citation may support mathematical
-correctness, but does not itself establish `COMPUTED` and is not `VERIFIED`. A
-producer result carries only the assurance stated by its operation contract.
-Put this rule in any ad hoc prompt that does not already expose the task's
-structured submission contract. Otherwise a control answer can reuse
+reserve `VERIFIED` for a result whose operator-authorized independent-checker
+record satisfies the task contract and binds the exact task input, claim,
+semantics, candidate, scope, certificate format, and checker identity. A correct
+manual derivation, self-written check, or source citation may support
+mathematical correctness, but does not itself establish `COMPUTED` and is not
+`VERIFIED`. A producer result carries only the assurance stated by its operation
+contract. Put this rule in any ad hoc prompt that does not already expose the
+task's structured submission contract. Otherwise a control answer can reuse
 `VERIFIED` as an ordinary English synonym and make the assurance comparison
 misleading.
 
@@ -287,13 +288,14 @@ Record the git tree, task digests, provider/runtime, model and prompt settings,
 raw trace location, and validation actually run. A public workflow result is
 regression or observation evidence; it is not held-out causal evidence.
 
-For unstructured pilot answers, record an assurance-vocabulary violation when
-the answer labels a result `VERIFIED` without the required verification record.
-Score that separately from mathematical correctness: a correct scalar or proof
-can still be correct while its assurance claim is false. Missing checker
-availability, a timeout, or failure to obtain a verification record is not
-evidence that the claim is false, but it also cannot raise the claim to
-`VERIFIED`.
+For unstructured pilot answers, validate every claimed assurance level against
+its supporting evidence or operation contract and record every unsupported
+label as an assurance-vocabulary violation. In particular, `VERIFIED` requires
+the complete task-bound record above. Score assurance separately from
+mathematical correctness: a correct scalar or proof can still be correct while
+its assurance claim is false. Missing checker availability, a timeout, or
+failure to obtain a verification record is not evidence that the claim is
+false, but it also cannot raise the claim to `VERIFIED`.
 
 ## Troubleshooting
 

--- a/docs/how-to/run-agent-evaluations.md
+++ b/docs/how-to/run-agent-evaluations.md
@@ -208,11 +208,13 @@ performs no Jacobian probe.
 Keep the assurance vocabulary identical in both conditions. In particular,
 reserve `VERIFIED` for a result bound to the exact task input by an
 operator-authorized checker and its verification record. A correct manual
-derivation, self-written check, source citation, or producer result may support
-`COMPUTED`, but it is not `VERIFIED`. Put this rule in any ad hoc prompt that
-does not already expose the task's structured submission contract. Otherwise a
-control answer can reuse `VERIFIED` as an ordinary English synonym and make the
-assurance comparison misleading.
+derivation, self-written check, or source citation may support mathematical
+correctness, but does not itself establish `COMPUTED` and is not `VERIFIED`. A
+producer result carries only the assurance stated by its operation contract.
+Put this rule in any ad hoc prompt that does not already expose the task's
+structured submission contract. Otherwise a control answer can reuse
+`VERIFIED` as an ordinary English synonym and make the assurance comparison
+misleading.
 
 `JACOBIAN_ENABLED=1` selects the treatment job and passes
 Harbor's `--mcp-config` option. `JACOBIAN_EVAL_PROXY=1` selects matching


### PR DESCRIPTION
## What

Clarify the assurance vocabulary used in paired and ad hoc agent evaluations:

- reserve `VERIFIED` for results bound to the exact task input by an operator-authorized checker and verification record;
- state that manual derivations, self-written checks, citations, and producer outputs are not independently verified;
- score false assurance language separately from mathematical correctness;
- keep missing checker availability, timeouts, and absent records as non-conclusions.

## Why

A recent no-Jacobian control pilot used uppercase `VERIFIED` in 4 of 6 answers for manual or self-run checks. The mathematics could be correct while the assurance claim crossed Jacobian's trust boundary. The maintained structured Harbor contract already enforces assurance ceilings; this closes the corresponding guidance gap for unstructured/ad hoc pilots.

## Impact

Documentation only. No mathematical capability, checker, benchmark task, routing policy, or existing draft PR is changed.

Closes #903.

## Checks

- `make docs-command-check`
- Markdown link check equivalent to `make docs-linkcheck` using the pinned `markdown-link-check@3.15.0` (the environment had Node but no `npx` executable)
- `make test-plan BASE=origin/main` → docs lane only