### PR TITLE
fix(benchmarks): clarify sparse Jacobian syzygy inputs

### DIFF
--- a/src/jacobian/domains/polynomial/jacobian_syzygy.py
+++ b/src/jacobian/domains/polynomial/jacobian_syzygy.py
@@ -325,7 +325,9 @@ GRADED_JACOBIAN_SYZYGY_CAPABILITY = polynomial_operation(
         "or as a labelled product of linear forms, exactly construct every "
         "graded map (QQ[x,y,z]_q)^3 -> QQ[x,y,z]_(q+deg(h)-1) from q=0, "
         "report rank certificates, and stop at the first nonzero kernel or the "
-        "declared finite degree bound. Full sparse maps are optional."
+        "declared finite degree bound. Sparse polynomial terms must have "
+        "nonzero coefficients and unique exponent tuples in descending "
+        "lexicographic order. Full sparse maps are optional."
     ),
     GradedJacobianSyzygyRequest,
     GradedJacobianSyzygyResult,
@@ -338,8 +340,38 @@ GRADED_JACOBIAN_SYZYGY_CAPABILITY = polynomial_operation(
     "rank",
     "kernel",
     "exact",
-    version="3",
+    version="4",
     invocation_examples=(
+        CapabilityInvocationExample(
+            name="sparse-homogeneous-polynomial",
+            description=(
+                "Supply h=x^2+y^2+z^2 with unique nonzero terms in descending "
+                "lexicographic exponent order."
+            ),
+            mode=CapabilityMode.EXPLORE,
+            input={
+                "polynomial": {
+                    "variables": ["x", "y", "z"],
+                    "polynomial": {
+                        "terms": [
+                            {
+                                "coefficient": {"num": "1", "den": "1"},
+                                "exponents": [2, 0, 0],
+                            },
+                            {
+                                "coefficient": {"num": "1", "den": "1"},
+                                "exponents": [0, 2, 0],
+                            },
+                            {
+                                "coefficient": {"num": "1", "den": "1"},
+                                "exponents": [0, 0, 2],
+                            },
+                        ]
+                    },
+                },
+                "max_degree": 0,
+            },
+        ),
         CapabilityInvocationExample(
             name="labelled-linear-factor-product",
             description=(

--- a/tests/composition/runtime/test_frontier_capabilities.py
+++ b/tests/composition/runtime/test_frontier_capabilities.py
@@ -250,6 +250,27 @@ def test_hamiltonian_path_decision_has_independent_replay(
 def test_graded_jacobian_syzygy_finds_and_verifies_the_first_kernel(
     frontier_services: DomainTestServices,
 ) -> None:
+    descriptor = next(
+        item
+        for item in frontier_services.core.capabilities.catalog().capabilities
+        if item.capability_id == "polynomial.jacobian_syzygy.minimum_degree.compute"
+    )
+    sparse_example = next(
+        item
+        for item in descriptor.invocation_examples
+        if item.name == "sparse-homogeneous-polynomial"
+    )
+    example_result = frontier_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id=descriptor.capability_id,
+            input=sparse_example.input,
+        )
+    )
+    assert example_result.execution.status is ExecutionStatus.COMPLETED
+    assert "unique exponent tuples in descending lexicographic order" in (
+        descriptor.description
+    )
+
     computed = frontier_services.core.capabilities.invoke(
         CapabilityRequest(
             capability_id=("polynomial.jacobian_syzygy.minimum_degree.compute"),


### PR DESCRIPTION
## What changed

- state the canonical sparse-polynomial term rules on the graded Jacobian-syzygy producer card;
- add a schema-valid sparse homogeneous polynomial invocation example;
- bump the experimental capability contract version;
- execute the example in the existing composition regression.

## Why

A held-out Orevkov degree-10 evaluation discovered the correct syzygy producer immediately, but the card showed only its labelled-linear-factor input form. The generated sparse schema did not expose the shared canonicalization rules. The model made three producer attempts: duplicate exponent tuples, then noncanonical term order twice. It completed the mathematics manually, so no Jacobian result reached the independent verifier.

The saved Gröbner recovery suite independently exercises the same shared sparse representation under duplicate exponents, reversed order, and explicit zero terms. This patch makes those factual input rules visible before invocation. It does not normalize malformed input or prescribe a workflow.

## Scope and overlap

This is producer-card presentation only.

- #917 owns the separate inline verifier-handoff metadata defect.
- #923 owns oversized exact-verifier diagnostics.
- #924 owns zero partial derivatives.
- Merged #818 already supplies specific recovery diagnostics.

No mathematical kernel, validator, bound, evidence, assurance, checker authorization, ranking, or routing behavior changes.

## Validation

Change-aware planner selected unit, component, domain, composition, static, and build.

- focused syzygy regression: 1 passed;
- unit: 869 passed;
- component: 759 passed, 3 expected platform skips;
- domain: 185 passed;
- composition: 475 passed, 2 expected Lean skips;
- Ruff, formatting, complexity, dependency, dead-code, mypy, test architecture, product architecture, and package build: passed.