### PR TITLE
fix(benchmarks): clarify finite partition verification scope

### DIFF
--- a/src/jacobian/finite_partition.py
+++ b/src/jacobian/finite_partition.py
@@ -375,6 +375,15 @@ class FinitePartitionAdapter:
             and not duplicate_case_ids
             and (not require_disjoint or not overlaps)
         )
+        verified_replay_basis = (
+            "authorized checker replayed equality-based coverage and required "
+            "disjointness within the caller-supplied universe"
+            if require_disjoint
+            else (
+                "authorized checker replayed equality-based coverage within the "
+                "caller-supplied universe; disjointness was not required"
+            )
+        )
         return CapabilityResult(
             capability_id=self.descriptor.capability_id,
             capability_version=self.descriptor.version,
@@ -414,9 +423,8 @@ class FinitePartitionAdapter:
                     else CapabilityCompletenessStatus.PARTIAL
                 ),
                 basis=(
-                    "authorized checker replayed equality-based coverage and "
-                    "disjointness within the caller-supplied universe; it did not "
-                    "check external-domain completeness or member/case semantics"
+                    f"{verified_replay_basis}; it did not check external-domain "
+                    "completeness or member/case semantics"
                     if verified
                     else "generator-side membership accounting; not independently checked"
                 ),
@@ -443,9 +451,8 @@ class FinitePartitionAdapter:
             assurance=CapabilityAssurance(
                 level=assurance_level,
                 basis=(
-                    "operator-authorized checker accepted equality-based coverage and "
-                    "disjointness within the caller-supplied universe; external-domain "
-                    "completeness and member/case semantics were not checked"
+                    f"{verified_replay_basis}; external-domain completeness and "
+                    "member/case semantics were not checked"
                     if verified
                     else "partition was proposed and inspected by its generator only"
                 ),
@@ -475,7 +482,7 @@ class FinitePartitionAdapter:
             scope_digest=scope.manifest.object_digest,
         )
         payload: dict[str, Any] = {
-            "replay": "exact finite membership",
+            "replay": "equality-based finite coverage and conditional disjointness",
             "relation_id": "case.relation.partitions",
             "obligation_uri": claim_uri,
         }

--- a/src/jacobian/finite_partition.py
+++ b/src/jacobian/finite_partition.py
@@ -195,7 +195,10 @@ class FinitePartitionAdapter:
             title="Partition an explicit finite domain",
             description=(
                 "Materialize named cases over an explicit finite scope and optionally "
-                "replay exact coverage and disjointness with an authorized checker."
+                "replay exact coverage and disjointness with an authorized checker. "
+                "Members and case labels are opaque caller-supplied strings; the "
+                "checker does not establish their mathematical meaning or that the "
+                "supplied universe exhausts an external domain."
             ),
             provider="jacobian.finite",
             provider_runtime=known_provider_runtime(
@@ -397,7 +400,10 @@ class FinitePartitionAdapter:
                 "duplicate_case_ids": duplicate_case_ids,
             },
             scope=CapabilityScope(
-                description="the exact supplied finite universe",
+                description=(
+                    "the exact caller-supplied finite universe; external-domain "
+                    "completeness and member semantics are not checked"
+                ),
                 parameters={"element_count": len(universe)},
                 artifact_uri=scope.artifact_uri,
             ),
@@ -408,7 +414,9 @@ class FinitePartitionAdapter:
                     else CapabilityCompletenessStatus.PARTIAL
                 ),
                 basis=(
-                    "authorized checker replayed exact finite membership"
+                    "authorized checker replayed equality-based coverage and "
+                    "disjointness within the caller-supplied universe; it did not "
+                    "check external-domain completeness or member/case semantics"
                     if verified
                     else "generator-side membership accounting; not independently checked"
                 ),
@@ -435,7 +443,9 @@ class FinitePartitionAdapter:
             assurance=CapabilityAssurance(
                 level=assurance_level,
                 basis=(
-                    "operator-authorized independent finite partition checker accepted"
+                    "operator-authorized checker accepted equality-based coverage and "
+                    "disjointness within the caller-supplied universe; external-domain "
+                    "completeness and member/case semantics were not checked"
                     if verified
                     else "partition was proposed and inspected by its generator only"
                 ),

--- a/tests/composition/runtime/test_finite_partition_capability.py
+++ b/tests/composition/runtime/test_finite_partition_capability.py
@@ -11,7 +11,12 @@ from jacobian.contracts.checkers import CheckerDecision
 from jacobian.contracts.results import Arithmetic, Conclusion, Coverage, Method
 
 
-def _request(mode: CapabilityMode, *, missing_last: bool = False) -> CapabilityRequest:
+def _request(
+    mode: CapabilityMode,
+    *,
+    missing_last: bool = False,
+    require_disjoint: bool = True,
+) -> CapabilityRequest:
     return CapabilityRequest(
         capability_id="case.partition.finite",
         mode=mode,
@@ -24,7 +29,7 @@ def _request(mode: CapabilityMode, *, missing_last: bool = False) -> CapabilityR
                     "members": ["1", "3"] if missing_last else ["1", "3", "5"],
                 },
             ],
-            "require_disjoint": True,
+            "require_disjoint": require_disjoint,
         },
     )
 
@@ -76,6 +81,25 @@ def test_finite_partition_contract_and_result_preserve_semantic_boundary(
     assert "external-domain completeness" in result.scope.description
     assert "member/case semantics were not checked" in result.assurance.basis
     assert "member/case semantics" in result.completeness.basis
+
+
+def test_finite_partition_reports_conditional_disjointness_scope(
+    authorized_complete_runtime,
+) -> None:
+    runtime = authorized_complete_runtime
+    request = _request(CapabilityMode.VERIFY, require_disjoint=False)
+    request.input["cases"][1]["members"].append("0")
+
+    result = runtime.core.capabilities.invoke(request)
+
+    assert result.assurance.level is CapabilityAssuranceLevel.VERIFIED
+    assert result.output["overlaps"] == ["0"]
+    assert "disjointness was not required" in result.assurance.basis
+    assert "disjointness was not required" in result.completeness.basis
+    certificate = runtime.core.store.get(result.output["certificate_uri"])
+    assert certificate.payload["payload"]["replay"] == (
+        "equality-based finite coverage and conditional disjointness"
+    )
 
 
 def test_finite_partition_verify_fails_closed_on_incomplete_cases(

--- a/tests/composition/runtime/test_finite_partition_capability.py
+++ b/tests/composition/runtime/test_finite_partition_capability.py
@@ -60,6 +60,24 @@ def test_finite_partition_verify_replays_and_discharges_obligation(
     assert result.obligations[0].status is CapabilityObligationStatus.DISCHARGED
 
 
+def test_finite_partition_contract_and_result_preserve_semantic_boundary(
+    authorized_complete_runtime,
+) -> None:
+    runtime = authorized_complete_runtime
+    descriptor = next(
+        item
+        for item in runtime.core.capabilities.catalog().capabilities
+        if item.capability_id == "case.partition.finite"
+    )
+    result = runtime.core.capabilities.invoke(_request(CapabilityMode.VERIFY))
+
+    assert "opaque caller-supplied strings" in descriptor.description
+    assert "does not establish their mathematical meaning" in descriptor.description
+    assert "external-domain completeness" in result.scope.description
+    assert "member/case semantics were not checked" in result.assurance.basis
+    assert "member/case semantics" in result.completeness.basis
+
+
 def test_finite_partition_verify_fails_closed_on_incomplete_cases(
     authorized_complete_runtime,
 ) -> None:


### PR DESCRIPTION
## Summary

- clarify that `case.partition.finite` treats universe members and case labels as opaque caller-supplied strings
- state in verified results that the checker replays only equality-based coverage and disjointness inside the supplied universe
- keep external-domain completeness and member/case semantics explicitly outside the verification record
- add a focused regression test for the model-visible contract and result wording

Closes #914.

## Root cause

A held-out weak-model evaluation correctly used the finite partition checker but promoted its verification record to the entire mathematical answer. The record established coverage and disjointness of a caller-constructed string universe; it did not establish that the universe was mathematically exhaustive or that its strings and case labels had the claimed semantics.

The checker, artifact bindings, and assurance decision were correct. The missing piece was a sufficiently explicit statement of that semantic boundary in the operation card and the successful result.

## Trust and compatibility

This does not change the checker, verification record, accepted inputs, output schema, or `VERIFIED` eligibility. It changes descriptive model-visible text only.

## Validation

- focused finite-partition suite: 6 passed
- `make check`: Ruff, formatting, complexity, mypy, 869 unit tests passed
- composition suite: 476 passed, 2 skipped (pinned Lean runtime unavailable)
- MCP suite: 45 passed; one localhost-binding test was blocked by the sandbox and passed separately with localhost permission
- `git diff --check`: passed
