### PR TITLE
fix(polynomials): handle zero Jacobian partial derivatives

### DIFF
--- a/src/jacobian/domains/polynomial/jacobian_syzygy.py
+++ b/src/jacobian/domains/polynomial/jacobian_syzygy.py
@@ -127,6 +127,8 @@ def _coefficient_matrix(
         for basis_index, multiplier_exponents in enumerate(source_basis):
             column = component * len(source_basis) + basis_index
             for partial_exponents, coefficient in partial.terms():
+                if coefficient == 0:
+                    continue
                 target_exponents = cast(
                     tuple[int, int, int],
                     tuple(

--- a/tests/composition/runtime/test_frontier_capabilities.py
+++ b/tests/composition/runtime/test_frontier_capabilities.py
@@ -289,6 +289,44 @@ def test_graded_jacobian_syzygy_finds_and_verifies_the_first_kernel(
     assert verified.output["status"] == "VERIFIED"
 
 
+def test_graded_jacobian_syzygy_handles_a_zero_partial_derivative(
+    frontier_services: DomainTestServices,
+) -> None:
+    input_payload = {
+        "polynomial": _polynomial([(1, (2, 0, 1))]),
+        "max_degree": 0,
+    }
+    computed = frontier_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="polynomial.jacobian_syzygy.minimum_degree.compute",
+            input=input_payload,
+        )
+    )
+
+    assert computed.execution.status is ExecutionStatus.COMPLETED
+    result = computed.output["result"]
+    assert result["first_syzygy_degree"] == 0
+    assert [(item["rank"], item["nullity"]) for item in result["degree_maps"]] == [
+        (2, 1)
+    ]
+    assert result["partial_derivatives"][1]["polynomial"]["terms"] == []
+    assert [item["num"] for item in result["kernel_witness"]["coefficient_vector"]] == [
+        "0",
+        "1",
+        "0",
+    ]
+
+    verified = frontier_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="polynomial.jacobian_syzygy.minimum_degree.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"input": input_payload, "candidate": result},
+        )
+    )
+    assert verified.execution.status is ExecutionStatus.COMPLETED
+    assert verified.output["status"] == "VERIFIED"
+
+
 @pytest.mark.parametrize(
     "forgery",
     ("map_digest", "rank_minor", "kernel_vector", "partial_derivative"),


### PR DESCRIPTION
## What changed

- ignore explicit zero coefficients emitted by SymPy while assembling graded Jacobian coefficient maps
- add an end-to-end compute-and-verify regression for `h=x^2 z`, whose `y` partial derivative is zero

## Why

For a valid homogeneous polynomial that omits one variable, SymPy represents the corresponding zero partial with a zero term at exponent `(0,0,0)`. The coefficient-map builder attempted to place that term in the positive-degree target basis and raised `KeyError`, surfacing as `ADAPTER_EXECUTION_FAILED`.

Skipping a zero coefficient preserves the exact linear map and lets the producer return the expected degree-0 kernel. The independent verifier accepts the resulting candidate.

## Validation

- `python -m pytest tests/composition/runtime/test_frontier_capabilities.py -k 'graded_jacobian_syzygy or syzygy_checker_rejects' -q` — 6 passed
- `python -m ruff check src/jacobian/domains/polynomial/jacobian_syzygy.py tests/composition/runtime/test_frontier_capabilities.py`
- `git diff --check`