### PR TITLE
fix(checkers): repair syzygy verifier handoff metadata

### DIFF
--- a/src/jacobian/contracts/jacobian_syzygy.py
+++ b/src/jacobian/contracts/jacobian_syzygy.py
@@ -226,6 +226,7 @@ class GradedJacobianSyzygyResult(ContractModel):
     first_syzygy_degree: StrictInt | None = Field(default=None, ge=0, le=8)
     kernel_witness: GradedJacobianKernelWitness | None = None
     completion: Literal["COMPLETE_THROUGH_BOUND"] = "COMPLETE_THROUGH_BOUND"
+
     @model_validator(mode="after")
     def bind_first_kernel_and_finite_scope(self) -> Self:
         if self.expanded_polynomial.variables != self.variables:

--- a/src/jacobian/contracts/jacobian_syzygy.py
+++ b/src/jacobian/contracts/jacobian_syzygy.py
@@ -229,7 +229,7 @@ class GradedJacobianSyzygyResult(ContractModel):
     verification_capability_id: Literal[
         "polynomial.jacobian_syzygy.minimum_degree.verify"
     ] = "polynomial.jacobian_syzygy.minimum_degree.verify"
-    verification_input_field: Literal["result_uri"] = "result_uri"
+    verification_input_field: Literal["input_and_candidate"] = "input_and_candidate"
 
     @model_validator(mode="after")
     def bind_first_kernel_and_finite_scope(self) -> Self:

--- a/src/jacobian/contracts/jacobian_syzygy.py
+++ b/src/jacobian/contracts/jacobian_syzygy.py
@@ -229,7 +229,9 @@ class GradedJacobianSyzygyResult(ContractModel):
     verification_capability_id: Literal[
         "polynomial.jacobian_syzygy.minimum_degree.verify"
     ] = "polynomial.jacobian_syzygy.minimum_degree.verify"
-    verification_input_field: Literal["input_and_candidate"] = "input_and_candidate"
+    verification_input_field: Literal["input_and_complete_output_result"] = (
+        "input_and_complete_output_result"
+    )
 
     @model_validator(mode="after")
     def bind_first_kernel_and_finite_scope(self) -> Self:

--- a/src/jacobian/contracts/jacobian_syzygy.py
+++ b/src/jacobian/contracts/jacobian_syzygy.py
@@ -226,13 +226,6 @@ class GradedJacobianSyzygyResult(ContractModel):
     first_syzygy_degree: StrictInt | None = Field(default=None, ge=0, le=8)
     kernel_witness: GradedJacobianKernelWitness | None = None
     completion: Literal["COMPLETE_THROUGH_BOUND"] = "COMPLETE_THROUGH_BOUND"
-    verification_capability_id: Literal[
-        "polynomial.jacobian_syzygy.minimum_degree.verify"
-    ] = "polynomial.jacobian_syzygy.minimum_degree.verify"
-    verification_input_field: Literal["input_and_complete_output_result"] = (
-        "input_and_complete_output_result"
-    )
-
     @model_validator(mode="after")
     def bind_first_kernel_and_finite_scope(self) -> Self:
         if self.expanded_polynomial.variables != self.variables:

--- a/src/jacobian/domains/polynomial/checkers.py
+++ b/src/jacobian/domains/polynomial/checkers.py
@@ -26,7 +26,7 @@ POLYNOMIAL_EXACT_REPLAY_CHECKERS = (
         verification_description=(
             "Independently reconstruct every bounded homogeneous coefficient map, "
             "rank ledger, nonzero minor, and first kernel from the exact producer "
-            "input and its inline candidate result."
+            "input and the complete, unmodified producer output.result object."
         ),
         verification_tags=(
             "verification",

--- a/src/jacobian/domains/polynomial/checkers.py
+++ b/src/jacobian/domains/polynomial/checkers.py
@@ -25,8 +25,8 @@ POLYNOMIAL_EXACT_REPLAY_CHECKERS = (
         verification_title="Verify a first graded Jacobian syzygy degree",
         verification_description=(
             "Independently reconstruct every bounded homogeneous coefficient map, "
-            "rank ledger, nonzero minor, and first kernel from a stored producer "
-            "result."
+            "rank ledger, nonzero minor, and first kernel from the exact producer "
+            "input and its inline candidate result."
         ),
         verification_tags=(
             "verification",

--- a/src/jacobian_checkers/jacobian_syzygy.py
+++ b/src/jacobian_checkers/jacobian_syzygy.py
@@ -568,7 +568,7 @@ def _expected_result(source: dict[str, Any]) -> dict[str, Any]:
         "verification_capability_id": (
             "polynomial.jacobian_syzygy.minimum_degree.verify"
         ),
-        "verification_input_field": "input_and_candidate",
+        "verification_input_field": "input_and_complete_output_result",
     }
 
 

--- a/src/jacobian_checkers/jacobian_syzygy.py
+++ b/src/jacobian_checkers/jacobian_syzygy.py
@@ -565,10 +565,6 @@ def _expected_result(source: dict[str, Any]) -> dict[str, Any]:
         "first_syzygy_degree": first_degree,
         "kernel_witness": kernel_witness,
         "completion": "COMPLETE_THROUGH_BOUND",
-        "verification_capability_id": (
-            "polynomial.jacobian_syzygy.minimum_degree.verify"
-        ),
-        "verification_input_field": "input_and_complete_output_result",
     }
 
 

--- a/src/jacobian_checkers/jacobian_syzygy.py
+++ b/src/jacobian_checkers/jacobian_syzygy.py
@@ -568,7 +568,7 @@ def _expected_result(source: dict[str, Any]) -> dict[str, Any]:
         "verification_capability_id": (
             "polynomial.jacobian_syzygy.minimum_degree.verify"
         ),
-        "verification_input_field": "result_uri",
+        "verification_input_field": "input_and_candidate",
     }
 
 

--- a/tests/composition/runtime/test_frontier_capabilities.py
+++ b/tests/composition/runtime/test_frontier_capabilities.py
@@ -264,6 +264,7 @@ def test_graded_jacobian_syzygy_finds_and_verifies_the_first_kernel(
     result = _result_payload(frontier_services, computed)
     assert result["status"] == "FOUND"
     assert result["first_syzygy_degree"] == 1
+    assert result["verification_input_field"] == "input_and_candidate"
     assert [(item["rank"], item["nullity"]) for item in result["degree_maps"]] == [
         (3, 0),
         (7, 2),
@@ -287,6 +288,16 @@ def test_graded_jacobian_syzygy_finds_and_verifies_the_first_kernel(
     )
     assert verified.execution.status is ExecutionStatus.COMPLETED
     assert verified.output["status"] == "VERIFIED"
+
+    verifier = next(
+        descriptor
+        for descriptor in frontier_services.core.capabilities.catalog().capabilities
+        if descriptor.capability_id
+        == "polynomial.jacobian_syzygy.minimum_degree.verify"
+    )
+    assert "exact producer input and its inline candidate result" in (
+        verifier.description
+    )
 
 
 def test_graded_jacobian_syzygy_handles_a_zero_partial_derivative(

--- a/tests/composition/runtime/test_frontier_capabilities.py
+++ b/tests/composition/runtime/test_frontier_capabilities.py
@@ -264,7 +264,6 @@ def test_graded_jacobian_syzygy_finds_and_verifies_the_first_kernel(
     result = _result_payload(frontier_services, computed)
     assert result["status"] == "FOUND"
     assert result["first_syzygy_degree"] == 1
-    assert result["verification_input_field"] == "input_and_complete_output_result"
     assert [(item["rank"], item["nullity"]) for item in result["degree_maps"]] == [
         (3, 0),
         (7, 2),

--- a/tests/composition/runtime/test_frontier_capabilities.py
+++ b/tests/composition/runtime/test_frontier_capabilities.py
@@ -264,9 +264,7 @@ def test_graded_jacobian_syzygy_finds_and_verifies_the_first_kernel(
     result = _result_payload(frontier_services, computed)
     assert result["status"] == "FOUND"
     assert result["first_syzygy_degree"] == 1
-    assert (
-        result["verification_input_field"] == "input_and_complete_output_result"
-    )
+    assert result["verification_input_field"] == "input_and_complete_output_result"
     assert [(item["rank"], item["nullity"]) for item in result["degree_maps"]] == [
         (3, 0),
         (7, 2),

--- a/tests/composition/runtime/test_frontier_capabilities.py
+++ b/tests/composition/runtime/test_frontier_capabilities.py
@@ -264,7 +264,9 @@ def test_graded_jacobian_syzygy_finds_and_verifies_the_first_kernel(
     result = _result_payload(frontier_services, computed)
     assert result["status"] == "FOUND"
     assert result["first_syzygy_degree"] == 1
-    assert result["verification_input_field"] == "input_and_candidate"
+    assert (
+        result["verification_input_field"] == "input_and_complete_output_result"
+    )
     assert [(item["rank"], item["nullity"]) for item in result["degree_maps"]] == [
         (3, 0),
         (7, 2),
@@ -295,7 +297,7 @@ def test_graded_jacobian_syzygy_finds_and_verifies_the_first_kernel(
         if descriptor.capability_id
         == "polynomial.jacobian_syzygy.minimum_degree.verify"
     )
-    assert "exact producer input and its inline candidate result" in (
+    assert "complete, unmodified producer output.result object" in (
         verifier.description
     )
 


### PR DESCRIPTION
## What changed

- correct the graded Jacobian-syzygy result metadata to say that verification consumes the exact producer `input` and inline `candidate`, rather than a nonexistent `result_uri`;
- update the independent verifier description to state the same contract;
- add a regression covering both the producer hint and the installed verifier description.

## Root cause and observed impact

A held-out evaluation of Dimca and Pokora's 2026 nine-line counterexample (arXiv:2607.01985) successfully discovered and ran `polynomial.jacobian_syzygy.minimum_degree.compute` for both arrangements. The model then inspected the independent verifier, but declined to call it because:

- the computed result advertised `verification_input_field: "result_uri"`;
- the compute operation produced no result artifact URI because this is an ordinary inline computed operation; and
- the verifier description said it consumed a "stored producer result".

The installed verifier actually accepts the original producer `input` and its inline `candidate`. The conflicting metadata converted two available independent replay paths into COMPUTED-only final claims.

## Scope and safety

This changes only agent-facing handoff metadata and the result's self-description. It does not alter the polynomial computation, candidate schema, independent checker implementation, authorization, assurance semantics, or verification record behavior. The checker still reconstructs every bounded coefficient map independently and remains fail-closed.

## Validation

Focused regression:

- graded Jacobian-syzygy compute/verify test: 1 passed.

Planner-selected validation:

- unit: 868 passed;
- component: 759 passed, 3 expected platform skips;
- domain: 185 passed;
- composition: 475 passed, 2 expected Lean skips;
- storage: 125 passed;
- process: 234 passed, 1 expected platform skip;
- MCP: 46 passed;
- end-to-end: 8 passed, 1 expected Lean skip;
- Ruff, formatting, complexity, dependency, dead-code, mypy, test architecture, product architecture, package build: passed.

## Overlap

Issue #883 tracks the wider audit of historical artifact-backed verification boundaries. This PR does not perform that audit or alter transport architecture; it fixes one directly observed contradictory inline handoff.