### PR TITLE
fix(polynomials): canonicalize sparse capability inputs

### DIFF
--- a/benchmarks/config/canonical-input-recovery-pr1.json
+++ b/benchmarks/config/canonical-input-recovery-pr1.json
@@ -1,0 +1,89 @@
+{
+  "schema_version": "1",
+  "study_id": "canonical-input-recovery-pr1",
+  "evidence_class": "public-host-local-semantic-tool-observation",
+  "causal_claim_authorized": false,
+  "harbor_execution_claimed": false,
+  "source_base_revision": "614fdc40511d41bf88607cb0c6cc7c1e6cb91667",
+  "model": {
+    "model_id": "gpt-5.4-mini",
+    "reasoning_effort": "medium",
+    "codex_cli_version": "codex-cli 0.147.0"
+  },
+  "agent_instructions": "Work only in the current directory. Read instruction.md, input.json, and submission_schema.json. Treat the current directory as /app and write submission.json plus every required evidence file there. Use the available Jacobian mathematical tools when they provide useful exact intermediate results, but choose your own mathematical route and tool order. Comply with the external reasoning-log protocol exposed by the Jacobian server. Do not use web search or inspect files outside the current directory. The task-owned verifier runs only after you exit, so independently check the terminal mathematical object, scope, completeness, evidence bindings, and assurance before finishing.",
+  "conditions": [
+    {
+      "id": "upstream",
+      "description": "Latest upstream Jacobian main without the candidate semantic changes."
+    },
+    {
+      "id": "canonicalization",
+      "description": "Upstream plus exact canonical sparse polynomial-map input normalization at capability boundaries."
+    },
+    {
+      "id": "canonicalization-recovery",
+      "description": "Canonicalization plus typed recovery semantics, only if the first two conditions justify a separate recovery change."
+    }
+  ],
+  "tasks": [
+    {
+      "dataset": "symbolic-coordination-v1",
+      "task_id": "symbolic-coordination-semantic-equivalence-01",
+      "harbor_task_digest": "799301c8118daf0c9328aafaace67e904eba0679bffd06ea44ff3c120137df4e",
+      "selection_basis": "Duplicate, reordered, cancelling, and zero sparse terms with renamed source and target variables."
+    },
+    {
+      "dataset": "symbolic-coordination-v1",
+      "task_id": "symbolic-coordination-semantic-equivalence-02",
+      "harbor_task_digest": "3e12d6a7959fdfc475251ac7e2a8ba5e8ca3ccd8868d12157711d981b536e1d2",
+      "selection_basis": "Affine duplicate terms with exact cancellation and renamed source and target variables."
+    },
+    {
+      "dataset": "symbolic-coordination-v1",
+      "task_id": "symbolic-coordination-semantic-equivalence-03",
+      "harbor_task_digest": "a43b3ff05f551628f6609df3910e63da846309391cb508f48ef0ed478ea27e35",
+      "selection_basis": "Equivalent reordered sparse inverse encoding."
+    }
+  ],
+  "execution": {
+    "repetitions_per_task": 3,
+    "ordering": "declared-task-order-then-repetition",
+    "timeout_seconds_per_rollout": 600,
+    "sandbox": "workspace-write",
+    "reasoning_log_mode": "REQUIRED",
+    "web_search": "disabled",
+    "wrong_answer_retries": 0,
+    "terminal_reward": "unchanged-task-owned-clean-room-verifier-only",
+    "tool_call_reward": 0
+  },
+  "primary_metric": "exact_terminal_verifier_acceptance",
+  "secondary_metrics": [
+    "valid_normalization_or_checker_invocation",
+    "schema_and_request_validation_failure_count",
+    "recovery_after_rejected_handoff",
+    "repeated_or_unnecessary_call_count",
+    "false_certification",
+    "scope_and_completeness_correctness"
+  ],
+  "invariants": [
+    "Do not change task files, prompts, verifier code, model, reasoning effort, timeout, or repetition count between conditions.",
+    "The canonicalization change may only parse exact rational terms, combine identical exponent vectors, cancel exact zero coefficients, remove zero terms, and deterministically order the canonical output.",
+    "Typed recovery semantics may expose state and permissible local corrections but cannot prescribe mathematical strategy, weaken validation, or authorize a checker.",
+    "Do not rerun a completed rollout to obtain a preferred result.",
+    "Do not interpret timeout, execution failure, incomplete search, or missing evidence as a mathematical conclusion."
+  ],
+  "stop_rules": [
+    "Stop after the three frozen conditions or earlier if canonicalization is not implemented safely.",
+    "Do not implement recovery unless upstream and canonicalization trajectories contain a repeated recoverable handoff failure that typed state can address.",
+    "Do not add benchmark cases, trajectory-value machinery, RL work, or prose-only affordance changes."
+  ],
+  "excluded_evidence": [
+    {
+      "task_id": "polynomial-normalization",
+      "reason": "Its README declares verification_record_schema.json agent-visible, but the environment Dockerfile does not copy that file; it remains excluded until fixed separately."
+    }
+  ],
+  "environment_limitations": [
+    "No Docker-compatible runtime is installed, so the frozen runs are host-local public-workspace observations and are not Harbor executions."
+  ]
+}

--- a/docs/reference/evaluations/canonical-input-recovery-pr1.md
+++ b/docs/reference/evaluations/canonical-input-recovery-pr1.md
@@ -27,3 +27,79 @@ The existing `polynomial-normalization` task is excluded. Its README declares
 `verification_record_schema.json` agent-visible, but its environment Dockerfile
 does not copy that file. That benchmark contract must be fixed separately before
 the task can provide evidence for checker handoffs.
+
+## PR1 observation
+
+The upstream condition used semantic base `614fdc40511d41bf88607cb0c6cc7c1e6cb91667`
+through preregistration commit `00f3e3d5560d3bacf4a4c698542e9512bc6972b5`.
+The canonicalization condition used
+`bdcdd9712f79942a6e9a975bdf4a67ea4523a29a`. The task, public-bundle, verifier,
+model, prompt, timeout, and repetition digests remained frozen by the study
+contract.
+
+| Condition | Exact accepted | Rejected | Inconclusive | False certification |
+| --- | ---: | ---: | ---: | ---: |
+| Upstream | 6/9 | 3/9 | 0/9 | 0 |
+| Canonicalization | 6/9 | 1/9 | 2/9 | 0 |
+
+The primary accepted count did not improve. Canonicalization did remove both
+observed `INVALID_POLYNOMIAL_MAP_INVERSE_REQUEST` representation failures. It
+also enabled two successful exact inverse-checker calls instead of one. In
+`symbolic-coordination-semantic-equivalence-01-r03`, the agent passed duplicate,
+cancelling, zero, and reordered sparse terms directly to
+`polynomial.map.inverse.verify`; the boundary stored canonical maps and the
+independent checker returned `VERIFIED`. Generic outer-request shape failures
+remained: three `INVALID_REQUEST` calls were observed in each condition.
+
+One canonicalization rollout, task 2 repetition 2, was interrupted externally
+after it began. It was preserved as `INCONCLUSIVE/INFRASTRUCTURE_FAILURE`; the
+model was not rerun. Task 3 repetition 1 produced a mathematically correct
+terminal object, but its reasoning run IDs were ambiguous, so the finalizer
+correctly recorded `INCONCLUSIVE/REASONING_PROTOCOL_INCOMPLETE`. These outcomes
+explain why the raw 6/9 acceptance count must not be restated as 6/7 without an
+explicit complete-case qualifier. Six canonicalization trajectories also
+reported noncanonical trajectory-value extraction errors in the observational
+runner; terminal verification and raw traces remain available, but those
+secondary extracted values are not evidence.
+
+## Recovery rationale and handoff
+
+The repeated failure justifying the separate recovery condition was a checker
+handoff shape error, not a mathematical rejection. In upstream task 2 repetition
+3, the agent placed the entire four-field inverse-check request under
+`forward_map`, received a root `required` failure, repeated the same nesting, and
+then did it a third time. The run eventually passed only after abandoning that
+checker path and constructing the terminal certificate locally. Existing prose
+listed missing fields, but did not encode that the nested object was a reusable
+request and belonged at the root. This is the bounded target for PR2; reasoning
+log write errors and strategy choices are out of scope.
+
+The installed upstream surface advertised Jacobian `0.10.0`, 332 capabilities,
+catalog digest
+`sha256:1b92becedb2ea91df037614cf12a3f7e22fa05b926c043e666ef96610e79851a`,
+content digest
+`sha256:84eefb7287eb623717839c65c34c91b9f9c3ac67668203aad6f5d7a94beb4ad8`,
+default policy digest
+`sha256:870a92b83d3e522e4015b6bb1cabda33086906f9de1c3c36e466251ea7ed1957`,
+and surface digest
+`sha256:c3ad3f2264850e8925122aa6beeaa577512bf9cbf2b7d52f083ac502e7cec4f8`.
+The canonicalization surface digest was
+`sha256:455d6cde933acdd0cfdfabf55090f5aeff9ad587b57272662e77fde1f7203228`.
+The sparse polynomial checker was available; Lean and external proof executables
+were absent and were not needed by these tasks.
+
+Raw evidence is under
+`benchmarks/results/canonical-input-recovery-pr1-upstream` and
+`benchmarks/results/canonical-input-recovery-pr1-canonicalization`. The named
+sessions were `jac-canonical-upstream`, `jac-canonical-treatment`, and
+`jac-canonical-resume-2`; the failed drift-check-only resume attempt was
+`jac-canonical-resume`. Session logs are
+`/private/tmp/jac-canonical-upstream.log`,
+`/private/tmp/jac-canonical-treatment.log`,
+`/private/tmp/jac-canonical-resume.log`, and
+`/private/tmp/jac-canonical-resume-2.log`. The successful focused implementation
+validation before this observation was 37 tests in the relevant contract and
+composition files plus one exact-rational capability test. Final PR validation
+is recorded in the pull request checks. The unresolved obligation is a held-out
+or Harbor execution before making a causal claim; the next action is the frozen
+canonicalization-plus-recovery condition.

--- a/docs/reference/evaluations/canonical-input-recovery-pr1.md
+++ b/docs/reference/evaluations/canonical-input-recovery-pr1.md
@@ -1,0 +1,29 @@
+# Canonical input and recovery study PR1
+
+This bounded public observation tests two semantic tool changes on three existing
+`symbolic-coordination-v1` tasks. The frozen contract is
+[`benchmarks/config/canonical-input-recovery-pr1.json`](../../../benchmarks/config/canonical-input-recovery-pr1.json).
+
+The primary outcome is unchanged task-owned exact verifier acceptance. Secondary
+diagnostics count valid normalization or checker invocations, request-validation
+failures, recovery after a rejected handoff, repeated calls, false certification,
+and scope or completeness mistakes. Tool calls receive no reward.
+
+The conditions are latest upstream, upstream plus exact canonical sparse-map input
+normalization, and canonicalization plus typed recovery semantics. The third
+condition and a recovery PR are conditional: they run only if the first two
+conditions show a repeated recoverable handoff failure. Each active condition uses
+three rollouts per task with Codex `gpt-5.4-mini`, medium reasoning, no web access,
+no wrong-answer retries, and a 600-second timeout.
+
+The host has no Docker-compatible runtime. Runs therefore use the locally
+authenticated Codex CLI in isolated public workspaces against a local Jacobian MCP
+server, followed by the unchanged clean-room verifier. They are host-local
+exploratory observations, not Harbor executions or causal evidence. Raw commands,
+timestamps, transcripts, MCP logs, workspaces, verifier records, and manifests are
+saved under `benchmarks/results/canonical-input-recovery-pr1-*`.
+
+The existing `polynomial-normalization` task is excluded. Its README declares
+`verification_record_schema.json` agent-visible, but its environment Dockerfile
+does not copy that file. That benchmark contract must be fixed separately before
+the task can provide evidence for checker handoffs.

--- a/docs/reference/evaluations/canonical-input-recovery-pr1.md
+++ b/docs/reference/evaluations/canonical-input-recovery-pr1.md
@@ -123,4 +123,5 @@ preserved one boundary-projection bug in the new guard; its rerun was not a mode
 rollout and did not alter the frozen study outcomes. After the final upstream
 restack, the same 48-test lane passed again in `jac-pr920-latest-final`, and
 `make check` passed 884 unit tests plus lint, format, and type checking in
-`jac-pr920-latest-check`.
+`jac-pr920-latest-check`. The final checker-seam restack passed the 48 focused
+tests and `make check` with 854 unit tests in `jac-pr920-main519-final`.

--- a/docs/reference/evaluations/canonical-input-recovery-pr1.md
+++ b/docs/reference/evaluations/canonical-input-recovery-pr1.md
@@ -104,3 +104,20 @@ composition files plus one exact-rational capability test. Final PR validation
 is recorded in the pull request checks. The unresolved obligation is a held-out
 or Harbor execution before making a causal claim; the next action is the frozen
 canonicalization-plus-recovery condition.
+
+## Engineering closeout
+
+The accepted canonicalization mechanism was rebased without an experimental
+rerun onto upstream `332f0a5d219628a56c790089dcf0f95fa3045955`. Review hardening
+now validates a canonical-support representative of the complete typed request
+before duplicate-coefficient accumulation, caps each coefficient involved in an
+accumulation at 256 digits, and validates the exact combined request again. This
+preserves canonical candidate and artifact identity while failing closed before
+expensive arithmetic for invalid cross-field requests.
+
+The final-tree focused lane passed 48 contract, inverse-composition, and identity
+boundary tests in tmux session `jac-pr920-review-hardening-r3`. `make check`
+passed 872 unit tests plus the repository lint, format, and type gates in session
+`jac-pr920-check`. The earlier `jac-pr920-review-hardening` failure exposed and
+preserved one boundary-projection bug in the new guard; its rerun was not a model
+rollout and did not alter the frozen study outcomes.

--- a/docs/reference/evaluations/canonical-input-recovery-pr1.md
+++ b/docs/reference/evaluations/canonical-input-recovery-pr1.md
@@ -66,13 +66,14 @@ secondary extracted values are not evidence.
 
 The repeated failure justifying the separate recovery condition was a checker
 handoff shape error, not a mathematical rejection. In upstream task 2 repetition
-3, the agent placed the entire four-field inverse-check request under
-`forward_map`, received a root `required` failure, repeated the same nesting, and
-then did it a third time. The run eventually passed only after abandoning that
-checker path and constructing the terminal certificate locally. Existing prose
-listed missing fields, but did not encode that the nested object was a reusable
-request and belonged at the root. This is the bounded target for PR2; reasoning
-log write errors and strategy choices are out of scope.
+3, the agent embedded `inverse_map` and both variable lists inside the
+`forward_map` object, received a root `required` failure, repeated the same
+nesting, and then did it a third time. The run eventually passed only after
+abandoning that checker path and constructing the terminal certificate locally.
+Existing prose listed missing fields, but did not encode stable failure class,
+contract dimension, candidate-reuse state, or expected request type. This is the
+bounded target for PR2; reasoning-log write errors and strategy choices are out
+of scope.
 
 The installed upstream surface advertised Jacobian `0.10.0`, 332 capabilities,
 catalog digest

--- a/docs/reference/evaluations/canonical-input-recovery-pr1.md
+++ b/docs/reference/evaluations/canonical-input-recovery-pr1.md
@@ -108,7 +108,7 @@ canonicalization-plus-recovery condition.
 ## Engineering closeout
 
 The accepted canonicalization mechanism was rebased without an experimental
-rerun onto upstream `71fa917c289c6214733d369b3dce35904ff47c18`. Review hardening
+rerun onto upstream `0052a5bf78f63f5539be13da6493abb395c5026d`. Review hardening
 now validates an inverse-verification structural representative of the complete
 typed request before duplicate-coefficient accumulation, caps each coefficient
 involved in an accumulation at 256 digits, caps each duplicate group at 64
@@ -142,3 +142,6 @@ lanes. Its component lane had one unrelated macOS timeout-marker failure in
 test, and the same environment race also reproduced in the isolated DRAT timeout
 test. This is retained as an upstream/environment obligation rather than folded
 into the canonicalization change.
+The final non-overlapping restack onto `0052a5bf` passed the 56 focused tests,
+`make check` with 856 unit tests, documentation link checking, test planning,
+and `git diff --check`.

--- a/docs/reference/evaluations/canonical-input-recovery-pr1.md
+++ b/docs/reference/evaluations/canonical-input-recovery-pr1.md
@@ -108,7 +108,7 @@ canonicalization-plus-recovery condition.
 ## Engineering closeout
 
 The accepted canonicalization mechanism was rebased without an experimental
-rerun onto upstream `9e87a4515208a462c440d317a8b0ca0d31f4a248`. Review hardening
+rerun onto upstream `519dd7b9e34b641dcc138e03af6ffc6e3ed736af`. Review hardening
 now validates a canonical-support representative of the complete typed request
 before duplicate-coefficient accumulation, caps each coefficient involved in an
 accumulation at 256 digits, and validates the exact combined request again. This

--- a/docs/reference/evaluations/canonical-input-recovery-pr1.md
+++ b/docs/reference/evaluations/canonical-input-recovery-pr1.md
@@ -108,7 +108,7 @@ canonicalization-plus-recovery condition.
 ## Engineering closeout
 
 The accepted canonicalization mechanism was rebased without an experimental
-rerun onto upstream `332f0a5d219628a56c790089dcf0f95fa3045955`. Review hardening
+rerun onto upstream `9e87a4515208a462c440d317a8b0ca0d31f4a248`. Review hardening
 now validates a canonical-support representative of the complete typed request
 before duplicate-coefficient accumulation, caps each coefficient involved in an
 accumulation at 256 digits, and validates the exact combined request again. This
@@ -120,4 +120,7 @@ boundary tests in tmux session `jac-pr920-review-hardening-r3`. `make check`
 passed 872 unit tests plus the repository lint, format, and type gates in session
 `jac-pr920-check`. The earlier `jac-pr920-review-hardening` failure exposed and
 preserved one boundary-projection bug in the new guard; its rerun was not a model
-rollout and did not alter the frozen study outcomes.
+rollout and did not alter the frozen study outcomes. After the final upstream
+restack, the same 48-test lane passed again in `jac-pr920-latest-final`, and
+`make check` passed 884 unit tests plus lint, format, and type checking in
+`jac-pr920-latest-check`.

--- a/docs/reference/evaluations/canonical-input-recovery-pr1.md
+++ b/docs/reference/evaluations/canonical-input-recovery-pr1.md
@@ -108,12 +108,15 @@ canonicalization-plus-recovery condition.
 ## Engineering closeout
 
 The accepted canonicalization mechanism was rebased without an experimental
-rerun onto upstream `519dd7b9e34b641dcc138e03af6ffc6e3ed736af`. Review hardening
-now validates a canonical-support representative of the complete typed request
-before duplicate-coefficient accumulation, caps each coefficient involved in an
-accumulation at 256 digits, and validates the exact combined request again. This
-preserves canonical candidate and artifact identity while failing closed before
-expensive arithmetic for invalid cross-field requests.
+rerun onto upstream `71fa917c289c6214733d369b3dce35904ff47c18`. Review hardening
+now validates an inverse-verification structural representative of the complete
+typed request before duplicate-coefficient accumulation, caps each coefficient
+involved in an accumulation at 256 digits, caps each duplicate group at 64
+terms, and validates the exact combined request again. The dedicated preflight
+checks ordered-ring alignment without applying composition budgets to supports
+that exact cancellation may remove. This preserves canonical candidate and
+artifact identity, accepts representations whose out-of-budget terms cancel,
+and fails closed before unbounded duplicate arithmetic or artifact writes.
 
 The final-tree focused lane passed 48 contract, inverse-composition, and identity
 boundary tests in tmux session `jac-pr920-review-hardening-r3`. `make check`
@@ -125,3 +128,17 @@ restack, the same 48-test lane passed again in `jac-pr920-latest-final`, and
 `make check` passed 884 unit tests plus lint, format, and type checking in
 `jac-pr920-latest-check`. The final checker-seam restack passed the 48 focused
 tests and `make check` with 854 unit tests in `jac-pr920-main519-final`.
+After rebasing onto `71fa917c`, the two final review findings were reproduced and
+covered by the focused lane: cancelled degree-33 terms no longer trigger the
+degree-32 operation budget, and a 65-term duplicate group is rejected before
+coefficient accumulation. The final focused lane contains 56 tests, including
+the interval-verification seam exposed by the broad gate; no model rollout was
+rerun.
+
+The final `make test-changed BASE=origin/main` run passed unit, domain,
+composition, storage, process, MCP, end-to-end, static, build, and documentation
+lanes. Its component lane had one unrelated macOS timeout-marker failure in
+`test_carcara_timeout_fails_closed`; the branch does not change that checker or
+test, and the same environment race also reproduced in the isolated DRAT timeout
+test. This is retained as an upstream/environment obligation rather than folded
+into the canonicalization change.

--- a/docs/reference/evaluations/canonical-input-recovery-pr1.md
+++ b/docs/reference/evaluations/canonical-input-recovery-pr1.md
@@ -109,14 +109,15 @@ canonicalization-plus-recovery condition.
 
 The accepted canonicalization mechanism was rebased without an experimental
 rerun onto upstream `0052a5bf78f63f5539be13da6493abb395c5026d`. Review hardening
-now validates an inverse-verification structural representative of the complete
-typed request before duplicate-coefficient accumulation, caps each coefficient
+now validates a structural representative of every complete canonicalizing
+request before duplicate-coefficient accumulation, caps each coefficient
 involved in an accumulation at 256 digits, caps each duplicate group at 64
-terms, and validates the exact combined request again. The dedicated preflight
-checks ordered-ring alignment without applying composition budgets to supports
-that exact cancellation may remove. This preserves canonical candidate and
-artifact identity, accepts representations whose out-of-budget terms cancel,
-and fails closed before unbounded duplicate arithmetic or artifact writes.
+terms, and validates the exact combined request again. A validation context
+keeps structural and cross-field invariants active while deferring only
+support-dependent operation semantics until after exact cancellation. This
+preserves canonical candidate and artifact identity, accepts representations
+whose out-of-budget terms cancel, and fails closed before unbounded duplicate
+arithmetic or artifact writes.
 
 The final-tree focused lane passed 48 contract, inverse-composition, and identity
 boundary tests in tmux session `jac-pr920-review-hardening-r3`. `make check`
@@ -135,13 +136,19 @@ coefficient accumulation. The final focused lane contains 56 tests, including
 the interval-verification seam exposed by the broad gate; no model rollout was
 rerun.
 
-The final `make test-changed BASE=origin/main` run passed unit, domain,
+The final `make test-changed BASE=origin/main` runs passed unit, domain,
 composition, storage, process, MCP, end-to-end, static, build, and documentation
-lanes. Its component lane had one unrelated macOS timeout-marker failure in
-`test_carcara_timeout_fails_closed`; the branch does not change that checker or
-test, and the same environment race also reproduced in the isolated DRAT timeout
-test. This is retained as an upstream/environment obligation rather than folded
-into the canonicalization change.
+lanes. Their component lanes had unrelated macOS timeout-marker failures in one
+or both of `test_carcara_timeout_fails_closed` and
+`test_drat_timeout_fails_closed`; the branch changes neither checker nor test,
+and the DRAT failure also reproduced in isolation. This is retained as an
+upstream/environment obligation rather than folded into the canonicalization
+change.
 The final non-overlapping restack onto `0052a5bf` passed the 56 focused tests,
 `make check` with 856 unit tests, documentation link checking, test planning,
 and `git diff --check`.
+The last review pass generalized full-request preflight beyond inverse
+verification and added an evaluation-dimension regression proving cross-field
+failure precedes duplicate accumulation. Its expanded focused lane passed 65
+tests, and `make check` again passed 856 unit tests plus lint, format, complexity,
+and type checking. No model rollout was rerun.

--- a/docs/reference/evaluations/index.md
+++ b/docs/reference/evaluations/index.md
@@ -1,5 +1,7 @@
 # Evaluation references
 
+- [Canonical input and recovery study PR1](canonical-input-recovery-pr1.md)
+
 [Documentation home](../../index.md) · [Capability surface](../tools.md)
 
 - [Benchmark contracts](benchmark-contracts.md) — Harbor task contracts, dataset inventory, registry/suite/members, snapshot locks, task and verifier validation

--- a/src/jacobian/contracts/polynomial_intervals.py
+++ b/src/jacobian/contracts/polynomial_intervals.py
@@ -16,13 +16,14 @@ from __future__ import annotations
 
 from typing import Literal, Self
 
-from pydantic import Field, model_validator
+from pydantic import Field, ValidationInfo, model_validator
 
 from jacobian.contracts.common import ArtifactUri, CheckerUri
 from jacobian.contracts.exact import CanonicalRational
 from jacobian.contracts.polynomials import (
     PolynomialVariable,
     SparseRationalPolynomial,
+    canonicalization_preflight_active,
 )
 from jacobian.contracts.results import ContractModel
 
@@ -52,12 +53,14 @@ class UnivariateRationalPolynomial(ContractModel):
     polynomial: SparseRationalPolynomial
 
     @model_validator(mode="after")
-    def require_univariate_and_bounded(self) -> Self:
+    def require_univariate_and_bounded(self, info: ValidationInfo) -> Self:
         if any(len(term.exponents) != 1 for term in self.polynomial.terms):
             raise ValueError(
                 "every term of a univariate polynomial must use a one-dimensional "
                 "exponent tuple"
             )
+        if canonicalization_preflight_active(info):
+            return self
         if any(
             term.exponents[0] < 0 or term.exponents[0] > _MAX_DEGREE
             for term in self.polynomial.terms
@@ -145,9 +148,12 @@ class PolynomialIntervalEnclosureVerifyRequest(ContractModel):
     claimed_hi: CanonicalRational
 
     @model_validator(mode="after")
-    def require_claimed_enclosure_consistency(self) -> Self:
+    def require_claimed_enclosure_consistency(self, info: ValidationInfo) -> Self:
         degree = self.polynomial.degree
-        if len(self.claimed_bernstein_coefficients) != degree + 1:
+        if (
+            not canonicalization_preflight_active(info)
+            and len(self.claimed_bernstein_coefficients) != degree + 1
+        ):
             raise ValueError(
                 "claimed Bernstein coefficient count must equal degree + 1"
             )

--- a/src/jacobian/contracts/polynomials.py
+++ b/src/jacobian/contracts/polynomials.py
@@ -7,7 +7,7 @@ from itertools import permutations
 from math import prod
 from typing import Annotated, Any, Literal, Self
 
-from pydantic import Field, StringConstraints, model_validator
+from pydantic import Field, StringConstraints, ValidationInfo, model_validator
 
 from jacobian.contracts.common import ArtifactUri, CheckerUri
 from jacobian.contracts.exact import (
@@ -31,6 +31,16 @@ MAX_POLYNOMIAL_EXPONENT = 32_768
 _MAX_JACOBIAN_SOURCE_EXPONENT = 32
 _MAX_JACOBIAN_PRODUCT_TERM_ESTIMATE = 1024
 _MAX_COMPOSITION_DERIVED_EXPONENT = 127
+_CANONICALIZATION_PREFLIGHT_CONTEXT_KEY = "polynomial_canonicalization_preflight"
+
+
+def canonicalization_preflight_active(info: ValidationInfo) -> bool:
+    """Whether validation is checking request shape before exact cancellation."""
+
+    return bool(
+        isinstance(info.context, dict)
+        and info.context.get(_CANONICALIZATION_PREFLIGHT_CONTEXT_KEY) is True
+    )
 
 
 def require_polynomial_budget(
@@ -193,10 +203,11 @@ class PolynomialEvaluationRequest(ContractModel):
     )
 
     @model_validator(mode="after")
-    def require_point_dimension(self) -> Self:
+    def require_point_dimension(self, info: ValidationInfo) -> Self:
         if len(self.point) != len(self.map.variables):
             raise ValueError("evaluation point dimension must match the polynomial map")
-        require_polynomial_map_budget(self.map, label="polynomial evaluation map")
+        if not canonicalization_preflight_active(info):
+            require_polynomial_map_budget(self.map, label="polynomial evaluation map")
         return self
 
 
@@ -204,10 +215,12 @@ class PolynomialJacobianRequest(ContractModel):
     map: RationalPolynomialMap
 
     @model_validator(mode="after")
-    def require_bounded_determinant_expansion(self) -> Self:
+    def require_bounded_determinant_expansion(self, info: ValidationInfo) -> Self:
         dimension = len(self.map.variables)
         if len(self.map.coordinates) != dimension:
             raise ValueError("Jacobian determinant requires a square polynomial map")
+        if canonicalization_preflight_active(info):
+            return self
         require_polynomial_map_budget(self.map, label="Jacobian source map")
         derivative_term_counts = tuple(
             tuple(
@@ -236,10 +249,11 @@ class PolynomialKellerConditionVerifyRequest(ContractModel):
     map: RationalPolynomialMap
 
     @model_validator(mode="after")
-    def require_square_map(self) -> Self:
+    def require_square_map(self, info: ValidationInfo) -> Self:
         if len(self.map.coordinates) != len(self.map.variables):
             raise ValueError("Keller-condition verification requires a square map")
-        require_polynomial_map_budget(self.map, label="Keller-condition map")
+        if not canonicalization_preflight_active(info):
+            require_polynomial_map_budget(self.map, label="Keller-condition map")
         return self
 
 
@@ -248,9 +262,11 @@ class PolynomialFactorRequest(ContractModel):
     polynomial: SparseRationalPolynomial
 
     @model_validator(mode="after")
-    def require_univariate_terms(self) -> Self:
+    def require_univariate_terms(self, info: ValidationInfo) -> Self:
         if any(len(term.exponents) != 1 for term in self.polynomial.terms):
             raise ValueError("factorization currently supports univariate polynomials")
+        if canonicalization_preflight_active(info):
+            return self
         if len(self.polynomial.terms) > 512:
             raise ValueError("factorization exceeds the 512-term operation budget")
         for term in self.polynomial.terms:
@@ -347,7 +363,7 @@ class RationalFunctionIdentityRequest(ContractModel):
     right: SparseRationalFunction
 
     @model_validator(mode="after")
-    def require_matching_bounded_fraction_field(self) -> Self:
+    def require_matching_bounded_fraction_field(self, info: ValidationInfo) -> Self:
         if len(set(self.variables)) != len(self.variables):
             raise ValueError("rational-function variables must be unique")
         dimension = len(self.variables)
@@ -363,6 +379,8 @@ class RationalFunctionIdentityRequest(ContractModel):
             for term in polynomial.terms
         ):
             raise ValueError("every monomial must match the declared variable order")
+        if canonicalization_preflight_active(info):
+            return self
         for polynomial in polynomials:
             require_sparse_polynomial_budget(
                 polynomial,
@@ -474,13 +492,15 @@ class PolynomialMapInverseVerifyRequest(ContractModel):
     target_variables: tuple[PolynomialVariable, ...] = Field(min_length=1, max_length=4)
 
     @model_validator(mode="after")
-    def require_compatible_ordered_rings(self) -> Self:
+    def require_compatible_ordered_rings(self, info: ValidationInfo) -> Self:
         _validate_ring_variable_alignment(
             self.forward_map,
             self.inverse_map,
             self.source_variables,
             self.target_variables,
         )
+        if canonicalization_preflight_active(info):
+            return self
         for outer, inner in (
             (self.inverse_map, self.forward_map),
             (self.forward_map, self.inverse_map),
@@ -523,7 +543,6 @@ def _validate_ansatz_ring_alignment(
         raise ValueError("source and target dimensions must agree")
     if len(forward_map.coordinates) != len(target_variables):
         raise ValueError("forward map coordinate count must match target_variables")
-    require_polynomial_map_budget(forward_map, label="inverse synthesis forward map")
     if len(set(source_variables)) != len(source_variables):
         raise ValueError("source variables must be unique")
     if len(set(target_variables)) != len(target_variables):
@@ -559,12 +578,17 @@ class PolynomialMapInverseSynthesisRequest(ContractModel):
     limits: PolynomialInverseSynthesisLimits
 
     @model_validator(mode="after")
-    def require_bounded_square_qq_ansatz(self) -> Self:
+    def require_bounded_square_qq_ansatz(self, info: ValidationInfo) -> Self:
         _validate_ansatz_ring_alignment(
             self.forward_map,
             self.source_variables,
             self.target_variables,
         )
+        if not canonicalization_preflight_active(info):
+            require_polynomial_map_budget(
+                self.forward_map,
+                label="inverse synthesis forward map",
+            )
         if self.inverse_degree_bound > self.limits.max_inverse_degree:
             raise ValueError("inverse_degree_bound exceeds the declared degree limit")
         if self.support_mode is PolynomialInverseSupportMode.EXPLICIT:
@@ -655,8 +679,9 @@ class PolynomialCollisionSearchRequest(ContractModel):
     max_denominator: int = Field(ge=1, le=8)
 
     @model_validator(mode="after")
-    def require_bounded_grid(self) -> Self:
-        require_polynomial_map_budget(self.map, label="collision search map")
+    def require_bounded_grid(self, info: ValidationInfo) -> Self:
+        if not canonicalization_preflight_active(info):
+            require_polynomial_map_budget(self.map, label="collision search map")
         if (
             bounded_rational_grid_size(
                 self.max_abs_numerator,
@@ -682,8 +707,11 @@ class PolynomialCollisionVerifyRequest(ContractModel):
     claimed_image: tuple[CanonicalRational, ...] = Field(min_length=1, max_length=4)
 
     @model_validator(mode="after")
-    def require_collision_dimensions_and_distinct_points(self) -> Self:
-        require_polynomial_map_budget(self.map, label="collision verification map")
+    def require_collision_dimensions_and_distinct_points(
+        self, info: ValidationInfo
+    ) -> Self:
+        if not canonicalization_preflight_active(info):
+            require_polynomial_map_budget(self.map, label="collision verification map")
         dimension = len(self.map.variables)
         if not (
             len(self.first_point)
@@ -709,8 +737,11 @@ class PolynomialMapInverseCollisionVerifyRequest(ContractModel):
     )
 
     @model_validator(mode="after")
-    def require_collision_dimensions_and_distinct_points(self) -> Self:
-        require_polynomial_map_budget(self.map, label="inverse collision map")
+    def require_collision_dimensions_and_distinct_points(
+        self, info: ValidationInfo
+    ) -> Self:
+        if not canonicalization_preflight_active(info):
+            require_polynomial_map_budget(self.map, label="inverse collision map")
         dimension = len(self.map.variables)
         if not (
             len(self.first_point)

--- a/src/jacobian/polynomials/_support.py
+++ b/src/jacobian/polynomials/_support.py
@@ -26,7 +26,7 @@ from jacobian.contracts.capabilities import (
     CapabilityResult,
     CapabilityScope,
 )
-from jacobian.contracts.exact import CanonicalRational
+from jacobian.contracts.exact import CanonicalRational, require_bounded_rational
 from jacobian.contracts.polynomials import (
     MAX_POLYNOMIAL_EXPONENT,
     MAX_POLYNOMIAL_TERMS,
@@ -56,6 +56,7 @@ if TYPE_CHECKING:
     from sympy import Poly
 
 _INVERSE_SOLVER_SHUTDOWN_TIMEOUT_SECONDS = 1.0
+_MAX_CANONICALIZATION_COEFFICIENT_DIGITS = 256
 
 
 class _SparsePolynomialInputTerm(ContractModel):
@@ -88,10 +89,48 @@ class _SparsePolynomialInput(ContractModel):
     )
 
 
+def _require_bounded_duplicate_accumulation(
+    parsed: _SparsePolynomialInput,
+) -> None:
+    counts: dict[tuple[int, ...], int] = {}
+    for term in parsed.terms:
+        counts[term.exponents] = counts.get(term.exponents, 0) + 1
+    for term in parsed.terms:
+        if counts[term.exponents] > 1:
+            require_bounded_rational(
+                term.coefficient,
+                max_digits=_MAX_CANONICALIZATION_COEFFICIENT_DIGITS,
+                label="duplicate-term canonicalization coefficient",
+            )
+
+
+def _structural_sparse_polynomial(
+    value: object,
+) -> SparseRationalPolynomial:
+    """Build a cheap canonical support representative without coefficient sums."""
+
+    parsed = _SparsePolynomialInput.model_validate(value)
+    _require_bounded_duplicate_accumulation(parsed)
+    representatives: dict[tuple[int, ...], _SparsePolynomialInputTerm] = {}
+    for term in parsed.terms:
+        if term.coefficient.num != "0":
+            representatives.setdefault(term.exponents, term)
+    return SparseRationalPolynomial(
+        terms=tuple(
+            RationalPolynomialTerm(
+                coefficient=term.coefficient,
+                exponents=term.exponents,
+            )
+            for _, term in sorted(representatives.items(), reverse=True)
+        )
+    )
+
+
 def _canonical_sparse_polynomial(
     value: object,
 ) -> SparseRationalPolynomial:
     parsed = _SparsePolynomialInput.model_validate(value)
+    _require_bounded_duplicate_accumulation(parsed)
     coefficients: dict[tuple[int, ...], Fraction] = {}
     for term in parsed.terms:
         coefficients[term.exponents] = (
@@ -113,18 +152,25 @@ def _canonical_sparse_polynomial(
     )
 
 
-def _canonicalize_sparse_polynomial_inputs(value: object) -> object:
-    """Canonicalize exact sparse leaves while retaining the request structure."""
+def _normalize_sparse_polynomial_inputs(
+    value: object,
+    *,
+    normalize: Callable[[object], SparseRationalPolynomial],
+) -> object:
+    """Normalize exact sparse leaves while retaining the request structure."""
 
     if isinstance(value, Mapping):
         if "terms" in value and set(value) == {"terms"}:
-            return _canonical_sparse_polynomial(value).model_dump(mode="json")
+            return normalize(value).model_dump(mode="json")
         return {
-            key: _canonicalize_sparse_polynomial_inputs(item)
+            key: _normalize_sparse_polynomial_inputs(item, normalize=normalize)
             for key, item in value.items()
         }
     if isinstance(value, (list, tuple)):
-        return [_canonicalize_sparse_polynomial_inputs(item) for item in value]
+        return [
+            _normalize_sparse_polynomial_inputs(item, normalize=normalize)
+            for item in value
+        ]
     return value
 
 
@@ -555,8 +601,17 @@ def _validate_request[RequestModel: ContractModel](
     error_factory: Callable[[str, str, str], CapabilityInvocationError] | None = None,
 ) -> RequestModel:
     try:
-        return model.model_validate(_canonicalize_sparse_polynomial_inputs(payload))
-    except ValidationError as exc:
+        structural_payload = _normalize_sparse_polynomial_inputs(
+            payload,
+            normalize=_structural_sparse_polynomial,
+        )
+        model.model_validate(structural_payload)
+        canonical_payload = _normalize_sparse_polynomial_inputs(
+            payload,
+            normalize=_canonical_sparse_polynomial,
+        )
+        return model.model_validate(canonical_payload)
+    except (ValidationError, ValueError) as exc:
         raise (error_factory or _polynomial_error)(
             code,
             "request_validation",

--- a/src/jacobian/polynomials/_support.py
+++ b/src/jacobian/polynomials/_support.py
@@ -36,6 +36,7 @@ from jacobian.contracts.polynomials import (
     PolynomialMapEvaluation,
     PolynomialMapInverseSynthesisRequest,
     PolynomialMapInverseVerifyRequest,
+    PolynomialVariable,
     RationalPolynomialMap,
     RationalPolynomialPoint,
     RationalPolynomialTerm,
@@ -57,6 +58,7 @@ if TYPE_CHECKING:
 
 _INVERSE_SOLVER_SHUTDOWN_TIMEOUT_SECONDS = 1.0
 _MAX_CANONICALIZATION_COEFFICIENT_DIGITS = 256
+_MAX_CANONICALIZATION_DUPLICATE_TERMS = 64
 
 
 class _SparsePolynomialInputTerm(ContractModel):
@@ -89,12 +91,40 @@ class _SparsePolynomialInput(ContractModel):
     )
 
 
+class _PolynomialMapInverseVerifyInput(ContractModel):
+    """Inverse-check request shape without composition operation budgets."""
+
+    forward_map: RationalPolynomialMap
+    inverse_map: RationalPolynomialMap
+    source_variables: tuple[PolynomialVariable, ...] = Field(min_length=1, max_length=4)
+    target_variables: tuple[PolynomialVariable, ...] = Field(min_length=1, max_length=4)
+
+    @model_validator(mode="after")
+    def require_compatible_ordered_rings(self) -> Self:
+        if self.forward_map.variables != self.source_variables:
+            raise ValueError("forward map variables must equal source_variables")
+        if self.inverse_map.variables != self.target_variables:
+            raise ValueError("inverse map variables must equal target_variables")
+        if len(self.source_variables) != len(self.target_variables):
+            raise ValueError("source and target dimensions must agree")
+        if len(self.forward_map.coordinates) != len(self.target_variables):
+            raise ValueError("forward map coordinate count must match target_variables")
+        if len(self.inverse_map.coordinates) != len(self.source_variables):
+            raise ValueError("inverse map coordinate count must match source_variables")
+        return self
+
+
 def _require_bounded_duplicate_accumulation(
     parsed: _SparsePolynomialInput,
 ) -> None:
     counts: dict[tuple[int, ...], int] = {}
     for term in parsed.terms:
         counts[term.exponents] = counts.get(term.exponents, 0) + 1
+    if any(count > _MAX_CANONICALIZATION_DUPLICATE_TERMS for count in counts.values()):
+        raise ValueError(
+            "duplicate-term canonicalization exceeds the "
+            f"{_MAX_CANONICALIZATION_DUPLICATE_TERMS}-term accumulation budget"
+        )
     for term in parsed.terms:
         if counts[term.exponents] > 1:
             require_bounded_rational(
@@ -107,7 +137,7 @@ def _require_bounded_duplicate_accumulation(
 def _structural_sparse_polynomial(
     value: object,
 ) -> SparseRationalPolynomial:
-    """Build a cheap canonical support representative without coefficient sums."""
+    """Build a cheap shape representative without applying operation budgets."""
 
     parsed = _SparsePolynomialInput.model_validate(value)
     _require_bounded_duplicate_accumulation(parsed)
@@ -601,11 +631,12 @@ def _validate_request[RequestModel: ContractModel](
     error_factory: Callable[[str, str, str], CapabilityInvocationError] | None = None,
 ) -> RequestModel:
     try:
-        structural_payload = _normalize_sparse_polynomial_inputs(
-            payload,
-            normalize=_structural_sparse_polynomial,
-        )
-        model.model_validate(structural_payload)
+        if model is PolynomialMapInverseVerifyRequest:
+            structural_payload = _normalize_sparse_polynomial_inputs(
+                payload,
+                normalize=_structural_sparse_polynomial,
+            )
+            _PolynomialMapInverseVerifyInput.model_validate(structural_payload)
         canonical_payload = _normalize_sparse_polynomial_inputs(
             payload,
             normalize=_canonical_sparse_polynomial,

--- a/src/jacobian/polynomials/_support.py
+++ b/src/jacobian/polynomials/_support.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import multiprocessing
 import time
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterator, Mapping
+from fractions import Fraction
 from math import prod as multiply
 from queue import Empty
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Self, cast
 
-from pydantic import ValidationError
+from pydantic import Field, ValidationError, model_validator
 
 from jacobian.canonical import format_canonical_integer
 from jacobian.capability_service import CapabilityInvocationError
@@ -27,6 +28,9 @@ from jacobian.contracts.capabilities import (
 )
 from jacobian.contracts.exact import CanonicalRational
 from jacobian.contracts.polynomials import (
+    MAX_POLYNOMIAL_EXPONENT,
+    MAX_POLYNOMIAL_TERMS,
+    MAX_POLYNOMIAL_VARIABLES,
     PolynomialInverseCoefficientEquation,
     PolynomialInverseSupportMode,
     PolynomialMapEvaluation,
@@ -52,6 +56,76 @@ if TYPE_CHECKING:
     from sympy import Poly
 
 _INVERSE_SOLVER_SHUTDOWN_TIMEOUT_SECONDS = 1.0
+
+
+class _SparsePolynomialInputTerm(ContractModel):
+    """One exact boundary term before like-term canonicalization."""
+
+    coefficient: CanonicalRational
+    exponents: tuple[int, ...] = Field(
+        min_length=1,
+        max_length=MAX_POLYNOMIAL_VARIABLES,
+    )
+
+    @model_validator(mode="after")
+    def require_bounded_exponents(self) -> Self:
+        if any(
+            exponent < 0 or exponent > MAX_POLYNOMIAL_EXPONENT
+            for exponent in self.exponents
+        ):
+            raise ValueError(
+                "polynomial exponents exceed the shared representation limit"
+            )
+        return self
+
+
+class _SparsePolynomialInput(ContractModel):
+    """Bounded noncanonical sparse terms accepted only at capability input."""
+
+    terms: tuple[_SparsePolynomialInputTerm, ...] = Field(
+        default=(),
+        max_length=MAX_POLYNOMIAL_TERMS,
+    )
+
+
+def _canonical_sparse_polynomial(
+    value: object,
+) -> SparseRationalPolynomial:
+    parsed = _SparsePolynomialInput.model_validate(value)
+    coefficients: dict[tuple[int, ...], Fraction] = {}
+    for term in parsed.terms:
+        coefficients[term.exponents] = (
+            coefficients.get(term.exponents, Fraction())
+            + term.coefficient.as_fraction()
+        )
+    return SparseRationalPolynomial(
+        terms=tuple(
+            RationalPolynomialTerm(
+                coefficient=CanonicalRational.from_fraction(coefficient),
+                exponents=exponents,
+            )
+            for exponents, coefficient in sorted(
+                coefficients.items(),
+                reverse=True,
+            )
+            if coefficient
+        )
+    )
+
+
+def _canonicalize_sparse_polynomial_inputs(value: object) -> object:
+    """Canonicalize exact sparse leaves while retaining the request structure."""
+
+    if isinstance(value, Mapping):
+        if "terms" in value and set(value) == {"terms"}:
+            return _canonical_sparse_polynomial(value).model_dump(mode="json")
+        return {
+            key: _canonicalize_sparse_polynomial_inputs(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [_canonicalize_sparse_polynomial_inputs(item) for item in value]
+    return value
 
 
 def _materialize_map(
@@ -481,7 +555,7 @@ def _validate_request[RequestModel: ContractModel](
     error_factory: Callable[[str, str, str], CapabilityInvocationError] | None = None,
 ) -> RequestModel:
     try:
-        return model.model_validate(payload)
+        return model.model_validate(_canonicalize_sparse_polynomial_inputs(payload))
     except ValidationError as exc:
         raise (error_factory or _polynomial_error)(
             code,

--- a/src/jacobian/polynomials/_support.py
+++ b/src/jacobian/polynomials/_support.py
@@ -28,6 +28,7 @@ from jacobian.contracts.capabilities import (
 )
 from jacobian.contracts.exact import CanonicalRational, require_bounded_rational
 from jacobian.contracts.polynomials import (
+    _CANONICALIZATION_PREFLIGHT_CONTEXT_KEY,
     MAX_POLYNOMIAL_EXPONENT,
     MAX_POLYNOMIAL_TERMS,
     MAX_POLYNOMIAL_VARIABLES,
@@ -36,7 +37,6 @@ from jacobian.contracts.polynomials import (
     PolynomialMapEvaluation,
     PolynomialMapInverseSynthesisRequest,
     PolynomialMapInverseVerifyRequest,
-    PolynomialVariable,
     RationalPolynomialMap,
     RationalPolynomialPoint,
     RationalPolynomialTerm,
@@ -89,29 +89,6 @@ class _SparsePolynomialInput(ContractModel):
         default=(),
         max_length=MAX_POLYNOMIAL_TERMS,
     )
-
-
-class _PolynomialMapInverseVerifyInput(ContractModel):
-    """Inverse-check request shape without composition operation budgets."""
-
-    forward_map: RationalPolynomialMap
-    inverse_map: RationalPolynomialMap
-    source_variables: tuple[PolynomialVariable, ...] = Field(min_length=1, max_length=4)
-    target_variables: tuple[PolynomialVariable, ...] = Field(min_length=1, max_length=4)
-
-    @model_validator(mode="after")
-    def require_compatible_ordered_rings(self) -> Self:
-        if self.forward_map.variables != self.source_variables:
-            raise ValueError("forward map variables must equal source_variables")
-        if self.inverse_map.variables != self.target_variables:
-            raise ValueError("inverse map variables must equal target_variables")
-        if len(self.source_variables) != len(self.target_variables):
-            raise ValueError("source and target dimensions must agree")
-        if len(self.forward_map.coordinates) != len(self.target_variables):
-            raise ValueError("forward map coordinate count must match target_variables")
-        if len(self.inverse_map.coordinates) != len(self.source_variables):
-            raise ValueError("inverse map coordinate count must match source_variables")
-        return self
 
 
 def _require_bounded_duplicate_accumulation(
@@ -631,12 +608,14 @@ def _validate_request[RequestModel: ContractModel](
     error_factory: Callable[[str, str, str], CapabilityInvocationError] | None = None,
 ) -> RequestModel:
     try:
-        if model is PolynomialMapInverseVerifyRequest:
-            structural_payload = _normalize_sparse_polynomial_inputs(
-                payload,
-                normalize=_structural_sparse_polynomial,
-            )
-            _PolynomialMapInverseVerifyInput.model_validate(structural_payload)
+        structural_payload = _normalize_sparse_polynomial_inputs(
+            payload,
+            normalize=_structural_sparse_polynomial,
+        )
+        model.model_validate(
+            structural_payload,
+            context={_CANONICALIZATION_PREFLIGHT_CONTEXT_KEY: True},
+        )
         canonical_payload = _normalize_sparse_polynomial_inputs(
             payload,
             normalize=_canonical_sparse_polynomial,

--- a/tests/boundary/providers/sympy/runtime/test_polynomial_identity.py
+++ b/tests/boundary/providers/sympy/runtime/test_polynomial_identity.py
@@ -200,7 +200,7 @@ def test_polynomial_identity_verifies_a_difference(authorized_complete_runtime) 
     assert record.payload["relation_id"] is None
 
 
-def test_polynomial_identity_duplicate_terms_return_actionable_recovery(
+def test_polynomial_identity_canonicalizes_duplicate_terms(
     authorized_complete_runtime,
 ) -> None:
     runtime = authorized_complete_runtime
@@ -224,9 +224,10 @@ def test_polynomial_identity_duplicate_terms_return_actionable_recovery(
         )
     )
 
-    assert result.execution.status.value == "ERROR"
-    assert result.diagnostics[0].code == "INVALID_POLYNOMIAL_IDENTITY_REQUEST"
-    assert "Combine duplicate exponent vectors" in result.diagnostics[0].hint
+    assert result.execution.status.value == "COMPLETED"
+    assert result.output["identical"] is True
+    assert result.output["conclusion"] == Conclusion.TRUE.value
+    assert result.assurance.level is CapabilityAssuranceLevel.VERIFIED
 
 
 def test_polynomial_identity_preserves_checker_rejection_as_unknown(

--- a/tests/composition/runtime/test_polynomial_map_inverse_verify.py
+++ b/tests/composition/runtime/test_polynomial_map_inverse_verify.py
@@ -5,11 +5,13 @@ from typing import Any
 
 import pytest
 
+import jacobian.polynomials._support as polynomial_support
 from jacobian.contracts.capabilities import (
     CapabilityAssuranceLevel,
     CapabilityMode,
     CapabilityRequest,
 )
+from jacobian.contracts.polynomials import SparseRationalPolynomial
 from jacobian.contracts.results import Conclusion, ExecutionStatus
 from jacobian.runtime.model import JacobianRuntime
 from jacobian_checkers.polynomial_maps import check_map_inverse
@@ -178,6 +180,51 @@ def test_sparse_input_normalization_rejects_malformed_terms_before_artifacts(
     assert result.execution.status is ExecutionStatus.ERROR
     assert result.output["error"]["code"] == "INVALID_REQUEST"
     assert result.output["error"]["stage"] == "capability_input_validation"
+    assert result.artifact_uris == ()
+
+
+def test_complete_request_is_rejected_before_duplicate_term_accumulation(
+    authorized_complete_runtime,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    forward, inverse = _triangular_maps()
+    forward["variables"] = ["z", "y"]
+    forward["coordinates"][0]["terms"].append(_term(1, [1, 0]))
+
+    def unexpected_accumulation(value: object) -> SparseRationalPolynomial:
+        raise AssertionError(f"canonical accumulation reached for {value!r}")
+
+    monkeypatch.setattr(
+        polynomial_support,
+        "_canonical_sparse_polynomial",
+        unexpected_accumulation,
+    )
+
+    result = authorized_complete_runtime.core.capabilities.invoke(
+        _request(forward, inverse)
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.output["error"]["code"] == "INVALID_POLYNOMIAL_MAP_INVERSE_REQUEST"
+    assert result.artifact_uris == ()
+
+
+def test_duplicate_accumulation_rejects_oversized_coefficients(
+    authorized_complete_runtime,
+) -> None:
+    forward, inverse = _triangular_maps()
+    oversized = "9" * 257
+    forward["coordinates"][0]["terms"] = [
+        {"coefficient": {"num": oversized, "den": "1"}, "exponents": [1, 0]},
+        _term(1, [1, 0]),
+    ]
+
+    result = authorized_complete_runtime.core.capabilities.invoke(
+        _request(forward, inverse)
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.output["error"]["code"] == "INVALID_POLYNOMIAL_MAP_INVERSE_REQUEST"
     assert result.artifact_uris == ()
 
 

--- a/tests/composition/runtime/test_polynomial_map_inverse_verify.py
+++ b/tests/composition/runtime/test_polynomial_map_inverse_verify.py
@@ -109,6 +109,78 @@ def test_two_sided_triangular_inverse_is_verified(authorized_complete_runtime) -
     assert residuals["forward_after_inverse"] == [{"terms": []}, {"terms": []}]
 
 
+def test_noncanonical_sparse_maps_are_normalized_before_verification(
+    authorized_complete_runtime,
+) -> None:
+    canonical_forward, canonical_inverse = _triangular_maps()
+    forward = deepcopy(canonical_forward)
+    inverse = deepcopy(canonical_inverse)
+    forward["coordinates"][0]["terms"] = [
+        _term(1, [0, 2]),
+        {
+            "coefficient": {"num": "3", "den": "2"},
+            "exponents": [1, 0],
+        },
+        {
+            "coefficient": {"num": "-1", "den": "2"},
+            "exponents": [1, 0],
+        },
+        _term(0, [0, 0]),
+    ]
+    inverse["coordinates"][0]["terms"] = [
+        _term(-1, [0, 2]),
+        {
+            "coefficient": {"num": "2", "den": "3"},
+            "exponents": [1, 0],
+        },
+        {
+            "coefficient": {"num": "1", "den": "3"},
+            "exponents": [1, 0],
+        },
+        _term(0, [0, 0]),
+    ]
+
+    normalized = authorized_complete_runtime.core.capabilities.invoke(
+        _request(forward, inverse)
+    )
+    canonical = authorized_complete_runtime.core.capabilities.invoke(
+        _request(canonical_forward, canonical_inverse)
+    )
+
+    assert normalized.output["inverse_verified"] is True
+    assert normalized.assurance.level is CapabilityAssuranceLevel.VERIFIED
+    assert normalized.output["forward_map_uri"] == canonical.output["forward_map_uri"]
+    assert normalized.output["inverse_map_uri"] == canonical.output["inverse_map_uri"]
+    assert (
+        authorized_complete_runtime.core.store.get(
+            normalized.output["forward_map_uri"]
+        ).payload
+        == canonical_forward
+    )
+    assert (
+        authorized_complete_runtime.core.store.get(
+            normalized.output["inverse_map_uri"]
+        ).payload
+        == canonical_inverse
+    )
+
+
+def test_sparse_input_normalization_rejects_malformed_terms_before_artifacts(
+    authorized_complete_runtime,
+) -> None:
+    forward, inverse = _triangular_maps()
+    forward["coordinates"][0]["terms"][0]["unexpected"] = True
+
+    result = authorized_complete_runtime.core.capabilities.invoke(
+        _request(forward, inverse)
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.output["error"]["code"] == "INVALID_REQUEST"
+    assert result.output["error"]["stage"] == "capability_input_validation"
+    assert result.artifact_uris == ()
+
+
 def test_overlapping_variable_names_use_simultaneous_composition(
     authorized_complete_runtime,
 ) -> None:

--- a/tests/composition/runtime/test_polynomial_map_inverse_verify.py
+++ b/tests/composition/runtime/test_polynomial_map_inverse_verify.py
@@ -228,6 +228,65 @@ def test_duplicate_accumulation_rejects_oversized_coefficients(
     assert result.artifact_uris == ()
 
 
+def test_duplicate_accumulation_rejects_oversized_groups(
+    authorized_complete_runtime,
+) -> None:
+    forward, inverse = _triangular_maps()
+    forward["coordinates"][0]["terms"] = [
+        _term(1, [1, 0])
+        for _ in range(polynomial_support._MAX_CANONICALIZATION_DUPLICATE_TERMS + 1)
+    ]
+
+    result = authorized_complete_runtime.core.capabilities.invoke(
+        _request(forward, inverse)
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.output["error"]["code"] == "INVALID_POLYNOMIAL_MAP_INVERSE_REQUEST"
+    assert result.artifact_uris == ()
+
+
+def test_cancelled_high_degree_terms_do_not_apply_operation_budget(
+    authorized_complete_runtime,
+) -> None:
+    forward = {
+        "map_schema_version": "1",
+        "domain": "QQ",
+        "variables": ["x"],
+        "coordinates": [
+            {
+                "terms": [
+                    _term(1, [33]),
+                    _term(-1, [33]),
+                    _term(1, [1]),
+                ]
+            }
+        ],
+    }
+    inverse = {
+        "map_schema_version": "1",
+        "domain": "QQ",
+        "variables": ["u"],
+        "coordinates": [{"terms": [_term(1, [1])]}],
+    }
+
+    result = authorized_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="polynomial.map.inverse.verify",
+            mode=CapabilityMode.VERIFY,
+            input={
+                "forward_map": forward,
+                "inverse_map": inverse,
+                "source_variables": ["x"],
+                "target_variables": ["u"],
+            },
+        )
+    )
+
+    assert result.output["inverse_verified"] is True
+    assert result.assurance.level is CapabilityAssuranceLevel.VERIFIED
+
+
 def test_overlapping_variable_names_use_simultaneous_composition(
     authorized_complete_runtime,
 ) -> None:

--- a/tests/composition/runtime/test_polynomial_map_inverse_verify.py
+++ b/tests/composition/runtime/test_polynomial_map_inverse_verify.py
@@ -209,6 +209,38 @@ def test_complete_request_is_rejected_before_duplicate_term_accumulation(
     assert result.artifact_uris == ()
 
 
+def test_evaluation_cross_field_error_precedes_duplicate_term_accumulation(
+    authorized_complete_runtime,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    polynomial_map, _inverse = _triangular_maps()
+    polynomial_map["coordinates"][0]["terms"].append(_term(1, [1, 0]))
+
+    def unexpected_accumulation(value: object) -> SparseRationalPolynomial:
+        raise AssertionError(f"canonical accumulation reached for {value!r}")
+
+    monkeypatch.setattr(
+        polynomial_support,
+        "_canonical_sparse_polynomial",
+        unexpected_accumulation,
+    )
+
+    result = authorized_complete_runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="polynomial.map.evaluate",
+            mode=CapabilityMode.EXPLORE,
+            input={
+                "map": polynomial_map,
+                "point": [{"num": "0", "den": "1"}],
+            },
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.output["error"]["code"] == "INVALID_POLYNOMIAL_EVALUATION_REQUEST"
+    assert result.artifact_uris == ()
+
+
 def test_duplicate_accumulation_rejects_oversized_coefficients(
     authorized_complete_runtime,
 ) -> None:

--- a/tests/unit/contracts/test_polynomial_contracts.py
+++ b/tests/unit/contracts/test_polynomial_contracts.py
@@ -178,6 +178,29 @@ def test_shared_polynomial_map_is_not_limited_to_square_maps() -> None:
     assert len(value.coordinates) == 2
 
 
+def test_canonical_sparse_value_still_rejects_duplicate_exponents() -> None:
+    with pytest.raises(ValidationError, match="exponent tuples must be unique"):
+        SparseRationalPolynomial.model_validate(
+            {
+                "terms": [
+                    {"coefficient": _rational(1), "exponents": [1]},
+                    {"coefficient": _rational(2), "exponents": [1]},
+                ]
+            }
+        )
+
+
+def test_canonical_sparse_value_still_rejects_zero_terms() -> None:
+    with pytest.raises(ValidationError, match="zero polynomial terms must be omitted"):
+        SparseRationalPolynomial.model_validate(
+            {
+                "terms": [
+                    {"coefficient": _rational(0), "exponents": [0]},
+                ]
+            }
+        )
+
+
 def test_shared_polynomial_representation_exceeds_gcd_input_budget() -> None:
     from jacobian.contracts.polynomial_operations import PolynomialGcdRequest
     from jacobian.contracts.polynomials import RationalPolynomial


### PR DESCRIPTION
## Summary

- canonicalize bounded sparse polynomial inputs at existing capability request boundaries
- combine duplicate exponent vectors exactly, remove cancellations and zero terms, and impose deterministic order
- preserve strict stored polynomial contracts, canonical artifact identity, and independent checker authority
- preflight structural and cross-field invariants for every canonicalizing request before bounded duplicate arithmetic
- cap duplicate inputs at 256 coefficient digits and 64 terms per exponent vector
- preregister and record a bounded host-local mechanism study

## Review hardening

The final review pass keeps support-dependent operation semantics on the exact canonical request, so an out-of-budget monomial that cancels does not reject a cheap canonical polynomial. A Pydantic validation context preserves structural and cross-field checks for every canonicalizing request before coefficient accumulation. Duplicate accumulation is bounded before arithmetic by both coefficient size and group cardinality.

## Validation

- upstream base: `0052a5bf78f63f5539be13da6493abb395c5026d`
- PR head: `334efd0717a31408a66d12dc71015bba6f4e52d8`
- focused polynomial contract, evaluation, inverse, identity, and interval lane: 65 passed
- `make check`: 856 unit tests plus lint, format, complexity, and type gates passed
- `make test-plan BASE=origin/main`: passed; selected the suite fallback because the frozen benchmark config has no exact ownership mapping
- `make test-changed BASE=origin/main`: unit, domain, composition, storage, process, MCP, end-to-end, static, build, and documentation lanes passed
- component lane: inherited macOS timeout-marker races in `test_carcara_timeout_fails_closed` and/or `test_drat_timeout_fails_closed`; the branch changes neither checker nor test, and DRAT also failed in isolation
- `make docs-linkcheck` and `git diff --check`: passed

## Evidence boundary

Both frozen conditions completed all 9 scheduled slots. Upstream produced 6 accepted and 3 rejected outcomes. Canonicalization produced 6 accepted, 1 rejected, and 2 preserved inconclusive outcomes: one external interruption and one reasoning-protocol ambiguity. Neither was rerun.

Canonicalization removed both observed representation failures and directly enabled a duplicate/zero/reordered polynomial-map candidate to reach `COMPLETED/VERIFIED`, but aggregate acceptance remained 6/9. This is host-local mechanism evidence, not a causal benchmark claim. No model rollout was rerun during review closeout.

Typed recovery remains isolated from this product change in #928.
